### PR TITLE
Fix unwanted warning for inherit_mode on global level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#5917](https://github.com/bbatsov/rubocop/issues/5917): Fix erroneous warning for `inherit_mode` directive. ([@jonas054][])
+
 ## 0.57.0 (2018-06-06)
 
 ### New features
@@ -31,7 +35,7 @@
 * [#5761](https://github.com/bbatsov/rubocop/pull/5761): Add `httpdate` to accepted `Rails/TimeZone` methods. ([@cupakromer][])
 * [#5899](https://github.com/bbatsov/rubocop/pull/5899): Add `xmlschema` to accepted `Rails/TimeZone` methods. ([@koic][])
 * [#5906](https://github.com/bbatsov/rubocop/pull/5906): Move REPL command from `rake repl` task to `bin/console` command. ([@koic][])
-* [#5917](https://github.com/bbatsov/rubocop/pull/5917): Let `inherit_mode` work for default configuration too. ([@jonas054][])
+* [#5917](https://github.com/bbatsov/rubocop/issues/5917): Let `inherit_mode` work for default configuration too. ([@jonas054][])
 * [#5929](https://github.com/bbatsov/rubocop/pull/5929): Stop including string extensions from `unicode/display_width`. ([@nroman-stripe][])
 
 ## 0.56.0 (2018-05-14)

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -459,6 +459,11 @@ module RuboCop
         # There could be a custom cop with this name. If so, don't warn
         next if Cop::Cop.registry.contains_cop_matching?([name])
 
+        # Special case for inherit_mode, which is a directive that we keep in
+        # the configuration (even though it's not a cop), because it's easier
+        # to do so than to pass the value around to various methods.
+        next if name == 'inherit_mode'
+
         warn Rainbow("Warning: unrecognized cop #{name} found in " \
                      "#{smart_loaded_path}").yellow
       end


### PR DESCRIPTION
PR #5924 introduced a bug. Having inherit_mode on the global level (not cop specific) would cause the warning `unrecognized cop inherit_mode found in .rubocop.yml`.

It's convenient to keep the inherit_mode directive in the `Config` object and not remove it like we do with inherit_from. So the solution is to just skip the warning.