### PR TITLE
Fix invalid tag format for example in Layout/LeadingBlankLines

### DIFF
--- a/lib/rubocop/cop/layout/leading_blank_lines.rb
+++ b/lib/rubocop/cop/layout/leading_blank_lines.rb
@@ -8,25 +8,25 @@ module RuboCop
       #
       # @example
       #
-      # # bad
-      # # (start of file)
+      #   # bad
+      #   # (start of file)
       #
-      # class Foo
-      # end
+      #   class Foo
+      #   end
       #
-      # # bad
-      # # (start of file)
+      #   # bad
+      #   # (start of file)
       #
-      # # a comment
+      #   # a comment
       #
-      # # good
-      # # (start of file)
-      # class Foo
-      # end
+      #   # good
+      #   # (start of file)
+      #   class Foo
+      #   end
       #
-      # # good
-      # # (start of file)
-      # # a comment
+      #   # good
+      #   # (start of file)
+      #   # a comment
       class LeadingBlankLines < Cop
         MSG = 'Unnecessary blank line at the beginning of the source.'.freeze
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2583,6 +2583,9 @@ Enabled | Yes
 This cop checks for unnecessary leading blank lines at the beginning
 of a file.
 
+### Examples
+
+```ruby
 # bad
 # (start of file)
 
@@ -2602,6 +2605,7 @@ end
 # good
 # (start of file)
 # a comment
+```
 
 ## Layout/LeadingCommentSpace
 


### PR DESCRIPTION
I noticed that a warning was reported when generating the document.

```
$ bundle exec rake generate_cops_documentation
[warn]: Invalid tag format for @example in file `lib/rubocop/cop/layout/leading_blank_lines.rb` near line 30
...
```

cc @rrosenblum 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
