### PR TITLE
[Fix #3998] Disable autocorrect for Security/YAMLLoad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * [#5520](https://github.com/bbatsov/rubocop/issues/5520): Fix `Style/RedundantException` auto-correction does not keep parenthesization. ([@dpostorivo][])
 * [#5524](https://github.com/bbatsov/rubocop/issues/5524): Return the instance based on the new type when calls `RuboCop::AST::Node#updated`. ([@wata727][])
 * [#5539](https://github.com/bbatsov/rubocop/pull/5539): Fix compilation error and ruby code generation when passing args to funcall and predicates. ([@Edouard-chin][])
+* [#3998](https://github.com/bbatsov/rubocop/issues/3998): Disable autocorrect for Security/YAMLLoad. ([@annaswims][])
 
 ### Changes
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1295,6 +1295,8 @@ Security/YAMLLoad:
                  security issues. See reference for more information.
   Reference: 'https://ruby-doc.org/stdlib-2.3.3/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security'
   Enabled: true
+  # Autocorrect will break yaml files using aliases
+  AutoCorrect: false
 
 #################### Style ###############################
 

--- a/lib/rubocop/cop/security/yaml_load.rb
+++ b/lib/rubocop/cop/security/yaml_load.rb
@@ -7,6 +7,9 @@ module RuboCop
       # potential security issues leading to remote code execution when
       # loading from an untrusted source.
       #
+      # Autocorrect is disabled by default because it's potentially dangerous.
+      # Autocorrect will break yaml files using aliases.
+      #
       # @example
       #   # bad
       #   YAML.load("--- foo")

--- a/manual/cops_security.md
+++ b/manual/cops_security.md
@@ -117,6 +117,9 @@ This cop checks for the use of YAML class methods which have
 potential security issues leading to remote code execution when
 loading from an untrusted source.
 
+Autocorrect is disabled by default because it's potentially dangerous.
+Autocorrect will break yaml files using aliases.
+
 ### Examples
 
 ```ruby
@@ -127,6 +130,12 @@ YAML.load("--- foo")
 YAML.safe_load("--- foo")
 YAML.dump("foo")
 ```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AutoCorrect | `false` | Boolean
 
 ### References
 


### PR DESCRIPTION
This pr fixes https://github.com/bbatsov/rubocop/issues/3998

YAML.safe_load won't work with yaml files that use aliases, so we
should not Auto-Correct.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
