### PR TITLE
Add Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:alpine
+FROM ruby:2.5.0
 RUN gem install rubocop
 WORKDIR /code
 ENTRYPOINT [ "rubocop","." ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM ruby:alpine
+RUN gem install rubocop
+WORKDIR /code
+ENTRYPOINT [ "rubocop","." ]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 [![Gem Version](https://badge.fury.io/rb/rubocop.svg)](http://badge.fury.io/rb/rubocop)
 [![Dependency Status](https://gemnasium.com/bbatsov/rubocop.svg)](https://gemnasium.com/bbatsov/rubocop)
 [![Travis Status](https://travis-ci.org/bbatsov/rubocop.svg?branch=master)](https://travis-ci.org/bbatsov/rubocop)
@@ -54,6 +55,10 @@ might want to use a conservative version locking in your `Gemfile`:
 ```rb
 gem 'rubocop', '~> 0.52.1', require: false
 ```
+To run RuboCop using the [Docker](https://hub.docker.com/r/coder95/tiller/) image
+```
+$ docker pull coder95/rubocop
+```
 
 ## Quickstart
 
@@ -63,6 +68,18 @@ Just type `rubocop` in a Ruby project's folder and watch the magic happen.
 $ cd my/cool/ruby/project
 $ rubocop
 ```
+### Docker
+```
+$ cd my/cool/ruby/project
+$ docker run -it --rm -v $PWD:/code --name rubocop coder95/rubocop
+```
+or alias docker image to mimic gem as follows
+```
+$ alias rubocop="docker run -it --rm -v $PWD:/code --name rubocop coder95/rubocop"
+$ cd my/cool/ruby/project
+$ rubocop
+```
+ 
 
 ## Official manual
 

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ might want to use a conservative version locking in your `Gemfile`:
 ```rb
 gem 'rubocop', '~> 0.52.1', require: false
 ```
-To run RuboCop using the [Docker](https://hub.docker.com/r/coder95/tiller/) image
+To run RuboCop using the [Docker](https://hub.docker.com/r/rubocopz/rubocop/) image
 ```
-$ docker pull coder95/rubocop
+$ docker pull rubocopz/rubocop
 ```
 
 ## Quickstart
@@ -71,11 +71,11 @@ $ rubocop
 ### Docker
 ```
 $ cd my/cool/ruby/project
-$ docker run -it --rm -v $PWD:/code --name rubocop coder95/rubocop
+$ docker run -it --rm -v $PWD:/code --name rubocop rubocopz/rubocop
 ```
 or alias docker image to mimic gem as follows
 ```
-$ alias rubocop="docker run -it --rm -v $PWD:/code --name rubocop coder95/rubocop"
+$ alias rubocop="docker run -it --rm -v $PWD:/code --name rubocop rubocopz/rubocop"
 $ cd my/cool/ruby/project
 $ rubocop
 ```


### PR DESCRIPTION
Adding docker support Rubcop decouples the dependency with underlying environment and has following advantages.
- Works independent of the environment.
- Doesn't require ruby to be installed in the underlying machine, and eliminates versioning issues.
- Easy and Clean quick start.

Limitations:
- requires Docker
- scope is limited to PWD i.e,  `-c, --config FILE` must be in PWD and `-o, --out FILE` can only be written to PWD. however this could be resolved by tweaking docker run params. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
