### PR TITLE
[Fix #5660] Disable auto-correct for `Lint/PercentStringArray` in default configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 * [#5752](https://github.com/bbatsov/rubocop/pull/5752): Add `String#delete_{prefix,suffix}` to Lint/Void cop. ([@bdewater][])
 * [#5734](https://github.com/bbatsov/rubocop/pull/5734): Add `by`, `on`, `in` and `at` to allowed names of `Naming/UncommunicativeMethodParamName` cop in default config. ([@AlexWayfer][])
+* [#5660](https://github.com/bbatsov/rubocop/pull/5660): Disable auto-correct for `Lint/PercentStringArray` cop in default configuration. ([@drenmi][])
 
 ## 0.54.0 (2018-03-21)
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -605,6 +605,9 @@ Lint/PercentStringArray:
   Description: >-
                  Checks for unwanted commas and quotes in %w/%W literals.
   Enabled: true
+  # This cop isn't smart enough to figure out when auto-correction is safe,
+  # and sometimes breaks the code.
+  AutoCorrect: false
 
 Lint/PercentSymbolArray:
   Description: >-

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1310,6 +1310,12 @@ rather than meant to be part of the resulting strings.
 %w(foo bar)
 ```
 
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AutoCorrect | `false` | Boolean
+
 ## Lint/PercentSymbolArray
 
 Enabled by default | Supports autocorrection


### PR DESCRIPTION
This cop isn't smart enough to figure out when auto-correction is safe and not, and sometimes breaks code.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
