### PR TITLE
[Fix #5968] Don't consider << heredocs for Layout/ClosingHeredocIndentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* [#5968](https://github.com/bbatsov/rubocop/issues/5968): Prevent `Layout/ClosingHeredocIndentation` from raising an error on `<<` heredocs. ([@dvandersluis][])
 * [#5965](https://github.com/bbatsov/rubocop/issues/5965): Prevent `Layout/ClosingHeredocIndentation` from raising an error on heredocs containing only a newline. ([@drenmi][])
 * Prevent a crash in `Layout/IndentationConsistency` cop triggered by an empty expression string interpolation. ([@alexander-lazarov][])
 

--- a/lib/rubocop/cop/layout/closing_heredoc_indentation.rb
+++ b/lib/rubocop/cop/layout/closing_heredoc_indentation.rb
@@ -49,18 +49,18 @@ module RuboCop
       class ClosingHeredocIndentation < Cop
         include Heredoc
 
+        SIMPLE_HEREDOC = '<<'.freeze
         MSG = '`%<closing>s` is not aligned with `%<opening>s`.'.freeze
         MSG_ARG = '`%<closing>s` is not aligned with `%<opening>s` or ' \
                   'beginning of method definition.'.freeze
 
         def on_heredoc(node)
+          return if heredoc_type(node) == SIMPLE_HEREDOC
+
           if empty_heredoc?(node) ||
              contents_indentation(node) >= closing_indentation(node)
             return if opening_indentation(node) == closing_indentation(node)
-            return if node.argument? &&
-                      opening_indentation(
-                        find_node_used_heredoc_argument(node.parent)
-                      ) == closing_indentation(node)
+            return if argument_indentation_correct?(node)
           end
 
           add_offense(node, location: :heredoc_end)
@@ -80,6 +80,13 @@ module RuboCop
 
         def empty_heredoc?(node)
           node.loc.heredoc_body.source.empty? || !contents_indentation(node)
+        end
+
+        def argument_indentation_correct?(node)
+          node.argument? &&
+            opening_indentation(
+              find_node_used_heredoc_argument(node.parent)
+            ) == closing_indentation(node)
         end
 
         def contents_indentation(node)

--- a/lib/rubocop/cop/mixin/heredoc.rb
+++ b/lib/rubocop/cop/mixin/heredoc.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     # Common functionality for working with heredoc strings.
     module Heredoc
-      OPENING_DELIMITER = /<<[~-]?['"`]?([^'"`]+)['"`]?/
+      OPENING_DELIMITER = /(<<[~-]?)['"`]?([^'"`]+)['"`]?/
 
       def on_str(node)
         return unless node.heredoc?
@@ -21,7 +21,11 @@ module RuboCop
       private
 
       def delimiter_string(node)
-        node.source.match(OPENING_DELIMITER).captures.first
+        node.source.match(OPENING_DELIMITER).captures[1]
+      end
+
+      def heredoc_type(node)
+        node.source.match(OPENING_DELIMITER).captures[0]
       end
     end
   end

--- a/lib/rubocop/cop/naming/heredoc_delimiter_naming.rb
+++ b/lib/rubocop/cop/naming/heredoc_delimiter_naming.rb
@@ -37,17 +37,13 @@ module RuboCop
         private
 
         def meaningful_delimiters?(node)
-          delimiters = delimiters(node)
+          delimiters = delimiter_string(node)
 
           return false unless delimiters =~ /\w/
 
           blacklisted_delimiters.none? do |blacklisted_delimiter|
             delimiters =~ Regexp.new(blacklisted_delimiter)
           end
-        end
-
-        def delimiters(node)
-          node.source.match(OPENING_DELIMITER).captures.first
         end
 
         def blacklisted_delimiters

--- a/spec/rubocop/cop/layout/closing_heredoc_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/closing_heredoc_indentation_spec.rb
@@ -119,6 +119,16 @@ RSpec.describe RuboCop::Cop::Layout::ClosingHeredocIndentation do
     RUBY
   end
 
+  it 'does not register an offense for a << heredoc' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def foo
+        <<NIL
+
+      NIL
+      end
+    RUBY
+  end
+
   describe '#autocorrect' do
     it 'corrects bad indentation' do
       corrected = autocorrect_source(<<-RUBY.strip_indent)


### PR DESCRIPTION
Detects `<<` heredocs (as opposed to `<<-` or `<<~`) and doesn't add an offense for those, as they require the closing identifier to be unindented.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
