### PR TITLE
[RFC / wip]: Add option to surround uncorrectable offenses with `# rubocop:disable`

### DIFF
--- a/lib/rubocop/cop/autocorrect_logic.rb
+++ b/lib/rubocop/cop/autocorrect_logic.rb
@@ -5,21 +5,81 @@ module RuboCop
     # This module encapsulates the logic for autocorrect behavior for a cop.
     module AutocorrectLogic
       def autocorrect?
-        autocorrect_requested? && support_autocorrect? && autocorrect_enabled?
+        autocorrect_requested? && correctable? && autocorrect_enabled?
       end
 
       def autocorrect_requested?
         @options.fetch(:auto_correct, false)
       end
 
+      def correctable?
+        support_autocorrect? || disable_uncorrectable?
+      end
+
       def support_autocorrect?
         respond_to?(:autocorrect, true)
+      end
+
+      def disable_uncorrectable?
+        @options[:disable_uncorrectable] == true
       end
 
       def autocorrect_enabled?
         # allow turning off autocorrect on a cop by cop basis
         return true unless cop_config
         cop_config['AutoCorrect'] != false
+      end
+
+      def disable_offense(node)
+        range = node.location.expression
+        range_by_lines = range_by_lines(range)
+
+        if range.line == range.last_line
+          disable_offense_at_end_of_line(range_by_lines)
+        else
+          disable_offense_before_and_after(range_by_lines)
+        end
+      end
+
+      private
+
+      # Expand the given range to include all of any lines it covers. Does not
+      # include newline at end of the last line.
+      def range_by_lines(range)
+        begin_of_first_line = range.begin_pos - range.column
+
+        last_line = range.source_buffer.source_line(range.last_line)
+        last_line_offset = last_line.length - range.last_column
+        end_of_last_line = range.end_pos + last_line_offset
+
+        Parser::Source::Range.new(range.source_buffer,
+                                  begin_of_first_line,
+                                  end_of_last_line)
+      end
+
+      def disable_offense_at_end_of_line(range_by_lines)
+        lambda do |corrector|
+          corrector.insert_after(
+            range_by_lines,
+            " # rubocop:disable #{cop_name}"
+          )
+        end
+      end
+
+      def disable_offense_before_and_after(range_by_lines)
+        lambda do |corrector|
+          range_with_newline = range_by_lines.resize(range_by_lines.size + 1)
+          leading_whitespace = range_by_lines.source_line[/^\s*/]
+
+          corrector.insert_before(
+            range_with_newline,
+            "#{leading_whitespace}# rubocop:disable #{cop_name}\n"
+          )
+          corrector.insert_after(
+            range_with_newline,
+            "#{leading_whitespace}# rubocop:enable #{cop_name}\n"
+          )
+        end
       end
     end
   end

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -128,12 +128,16 @@ module RuboCop
       end
 
       def correct(node)
-        return :unsupported unless support_autocorrect?
+        return :unsupported unless correctable?
         return :uncorrected unless autocorrect?
 
-        correction = autocorrect(node)
-        return :uncorrected unless correction
-        @corrections << correction
+        if support_autocorrect?
+          correction = autocorrect(node)
+          return :uncorrected unless correction
+          @corrections << correction
+        elsif disable_uncorrectable?
+          @corrections << disable_offense(node)
+        end
         :corrected
       end
 

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -99,6 +99,8 @@ module RuboCop
         @validator.validate_exclude_limit_option(args)
       end
 
+      option(opts, '--disable-uncorrectable')
+
       option(opts, '--force-exclusion')
 
       option(opts, '--force-default-config')
@@ -300,6 +302,10 @@ module RuboCop
       exclude_limit:        ['Used together with --auto-gen-config to',
                              'set the limit for how many Exclude',
                              "properties to generate. Default is #{MAX_EXCL}."],
+      disable_uncorrectable:
+                            ['Used with --auto-correct to annotate any',
+                             'offenses that do not support autocorrect',
+                             'with `rubocop:disable` comments.'],
       force_exclusion:      ['Force excluding files specified in the',
                              'configuration `Exclude` even if they are',
                              'explicitly passed as arguments.'],

--- a/spec/rubocop/cli/cli_disable_uncorrectable_spec.rb
+++ b/spec/rubocop/cli/cli_disable_uncorrectable_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+describe RuboCop::CLI, :isolated_environment do
+  include_context 'cli spec behavior'
+
+  subject(:cli) { described_class.new }
+
+  describe '--disable-uncorrectable' do
+    subject do
+      cli.run(%w[--auto-correct --format emacs --disable-uncorrectable])
+    end
+
+    it 'does not disable anything for cops that support autocorrect' do
+      create_file('example.rb', 'puts 1==2')
+      expect(subject).to eq(0)
+      expect($stderr.string).to eq('')
+      expect($stdout.string)
+        .to eq("#{abs('example.rb')}:1:7: C: [Corrected] Surrounding " \
+               "space missing for operator `==`.\n")
+      expect(IO.read('example.rb')).to eq("puts 1 == 2\n")
+    end
+
+    it 'adds one-line disable statement for one-line offenses' do
+      create_file('example.rb', ['def is_example',
+                                 '  true',
+                                 'end'])
+      expect(subject).to eq(0)
+      expect($stderr.string).to eq('')
+      expect($stdout.string)
+        .to eq("#{abs('example.rb')}:1:5: C: [Corrected] Rename `is_example` " \
+               "to `example?`.\n")
+      expect(IO.readlines('example.rb').map(&:chomp))
+        .to eq(['def is_example # rubocop:disable Style/PredicateName',
+                '  true',
+                'end'])
+    end
+
+    it 'adds before-and-after disable statement for multiline offenses' do
+      create_file('.rubocop.yml', ['Metrics/MethodLength:',
+                                   '  Max: 1'])
+      create_file('example.rb', ['def example',
+                                 "  puts 'line 1'",
+                                 "  puts 'line 2'",
+                                 'end'])
+      expect(subject).to eq(0)
+      expect($stderr.string).to eq('')
+      expect($stdout.string)
+        .to eq("#{abs('example.rb')}:1:1: C: [Corrected] Method " \
+               "has too many lines. [2/1]\n")
+      expect(IO.readlines('example.rb').map(&:chomp))
+        .to eq(['# rubocop:disable Metrics/MethodLength',
+                'def example',
+                "  puts 'line 1'",
+                "  puts 'line 2'",
+                'end',
+                '# rubocop:enable Metrics/MethodLength'])
+    end
+  end
+end

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -103,6 +103,30 @@ describe RuboCop::Cop::Cop do
         cop.add_offense(nil, location, 'message')
         expect(cop.offenses.first.corrected?).to be(false)
       end
