### PR TITLE
[Fix #5936] Add new `--fix-layout` alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Changes
 
+* [#5937](https://github.com/rubocop-hq/rubocop/pull/5937): Add new `--update-layout` command line alias. ([@scottmatthewman][])
 * [#5887](https://github.com/bbatsov/rubocop/issues/5887): Remove `Lint/SplatKeywordArguments` cop. ([@koic][])
 * [#5761](https://github.com/bbatsov/rubocop/pull/5761): Add `httpdate` to accepted `Rails/TimeZone` methods. ([@cupakromer][])
 * [#5899](https://github.com/bbatsov/rubocop/pull/5899): Add `xmlschema` to accepted `Rails/TimeZone` methods. ([@koic][])

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -65,6 +65,7 @@ module RuboCop
         add_severity_option(opts)
         add_flags_with_optional_args(opts)
         add_boolean_flags(opts)
+        add_aliases(opts)
 
         option(opts, '-s', '--stdin FILE')
       end
@@ -142,7 +143,7 @@ module RuboCop
       end
     end
 
-    def add_boolean_flags(opts) # rubocop:disable Metrics/MethodLength
+    def add_boolean_flags(opts)
       option(opts, '-F', '--fail-fast')
       option(opts, '-C', '--cache FLAG')
       option(opts, '-d', '--debug')
@@ -150,10 +151,6 @@ module RuboCop
       option(opts, '-E', '--extra-details')
       option(opts, '-S', '--display-style-guide')
       option(opts, '-R', '--rails')
-      option(opts, '-l', '--lint') do
-        @options[:only] ||= []
-        @options[:only] << 'Lint'
-      end
       option(opts, '-a', '--auto-correct')
 
       option(opts, '--[no-]color')
@@ -161,6 +158,18 @@ module RuboCop
       option(opts, '-v', '--version')
       option(opts, '-V', '--verbose-version')
       option(opts, '-P', '--parallel')
+    end
+
+    def add_aliases(opts)
+      option(opts, '-l', '--lint') do
+        @options[:only] ||= []
+        @options[:only] << 'Lint'
+      end
+      option(opts, '-x', '--fix-layout') do
+        @options[:only] ||= []
+        @options[:only] << 'Layout'
+        @options[:auto_correct] = true
+      end
     end
 
     def add_list_options(opts)
@@ -379,6 +388,7 @@ module RuboCop
       lint:                  'Run only lint cops.',
       list_target_files:     'List all files RuboCop will inspect.',
       auto_correct:          'Auto-correct offenses.',
+      fix_layout:            'Run only layout cops, with auto-correct on.',
       color:                 'Force color output on or off.',
       version:               'Display version.',
       verbose_version:       'Display verbose version.',

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -97,13 +97,14 @@ RSpec.describe RuboCop::Options, :isolated_environment do
               -E, --extra-details              Display extra details in offense messages.
               -S, --display-style-guide        Display style guide URLs in offense messages.
               -R, --rails                      Run extra Rails cops.
-              -l, --lint                       Run only lint cops.
               -a, --auto-correct               Auto-correct offenses.
                   --[no-]color                 Force color output on or off.
               -v, --version                    Display version.
               -V, --verbose-version            Display verbose version.
               -P, --parallel                   Use available CPUs to execute inspection in
                                                parallel.
+              -l, --lint                       Run only lint cops.
+              -x, --fix-layout                 Run only layout cops, with auto-correct on.
               -s, --stdin FILE                 Pipe source from STDIN, using FILE in offense
                                                reports. This is useful for editor integration.
         OUTPUT


### PR DESCRIPTION
Provide an alias for `--only Layout -a`. The new alias may be specified as either `--auto-correct-layout` or `-A`.

I opted for this alias over the suggested `--fix-formatting` or `--reformat` to more strongly associate the option with the Layout cops (in the same way that `--lint` is used to run the Lint cops), and also to emphasis that we are running autocorrect, which should (but may not) "fix" everything.

I felt that given the alias name is quite long, a shorthand character may be appropriate. However, I'm not sure that `-A` is necessarily the best. I'm certainly open to suggestions for an alternative!

Both this and the existing `--lint` alias are moved to a new method, `#add_aliases`. Keeping them both in the core `#add_boolean_flags` method would have increased its complexity above allowed tolerances; removing them is both more accurate (they're not flags) and also allows the method exception to be removed. This does, however, reorder the options as listed in `rubocop --help`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
