### PR TITLE
[Fix #5954] Make `Style/UnneededCondition` accepts hard write case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#5917](https://github.com/bbatsov/rubocop/issues/5917): Fix erroneous warning for `inherit_mode` directive. ([@jonas054][])
+* [#5954](https://github.com/bbatsov/rubocop/issues/5954): Make `Style/UnneededCondition` cop accepts a case of condition and `if_branch` are same when using `elsif` branch. ([@koic][])
 
 ## 0.57.0 (2018-06-06)
 

--- a/lib/rubocop/cop/style/unneeded_condition.rb
+++ b/lib/rubocop/cop/style/unneeded_condition.rb
@@ -22,6 +22,14 @@ module RuboCop
       #
       #   # good
       #   b || c
+      #
+      #   # good
+      #   if b
+      #     b
+      #   elsif cond
+      #     c
+      #   end
+      #
       class UnneededCondition < Cop
         include RangeHelp
 
@@ -53,6 +61,8 @@ module RuboCop
         end
 
         def offense?(node)
+          return false if node.elsif_conditional?
+
           condition, if_branch, else_branch = *node
 
           condition == if_branch && !node.elsif? && (

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -6200,6 +6200,13 @@ end
 
 # good
 b || c
+
+# good
+if b
+  b
+elsif cond
+  c
+end
 ```
 
 ## Style/UnneededInterpolation

--- a/spec/rubocop/cop/style/unneeded_condition_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_condition_spec.rb
@@ -51,6 +51,18 @@ RSpec.describe RuboCop::Cop::Style::UnneededCondition do
           RUBY
         end
       end
+
+      context 'when using elsif branch' do
+        it 'registers no offense' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            if a
+              a
+            elsif cond
+              d
+            end
+          RUBY
+        end
+      end
     end
 
     describe '#autocorrection' do


### PR DESCRIPTION
Fixes #5954.

This PR will make `Style/UnneededCondition` cop accept the following case.

```ruby
if a
  a
elsif cond
  d
end
```

Becase this code is hard to write and read a one liner.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