+
+      context 'when autocorrect is requested' do
+        before do
+          allow(cop).to receive(:autocorrect_requested?).and_return(true)
+        end
+
+        it 'is not specified (set to nil)' do
+          cop.add_offense(nil, location, 'message')
+          expect(cop.offenses.first.corrected?).to be(false)
+        end
+
+        context 'when disable_uncorrectable is enabled' do
+          before do
+            allow(cop).to receive(:disable_uncorrectable?).and_return(true)
+          end
+
+          let(:node) { double(location: double(expression: location)) }
+
+          it 'is set to true' do
+            cop.add_offense(node, location, 'message')
+            expect(cop.offenses.first.corrected?).to be(true)
+          end
+        end
+      end
     end
 
     context 'when cop supports autocorrection' do
@@ -210,10 +234,12 @@ describe RuboCop::Cop::Cop do
     let(:config) { RuboCop::Config.new({}) }
     let(:cop) { described_class.new(config, options) }
     let(:support_autocorrect) { true }
+    let(:disable_uncorrectable) { false }
     subject { cop.autocorrect? }
 
     before do
       allow(cop).to receive(:support_autocorrect?) { support_autocorrect }
+      allow(cop).to receive(:disable_uncorrectable?) { disable_uncorrectable }
     end
 
     context 'when the option is not given' do
@@ -228,6 +254,11 @@ describe RuboCop::Cop::Cop do
       context 'when cop does not support autocorrection' do
         let(:support_autocorrect) { false }
         it { is_expected.to be(false) }
+
+        context 'when disable_uncorrectable is enabled' do
+          let(:disable_uncorrectable) { true }
+          it { is_expected.to be(true) }
+        end
       end
 
       context 'when the cop is set to not autocorrect' do

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -45,6 +45,9 @@ describe RuboCop::Options, :isolated_environment do
                   --exclude-limit COUNT        Used together with --auto-gen-config to
                                                set the limit for how many Exclude
                                                properties to generate. Default is 15.
+                  --disable-uncorrectable      Used with --auto-correct to annotate any
+                                               offenses that do not support autocorrect
+                                               with `rubocop:disable` comments.
                   --force-exclusion            Force excluding files specified in the
                                                configuration `Exclude` even if they are
                                                explicitly passed as arguments.


### PR DESCRIPTION
Hi all. Today I had an idea that rethinks the workflow surrounding the `--auto-gen-config` option, and I wanted to see what you all think.

_Note: I created this as a PR because I made a proof-of-concept for myself this morning and I thought I'd share that. However since the PR clearly is not ready to be merged and this is more of an RFC, if you'd prefer this be an issue I'd be happy to close and reopen._

## Situation

I maintain a large-ish Rails app (~16k nonblank lines of Ruby code) which has been in development for ~2 years now with 3 different primary maintainers. Rubocop was just recently introduced, so there's a lot of inconsistently-styled code lying around.

## Current best practice

If I understand correctly the current recommendation for introducing Rubocop to a legacy codebase is to use `--auto-gen-todo` to create a `.rubocop_todo.yml` file with your "todo list" that you chip away at over time.

I did this a few months ago, but the solution hasn't been especially satisfying to me, for a few reasons:

1. You have to decide to visit `.rubocop_todo.yml` and actively search for something to fix if you're in the mood, and while perusing it you have to be able to quickly understand what the various cop names refer to.

2. The format of `.rubocop_todo.yml` makes the [Boy Scout rule](http://deviq.com/boy-scout-rule/) difficult to enforce. Since the todo list's finest level of granularity is the _file_ level, once a file violates a given cop _anywhere_ (and that violation gets the file added to `.rubocop_todo.yml`'s exclude list), it's easy to just keep on adding violations in new code instead of fixing things as you go.

## Proposed alternative

What if Rubocop had an option to add `# rubocop:disable` to all current violations rather than adding them to a todo list? This would make it much easier to see styleguide violations present in the section of code being edited, and would make the process for fixing them obvious.

For example if I'm editing method `foo` and I see it's surrounded by `# rubocop:disable Metrics/MethodLength`, then that's a lot more likely to prod me to refactor the method than if `Metrics/MethodLength` happened to include the file in its exclude list in a yaml todo list file I never think to check. (I wouldn't even know from the current todo list format which method it is that's too long unless I go through the trouble to look up the metric's default max value! That's a lot of work for something that's supposed to happen frequently--i.e. leaving a section of code cleaner than you found it.)

## Proof of concept

My thought was that `--auto-correct` could have a companion flag `--disable-uncorrectable` which would add a properly-indented `# rubocop:disable #{cop_name}` line before the violation and `# rubocop:enable #{cop_name}` after the violation, for cops that do not support an autocorrection of their own.

What do you think?