### PR TITLE
[Fix #5965] Prevent `Layout/ClosingHeredocIndentation` from raising an error on heredocs containing only a newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#5965](https://github.com/bbatsov/rubocop/issues/5965): Prevent `Layout/ClosingHeredocIndentation` from raising an error on heredocs containing only a newline. ([@drenmi][])
+
 ## 0.57.1 (2018-06-07)
 
 ### Bug fixes

--- a/lib/rubocop/cop/layout/closing_heredoc_indentation.rb
+++ b/lib/rubocop/cop/layout/closing_heredoc_indentation.rb
@@ -54,7 +54,7 @@ module RuboCop
                   'beginning of method definition.'.freeze
 
         def on_heredoc(node)
-          if node.loc.heredoc_body.source.empty? ||
+          if empty_heredoc?(node) ||
              contents_indentation(node) >= closing_indentation(node)
             return if opening_indentation(node) == closing_indentation(node)
             return if node.argument? &&
@@ -76,6 +76,10 @@ module RuboCop
 
         def opening_indentation(node)
           indent_level(heredoc_opening(node))
+        end
+
+        def empty_heredoc?(node)
+          node.loc.heredoc_body.source.empty? || !contents_indentation(node)
         end
 
         def contents_indentation(node)

--- a/spec/rubocop/cop/layout/closing_heredoc_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/closing_heredoc_indentation_spec.rb
@@ -98,6 +98,27 @@ RSpec.describe RuboCop::Cop::Layout::ClosingHeredocIndentation do
     RUBY
   end
 
+  it 'registers an offense for incorrectly indented empty heredocs' do
+    expect_offense(<<-RUBY.strip_indent)
+      def foo
+        <<-NIL
+
+          NIL
+      ^^^^^^^ `NIL` is not aligned with `<<-NIL`.
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for correctly indented empty heredocs' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def foo
+        <<-NIL
+
+        NIL
+      end
+    RUBY
+  end
+
   describe '#autocorrect' do
     it 'corrects bad indentation' do
       corrected = autocorrect_source(<<-RUBY.strip_indent)


### PR DESCRIPTION
This cop would blow up when it encountered a heredoc containing only a single newline. This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
