### PR TITLE
[#5265] Improve ExtraSpacing Cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 * [#5390](https://github.com/bbatsov/rubocop/issues/5390): Allow exceptions to `Style/InlineComment` for inline comments which enable or disable rubocop cops. ([@jfelchner][])
 * Add progress bar to offenses formatter. ([@drewpterry][])
 * [#5498](https://github.com/bbatsov/rubocop/issues/5498): Correct `IndentHeredoc` message for Ruby 2.3 when using `<<~` operator with invalid indentation. ([@hamada14][])
+* [#5265](https://github.com/bbatsov/rubocop/issues/5265): Improved `Layout/ExtraSpacing` cop to handle nested consecutive assignments. ([@jfelchner][])
 
 ## 0.53.0 (2018-03-05)
 

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -33,14 +33,14 @@ module RuboCop
 
           return if hash_table_style? && !node.parent.pairs_on_same_line?
 
-          check_operator(node.loc.operator, node.source_range)
+          check_operator(:pair, node.loc.operator, node.source_range)
         end
 
         def on_if(node)
           return unless node.ternary?
 
-          check_operator(node.loc.question, node.if_branch.source_range)
-          check_operator(node.loc.colon, node.else_branch.source_range)
+          check_operator(:if, node.loc.question, node.if_branch.source_range)
+          check_operator(:if, node.loc.colon, node.else_branch.source_range)
         end
 
         def on_resbody(node)
@@ -48,15 +48,25 @@ module RuboCop
 
           _, variable, = *node
 
-          check_operator(node.loc.assoc, variable.source_range)
+          check_operator(:resbody, node.loc.assoc, variable.source_range)
         end
 
         def on_send(node)
           if node.setter_method?
             on_special_asgn(node)
           elsif regular_operator?(node)
-            check_operator(node.loc.selector, node.first_argument.source_range)
+            check_operator(:send,
+                           node.loc.selector,
+                           node.first_argument.source_range)
           end
+        end
+
+        def on_assignment(node)
+          _, rhs, = *node
+
+          return unless rhs
+
+          check_operator(:assignment, node.loc.operator, rhs.source_range)
         end
 
         def on_binary(node)
@@ -64,27 +74,27 @@ module RuboCop
 
           return unless rhs
 
-          check_operator(node.loc.operator, rhs.source_range)
+          check_operator(:binary, node.loc.operator, rhs.source_range)
         end
 
         def on_special_asgn(node)
           _, _, right, = *node
 
           return unless right
-          check_operator(node.loc.operator, right.source_range)
+          check_operator(:special_asgn, node.loc.operator, right.source_range)
         end
 
         alias on_or       on_binary
         alias on_and      on_binary
-        alias on_lvasgn   on_binary
-        alias on_masgn    on_binary
+        alias on_lvasgn   on_assignment
+        alias on_masgn    on_assignment
         alias on_casgn    on_special_asgn
-        alias on_ivasgn   on_binary
-        alias on_cvasgn   on_binary
-        alias on_gvasgn   on_binary
+        alias on_ivasgn   on_assignment
+        alias on_cvasgn   on_assignment
+        alias on_gvasgn   on_assignment
         alias on_class    on_binary
-        alias on_or_asgn  on_binary
-        alias on_and_asgn on_binary
+        alias on_or_asgn  on_assignment
+        alias on_and_asgn on_assignment
         alias on_op_asgn  on_special_asgn
 
         def autocorrect(range)
@@ -111,35 +121,44 @@ module RuboCop
             !IRREGULAR_METHODS.include?(send_node.method_name)
         end
 
-        def check_operator(operator, right_operand)
+        def check_operator(type, operator, right_operand)
           with_space = range_with_surrounding_space(range: operator)
+          pp with_space.source
           return if with_space.source.start_with?("\n")
 
-          offense(operator, with_space, right_operand) do |msg|
+          offense(type, operator, with_space, right_operand) do |msg|
             add_offense(with_space, location: operator, message: msg)
           end
         end
 
-        def offense(operator, with_space, right_operand)
-          msg = offense_message(operator, with_space, right_operand)
+        def offense(type, operator, with_space, right_operand)
+          msg = offense_message(type, operator, with_space, right_operand)
           yield msg if msg
         end
 
-        def offense_message(operator, with_space, right_operand)
+        def offense_message(type, operator, with_space, right_operand)
           if operator.is?('**')
             'Space around operator `**` detected.' unless with_space.is?('**')
           elsif with_space.source !~ /^\s.*\s$/
             "Surrounding space missing for operator `#{operator.source}`."
-          elsif excess_leading_space?(operator, with_space) ||
+          elsif excess_leading_space?(type, operator, with_space) ||
                 excess_trailing_space?(right_operand, with_space)
             "Operator `#{operator.source}` should be surrounded " \
             'by a single space.'
           end
         end
 
-        def excess_leading_space?(operator, with_space)
-          with_space.source =~ /^  / &&
-            (!allow_for_alignment? || !aligned_with_operator?(operator))
+        def excess_leading_space?(type, operator, with_space)
+          return false unless allow_for_alignment?
+          return false unless with_space.source =~ /^  /
+
+          if type == :assignment
+            token = Token.new(operator, nil, operator.source)
+
+            !aligned_with_assignment?(token)
+          else
+            !aligned_with_operator?(operator)
+          end
         end
 
         def excess_trailing_space?(right_operand, with_space)

--- a/lib/rubocop/cop/mixin/preceding_following_alignment.rb
+++ b/lib/rubocop/cop/mixin/preceding_following_alignment.rb
@@ -19,6 +19,34 @@ module RuboCop
         aligned_with_adjacent_line?(range, method(:aligned_operator?))
       end
 
+      # rubocop:disable Metrics/MethodLength
+      def aligned_with_assignment?(token)
+        token_line_indent              = processed_source
+                                         .line_indentation(token.line)
+
+        preceding_line_range           = token.line.downto(1)
+        preceding_assignment_lines     = \
+          relevant_assignment_lines(preceding_line_range)
+        preceding_relevant_line_number = preceding_assignment_lines[1]
+
+        return true unless preceding_relevant_line_number
+
+        preceding_relevant_indent = \
+          processed_source
+          .line_indentation(preceding_relevant_line_number)
+
+        return true if preceding_relevant_indent < token_line_indent
+
+        assignment_line = processed_source
+                          .lines[preceding_relevant_line_number - 1]
+
+        return true unless assignment_line
+        return true if aligned_assignment?(token.pos, assignment_line)
+
+        false
+      end
+      # rubocop:enable Metrics/MethodLength
+
       def aligned_with_adjacent_line?(range, predicate)
         # minus 2 because node.loc.line is zero-based
         pre  = (range.line - 2).downto(0)
@@ -86,6 +114,61 @@ module RuboCop
 
       def aligned_identical?(range, line)
         range.source == line[range.column, range.size]
+      end
+
+      def assignment_lines
+        @assignment_lines ||= assignment_tokens.map(&:line)
+      end
+
+      def assignment_tokens
+        @assignment_tokens ||= begin
+          tokens = processed_source.tokens.select(&:equal_sign?)
+
+          # we don't want to operate on equals signs which are part of an
+          #   optarg in a method definition
+          # e.g.: def method(optarg = default_val); end
+          tokens = remove_optarg_equals(tokens, processed_source)
+
+          # Only attempt to align the first = on each line
+          Set.new(tokens.uniq(&:line))
+        end
+      end
+
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/PerceivedComplexity, Metrics/MethodLength
+      def relevant_assignment_lines(line_range)
+        result               = []
+        original_line_indent = processed_source
+                               .line_indentation(line_range.first)
+        previous_line_indent_at_level = true
+
+        line_range.each do |line_number|
+          current_line_indent = processed_source.line_indentation(line_number)
+          blank_line          = processed_source.lines[line_number - 1].blank?
+
+          if (current_line_indent < original_line_indent && !blank_line) ||
+             (previous_line_indent_at_level && blank_line)
+            break
+          end
+
+          result << line_number if assignment_lines.include?(line_number) &&
+                                   current_line_indent == original_line_indent
+
+          unless blank_line
+            previous_line_indent_at_level = \
+              current_line_indent == original_line_indent
+          end
+        end
+
+        result
+      end
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/PerceivedComplexity, Metrics/MethodLength
+
+      def remove_optarg_equals(asgn_tokens, processed_source)
+        optargs    = processed_source.ast.each_node(:optarg)
+        optarg_eql = optargs.map { |o| o.loc.operator.begin_pos }.to_set
+        asgn_tokens.reject { |t| optarg_eql.include?(t.begin_pos) }
       end
     end
   end

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -123,8 +123,19 @@ module RuboCop
       lines[token.line - 2]
     end
 
+    def current_line(token)
+      lines[token.line - 1]
+    end
+
     def following_line(token)
       lines[token.line]
+    end
+
+    def line_indentation(line_number)
+      lines[line_number - 1]
+        .match(/^(\s*)/)[1]
+        .to_s
+        .length
     end
 
     private

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -31,6 +31,77 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     expect(IO.read('example.rb')).to eq(source)
   end
 
+  it 'plays nicely with default cops in complex ExtraSpacing scenarios' do
+    create_file('.rubocop.yml', <<-YAML.strip_indent)
+      # These cops change indentation and thus need disabling in order for the
+      # ExtraSpacing rules to apply to this scenario.
+
+      Layout/BlockAlignment:
+        Enabled: false
+
+      Layout/ExtraSpacingCop:
+        ForceEqualSignAlignment: true
+
+      Layout/MultilineMethodCallBraceLayout:
+        Enabled: false
+    YAML
+
+    source = <<-RUBY.strip_indent
+      def batch
+        @areas = params[:param].map do
+                     var_1 = 123_456
+                     variable_2 = 456_123
+                 end
+        @another = params[:param].map do
+                     char_1 = begin
+                                variable_1_1     = 'a'
+                                variable_1_20  = 'b'
+
+                                variable_1_300    = 'c'
+                                # A Comment
+                                variable_1_4000      = 'd'
+
+                                variable_1_50000     = 'e'
+                                puts 'a non-assignment statement without a blank line'
+                                some_other_length_variable     = 'f'
+                              end
+                     var_2 = 456_123
+                   end
+
+        render json: @areas
+      end
+    RUBY
+
+    create_file('example.rb', source)
+    expect(cli.run(['--auto-correct'])).to eq(1)
+
+    expect(IO.read('example.rb')).to eq(<<-RUBY.strip_indent)
+      def batch
+        @areas   = params[:param].map do
+                     var_1      = 123_456
+                     variable_2 = 456_123
+                   end
+        @another = params[:param].map do
+                     char_1 = begin
+                                variable_1_1  = 'a'
+                                variable_1_20 = 'b'
+
+                                variable_1_300  = 'c'
+                                # A Comment
+                                variable_1_4000 = 'd'
+
+                                variable_1_50000           = 'e'
+                                puts 'a non-assignment statement without a blank line'
+                                some_other_length_variable = 'f'
+                              end
+                     var_2  = 456_123
+                   end
+
+        render json: @areas
+      end
+    RUBY
+  end
+
   it 'does not correct SpaceAroundOperators in a hash that would be ' \
      'changed back' do
     create_file('.rubocop.yml', <<-YAML.strip_indent)

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       Layout/BlockAlignment:
         Enabled: false
 
-      Layout/ExtraSpacingCop:
+      Layout/ExtraSpacing:
         ForceEqualSignAlignment: true
 
       Layout/MultilineMethodCallBraceLayout:
@@ -49,9 +49,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     source = <<-RUBY.strip_indent
       def batch
         @areas = params[:param].map do
-                     var_1 = 123_456
-                     variable_2 = 456_123
-                 end
+                        var_1 = 123_456
+                        variable_2 = 456_123
+                   end
         @another = params[:param].map do
                      char_1 = begin
                                 variable_1_1     = 'a'
@@ -74,6 +74,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
     create_file('example.rb', source)
     expect(cli.run(['--auto-correct'])).to eq(1)
+
+    expect($stderr.string).to eql 'foo'
 
     expect(IO.read('example.rb')).to eq(<<-RUBY.strip_indent)
       def batch

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
   let(:config) do
     RuboCop::Config
       .new(
+        'Layout/ExtraSpacing' => { 'ForceEqualSignAlignment' => true },
         'Layout/AlignHash' => { 'EnforcedHashRocketStyle' => hash_style },
         'Layout/SpaceAroundOperators' => {
           'AllowForAlignment' => allow_for_alignment
@@ -46,6 +47,34 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
     expect_no_offenses(<<-RUBY.strip_indent)
       def !
         !__getobj__
+      end
+    RUBY
+  end
+
+  it 'accepts the result of the ExtraSpacing Cop' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def batch
+        @areas   = params[:param].map do
+                     var_1      = 123_456
+                     variable_2 = 456_123
+                   end
+        @another = params[:param].map do
+                     char_1 = begin
+                                variable_1_1  = 'a'
+                                variable_1_20 = 'b'
+
+                                variable_1_300  = 'c'
+                                # A Comment
+                                variable_1_4000 = 'd'
+
+                                variable_1_50000           = 'e'
+                                puts 'a non-assignment statement without a blank line'
+                                some_other_length_variable = 'f'
+                              end
+                     var_2  = 456_123
+                   end
+
+        render json: @areas
       end
     RUBY
   end


### PR DESCRIPTION
This allows for more complex `=` alignments which previously either caused false positives or autocorrected to the wrong result, or both.

The ultimate result is to be able to give Rubocop something like this:

```ruby
def batch
  @areas = params[:param].map {
             var_1 = 123_456
             variable_2 = 456_123 }
  @another = params[:param].map {
               char_1 = begin
                          variable_1_1    = 'a'
                          variable_1_2  = 'b'
                        end
               var_2 = 456_123 }

  render json: @areas
end
```

and have it autocorrect it to:

```ruby
def batch
  @areas   = params[:param].map {
               var_1      = 123_456
               variable_2 = 456_123 }
  @another = params[:param].map {
               char_1 = begin
                          variable_1_1 = 'a'
                          variable_1_2 = 'b'
                        end
               var_2  = 456_123 }

  render json: @areas
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/