### PR TITLE
Allow prefixing memoized variables with underscores

### DIFF
--- a/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
+++ b/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
@@ -21,6 +21,11 @@ module RuboCop
       #
       #   # good
       #   def foo
+      #     @_foo ||= calculate_expensive_thing
+      #   end
+      #
+      #   # good
+      #   def foo
       #     @foo ||= begin
       #       calculate_expensive_thing
       #     end
@@ -68,7 +73,10 @@ module RuboCop
           return true if ivar_assign.nil? || method_name == :initialize
           method_name = method_name.to_s.delete('!?')
           variable = ivar_assign.children.first
-          variable_name = variable.to_s.sub('@', '')
+          variable_name = variable
+                          .to_s
+                          .sub('@_', '')
+                          .sub('@', '')
           variable_name == method_name
         end
       end

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -307,6 +307,11 @@ end
 
 # good
 def foo
+  @_foo ||= calculate_expensive_thing
+end
+
+# good
+def foo
   @foo ||= begin
     calculate_expensive_thing
   end

--- a/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
@@ -174,4 +174,14 @@ RSpec.describe RuboCop::Cop::Naming::MemoizedInstanceVariableName do
       end
     end
   end
+
+  context 'memoized variable using underscores matches method name' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def x
+          @_x ||= :foo
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
A convention to avoid instance variables leaking private details out of
their current scope is to prefix the memoized variable with an
underscore. This is commonly used in objects that exposes its values
using instance variables, i.e in how a Rails controller communicates
with its corresponding view.

This commit allows prefixing memoized instance variables to use this
syntax and not generate any warnings.