### PR TITLE
Prevent a crash in `Layout/IndentationConsistency` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#5965](https://github.com/bbatsov/rubocop/issues/5965): Prevent `Layout/ClosingHeredocIndentation` from raising an error on heredocs containing only a newline. ([@drenmi][])
+* Prevent a crash in `Layout/IndentationConsistency` cop triggered by an empty expression string interpolation. ([@alexander-lazarov][])
 
 ## 0.57.1 (2018-06-07)
 
@@ -3418,3 +3419,4 @@
 [@nroman-stripe]: https://github.com/nroman-stripe
 [@sunny]: https://github.com/sunny
 [@tatsuyafw]: https://github.com/tatsuyafw
+[@alexander-lazarov]: https://github.com/alexander-lazarov

--- a/lib/rubocop/cop/layout/indentation_consistency.rb
+++ b/lib/rubocop/cop/layout/indentation_consistency.rb
@@ -149,7 +149,7 @@ module RuboCop
         # is not an access modifier.
         def base_column_for_normal_style(node)
           first_child = node.children.first
-          return unless bare_access_modifier?(first_child)
+          return unless first_child && bare_access_modifier?(first_child)
 
           # If, as is most common, the access modifier is indented deeper than
           # the module (`access_modifier_indent > module_indent`) then the

--- a/spec/rubocop/cop/layout/indentation_consistency_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_consistency_spec.rb
@@ -5,6 +5,14 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
 
   let(:cop_config) { { 'EnforcedStyle' => 'normal' } }
 
+  context 'with top-level code' do
+    it 'accepts an empty expression string interpolation' do
+      expect_no_offenses(<<-'RUBY'.strip_indent)
+        "#{}"
+      RUBY
+    end
+  end
+
   context 'with if statement' do
     it 'registers an offense for bad indentation in an if body' do
       expect_offense(<<-RUBY.strip_indent)


### PR DESCRIPTION
Prevent a crash in `Layout/IndentationConsistency` cop triggered by an empty expression string interpolation.

This is the simplest code that triggers the crash:
```ruby
#{}
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/

