### PR TITLE
[Fix #3697] Lint/UnusedBlockArgument: Use better suggestion for unused keyword arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,7 @@
 * [#5599](https://github.com/bbatsov/rubocop/issues/5599): Fix the suggestion being used by `Lint/NumberConversion` to use base 10 with Integer. ([@rrosenblum][])
 * [#5534](https://github.com/bbatsov/rubocop/issues/5534): Fix `Style/EachWithObject` auto-correction leaves an empty line. ([@flyerhzm][])
 * Fix `Layout/EmptyLinesAroundAccessModifier` false-negative when next string after access modifier started with end. ([@unkmas][])
+* [#3697](https://github.com/bbatsov/rubocop/issues/3697): Fix `Lint/UnusedBlockArgument` suggestion for multiple keyword arguments. ([@leklund][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/unused_block_argument.rb
+++ b/lib/rubocop/cop/lint/unused_block_argument.rb
@@ -21,6 +21,10 @@ module RuboCop
       #     puts :baz
       #   end
       #
+      #   do_something do |used:, unused:|
+      #     puts used
+      #   end
+      #
       # @example
       #
       #   #good
@@ -35,6 +39,11 @@ module RuboCop
       #
       #   define_method(:foo) do |_bar|
       #     puts :baz
+      #   end
+      #
+      #   do_something do |used:, **|
+      #
+      #     puts used
       #   end
       class UnusedBlockArgument < Cop
         include UnusedArgument
@@ -102,12 +111,12 @@ module RuboCop
               "You can omit the argument if you don't care about it."
             end
           else
-            message_for_underscore_prefix(variable)
+            message_for_variable(variable, all_arguments.count)
           end
         end
 
         def message_for_lambda(variable, all_arguments)
-          message = message_for_underscore_prefix(variable)
+          message = message_for_variable(variable, all_arguments.count)
 
           if all_arguments.none?(&:referenced?)
             proc_message = 'Also consider using a proc without arguments ' \
@@ -116,6 +125,17 @@ module RuboCop
           end
 
           [message, proc_message].compact.join(' ')
+        end
+
+        def message_for_variable(variable, argument_count)
+          return message_for_keyword_argument if variable.keyword_argument? &&
+                                                 argument_count > 1
+          message_for_underscore_prefix(variable)
+        end
+
+        def message_for_keyword_argument
+          "If it's necessary, use a trailing `**` for unused keyword " \
+          "arguments to indicate that they won't be used."
         end
 
         def message_for_underscore_prefix(variable)

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -2192,6 +2192,10 @@ end
 define_method(:foo) do |bar|
   puts :baz
 end
+
+do_something do |used:, unused:|
+  puts used
+end
 ```
 ```ruby
 #good
@@ -2206,6 +2210,11 @@ end
 
 define_method(:foo) do |_bar|
   puts :baz
+end
+
+do_something do |used:, **|
+
+  puts used
 end
 ```
 


### PR DESCRIPTION
The suggestion from `Lint/UnusedBlockArgument` when using named keywords for block arguments is not helpful and will result in broken code. See #3697 for an example.

This PR updates the warning message to indicate that a trailing `**` should be used for any used keyword arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/