### PR TITLE
Change indent rule for `Layout/ClosingHeredocIndentation` cop

### DIFF
--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -665,7 +665,6 @@ Checks the indentation of here document closings.
 
 ```ruby
 # bad
-
 class Foo
   def bar
     <<~SQL
@@ -675,7 +674,6 @@ class Foo
 end
 
 # good
-
 class Foo
   def bar
     <<~SQL
@@ -683,6 +681,26 @@ class Foo
     SQL
   end
 end
+
+# bad
+
+# heredoc contents is before closing heredoc.
+foo arg,
+    <<~EOS
+  Hi
+    EOS
+
+# good
+foo arg,
+    <<~EOS
+  Hi
+EOS
+
+# good
+foo arg,
+    <<~EOS
+      Hi
+    EOS
 ```
 
 ## Layout/ClosingParenthesisIndentation

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
               # URISchemes: http, https
               Metrics/LineLength:
                 Max: 99
-            YAML
+          YAML
           expect(IO.read('.rubocop.yml').strip).to eq(exp_dotfile.join($RS))
           $stdout = StringIO.new
           expect(described_class.new.run([])).to eq(0)

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -535,18 +535,18 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
   it 'corrects InitialIndentation offenses' do
     source = <<-RUBY.strip_indent
-        # comment 1
+      # comment 1
 
-        # comment 2
-        def func
-          begin
-            foo
-            bar
-          rescue StandardError
-            baz
-          end
+      # comment 2
+      def func
+        begin
+          foo
+          bar
+        rescue StandardError
+          baz
         end
-      RUBY
+      end
+    RUBY
     create_file('example.rb', source)
     create_file('.rubocop.yml', <<-YAML.strip_indent)
       Layout/DefEndAlignment:

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -546,7 +546,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             baz
           end
         end
-    RUBY
+      RUBY
     create_file('example.rb', source)
     create_file('.rubocop.yml', <<-YAML.strip_indent)
       Layout/DefEndAlignment:

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -1061,7 +1061,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       expect(File.read('emacs_output.txt'))
         .to eq(<<-RESULT.strip_indent)
           #{abs(target_file)}:1:81: C: Metrics/LineLength: Line is too long. [90/80]
-        RESULT
+      RESULT
     end
   end
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             W:  1:  1: Lint/UselessAssignment: Useless assignment to variable - x.
 
             1 file inspected, 1 offense detected
-          RESULT
+        RESULT
       end
     end
 
@@ -123,7 +123,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           C:  1:  1: Layout/EndOfLine: Carriage return character detected.
 
           1 file inspected, 1 offense detected
-        RESULT
+      RESULT
     end
   end
 
@@ -135,7 +135,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         .to eq(<<-RESULT.strip_indent)
 
           1 file inspected, no offenses detected
-        RESULT
+      RESULT
     end
 
     context 'when super is used with a block' do
@@ -163,7 +163,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           .to eq(<<-RESULT.strip_indent)
 
             1 file inspected, no offenses detected
-          RESULT
+        RESULT
       end
     end
   end
@@ -177,7 +177,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         C:  1:  6: Layout/TrailingWhitespace: Trailing whitespace detected.
 
         1 file inspected, 1 offense detected
-      RESULT
+    RESULT
   end
 
   it 'registers an offense for a syntax error' do
@@ -212,7 +212,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     expect($stdout.string)
       .to eq(<<-RESULT.strip_indent)
         #{abs('example.rb')}:1:1: F: Lint/Syntax: Invalid byte sequence in utf-8.
-      RESULT
+    RESULT
   end
 
   context 'when errors are raised while processing files due to bugs' do
@@ -277,7 +277,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             # frozen_string_literal: true
 
             a = 1 # rubocop:disable Lint/UselessAssignment
-          RUBY
+        RUBY
       end
     end
 
@@ -326,7 +326,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       expect($stdout.string)
         .to eq(<<-RESULT.strip_indent)
           #{abs('example.rb')}:2:81: C: Metrics/LineLength: Line is too long. [95/80]
-        RESULT
+      RESULT
     end
 
     context 'without using namespace' do
@@ -339,7 +339,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect($stdout.string)
           .to eq(<<-RESULT.strip_indent)
             #{abs('example.rb')}:2:81: C: Metrics/LineLength: Line is too long. [95/80]
-          RESULT
+        RESULT
       end
     end
 
