### PR TITLE
Bump jaro_winkler gem to 1.5.1

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => 'https://github.com/rubocop-hq/rubocop/issues'
   }
 
-  s.add_runtime_dependency('jaro_winkler', '~> 1.4.0')
+  s.add_runtime_dependency('jaro_winkler', '~> 1.5.1')
   s.add_runtime_dependency('parallel', '~> 1.10')
   s.add_runtime_dependency('parser', '>= 2.5')
   s.add_runtime_dependency('powerpack', '~> 0.1')


### PR DESCRIPTION
Was 1.4.0 in #5927 but this was a mistake. Latest version is 1.5.0.