### PR TITLE
Fix NameError when execute Rails/HttpStatus cop without Rack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#5707](https://github.com/bbatsov/rubocop/pull/5707): Fix NameError when execute `Rails/HttpStatus` cop without Rack. ([@onk][])
+
 ## 0.54.0 (2018-03-21)
 
 ### New features

--- a/lib/rubocop/cop/rails/http_status.rb
+++ b/lib/rubocop/cop/rails/http_status.rb
@@ -93,7 +93,10 @@ module RuboCop
           MSG = 'Prefer `%<prefer>s` over `%<current>s` ' \
                 'to define HTTP status code.'.freeze
           DEFAULT_MSG = 'Prefer `symbolic` over `numeric` ' \
-                        'to define HTTP status code.'.freeze
+                        'to define HTTP status code. ' \
+                        'If the status code can not be written as symbol, ' \
+                        'this warning can be silenced ' \
+                        'by running rubocop with rack gem.'.freeze
 
           attr_reader :node
           def initialize(node)
@@ -127,6 +130,10 @@ module RuboCop
           end
 
           def custom_http_status_code?
+            # Can not check if it is custom status code without Rack.
+            # So all int value are offensed (this make false positive)
+            return false unless RACK_LOADED
+
             node.int_type? &&
               !::Rack::Utils::SYMBOL_TO_STATUS_CODE.value?(number)
           end

--- a/spec/rubocop/cop/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rails/http_status_spec.rb
@@ -43,13 +43,13 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
       it 'registers an offense when using numeric value' do
         expect_offense(<<-RUBY)
           render :foo, status: 200
-                               ^^^ Prefer `symbolic` over `numeric` to define HTTP status code.
+                               ^^^ Prefer `symbolic` over `numeric` to define HTTP status code. If the status code can not be written as symbol, this warning can be silenced by running rubocop with rack gem.
           render json: { foo: 'bar' }, status: 404
-                                               ^^^ Prefer `symbolic` over `numeric` to define HTTP status code.
+                                               ^^^ Prefer `symbolic` over `numeric` to define HTTP status code. If the status code can not be written as symbol, this warning can be silenced by running rubocop with rack gem.
           render plain: 'foo/bar', status: 304
-                                           ^^^ Prefer `symbolic` over `numeric` to define HTTP status code.
+                                           ^^^ Prefer `symbolic` over `numeric` to define HTTP status code. If the status code can not be written as symbol, this warning can be silenced by running rubocop with rack gem.
           redirect_to root_url, status: 301
-                                        ^^^ Prefer `symbolic` over `numeric` to define HTTP status code.
+                                        ^^^ Prefer `symbolic` over `numeric` to define HTTP status code. If the status code can not be written as symbol, this warning can be silenced by running rubocop with rack gem.
         RUBY
       end
     end


### PR DESCRIPTION
Rails/HttpStatus cop with symbolic style raise `NameError (uninitialized constant Rack)`.

```ruby
class FooController < ApplicationController
  def bar
    render :foo, status: 418
  end
end
```

```
$ rubocop --only Rails/HttpStatus app/controllers/foo_controller.rb -d
For /Users/onaka/sample_app: configuration from /Users/onaka/.gem/ruby/2.6.0/gems/rubocop-0.54.0/config/default.yml
Inheriting configuration from /Users/onaka/.gem/ruby/2.6.0/gems/rubocop-0.54.0/config/enabled.yml
Inheriting configuration from /Users/onaka/.gem/ruby/2.6.0/gems/rubocop-0.54.0/config/disabled.yml
Inspecting 1 file
Scanning /Users/onaka/sample_app/app/controllers/foo_controller.rb
An error occurred while Rails/HttpStatus cop was inspecting /Users/onaka/sample_app/app/controllers/foo_controller.rb:3:4.
uninitialized constant Rack
Did you mean?  Racc
/Users/onaka/.gem/ruby/2.6.0/gems/rubocop-0.54.0/lib/rubocop/cop/rails/http_status.rb:131:in `custom_http_status_code?'
/Users/onaka/.gem/ruby/2.6.0/gems/rubocop-0.54.0/lib/rubocop/cop/rails/http_status.rb:104:in `offensive?'
...
```

I think that there are 3 solutions.

1. Add rack gem in runtime dependency
  * Too strong solution.
  * I want to extract Rails cops to another gem. :cry:
2. Disable this cop if rack cannot be loaded
  * I failed to find a way to notify the user to install rack gem to enable this cop.  :thinking:
3. Disable `custom_http_status_code?` check if rack cannot be loaded
  * This makes false positive in case of HTTP status which can not be written as symbol.
  * This solution needs to tell the user to install Rack to know why false positives exist.

3 and tell to users via Offense Message is better.
What do you think?

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