@@ -391,18 +391,18 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                        'individually disabled', <<-YAML.strip_indent
         Lint/UnneededCopDisableDirective:
           Enabled: false
-                       YAML
+      YAML
       include_examples 'UnneededCopDisableDirective not run',
                        'individually excluded', <<-YAML.strip_indent
         Lint/UnneededCopDisableDirective:
           Exclude:
             - example.rb
-                       YAML
+      YAML
       include_examples 'UnneededCopDisableDirective not run',
                        'disabled through department', <<-YAML.strip_indent
         Lint:
           Enabled: false
-                       YAML
+      YAML
     end
   end
 
@@ -789,7 +789,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
               C: 16:  3: Layout/IndentationWidth: Use 2 (not 0) spaces for rails indentation.
 
               1 file inspected, 2 offenses detected
-            RESULT
+          RESULT
         end
       end
     end

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -615,18 +615,18 @@ RSpec.describe RuboCop::ConfigLoader do
             Enabled: false
             Max: 200
             CountComments: false
-                    YAML
+        YAML
         create_file("#{gem_root}/gemtwo/config/default.yml",
                     <<-YAML.strip_indent)
           Metrics/LineLength:
             Enabled: true
-                    YAML
+        YAML
         create_file("#{gem_root}/gemtwo/config/strict.yml",
                     <<-YAML.strip_indent)
           Metrics/LineLength:
             Max: 72
             AllowHeredoc: false
-                    YAML
+        YAML
         create_file('local.yml', <<-YAML.strip_indent)
           Metrics/MethodLength:
             CountComments: true

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
           extend SomeModule
           CONST = 1
         end
-        RUBY
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/layout/closing_heredoc_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/closing_heredoc_indentation_spec.rb
@@ -20,6 +20,58 @@ RSpec.describe RuboCop::Cop::Layout::ClosingHeredocIndentation do
     RUBY
   end
 
+  it 'accepts correctly indented closing heredoc when ' \
+     'heredoc contents is after closing heredoc' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      include_examples :offense,
+                       <<-EOS
+                         foo
+                           bar
+                       EOS
+    RUBY
+  end
+
+  it 'accepts correctly indented closing heredoc when ' \
+     'heredoc contents with blank line' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def_node_matcher :eval_without_location?, <<-PATTERN
+        {
+          (send $(send _ $:sort ...) ${:[] :at :slice} {(int 0) (int -1)})
+
+          (send $(send _ $:sort_by _) ${:last :first})
+        }
+      PATTERN
+    RUBY
+  end
+
+  it 'accepts correctly indented closing heredoc when aligned at ' \
+     'the beginning of method definition' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      include_examples :offense,
+                       <<-EOS
+        bar
+      EOS
+    RUBY
+  end
+
+  it 'accepts correctly indented closing heredoc when aligned at ' \
+     'the beginning of method definition and using `strip_indent`' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      include_examples :offense,
+                       <<-EOS.strip_indent
+        bar
+      EOS
+    RUBY
+  end
+
+  it 'accepts correctly indented closing heredoc when aligned at ' \
+     'the beginning of method definition and content is empty' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      let(:source) { <<-EOS.strip_indent }
+      EOS
+    RUBY
+  end
+
   it 'registers an offence for bad indentation of a closing heredoc' do
     expect_offense(<<-RUBY.strip_indent)
       class Test
@@ -30,6 +82,19 @@ RSpec.describe RuboCop::Cop::Layout::ClosingHeredocIndentation do
       ^^^^^ `SQL` is not aligned with `<<-SQL`.
         end
       end
+    RUBY
+  end
+
+  it 'registers correctly indented closing heredoc when ' \
+     'heredoc contents is before closing heredoc' do
+    expect_offense(<<-RUBY.strip_indent)
+      include_examples :offense,
+                       <<-EOS
+                         foo
+        bar
+                         baz
+                       EOS
+      ^^^^^^^^^^^^^^^^^^^^ `EOS` is not aligned with `<<-EOS` or beginning of method definition.
     RUBY
   end
 

--- a/spec/rubocop/cop/layout/empty_lines_around_begin_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_begin_body_spec.rb
@@ -31,11 +31,11 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
 
       foo
     end
-                   CODE
+  CODE
     begin
       foo
     end
-                   CORRECTION
+  CORRECTION
   include_examples :offense, 'begin body ending', 'end', <<-CODE, <<-CORRECTION
     begin
       foo
