### PR TITLE
Revert "Workaround for broke Travis with YARD 0.9.13"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'rspec', '~> 3.7'
 gem 'rubocop-rspec', '~> 1.22.0'
 gem 'simplecov', '~> 0.10'
 gem 'test-queue'
-gem 'yard', '0.9.12'
+gem 'yard', '~> 0.9'
 
 group :test do
   gem 'codeclimate-test-reporter', '~> 1.0', require: false


### PR DESCRIPTION
This reverts commit 54b71f18226121c2660cccca06b4e2a8a46ceb85.

The above issue has been resolved by YARD 0.9.14.
https://rubygems.org/gems/yard/versions/0.9.14

This PR will revert the workaround.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
