### PR TITLE
Use CircleCI as an alternative to Travis CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,126 @@
+version: 2
+
+steps: &steps
+  steps:
+    - checkout
+    - run: bundle install
+    - run: ruby .travis.rb
+
+spec_env: &spec_env
+  environment:
+    - TASK: "spec"
+
+ascii_spec_env: &ascii_spec_env
+  environment:
+    - TASK: "ascii_spec"
+
+rubocop_env: &rubocop_env
+  environment:
+    - TASK: "internal_investigation"
+
+jobs:
+
+  # Ruby 2.2
+  ruby-2.2-spec:
+    docker:
+      - image: circleci/ruby:2.2
+    <<: *spec_env
+    <<: *steps
+  ruby-2.2-ascii_spec:
+    docker:
+      - image: circleci/ruby:2.2
+    <<: *ascii_spec_env
+    <<: *steps
+  ruby-2.2-rubocop:
+    docker:
+      - image: circleci/ruby:2.2
+    <<: *rubocop_env
+    <<: *steps
+
+  # Ruby 2.3
+  ruby-2.3-spec:
+    docker:
+      - image: circleci/ruby:2.3
+    <<: *spec_env
+    <<: *steps
+  ruby-2.3-ascii_spec:
+    docker:
+      - image: circleci/ruby:2.3
+    <<: *ascii_spec_env
+    <<: *steps
+  ruby-2.3-rubocop:
+    docker:
+      - image: circleci/ruby:2.3
+    <<: *rubocop_env
+    <<: *steps
+
+  # Ruby 2.4
+  ruby-2.4-spec:
+    docker:
+      - image: circleci/ruby:2.4
+    <<: *spec_env
+    <<: *steps
+  ruby-2.4-ascii_spec:
+    docker:
+      - image: circleci/ruby:2.4
+    <<: *ascii_spec_env
+    <<: *steps
+  ruby-2.4-rubocop:
+    docker:
+      - image: circleci/ruby:2.4
+    <<: *rubocop_env
+    <<: *steps
+
+  # Ruby 2.5
+  ruby-2.5-spec:
+    docker:
+      - image: circleci/ruby:2.5
+    <<: *spec_env
+    <<: *steps
+  ruby-2.5-ascii_spec:
+    docker:
+      - image: circleci/ruby:2.5
+    <<: *ascii_spec_env
+    <<: *steps
+  ruby-2.5-rubocop:
+    docker:
+      - image: circleci/ruby:2.5
+    <<: *rubocop_env
+    <<: *steps
+
+  # JRuby 9.2
+  jruby-9.2-spec:
+    docker:
+      - image: circleci/jruby:9.2
+    <<: *spec_env
+    <<: *steps
+  jruby-9.2-ascii_spec:
+    docker:
+      - image: circleci/jruby:9.2
+    <<: *ascii_spec_env
+    <<: *steps
+  jruby-9.2-rubocop:
+    docker:
+      - image: circleci/jruby:9.2
+    <<: *rubocop_env
+    <<: *steps
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - ruby-2.2-spec
+      - ruby-2.2-ascii_spec
+      - ruby-2.2-rubocop
+      - ruby-2.3-spec
+      - ruby-2.3-ascii_spec
+      - ruby-2.3-rubocop
+      - ruby-2.4-spec
+      - ruby-2.4-ascii_spec
+      - ruby-2.4-rubocop
+      - ruby-2.5-spec
+      - ruby-2.5-ascii_spec
+      - ruby-2.5-rubocop
+      - jruby-9.2-spec
+      - jruby-9.2-ascii_spec
+      - jruby-9.2-rubocop


### PR DESCRIPTION
I noticed in #5733 @bbatsov mention that

> Perhaps it's time to start evaluating some alternative to Travis. Often I hear that Circle CI is more robust and less painful to use.

I agree!

This PR provides Circle CI configuration file. I have tested it from my fork of Rubocop, where [a build](https://circleci.com/workflow-run/4319fd24-31a8-4523-935d-acac9628b758) finished in 11:49 which can be compared to 25:26 for [the latest master build on Travis](https://travis-ci.org/bbatsov/rubocop/builds/361477483).

The plan is to keep running both CIs for a while, but eventually we will only run things in Travis that cannot easily be run on Circle – for example the builds against ruby-head and jruby-head.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