@@ -55,13 +55,13 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
         foo
       end
     end
-                   CODE
+  CODE
     def bar
       begin
         foo
       end
     end
-                   CORRECTION
+  CORRECTION
   include_examples :offense,
                    'begin body ending in method', 'end', <<-CODE, <<-CORRECTION
     def bar
@@ -70,13 +70,13 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
 
       end
     end
-                   CODE
+  CODE
     def bar
       begin
         foo
       end
     end
-                   CORRECTION
+  CORRECTION
 
   include_examples :offense,
                    'begin body starting with rescue', 'beginning',
@@ -87,13 +87,13 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
     rescue
       bar
     end
-                   CODE
+  CODE
     begin
       foo
     rescue
       bar
     end
-                   CORRECTION
+  CORRECTION
   include_examples :offense, 'rescue body ending', 'end', <<-CODE, <<-CORRECTION
     begin
       foo
@@ -199,5 +199,5 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
         bar
       end
     end
-                   RUBY
+  RUBY
 end

--- a/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb
@@ -35,13 +35,13 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords d
     rescue
       f2
     end
-                   CODE
+  CODE
     begin
       f1
     rescue
       f2
     end
-                   CORRECTION
+  CORRECTION
 
   include_examples :offense,
                    'rescue section starting',
@@ -53,13 +53,13 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords d
 
       f2
     end
-                   CODE
+  CODE
     begin
       f1
     rescue
       f2
     end
-                   CORRECTION
+  CORRECTION
 
   include_examples :offense,
                    'rescue section ending',
@@ -73,7 +73,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords d
     else
       f3
     end
-                   CODE
+  CODE
     begin
       f1
     rescue
@@ -81,7 +81,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords d
     else
       f3
     end
-                   CORRECTION
+  CORRECTION
 
   include_examples :offense,
                    'rescue section ending for method definition',
@@ -95,7 +95,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords d
     else
       f3
     end
-                   CODE
+  CODE
     def foo
       f1
     rescue
@@ -103,7 +103,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords d
     else
       f3
     end
-                   CORRECTION
+  CORRECTION
 
   include_examples :accepts, 'no empty line', <<-RUBY
     begin

--- a/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
@@ -69,19 +69,19 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
 
   it 'ignores params listed on a single line' do
     expect_no_offenses(<<-RUBY.strip_indent)
-        def foo(bar, baz, bing)
-          do_something
-        end
-      RUBY
+      def foo(bar, baz, bing)
+        do_something
+      end
+    RUBY
   end
 
   it 'ignores params without parens' do
     expect_no_offenses(<<-RUBY.strip_indent)
-        def foo bar,
-          baz
-          do_something
-        end
-      RUBY
+      def foo bar,
+        baz
+        do_something
+      end
+    RUBY
   end
 
   it 'ignores single-line methods' do
@@ -90,10 +90,10 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
 
   it 'ignores methods without params' do
     expect_no_offenses(<<-RUBY.strip_indent)
-        def foo
-          bing
-        end
-      RUBY
+      def foo
+        bing
+      end
+    RUBY
   end
 
   context 'params with default values' do

--- a/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
         def foo(bar, baz, bing)
           do_something
         end
-    RUBY
+      RUBY
   end
 
   it 'ignores params without parens' do
@@ -81,7 +81,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
           baz
           do_something
         end
-    RUBY
+      RUBY
   end
 
   it 'ignores single-line methods' do
@@ -93,7 +93,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
         def foo
           bing
         end
-    RUBY
+      RUBY
   end
 
   context 'params with default values' do

--- a/spec/rubocop/cop/layout/indent_heredoc_spec.rb
+++ b/spec/rubocop/cop/layout/indent_heredoc_spec.rb
@@ -99,12 +99,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentHeredoc, :config do
         \#{foo}
         bar
         RUBY2
-                       RUBY
+      RUBY
         <<-#{quote}RUBY2#{quote}.strip_indent
           \#{foo}
           bar
         RUBY2
-                       CORRECTION
+      CORRECTION
       include_examples :offense, 'minus level indented, with `-`',
                        <<-RUBY, <<-CORRECTION
         def foo
@@ -113,14 +113,14 @@ RSpec.describe RuboCop::Cop::Layout::IndentHeredoc, :config do
         bar
           RUBY2
         end
