### PR TITLE
[Fix #5963] Allow Performance/ReverseEach to add offense regardless of receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* [#5963](https://github.com/bbatsov/rubocop/issues/5963): Allow Performance/ReverseEach to apply to any receiver. ([@dvandersluis][])
 * [#5917](https://github.com/bbatsov/rubocop/issues/5917): Fix erroneous warning for `inherit_mode` directive. ([@jonas054][])
 
 ## 0.57.0 (2018-06-06)

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -42,7 +42,7 @@ module RuboCop
         end
 
         hash['inherit_from'] = Array(hash['inherit_from'])
-        Array(config_path).reverse.each do |path|
+        Array(config_path).reverse_each do |path|
           # Put gem configuration first so local configuration overrides it.
           hash['inherit_from'].unshift gem_config_path(gem_name, path)
         end

--- a/lib/rubocop/cop/performance/reverse_each.rb
+++ b/lib/rubocop/cop/performance/reverse_each.rb
@@ -19,7 +19,7 @@ module RuboCop
         UNDERSCORE = '_'.freeze
 
         def_node_matcher :reverse_each?, <<-MATCHER
-          (send $(send array :reverse) :each)
+          (send $(send _ :reverse) :each)
         MATCHER
 
         def on_send(node)

--- a/spec/rubocop/cop/performance/reverse_each_spec.rb
+++ b/spec/rubocop/cop/performance/reverse_each_spec.rb
@@ -10,6 +10,25 @@ RSpec.describe RuboCop::Cop::Performance::ReverseEach do
     RUBY
   end
 
+  it 'registers an offense when each is called on reverse on a variable' do
+    expect_offense(<<-RUBY.strip_indent)
+      arr = [1, 2, 3]
+      arr.reverse.each { |e| puts e }
+          ^^^^^^^^^^^^ Use `reverse_each` instead of `reverse.each`.
+    RUBY
+  end
+
+  it 'registers an offense when each is called on reverse on a method call' do
+    expect_offense(<<-RUBY.strip_indent)
+      def arr
+        [1, 2, 3]
+      end
+
+      arr.reverse.each { |e| puts e }
+          ^^^^^^^^^^^^ Use `reverse_each` instead of `reverse.each`.
+    RUBY
+  end
+
   it 'does not register an offense when reverse is used without each' do
     expect_no_offenses('[1, 2, 3].reverse')
   end
@@ -23,6 +42,36 @@ RSpec.describe RuboCop::Cop::Performance::ReverseEach do
       new_source = autocorrect_source('[1, 2].reverse.each { |e| puts e }')
 
       expect(new_source).to eq('[1, 2].reverse_each { |e| puts e }')
+    end
+
+    it 'corrects reverse.each to reverse_each on a variable' do
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        arr = [1, 2]
+        arr.reverse.each { |e| puts e }
+      RUBY
+
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        arr = [1, 2]
+        arr.reverse_each { |e| puts e }
+      RUBY
+    end
+
+    it 'corrects reverse.each to reverse_each on a method call' do
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        def arr
+          [1, 2]
+        end
+
+        arr.reverse.each { |e| puts e }
+      RUBY
+
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        def arr
+          [1, 2]
+        end
+
+        arr.reverse_each { |e| puts e }
+      RUBY
     end
   end
 end


### PR DESCRIPTION
This attempts to fix #5963 by having the node matcher ignore the receiver instead of being hardcoded to an array.

The caveat here is that it's possible that a class could implement `reverse.each` without implementing `reverse_each` would would cause a false positive.

I'm not sure if there's any way to verify that the receiver responds to `reverse_each` or is an enumerable in the matcher, but if there is please let me know so I can update the PR!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
