### PR TITLE
Add AccessModifierDeclarations cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 * [#5917](https://github.com/bbatsov/rubocop/pull/5917): Let `inherit_mode` work for default configuration too. ([@jonas054][])
 * [#5929](https://github.com/bbatsov/rubocop/pull/5929): Stop including string extensions from `unicode/display_width`. ([@nroman-stripe][])
 
+### New features
+
+* [#5444](https://github.com/bbatsov/rubocop/pull/5444): Add new `Style/AccessModifierDeclarations` cop. ([@brandonweiss][])
+
 ## 0.56.0 (2018-05-14)
 
 ### New features

--- a/config/default.yml
+++ b/config/default.yml
@@ -809,6 +809,12 @@ Naming/VariableNumber:
 
 #################### Style ###########################
 
+Style/AccessModifierDeclarations:
+  EnforcedStyle: group
+  SupportedStyles:
+    - inline
+    - group
+
 Style/Alias:
   EnforcedStyle: prefer_alias
   SupportedStyles:

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1324,6 +1324,10 @@ Security/YAMLLoad:
 
 #################### Style ###############################
 
+Style/AccessModifierDeclarations:
+  Description: 'Checks style of how access modifiers are used.'
+  Enabled: true
+
 Style/Alias:
   Description: 'Use alias instead of alias_method.'
   StyleGuide: '#alias-method'

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -377,6 +377,7 @@ require_relative 'rubocop/cop/performance/unfreeze_string'
 require_relative 'rubocop/cop/performance/unneeded_sort'
 require_relative 'rubocop/cop/performance/uri_default_parser'
 
+require_relative 'rubocop/cop/style/access_modifier_declarations'
 require_relative 'rubocop/cop/style/alias'
 require_relative 'rubocop/cop/style/and_or'
 require_relative 'rubocop/cop/style/array_join'

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -91,7 +91,7 @@ module RuboCop
         @mutable_attributes.frozen?
       end
 
-      protected :parent=
+      protected :parent= # rubocop:disable Style/AccessModifierDeclarations
 
       # Override `AST::Node#updated` so that `AST::Processor` does not try to
       # mutate our ASTs. Since we keep references from children to parents and
@@ -321,7 +321,9 @@ module RuboCop
          (casgn $_ $_        (send (const nil? {:Class :Module}) :new ...))
          (casgn $_ $_ (block (send (const nil? {:Class :Module}) :new ...) ...))}
       PATTERN
+      # rubocop:disable Style/AccessModifierDeclarations
       private :defined_module0
+      # rubocop:enable Style/AccessModifierDeclarations
 
       def defined_module
         namespace, name = *defined_module0

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -169,6 +169,10 @@ module RuboCop
       def_node_matcher :bare_access_modifier?, <<-PATTERN
         (send nil? {:public :protected :private :module_function})
       PATTERN
+
+      def_node_matcher :non_bare_access_modifier?, <<-PATTERN
+        (send nil? {:public :protected :private :module_function} _)
+      PATTERN
     end
   end
 end

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -40,12 +40,29 @@ module RuboCop
         !receiver && macro_scope?
       end
 
-      # Checks whether the dispatched method is a bare access modifier affects
-      # all methods defined after the macro.
+      # Checks whether the dispatched method is an access modifier.
       #
-      # @return [Boolean] whether the dispatched method is access modifier
+      # @return [Boolean] whether the dispatched method is an access modifier
       def access_modifier?
-        macro? && bare_access_modifier?
+        bare_access_modifier? || non_bare_access_modifier?
+      end
+
+      # Checks whether the dispatched method is a bare access modifier that
+      # affects all methods defined after the macro.
+      #
+      # @return [Boolean] whether the dispatched method is a bare
+      #                   access modifier
+      def bare_access_modifier?
+        macro? && bare_access_modifier_declaration?
+      end
+
+      # Checks whether the dispatched method is a non-bare access modifier that
+      # affects only the method it receives.
+      #
+      # @return [Boolean] whether the dispatched method is a non-bare
+      #                   access modifier
+      def non_bare_access_modifier?
+        macro? && non_bare_access_modifier_declaration?
       end
 
       # Checks whether the name of the dispatched method matches the argument
@@ -166,11 +183,11 @@ module RuboCop
         (send nil? _ ({def defs} ...))
       PATTERN
 
-      def_node_matcher :bare_access_modifier?, <<-PATTERN
+      def_node_matcher :bare_access_modifier_declaration?, <<-PATTERN
         (send nil? {:public :protected :private :module_function})
       PATTERN
 
-      def_node_matcher :non_bare_access_modifier?, <<-PATTERN
+      def_node_matcher :non_bare_access_modifier_declaration?, <<-PATTERN
         (send nil? {:public :protected :private :module_function} _)
       PATTERN
     end

--- a/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
@@ -30,7 +30,7 @@ module RuboCop
                                '`%<modifier>s`.'.freeze
 
         def on_send(node)
-          return unless node.access_modifier?
+          return unless node.bare_access_modifier?
 
           return if empty_lines_around?(node)
 

--- a/lib/rubocop/cop/layout/indentation_consistency.rb
+++ b/lib/rubocop/cop/layout/indentation_consistency.rb
@@ -144,7 +144,7 @@ module RuboCop
             # the AccessModifierIndentation cop. This cop uses them as dividers
             # in rails mode. Then consistency is checked only within each
             # section delimited by a modifier node.
-            if child.send_type? && child.access_modifier?
+            if child.send_type? && child.bare_access_modifier?
               children_to_check << [] if style == :rails
             else
               children_to_check.last << child

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -173,7 +173,7 @@ module RuboCop
         end
 
         def special_modifier?(node)
-          node.access_modifier? && SPECIAL_MODIFIERS.include?(node.source)
+          node.bare_access_modifier? && SPECIAL_MODIFIERS.include?(node.source)
         end
 
         def indentation_consistency_style
@@ -307,7 +307,7 @@ module RuboCop
           return unless body_node.begin_type?
 
           starting_node = body_node.children.first
-          starting_node.send_type? && starting_node.access_modifier?
+          starting_node.send_type? && starting_node.bare_access_modifier?
         end
 
         def configured_indentation_width

--- a/lib/rubocop/cop/lint/ineffective_access_modifier.rb
+++ b/lib/rubocop/cop/lint/ineffective_access_modifier.rb
@@ -116,7 +116,7 @@ module RuboCop
         end
 
         def check_send(node, cur_vis)
-          if node.access_modifier? && !node.method?(:module_function)
+          if node.bare_access_modifier? && !node.method?(:module_function)
             @last_access_modifier = node
             return node.method_name
           elsif (methods = private_class_method(node))

--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -134,7 +134,7 @@ module RuboCop
 
           if node.begin_type?
             check_scope(node)
-          elsif node.send_type? && node.access_modifier?
+          elsif node.send_type? && node.bare_access_modifier?
             add_offense(node, message: format(MSG, current: node.method_name))
           end
         end
@@ -147,7 +147,7 @@ module RuboCop
 
         def check_child_nodes(node, unused, cur_vis)
           node.child_nodes.each do |child|
-            if child.send_type? && child.access_modifier?
+            if child.send_type? && child.bare_access_modifier?
               cur_vis, unused =
                 check_new_visibility(child, unused, child.method_name, cur_vis)
             elsif method_definition?(child)

--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -62,7 +62,7 @@ module RuboCop
         ].join(' ')
 
         def on_send(node)
-          return unless node.access_modifier? || node.non_bare_access_modifier?
+          return unless node.access_modifier?
 
           if offense?(node)
             add_offense(node, location: :selector) do

--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Style
+      # Access modifiers should be declared to apply to a group of methods
+      # or inline before each method, depending on configuration.
+      #
+      # @example EnforcedStyle: group (default)
+      #
+      #   # bad
+      #
+      #   class Foo
+      #
+      #     private def bar; end
+      #     private def baz; end
+      #
+      #   end
+      #
+      #   # good
+      #
+      #   class Foo
+      #
+      #     private
+      #
+      #     def bar; end
+      #     def baz; end
+      #
+      #   end
+      # @example EnforcedStyle: inline
+      #
+      #   # bad
+      #
+      #   class Foo
+      #
+      #     private
+      #
+      #     def bar; end
+      #     def baz; end
+      #
+      #   end
+      #
+      #   # good
+      #
+      #   class Foo
+      #
+      #     private def bar; end
+      #     private def baz; end
+      #
+      #   end
+      class AccessModifierDeclarations < Cop
+        include ConfigurableEnforcedStyle
+
+        GROUP_STYLE_MESSAGE = [
+          '`%<access_modifier>s` should not be',
+          'inlined in method definitions.'
+        ].join(' ')
+
+        INLINE_STYLE_MESSAGE = [
+          '`%<access_modifier>s` should be',
+          'inlined in method definitions.'
+        ].join(' ')
+
+        def on_send(node)
+          return unless node.access_modifier? || node.non_bare_access_modifier?
+
+          if offense?(node)
+            add_offense(node, location: :selector) do
+              opposite_style_detected
+            end
+          else
+            correct_style_detected
+          end
+        end
+
+        private
+
+        def offense?(node)
+          (group_style? && access_modifier_is_inlined?(node)) ||
+            (inline_style? && access_modifier_is_not_inlined?(node))
+        end
+
+        def group_style?
+          style == :group
+        end
+
+        def inline_style?
+          style == :inline
+        end
+
+        def access_modifier_is_inlined?(node)
+          node.arguments.any?
+        end
+
+        def access_modifier_is_not_inlined?(node)
+          !access_modifier_is_inlined?(node)
+        end
+
+        def message(node)
+          access_modifier = node.loc.selector.source
+
+          if group_style?
+            format(GROUP_STYLE_MESSAGE, access_modifier: access_modifier)
+          elsif inline_style?
+            format(INLINE_STYLE_MESSAGE, access_modifier: access_modifier)
+          end
+        end
+      end
+    end
+  end
+end

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -380,6 +380,7 @@ In the following section you find all available cops:
 
 #### Department [Style](cops_style.md)
 
+* [Style/AccessModifierDeclarations](cops_style.md#styleaccessmodifierdeclarations)
 * [Style/Alias](cops_style.md#stylealias)
 * [Style/AndOr](cops_style.md#styleandor)
 * [Style/ArrayJoin](cops_style.md#stylearrayjoin)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1,5 +1,69 @@
 # Style
 
+## Style/AccessModifierDeclarations
+
+Enabled by default | Supports autocorrection
+--- | ---
+Enabled | No
+
+Access modifiers should be declared to apply to a group of methods
+or inline before each method, depending on configuration.
+
+### Examples
+
+#### EnforcedStyle: group (default)
+
+```ruby
+# bad
+
+class Foo
+
+  private def bar; end
+  private def baz; end
+
+end
+
+# good
+
+class Foo
+
+  private
+
+  def bar; end
+  def baz; end
+
+end
+```
+#### EnforcedStyle: inline
+
+```ruby
+# bad
+
+class Foo
+
+  private
+
+  def bar; end
+  def baz; end
+
+end
+
+# good
+
+class Foo
+
+  private def bar; end
+  private def baz; end
+
+end
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `group` | `inline`, `group`
+
 ## Style/Alias
 
 Enabled by default | Supports autocorrection

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -99,9 +99,23 @@ RSpec.describe RuboCop::AST::SendNode do
 
     context 'when node is a bare `module_function`' do
       let(:source) do
-        ['module Foo',
-         '  module_function',
-         'end'].join("\n")
+        <<-RUBY.strip_indent
+          module Foo
+            module_function
+          end
+        RUBY
+      end
+
+      it { expect(send_node.access_modifier?).to be_truthy }
+    end
+
+    context 'when node is a non-bare `module_function`' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          module Foo
+            module_function :foo
+          end
+        RUBY
       end
 
       it { expect(send_node.access_modifier?).to be_truthy }
@@ -109,9 +123,23 @@ RSpec.describe RuboCop::AST::SendNode do
 
     context 'when node is a bare `private`' do
       let(:source) do
-        ['module Foo',
-         '  private',
-         'end'].join("\n")
+        <<-RUBY.strip_indent
+          module Foo
+            private
+          end
+        RUBY
+      end
+
+      it { expect(send_node.access_modifier?).to be_truthy }
+    end
+
+    context 'when node is a non-bare `private`' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          module Foo
+            private :foo
+          end
+        RUBY
       end
 
       it { expect(send_node.access_modifier?).to be_truthy }
@@ -119,9 +147,23 @@ RSpec.describe RuboCop::AST::SendNode do
 
     context 'when node is a bare `protected`' do
       let(:source) do
-        ['module Foo',
-         '  protected',
-         'end'].join("\n")
+        <<-RUBY.strip_indent
+          module Foo
+            protected
+          end
+        RUBY
+      end
+
+      it { expect(send_node.access_modifier?).to be_truthy }
+    end
+
+    context 'when node is a non-bare `protected`' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          module Foo
+            protected :foo
+          end
+        RUBY
       end
 
       it { expect(send_node.access_modifier?).to be_truthy }
@@ -129,32 +171,190 @@ RSpec.describe RuboCop::AST::SendNode do
 
     context 'when node is a bare `public`' do
       let(:source) do
-        ['module Foo',
-         '  public',
-         'end'].join("\n")
+        <<-RUBY.strip_indent
+          module Foo
+            public
+          end
+        RUBY
       end
 
       it { expect(send_node.access_modifier?).to be_truthy }
     end
 
-    context 'when node has an argument' do
+    context 'when node is a non-bare `public`' do
       let(:source) do
-        ['module Foo',
-         '  private :foo',
-         'end'].join("\n")
+        <<-RUBY.strip_indent
+          module Foo
+            public :foo
+          end
+        RUBY
       end
 
-      it { expect(send_node.access_modifier?).to be_falsey }
+      it { expect(send_node.access_modifier?).to be_truthy }
     end
 
     context 'when node is not an access modifier' do
       let(:source) do
-        ['module Foo',
-         '  some_command',
-         'end'].join("\n")
+        <<-RUBY.strip_indent
+          module Foo
+            some_command
+          end
+        RUBY
       end
 
-      it { expect(send_node.access_modifier?).to be_falsey }
+      it { expect(send_node.bare_access_modifier?).to be_falsey }
+    end
+  end
+
+  describe '#bare_access_modifier?' do
+    let(:send_node) { parse_source(source).ast.children[1] }
+
+    context 'when node is a bare `module_function`' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          module Foo
+            module_function
+          end
+        RUBY
+      end
+
+      it { expect(send_node.bare_access_modifier?).to be_truthy }
+    end
+
+    context 'when node is a bare `private`' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          module Foo
+            private
+          end
+        RUBY
+      end
+
+      it { expect(send_node.bare_access_modifier?).to be_truthy }
+    end
+
+    context 'when node is a bare `protected`' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          module Foo
+            protected
+          end
+        RUBY
+      end
+
+      it { expect(send_node.bare_access_modifier?).to be_truthy }
+    end
+
+    context 'when node is a bare `public`' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          module Foo
+            public
+          end
+        RUBY
+      end
+
+      it { expect(send_node.bare_access_modifier?).to be_truthy }
+    end
+
+    context 'when node has an argument' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          module Foo
+            private :foo
+          end
+        RUBY
+      end
+
+      it { expect(send_node.bare_access_modifier?).to be_falsey }
+    end
+
+    context 'when node is not an access modifier' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          module Foo
+            some_command
+          end
+        RUBY
+      end
+
+      it { expect(send_node.bare_access_modifier?).to be_falsey }
+    end
+  end
+
+  describe '#non_bare_access_modifier?' do
+    let(:send_node) { parse_source(source).ast.children[1] }
+
+    context 'when node is a non-bare `module_function`' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          module Foo
+            module_function :foo
+          end
+        RUBY
+      end
+
+      it { expect(send_node.non_bare_access_modifier?).to be_truthy }
+    end
+
+    context 'when node is a non-bare `private`' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          module Foo
+            private :foo
+          end
+        RUBY
+      end
+
+      it { expect(send_node.non_bare_access_modifier?).to be_truthy }
+    end
+
+    context 'when node is a non-bare `protected`' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          module Foo
+            protected :foo
+          end
+        RUBY
+      end
+
+      it { expect(send_node.non_bare_access_modifier?).to be_truthy }
+    end
+
+    context 'when node is a non-bare `public`' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          module Foo
+            public :foo
+          end
+        RUBY
+      end
+
+      it { expect(send_node.non_bare_access_modifier?).to be_truthy }
+    end
+
+    context 'when node does not have an argument' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          module Foo
+            private
+          end
+        RUBY
+      end
+
+      it { expect(send_node.non_bare_access_modifier?).to be_falsey }
+    end
+
+    context 'when node is not an access modifier' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          module Foo
+            some_command
+          end
+        RUBY
+      end
+
+      it { expect(send_node.non_bare_access_modifier?).to be_falsey }
     end
   end
 

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
+  subject(:cop) { described_class.new(config) }
+
+  context 'when `group` is configured' do
+    let(:cop_config) do
+      {
+        'EnforcedStyle' => 'group'
+      }
+    end
+
+    %w[private protected public].each do |access_modifier|
+      it "offends when #{access_modifier} is inlined with a method" do
+        expect_offense(<<-RUBY.strip_indent)
+          class Test
+            #{access_modifier} def foo; end
+            #{'^' * access_modifier.length} `#{access_modifier}` should not be inlined in method definitions.
+          end
+        RUBY
+      end
+
+      it "offends when #{access_modifier} is inlined with a symbol" do
+        expect_offense(<<-RUBY.strip_indent)
+          class Test
+            #{access_modifier} :foo
+            #{'^' * access_modifier.length} `#{access_modifier}` should not be inlined in method definitions.
+
+            def foo; end
+          end
+        RUBY
+      end
+
+      it "does not offend when #{access_modifier} is not inlined" do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          class Test
+            #{access_modifier}
+          end
+        RUBY
+      end
+
+      it "does not offend when #{access_modifier} is not inlined and " \
+         'has a comment' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          class Test
+            #{access_modifier} # hey
+          end
+        RUBY
+      end
+    end
+  end
+
+  context 'when `inline` is configured' do
+    let(:cop_config) do
+      {
+        'EnforcedStyle' => 'inline'
+      }
+    end
+
+    %w[private protected public].each do |access_modifier|
+      it "offends when #{access_modifier} is not inlined" do
+        expect_offense(<<-RUBY.strip_indent)
+          class Test
+            #{access_modifier}
+            #{'^' * access_modifier.length} `#{access_modifier}` should be inlined in method definitions.
+          end
+        RUBY
+      end
+
+      it "offends when #{access_modifier} is not inlined and has a comment" do
+        expect_offense(<<-RUBY.strip_indent)
+          class Test
+            #{access_modifier} # hey
+            #{'^' * access_modifier.length} `#{access_modifier}` should be inlined in method definitions.
+          end
+        RUBY
+      end
+
+      it "does not offend when #{access_modifier} is inlined with a method" do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          class Test
+            #{access_modifier} def foo; end
+          end
+        RUBY
+      end
+
+      it "does not offend when #{access_modifier} is inlined with a symbol" do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          class Test
+            #{access_modifier} :foo
+
+            def foo; end
+          end
+        RUBY
+      end
+    end
+  end
+end


### PR DESCRIPTION
This cop checks that access modifiers (private, protected, and public) are inlined rather than used in the manner that changes the visibility for all future method definitions. Although the former can be repetetive, it's infinitely preferable to constantly having to check where the method you're currently looking at is relative to the accessor visibility declaration. It also completely negates the issue that many people are unaware that `private` only affects instance methods and not class methods.

I wrote my thoughts in more detail in this [blog post](https://anti-pattern.com/explicit-privates).

I disabled this cop by default because this is a much different style than most Rubyists use. That said, everyone who I've introduced it to comes to love it and I think it's objectively better enough that it _should_ be enabled by default. If you agree let me know and I'll enable it!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
