### PR TITLE
[Fix #5788] `Layout/MultilineBlockLayout` cop auto-correct ignoring LineLength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix the indentation of autocorrected closing squiggly heredocs. ([@garettarrowood][])
 * [#5908](https://github.com/bbatsov/rubocop/pull/5908): Fix `Style/BracesAroundHashParameters` auto-correct going past the end of the file when the closing curly brace is on the last line of a file. ([@EiNSTeiN-][])
 * Fix a bug where `Style/FrozenStringLiteralComment` would be added to the second line if the first line is empty. ([@rrosenblum][])
+* [#5788](https://github.com/bbatsov/rubocop/issues/5788): Fix `Layout/MultilineBlockLayout` cop auto-correct ignoring LineLength. ([@dpostorivo][])
 
 ### Changes
 

--- a/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
-  subject(:cop) { described_class.new }
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) do
+    RuboCop::Config.new('Metrics/LineLength' => {
+                          'Max' => 80,
+                          'Enabled' => true
+                        })
+  end
 
   it 'registers an offense for missing newline in do/end block w/o params' do
     expect_offense(<<-RUBY.strip_indent)
@@ -238,6 +245,27 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
       def f
         X.map do |(a, b)|
         end
+      end
+    RUBY
+  end
+
+  it "doesn't autocorrect if line will be too long" do
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
+      some_result = lambda do |
+          so_many_parameters,
+          it_will_be_too_long,
+          for_one_line_and_cop,
+          will_not_correct|
+        do_something
+      end
+    RUBY
+    expect(new_source).to eq(<<-RUBY.strip_indent)
+      some_result = lambda do |
+          so_many_parameters,
+          it_will_be_too_long,
+          for_one_line_and_cop,
+          will_not_correct|
+        do_something
       end
     RUBY
   end


### PR DESCRIPTION
This PR fixes #5788 by checking max_line_length and the resulting line length before making the correction. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