-                       RUBY
+      RUBY
         def foo
           <<-#{quote}RUBY2#{quote}.strip_indent
             \#{foo}
             bar
           RUBY2
         end
-                       CORRECTION
+      CORRECTION
 
       include_examples :accept, 'not indented but with whitespace, with `-`',
                        <<-RUBY
@@ -129,7 +129,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentHeredoc, :config do
           something
           RUBY2
         end
-                       RUBY
+      RUBY
       include_examples :accept, 'indented, but with `-`', <<-RUBY
         def foo
           <<-#{quote}RUBY2#{quote}
@@ -203,7 +203,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentHeredoc, :config do
             \#{foo}
             bar
             RUBY2
-                           RUBY
+          RUBY
 
           type_message = 'Use 2 spaces for indentation in a heredoc by using ' \
                          '`<<~` instead of `<<-`.'
@@ -261,13 +261,13 @@ RSpec.describe RuboCop::Cop::Layout::IndentHeredoc, :config do
           something
             RUBY2
           end
-                         RUBY
+        RUBY
           def foo
             <<~#{quote}RUBY2#{quote}
               something
             RUBY2
           end
-                         CORRECTION
+        CORRECTION
         include_examples :offense, 'too deep indented', <<-RUBY, <<-CORRECTION
           <<~#{quote}RUBY2#{quote}
               something
@@ -282,22 +282,22 @@ RSpec.describe RuboCop::Cop::Layout::IndentHeredoc, :config do
           <<#{quote}RUBY2#{quote}
           foo
           RUBY2
-                         RUBY
+        RUBY
           <<~#{quote}RUBY2#{quote}
             foo
           RUBY2
-                         CORRECTION
+        CORRECTION
 
         include_examples :offense, 'not indented, with `~`',
                          <<-RUBY, <<-CORRECTION
           <<~#{quote}RUBY2#{quote}
           foo
           RUBY2
-                         RUBY
+        RUBY
           <<~#{quote}RUBY2#{quote}
             foo
           RUBY2
-                         CORRECTION
+        CORRECTION
 
         include_examples :offense, 'first line minus-level indented, with `-`',
                          <<-RUBY, <<-CORRECTION, false
@@ -306,13 +306,13 @@ RSpec.describe RuboCop::Cop::Layout::IndentHeredoc, :config do
             bar
           end
           RUBY2
-                         RUBY
+        RUBY
         puts <<~#{quote}RUBY2#{quote}
           def foo
             bar
           end
         RUBY2
-                         CORRECTION
+        CORRECTION
 
         include_examples :accept, 'indented, with `~`', <<-RUBY
           <<~#{quote}RUBY2#{quote}

--- a/spec/rubocop/cop/lint/script_permission_spec.rb
+++ b/spec/rubocop/cop/lint/script_permission_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe RuboCop::Cop::Lint::ScriptPermission do
       context 'Windows' do
         it 'allows any file permissions' do
           expect_no_offenses(<<-RUBY.strip_indent, file)
-        #!/usr/bin/ruby
+            #!/usr/bin/ruby
 
           RUBY
         end
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Cop::Lint::ScriptPermission do
         #!/usr/bin/ruby
         ^^^^^^^^^^^^^^^ Script file #{filename} doesn't have execute permission.
 
-         RUBY
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/lint/script_permission_spec.rb
+++ b/spec/rubocop/cop/lint/script_permission_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Cop::Lint::ScriptPermission do
         #!/usr/bin/ruby
         ^^^^^^^^^^^^^^^ Script file #{filename} doesn't have execute permission.
 
-        RUBY
+         RUBY
       end
     end
   end

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
             def some_method(foo)
               super
             end
-          RUBY
+           RUBY
         end
       end
     end

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
             def some_method(foo)
               super
             end
-           RUBY
+          RUBY
         end
       end
     end

--- a/spec/rubocop/cop/naming/variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/variable_name_spec.rb
@@ -55,9 +55,9 @@ RSpec.describe RuboCop::Cop::Naming::VariableName, :config do
 
     it 'registers an offense for camel case local variables marked as unused' do
       expect_offense(<<-RUBY.strip_indent)
-    _myLocal = 1
-    ^^^^^^^^ Use snake_case for variable names.
-    RUBY
+        _myLocal = 1
+        ^^^^^^^^ Use snake_case for variable names.
+      RUBY
     end
 
     it 'registers an offense for method arguments' do

