### PR TITLE
Restore previous interrupt handler after run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#5713](https://github.com/bbatsov/rubocop/issues/5713): Fix `Style/CommentAnnotation` reporting only the first of multiple consecutive offending lines. ([@svendittmer][])
 * [#5791](https://github.com/bbatsov/rubocop/issues/5791): Fix exception in `Lint/SafeNavigationConsistency` when there is code around the condition. ([@rrosenblum][])
 * [#5784](https://github.com/bbatsov/rubocop/issues/5784): Fix a false positive for `Rails/HasManyOrHasOneDependent` when using nested `with_options`. ([@koic][])
+* [#5808](https://github.com/bbatsov/rubocop/pull/5808): Fix original interrupt signal handler not being restored after the rubocop run. ([@deivid-rodriguez][])
 
 ## 0.55.0 (2018-04-16)
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -54,16 +54,22 @@ module RuboCop
       warn e.message
       warn e.backtrace
       STATUS_ERROR
+    ensure
+      untrap_interrupt
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
     def trap_interrupt(runner)
-      Signal.trap('INT') do
+      @old_interrupt_handler = Signal.trap('INT') do
         exit!(1) if runner.aborting?
         runner.abort
         warn
         warn 'Exiting... Interrupt again to exit immediately.'
       end
+    end
+
+    def untrap_interrupt
+      Signal.trap('INT', @old_interrupt_handler)
     end
 
     private


### PR DESCRIPTION
I was running `puma`'s test suite, where [rubocop is run](https://github.com/puma/puma/blob/8dbc6eb6ed96b2cefa7092dd398ea2c0a4a0be80/Rakefile#L100) before the test suite. One of the tests [was hanging](https://github.com/puma/puma/pull/1567), and when pressing Ctrl-C to abort it, I would get `rubocop's` Ctrl-C handler run.

That seemed unexpected, I think rubocop should probably restore the previously installed handler after it's run?

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
