### PR TITLE
[Fix #5799] Check only top-level includes on class/module def

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#5908](https://github.com/bbatsov/rubocop/pull/5908): Fix `Style/BracesAroundHashParameters` auto-correct going past the end of the file when the closing curly brace is on the last line of a file. ([@EiNSTeiN-][])
 * Fix a bug where `Style/FrozenStringLiteralComment` would be added to the second line if the first line is empty. ([@rrosenblum][])
 * [#5914](https://github.com/bbatsov/rubocop/issues/5914): Make `Layout/SpaceInsideReferenceBrackets` aware of `no_space` when using nested reference brackets. ([@koic][])
+* [#5799](https://github.com/bbatsov/rubocop/issues/5799): Fix false positive in `Style/MixinGrouping` when method named `include` accepts block. ([@Darhazer][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/mixin_grouping.rb
+++ b/lib/rubocop/cop/style/mixin_grouping.rb
@@ -36,11 +36,16 @@ module RuboCop
         MIXIN_METHODS = %i[extend include prepend].freeze
         MSG = 'Put `%<mixin>s` mixins in %<suffix>s.'.freeze
 
-        def on_send(node)
-          return unless node.macro? && MIXIN_METHODS.include?(node.method_name)
+        def on_class(node)
+          begin_node = node.child_nodes.find(&:begin_type?) || node
+          begin_node.each_child_node(:send).select(&:macro?).each do |macro|
+            next unless MIXIN_METHODS.include?(macro.method_name)
 
-          check(node)
+            check(macro)
+          end
         end
+
+        alias on_module on_class
 
         def autocorrect(node)
           range = node.loc.expression

--- a/spec/rubocop/cop/style/mixin_grouping_spec.rb
+++ b/spec/rubocop/cop/style/mixin_grouping_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe RuboCop::Cop::Style::MixinGrouping, :config do
 
       context 'when include call is an argument to another method' do
         it_behaves_like 'code without offense',
-                        'expect(foo).to include(bar, baz)'
+                        'expect(foo).to include { { bar: baz } }'
       end
 
       context 'with several mixins in separate calls' do


### PR DESCRIPTION
* Replaced the test case 'when include call is an argument to another method' with the minimum reproducible example of the bug
* Changed the cop to look for class and module definition, instead of inspecting each send node

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