--- a/spec/rubocop/cop/naming/variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/variable_name_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe RuboCop::Cop::Naming::VariableName, :config do
       expect_offense(<<-RUBY.strip_indent)
     _myLocal = 1
     ^^^^^^^^ Use snake_case for variable names.
-      RUBY
+    RUBY
     end
 
     it 'registers an offense for method arguments' do

--- a/spec/rubocop/cop/performance/regexp_match_spec.rb
+++ b/spec/rubocop/cop/performance/regexp_match_spec.rb
@@ -77,13 +77,13 @@ RSpec.describe RuboCop::Cop::Performance::RegexpMatch, :config do
           do_something
         end
       end
-                     RUBY
+    RUBY
       def foo
         if #{correction}
           do_something
         end
       end
-                     RUBY2
+    RUBY2
 
     %w[
       $& $' $` $~ $1 $2 $100
@@ -147,14 +147,14 @@ RSpec.describe RuboCop::Cop::Performance::RegexpMatch, :config do
             do_something2
           end
         end
-                       RUBY
+      RUBY
         def foo
           do_something(#{var})
           if #{correction}
             do_something2
           end
         end
-                       RUBY2
+      RUBY2
 
       include_examples :offense,
                        "#{name} in method, `#{var}` is in other method",
@@ -168,7 +168,7 @@ RSpec.describe RuboCop::Cop::Performance::RegexpMatch, :config do
         def bar
           do_something(#{var})
         end
-                       RUBY
+      RUBY
         def foo
           if #{correction}
             do_something2
@@ -178,7 +178,7 @@ RSpec.describe RuboCop::Cop::Performance::RegexpMatch, :config do
         def bar
           do_something(#{var})
         end
-                       RUBY2
+      RUBY2
 
       include_examples :offense,
                        "#{name} in class method, `#{var}` is in other method",
@@ -192,7 +192,7 @@ RSpec.describe RuboCop::Cop::Performance::RegexpMatch, :config do
         def self.bar
           do_something(#{var})
         end
-                       RUBY
+      RUBY
         def self.foo
           if #{correction}
             do_something2
@@ -202,7 +202,7 @@ RSpec.describe RuboCop::Cop::Performance::RegexpMatch, :config do
         def self.bar
           do_something(#{var})
         end
-                       RUBY2
+      RUBY2
 
       include_examples :offense,
                        "#{name} in class, `#{var}` is in method",
@@ -216,7 +216,7 @@ RSpec.describe RuboCop::Cop::Performance::RegexpMatch, :config do
             #{var}
           end
         end
-                       RUBY
+      RUBY
         class Foo
           if #{correction}
             do_something
@@ -226,7 +226,7 @@ RSpec.describe RuboCop::Cop::Performance::RegexpMatch, :config do
             #{var}
           end
         end
-                       RUBY2
+      RUBY2
 
       include_examples :offense,
                        "#{name} in module, `#{var}` is in method",
@@ -240,7 +240,7 @@ RSpec.describe RuboCop::Cop::Performance::RegexpMatch, :config do
             #{var}
           end
         end
-                       RUBY
+      RUBY
         module Foo
           if #{correction}
             do_something
@@ -250,7 +250,7 @@ RSpec.describe RuboCop::Cop::Performance::RegexpMatch, :config do
             #{var}
           end
         end
-                       RUBY2
+      RUBY2
 
       include_examples :offense, "#{name}, #{var} reference is overrided",
                        <<-RUBY, <<-RUBY2
@@ -259,13 +259,13 @@ RSpec.describe RuboCop::Cop::Performance::RegexpMatch, :config do
           #{cond}
           #{var}
         end
-                       RUBY
+      RUBY
         if #{correction}
           do_something
           #{cond}
           #{var}
         end
-                       RUBY2
+      RUBY2
     end
   end
 

--- a/spec/rubocop/cop/performance/unneeded_sort_spec.rb
+++ b/spec/rubocop/cop/performance/unneeded_sort_spec.rb
@@ -42,14 +42,14 @@ RSpec.describe RuboCop::Cop::Performance::UnneededSort do
     expect_offense(<<-RUBY.strip_indent)
       [1, 2, 3].sort[0]
                 ^^^^^^^ Use `min` instead of `sort...[0]`.
-     RUBY
+    RUBY
   end
 
   it 'registers an offense when [](0) is called on sort' do
     expect_offense(<<-RUBY.strip_indent)
       [1, 2, 3].sort.[](0)
                 ^^^^^^^^^^ Use `min` instead of `sort...[](0)`.
-     RUBY
+    RUBY
   end
 
   it 'registers an offense when at(0) is called on sort_by' do

--- a/spec/rubocop/cop/performance/unneeded_sort_spec.rb
+++ b/spec/rubocop/cop/performance/unneeded_sort_spec.rb
@@ -42,14 +42,14 @@ RSpec.describe RuboCop::Cop::Performance::UnneededSort do
     expect_offense(<<-RUBY.strip_indent)
       [1, 2, 3].sort[0]
                 ^^^^^^^ Use `min` instead of `sort...[0]`.
-    RUBY
+     RUBY
   end
 
   it 'registers an offense when [](0) is called on sort' do
     expect_offense(<<-RUBY.strip_indent)
       [1, 2, 3].sort.[](0)
                 ^^^^^^^^^^ Use `min` instead of `sort...[](0)`.
-    RUBY
+     RUBY
   end
 
   it 'registers an offense when at(0) is called on sort_by' do

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -93,12 +93,12 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
     it_behaves_like :accepts,
                     'change_column_default(with :from and :to)', <<-RUBY
       change_column_default(:posts, :state, from: nil, to: "draft")
-                    RUBY
+    RUBY
 
     it_behaves_like :offense,
                     'change_column_default(without :from and :to)', <<-RUBY
       change_column_default(:suppliers, :qualification, 'new')
-                    RUBY
+    RUBY
   end
 
   context 'remove_column' do

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
           # -*- encoding: UTF-8; frozen_string_literal: true -*-
           # encoding: utf-8
           puts 1
-      RUBY
+        RUBY
     end
 
     context 'auto-correct' do

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -147,11 +147,11 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'accepts an emacs style combined magic comment' do
       expect_no_offenses(<<-RUBY.strip_indent)
-          #!/usr/bin/env ruby
-          # -*- encoding: UTF-8; frozen_string_literal: true -*-
-          # encoding: utf-8
-          puts 1
-        RUBY
+        #!/usr/bin/env ruby
+        # -*- encoding: UTF-8; frozen_string_literal: true -*-
+        # encoding: utf-8
+        puts 1
+      RUBY
     end
 
     context 'auto-correct' do

--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -502,7 +502,7 @@ RSpec.describe RuboCop::Cop::Style::ParallelAssignment, :config do
                     'when expanding an assigned variable', <<-RUBY.strip_indent
       foo = [1, 2, 3]
       a, b, c = foo
-                    RUBY
+    RUBY
 
     describe 'using custom indentation width' do
       let(:config) do

--- a/spec/rubocop/formatter/clang_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/clang_style_formatter_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe RuboCop::Formatter::ClangStyleFormatter do
             test:1:14: C: message 1
             do_something([this, #{described_class::ELLIPSES}
                          ^^^^^^
-          OUTPUT
+        OUTPUT
       end
     end
 


### PR DESCRIPTION
## Summary

Follow up of #5557 (comment).

In the current RuboCop codes, it seems that there are many cases that are aligned at beggining of method definition, not an argument.

This PR will change to accept both the following case.

```ruby
# good
foo arg,
    <<~EOS
  Hi
EOS

# good
foo arg,
    <<~EOS
      Hi
    EOS
```

On other hand, this PR will change to deny the following case.

```ruby
# bad

# heredoc contents is before closing heredoc.
foo arg,
    <<~EOS
  Hi
    EOS
```

And this PR applies a new indentation rule, so it reverts the (auto)corrected codes in #5557.
(https://github.com/rubocop-hq/rubocop/commit/fa5f1dff4531c71648c9d96061709099770d081b)

## Other Information

Autocorrect has not been implemented yet for the case where heredoc contents are before heredoc closing.

```diff
     it 'registers an offense for camel case local variables marked as unused' do
       expect_offense(<<-RUBY.strip_indent)
-    _myLocal = 1
-    ^^^^^^^^ Use snake_case for variable names.
-    RUBY
+        _myLocal = 1
+        ^^^^^^^^ Use snake_case for variable names.
+      RUBY
     end
```

In this commit, heredoc contents are indented by hand craft.

Cc @bbatsov @Drenmi @siegfault 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
