### PR TITLE
[#5932] WIP - Breaking test added for Multiline*BraceLayout/TrailingCommaIn*Literal autocorrection

### DIFF
--- a/lib/rubocop/cop/correctors/punctuation_corrector.rb
+++ b/lib/rubocop/cop/correctors/punctuation_corrector.rb
@@ -5,6 +5,10 @@ module RuboCop
     # This auto-corrects punctuation
     class PunctuationCorrector
       class << self
+        include RangeHelp
+
+        attr_reader :processed_source
+
         def remove_space(space_before)
           ->(corrector) { corrector.remove(space_before) }
         end
@@ -13,15 +17,26 @@ module RuboCop
           ->(corrector) { corrector.replace(token.pos, token.pos.source + ' ') }
         end
 
-        def swap_comma(range)
+        def swap_comma(range, processed_source)
           return unless range
+          @processed_source = processed_source
 
           lambda do |corrector|
             case range.source
             when ',' then corrector.remove(range)
-            else          corrector.insert_after(range, ',')
+            else
+              verify_correction_still_needed(range)
+              corrector.insert_after(range, ',')
             end
           end
+        end
+
+        private
+
+        def verify_correction_still_needed(range)
+          # This should check whether the correction is still needed.
+          # However, the processed_source represents the original code and not
+          # the newly modified code.
         end
       end
     end

--- a/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
@@ -52,7 +52,7 @@ module RuboCop
         end
 
         def autocorrect(range)
-          PunctuationCorrector.swap_comma(range)
+          PunctuationCorrector.swap_comma(range, processed_source)
         end
 
         private

--- a/lib/rubocop/cop/style/trailing_comma_in_array_literal.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_array_literal.rb
@@ -49,7 +49,7 @@ module RuboCop
         end
 
         def autocorrect(range)
-          PunctuationCorrector.swap_comma(range)
+          PunctuationCorrector.swap_comma(range, processed_source)
         end
       end
     end

--- a/lib/rubocop/cop/style/trailing_comma_in_hash_literal.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_hash_literal.rb
@@ -48,7 +48,7 @@ module RuboCop
         end
 
         def autocorrect(range)
-          PunctuationCorrector.swap_comma(range)
+          PunctuationCorrector.swap_comma(range, processed_source)
         end
       end
     end

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -116,8 +116,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     end
 
     shared_examples 'corrects offenses without producing a double comma' do
-      it 'corrects TrailingCommaInLiteral and TrailingCommaInArguments ' \
-         'without producing a double comma' do
+      it 'corrects TrailingCommaInArrayLiteral, TrailingCommaInHashLiteral,' \
+         'and TrailingCommaInArguments without producing a double comma' do
         cli.run(['--auto-correct'])
 
         expect(IO.read('example.rb'))
@@ -162,6 +162,39 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         end
 
         include_examples 'corrects offenses without producing a double comma'
+
+        context 'within a nested Array' do
+          let(:source) do
+            <<-RUBY.strip_indent
+              [
+                { one: 'bar',
+                  bar: 'baz'
+                },
+                [
+                  1,
+                  2
+                ],
+              ]
+            RUBY
+          end
+
+          let(:expected_corrected_source) do
+            <<-RUBY.strip_indent
+              [
+                { one: 'bar',
+                  bar: 'baz'},,
+                [
+                  1,
+                  2,
+                ],
+              ]
+            RUBY
+          end
+
+          # The expected_corrected_source above is incorrect. Remove the
+          # double comma to produce the failure from issue #5932
+          include_examples 'corrects offenses without producing a double comma'
+        end
       end
 
       context 'and BracesAroundHashParameters style is `no_braces`' do


### PR DESCRIPTION
I'm stumped. I can duplicate the bug from #5932 with an abbreviated breaking code snippet by adding it to the `cli_autocorrect_spec.rb`. I can then track the `Layout/MultilineHashBraceLayout` cop which removes the correct extra whitespaces, and then get to the point in which `TrailingCommaInHashLiteral` adds its comma.  However, even though the whitespaces have been deleted, the `processed_source` at this last step is not updated. 

So the `PunctuationCorrector` does not have the correct code available to make it intelligent enough to account for this scenario. I need to figure out exactly why the `processed_source` is not updated, then how to access this updated code to fix the issue.

----

This can be cleaned up to just add a breaking test. Or if anyone has a suggestion for the outdated `processed_source` problem, I can finish off this fix.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
