### PR TITLE
[Fix #5916] Comma at end of URI causes Rubocop to alert `Metrics/LineLength`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix the indentation of autocorrected closing squiggly heredocs. ([@garettarrowood][])
 * [#5908](https://github.com/bbatsov/rubocop/pull/5908): Fix `Style/BracesAroundHashParameters` auto-correct going past the end of the file when the closing curly brace is on the last line of a file. ([@EiNSTeiN-][])
 * Fix a bug where `Style/FrozenStringLiteralComment` would be added to the second line if the first line is empty. ([@rrosenblum][])
+* [#5916](https://github.com/bbatsov/rubocop/issues/5916): Fix Comma at end of URI causes Rubocop to alert `Metrics/LineLength`. ([@dpostorivo][])
 
 ### Changes
 

--- a/lib/rubocop/cop/metrics/line_length.rb
+++ b/lib/rubocop/cop/metrics/line_length.rb
@@ -99,8 +99,8 @@ module RuboCop
         end
 
         def allowed_uri_position?(line, uri_range)
-          uri_range.begin < max &&
-            (uri_range.end == line.length || uri_range.end == line.length - 1)
+          clean_line = line.gsub(/.[,"'}]$/, '')
+          uri_range.begin < max && uri_range.end >= clean_line.length
         end
 
         def find_excessive_uri_range(line)

--- a/spec/rubocop/cop/metrics/line_length_spec.rb
+++ b/spec/rubocop/cop/metrics/line_length_spec.rb
@@ -65,6 +65,20 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
           expect(cop.offenses.empty?).to be(true)
         end
       end
+
+      context 'and the URL has comma at the end' do
+        let(:source) { <<-RUBY }
+          {
+            confirmation_url: "https://subodomain.example.com/with_a_length_path/?and=some&more=params",
+            foo: :bar
+          }
+        RUBY
+
+        it 'accepts the line' do
+          inspect_source(source)
+          expect(cop.offenses.empty?).to be(true)
+        end
+      end
     end
 
     context 'and the excessive characters include a complete URL' do


### PR DESCRIPTION
This fixes #5916 by trimming characters from the end of the URI string like the comma and then seeing if the uri string is at the end of the line.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
