### PR TITLE
[Fix #5843] Add EnforcedStyleForLeadingUnderscores to Naming/MemoizedInstanceVariableName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@
 * [#5845](https://github.com/bbatsov/rubocop/pull/5845): Add new `Lint/ErbNewArguments` cop. ([@koic][])
 * [#5871](https://github.com/bbatsov/rubocop/pull/5871): Add new `Lint/SplatKeywordArguments` cop. ([@koic][])
 * [#4247](https://github.com/bbatsov/rubocop/issues/4247): Remove hard-coded file patterns and use only `Include`, `Exclude` and the new `RubyInterpreters` parameters for file selection. ([@jonas054][])
+* [#5843](https://github.com/bbatsov/rubocop/issues/5843): Add configuration options to `Naming/MemoizedInstanceVariableName` cop to allow leading underscores. ([@leklund][])
+* [#5843](https://github.com/bbatsov/rubocop/issues/5843): Add `EnforcedStyleForLeadingUnderscores` to `Naming/MemoizedInstanceVariableName` cop to allow leading underscores. ([@leklund][])
 
 ### Bug fixes
 
@@ -3386,7 +3388,6 @@
 [@Edouard-chin]: https://github.com/Edouard-chin
 [@eostrom]: https://github.com/eostrom
 [@roberts1000]: https://github.com/roberts1000
-[@leklund]: https://github.com/leklund
 [@walinga]: https://github.com/walinga
 [@georf]: https://github.com/georf
 [@satyap]: https://github.com/satyap

--- a/config/default.yml
+++ b/config/default.yml
@@ -739,6 +739,13 @@ Naming/HeredocDelimiterCase:
     - lowercase
     - uppercase
 
+Naming/MemoizedInstanceVariableName:
+  EnforcedStyleForLeadingUnderscores: disallowed
+  SupportedStylesForLeadingUnderscores:
+    - disallowed
+    - required
+    - optional
+
 Naming/MethodName:
   EnforcedStyle: snake_case
   SupportedStyles:

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -290,7 +290,15 @@ Enabled | No
 This cop checks for memoized methods whose instance variable name
 does not match the method name.
 
+This cop can be configured with the EnforcedStyleForLeadingUnderscores
+directive. It can be configured to allow for memoized instance variables
+prefixed with an underscore. Prefixing ivars with an undersscore is a
+convention that is used to implicitly indicate that an ivar should not
+be set or referencd outside of the memoization method.
+
 ### Examples
+
+#### EnforcedStyleForLeadingUnderscores: disallowed (default)
 
 ```ruby
 # bad
@@ -318,6 +326,48 @@ def foo
   @foo ||= calculate_expensive_thing(helper_variable)
 end
 ```
+#### EnforcedStyleForLeadingUnderscores :required
+
+```ruby
+# bad
+def foo
+  @something ||= calculate_expensive_thing
+end
+
+# bad
+def foo
+  @foo ||= calculate_expensive_thing
+end
+
+# good
+def foo
+  @_foo ||= calculate_expensive_thing
+end
+```
+#### EnforcedStyleForLeadingUnderscores :optional
+
+```ruby
+# bad
+def foo
+  @something ||= calculate_expensive_thing
+end
+
+# good
+def foo
+  @foo ||= calculate_expensive_thing
+end
+
+# good
+def foo
+  @_foo ||= calculate_expensive_thing
+end
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyleForLeadingUnderscores | `disallowed` | `disallowed`, `required`, `optional`
 
 ## Naming/MethodName
 

--- a/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
@@ -1,176 +1,226 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Naming::MemoizedInstanceVariableName do
-  subject(:cop) { described_class.new }
+RSpec.describe RuboCop::Cop::Naming::MemoizedInstanceVariableName, :config do
+  subject(:cop) { described_class.new(config) }
 
-  context 'memoized variable does not match method name' do
-    it 'registers an offense' do
-      expect_offense(<<-RUBY.strip_indent)
-      def x
-        @my_var ||= :foo
-        ^^^^^^^ Memoized variable `@my_var` does not match method name `x`. Use `@x` instead.
-      end
-      RUBY
-    end
-  end
-
-  context 'memoized variable does not match class method name' do
-    it 'registers an offense' do
-      expect_offense(<<-RUBY.strip_indent)
-      def self.x
-        @my_var ||= :foo
-        ^^^^^^^ Memoized variable `@my_var` does not match method name `x`. Use `@x` instead.
-      end
-      RUBY
-    end
-  end
-
-  context 'memoized variable does not match method name during assignment' do
-    it 'registers an offense' do
-      expect_offense(<<-RUBY.strip_indent)
-      foo = def x
-        @y ||= :foo
-        ^^ Memoized variable `@y` does not match method name `x`. Use `@x` instead.
-      end
-      RUBY
-    end
-  end
-
-  context 'memoized variable does not match method name for block' do
-    it 'registers an offense' do
-      expect_offense(<<-RUBY.strip_indent)
-      def x
-        @y ||= begin
-        ^^ Memoized variable `@y` does not match method name `x`. Use `@x` instead.
-          :foo
-        end
-      end
-      RUBY
-    end
-  end
-
-  context 'memoized variable after other code does not match method name' do
-    it 'registers an offense' do
-      expect_offense(<<-RUBY.strip_indent)
-        def foo
-          helper_variable = something_we_need_to_calculate_foo
-          @bar ||= calculate_expensive_thing(helper_variable)
-          ^^^^ Memoized variable `@bar` does not match method name `foo`. Use `@foo` instead.
-        end
-      RUBY
+  context 'with default EnforcedStyleForLeadingUnderscores => disallowed' do
+    let(:cop_config) do
+      { 'EnforcedStyleForLeadingUnderscores' => 'disallowed' }
     end
 
-    it 'registers an offense for a predicate method' do
-      expect_offense(<<-RUBY.strip_indent)
-        def foo?
-          helper_variable = something_we_need_to_calculate_foo
-          @bar ||= calculate_expensive_thing(helper_variable)
-          ^^^^ Memoized variable `@bar` does not match method name `foo?`. Use `@foo` instead.
-        end
-      RUBY
-    end
-
-    it 'registers an offense for a bang method' do
-      expect_offense(<<-RUBY.strip_indent)
-        def foo!
-          helper_variable = something_we_need_to_calculate_foo
-          @bar ||= calculate_expensive_thing(helper_variable)
-          ^^^^ Memoized variable `@bar` does not match method name `foo!`. Use `@foo` instead.
-        end
-      RUBY
-    end
-  end
-
-  context 'memoized variable matches method name' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+    context 'memoized variable does not match method name' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
         def x
-          @x ||= :foo
+          @my_var ||= :foo
+          ^^^^^^^ Memoized variable `@my_var` does not match method name `x`. Use `@x` instead.
         end
+        RUBY
+      end
+    end
+
+    context 'memoized variable does not match class method name' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
+        def self.x
+          @my_var ||= :foo
+          ^^^^^^^ Memoized variable `@my_var` does not match method name `x`. Use `@x` instead.
+        end
+        RUBY
+      end
+    end
+
+    context 'memoized variable does not match method name during assignment' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
+        foo = def x
+          @y ||= :foo
+          ^^ Memoized variable `@y` does not match method name `x`. Use `@x` instead.
+        end
+        RUBY
+      end
+    end
+
+    context 'memoized variable does not match method name for block' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
+        def x
+          @y ||= begin
+          ^^ Memoized variable `@y` does not match method name `x`. Use `@x` instead.
+            :foo
+          end
+        end
+        RUBY
+      end
+    end
+
+    context 'memoized variable after other code does not match method name' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
+          def foo
+            helper_variable = something_we_need_to_calculate_foo
+            @bar ||= calculate_expensive_thing(helper_variable)
+            ^^^^ Memoized variable `@bar` does not match method name `foo`. Use `@foo` instead.
+          end
+        RUBY
+      end
+
+      it 'registers an offense for a predicate method' do
+        expect_offense(<<-RUBY.strip_indent)
+          def foo?
+            helper_variable = something_we_need_to_calculate_foo
+            @bar ||= calculate_expensive_thing(helper_variable)
+            ^^^^ Memoized variable `@bar` does not match method name `foo?`. Use `@foo` instead.
+          end
+        RUBY
+      end
+
+      it 'registers an offense for a bang method' do
+        expect_offense(<<-RUBY.strip_indent)
+          def foo!
+            helper_variable = something_we_need_to_calculate_foo
+            @bar ||= calculate_expensive_thing(helper_variable)
+            ^^^^ Memoized variable `@bar` does not match method name `foo!`. Use `@foo` instead.
+          end
+        RUBY
+      end
+    end
+
+    context 'memoized variable matches method name' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          def x
+            @x ||= :foo
+          end
+        RUBY
+      end
+
+      context 'memoized variable matches method name during assignment' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            foo = def y
+              @y ||= :foo
+            end
+          RUBY
+        end
+      end
+
+      context 'memoized variable matches method name for block' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            def z
+              @z ||= begin
+                :foo
+              end
+            end
+          RUBY
+        end
+      end
+
+      context 'non-memoized variable does not match method name' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            def a
+              x ||= :foo
+            end
+          RUBY
+        end
+      end
+
+      context 'memoized variable matches predicate method name' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            def a?
+              @a ||= :foo
+            end
+          RUBY
+        end
+      end
+
+      context 'memoized variable matches bang method name' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            def a!
+              @a ||= :foo
+            end
+          RUBY
+        end
+      end
+
+      context 'code follows memoized variable assignment' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            def a
+              @b ||= :foo
+              call_something_else
+            end
+          RUBY
+        end
+
+        context 'memoized variable after other code' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<-RUBY.strip_indent)
+              def foo
+                helper_variable = something_we_need_to_calculate_foo
+                @foo ||= calculate_expensive_thing(helper_variable)
+              end
+            RUBY
+          end
+        end
+
+        context 'instance variables in initialize methods' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<-RUBY.strip_indent)
+              def initialize
+                @files_with_offenses ||= {}
+              end
+            RUBY
+          end
+        end
+      end
+    end
+  end
+
+  context 'EnforcedStyleForLeadingUnderscores: required' do
+    let(:cop_config) { { 'EnforcedStyleForLeadingUnderscores' => 'required' } }
+
+    it 'registers an offense when names match but missing a leading _' do
+      expect_offense(<<-RUBY.strip_indent)
+      def foo
+        @foo ||= :foo
+        ^^^^ Memoized variable `@foo` does not start with `_`. Use `@_foo` instead.
+      end
       RUBY
     end
 
-    context 'memoized variable matches method name during assignment' do
-      it 'does not register an offense' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          foo = def y
-            @y ||= :foo
-          end
-        RUBY
+    it 'registers an offense when it has leading `_` but names do not match' do
+      expect_offense(<<-RUBY.strip_indent)
+      def foo
+        @_my_var ||= :foo
+        ^^^^^^^^ Memoized variable `@_my_var` does not match method name `foo`. Use `@_foo` instead.
       end
+      RUBY
     end
+  end
 
-    context 'memoized variable matches method name for block' do
-      it 'does not register an offense' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          def z
-            @z ||= begin
-              :foo
-            end
-          end
-        RUBY
-      end
-    end
+  context 'EnforcedStyleForLeadingUnderscores: optional' do
+    let(:cop_config) { { 'EnforcedStyleForLeadingUnderscores' => 'optional' } }
 
-    context 'non-memoized variable does not match method name' do
-      it 'does not register an offense' do
+    context 'memoized variable matches method name' do
+      it 'does not register an offense with a leading underscore' do
         expect_no_offenses(<<-RUBY.strip_indent)
-          def a
-            x ||= :foo
-          end
-        RUBY
-      end
-    end
-
-    context 'memoized variable matches predicate method name' do
-      it 'does not register an offense' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          def a?
-            @a ||= :foo
-          end
-        RUBY
-      end
-    end
-
-    context 'memoized variable matches bang method name' do
-      it 'does not register an offense' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          def a!
-            @a ||= :foo
-          end
-        RUBY
-      end
-    end
-
-    context 'code follows memoized variable assignment' do
-      it 'does not register an offense' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          def a
-            @b ||= :foo
-            call_something_else
+          def x
+            @_x ||= :foo
           end
         RUBY
       end
 
-      context 'memoized variable after other code' do
-        it 'does not register an offense' do
-          expect_no_offenses(<<-RUBY.strip_indent)
-            def foo
-              helper_variable = something_we_need_to_calculate_foo
-              @foo ||= calculate_expensive_thing(helper_variable)
-            end
-          RUBY
-        end
-      end
-
-      context 'instance variables in initialize methods' do
-        it 'does not register an offense' do
-          expect_no_offenses(<<-RUBY.strip_indent)
-            def initialize
-              @files_with_offenses ||= {}
-            end
-          RUBY
-        end
+      it 'does not register an offense without a leading underscore' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          def x
+            @x ||= :foo
+          end
+        RUBY
       end
     end
   end


### PR DESCRIPTION
Adds an `EnforcedStyleForLeadingUnderscores` configuration option to `Naming/MemoizedInstanceVariableName`:

Options include:

**disallowed**
Instance variable names must match the method name exactly without a leading underscore. 
```
Naming/MemoizedInstanceVariableName:
  EnforcedStyleForLeadingUnderscores: disallowed   

def foo
  @foo = my_foo
end
```

**required**
Instance variable names must match the method name exactly *with* a leading underscore. 
```
Naming/MemoizedInstanceVariableName:
  EnforcedStyleForLeadingUnderscores: required   

def foo
  @_foo = my_foo
end
```

**optional**
Instance variable names must match the method name exactly and may optionally have a leading underscore.
```
Naming/MemoizedInstanceVariableName:
  EnforcedStyleForLeadingUnderscores: optional   

def foo
  @foo = my_foo
end

# or

def foo
  @_foo = my_foo
end
```

Closes #5843 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/