### PR TITLE
Improve usage of offense matchers and heredocs in specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,6 +51,10 @@ Layout/ClassStructure:
 Layout/IndentHeredoc:
   EnforcedStyle: powerpack
 
+# Trailing white space is meaningful in code examples
+Layout/TrailingWhitespace:
+  AllowInHeredoc: true
+
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - 'spec/**/*.rb'

--- a/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
+++ b/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::Bundler::DuplicatedGem, :config do
       end
 
       it 'does not register any offenses' do
-        expect(cop.offenses.empty?).to be(true)
+        expect(cop.offenses.empty?).to eq(true)
       end
     end
 

--- a/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
@@ -15,83 +15,67 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
     let(:cop_config) { { 'EnforcedStyle' => 'indent' } }
 
     it 'registers an offense for misaligned private' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         class Test
 
         private
+        ^^^^^^^ Indent access modifiers like `private`.
 
           def test; end
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Indent access modifiers like `private`.'])
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'outdent')
     end
 
     it 'registers an offense for misaligned private in module' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         module Test
 
          private
+         ^^^^^^^ Indent access modifiers like `private`.
 
           def test; end
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Indent access modifiers like `private`.'])
-      # Not aligned according to `indent` or `outdent` style:
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for misaligned module_function in module' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         module Test
 
          module_function
+         ^^^^^^^^^^^^^^^ Indent access modifiers like `module_function`.
 
           def test; end
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Indent access modifiers like `module_function`.'])
-      # Not aligned according to `indent` or `outdent` style:
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for correct + opposite alignment' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         module Test
 
           public
 
         private
+        ^^^^^^^ Indent access modifiers like `private`.
 
           def test; end
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Indent access modifiers like `private`.'])
-      # No EnforcedStyle can allow both alignments:
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for opposite + correct alignment' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         module Test
 
         public
+        ^^^^^^ Indent access modifiers like `public`.
 
           private
 
           def test; end
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Indent access modifiers like `public`.'])
-      # No EnforcedStyle can allow both alignments:
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for misaligned private in singleton class' do
@@ -108,22 +92,20 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
 
     it 'registers an offense for misaligned private in class ' \
        'defined with Class.new' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         Test = Class.new do
 
         private
+        ^^^^^^^ Indent access modifiers like `private`.
 
           def test; end
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Indent access modifiers like `private`.'])
     end
 
     it 'accepts misaligned private in blocks that are not recognized as ' \
        'class/module definitions' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         Test = func do
 
         private
@@ -131,22 +113,19 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
           def test; end
         end
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'registers an offense for misaligned private in module ' \
        'defined with Module.new' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         Test = Module.new do
 
         private
+        ^^^^^^^ Indent access modifiers like `private`.
 
           def test; end
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Indent access modifiers like `private`.'])
     end
 
     it 'registers an offense for misaligned protected' do
@@ -277,20 +256,17 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
 
   context 'when EnforcedStyle is set to outdent' do
     let(:cop_config) { { 'EnforcedStyle' => 'outdent' } }
-    let(:indent_msg) { 'Outdent access modifiers like `private`.' }
 
     it 'registers offense for private indented to method depth in a class' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         class Test
 
           private
+          ^^^^^^^ Outdent access modifiers like `private`.
 
           def test; end
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq([indent_msg])
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'indent')
     end
 
     it 'registers offense for private indented to method depth in a module' do
@@ -319,44 +295,41 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
 
     it 'registers offense for private indented to method depth in singleton' \
        'class' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         class << self
 
           private
+          ^^^^^^^ Outdent access modifiers like `private`.
 
           def test; end
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq([indent_msg])
     end
 
     it 'registers offense for private indented to method depth in class ' \
        'defined with Class.new' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         Test = Class.new do
 
           private
+          ^^^^^^^ Outdent access modifiers like `private`.
 
           def test; end
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq([indent_msg])
     end
 
     it 'registers offense for private indented to method depth in module ' \
        'defined with Module.new' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         Test = Module.new do
 
           private
+          ^^^^^^^ Outdent access modifiers like `private`.
 
           def test; end
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq([indent_msg])
     end
 
     it 'accepts private indented to the containing class indent level' do

--- a/spec/rubocop/cop/layout/block_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/block_alignment_spec.rb
@@ -183,27 +183,22 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
     end
 
     it 'registers offenses for misaligned ends' do
-      src = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         def foo(bar)
           bar.get_stuffs
               .reject do |stuff|
                 stuff.with_a_very_long_expression_that_doesnt_fit_the_line
                 end.select do |stuff|
+                ^^^ `end` at 5, 8 is not aligned with `bar.get_stuffs` at 2, 2 or `.reject do |stuff|` at 3, 6.
                 stuff.another_very_long_expression_that_doesnt_fit_the_line
             end
+            ^^^ `end` at 7, 4 is not aligned with `bar.get_stuffs` at 2, 2 or `end.select do |stuff|` at 5, 8.
               .select do |stuff|
                 stuff.another_very_long_expression_that_doesnt_fit_the_line
                 end
+                ^^^ `end` at 10, 8 is not aligned with `bar.get_stuffs` at 2, 2 or `.select do |stuff|` at 8, 6.
         end
       RUBY
-      inspect_source(src)
-      expect(cop.messages)
-        .to eq(['`end` at 5, 8 is not aligned with `bar.get_stuffs` at 2, 2' \
-                ' or `.reject do |stuff|` at 3, 6.',
-                '`end` at 7, 4 is not aligned with `bar.get_stuffs` at 2, 2' \
-                ' or `end.select do |stuff|` at 5, 8.',
-                '`end` at 10, 8 is not aligned with `bar.get_stuffs` at 2, 2' \
-                ' or `.select do |stuff|` at 8, 6.'])
     end
 
     # Example from issue 393 of rubocop-hq/rubocop on github:
@@ -284,16 +279,13 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
     end
 
     it 'registers an offense for end aligned with the block' do
-      src = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         e,
         f = [5, 6].map do |i|
           i - 5
             end
+            ^^^ `end` at 4, 4 is not aligned with `e,` at 1, 0 or `f = [5, 6].map do |i|` at 2, 0.
       RUBY
-      inspect_source(src)
-      expect(cop.messages)
-        .to eq(['`end` at 4, 4 is not aligned with `e,` at 1, 0 or' \
-                ' `f = [5, 6].map do |i|` at 2, 0.'])
     end
 
     it 'auto-corrects' do
@@ -323,13 +315,11 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
 
   it 'registers an offense for mismatched block end with' \
      ' an instance variable' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       @variable = test do |ala|
         end
+        ^^^ `end` at 2, 2 is not aligned with `@variable = test do |ala|` at 1, 0.
     RUBY
-    expect(cop.messages)
-      .to eq(['`end` at 2, 2 is not aligned with `@variable = test do |ala|`' \
-              ' at 1, 0.'])
   end
 
   it 'accepts end aligned with a class variable' do
@@ -404,14 +394,12 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
 
   it 'registers an offense for mismatched end with a method call' \
      ' with arguments' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       @h[:f] = f.each_pair.map do |f, v|
         v = 1
         end
+        ^^^ `end` at 3, 2 is not aligned with `@h[:f] = f.each_pair.map do |f, v|` at 1, 0.
     RUBY
-    expect(cop.messages)
-      .to eq(['`end` at 3, 2 is not aligned with' \
-              ' `@h[:f] = f.each_pair.map do |f, v|` at 1, 0.'])
   end
 
   it 'does not raise an error for nested block in a method call' do
@@ -428,14 +416,12 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
 
   it 'registers an offense for mismatched end not aligned with the block' \
      ' that is an argument' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       expect(arr.all? do |o|
         o.valid?
         end)
+        ^^^ `end` at 3, 2 is not aligned with `arr.all? do |o|` at 1, 7 or `expect(arr.all? do |o|` at 1, 0.
     RUBY
-    expect(cop.messages)
-      .to eq(['`end` at 3, 2 is not aligned with `arr.all? do |o|` at 1, 7 or' \
-              ' `expect(arr.all? do |o|` at 1, 0.'])
   end
 
   it 'accepts end aligned with an op-asgn (+=, -=)' do
@@ -676,16 +662,13 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
     end
 
     it 'errors when do aligned' do
-      src = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         foo.bar
           .each do
             baz
           end
+          ^^^ `end` at 4, 2 is not aligned with `foo.bar` at 1, 0.
       RUBY
-      inspect_source(src)
-      expect(cop.messages)
-        .to eq(['`end` at 4, 2 is not aligned with ' \
-                '`foo.bar` at 1, 0.'])
     end
 
     it 'autocorrects' do
@@ -722,16 +705,13 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
     end
 
     it 'errors when start_of_line aligned' do
-      src = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         foo.bar
           .each do
             baz
         end
+        ^^^ `end` at 4, 0 is not aligned with `.each do` at 2, 2.
       RUBY
-      inspect_source(src)
-      expect(cop.messages)
-        .to eq(['`end` at 4, 0 is not aligned with ' \
-                '`.each do` at 2, 2.'])
     end
 
     it 'autocorrects' do

--- a/spec/rubocop/cop/layout/dot_position_spec.rb
+++ b/spec/rubocop/cop/layout/dot_position_spec.rb
@@ -7,24 +7,21 @@ RSpec.describe RuboCop::Cop::Layout::DotPosition, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'leading' } }
 
     it 'registers an offense for trailing dot in multi-line call' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         something.
+                 ^ Place the . on the next line, together with the method name.
           method_name
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['.'])
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'trailing')
     end
 
     it 'registers an offense for correct + opposite' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         something
           .method_name
         something.
+                 ^ Place the . on the next line, together with the method name.
           method_name
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'accepts leading do in multi-line method call' do
@@ -112,15 +109,11 @@ RSpec.describe RuboCop::Cop::Layout::DotPosition, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'trailing' } }
 
     it 'registers an offense for leading dot in multi-line call' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         something
           .method_name
+          ^ Place the . on the previous line, together with the method call receiver.
       RUBY
-      expect(cop.messages)
-        .to eq(['Place the . on the previous line, together with the method ' \
-                'call receiver.'])
-      expect(cop.highlights).to eq(['.'])
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'leading')
     end
 
     it 'accepts trailing dot in multi-line method call' do

--- a/spec/rubocop/cop/layout/else_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/else_alignment_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::Cop::Layout::ElseAlignment do
 
     it 'accepts indentation after else when if is on new line after ' \
        'assignment' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         Rails.application.config.ideal_postcodes_key =
           if Rails.env.production? || Rails.env.staging?
             "AAAA-AAAA-AAAA-AAAA"
@@ -47,7 +47,6 @@ RSpec.describe RuboCop::Cop::Layout::ElseAlignment do
             "BBBB-BBBB-BBBB-BBBB"
           end
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     describe '#autocorrect' do

--- a/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
   let(:cop_config) { { 'AllowAdjacentOneLineDefs' => false } }
 
   it 'finds offenses in inner classes' do
-    source = <<-RUBY.strip_indent
+    expect_offense(<<-RUBY.strip_indent)
       class K
         def m
         end
@@ -14,6 +14,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
           def n
           end
           def o
+          ^^^ Use empty lines between method definitions.
           end
         end
         # checks something
@@ -21,25 +22,9 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
         end
       end
     RUBY
-    inspect_source(source)
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.offenses.map(&:line).sort).to eq([7])
   end
 
   context 'when there are only comments between defs' do
-    let(:source) do
-      <<-RUBY.strip_indent
-        class J
-          def n
-          end # n-related
-          # checks something o-related
-          # and more
-          def o
-          end
-        end
-      RUBY
-    end
-
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)
         class J
@@ -55,7 +40,17 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
     end
 
     it 'auto-corrects' do
-      corrected = autocorrect_source(source)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
+        class J
+          def n
+          end # n-related
+          # checks something o-related
+          # and more
+          def o
+          end
+        end
+      RUBY
+
       expect(corrected).to eq(<<-RUBY.strip_indent)
         class J
           def n
@@ -86,12 +81,13 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
     end
 
     it 'registers an offense for consecutive defs inside a conditional' do
-      source = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         if condition
           def foo
             true
           end
           def bar
+          ^^^ Use empty lines between method definitions.
             true
           end
         else
@@ -100,26 +96,11 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
           end
         end
       RUBY
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
     end
   end
 
   context 'class methods' do
     context 'adjacent class methods' do
-      let(:offending_source) do
-        <<-RUBY.strip_indent
-          class Test
-            def self.foo
-              true
-            end
-            def self.bar
-              true
-            end
-          end
-        RUBY
-      end
-
       it 'registers an offense for missing blank line between methods' do
         expect_offense(<<-RUBY.strip_indent)
           class Test
@@ -135,7 +116,17 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
       end
 
       it 'autocorrects it' do
-        corrected = autocorrect_source(offending_source)
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
+          class Test
+            def self.foo
+              true
+            end
+            def self.bar
+              true
+            end
+          end
+        RUBY
+
         expect(corrected).to eq(<<-RUBY.strip_indent)
           class Test
             def self.foo
@@ -151,19 +142,6 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
     end
 
     context 'mixed instance and class methods' do
-      let(:offending_source) do
-        <<-RUBY.strip_indent
-          class Test
-            def foo
-              true
-            end
-            def self.bar
-              true
-            end
-          end
-        RUBY
-      end
-
       it 'registers an offense for missing blank line between methods' do
         expect_offense(<<-RUBY.strip_indent)
           class Test
@@ -179,7 +157,17 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
       end
 
       it 'autocorrects it' do
-        corrected = autocorrect_source(offending_source)
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
+          class Test
+            def foo
+              true
+            end
+            def self.bar
+              true
+            end
+          end
+        RUBY
+
         expect(corrected).to eq(<<-RUBY.strip_indent)
           class Test
             def foo
@@ -263,12 +251,11 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
   end
 
   it 'registers an offense for adjacent one-liners by default' do
-    source = <<-RUBY.strip_indent
+    expect_offense(<<-RUBY.strip_indent)
       def a; end
       def b; end
+      ^^^ Use empty lines between method definitions.
     RUBY
-    inspect_source(source)
-    expect(cop.offenses.size).to eq(1)
   end
 
   it 'auto-corrects adjacent one-liners by default' do
@@ -311,18 +298,17 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
   end
 
   it "doesn't allow more than the required number of newlines" do
-    source = <<-RUBY.strip_indent
+    expect_offense(<<-RUBY.strip_indent)
       class A
         def n
         end
 
 
         def o
+        ^^^ Use empty lines between method definitions.
         end
       end
     RUBY
-    inspect_source(source)
-    expect(cop.offenses.size).to eq(1)
   end
 
   context 'when AllowAdjacentOneLineDefs is enabled' do
@@ -336,15 +322,15 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
     end
 
     it 'registers an offense for adjacent defs if some are multi-line' do
-      source = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         def a; end
         def b; end
         def c # Not a one-liner, so this is an offense.
+        ^^^ Use empty lines between method definitions.
         end
         def d; end # Also an offense since previous was multi-line:
+        ^^^ Use empty lines between method definitions.
       RUBY
-      inspect_source(source)
-      expect(cop.offenses.map(&:line)).to eq([3, 5])
     end
   end
 
@@ -371,20 +357,19 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
     end
 
     it 'finds an  offense for two empty lines' do
-      source = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         def n
         end
 
 
         def o
+        ^^^ Use empty lines between method definitions.
         end
       RUBY
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
     end
 
     it 'auto-corrects' do
-      source = <<-RUBY.strip_indent
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         def n
         end
 
@@ -392,7 +377,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
         def o
         end
       RUBY
-      corrected = autocorrect_source(source)
+
       expect(corrected).to eq(<<-RUBY.strip_indent)
         def n
         end
@@ -407,25 +392,24 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
     let(:cop_config) { { 'NumberOfEmptyLines' => 2 } }
 
     it 'treats lines with whitespaces as blank' do
-      source = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         def n
         end
 
         def o
+        ^^^ Use empty lines between method definitions.
         end
       RUBY
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
     end
 
     it 'auto-corrects when there are no new lines' do
-      source = <<-RUBY.strip_indent
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         def n
         end
         def o
         end
       RUBY
-      corrected = autocorrect_source(source)
+
       expect(corrected).to eq(<<-RUBY.strip_indent)
         def n
         end
@@ -437,14 +421,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
     end
 
     it 'auto-corrects when there are too few new lines' do
-      source = <<-RUBY.strip_indent
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         def n
         end
 
         def o
         end
       RUBY
-      corrected = autocorrect_source(source)
+
       expect(corrected).to eq(<<-RUBY.strip_indent)
         def n
         end
@@ -456,7 +440,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
     end
 
     it 'auto-corrects when there are too many new lines' do
-      source = <<-RUBY.strip_indent
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         def n
         end
 
@@ -466,7 +450,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
         def o
         end
       RUBY
-      corrected = autocorrect_source(source)
+
       expect(corrected).to eq(<<-RUBY.strip_indent)
         def n
         end

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
     end
 
     it "ignores comment line before #{access_modifier}" do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         class Test
           something
 
@@ -43,22 +43,20 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
           def test; end
         end
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it "ignores #{access_modifier} inside a method call" do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         class Test
           def #{access_modifier}?
             #{access_modifier}
           end
         end
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it "ignores #{access_modifier} deep inside a method call" do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         class Test
           def #{access_modifier}?
             if true
@@ -67,18 +65,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
           end
         end
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it "ignores #{access_modifier} with a right-hand-side condition" do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         class Test
           def #{access_modifier}?
             #{access_modifier} if true
           end
         end
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it "autocorrects blank line before #{access_modifier}" do

--- a/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
@@ -126,72 +126,95 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
     end
 
     it 'autocorrects empty line detected at top' do
-      corrected = autocorrect_source(['foo(',
-                                      '',
-                                      '  bar',
-                                      ')'].join("\n"))
-      expect(corrected).to eq ['foo(',
-                               '  bar',
-                               ')'].join("\n")
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
+        foo(
+
+          bar
+        )
+      RUBY
+
+      expect(corrected).to eq(<<-RUBY.strip_indent)
+        foo(
+          bar
+        )
+      RUBY
     end
 
     it 'autocorrects empty line detected at bottom' do
-      corrected = autocorrect_source(['foo(',
-                                      '  baz: 1',
-                                      '',
-                                      ')'].join("\n"))
-      expect(corrected).to eq ['foo(',
-                               '  baz: 1',
-                               ')'].join("\n")
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
+        foo(
+          baz: 1
+
+        )
+      RUBY
+
+      expect(corrected).to eq(<<-RUBY.strip_indent)
+        foo(
+          baz: 1
+        )
+      RUBY
     end
 
     it 'autocorrects empty line detected in the middle' do
-      corrected = autocorrect_source(['do_something(',
-                                      '  [baz],',
-                                      '',
-                                      '  qux: 0',
-                                      ')'].join("\n"))
-      expect(corrected).to eq ['do_something(',
-                               '  [baz],',
-                               '  qux: 0',
-                               ')'].join("\n")
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
+        do_something(
+          [baz],
+
+          qux: 0
+        )
+      RUBY
+
+      expect(corrected).to eq(<<-RUBY.strip_indent)
+        do_something(
+          [baz],
+          qux: 0
+        )
+      RUBY
     end
 
     it 'autocorrects multiple empty lines' do
-      corrected = autocorrect_source(['do_stuff(',
-                                      '  baz,',
-                                      '',
-                                      '  qux,',
-                                      '',
-                                      '  bar: 0,',
-                                      '',
-                                      ')'].join("\n"))
-      expect(corrected).to eq ['do_stuff(',
-                               '  baz,',
-                               '  qux,',
-                               '  bar: 0,',
-                               ')'].join("\n")
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
+        do_stuff(
+          baz,
+
+          qux,
+
+          bar: 0,
+        )
+      RUBY
+
+      expect(corrected).to eq(<<-RUBY.strip_indent)
+        do_stuff(
+          baz,
+          qux,
+          bar: 0,
+        )
+      RUBY
     end
 
     it 'autocorrects args that start on definition line' do
-      corrected = autocorrect_source(['bar(qux,',
-                                      '',
-                                      '    78)'].join("\n"))
-      expect(corrected).to eq ['bar(qux,',
-                               '    78)'].join("\n")
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
+        bar(qux,
+
+            78)
+      RUBY
+
+      expect(corrected).to eq(<<-RUBY.strip_indent)
+        bar(qux,
+            78)
+      RUBY
     end
   end
 
   context 'when no extra lines' do
     it 'accpets one line methods' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         foo(bar)
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'accepts multiple listed mixed args' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         foo(
           bar,
           [],
@@ -199,31 +222,28 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
           qux: 2
         )
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'accepts listed args starting on definition line' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         foo(bar,
             [],
             qux: 2)
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'accepts block argument with empty line' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         Foo.prepend(Module.new do
           def something; end
 
           def anything; end
         end)
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'accepts method with argument that trails off block' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         fred.map do
           <<-EOT
             bar
@@ -232,51 +252,46 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
           EOT
         end.join("\n")
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'accepts method with no arguments that trails off block' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         foo.baz do
 
           bar
         end.compact
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'accepts method with argument that trails off heredoc' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         bar(<<-DOCS)
           foo
 
         DOCS
           .call!(true)
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     context 'with one argument' do
       it 'ignores empty lines inside of method arguments' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           private(def bar
 
             baz
           end)
         RUBY
-        expect(cop.offenses.empty?).to be(true)
       end
     end
 
     context 'with multiple arguments' do
       it 'ignores empty lines inside of method arguments' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           foo(:bar, [1,
 
                      2]
           )
         RUBY
-        expect(cop.offenses.empty?).to be(true)
       end
     end
   end

--- a/spec/rubocop/cop/layout/empty_lines_around_begin_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_begin_body_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
 
   shared_examples 'accepts' do |name, code|
     it "accepts #{name}" do
-      inspect_source(code)
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(code)
     end
   end
 

--- a/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
@@ -9,37 +9,49 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBlockBody, :config do
       let(:cop_config) { { 'EnforcedStyle' => 'no_empty_lines' } }
 
       it 'registers an offense for block body starting with a blank' do
-        inspect_source(["some_method #{open}",
-                        '',
-                        '  do_something',
-                        close])
+        inspect_source(<<-RUBY.strip_indent)
+          some_method #{open}
+
+            do_something
+          #{close}
+        RUBY
+
         expect(cop.messages)
           .to eq(['Extra empty line detected at block body beginning.'])
       end
 
       it 'autocorrects block body containing only a blank' do
-        corrected = autocorrect_source(["some_method #{open}",
-                                        '',
-                                        close])
-        expect(corrected).to eq ["some_method #{open}",
-                                 close].join("\n")
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
+          some_method #{open}
+
+          #{close}
+        RUBY
+
+        expect(corrected).to eq(<<-RUBY.strip_indent)
+          some_method #{open}
+          #{close}
+        RUBY
       end
 
       it 'registers an offense for block body ending with a blank' do
-        inspect_source(["some_method #{open}",
-                        '  do_something',
-                        '',
-                        close])
+        inspect_source(<<-RUBY.strip_indent)
+          some_method #{open}
+            do_something
+
+            #{close}
+        RUBY
+
         expect(cop.messages)
           .to eq(['Extra empty line detected at block body end.'])
       end
 
       it 'accepts block body starting with a line with spaces' do
-        inspect_source(["some_method #{open}",
-                        '  ',
-                        '  do_something',
-                        close])
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(<<-RUBY.strip_indent)
+          some_method #{open}
+            
+            do_something
+          #{close}
+        RUBY
       end
 
       it 'is not fooled by single line blocks' do
@@ -56,9 +68,12 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBlockBody, :config do
 
       it 'registers an offense for block body not starting or ending with a ' \
          'blank' do
-        inspect_source(["some_method #{open}",
-                        '  do_something',
-                        close])
+        inspect_source(<<-RUBY.strip_indent)
+          some_method #{open}
+            do_something
+          #{close}
+        RUBY
+
         expect(cop.messages).to eq(['Empty line missing at block body '\
                                     'beginning.',
                                     'Empty line missing at block body end.'])
@@ -71,14 +86,19 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBlockBody, :config do
       end
 
       it 'autocorrects beginning and end' do
-        new_source = autocorrect_source(["some_method #{open}",
-                                         '  do_something',
-                                         close])
-        expect(new_source).to eq(["some_method #{open}",
-                                  '',
-                                  '  do_something',
-                                  '',
-                                  close].join("\n"))
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+          some_method #{open}
+            do_something
+          #{close}
+        RUBY
+
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          some_method #{open}
+
+            do_something
+
+          #{close}
+        RUBY
       end
 
       it 'is not fooled by single line blocks' do

--- a/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords d
 
   shared_examples 'accepts' do |name, code|
     it "accepts #{name}" do
-      inspect_source(code)
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(code)
     end
   end
 

--- a/spec/rubocop/cop/layout/empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_spec.rb
@@ -4,13 +4,30 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLines do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for consecutive empty lines' do
-    inspect_source(['test = 5', '', '', '', 'top'])
+    inspect_source(<<-RUBY.strip_indent)
+      test = 5
+
+
+
+      top
+    RUBY
     expect(cop.offenses.size).to eq(2)
   end
 
   it 'auto-corrects consecutive empty lines' do
-    corrected = autocorrect_source(['test = 5', '', '', '', 'top'])
-    expect(corrected).to eq ['test = 5', '', 'top'].join("\n")
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
+      test = 5
+
+
+
+      top
+    RUBY
+
+    expect(corrected).to eq(<<-RUBY.strip_indent)
+      test = 5
+
+      top
+    RUBY
   end
 
   it 'works when there are no tokens' do

--- a/spec/rubocop/cop/layout/end_of_line_spec.rb
+++ b/spec/rubocop/cop/layout/end_of_line_spec.rb
@@ -64,7 +64,12 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
 
     context 'and there are many lines ending with LF' do
       it 'registers only one offense' do
-        inspect_source_file(['x=0', '', 'y=1'].join("\n"))
+        inspect_source_file(<<-RUBY.strip_indent)
+          x=0
+
+          y=1
+        RUBY
+
         expect(cop.messages.size).to eq(1)
       end
 

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -7,27 +7,25 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
     it 'registers an offense for alignment with token not preceded by space' do
       # The = and the ( are on the same column, but this is not for alignment,
       # it's just a mistake.
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         website("example.org")
         name   = "Jill"
+            ^^ Unnecessary spacing detected.
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
 
     it 'accepts aligned values of an implicit hash literal' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         register(street1:    '1 Market',
                  street2:    '#200',
                  :city =>    'Some Town',
                  state:      'CA',
                  postal_code:'99999-1111')
       RUBY
-      inspect_source(source)
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'accepts space between key and value in a hash with hash rockets' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         ospf_h = {
           'ospfTest'    => {
             'foo'      => {
@@ -47,59 +45,58 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
           }
         }
       RUBY
-      inspect_source(source)
-      expect(cop.offenses.empty?).to be(true)
     end
 
     context 'when spaces are present in a single-line hash literal' do
       it 'registers an offense for hashes with symbol keys' do
-        inspect_source('hash = {a:   1,  b:    2}')
-        expect(cop.offenses.size).to eq(3)
+        expect_offense(<<-RUBY.strip_indent)
+          hash = {a:   1,  b:    2}
+                    ^^ Unnecessary spacing detected.
+                         ^ Unnecessary spacing detected.
+                             ^^^ Unnecessary spacing detected.
+        RUBY
       end
 
       it 'registers an offense for hashes with hash rockets' do
-        source = <<-RUBY.strip_indent
+        expect_offense(<<-RUBY.strip_indent)
           let(:single_line_hash) {
             {"a"   => "1", "b" => "2"}
+                ^^ Unnecessary spacing detected.
           }
         RUBY
-
-        inspect_source(source)
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.offenses.first.line).to eq(2)
       end
     end
 
     it 'can handle extra space before a float' do
-      source = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         {:a => "a",
          :b => [nil,  2.5]}
+                    ^ Unnecessary spacing detected.
       RUBY
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
     end
 
     it 'can handle unary plus in an argument list' do
-      source = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         assert_difference(MyModel.count, +2,
                           3,  +3, # Extra spacing only here.
+                            ^ Unnecessary spacing detected.
                           4,+4)
       RUBY
-      inspect_source(source)
-      expect(cop.offenses.map { |o| o.location.line }).to eq([2])
     end
 
     it 'gives the correct line' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         class A   < String
+               ^^ Unnecessary spacing detected.
         end
       RUBY
-      expect(cop.offenses.first.location.line).to eq(1)
     end
 
     it 'registers an offense for double extra spacing on variable assignment' do
-      inspect_source('m    = "hello"')
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        m    = "hello"
+         ^^^ Unnecessary spacing detected.
+      RUBY
     end
 
     it 'ignores whitespace at the beginning of the line' do
@@ -111,17 +108,16 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
     end
 
     it 'ignores trailing whitespace' do
-      inspect_source(['      class Benchmarker < Performer     ',
-                      '      end'])
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(['      class Benchmarker < Performer     ',
+                          '      end'])
     end
 
     it 'registers an offense on class inheritance' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         class A   < String
+               ^^ Unnecessary spacing detected.
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
 
     it 'auto-corrects a line indented with mixed whitespace' do
@@ -232,8 +228,7 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
       sources.each do |reason, src|
         context "such as #{reason}" do
           it 'allows it' do
-            inspect_source(src)
-            expect(cop.offenses.empty?).to be(true)
+            expect_no_offenses(src)
           end
         end
       end
@@ -265,17 +260,14 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
     end
 
     it 'registers an offense if consecutive assignments are not aligned' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a = 1
+          ^ `=` is not aligned with the following assignment.
         bb = 2
+           ^ `=` is not aligned with the preceding assignment.
         ccc = 3
+            ^ `=` is not aligned with the preceding assignment.
       RUBY
-      expect(cop.offenses.size).to eq(3)
-      expect(cop.messages).to eq(
-        ['`=` is not aligned with the following assignment.',
-         '`=` is not aligned with the preceding assignment.',
-         '`=` is not aligned with the preceding assignment.']
-      )
     end
 
     it 'does not register an offense if assignments are separated by blanks' do
@@ -390,12 +382,11 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
 
     it 'does not register an offense when optarg equals is not aligned with ' \
        'assignment equals sign' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         def method(arg = 1)
           var = arg
         end
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
   end
 end

--- a/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
@@ -22,12 +22,11 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak do
     it 'autocorrects the offense' do
       new_source = autocorrect_source(source)
 
-      expect(new_source).to eq([
-        'foo(',
-        'bar,',
-        '  baz)',
-        ''
-      ].join("\n"))
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        foo(
+        bar,
+          baz)
+      RUBY
     end
   end
 
@@ -50,12 +49,11 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak do
     it 'autocorrects the offense' do
       new_source = autocorrect_source(source)
 
-      expect(new_source).to eq([
-        'something(',
-        '3, bar: 1,',
-        'baz: 2)',
-        ''
-      ].join("\n"))
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        something(
+        3, bar: 1,
+        baz: 2)
+      RUBY
     end
   end
 
@@ -78,12 +76,11 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak do
     it 'autocorrects the offense' do
       new_source = autocorrect_source(source)
 
-      expect(new_source).to eq([
-        'something(',
-        'bar: 1,',
-        'baz: 2)',
-        ''
-      ].join("\n"))
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        something(
+        bar: 1,
+        baz: 2)
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
@@ -24,14 +24,13 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
     it 'autocorrects the offense' do
       new_source = autocorrect_source(source)
 
-      expect(new_source).to eq([
-        'def foo(',
-        'bar,',
-        '  baz)',
-        '  do_something',
-        'end',
-        ''
-      ].join("\n"))
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        def foo(
+        bar,
+          baz)
+          do_something
+        end
+      RUBY
     end
   end
 
@@ -56,14 +55,13 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
     it 'autocorrects the offense' do
       new_source = autocorrect_source(source)
 
-      expect(new_source).to eq([
-        'def self.foo(',
-        'bar,',
-        '  baz)',
-        '  do_something',
-        'end',
-        ''
-      ].join("\n"))
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        def self.foo(
+        bar,
+          baz)
+          do_something
+        end
+      RUBY
     end
   end
 
@@ -117,14 +115,13 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
     it 'autocorrects the offense' do
       new_source = autocorrect_source(source)
 
-      expect(new_source).to eq([
-        'def foo(',
-        'bar = [],',
-        '  baz = 2)',
-        '  do_something',
-        'end',
-        ''
-      ].join("\n"))
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        def foo(
+        bar = [],
+          baz = 2)
+          do_something
+        end
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
@@ -84,13 +84,12 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
       context 'for assignment' do
         it 'accepts a correctly indented first parameter and does not care ' \
            'about the second parameter' do
-          inspect_source(<<-RUBY.strip_indent)
+          expect_no_offenses(<<-RUBY.strip_indent)
             x = run(
               :foo,
                 bar: 3
             )
           RUBY
-          expect(cop.offenses.empty?).to be(true)
         end
 
         context 'with line break' do
@@ -103,12 +102,12 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
           end
 
           it 'registers an offense for an under-indented first parameter' do
-            inspect_source(<<-RUBY.strip_indent)
+            expect_offense(<<-RUBY.strip_indent)
               @x =
                 run(
                 :foo)
+                ^^^^ Indent the first parameter one step more than the start of the previous line.
             RUBY
-            expect(cop.highlights).to eq([':foo'])
           end
         end
       end
@@ -131,28 +130,24 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
         end
 
         it 'registers an offense for an over-indented first parameter' do
-          inspect_source(<<-RUBY.strip_indent)
+          expect_offense(<<-RUBY.strip_indent)
             puts x.
               merge(
                   b: 2
+                  ^^^^ Indent the first parameter one step more than the start of the previous line.
               )
           RUBY
-          expect(cop.messages).to eq(['Indent the first parameter one step ' \
-                                      'more than the start of the ' \
-                                      'previous line.'])
-          expect(cop.highlights).to eq(['b: 2'])
         end
 
         it 'accepts a correctly indented first parameter preceded by an ' \
            'empty line' do
-          inspect_source(<<-RUBY.strip_indent)
+          expect_no_offenses(<<-RUBY.strip_indent)
             puts x.
               merge(
 
                 b: 2
               )
           RUBY
-          expect(cop.offenses.empty?).to be(true)
         end
 
         context 'when preceded by a comment line' do
@@ -167,17 +162,14 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
           end
 
           it 'registers an offense for an under-indented first parameter' do
-            inspect_source(<<-RUBY.strip_indent)
+            expect_offense(<<-RUBY.strip_indent)
               puts x.
                 merge(
                 # comment
                 b: 2
+                ^^^^ Indent the first parameter one step more than the start of the previous line (not counting the comment).
                 )
             RUBY
-            expect(cop.messages).to eq(['Indent the first parameter one step ' \
-                                        'more than the start of the previous ' \
-                                        'line (not counting the comment).'])
-            expect(cop.highlights).to eq(['b: 2'])
           end
         end
       end
@@ -206,13 +198,12 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
       end
 
       it 'does not view chained call as an outer method call' do
-        inspect_source(<<-'RUBY'.strip_margin('|'))
+        expect_no_offenses(<<-'RUBY'.strip_margin('|'))
           |  A = Regexp.union(
           |    /[A-Za-z_][A-Za-z\d_]*[!?=]?/,
           |    *AST::Types::OPERATOR_METHODS.map(&:to_s)
           |  ).freeze
         RUBY
-        expect(cop.offenses.empty?).to be(true)
       end
 
       it 'auto-corrects an under-indented first parameter' do
@@ -361,11 +352,10 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
 
         it 'accepts a correctly indented first parameter with fullwidth ' \
            'characters' do
-          inspect_source(<<-RUBY.strip_indent)
+          expect_no_offenses(<<-RUBY.strip_indent)
             puts('Ｒｕｂｙ', f(
                                a))
           RUBY
-          expect(cop.offenses.empty?).to be(true)
         end
       end
 

--- a/spec/rubocop/cop/layout/indent_array_spec.rb
+++ b/spec/rubocop/cop/layout/indent_array_spec.rb
@@ -50,15 +50,11 @@ RSpec.describe RuboCop::Cop::Layout::IndentArray do
     end
 
     it 'registers an offense for incorrectly indented ]' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a << [
           ]
+          ^ Indent the right bracket the same as the start of the line where the left bracket is.
       RUBY
-      expect(cop.highlights).to eq([']'])
-      expect(cop.messages)
-        .to eq(['Indent the right bracket the same as the start of the line ' \
-                'where the left bracket is.'])
-      expect(cop.config_to_allow_offenses.empty?).to be(true)
     end
 
     context 'when indentation width is overridden for this cop' do
@@ -73,13 +69,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentArray do
       end
 
       it 'registers an offense for incorrectly indented first element' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           a << [
             1
+            ^ Use 4 spaces for indentation in an array, relative to the start of the line where the left square bracket is.
           ]
         RUBY
-        expect(cop.highlights).to eq(['1'])
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
     end
   end
@@ -96,32 +91,27 @@ RSpec.describe RuboCop::Cop::Layout::IndentArray do
     end
 
     it 'registers an offense for incorrectly indented first element' do
-      inspect_source(<<-RUBY.strip_margin('|'))
-        |   config.rack_cache = [
-        |   "rails:/",
-        |   "rails:/",
-        |   false
-        |   ]
+      expect_offense(<<-RUBY.strip_indent)
+        config.rack_cache = [
+        "rails:/",
+        ^^^^^^^^^ Use 2 spaces for indentation in an array, relative to the start of the line where the left square bracket is.
+        "rails:/",
+        false
+        ]
       RUBY
-      expect(cop.highlights).to eq(['"rails:/"'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
   end
 
   context 'when array is right hand side in assignment' do
     it 'registers an offense for incorrectly indented first element' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a = [
             1,
+            ^ Use 2 spaces for indentation in an array, relative to the start of the line where the left square bracket is.
           2,
          3
         ]
       RUBY
-      expect(cop.messages)
-        .to eq(['Use 2 spaces for indentation in an array, relative to the ' \
-                'start of the line where the left square bracket is.'])
-      expect(cop.highlights).to eq(['1'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'auto-corrects incorrectly indented first element' do
@@ -205,34 +195,23 @@ RSpec.describe RuboCop::Cop::Layout::IndentArray do
         end
 
         it "registers an offense for 'consistent' indentation" do
-          inspect_source(<<-RUBY.strip_indent)
+          expect_offense(<<-RUBY.strip_indent)
             func([
               1
+              ^ Use 2 spaces for indentation in an array, relative to the first position after the preceding left parenthesis.
             ])
+            ^ Indent the right bracket the same as the first position after the preceding left parenthesis.
           RUBY
-          expect(cop.messages)
-            .to eq(['Use 2 spaces for indentation in an array, relative to ' \
-                    'the first position after the preceding left parenthesis.',
-                    'Indent the right bracket the same as the first position ' \
-                    'after the preceding left parenthesis.'])
-          expect(cop.config_to_allow_offenses)
-            .to eq('EnforcedStyle' => 'consistent')
         end
 
         it "registers an offense for 'align_brackets' indentation" do
-          inspect_source(<<-RUBY.strip_indent)
+          expect_offense(<<-RUBY.strip_indent)
             var = [
                     1
+                    ^ Use 2 spaces for indentation in an array, relative to the start of the line where the left square bracket is.
                   ]
+                  ^ Indent the right bracket the same as the start of the line where the left bracket is.
           RUBY
-          # since there are no parens, warning message is for 'consistent' style
-          expect(cop.messages)
-            .to eq(['Use 2 spaces for indentation in an array, relative to ' \
-                    'the start of the line where the left square bracket is.',
-                    'Indent the right bracket the same as the start of the ' \
-                    'line where the left bracket is.'])
-          expect(cop.config_to_allow_offenses)
-            .to eq('EnforcedStyle' => 'align_brackets')
         end
 
         it 'auto-corrects incorrectly indented first element' do
@@ -290,18 +269,13 @@ RSpec.describe RuboCop::Cop::Layout::IndentArray do
         end
 
         it 'registers an offense for incorrect indentation' do
-          inspect_source(<<-RUBY.strip_indent)
+          expect_offense(<<-RUBY.strip_indent)
             func([
                    1
+                   ^ Use 2 spaces for indentation in an array, relative to the start of the line where the left square bracket is.
                  ])
+                 ^ Indent the right bracket the same as the start of the line where the left bracket is.
           RUBY
-          expect(cop.messages)
-            .to eq(['Use 2 spaces for indentation in an array, relative to ' \
-                    'the start of the line where the left square bracket is.',
-                    'Indent the right bracket the same as the start of the ' \
-                    'line where the left bracket is.'])
-          expect(cop.config_to_allow_offenses)
-            .to eq('EnforcedStyle' => 'special_inside_parentheses')
         end
 
         it 'accepts normal indentation for second argument' do
@@ -331,15 +305,11 @@ RSpec.describe RuboCop::Cop::Layout::IndentArray do
 
       it 'registers an offense for incorrectly indented multi-line array ' \
          'with brackets' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           func x, [
                  1, 2]
+                 ^ Use 2 spaces for indentation in an array, relative to the start of the line where the left square bracket is.
         RUBY
-        expect(cop.messages)
-          .to eq(['Use 2 spaces for indentation in an array, relative to the ' \
-                  'start of the line where the left square bracket is.'])
-        expect(cop.highlights).to eq(['1'])
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
     end
   end
@@ -417,32 +387,25 @@ RSpec.describe RuboCop::Cop::Layout::IndentArray do
 
     context "when 'special_inside_parentheses' style is used" do
       it 'registers an offense for incorrect indentation' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           var = [
             1
+            ^ Use 2 spaces for indentation in an array, relative to the position of the opening bracket.
           ]
+          ^ Indent the right bracket the same as the left bracket.
           func([
                  1
                ])
         RUBY
-        expect(cop.messages)
-          .to eq(['Use 2 spaces for indentation in an array, relative to the' \
-                  ' position of the opening bracket.',
-                  'Indent the right bracket the same as the left bracket.'])
-        expect(cop.config_to_allow_offenses)
-          .to eq('EnforcedStyle' => 'special_inside_parentheses')
       end
     end
 
     it 'registers an offense for incorrectly indented ]' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a << [
           ]
+          ^ Indent the right bracket the same as the left bracket.
       RUBY
-      expect(cop.highlights).to eq([']'])
-      expect(cop.messages)
-        .to eq(['Indent the right bracket the same as the left bracket.'])
-      expect(cop.config_to_allow_offenses.empty?).to be(true)
     end
 
     context 'when indentation width is overridden for this cop' do

--- a/spec/rubocop/cop/layout/indent_hash_spec.rb
+++ b/spec/rubocop/cop/layout/indent_hash_spec.rb
@@ -27,15 +27,11 @@ RSpec.describe RuboCop::Cop::Layout::IndentHash do
 
   shared_examples 'right brace' do
     it 'registers an offense for incorrectly indented }' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a << {
           }
+          ^ Indent the right brace the same as the start of the line where the left brace is.
       RUBY
-      expect(cop.highlights).to eq(['}'])
-      expect(cop.messages)
-        .to eq(['Indent the right brace the same as the start of the line ' \
-                'where the left brace is.'])
-      expect(cop.config_to_allow_offenses.empty?).to be(true)
     end
   end
 
@@ -484,32 +480,25 @@ RSpec.describe RuboCop::Cop::Layout::IndentHash do
 
     context "when 'special_inside_parentheses' style is used" do
       it 'registers an offense for incorrect indentation' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           var = {
             a: 1
+            ^^^^ Use 2 spaces for indentation in a hash, relative to the position of the opening brace.
           }
+          ^ Indent the right brace the same as the left brace.
           func({
                  a: 1
                })
         RUBY
-        expect(cop.messages)
-          .to eq(['Use 2 spaces for indentation in a hash, relative to the' \
-                  ' position of the opening brace.',
-                  'Indent the right brace the same as the left brace.'])
-        expect(cop.config_to_allow_offenses)
-          .to eq('EnforcedStyle' => 'special_inside_parentheses')
       end
     end
 
     it 'registers an offense for incorrectly indented }' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a << {
           }
+          ^ Indent the right brace the same as the left brace.
       RUBY
-      expect(cop.highlights).to eq(['}'])
-      expect(cop.messages)
-        .to eq(['Indent the right brace the same as the left brace.'])
-      expect(cop.config_to_allow_offenses.empty?).to be(true)
     end
   end
 end

--- a/spec/rubocop/cop/layout/indent_heredoc_spec.rb
+++ b/spec/rubocop/cop/layout/indent_heredoc_spec.rb
@@ -28,8 +28,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentHeredoc, :config do
 
   shared_examples 'accept' do |name, code|
     it "accepts for #{name}" do
-      inspect_source(code.strip_indent)
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(code.strip_indent)
     end
   end
 

--- a/spec/rubocop/cop/layout/indentation_consistency_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_consistency_spec.rb
@@ -154,26 +154,24 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
 
     it 'accepts an if/else in assignment with end aligned with variable ' \
        'and chaining after the end' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         var = if a
           0
         else
           1
         end.abc.join("")
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'accepts an if/else in assignment with end aligned with variable ' \
        'and chaining with a block after the end' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         var = if a
           0
         else
           1
         end.abc.tap {}
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'accepts an if in assignment with end aligned with if' do
@@ -196,7 +194,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
 
     it 'accepts an if/else in assignment on next line with end aligned ' \
        'with if' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         var =
           if a
             0
@@ -204,7 +202,6 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
             1
           end
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'accepts an if/else branches with rescue clauses' do
@@ -493,7 +490,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
 
       it 'registers an offense for bad indentation in def but not for ' \
          'outdented public, protected, and private' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           class Test
           public
 
@@ -508,11 +505,10 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
           private
 
            def g
+           ^^^^^ Inconsistent indentation detected.
            end
           end
         RUBY
-        expect(cop.messages).to eq(['Inconsistent indentation detected.'])
-        expect(cop.highlights).to eq(["def g\n end"])
       end
     end
   end

--- a/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
@@ -119,10 +119,11 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
 
     new_source = autocorrect_source(src)
 
-    expect(new_source).to eq(['test do |foo| ',
-                              '  bar',
-                              'end',
-                              ''].join("\n"))
+    expect(new_source).to eq(<<-RUBY.strip_indent)
+      test do |foo| 
+        bar
+      end
+    RUBY
   end
 
   it 'auto-corrects a do/end block with a mult-line body' do
@@ -134,11 +135,12 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
 
     new_source = autocorrect_source(src)
 
-    expect(new_source).to eq(['test do |foo| ',
-                              '  bar',
-                              '  test',
-                              'end',
-                              ''].join("\n"))
+    expect(new_source).to eq(<<-RUBY.strip_indent)
+      test do |foo| 
+        bar
+        test
+      end
+    RUBY
   end
 
   it 'auto-corrects a {} block with params that is missing newlines' do
@@ -149,10 +151,11 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
 
     new_source = autocorrect_source(src)
 
-    expect(new_source).to eq(['test { |foo| ',
-                              '  bar',
-                              '}',
-                              ''].join("\n"))
+    expect(new_source).to eq(<<-RUBY.strip_indent)
+      test { |foo| 
+        bar
+      }
+    RUBY
   end
 
   it 'autocorrects in more complex case with lambda and assignment, and '\
@@ -165,11 +168,12 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
 
     new_source = autocorrect_source(src)
 
-    expect(new_source).to eq(['x = -> (y) { ',
-                              '      foo',
-                              '  bar',
-                              '}',
-                              ''].join("\n"))
+    expect(new_source).to eq(<<-RUBY.strip_indent)
+      x = -> (y) { 
+            foo
+        bar
+      }
+    RUBY
   end
 
   it 'auto-corrects a line-break before arguments' do

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'accepts indented methods inside and outside a block' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         a = b.map do |c|
           c
             .b
@@ -34,7 +34,6 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
             end
         end
       RUBY
-      expect(cop.messages.empty?).to be(true)
     end
 
     it 'accepts indentation relative to first receiver' do
@@ -46,66 +45,59 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'accepts indented methods in ordinary statement' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         a.
           b
       RUBY
-      expect(cop.messages.empty?).to be(true)
     end
 
     it 'accepts no extra indentation of third line' do
-      inspect_source(<<-RUBY.strip_margin('|'))
-        |   a.
-        |     b.
-        |     c
+      expect_no_offenses(<<-RUBY.strip_indent)
+        a.
+          b.
+          c
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'accepts indented methods in for body' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         for x in a
           something.
             something_else
         end
       RUBY
-      expect(cop.highlights.empty?).to be(true)
     end
 
     it 'accepts alignment inside a grouped expression' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         (a.
          b)
       RUBY
-      expect(cop.messages.empty?).to be(true)
     end
 
     it 'accepts an expression where the first method spans multiple lines' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         subject.each do |item|
           result = resolve(locale) and return result
         end.a
       RUBY
-      expect(cop.messages.empty?).to be(true)
     end
 
     it 'accepts any indentation of parameters to #[]' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         payment = Models::IncomingPayments[
                 id:      input['incoming-payment-id'],
                    user_id: @user[:id]]
       RUBY
-      expect(cop.messages.empty?).to be(true)
     end
 
     it "doesn't fail on unary operators" do
-      inspect_source(<<-RUBY.strip_indent)
+      expect { inspect_source(<<-RUBY.strip_indent) }.not_to raise_error
         def foo
           !0
           .nil?
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
 
     it "doesn't crash on unaligned multiline lambdas" do
@@ -118,94 +110,76 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
 
   shared_examples 'common for aligned and indented' do
     it 'accepts even indentation of consecutive lines in typical RSpec code' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         expect { Foo.new }.
           to change { Bar.count }.
           from(1).to(2)
       RUBY
-      expect(cop.messages.empty?).to be(true)
     end
 
     it 'registers an offense for no indentation of second line' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a.
         b
+        ^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
       RUBY
-      expect(cop.messages)
-        .to eq(['Use 2 (not 0) spaces for indenting an expression spanning ' \
-                'multiple lines.'])
-      expect(cop.highlights).to eq(['b'])
     end
 
     it 'registers an offense for 3 spaces indentation of second line' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a.
            b
+           ^ Use 2 (not 3) spaces for indenting an expression spanning multiple lines.
         c.
            d
+           ^ Use 2 (not 3) spaces for indenting an expression spanning multiple lines.
       RUBY
-      expect(cop.messages)
-        .to eq(['Use 2 (not 3) spaces for indenting an expression spanning ' \
-                'multiple lines.'] * 2)
-      expect(cop.highlights).to eq(%w[b d])
     end
 
     it 'registers an offense for extra indentation of third line' do
-      inspect_source(<<-RUBY.strip_margin('|'))
-        |   a.
-        |     b.
-        |       c
+      expect_offense(<<-RUBY.strip_indent)
+        a.
+          b.
+            c
+            ^ Use 2 (not 4) spaces for indenting an expression spanning multiple lines.
       RUBY
-      expect(cop.messages)
-        .to eq(['Use 2 (not 4) spaces for indenting an expression spanning ' \
-                'multiple lines.'])
-      expect(cop.highlights).to eq(['c'])
     end
 
     it 'registers an offense for the emacs ruby-mode 1.1 indentation of an ' \
        'expression in an array' do
-      inspect_source(<<-RUBY.strip_margin('|'))
-        |  [
-        |   a.
-        |   b
-        |  ]
+      expect_offense(<<-RUBY.strip_indent)
+        [
+         a.
+         b
+         ^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
+        ]
       RUBY
-      expect(cop.messages)
-        .to eq(['Use 2 (not 0) spaces for indenting an expression spanning ' \
-                'multiple lines.'])
-      expect(cop.highlights).to eq(['b'])
     end
 
     it 'registers an offense for extra indentation of 3rd line in typical ' \
        'RSpec code' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         expect { Foo.new }.
           to change { Bar.count }.
               from(1).to(2)
+              ^^^^ Use 2 (not 6) spaces for indenting an expression spanning multiple lines.
       RUBY
-      expect(cop.messages).to eq(['Use 2 (not 6) spaces for indenting an ' \
-                                  'expression spanning multiple lines.'])
-      expect(cop.highlights).to eq(['from'])
     end
 
     it 'registers an offense for proc call without a selector' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a
          .(args)
+         ^^ Use 2 (not 1) spaces for indenting an expression spanning multiple lines.
       RUBY
-      expect(cop.messages).to eq(['Use 2 (not 1) spaces for indenting an ' \
-                                  'expression spanning multiple lines.'])
-      expect(cop.highlights).to eq(['.('])
     end
 
     it 'registers an offense for one space indentation of second line' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a
          .b
+         ^^ Use 2 (not 1) spaces for indenting an expression spanning multiple lines.
       RUBY
-      expect(cop.messages).to eq(['Use 2 (not 1) spaces for indenting an ' \
-                                  'expression spanning multiple lines.'])
-      expect(cop.highlights).to eq(['.b'])
     end
   end
 
@@ -234,9 +208,10 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
 
       it 'accepts method being aligned with method that is an argument in ' \
          'assignment' do
-        inspect_source(['user = authorize scope.includes(:user)',
-                        '                      .order(:name)'])
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(<<-RUBY.strip_indent)
+          user = authorize scope.includes(:user)
+                                .order(:name)
+        RUBY
       end
 
       it 'accepts method being aligned with method in assignment' do
@@ -396,15 +371,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for misaligned methods in if condition' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         if a.
             b
+            ^ Align `b` with `a.` on line 1.
           something
         end
       RUBY
-      expect(cop.messages).to eq(['Align `b` with `a.` on line 1.'])
-      expect(cop.highlights).to eq(['b'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'does not check binary operations when string wrapped with backslash' do
@@ -433,15 +406,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for misaligned methods in unless condition' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         unless a
         .b
+        ^^ Align `.b` with `a` on line 1.
           something
         end
       RUBY
-      expect(cop.messages).to eq(['Align `.b` with `a` on line 1.'])
-      expect(cop.highlights).to eq(['.b'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for misaligned methods in while condition' do
@@ -493,12 +464,11 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
 
     it 'registers an offense for misaligned methods in local variable ' \
        'assignment' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a = b.c.
          d
+         ^ Align `d` with `b.c.` on line 1.
       RUBY
-      expect(cop.messages).to eq(['Align `d` with `b.c.` on line 1.'])
-      expect(cop.highlights).to eq(['d'])
     end
 
     it 'accepts aligned methods in constant assignment' do
@@ -547,14 +517,11 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     # indented style, it doesn't come into play.
     context 'for possible semantic alignment' do
       it 'accepts indented methods' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           User.a
             .c
             .b
         RUBY
-        expect(cop.messages.empty?).to be(true)
-        expect(cop.highlights.empty?).to be(true)
-        expect(cop.offenses.empty?).to be(true)
       end
     end
   end
@@ -566,13 +533,11 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     include_examples 'both indented* styles'
 
     it 'accepts correctly indented methods in operation' do
-      inspect_source(<<-RUBY.strip_margin('|'))
-        |        1 + a
-        |              .b
-        |              .c
+      expect_no_offenses(<<-RUBY.strip_indent)
+        1 + a
+              .b
+              .c
       RUBY
-      expect(cop.highlights.empty?).to be(true)
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'accepts indentation of consecutive lines in typical RSpec code' do
@@ -592,14 +557,12 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
 
     it 'registers an offense for extra indentation of 3rd line in typical ' \
        'RSpec code' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         expect { Foo.new }.
           to change { Bar.count }.
               from(1).to(2)
+              ^^^^ Indent `from` 2 spaces more than `change { Bar.count }` on line 2.
       RUBY
-      expect(cop.messages).to eq(['Indent `from` 2 spaces more than `change ' \
-                                  '{ Bar.count }` on line 2.'])
-      expect(cop.highlights).to eq(['from'])
     end
 
     it 'registers an offense for proc call without a selector' do
@@ -640,15 +603,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
 
     it 'registers an offense for the emacs ruby-mode 1.1 indentation of an ' \
        'expression in an array' do
-      inspect_source(<<-RUBY.strip_margin('|'))
-        |  [
-        |   a.
-        |   b
-        |  ]
+      expect_offense(<<-RUBY.strip_indent)
+        [
+         a.
+         b
+         ^ Indent `b` 2 spaces more than `a` on line 2.
+        ]
       RUBY
-      expect(cop.messages)
-        .to eq(['Indent `b` 2 spaces more than `a` on line 2.'])
-      expect(cop.highlights).to eq(['b'])
     end
 
     it 'auto-corrects' do
@@ -675,13 +636,11 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     include_examples 'both indented* styles'
 
     it 'accepts correctly indented methods in operation' do
-      inspect_source(<<-RUBY.strip_margin('|'))
-        |        1 + a
-        |          .b
-        |          .c
+      expect_no_offenses(<<-RUBY.strip_indent)
+        1 + a
+          .b
+          .c
       RUBY
-      expect(cop.offenses.empty?).to be(true)
-      expect(cop.highlights.empty?).to be(true)
     end
 
     it 'registers an offense for one space indentation of third line' do
@@ -703,17 +662,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for aligned methods in if condition' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         if a.
            b
+           ^ Use 4 (not 3) spaces for indenting a condition in an `if` statement spanning multiple lines.
           something
         end
       RUBY
-      expect(cop.messages).to eq(['Use 4 (not 3) spaces for indenting a ' \
-                                  'condition in an `if` statement spanning ' \
-                                  'multiple lines.'])
-      expect(cop.highlights).to eq(['b'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'accepts normal indentation of method parameters' do
@@ -748,48 +703,42 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       %w[an until]
     ].each do |article, keyword|
       it "accepts double indentation of #{keyword} condition" do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           #{keyword} receiver.
               nil? &&
               !args.empty?
           end
         RUBY
-        expect(cop.messages.empty?).to be(true)
       end
 
       it "registers an offense for a 2 space indentation of #{keyword} " \
          'condition' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           #{keyword} receiver
             .nil? &&
+            ^^^^^ Use 4 (not 2) spaces for indenting a condition in #{article} `#{keyword}` statement spanning multiple lines.
             !args.empty?
           end
         RUBY
-        expect(cop.highlights).to eq(['.nil?'])
-        expect(cop.messages).to eq(['Use 4 (not 2) spaces for indenting a ' \
-                                    "condition in #{article} `#{keyword}` " \
-                                    'statement spanning multiple lines.'])
       end
 
       it "accepts indented methods in #{keyword} body" do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           #{keyword} a
             something.
               something_else
           end
         RUBY
-        expect(cop.highlights.empty?).to be(true)
       end
     end
 
     %w[unless if].each do |keyword|
       it "accepts special indentation of return #{keyword} condition" do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           return #{keyword} receiver.nil? &&
               !args.empty? &&
               BLACKLIST.include?(method_name)
         RUBY
-        expect(cop.messages.empty?).to be(true)
       end
     end
 
@@ -822,16 +771,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for correct + unrecognized style' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a.
           b
         c.
             d
+            ^ Use 2 (not 4) spaces for indenting an expression spanning multiple lines.
       RUBY
-      expect(cop.messages).to eq(['Use 2 (not 4) spaces for indenting an ' \
-                                  'expression spanning multiple lines.'])
-      expect(cop.highlights).to eq(%w[d])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for aligned operators in assignment' do
@@ -874,13 +820,11 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       end
 
       it 'accepts correctly indented methods in operation' do
-        inspect_source(<<-RUBY.strip_margin('|'))
-          |        1 + a
-          |               .b
-          |               .c
+        expect_no_offenses(<<-RUBY.strip_indent)
+          1 + a
+                 .b
+                 .c
         RUBY
-        expect(cop.offenses.empty?).to be(true)
-        expect(cop.highlights.empty?).to be(true)
       end
 
       it 'accepts indented methods in if condition' do
@@ -912,37 +856,32 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
           # normal code indentation is 2 spaces, and we have configured
           # multiline method indentation to 7 spaces
           # so in this case, 9 spaces are required
-          inspect_source(<<-RUBY.strip_indent)
+          expect_no_offenses(<<-RUBY.strip_indent)
             #{keyword} receiver.
                      nil? &&
                      !args.empty?
             end
           RUBY
-          expect(cop.messages.empty?).to be(true)
         end
 
         it "registers an offense for a 4 space indentation of #{keyword} " \
            'condition' do
-          inspect_source(<<-RUBY.strip_indent)
+          expect_offense(<<-RUBY.strip_indent)
             #{keyword} receiver
                 .nil? &&
+                ^^^^^ Use 9 (not 4) spaces for indenting a condition in #{article} `#{keyword}` statement spanning multiple lines.
                 !args.empty?
             end
           RUBY
-          expect(cop.highlights).to eq(['.nil?'])
-          expect(cop.messages).to eq(['Use 9 (not 4) spaces for indenting a ' \
-                                      "condition in #{article} `#{keyword}` " \
-                                      'statement spanning multiple lines.'])
         end
 
         it "accepts indented methods in #{keyword} body" do
-          inspect_source(<<-RUBY.strip_indent)
+          expect_no_offenses(<<-RUBY.strip_indent)
             #{keyword} a
               something.
                      something_else
             end
           RUBY
-          expect(cop.highlights.empty?).to be(true)
         end
       end
     end

--- a/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
@@ -17,15 +17,14 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
 
   shared_examples 'common' do
     it 'accepts indented operands in ordinary statement' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         a +
           b
       RUBY
-      expect(cop.messages.empty?).to be(true)
     end
 
     it 'accepts indented operands inside and outside a block' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         a = b.map do |c|
           c +
             b +
@@ -35,27 +34,22 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
             end
         end
       RUBY
-      expect(cop.messages.empty?).to be(true)
     end
 
     it 'registers an offense for no indentation of second line' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a +
         b
+        ^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
       RUBY
-      expect(cop.messages).to eq(['Use 2 (not 0) spaces for indenting an ' \
-                                  'expression spanning multiple lines.'])
-      expect(cop.highlights).to eq(['b'])
     end
 
     it 'registers an offense for one space indentation of second line' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a +
          b
+         ^ Use 2 (not 1) spaces for indenting an expression spanning multiple lines.
       RUBY
-      expect(cop.messages).to eq(['Use 2 (not 1) spaces for indenting an ' \
-                                  'expression spanning multiple lines.'])
-      expect(cop.highlights).to eq(['b'])
     end
 
     it 'does not check method calls' do
@@ -78,133 +72,117 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'registers an offense for three spaces indentation of second line' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a ||
            b
+           ^ Use 2 (not 3) spaces for indenting an expression spanning multiple lines.
         c and
            d
+           ^ Use 2 (not 3) spaces for indenting an expression spanning multiple lines.
       RUBY
-      expect(cop.messages).to eq(['Use 2 (not 3) spaces for indenting an ' \
-                                  'expression spanning multiple lines.'] * 2)
-      expect(cop.highlights).to eq(%w[b d])
     end
 
     it 'registers an offense for extra indentation of third line' do
-      inspect_source(<<-RUBY.strip_margin('|'))
-        |   a ||
-        |     b ||
-        |       c
+      expect_offense(<<-RUBY.strip_indent)
+        a ||
+          b ||
+            c
+            ^ Use 2 (not 4) spaces for indenting an expression spanning multiple lines.
       RUBY
-      expect(cop.messages).to eq(['Use 2 (not 4) spaces for indenting an ' \
-                                  'expression spanning multiple lines.'])
-      expect(cop.highlights).to eq(['c'])
     end
 
     it 'registers an offense for the emacs ruby-mode 1.1 indentation of an ' \
        'expression in an array' do
-      inspect_source(<<-RUBY.strip_margin('|'))
-        |  [
-        |   a +
-        |   b
-        |  ]
+      expect_offense(<<-RUBY.strip_indent)
+        [
+         a +
+         b
+         ^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
+        ]
       RUBY
-      expect(cop.messages).to eq(['Use 2 (not 0) spaces for indenting an ' \
-                                  'expression spanning multiple lines.'])
-      expect(cop.highlights).to eq(['b'])
     end
 
     it 'accepts indented operands in an array' do
-      inspect_source(<<-RUBY.strip_margin('|'))
-        |    dm[i][j] = [
-        |      dm[i-1][j-1] +
-        |        (this[j-1] == that[i-1] ? 0 : sub),
-        |      dm[i][j-1] + ins,
-        |      dm[i-1][j] + del
-        |    ].min
+      expect_no_offenses(<<-RUBY.strip_indent)
+        dm[i][j] = [
+          dm[i-1][j-1] +
+            (this[j-1] == that[i-1] ? 0 : sub),
+          dm[i][j-1] + ins,
+          dm[i-1][j] + del
+        ].min
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'accepts two spaces indentation in assignment of local variable' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         a =
           'foo' +
           'bar'
       RUBY
-      expect(cop.messages.empty?).to be(true)
     end
 
     it 'accepts two spaces indentation in assignment of array element' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         a['test'] =
           'foo' +
           'bar'
       RUBY
-      expect(cop.messages.empty?).to be(true)
     end
 
     it 'accepts two spaces indentation of second line' do
-      inspect_source(<<-RUBY.strip_margin('|'))
-        |   a ||
-        |     b
+      expect_no_offenses(<<-RUBY.strip_indent)
+        a ||
+          b
       RUBY
-      expect(cop.messages.empty?).to be(true)
     end
 
     it 'accepts no extra indentation of third line' do
-      inspect_source(<<-RUBY.strip_margin('|'))
-        |   a &&
-        |     b &&
-        |     c
+      expect_no_offenses(<<-RUBY.strip_indent)
+        a &&
+          b &&
+          c
       RUBY
-      expect(cop.messages.empty?).to be(true)
     end
 
     it 'accepts indented operands in for body' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         for x in a
           something &&
             something_else
         end
       RUBY
-      expect(cop.highlights.empty?).to be(true)
     end
 
     it 'accepts alignment inside a grouped expression' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         (a +
          b)
       RUBY
-      expect(cop.messages.empty?).to be(true)
     end
 
     it 'accepts an expression where the first operand spans multiple lines' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         subject.each do |item|
           result = resolve(locale) and return result
         end and nil
       RUBY
-      expect(cop.messages.empty?).to be(true)
     end
 
     it 'accepts any indentation of parameters to #[]' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         payment = Models::IncomingPayments[
                 id:      input['incoming-payment-id'],
                    user_id: @user[:id]]
       RUBY
-      expect(cop.messages.empty?).to be(true)
     end
 
     it 'registers an offense for an unindented multiline operation that is ' \
        'the left operand in another operation' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a +
         b < 3
+        ^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
       RUBY
-      expect(cop.messages).to eq(['Use 2 (not 0) spaces for indenting an ' \
-                                  'expression spanning multiple lines.'])
-      expect(cop.highlights).to eq(['b'])
     end
   end
 
@@ -223,16 +201,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'registers an offense for indented operands in if condition' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         if a +
             b
+            ^ Align the operands of a condition in an `if` statement spanning multiple lines.
           something
         end
       RUBY
-      expect(cop.messages).to eq(['Align the operands of a condition in an ' \
-                                  '`if` statement spanning multiple lines.'])
-      expect(cop.highlights).to eq(['b'])
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'indented')
     end
 
     it 'accepts indented code on LHS of equality operator' do
@@ -266,39 +241,34 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'registers an offense for indented second part of string' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         it "should convert " +
           "a to " +
+          ^^^^^^^ Align the operands of an expression spanning multiple lines.
           "b" do
+          ^^^ Align the operands of an expression spanning multiple lines.
         end
       RUBY
-      expect(cop.messages).to eq(['Align the operands of an expression ' \
-                                  'spanning multiple lines.'] * 2)
-      expect(cop.highlights).to eq(['"a to "', '"b"'])
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'indented')
     end
 
     it 'registers an offense for indented operand in second argument' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         puts a, 1 +
           2
+          ^ Align the operands of an expression spanning multiple lines.
       RUBY
-      expect(cop.messages)
-        .to eq(['Align the operands of an expression spanning multiple lines.'])
-      expect(cop.highlights).to eq(['2'])
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'indented')
     end
 
     it 'registers an offense for misaligned string operand when the first ' \
        'operand has backslash continuation' do
-      inspect_source(['def f',
-                      "  flash[:error] = 'Here is a string ' \\",
-                      "                  'That spans' <<",
-                      "    'multiple lines'",
-                      'end'])
-      expect(cop.messages).to eq(['Align the operands of an expression in an ' \
-                                  'assignment spanning multiple lines.'])
-      expect(cop.highlights).to eq(["'multiple lines'"])
+      expect_offense(<<-RUBY.strip_indent)
+        def f
+          flash[:error] = 'Here is a string ' \
+                          'That spans' <<
+              'multiple lines'
+              ^^^^^^^^^^^^^^^^ Align the operands of an expression in an assignment spanning multiple lines.
+        end
+      RUBY
     end
 
     it 'registers an offense for misaligned string operand when plus is used' do
@@ -311,17 +281,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'registers an offense for misaligned operands in unless condition' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         unless a +
           b
+          ^ Align the operands of a condition in an `unless` statement spanning multiple lines.
           something
         end
       RUBY
-      expect(cop.messages).to eq(['Align the operands of a condition in an ' \
-                                  '`unless` statement spanning multiple ' \
-                                  'lines.'])
-      expect(cop.highlights).to eq(['b'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     [
@@ -332,18 +298,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     ].each do |article, keyword|
       it "registers an offense for misaligned operands in #{keyword} " \
          'condition' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           #{keyword} a or
               b
+              ^ Align the operands of a condition in #{article} `#{keyword}` statement spanning multiple lines.
             something
           end
         RUBY
-        expect(cop.messages).to eq(['Align the operands of a condition in ' \
-                                    "#{article} `#{keyword}` statement " \
-                                    'spanning multiple lines.'])
-        expect(cop.highlights).to eq(['b'])
-        expect(cop.config_to_allow_offenses)
-          .to eq('EnforcedStyle' => 'indented')
       end
     end
 
@@ -402,17 +363,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'registers an offense for aligned operands in if condition' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         if a +
            b
+           ^ Use 4 (not 3) spaces for indenting a condition in an `if` statement spanning multiple lines.
           something
         end
       RUBY
-      expect(cop.messages).to eq(['Use 4 (not 3) spaces for indenting a ' \
-                                  'condition in an `if` statement spanning ' \
-                                  'multiple lines.'])
-      expect(cop.highlights).to eq(['b'])
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'aligned')
     end
 
     it 'accepts the indentation of a broken string' do
@@ -464,7 +421,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
       %w[an until]
     ].each do |article, keyword|
       it "accepts double indentation of #{keyword} condition" do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           #{keyword} receiver.nil? &&
               !args.empty? &&
               BLACKLIST.include?(method_name)
@@ -473,43 +430,37 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
               nil?
           end
         RUBY
-        expect(cop.messages.empty?).to be(true)
       end
 
       it "registers an offense for a 2 space indentation of #{keyword} " \
          'condition' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           #{keyword} receiver.nil? &&
             !args.empty? &&
-            BLACKLIST.include?(method_name)
+            ^^^^^^^^^^^^ Use 4 (not 2) spaces for indenting a condition in #{article} `#{keyword}` statement spanning multiple lines.
+            BLACKLIST.include?(method_name) 
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use 4 (not 2) spaces for indenting a condition in #{article} `#{keyword}` statement spanning multiple lines.
           end
         RUBY
-        expect(cop.highlights).to eq(['!args.empty?',
-                                      'BLACKLIST.include?(method_name)'])
-        expect(cop.messages).to eq(['Use 4 (not 2) spaces for indenting a ' \
-                                    "condition in #{article} `#{keyword}` " \
-                                    'statement spanning multiple lines.'] * 2)
       end
 
       it "accepts indented operands in #{keyword} body" do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           #{keyword} a
             something &&
               something_else
           end
         RUBY
-        expect(cop.highlights.empty?).to be(true)
       end
     end
 
     %w[unless if].each do |keyword|
       it "accepts special indentation of return #{keyword} condition" do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           return #{keyword} receiver.nil? &&
               !args.empty? &&
               BLACKLIST.include?(method_name)
         RUBY
-        expect(cop.messages.empty?).to be(true)
       end
     end
 
@@ -539,16 +490,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'registers an offense for correct + unrecognized style' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a ||
           b
         c and
             d
+            ^ Use 2 (not 4) spaces for indenting an expression spanning multiple lines.
       RUBY
-      expect(cop.messages).to eq(['Use 2 (not 4) spaces for indenting an ' \
-                                  'expression spanning multiple lines.'])
-      expect(cop.highlights).to eq(%w[d])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for aligned operators in assignment' do
@@ -601,7 +549,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
           # normal code indentation is 2 spaces, and we have configured
           # multiline method indentation to 6 spaces
           # so in this case, 8 spaces are required
-          inspect_source(<<-RUBY.strip_indent)
+          expect_no_offenses(<<-RUBY.strip_indent)
             #{keyword} receiver.nil? &&
                     !args.empty? &&
                     BLACKLIST.include?(method_name)
@@ -610,32 +558,27 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
                     nil?
             end
           RUBY
-          expect(cop.messages.empty?).to be(true)
         end
 
         it "registers an offense for a 4 space indentation of #{keyword} " \
            'condition' do
-          inspect_source(<<-RUBY.strip_indent)
+          expect_offense(<<-RUBY.strip_indent)
             #{keyword} receiver.nil? &&
                 !args.empty? &&
+                ^^^^^^^^^^^^ Use 8 (not 4) spaces for indenting a condition in #{article} `#{keyword}` statement spanning multiple lines.
                 BLACKLIST.include?(method_name)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use 8 (not 4) spaces for indenting a condition in #{article} `#{keyword}` statement spanning multiple lines.
             end
           RUBY
-          expect(cop.highlights).to eq(['!args.empty?',
-                                        'BLACKLIST.include?(method_name)'])
-          expect(cop.messages).to eq(['Use 8 (not 4) spaces for indenting a ' \
-                                      "condition in #{article} `#{keyword}` " \
-                                      'statement spanning multiple lines.'] * 2)
         end
 
         it "accepts indented operands in #{keyword} body" do
-          inspect_source(<<-RUBY.strip_indent)
+          expect_no_offenses(<<-RUBY.strip_indent)
             #{keyword} a
               something &&
                     something_else
             end
           RUBY
-          expect(cop.highlights.empty?).to be(true)
         end
       end
 

--- a/spec/rubocop/cop/layout/space_around_equals_in_parameter_default_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_equals_in_parameter_default_spec.rb
@@ -42,8 +42,15 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :confi
     end
 
     it 'auto-corrects missing space' do
-      new_source = autocorrect_source(['def f(x, y=0, z=1)', 'end'])
-      expect(new_source).to eq(['def f(x, y = 0, z = 1)', 'end'].join("\n"))
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        def f(x, y=0, z=1)
+        end
+      RUBY
+
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        def f(x, y = 0, z = 1)
+        end
+      RUBY
     end
 
     it 'accepts default value assignment with spaces and unary + operator' do

--- a/spec/rubocop/cop/layout/space_around_keyword_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_keyword_spec.rb
@@ -33,22 +33,19 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword do
 
   shared_examples 'accept before' do |after, expr|
     it "accepts `#{after}` before keyword in `#{expr}`" do
-      inspect_source(expr)
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(expr)
     end
   end
 
   shared_examples 'accept after' do |after, expr|
     it "accepts `#{after}` after keyword in `#{expr}`" do
-      inspect_source(expr)
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(expr)
     end
   end
 
   shared_examples 'accept around' do |after, expr|
     it "accepts `#{after}` around keyword in `#{expr}`" do
-      inspect_source(expr)
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(expr)
     end
   end
 

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -226,8 +226,17 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'auto-corrects assignment without space on both sides' do
-      new_source = autocorrect_source(['x=0', 'y= 0', 'z =0'])
-      expect(new_source).to eq(['x = 0', 'y = 0', 'z = 0'].join("\n"))
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        x=0
+        y= 0
+        z =0
+      RUBY
+
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        x = 0
+        y = 0
+        z = 0
+      RUBY
     end
 
     context 'ternary operators' do
@@ -278,8 +287,17 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'auto-corrects missing space in binary operators that could be unary' do
-      new_source = autocorrect_source(['a-3', 'x&0xff', 'z+0'])
-      expect(new_source).to eq(['a - 3', 'x & 0xff', 'z + 0'].join("\n"))
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        a-3
+        x&0xff
+        z+0
+      RUBY
+
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        a - 3
+        x & 0xff
+        z + 0
+      RUBY
     end
 
     it 'registers an offense for arguments to a method' do
@@ -332,14 +350,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     context 'when a hash literal is on a single line' do
-      before { inspect_source('{ 1=>2, a: b }') }
-
       context 'and Layout/AlignHash:EnforcedHashRocketStyle is key' do
         let(:hash_style) { 'key' }
 
         it 'registers an offense for a hash rocket without spaces' do
-          expect(cop.messages)
-            .to eq(['Surrounding space missing for operator `=>`.'])
+          expect_offense(<<-RUBY.strip_indent)
+            { 1=>2, a: b }
+               ^^ Surrounding space missing for operator `=>`.
+          RUBY
         end
       end
 
@@ -347,28 +365,26 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
         let(:hash_style) { 'table' }
 
         it 'registers an offense for a hash rocket without spaces' do
-          expect(cop.messages)
-            .to eq(['Surrounding space missing for operator `=>`.'])
+          expect_offense(<<-RUBY.strip_indent)
+            { 1=>2, a: b }
+               ^^ Surrounding space missing for operator `=>`.
+          RUBY
         end
       end
     end
 
     context 'when a hash literal is on multiple lines' do
-      before do
-        inspect_source(<<-RUBY.strip_indent)
-          {
-            1=>2,
-            a: b
-          }
-        RUBY
-      end
-
       context 'and Layout/AlignHash:EnforcedHashRocketStyle is key' do
         let(:hash_style) { 'key' }
 
         it 'registers an offense for a hash rocket without spaces' do
-          expect(cop.messages)
-            .to eq(['Surrounding space missing for operator `=>`.'])
+          expect_offense(<<-RUBY.strip_indent)
+            {
+              1=>2,
+               ^^ Surrounding space missing for operator `=>`.
+              a: b
+            }
+          RUBY
         end
       end
 
@@ -633,25 +649,22 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
 
     it 'registers an offense for a hash rocket with an extra space' \
       'on multiple line' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         {
           1 =>  2
+            ^^ Operator `=>` should be surrounded by a single space.
         }
       RUBY
-      expect(cop.messages).to eq(
-        ['Operator `=>` should be surrounded by a single space.']
-      )
     end
 
     it 'accepts for a hash rocket with an extra space for alignment' \
       'on multiple line' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         {
           1 =>  2,
           11 => 3
         }
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     context 'when does not allowed for alignment' do
@@ -717,9 +730,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
 
     it 'registers an offense for - with too many spaces with ' \
        'negative lhs operand' do
-      inspect_source('-1  - arg')
-      expect(cop.messages)
-        .to eq(['Operator `-` should be surrounded by a single space.'])
+      expect_offense(<<-RUBY.strip_indent)
+        -1  - arg
+            ^ Operator `-` should be surrounded by a single space.
+      RUBY
     end
 
     it 'registers an offense for inheritance < with too many spaces' do

--- a/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
@@ -46,22 +46,21 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
   end
 
   it 'registers an offense for hashes with no spaces if so configured' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       h = {a: 1, b: 2}
+          ^ Space inside { missing.
+                     ^ Space inside } missing.
       h = {a => 1}
+          ^ Space inside { missing.
+                 ^ Space inside } missing.
     RUBY
-    expect(cop.messages).to eq(['Space inside { missing.',
-                                'Space inside } missing.',
-                                'Space inside { missing.',
-                                'Space inside } missing.'])
-    expect(cop.highlights).to eq(['{', '}', '{', '}'])
-    expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'no_space')
   end
 
   it 'registers an offense for correct + opposite' do
-    inspect_source('h = { a: 1}')
-    expect(cop.messages).to eq(['Space inside } missing.'])
-    expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+    expect_offense(<<-RUBY.strip_indent)
+      h = { a: 1}
+                ^ Space inside } missing.
+    RUBY
   end
 
   it 'auto-corrects missing space' do
@@ -79,17 +78,18 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'no_space' } }
 
     it 'registers an offense for hashes with spaces' do
-      inspect_source('h = { a: 1, b: 2 }')
-      expect(cop.messages).to eq(['Space inside { detected.',
-                                  'Space inside } detected.'])
-      expect(cop.highlights).to eq([' ', ' '])
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'space')
+      expect_offense(<<-RUBY.strip_indent)
+        h = { a: 1, b: 2 }
+             ^ Space inside { detected.
+                        ^ Space inside } detected.
+      RUBY
     end
 
     it 'registers an offense for opposite + correct' do
-      inspect_source('h = {a: 1 }')
-      expect(cop.messages).to eq(['Space inside } detected.'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      expect_offense(<<-RUBY.strip_indent)
+        h = {a: 1 }
+                 ^ Space inside } detected.
+      RUBY
     end
 
     it 'auto-corrects unwanted space' do
@@ -133,9 +133,9 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'compact' } }
 
     it "doesn't register an offense for non-nested hashes with spaces" do
-      inspect_source('h = { a: 1, b: 2 }')
-      expect(cop.offenses.empty?).to be(true)
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'compact')
+      expect_no_offenses(<<-RUBY.strip_indent)
+        h = { a: 1, b: 2 }
+      RUBY
     end
 
     it 'registers an offense for nested hashes with spaces' do
@@ -146,9 +146,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     end
 
     it 'registers an offense for opposite + correct' do
-      inspect_source('h = {a: 1 }')
-      expect(cop.messages).to eq(['Space inside { missing.'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      expect_offense(<<-RUBY.strip_indent)
+        h = {a: 1 }
+            ^ Space inside { missing.
+      RUBY
     end
 
     it 'auto-corrects hashes with no space' do

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -8,13 +8,9 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
       'associated with the `%s` method call.'
   end
 
-  before { inspect_source(source) }
-
   shared_examples 'accepts' do |code|
-    let(:source) { code }
-
     it 'does not register an offense' do
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(code)
     end
   end
 
@@ -56,59 +52,49 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
 
   context 'without parentheses' do
     context 'without receiver' do
-      let(:source) { 'some_method a { |el| puts el }' }
-
       it 'registers an offense' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.offenses.first.message).to(
-          eq(format(error_message, 'a { |el| puts el }', 'a'))
-        )
+        expect_offense(<<-RUBY.strip_indent)
+          some_method a { |el| puts el }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Parenthesize the param `a { |el| puts el }` to make sure that the block will be associated with the `a` method call.
+        RUBY
       end
     end
 
     context 'with receiver' do
-      let(:source) { 'Foo.some_method a { |el| puts el }' }
+      let(:source) { '' }
 
       it 'registers an offense' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.offenses.first.message).to(
-          eq(format(error_message, 'a { |el| puts el }', 'a'))
-        )
+        expect_offense(<<-RUBY.strip_indent)
+          Foo.some_method a { |el| puts el }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Parenthesize the param `a { |el| puts el }` to make sure that the block will be associated with the `a` method call.
+        RUBY
       end
     end
 
     context 'rspec expect {}.to change {}' do
-      let(:source) do
-        'expect { order.expire }.to change { order.events }'
-      end
-
       it 'registers an offense' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.offenses.first.message).to(
-          eq(format(error_message, 'change { order.events }', 'change'))
-        )
+        expect_offense(<<-RUBY.strip_indent)
+          expect { order.expire }.to change { order.events }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Parenthesize the param `change { order.events }` to make sure that the block will be associated with the `change` method call.
+        RUBY
       end
     end
 
     context 'as a hash key' do
-      let(:source) { 'Hash[some_method a { |el| el }]' }
-
       it 'registers an offense' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.offenses.first.message).to(
-          eq(format(error_message, 'a { |el| el }', 'a'))
-        )
+        expect_offense(<<-RUBY.strip_indent)
+          Hash[some_method a { |el| el }]
+               ^^^^^^^^^^^^^^^^^^^^^^^^^ Parenthesize the param `a { |el| el }` to make sure that the block will be associated with the `a` method call.
+        RUBY
       end
     end
 
     context 'with assignment' do
-      let(:source) { 'foo = some_method a { |el| puts el }' }
-
       it 'registers an offense' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.offenses.first.message).to(
-          eq(format(error_message, 'a { |el| puts el }', 'a'))
-        )
+        expect_offense(<<-RUBY.strip_indent)
+          foo = some_method a { |el| puts el }
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Parenthesize the param `a { |el| puts el }` to make sure that the block will be associated with the `a` method call.
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/lint/ambiguous_operator_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_operator_spec.rb
@@ -6,29 +6,17 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousOperator do
   context 'with a splat operator in the first argument' do
     context 'without parentheses' do
       context 'without whitespaces on the right of the operator' do
-        let(:source) do
-          <<-RUBY.strip_indent
+        it 'registers an offense' do
+          expect_offense(<<-RUBY.strip_indent)
             array = [1, 2, 3]
             puts *array
+                 ^ Ambiguous splat operator. Parenthesize the method arguments if it's surely a splat operator, or add a whitespace to the right of the `*` if it should be a multiplication.
           RUBY
-        end
-
-        it 'registers an offense' do
-          inspect_source(source)
-          expect(cop.offenses.size).to eq(1)
-          expect(cop.offenses.first.message).to eq(
-            'Ambiguous splat operator. ' \
-            "Parenthesize the method arguments if it's surely a splat " \
-            'operator, ' \
-            'or add a whitespace to the right of the `*` if it should be a ' \
-            'multiplication.'
-          )
-          expect(cop.highlights).to eq(['*'])
         end
       end
 
       context 'with a whitespace on the right of the operator' do
-        it 'accepts' do
+        it 'does not register an offense' do
           expect_no_offenses(<<-RUBY.strip_indent)
             array = [1, 2, 3]
             puts * array
@@ -37,8 +25,8 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousOperator do
       end
     end
 
-    context 'with parentheses' do
-      it 'accepts' do
+    context 'with parentheses around the splatted argument' do
+      it 'does not register an offense' do
         expect_no_offenses(<<-RUBY.strip_indent)
           array = [1, 2, 3]
           puts(*array)
@@ -50,29 +38,17 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousOperator do
   context 'with a block ampersand in the first argument' do
     context 'without parentheses' do
       context 'without whitespaces on the right of the operator' do
-        let(:source) do
-          <<-RUBY.strip_indent
+        it 'registers an offense' do
+          expect_offense(<<-RUBY.strip_indent)
             process = proc { do_something }
             2.times &process
+                    ^ Ambiguous block operator. Parenthesize the method arguments if it's surely a block operator, or add a whitespace to the right of the `&` if it should be a binary AND.
           RUBY
-        end
-
-        it 'registers an offense' do
-          inspect_source(source)
-          expect(cop.offenses.size).to eq(1)
-          expect(cop.offenses.first.message).to eq(
-            'Ambiguous block operator. ' \
-            "Parenthesize the method arguments if it's surely a block " \
-            'operator, ' \
-            'or add a whitespace to the right of the `&` if it should be a ' \
-            'binary AND.'
-          )
-          expect(cop.highlights).to eq(['&'])
         end
       end
 
       context 'with a whitespace on the right of the operator' do
-        it 'accepts' do
+        it 'does not register an offense' do
           expect_no_offenses(<<-RUBY.strip_indent)
             process = proc { do_something }
             2.times & process
@@ -81,8 +57,8 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousOperator do
       end
     end
 
-    context 'with parentheses' do
-      it 'accepts' do
+    context 'with parentheses around the block argument' do
+      it 'does not register an offense' do
         expect_no_offenses(<<-RUBY.strip_indent)
           process = proc { do_something }
           2.times(&process)

--- a/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
@@ -5,17 +5,11 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousRegexpLiteral do
 
   context 'with a regexp literal in the first argument' do
     context 'without parentheses' do
-      let(:source) { 'p /pattern/' }
-
       it 'registers an offense' do
-        inspect_source(source)
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.offenses.first.message).to eq(
-          'Ambiguous regexp literal. Parenthesize the method arguments ' \
-          "if it's surely a regexp literal, or add a whitespace to the " \
-          'right of the `/` if it should be a division.'
-        )
-        expect(cop.highlights).to eq(['/'])
+        expect_offense(<<-RUBY.strip_indent)
+          p /pattern/
+            ^ Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal, or add a whitespace to the right of the `/` if it should be a division.
+        RUBY
       end
     end
 

--- a/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
+++ b/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
@@ -4,36 +4,18 @@ RSpec.describe RuboCop::Cop::Lint::CircularArgumentReference do
   subject(:cop) { described_class.new }
 
   describe 'circular argument references in ordinal arguments' do
-    before do
-      inspect_source(source)
-    end
-
     context 'when the method contains a circular argument reference' do
-      let(:source) do
-        <<-RUBY.strip_indent
-          def omg_wow(msg = msg)
-            puts msg
-          end
-        RUBY
-      end
-
       it 'registers an offense' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.offenses.first.message)
-          .to eq('Circular argument reference - `msg`.')
-        expect(cop.highlights).to eq ['msg']
+        expect_offense(<<-RUBY.strip_indent)
+            def omg_wow(msg = msg)
+                              ^^^ Circular argument reference - `msg`.
+              puts msg
+            end
+        RUBY
       end
     end
 
     context 'when the method does not contain a circular argument reference' do
-      let(:source) do
-        <<-RUBY.strip_indent
-          def omg_wow(msg)
-            puts msg
-          end
-        RUBY
-      end
-
       it 'does not register an offense' do
         expect_no_offenses(<<-RUBY.strip_indent)
           def omg_wow(msg)
@@ -44,14 +26,6 @@ RSpec.describe RuboCop::Cop::Lint::CircularArgumentReference do
     end
 
     context 'when the seemingly-circular default value is a method call' do
-      let(:source) do
-        <<-RUBY.strip_indent
-          def omg_wow(msg = self.msg)
-            puts msg
-          end
-        RUBY
-      end
-
       it 'does not register an offense' do
         expect_no_offenses(<<-RUBY.strip_indent)
           def omg_wow(msg = self.msg)
@@ -63,19 +37,7 @@ RSpec.describe RuboCop::Cop::Lint::CircularArgumentReference do
   end
 
   describe 'circular argument references in keyword arguments' do
-    before do
-      inspect_source(source)
-    end
-
     context 'when the keyword argument is not circular' do
-      let(:source) do
-        <<-RUBY.strip_indent
-          def some_method(some_arg: nil)
-            puts some_arg
-          end
-        RUBY
-      end
-
       it 'does not register an offense' do
         expect_no_offenses(<<-RUBY.strip_indent)
           def some_method(some_arg: nil)
@@ -86,14 +48,6 @@ RSpec.describe RuboCop::Cop::Lint::CircularArgumentReference do
     end
 
     context 'when the keyword argument is not circular, and calls a method' do
-      let(:source) do
-        <<-RUBY.strip_indent
-          def some_method(some_arg: some_method)
-            puts some_arg
-          end
-        RUBY
-      end
-
       it 'does not register an offense' do
         expect_no_offenses(<<-RUBY.strip_indent)
           def some_method(some_arg: some_method)
@@ -104,32 +58,18 @@ RSpec.describe RuboCop::Cop::Lint::CircularArgumentReference do
     end
 
     context 'when there is one circular argument reference' do
-      let(:source) do
-        <<-RUBY.strip_indent
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
           def some_method(some_arg: some_arg)
+                                    ^^^^^^^^ Circular argument reference - `some_arg`.
             puts some_arg
           end
         RUBY
-      end
-
-      it 'registers an offense' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.offenses.first.message)
-          .to eq('Circular argument reference - `some_arg`.')
-        expect(cop.highlights).to eq ['some_arg']
       end
     end
 
     context 'when the keyword argument is not circular, but calls a method ' \
             'of its own class with a self specification' do
-      let(:source) do
-        <<-RUBY.strip_indent
-          def puts_value(value: self.class.value, smile: self.smile)
-            puts value
-          end
-        RUBY
-      end
-
       it 'does not register an offense' do
         expect_no_offenses(<<-RUBY.strip_indent)
           def puts_value(value: self.class.value, smile: self.smile)
@@ -141,14 +81,6 @@ RSpec.describe RuboCop::Cop::Lint::CircularArgumentReference do
 
     context 'when the keyword argument is not circular, but calls a method ' \
             'of some other object with the same name' do
-      let(:source) do
-        <<-RUBY.strip_indent
-          def puts_length(length: mystring.length)
-            puts length
-          end
-        RUBY
-      end
-
       it 'does not register an offense' do
         expect_no_offenses(<<-RUBY.strip_indent)
           def puts_length(length: mystring.length)
@@ -159,21 +91,14 @@ RSpec.describe RuboCop::Cop::Lint::CircularArgumentReference do
     end
 
     context 'when there are multiple offensive keyword arguments' do
-      let(:source) do
-        <<-RUBY.strip_indent
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
           def some_method(some_arg: some_arg, other_arg: other_arg)
+                                    ^^^^^^^^ Circular argument reference - `some_arg`.
+                                                         ^^^^^^^^^ Circular argument reference - `other_arg`.
             puts [some_arg, other_arg]
           end
         RUBY
-      end
-
-      it 'registers two offenses' do
-        expect(cop.offenses.size).to eq(2)
-        expect(cop.offenses.first.message)
-          .to eq('Circular argument reference - `some_arg`.')
-        expect(cop.offenses.last.message)
-          .to eq('Circular argument reference - `other_arg`.')
-        expect(cop.highlights).to eq %w[some_arg other_arg]
       end
     end
   end

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -19,15 +19,16 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods do
     end
 
     it "doesn't register an offense for non-duplicate method in #{type}" do
-      inspect_source([opening_line,
-                      '  def some_method',
-                      '    implement 1',
-                      '  end',
-                      '  def any_method',
-                      '    implement 2',
-                      '  end',
-                      'end'])
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(<<-RUBY.strip_indent)
+        #{opening_line}
+          def some_method
+            implement 1
+          end
+          def any_method
+            implement 2
+          end
+        end
+      RUBY
     end
 
     it "registers an offense for duplicate class methods in #{type}" do
@@ -46,75 +47,84 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods do
     end
 
     it "doesn't register offense for non-duplicate class methods in #{type}" do
-      inspect_source([opening_line,
-                      '  def self.some_method',
-                      '    implement 1',
-                      '  end',
-                      '  def self.any_method',
-                      '    implement 2',
-                      '  end',
-                      'end'])
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(<<-RUBY.strip_indent)
+        #{opening_line}
+          def self.some_method
+            implement 1
+          end
+          def self.any_method
+            implement 2
+          end
+        end
+      RUBY
     end
 
     it "recognizes difference between instance and class methods in #{type}" do
-      inspect_source([opening_line,
-                      '  def some_method',
-                      '    implement 1',
-                      '  end',
-                      '  def self.some_method',
-                      '    implement 2',
-                      '  end',
-                      'end'])
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(<<-RUBY.strip_indent)
+        #{opening_line}
+          def some_method
+            implement 1
+          end
+          def self.some_method
+            implement 2
+          end
+        end
+      RUBY
     end
 
     it "registers an offense for duplicate private methods in #{type}" do
-      inspect_source([opening_line,
-                      '  private def some_method',
-                      '    implement 1',
-                      '  end',
-                      '  private def some_method',
-                      '    implement 2',
-                      '  end',
-                      'end'])
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        #{opening_line}
+          private def some_method
+            implement 1
+          end
+          private def some_method
+                  ^^^ Method `A#some_method` is defined at both (string):2 and (string):5.
+            implement 2
+          end
+        end
+      RUBY
     end
 
     it "registers an offense for duplicate private self methods in #{type}" do
-      inspect_source([opening_line,
-                      '  private def self.some_method',
-                      '    implement 1',
-                      '  end',
-                      '  private def self.some_method',
-                      '    implement 2',
-                      '  end',
-                      'end'])
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        #{opening_line}
+          private def self.some_method
+            implement 1
+          end
+          private def self.some_method
+                  ^^^ Method `A.some_method` is defined at both (string):2 and (string):5.
+            implement 2
+          end
+        end
+      RUBY
     end
 
     it "doesn't register an offense for different private methods in #{type}" do
-      inspect_source([opening_line,
-                      '  private def some_method',
-                      '    implement 1',
-                      '  end',
-                      '  private def any_method',
-                      '    implement 2',
-                      '  end',
-                      'end'])
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(<<-RUBY.strip_indent)
+        #{opening_line}
+          private def some_method
+            implement 1
+          end
+          private def any_method
+            implement 2
+          end
+        end
+      RUBY
     end
 
     it "registers an offense for duplicate protected methods in #{type}" do
-      inspect_source([opening_line,
-                      '  protected def some_method',
-                      '    implement 1',
-                      '  end',
-                      '  protected def some_method',
-                      '    implement 2',
-                      '  end',
-                      'end'])
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        #{opening_line}
+          protected def some_method
+            implement 1
+          end
+          protected def some_method
+                    ^^^ Method `A#some_method` is defined at both (string):2 and (string):5.
+            implement 2
+          end
+        end
+      RUBY
     end
 
     it "registers 2 offenses for pair of duplicate methods in #{type}" do

--- a/spec/rubocop/cop/lint/duplicated_key_spec.rb
+++ b/spec/rubocop/cop/lint/duplicated_key_spec.rb
@@ -3,43 +3,32 @@
 RSpec.describe RuboCop::Cop::Lint::DuplicatedKey do
   subject(:cop) { described_class.new }
 
-  context 'When there is a duplicated key in the hash literal' do
-    let(:source) do
-      "hash = { 'otherkey' => 'value', 'key' => 'value', 'key' => 'hi' }"
-    end
-
+  context 'when there is a duplicated key in the hash literal' do
     it 'registers an offense' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.message)
-        .to eq('Duplicated key in hash literal.')
-      expect(cop.highlights).to eq ["'key'"]
+      expect_offense(<<-RUBY.strip_indent)
+        hash = { 'otherkey' => 'value', 'key' => 'value', 'key' => 'hi' }
+                                                          ^^^^^ Duplicated key in hash literal.
+      RUBY
     end
   end
 
-  context 'When there are two duplicated keys in a hash' do
-    let(:source) do
-      "hash = { fruit: 'apple', veg: 'kale', veg: 'cuke', fruit: 'orange' }"
-    end
-
+  context 'when there are two duplicated keys in a hash' do
     it 'registers two offenses' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(2)
-      expect(cop.messages).to eq(['Duplicated key in hash literal.'] * 2)
-      expect(cop.highlights).to eq %w[veg fruit]
+      expect_offense(<<-RUBY.strip_indent)
+        hash = { fruit: 'apple', veg: 'kale', veg: 'cuke', fruit: 'orange' }
+                                              ^^^ Duplicated key in hash literal.
+                                                           ^^^^^ Duplicated key in hash literal.
+      RUBY
     end
   end
 
   context 'When a key is duplicated three times in a hash literal' do
-    let(:source) do
-      'hash = { 1 => 2, 1 => 3, 1 => 4 }'
-    end
-
     it 'registers two offenses' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(2)
-      expect(cop.messages).to eq(['Duplicated key in hash literal.'] * 2)
-      expect(cop.highlights).to eq %w[1 1]
+      expect_offense(<<-RUBY.strip_indent)
+        hash = { 1 => 2, 1 => 3, 1 => 4 }
+                         ^ Duplicated key in hash literal.
+                                 ^ Duplicated key in hash literal.
+      RUBY
     end
   end
 
@@ -80,8 +69,9 @@ RSpec.describe RuboCop::Cop::Lint::DuplicatedKey do
 
   shared_examples 'duplicated non literal key' do |key|
     it "does not register an offense for duplicated `#{key}` hash keys" do
-      inspect_source("hash = { #{key} => 1, #{key} => 4}")
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(<<-RUBY.strip_indent)
+        hash = { #{key} => 1, #{key} => 4}
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/lint/end_in_method_spec.rb
+++ b/spec/rubocop/cop/lint/end_in_method_spec.rb
@@ -3,24 +3,22 @@
 RSpec.describe RuboCop::Cop::Lint::EndInMethod do
   subject(:cop) { described_class.new }
 
-  it 'reports an offense for def with an RUBY inside' do
-    src = <<-RUBY.strip_indent
+  it 'registers an offense for def with an END inside' do
+    expect_offense(<<-RUBY.strip_indent)
       def test
         END { something }
+        ^^^ `END` found in method definition. Use `at_exit` instead.
       end
     RUBY
-    inspect_source(src)
-    expect(cop.offenses.size).to eq(1)
   end
 
-  it 'reports an offense for defs with an RUBY inside' do
-    src = <<-RUBY.strip_indent
+  it 'registers an offense for defs with an END inside' do
+    expect_offense(<<-RUBY.strip_indent)
       def self.test
         END { something }
+        ^^^ `END` found in method definition. Use `at_exit` instead.
       end
     RUBY
-    inspect_source(src)
-    expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts END outside of def(s)' do

--- a/spec/rubocop/cop/lint/ensure_return_spec.rb
+++ b/spec/rubocop/cop/lint/ensure_return_spec.rb
@@ -27,13 +27,11 @@ RSpec.describe RuboCop::Cop::Lint::EnsureReturn do
   end
 
   it 'does not check when ensure block has no body' do
-    expect do
-      inspect_source(<<-RUBY.strip_indent)
-        begin
-          something
-        ensure
-        end
-      RUBY
-    end.not_to raise_exception
+    expect_no_offenses(<<-RUBY.strip_indent)
+      begin
+        something
+      ensure
+      end
+    RUBY
   end
 end

--- a/spec/rubocop/cop/lint/literal_as_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_as_condition_spec.rb
@@ -70,12 +70,11 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition do
 
     it "accepts literal #{lit} in a when of a case with " \
        'something after case keyword' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         case x
         when #{lit} then top
         end
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it "registers an offense for literal #{lit} in &&" do
@@ -115,21 +114,19 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition do
     end
 
     it "accepts literal #{lit} if it's not an and/or operand" do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         if test(#{lit})
           top
         end
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it "accepts literal #{lit} in non-toplevel and/or" do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         if (a || #{lit}).something
           top
         end
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it "registers an offense for `!#{lit}`" do

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -99,8 +99,9 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
 
   shared_examples 'special keywords' do |keyword|
     it "accepts strings like #{keyword}" do
-      inspect_source(%("this is \#{#{keyword}} silly"))
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(<<-RUBY.strip_indent)
+        %("this is \#{#{keyword}} silly")
+      RUBY
     end
 
     it "does not try to autocorrect strings like #{keyword}" do

--- a/spec/rubocop/cop/lint/multiple_compare_spec.rb
+++ b/spec/rubocop/cop/lint/multiple_compare_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe RuboCop::Cop::Lint::MultipleCompare do
     end
 
     it "accepts for #{good_source}" do
-      inspect_source(good_source)
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(good_source)
     end
   end
 

--- a/spec/rubocop/cop/lint/next_without_accumulator_spec.rb
+++ b/spec/rubocop/cop/lint/next_without_accumulator_spec.rb
@@ -42,13 +42,11 @@ RSpec.describe RuboCop::Cop::Lint::NextWithoutAccumulator do
       end
 
       it 'accepts next with a value' do
-        inspect_source(code_with_accumulator(reduce_alias))
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(code_with_accumulator(reduce_alias))
       end
 
       it 'accepts next within a nested block' do
-        inspect_source(code_with_nested_block(reduce_alias))
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(code_with_nested_block(reduce_alias))
       end
     end
   end

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -5,14 +5,18 @@ RSpec.describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression do
 
   it 'registers an offense for method call with space before the ' \
      'parenthesis' do
-    inspect_source('a.func (x)')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      a.func (x)
+            ^ `(...)` interpreted as grouped expression.
+    RUBY
   end
 
   it 'registers an offense for predicate method call with space ' \
      'before the parenthesis' do
-    inspect_source('is? (x)')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      is? (x)
+         ^ `(...)` interpreted as grouped expression.
+    RUBY
   end
 
   it 'registers an offense for math expression' do
@@ -53,8 +57,7 @@ RSpec.describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression do
     expect_no_offenses('a( (b) )')
   end
 
-  it "doesn't register an offense for a call with multiple arguments" do
-    # there is no ambiguity here
+  it 'does not register an offense for a call with multiple arguments' do
     expect_no_offenses('assert_equal (0..1.9), acceleration.domain')
   end
 end

--- a/spec/rubocop/cop/lint/rand_one_spec.rb
+++ b/spec/rubocop/cop/lint/rand_one_spec.rb
@@ -3,13 +3,10 @@
 RSpec.describe RuboCop::Cop::Lint::RandOne do
   subject(:cop) { described_class.new }
 
-  before { inspect_source(source) }
-
   shared_examples 'offenses' do |source|
     describe source do
-      let(:source) { source }
-
       it 'registers an offense' do
+        inspect_source(source)
         expect(cop.messages).to eq(
           [
             "`#{source}` always returns `0`. " \
@@ -23,10 +20,8 @@ RSpec.describe RuboCop::Cop::Lint::RandOne do
 
   shared_examples 'no offense' do |source|
     describe source do
-      let(:source) { source }
-
-      it "doesn't register an offense" do
-        expect(cop.messages.empty?).to be(true)
+      it 'does not register an offense' do
+        expect_no_offenses(source)
       end
     end
   end

--- a/spec/rubocop/cop/lint/require_parentheses_spec.rb
+++ b/spec/rubocop/cop/lint/require_parentheses_spec.rb
@@ -5,27 +5,28 @@ RSpec.describe RuboCop::Cop::Lint::RequireParentheses do
 
   it 'registers an offense for missing parentheses around expression with ' \
      '&& operator' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       if day.is? 'monday' && month == :jan
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use parentheses in the method call to avoid confusion about precedence.
         foo
       end
     RUBY
-    expect(cop.highlights).to eq(["day.is? 'monday' && month == :jan"])
-    expect(cop.messages)
-      .to eq(['Use parentheses in the method call to avoid confusion about ' \
-              'precedence.'])
   end
 
   it 'registers an offense for missing parentheses around expression with ' \
      '|| operator' do
-    inspect_source("day_is? 'tuesday' || true")
-    expect(cop.highlights).to eq(["day_is? 'tuesday' || true"])
+    expect_offense(<<-RUBY.strip_indent)
+      day_is? 'tuesday' || true
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Use parentheses in the method call to avoid confusion about precedence.
+    RUBY
   end
 
   it 'registers an offense for missing parentheses around expression in ' \
      'ternary' do
-    inspect_source("wd.include? 'tuesday' && true == true ? a : b")
-    expect(cop.highlights).to eq(["wd.include? 'tuesday' && true == true"])
+    expect_offense(<<-RUBY.strip_indent)
+      wd.include? 'tuesday' && true == true ? a : b
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use parentheses in the method call to avoid confusion about precedence.
+    RUBY
   end
 
   it 'accepts missing parentheses around expression with + operator' do

--- a/spec/rubocop/cop/lint/rescue_exception_spec.rb
+++ b/spec/rubocop/cop/lint/rescue_exception_spec.rb
@@ -115,12 +115,11 @@ RSpec.describe RuboCop::Cop::Lint::RescueException do
 
   it 'does not crash when the namespace of a rescued class is in a local ' \
      'variable' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       adapter = current_adapter
       begin
       rescue adapter::ParseError
       end
     RUBY
-    expect(cop.offenses.empty?).to be(true)
   end
 end

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -9,9 +9,7 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
 
   shared_examples 'accepts' do |name, code|
     it "accepts usages of #{name}" do
-      inspect_source(code)
-
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(code)
     end
   end
 

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -227,48 +227,40 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedException do
   context 'multiple rescues' do
     it 'registers an offense when a higher level exception is rescued before' \
        ' a lower level exception' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         begin
           something
         rescue Exception
+        ^^^^^^^^^^^^^^^^ Do not shadow rescued Exceptions.
           handle_exception
         rescue StandardError
           handle_standard_error
         end
       RUBY
-
-      expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
-      expect(cop.highlights).to eq([['rescue Exception',
-                                     '  handle_exception',
-                                     'rescue StandardError'].join("\n")])
     end
 
     it 'registers an offense when a higher level exception is rescued before ' \
        'a lower level exception when there are multiple exceptions ' \
        'rescued in a group' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         begin
           something
         rescue Exception
+        ^^^^^^^^^^^^^^^^ Do not shadow rescued Exceptions.
           handle_exception
         rescue NoMethodError, ZeroDivisionError
           handle_standard_error
         end
       RUBY
-
-      expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
-      expect(cop.highlights).to eq([['rescue Exception',
-                                     '  handle_exception',
-                                     'rescue NoMethodError, ZeroDivisionError']
-                                     .join("\n")])
     end
 
     it 'registers an offense rescuing out of order exceptions when there ' \
        'is an ensure' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         begin
           something
         rescue Exception
+        ^^^^^^^^^^^^^^^^ Do not shadow rescued Exceptions.
           handle_exception
         rescue StandardError
           handle_standard_error
@@ -276,11 +268,6 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedException do
           everything_is_ok
         end
       RUBY
-
-      expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
-      expect(cop.highlights).to eq([['rescue Exception',
-                                     '  handle_exception',
-                                     'rescue StandardError'].join("\n")])
     end
 
     it 'accepts rescuing exceptions in order of level' do
@@ -383,20 +370,16 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedException do
 
       it 'registers an offense for splat arguments rescued after ' \
          'rescuing Exception' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           begin
             a
           rescue Exception
+          ^^^^^^^^^^^^^^^^ Do not shadow rescued Exceptions.
             b
           rescue *BAR
             c
           end
         RUBY
-
-        expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
-        expect(cop.highlights).to eq([['rescue Exception',
-                                       '  b',
-                                       'rescue *BAR'].join("\n")])
       end
     end
 
@@ -489,20 +472,16 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedException do
     end
 
     it 'registers an offense rescuing Exception before an unknown exceptions' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         begin
           a
         rescue Exception
+        ^^^^^^^^^^^^^^^^ Do not shadow rescued Exceptions.
           b
         rescue UnknownException
           c
         end
       RUBY
-
-      expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
-      expect(cop.highlights).to eq([['rescue Exception',
-                                     '  b',
-                                     'rescue UnknownException'].join("\n")])
     end
 
     it 'ignores expressions of non-const' do
@@ -518,23 +497,6 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedException do
     end
 
     context 'last rescue does not specify exception class' do
-      let(:source) do
-        <<-RUBY.strip_indent
-          begin
-          rescue A, B
-            do_something
-          rescue C
-            do_something
-          rescue
-            do_something
-          end
-        RUBY
-      end
-
-      it 'does not raise error' do
-        expect { inspect_source(source) }.not_to raise_error
-      end
-
       it 'highlights range ending at rescue keyword' do
         expect_no_offenses(<<-RUBY.strip_indent)
           begin

--- a/spec/rubocop/cop/lint/underscore_prefixed_variable_name_spec.rb
+++ b/spec/rubocop/cop/lint/underscore_prefixed_variable_name_spec.rb
@@ -4,26 +4,19 @@ RSpec.describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
   subject(:cop) { described_class.new }
 
   context 'when an underscore-prefixed variable is used' do
-    let(:source) { <<-RUBY }
-      def some_method
-        _foo = 1
-        puts _foo
-      end
-    RUBY
-
     it 'registers an offense' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.message)
-        .to eq('Do not use prefix `_` for a variable that is used.')
-      expect(cop.offenses.first.severity.name).to eq(:warning)
-      expect(cop.offenses.first.line).to eq(2)
-      expect(cop.highlights).to eq(['_foo'])
+      expect_offense(<<-RUBY.strip_indent)
+        def some_method
+          _foo = 1
+          ^^^^ Do not use prefix `_` for a variable that is used.
+          puts _foo
+        end
+      RUBY
     end
   end
 
   context 'when non-underscore-prefixed variable is used' do
-    it 'accepts' do
+    it 'does not register an offense' do
       expect_no_offenses(<<-RUBY.strip_indent)
         def some_method
           foo = 1
@@ -34,7 +27,7 @@ RSpec.describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
   end
 
   context 'when an underscore-prefixed variable is reassigned' do
-    it 'accepts' do
+    it 'does not register an offense' do
       expect_no_offenses(<<-RUBY.strip_indent)
         def some_method
           _foo = 1
@@ -45,46 +38,34 @@ RSpec.describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
   end
 
   context 'when an underscore-prefixed method argument is used' do
-    let(:source) { <<-RUBY }
-      def some_method(_foo)
-        puts _foo
-      end
-    RUBY
-
     it 'registers an offense' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(['_foo'])
+      expect_offense(<<-RUBY.strip_indent)
+        def some_method(_foo)
+                        ^^^^ Do not use prefix `_` for a variable that is used.
+          puts _foo
+        end
+      RUBY
     end
   end
 
   context 'when an underscore-prefixed block argument is used' do
-    let(:source) { <<-RUBY }
-      1.times do |_foo|
-        puts _foo
-      end
-    RUBY
-
     it 'registers an offense' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(['_foo'])
+      expect_offense(<<-RUBY.strip_indent)
+        1.times do |_foo|
+                    ^^^^ Do not use prefix `_` for a variable that is used.
+          puts _foo
+        end
+      RUBY
     end
   end
 
   context 'when an underscore-prefixed variable in top-level scope is used' do
-    let(:source) { <<-RUBY }
-      _foo = 1
-      puts _foo
-    RUBY
-
     it 'registers an offense' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(['_foo'])
+      expect_offense(<<-RUBY.strip_indent)
+        _foo = 1
+        ^^^^ Do not use prefix `_` for a variable that is used.
+        puts _foo
+      RUBY
     end
   end
 
@@ -100,77 +81,59 @@ RSpec.describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
   end
 
   context 'when an underscore-prefixed named capture variable is used' do
-    let(:source) { <<-RUBY }
-      /(?<_foo>\\w+)/ =~ 'FOO'
-      puts _foo
-    RUBY
-
     it 'registers an offense' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(['/(?<_foo>\\w+)/'])
+      expect_offense(<<-RUBY.strip_indent)
+        /(?<_foo>\\w+)/ =~ 'FOO'
+        ^^^^^^^^^^^^^^ Do not use prefix `_` for a variable that is used.
+        puts _foo
+      RUBY
     end
   end
 
   %w[super binding].each do |keyword|
     context "in a method calling `#{keyword}` without arguments" do
       context 'when an underscore-prefixed argument is not used explicitly' do
-        let(:source) { <<-RUBY }
-          def some_method(*_)
-            #{keyword}
-          end
-        RUBY
-
-        it 'accepts' do
-          inspect_source(source)
-          expect(cop.offenses.empty?).to be(true)
+        it 'does not register an offense' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            def some_method(*_)
+              #{keyword}
+            end
+          RUBY
         end
       end
 
       context 'when an underscore-prefixed argument is used explicitly' do
-        let(:source) { <<-RUBY }
-          def some_method(*_)
-            #{keyword}
-            puts _
-          end
-        RUBY
-
         it 'registers an offense' do
-          inspect_source(source)
-          expect(cop.offenses.size).to eq(1)
-          expect(cop.offenses.first.line).to eq(1)
-          expect(cop.highlights).to eq(['_'])
+          expect_offense(<<-RUBY.strip_indent)
+            def some_method(*_)
+                             ^ Do not use prefix `_` for a variable that is used.
+              #{keyword}
+              puts _
+            end
+          RUBY
         end
       end
     end
 
     context "in a method calling `#{keyword}` with arguments" do
       context 'when an underscore-prefixed argument is not used' do
-        let(:source) { <<-RUBY }
-          def some_method(*_)
-            #{keyword}(:something)
-          end
-        RUBY
-
-        it 'accepts' do
-          inspect_source(source)
-          expect(cop.offenses.empty?).to be(true)
+        it 'does not register an offense' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            def some_method(*_)
+              #{keyword}(:something)
+            end
+          RUBY
         end
       end
 
       context 'when an underscore-prefixed argument is used explicitly' do
-        let(:source) { <<-RUBY }
-          def some_method(*_)
-            #{keyword}(*_)
-          end
-        RUBY
-
         it 'registers an offense' do
-          inspect_source(source)
-          expect(cop.offenses.size).to eq(1)
-          expect(cop.offenses.first.line).to eq(1)
-          expect(cop.highlights).to eq(['_'])
+          expect_offense(<<-RUBY.strip_indent)
+            def some_method(*_)
+                             ^ Do not use prefix `_` for a variable that is used.
+              #{keyword}(*_)
+            end
+          RUBY
         end
       end
     end

--- a/spec/rubocop/cop/lint/unneeded_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/unneeded_cop_disable_directive_spec.rb
@@ -346,15 +346,17 @@ RSpec.describe RuboCop::Cop::Lint::UnneededCopDisableDirective do
         context 'and a comment disables' do
           context 'one cop twice' do
             let(:source) do
-              ['class One',
-               '  # rubocop:disable Style/ClassVars',
-               '  @@class_var = 1',
-               'end',
-               '',
-               'class Two',
-               '  # rubocop:disable Style/ClassVars',
-               '  @@class_var = 2',
-               'end'].join("\n")
+              <<-RUBY.strip_indent
+               class One
+                 # rubocop:disable Style/ClassVars
+                 @@class_var = 1
+               end
+
+               class Two
+                 # rubocop:disable Style/ClassVars
+                 @@class_var = 2
+               end
+              RUBY
             end
             let(:offense_lines) { [3, 8] }
             let(:cop_disabled_line_ranges) do
@@ -371,11 +373,13 @@ RSpec.describe RuboCop::Cop::Lint::UnneededCopDisableDirective do
 
           context 'one cop and then all cops' do
             let(:source) do
-              ['class One',
-               '  # rubocop:disable Style/ClassVars',
-               '  # rubocop:disable all',
-               '  @@class_var = 1',
-               'end'].join("\n")
+              <<-RUBY.strip_indent
+                class One
+                 # rubocop:disable Style/ClassVars
+                 # rubocop:disable all
+                 @@class_var = 1
+               end
+              RUBY
             end
             let(:offense_lines) { [4] }
             let(:cop_disabled_line_ranges) do

--- a/spec/rubocop/cop/lint/useless_else_without_rescue_spec.rb
+++ b/spec/rubocop/cop/lint/useless_else_without_rescue_spec.rb
@@ -3,42 +3,20 @@
 RSpec.describe RuboCop::Cop::Lint::UselessElseWithoutRescue do
   subject(:cop) { described_class.new }
 
-  before do
-    inspect_source(source)
-  end
-
   context 'with `else` without `rescue`' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'registers an offense' do
+      expect_offense(<<-RUBY.strip_indent)
         begin
           do_something
         else
+        ^^^^ `else` without `rescue` is useless.
           handle_unknown_errors
         end
       RUBY
-    end
-
-    it 'registers an offense' do
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.message)
-        .to eq('`else` without `rescue` is useless.')
-      expect(cop.highlights).to eq(['else'])
     end
   end
 
   context 'with `else` with `rescue`' do
-    let(:source) do
-      <<-RUBY.strip_indent
-        begin
-          do_something
-        rescue ArgumentError
-          handle_argument_error
-        else
-          handle_unknown_errors
-        end
-      RUBY
-    end
-
     it 'accepts' do
       expect_no_offenses(<<-RUBY.strip_indent)
         begin

--- a/spec/rubocop/cop/metrics/abc_size_spec.rb
+++ b/spec/rubocop/cop/metrics/abc_size_spec.rb
@@ -21,50 +21,37 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
     end
 
     it 'registers an offense for an if modifier' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def method_name
+        ^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [2.24/0]
           call_foo if some_condition # 0 + 2*2 + 1*1
         end
       RUBY
-      expect(cop.messages)
-        .to eq(['Assignment Branch Condition size for method_name is too ' \
-                'high. [2.24/0]'])
-      expect(cop.highlights).to eq([<<-RUBY.strip_indent.chomp])
-        def method_name
-          call_foo if some_condition # 0 + 2*2 + 1*1
-        end
-      RUBY
-      expect(cop.config_to_allow_offenses).to eq('Max' => 3)
     end
 
     it 'registers an offense for an assignment of a local variable' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def method_name
+        ^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [1/0]
           x = 1
         end
       RUBY
-      expect(cop.messages)
-        .to eq(['Assignment Branch Condition size for method_name is too ' \
-                'high. [1/0]'])
-      expect(cop.config_to_allow_offenses).to eq('Max' => 1)
     end
 
     it 'registers an offense for an assignment of an element' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def method_name
+        ^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [1.41/0]
           x[0] = 1
         end
       RUBY
-      expect(cop.messages)
-        .to eq(['Assignment Branch Condition size for method_name is too ' \
-                'high. [1.41/0]'])
-      expect(cop.config_to_allow_offenses).to eq('Max' => 2)
     end
 
     it 'registers an offense for complex content including A, B, and C ' \
        'scores' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def method_name
+        ^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [6.4/0]
           my_options = Hash.new if 1 == 1 || 2 == 2 # 1, 3, 2
           my_options.each do |key, value|           # 0, 1, 0
             p key                                   # 0, 1, 0
@@ -72,9 +59,6 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
           end
         end
       RUBY
-      expect(cop.messages)
-        .to eq(['Assignment Branch Condition size for method_name is too ' \
-                'high. [6.4/0]']) # sqrt(1*1 + 6*6 + 2*2) => 6.4
     end
 
     it 'registers an offense for a `define_method`' do

--- a/spec/rubocop/cop/metrics/class_length_spec.rb
+++ b/spec/rubocop/cop/metrics/class_length_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
   let(:cop_config) { { 'Max' => 5, 'CountComments' => false } }
 
   it 'rejects a class with more than 5 lines' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       class Test
+      ^^^^^^^^^^ Class has too many lines. [6/5]
         a = 1
         a = 2
         a = 3
@@ -16,9 +17,6 @@ RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
         a = 6
       end
     RUBY
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Class has too many lines. [6/5]'])
-    expect(cop.config_to_allow_offenses).to eq('Max' => 6)
   end
 
   it 'reports the correct beginning and end lines' do
@@ -110,8 +108,9 @@ RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
     end
 
     it 'rejects a class with 6 lines that belong to the class directly' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         class NamespaceClass
+        ^^^^^^^^^^^^^^^^^^^^ Class has too many lines. [6/5]
           class TestOne
             a = 1
             a = 2
@@ -134,7 +133,6 @@ RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
           a = 6
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
   end
 
@@ -142,8 +140,9 @@ RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
     before { cop_config['CountComments'] = true }
 
     it 'also counts commented lines' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         class Test
+        ^^^^^^^^^^ Class has too many lines. [6/5]
           a = 1
           #a = 2
           a = 3
@@ -152,7 +151,6 @@ RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
           a = 6
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
   end
 end

--- a/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
@@ -42,19 +42,12 @@ RSpec.describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     end
 
     it 'registers an offense for an if modifier' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def self.method_name
+        ^^^^^^^^^^^^^^^^^^^^ Cyclomatic complexity for method_name is too high. [2/1]
           call_foo if some_condition
         end
       RUBY
-      expect(cop.messages)
-        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
-      expect(cop.highlights).to eq([<<-RUBY.strip_indent.chomp])
-        def self.method_name
-          call_foo if some_condition
-        end
-      RUBY
-      expect(cop.config_to_allow_offenses).to eq('Max' => 2)
     end
 
     it 'registers an offense for an unless modifier' do

--- a/spec/rubocop/cop/metrics/line_length_spec.rb
+++ b/spec/rubocop/cop/metrics/line_length_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
   end
 
   it "accepts a line that's 80 characters wide" do
-    inspect_source('#' * 80)
-    expect(cop.offenses.empty?).to be(true)
+    expect_no_offenses('#' * 80)
   end
 
   it 'registers an offense for long line before __END__ but not after' do
@@ -33,71 +32,47 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
     let(:cop_config) { { 'Max' => 80, 'AllowURI' => true } }
 
     context 'and all the excessive characters are part of an URL' do
-      # This code example is allowed by AllowURI feature itself :).
-      let(:source) { <<-RUBY }
-        # Some documentation comment...
-        # See: https://github.com/rubocop-hq/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c
-      RUBY
-
       it 'accepts the line' do
-        inspect_source(source)
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(<<-RUBY)
+          # Some documentation comment...
+          # See: https://github.com/rubocop-hq/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c
+        RUBY
       end
 
       context 'and the URL is wrapped in single quotes' do
-        let(:source) { <<-RUBY }
-          # See: 'https://github.com/rubocop-hq/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c'
-        RUBY
-
         it 'accepts the line' do
-          inspect_source(source)
-          expect(cop.offenses.empty?).to be(true)
+          expect_no_offenses(<<-RUBY)
+            # See: 'https://github.com/rubocop-hq/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c'
+          RUBY
         end
       end
 
       context 'and the URL is wrapped in double quotes' do
-        let(:source) { <<-RUBY }
-          # See: "https://github.com/rubocop-hq/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c"
-        RUBY
-
         it 'accepts the line' do
-          inspect_source(source)
-          expect(cop.offenses.empty?).to be(true)
+          expect_no_offenses(<<-RUBY)
+            # See: "https://github.com/rubocop-hq/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c"
+          RUBY
         end
       end
     end
 
     context 'and the excessive characters include a complete URL' do
-      let(:source) { <<-RUBY }
-        # See: http://google.com/, http://gmail.com/, https://maps.google.com/, http://plus.google.com/
-      RUBY
-
       it 'registers an offense for the line' do
-        inspect_source(source)
-        expect(cop.offenses.size).to eq(1)
-      end
-
-      it 'highlights all the excessive characters' do
-        inspect_source(source)
-        expect(cop.highlights).to eq(['http://plus.google.com/'])
+        expect_offense(<<-RUBY)
+          # See: http://google.com/, http://gmail.com/, https://maps.google.com/, http://plus.google.com/
+                                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [105/80]
+        RUBY
       end
     end
 
     context 'and the excessive characters include part of an URL ' \
             'and another word' do
-      let(:source) { <<-RUBY }
-        # See: https://github.com/rubocop-hq/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c and
-        #   http://google.com/
-      RUBY
-
       it 'registers an offense for the line' do
-        inspect_source(source)
-        expect(cop.offenses.size).to eq(1)
-      end
-
-      it 'highlights only the non-URL part' do
-        inspect_source(source)
-        expect(cop.highlights).to eq([' and'])
+        expect_offense(<<-RUBY)
+          # See: https://github.com/rubocop-hq/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c and
+                                                                                                      ^^^^ Line is too long. [106/80]
+          #   http://google.com/
+        RUBY
       end
     end
 
@@ -131,9 +106,8 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
           { 'Max' => 80, 'AllowURI' => true, 'URISchemes' => %w[otherprotocol] }
         end
 
-        it 'accepts the line' do
-          inspect_source(source)
-          expect(cop.offenses.empty?).to be(true)
+        it 'does not register an offense' do
+          expect_no_offenses(source)
         end
       end
     end
@@ -174,8 +148,7 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
     RUBY
 
     it 'accepts long lines in heredocs' do
-      inspect_source(source)
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(source)
     end
 
     context 'when the source has no AST' do
@@ -287,8 +260,7 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
       RUBY
 
       it 'accepts the line' do
-        inspect_source(source)
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(source)
       end
     end
 
@@ -300,8 +272,7 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
       RUBY
 
       it 'accepts the line' do
-        inspect_source(source)
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(source)
       end
 
       context 'and has explanatory text' do
@@ -311,9 +282,8 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
           end
         RUBY
 
-        it 'accepts the line' do
-          inspect_source(source)
-          expect(cop.offenses.empty?).to be(true)
+        it 'does not register an offense' do
+          expect_no_offenses(source)
         end
       end
     end

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
 
   it 'accepts a method with multiline arguments ' \
      'and less than 5 lines of body' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def m(x,
             y,
             z)
@@ -115,7 +115,6 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
         a = 4
       end
     RUBY
-    expect(cop.offenses.empty?).to be(true)
   end
 
   it 'does not count blank lines' do

--- a/spec/rubocop/cop/metrics/parameter_lists_spec.rb
+++ b/spec/rubocop/cop/metrics/parameter_lists_spec.rb
@@ -62,11 +62,10 @@ RSpec.describe RuboCop::Cop::Metrics::ParameterLists, :config do
     end
 
     it 'does not count keyword arguments without default values', ruby: 2.1 do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         def meth(a, b, c, d:, e:)
         end
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
   end
 end

--- a/spec/rubocop/cop/naming/uncommunicative_block_param_name_spec.rb
+++ b/spec/rubocop/cop/naming/uncommunicative_block_param_name_spec.rb
@@ -54,17 +54,14 @@ RSpec.describe RuboCop::Cop::Naming::UncommunicativeBlockParamName, :config do
   end
 
   it 'can register multiple offenses in one block' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       something do |y, num1, oFo|
+                    ^ Block parameter must be at least 2 characters long.
+                       ^^^^ Do not end block parameter with a number.
+                             ^^^ Only use lowercase characters for block parameter.
         do_stuff
       end
     RUBY
-    expect(cop.offenses.size).to eq(3)
-    expect(cop.messages).to eq [
-      'Block parameter must be at least 2 characters long.',
-      'Do not end block parameter with a number.',
-      'Only use lowercase characters for block parameter.'
-    ]
   end
 
   context 'with AllowedNames' do

--- a/spec/rubocop/cop/naming/uncommunicative_method_param_name_spec.rb
+++ b/spec/rubocop/cop/naming/uncommunicative_method_param_name_spec.rb
@@ -121,17 +121,14 @@ RSpec.describe RuboCop::Cop::Naming::UncommunicativeMethodParamName, :config do
   end
 
   it 'can register multiple offenses in one method definition' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def self.something(y, num1, oFo)
+                         ^ Method parameter must be at least 3 characters long.
+                            ^^^^ Do not end method parameter with a number.
+                                  ^^^ Only use lowercase characters for method parameter.
         do_stuff
       end
     RUBY
-    expect(cop.offenses.size).to eq(3)
-    expect(cop.messages).to eq [
-      'Method parameter must be at least 3 characters long.',
-      'Do not end method parameter with a number.',
-      'Only use lowercase characters for method parameter.'
-    ]
   end
 
   context 'with AllowedNames' do

--- a/spec/rubocop/cop/naming/variable_number_spec.rb
+++ b/spec/rubocop/cop/naming/variable_number_spec.rb
@@ -21,9 +21,7 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
 
   shared_examples 'accepts' do |style, variable|
     it "accepts #{variable} in #{style}" do
-      inspect_source("#{variable} = 1")
-
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses("#{variable} = 1")
     end
   end
 

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -33,14 +33,15 @@ RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
 
       it 'does not register an offense when a .new method is made
         independently of the Time class' do
-        inspect_source('Range.new(1,
-                                  Time.days_in_month(date.month, date.year))')
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(<<-RUBY.strip_indent)
+          Range.new(1, Time.days_in_month(date.month, date.year))
+        RUBY
       end
 
       it "does not register an offense for #{klass}.new with zone argument" do
-        inspect_source("#{klass}.new(1988, 3, 15, 3, 0, 0, '-05:00')")
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(<<-RUBY.strip_indent)
+          #{klass}.new(1988, 3, 15, 3, 0, 0, '-05:00')
+        RUBY
       end
 
       it "registers an offense for ::#{klass}.now" do
@@ -49,8 +50,9 @@ RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
       end
 
       it "accepts Some::#{klass}.now" do
-        inspect_source("Some::#{klass}.forward(0).strftime('%H:%M')")
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(<<-RUBY.strip_indent)
+          Some::#{klass}.forward(0).strftime('%H:%M')
+        RUBY
       end
 
       described_class::ACCEPTED_METHODS.each do |a_method|
@@ -169,8 +171,9 @@ RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
 
     described_class::DANGEROUS_METHODS.each do |a_method|
       it "accepts Some::Time.#{a_method}" do
-        inspect_source("Some::Time.#{a_method}")
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(<<-RUBY.strip_indent)
+          Some::Time.#{a_method}
+        RUBY
       end
     end
   end
@@ -194,41 +197,48 @@ RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
       end
 
       it "accepts #{klass}.current" do
-        inspect_source("#{klass}.current")
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(<<-RUBY.strip_indent)
+          #{klass}.current
+        RUBY
       end
 
       described_class::ACCEPTED_METHODS.each do |a_method|
         it "accepts #{klass}.now.#{a_method}" do
-          inspect_source("#{klass}.now.#{a_method}")
-          expect(cop.offenses.empty?).to be(true)
+          expect_no_offenses(<<-RUBY.strip_indent)
+            #{klass}.now.#{a_method}
+          RUBY
         end
       end
 
       it "accepts #{klass}.zone.now" do
-        inspect_source("#{klass}.zone.now")
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(<<-RUBY.strip_indent)
+          #{klass}.zone.now
+        RUBY
       end
 
       it "accepts #{klass}.zone_default.now" do
-        inspect_source("#{klass}.zone_default.now")
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(<<-RUBY.strip_indent)
+          #{klass}.zone_default.now
+        RUBY
       end
 
       it "accepts #{klass}.find_zone(time_zone).now" do
-        inspect_source("#{klass}.find_zone('EST').now")
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(<<-RUBY.strip_indent)
+          #{klass}.find_zone('EST').now
+        RUBY
       end
 
       it "accepts #{klass}.find_zone!(time_zone).now" do
-        inspect_source("#{klass}.find_zone!('EST').now")
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(<<-RUBY.strip_indent)
+          #{klass}.find_zone!('EST').now
+        RUBY
       end
 
       described_class::DANGEROUS_METHODS.each do |a_method|
         it "accepts #{klass}.current.#{a_method}" do
-          inspect_source("#{klass}.current.#{a_method}")
-          expect(cop.offenses.empty?).to be(true)
+          expect_no_offenses(<<-RUBY.strip_indent)
+            #{klass}.current.#{a_method}
+          RUBY
         end
       end
     end

--- a/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
+++ b/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
@@ -15,10 +15,7 @@ RSpec.describe RuboCop::Cop::Rails::UniqBeforePluck, :config do
         end
       else
         it "ignores pluck without errors in #{source}" do
-          inspect_source(source)
-          expect(cop.messages.empty?).to be(true)
-          expect(cop.highlights.empty?).to be(true)
-          expect(cop.offenses.empty?).to be(true)
+          expect_no_offenses(source)
         end
       end
     end

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -12,8 +12,9 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
 
     %w[and or].each do |operator|
       it "accepts \"#{operator}\" outside of conditional" do
-        inspect_source("x = a + b #{operator} return x")
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(<<-RUBY.strip_indent)
+          x = a + b #{operator} return x
+        RUBY
       end
 
       {
@@ -41,21 +42,22 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           }
           source = format(snippet_format, elements)
 
-          inspect_source(source)
-          expect(cop.offenses.empty?).to be(true)
+          expect_no_offenses(source)
         end
       end
     end
 
     %w[&& ||].each do |operator|
       it "accepts #{operator} inside of conditional" do
-        inspect_source("test if a #{operator} b")
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(<<-RUBY.strip_indent)
+          test if a #{operator} b
+        RUBY
       end
 
       it "accepts #{operator} outside of conditional" do
-        inspect_source("x = a #{operator} b")
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(<<-RUBY.strip_indent)
+          x = a #{operator} b
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/style/attr_spec.rb
+++ b/spec/rubocop/cop/style/attr_spec.rb
@@ -43,27 +43,32 @@ RSpec.describe RuboCop::Cop::Style::Attr do
   end
 
   context 'offense message' do
-    let(:msg_reader) { 'Do not use `attr`. Use `attr_reader` instead.' }
-    let(:msg_accessor) { 'Do not use `attr`. Use `attr_accessor` instead.' }
-
     it 'for attr :name suggests to use attr_reader' do
-      inspect_source('attr :name')
-      expect(cop.offenses.first.message).to eq(msg_reader)
+      expect_offense(<<-RUBY.strip_indent)
+        attr :foo
+        ^^^^ Do not use `attr`. Use `attr_reader` instead.
+      RUBY
     end
 
     it 'for attr :name, false suggests to use attr_reader' do
-      inspect_source('attr :name, false')
-      expect(cop.offenses.first.message).to eq(msg_reader)
+      expect_offense(<<-RUBY.strip_indent)
+        attr :foo, false
+        ^^^^ Do not use `attr`. Use `attr_reader` instead.
+      RUBY
     end
 
     it 'for attr :name, true suggests to use attr_accessor' do
-      inspect_source('attr :name, true')
-      expect(cop.offenses.first.message).to eq(msg_accessor)
+      expect_offense(<<-RUBY.strip_indent)
+        attr :foo, true
+        ^^^^ Do not use `attr`. Use `attr_accessor` instead.
+      RUBY
     end
 
     it 'for attr with multiple names suggests to use attr_reader' do
-      inspect_source('attr :foo, :bar')
-      expect(cop.offenses.first.message).to eq(msg_reader)
+      expect_offense(<<-RUBY.strip_indent)
+        attr :foo, :bar
+        ^^^^ Do not use `attr`. Use `attr_reader` instead.
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/begin_block_spec.rb
+++ b/spec/rubocop/cop/style/begin_block_spec.rb
@@ -4,8 +4,9 @@ RSpec.describe RuboCop::Cop::Style::BeginBlock do
   subject(:cop) { described_class.new }
 
   it 'reports an offense for a BEGIN block' do
-    src = 'BEGIN { test }'
-    inspect_source(src)
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      BEGIN { test }
+      ^^^^^ Avoid the use of `BEGIN` blocks.
+    RUBY
   end
 end

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -45,40 +45,44 @@ RSpec.describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
   end
 
   shared_examples 'no_braces and context_dependent offenses' do
-    let(:msg) { 'Redundant curly braces around a hash parameter.' }
-
     it 'registers an offense for one non-hash parameter followed by a hash ' \
        'parameter with braces' do
-      inspect_source('where(1, { y: 2 })')
-      expect(cop.messages).to eq([msg])
-      expect(cop.highlights).to eq(['{ y: 2 }'])
+      expect_offense(<<-RUBY.strip_indent)
+        where(1, { y: 2 })
+                 ^^^^^^^^ Redundant curly braces around a hash parameter.
+      RUBY
     end
 
     it 'registers an offense for one object method hash parameter with ' \
        'braces' do
-      inspect_source('x.func({ y: "z" })')
-      expect(cop.messages).to eq([msg])
-      expect(cop.highlights).to eq(['{ y: "z" }'])
+      expect_offense(<<-RUBY.strip_indent)
+        x.func({ y: "z" })
+               ^^^^^^^^^^ Redundant curly braces around a hash parameter.
+      RUBY
     end
 
     it 'registers an offense for one hash parameter with braces' do
-      inspect_source('where({ x: 1 })')
-      expect(cop.messages).to eq([msg])
-      expect(cop.highlights).to eq(['{ x: 1 }'])
+      expect_offense(<<-RUBY.strip_indent)
+        where({ x: 1 })
+              ^^^^^^^^ Redundant curly braces around a hash parameter.
+      RUBY
     end
 
     it 'registers an offense for one hash parameter with braces and ' \
        'whitespace' do
-      inspect_source("where(  \n { x: 1 }   )")
-      expect(cop.messages).to eq([msg])
-      expect(cop.highlights).to eq(['{ x: 1 }'])
+      expect_offense(<<-RUBY.strip_indent)
+        where(  
+          { x: 1 }   )
+          ^^^^^^^^ Redundant curly braces around a hash parameter.
+      RUBY
     end
 
     it 'registers an offense for one hash parameter with braces and multiple ' \
        'keys' do
-      inspect_source('where({ x: 1, foo: "bar" })')
-      expect(cop.messages).to eq([msg])
-      expect(cop.highlights).to eq(['{ x: 1, foo: "bar" }'])
+      expect_offense(<<-RUBY.strip_indent)
+        where({ x: 1, foo: "bar" })
+              ^^^^^^^^^^^^^^^^^^^^ Redundant curly braces around a hash parameter.
+      RUBY
     end
   end
 
@@ -344,10 +348,10 @@ RSpec.describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
 
       it 'registers an offense for one hash parameter with braces and one ' \
          'without' do
-        inspect_source('where({ x: 1 }, y: 2)')
-        expect(cop.messages)
-          .to eq(['Missing curly braces around a hash parameter.'])
-        expect(cop.highlights).to eq(['y: 2'])
+        expect_offense(<<-RUBY.strip_indent)
+          where({ x: 1 }, y: 2)
+                          ^^^^ Missing curly braces around a hash parameter.
+        RUBY
       end
     end
 

--- a/spec/rubocop/cop/style/collection_methods_spec.rb
+++ b/spec/rubocop/cop/style/collection_methods_spec.rb
@@ -30,13 +30,15 @@ RSpec.describe RuboCop::Cop::Style::CollectionMethods, :config do
     end
 
     it "accepts #{method} with more than 1 param" do
-      inspect_source("[1, 2, 3].#{method}(other, &:test)")
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(<<-RUBY.strip_indent)
+        [1, 2, 3].#{method}(other, &:test)
+      RUBY
     end
 
     it "accepts #{method} without a block" do
-      inspect_source("[1, 2, 3].#{method}")
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(<<-RUBY.strip_indent)
+        [1, 2, 3].#{method}
+      RUBY
     end
 
     it 'auto-corrects to preferred method' do

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -133,16 +133,16 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
 
   context 'offenses in consecutive inline comments' do
     it 'registers each of them' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         class ToBeDone
           ITEMS = [
             '', # TODO Item 1
+                  ^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a colon, and a space, then a note describing the problem.
             '', # TODO Item 2
+                  ^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a colon, and a space, then a note describing the problem.
           ].freeze
         end
       RUBY
-
-      expect(cop.offenses.size).to be(2)
     end
   end
 end

--- a/spec/rubocop/cop/style/commented_keyword_spec.rb
+++ b/spec/rubocop/cop/style/commented_keyword_spec.rb
@@ -6,82 +6,68 @@ RSpec.describe RuboCop::Cop::Style::CommentedKeyword do
   let(:config) { RuboCop::Config.new }
 
   it 'registers an offense when commenting on the same line as `end`' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       if x
         y
       end # comment
+          ^^^^^^^^^ Do not place comments on the same line as the `end` keyword.
     RUBY
-    expect(cop.highlights).to eq(['# comment'])
-    expect(cop.messages).to eq(['Do not place comments on the same line as ' \
-                                'the `end` keyword.'])
   end
 
   it 'registers an offense when commenting on the same line as `begin`' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       begin # comment
+            ^^^^^^^^^ Do not place comments on the same line as the `begin` keyword.
         y
       end
     RUBY
-    expect(cop.highlights).to eq(['# comment'])
-    expect(cop.messages).to eq(['Do not place comments on the same line as ' \
-                                'the `begin` keyword.'])
   end
 
   it 'registers an offense when commenting on the same line as `class`' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       class X # comment
+              ^^^^^^^^^ Do not place comments on the same line as the `class` keyword.
         y
       end
     RUBY
-    expect(cop.highlights).to eq(['# comment'])
-    expect(cop.messages).to eq(['Do not place comments on the same line as ' \
-                                'the `class` keyword.'])
   end
 
   it 'registers an offense when commenting on the same line as `module`' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       module X # comment
+               ^^^^^^^^^ Do not place comments on the same line as the `module` keyword.
         y
       end
     RUBY
-    expect(cop.highlights).to eq(['# comment'])
-    expect(cop.messages).to eq(['Do not place comments on the same line as ' \
-                                'the `module` keyword.'])
   end
 
   it 'registers an offense when commenting on the same line as `def`' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def x # comment
+            ^^^^^^^^^ Do not place comments on the same line as the `def` keyword.
         y
       end
     RUBY
-    expect(cop.highlights).to eq(['# comment'])
-    expect(cop.messages).to eq(['Do not place comments on the same line as ' \
-                                'the `def` keyword.'])
   end
 
   it 'registers an offense when commenting on indented keywords' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       module X
         class Y # comment
+                ^^^^^^^^^ Do not place comments on the same line as the `class` keyword.
           z
         end
       end
     RUBY
-    expect(cop.highlights).to eq(['# comment'])
-    expect(cop.messages).to eq(['Do not place comments on the same line as ' \
-                                'the `class` keyword.'])
   end
 
   it 'registers an offense when commenting after keyword with spaces' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def x(a, b) # comment
+                  ^^^^^^^^^ Do not place comments on the same line as the `def` keyword.
         y
       end
     RUBY
-    expect(cop.highlights).to eq(['# comment'])
-    expect(cop.messages).to eq(['Do not place comments on the same line as ' \
-                                'the `def` keyword.'])
   end
 
   it 'registers an offense for one-line cases' do

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
     it 'registers an offense assigning any variable type to ternary' do
       inspect_source("#{variable} = foo? ? 1 : 2")
 
-      expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
+      expect(cop.messages).to eq(['Assign variables inside of conditionals'])
     end
 
     it 'allows assigning any variable type inside ternary' do
-      inspect_source("foo? ? #{variable} = 1 : #{variable} = 2")
-
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(<<-RUBY.strip_indent)
+        foo? ? #{variable} = 1 : #{variable} = 2
+      RUBY
     end
 
     it 'registers an offense assigning any variable type to if else' do
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
       RUBY
       inspect_source(source)
 
-      expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
+      expect(cop.messages).to eq(['Assign variables inside of conditionals'])
     end
 
     it 'registers an offense assigning any variable type to if elsif else' do
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
       RUBY
       inspect_source(source)
 
-      expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
+      expect(cop.messages).to eq(['Assign variables inside of conditionals'])
     end
 
     it 'registers an offense assigning any variable type to if else' \
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
       RUBY
       inspect_source(source)
 
-      expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
+      expect(cop.messages).to eq(['Assign variables inside of conditionals'])
     end
 
     it 'allows assigning any variable type inside if else' \
@@ -73,27 +73,21 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
     end
 
     it 'allows assigning any variable type inside if else' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         if foo
           #{variable} = 1
         else
           #{variable} = 2
         end
       RUBY
-      inspect_source(source)
-
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'allows assignment to if without else' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         #{variable} = if foo
                         1
                       end
       RUBY
-      inspect_source(source)
-
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'registers an offense assigning any variable type to unless else' do
@@ -106,20 +100,17 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
       RUBY
       inspect_source(source)
 
-      expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
+      expect(cop.messages).to eq(['Assign variables inside of conditionals'])
     end
 
     it 'allows assigning any variable type inside unless else' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         unless foo
           #{variable} = 1
         else
           #{variable} = 2
         end
       RUBY
-      inspect_source(source)
-
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'registers an offense for assigning any variable type to case when' do
@@ -133,11 +124,11 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
       RUBY
       inspect_source(source)
 
-      expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
+      expect(cop.messages).to eq(['Assign variables inside of conditionals'])
     end
 
     it 'allows assigning any variable type inside case when' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         case foo
         when "a"
           #{variable} = 1
@@ -145,22 +136,16 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
           #{variable} = 2
         end
       RUBY
-      inspect_source(source)
-
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'does not crash for rescue assignment' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         begin
           foo
         rescue => #{variable}
           bar
         end
       RUBY
-      inspect_source(source)
-
-      expect(cop.offenses.empty?).to be(true)
     end
 
     context 'auto-correct' do
@@ -243,7 +228,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
     it 'registers an offense for any assignment to ternary' do
       inspect_source("bar #{assignment} (foo? ? 1 : 2)")
 
-      expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
+      expect(cop.messages).to eq(['Assign variables inside of conditionals'])
     end
 
     it 'registers an offense any assignment to if else' do
@@ -256,18 +241,15 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
       RUBY
       inspect_source(source)
 
-      expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
+      expect(cop.messages).to eq(['Assign variables inside of conditionals'])
     end
 
     it 'allows any assignment to if without else' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         bar #{assignment} if foo
                         1
                       end
       RUBY
-      inspect_source(source)
-
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'registers an offense for any assignment to unless else' do
@@ -280,7 +262,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
       RUBY
       inspect_source(source)
 
-      expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
+      expect(cop.messages).to eq(['Assign variables inside of conditionals'])
     end
 
     it 'registers an offense any assignment to case when' do
@@ -294,7 +276,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
       RUBY
       inspect_source(source)
 
-      expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
+      expect(cop.messages).to eq(['Assign variables inside of conditionals'])
     end
 
     context 'auto-correct' do
@@ -728,7 +710,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
        'an equal sign' do
       inspect_source('self.attributes = foo? ? 1 : 2')
 
-      expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
+      expect(cop.messages).to eq(['Assign variables inside of conditionals'])
     end
 
     it 'registers an offense for assignment using []=' do
@@ -741,7 +723,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
       RUBY
       inspect_source(source)
 
-      expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
+      expect(cop.messages).to eq(['Assign variables inside of conditionals'])
     end
 
     it 'registers an offense for assignment to an if then else' do
@@ -752,7 +734,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
       RUBY
       inspect_source(source)
 
-      expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
+      expect(cop.messages).to eq(['Assign variables inside of conditionals'])
     end
 
     it 'registers an offense for assignment to case when then else' do
@@ -764,7 +746,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
       RUBY
       inspect_source(source)
 
-      expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
+      expect(cop.messages).to eq(['Assign variables inside of conditionals'])
     end
 
     context 'for loop' do
@@ -886,19 +868,19 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
     it_behaves_like('all variable types', 'foo.bar')
 
     it_behaves_like('multiline all variable types', 'bar',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all variable types', 'BAR',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all variable types', 'FOO::BAR',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all variable types', '@bar',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all variable types', '@@bar',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all variable types', '$BAR',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all variable types', 'foo.bar',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
 
     it_behaves_like('all assignment types', '=')
     it_behaves_like('all assignment types', '==')
@@ -923,47 +905,47 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
     it_behaves_like('all assignment types', '<<')
 
     it_behaves_like('multiline all assignment types', '=',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all assignment types', '==',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all assignment types', '===',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all assignment types', '+=',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all assignment types', '-=',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all assignment types', '*=',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all assignment types', '**=',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all assignment types', '/=',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all assignment types', '%=',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all assignment types', '^=',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all assignment types', '&=',
                     [described_class::ASSIGN_TO_CONDITION_MSG])
     it_behaves_like('multiline all assignment types', '|=',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all assignment types', '<=',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all assignment types', '>=',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all assignment types', '<<=',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all assignment types', '>>=',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all assignment types', '||=',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all assignment types', '&&=',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all assignment types', '+=',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all assignment types', '-=',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
     it_behaves_like('multiline all assignment types', '<<',
-                    [described_class::ASSIGN_TO_CONDITION_MSG])
+                    ['Assign variables inside of conditionals'])
 
     it_behaves_like('single line condition auto-correct')
 

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -24,11 +24,6 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
 
   let(:end_alignment_align_with) { 'start_of_line' }
 
-  let(:message) do
-    'Use the return of the conditional ' \
-    'for variable assignment and comparison.'
-  end
-
   it 'counts array assignment when determining multiple assignment' do
     expect_no_offenses(<<-RUBY.strip_indent)
       if foo
@@ -66,10 +61,10 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
   end
 
   it 'registers an offense for assignment in ternary operation' do
-    source = 'foo? ? bar = "a" : bar = "b"'
-    inspect_source(source)
-
-    expect(cop.messages).to eq([message])
+    expect_offense(<<-RUBY.strip_indent)
+      foo? ? bar = "a" : bar = "b"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
+    RUBY
   end
 
   it 'allows modifier if' do
@@ -89,61 +84,49 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
   it "doesn't crash when assignment statement uses chars which have " \
      'special meaning in a regex' do
     # regression test; see GH issue 2876
-    source = <<-RUBY.strip_indent
+    expect_offense(<<-RUBY.strip_indent)
       if condition
+      ^^^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
         default['key-with-dash'] << a
       else
         default['key-with-dash'] << b
       end
     RUBY
-
-    inspect_source(source)
-
-    expect(cop.offenses.size).to eq(1)
   end
 
   shared_examples 'comparison methods' do |method|
     it 'registers an offense for comparison methods in if else' do
-      source = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         if foo
+        ^^^^^^ Use the return of the conditional for variable assignment and comparison.
           a #{method} b
         else
           a #{method} d
         end
       RUBY
-
-      inspect_source(source)
-
-      expect(cop.messages).to eq([message])
     end
 
     it 'registers an offense for comparison methods in unless else' do
-      source = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         unless foo
+        ^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
           a #{method} b
         else
           a #{method} d
         end
       RUBY
-
-      inspect_source(source)
-
-      expect(cop.messages).to eq([message])
     end
 
     it 'registers an offense for comparison methods in case when' do
-      source = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         case foo
+        ^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
         when bar
           a #{method} b
         else
           a #{method} d
         end
       RUBY
-
-      inspect_source(source)
-
-      expect(cop.messages).to eq([message])
     end
   end
 
@@ -349,23 +332,20 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
 
   it 'registers an offense in an if else if the assignment is already ' \
     'at the line length limit' do
-    source = <<-RUBY.strip_indent
+    expect_offense(<<-RUBY.strip_indent)
       if foo
+      ^^^^^^ Use the return of the conditional for variable assignment and comparison.
         bar = #{'a' * 72}
       else
         bar = #{'b' * 72}
       end
     RUBY
-
-    inspect_source(source)
-
-    expect(cop.messages).to eq([message])
   end
 
   context 'correction would exceed max line length' do
     it 'allows assignment to the same variable in if else if the correction ' \
        'would create a line longer than the configured LineLength' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         if foo
           #{'a' * 78}
           bar = 1
@@ -373,30 +353,22 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
           bar = 2
         end
       RUBY
-
-      inspect_source(source)
-
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'allows assignment to the same variable in if else if the correction ' \
        'would cause the condition to exceed the configured LineLength' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         if #{'a' * 78}
           bar = 1
         else
           bar = 2
         end
       RUBY
-
-      inspect_source(source)
-
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'allows assignment to the same variable in case when else if the ' \
        'correction would create a line longer than the configured LineLength' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         case foo
         when foobar
           #{'a' * 78}
@@ -405,10 +377,6 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
           bar = 2
         end
       RUBY
-
-      inspect_source(source)
-
-      expect(cop.offenses.empty?).to be(true)
     end
   end
 
@@ -416,7 +384,8 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
     it 'registers an offense assigning any variable type in ternary' do
       inspect_source("foo? ? #{variable} = 1 : #{variable} = 2")
 
-      expect(cop.messages).to eq([message])
+      expect(cop.messages).to eq(['Use the return of the conditional for ' \
+        'variable assignment and comparison.'])
     end
 
     it 'registers an offense assigning any variable type in if else' do
@@ -429,7 +398,8 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
       RUBY
       inspect_source(source)
 
-      expect(cop.messages).to eq([message])
+      expect(cop.messages).to eq(['Use the return of the conditional for ' \
+        'variable assignment and comparison.'])
     end
 
     it 'registers an offense assigning any variable type in case when' do
@@ -443,24 +413,22 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
       RUBY
       inspect_source(source)
 
-      expect(cop.messages).to eq([message])
+      expect(cop.messages).to eq(['Use the return of the conditional for ' \
+        'variable assignment and comparison.'])
     end
 
     it 'allows assignment to the return of if else' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         #{variable} = if foo
                         1
                       else
                         2
                       end
       RUBY
-      inspect_source(source)
-
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'allows assignment to the return of case when' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         #{variable} = case foo
                       when bar
                         1
@@ -468,15 +436,12 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
                         2
                       end
       RUBY
-      inspect_source(source)
-
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'allows assignment to the return of a ternary' do
-      inspect_source("#{variable} = foo? ? 1 : 2")
-
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(<<-RUBY.strip_indent)
+        #{variable} = foo? ? 1 : 2
+      RUBY
     end
   end
 
@@ -502,14 +467,14 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
           source = "foo? ? #{name} #{assignment} 1 : #{name} #{assignment} 2"
           inspect_source(source)
 
-          expect(cop.messages).to eq([message])
+          expect(cop.messages).to eq(['Use the return of the conditional for ' \
+            'variable assignment and comparison.'])
         end
 
         it "allows assignment using #{assignment} to ternary" do
-          source = "#{name} #{assignment} foo? ? 1 : 2"
-          inspect_source(source)
-
-          expect(cop.offenses.empty?).to be(true)
+          expect_no_offenses(<<-RUBY.strip_indent)
+            #{name} #{assignment} foo? ? 1 : 2
+          RUBY
         end
 
         it "registers an offense for assignment using #{assignment} in " \
@@ -523,7 +488,8 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
           RUBY
           inspect_source(source)
 
-          expect(cop.messages).to eq([message])
+          expect(cop.messages).to eq(['Use the return of the conditional for ' \
+            'variable assignment and comparison.'])
         end
 
         it "registers an offense for assignment using #{assignment} in "\
@@ -538,7 +504,8 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
           RUBY
           inspect_source(source)
 
-          expect(cop.messages).to eq([message])
+          expect(cop.messages).to eq(['Use the return of the conditional for ' \
+            'variable assignment and comparison.'])
         end
 
         it "autocorrects for assignment using #{assignment} in if else" do
@@ -587,8 +554,9 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
   it_behaves_like('all assignment types', '-=')
 
   it 'registers an offense for assignment in if elsif else' do
-    source = <<-RUBY.strip_indent
+    expect_offense(<<-RUBY.strip_indent)
       if foo
+      ^^^^^^ Use the return of the conditional for variable assignment and comparison.
         bar = 1
       elsif baz
         bar = 2
@@ -596,14 +564,12 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
         bar = 3
       end
     RUBY
-    inspect_source(source)
-
-    expect(cop.messages).to eq([message])
   end
 
   it 'registers an offense for assignment in if elsif elsif else' do
-    source = <<-RUBY.strip_indent
+    expect_offense(<<-RUBY.strip_indent)
       if foo
+      ^^^^^^ Use the return of the conditional for variable assignment and comparison.
         bar = 1
       elsif baz
         bar = 2
@@ -613,15 +579,13 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
         bar = 4
       end
     RUBY
-    inspect_source(source)
-
-    expect(cop.messages).to eq([message])
   end
 
   it 'registers an offense for assignment in if else when the assignment ' \
     'spans multiple lines' do
-    source = <<-RUBY.strip_indent
+    expect_offense(<<-RUBY.strip_indent)
       if foo
+      ^^^^^^ Use the return of the conditional for variable assignment and comparison.
         foo = {
           a: 1,
           b: 2,
@@ -636,9 +600,6 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
         foo = { }
       end
     RUBY
-    inspect_source(source)
-
-    expect(cop.messages).to eq([message])
   end
 
   it 'autocorrects assignment in if else when the assignment ' \
@@ -755,7 +716,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
     it 'allows multiple assignment in if elsif else when the last ' \
        'assignment is the same and the earlier assignments do not appear in ' \
        'all branches' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         if baz
           foo = 1
           bar = 1
@@ -767,15 +728,12 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
           bar = 3
         end
       RUBY
-      inspect_source(source)
-
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'allows multiple assignment in case when else when the last ' \
        'assignment is the same and the earlier assignments do not appear ' \
        'in all branches' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         case foo
         when foobar
           baz = 1
@@ -788,9 +746,6 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
           bar = 3
         end
       RUBY
-      inspect_source(source)
-
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'allows out of order multiple assignment in if elsif else' do
@@ -851,7 +806,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
 
     it 'allows multiple assignments in case when if there are uniq ' \
        'variables in the when branches' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         case foo
         when foobar
           foo = 1
@@ -866,15 +821,12 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
           bar = 3
         end
       RUBY
-      inspect_source(source)
-
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'allows multiple assignment in case statements when the last ' \
        'assignment is the same and the earlier assignments do not appear in ' \
        'all branches' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         case foo
         when foobar
           foo = 1
@@ -887,15 +839,12 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
           bar = 3
         end
       RUBY
-      inspect_source(source)
-
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'allows assignment in if elsif else with some branches only ' \
        'containing variable assignment and others containing more than ' \
        'variable assignment' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         if foo
           bar = 1
         elsif foobar
@@ -908,14 +857,11 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
           bar = 4
         end
       RUBY
-      inspect_source(source)
-
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'allows variable assignment in unless else with more than ' \
        'variable assignment' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         unless foo
           method_call
           bar = 1
@@ -924,14 +870,11 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
           bar = 2
         end
       RUBY
-      inspect_source(source)
-
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'allows variable assignment in case when else with more than ' \
        'variable assignment' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         case foo
         when foobar
           method_call
@@ -941,10 +884,6 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
           bar = 2
         end
       RUBY
-
-      inspect_source(source)
-
-      expect(cop.offenses.empty?).to be(true)
     end
 
     context 'multiple assignment in only one branch' do
@@ -996,44 +935,39 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
   end
 
   it 'registers an offense for assignment in if then else' do
-    source = <<-RUBY.strip_indent
+    expect_offense(<<-RUBY.strip_indent)
       if foo then bar = 1
+      ^^^^^^^^^^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
       else bar = 2
       end
     RUBY
-    inspect_source(source)
-
-    expect(cop.messages).to eq([message])
   end
 
   it 'registers an offense for assignment in unless else' do
-    source = <<-RUBY.strip_indent
+    expect_offense(<<-RUBY.strip_indent)
       unless foo
+      ^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
         bar = 1
       else
         bar = 2
       end
     RUBY
-    inspect_source(source)
-
-    expect(cop.messages).to eq([message])
   end
 
   it 'registers an offense for assignment in case when then else' do
-    source = <<-RUBY.strip_indent
+    expect_offense(<<-RUBY.strip_indent)
       case foo
+      ^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
       when bar then baz = 1
       else baz = 2
       end
     RUBY
-    inspect_source(source)
-
-    expect(cop.messages).to eq([message])
   end
 
   it 'registers an offense for assignment in case with when when else' do
-    source = <<-RUBY.strip_indent
+    expect_offense(<<-RUBY.strip_indent)
       case foo
+      ^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
       when foobar
         bar = 1
       when baz
@@ -1042,9 +976,6 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
         bar = 3
       end
     RUBY
-    inspect_source(source)
-
-    expect(cop.messages).to eq([message])
   end
 
   it 'allows different assignment types in case with when when else' do
@@ -1060,16 +991,13 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
 
   it 'allows assignment in multiple branches when it is ' \
      'wrapped in a modifier' do
-    source = <<-RUBY.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       if foo
         bar << 1
       else
         bar << 2 if foobar
       end
     RUBY
-    inspect_source(source)
-
-    expect(cop.offenses.empty?).to be(true)
   end
 
   context 'auto-correct' do
@@ -1744,8 +1672,9 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
 
     context 'assignment as the last statement' do
       it 'registers an offense in if else with more than variable assignment' do
-        source = <<-RUBY.strip_indent
+        expect_offense(<<-RUBY.strip_indent)
           if foo
+          ^^^^^^ Use the return of the conditional for variable assignment and comparison.
             method_call
             bar = 1
           else
@@ -1753,15 +1682,13 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 2
           end
         RUBY
-        inspect_source(source)
-
-        expect(cop.messages).to eq([message])
       end
 
       it 'registers an offense in if elsif else with more than ' \
          'variable assignment' do
-        source = <<-RUBY.strip_indent
+        expect_offense(<<-RUBY.strip_indent)
           if foo
+          ^^^^^^ Use the return of the conditional for variable assignment and comparison.
             method_call
             bar = 1
           elsif foobar
@@ -1772,14 +1699,12 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 3
           end
         RUBY
-        inspect_source(source)
-
-        expect(cop.messages).to eq([message])
       end
 
       it 'register an offense for multiple assignment in if else' do
-        source = <<-RUBY.strip_indent
+        expect_offense(<<-RUBY.strip_indent)
           if baz
+          ^^^^^^ Use the return of the conditional for variable assignment and comparison.
             foo = 1
             bar = 1
           else
@@ -1787,14 +1712,12 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 2
           end
         RUBY
-        inspect_source(source)
-
-        expect(cop.messages).to eq([message])
       end
 
       it 'registers an offense for multiple assignment in if elsif else' do
-        source = <<-RUBY.strip_indent
+        expect_offense(<<-RUBY.strip_indent)
           if baz
+          ^^^^^^ Use the return of the conditional for variable assignment and comparison.
             foo = 1
             bar = 1
           elsif foobar
@@ -1805,14 +1728,12 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 3
           end
         RUBY
-        inspect_source(source)
-
-        expect(cop.messages).to eq([message])
       end
 
       it 'allows multiple assignment in if elsif elsif else' do
-        source = <<-RUBY.strip_indent
+        expect_offense(<<-RUBY.strip_indent)
           if baz
+          ^^^^^^ Use the return of the conditional for variable assignment and comparison.
             foo = 1
             bar = 1
           elsif foobar
@@ -1826,9 +1747,6 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 4
           end
         RUBY
-        inspect_source(source)
-
-        expect(cop.messages).to eq([message])
       end
 
       it 'allows out of order multiple assignment in if elsif else' do
@@ -1847,8 +1765,9 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
       end
 
       it 'allows multiple assignment in unless else' do
-        source = <<-RUBY.strip_indent
+        expect_offense(<<-RUBY.strip_indent)
           unless baz
+          ^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
             foo = 1
             bar = 1
           else
@@ -1856,14 +1775,12 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 2
           end
         RUBY
-        inspect_source(source)
-
-        expect(cop.messages).to eq([message])
       end
 
       it 'allows multiple assignments in case when with only one when' do
-        source = <<-RUBY.strip_indent
+        expect_offense(<<-RUBY.strip_indent)
           case foo
+          ^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
           when foobar
             foo = 1
             bar = 1
@@ -1872,14 +1789,12 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 3
           end
         RUBY
-        inspect_source(source)
-
-        expect(cop.messages).to eq([message])
       end
 
       it 'allows multiple assignments in case when with multiple whens' do
-        source = <<-RUBY.strip_indent
+        expect_offense(<<-RUBY.strip_indent)
           case foo
+          ^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
           when foobar
             foo = 1
             bar = 1
@@ -1891,16 +1806,14 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 3
           end
         RUBY
-        inspect_source(source)
-
-        expect(cop.messages).to eq([message])
       end
 
       it 'registers an offense in if elsif else with some branches only ' \
           'containing variable assignment and others containing more than ' \
           'variable assignment' do
-        source = <<-RUBY.strip_indent
+        expect_offense(<<-RUBY.strip_indent)
           if foo
+          ^^^^^^ Use the return of the conditional for variable assignment and comparison.
             bar = 1
           elsif foobar
             method_call
@@ -1912,15 +1825,13 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 4
           end
         RUBY
-        inspect_source(source)
-
-        expect(cop.messages).to eq([message])
       end
 
       it 'registers an offense in unless else with more than ' \
          'variable assignment' do
-        source = <<-RUBY.strip_indent
+        expect_offense(<<-RUBY.strip_indent)
           unless foo
+          ^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
             method_call
             bar = 1
           else
@@ -1928,15 +1839,13 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 2
           end
         RUBY
-        inspect_source(source)
-
-        expect(cop.messages).to eq([message])
       end
 
       it 'registers an offense in case when else with more than ' \
          'variable assignment' do
-        source = <<-RUBY.strip_indent
+        expect_offense(<<-RUBY.strip_indent)
           case foo
+          ^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
           when foobar
             method_call
             bar = 1
@@ -1945,16 +1854,13 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 2
           end
         RUBY
-
-        inspect_source(source)
-
-        expect(cop.messages).to eq([message])
       end
 
       context 'multiple assignment in only one branch' do
         it 'registers an offense when multiple assignment is in if' do
-          source = <<-RUBY.strip_indent
+          expect_offense(<<-RUBY.strip_indent)
             if foo
+            ^^^^^^ Use the return of the conditional for variable assignment and comparison.
               baz = 1
               bar = 1
             elsif foobar
@@ -1965,14 +1871,12 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
               bar = 3
             end
           RUBY
-          inspect_source(source)
-
-          expect(cop.offenses.size).to eq(1)
         end
 
         it 'registers an offense when multiple assignment is in elsif' do
-          source = <<-RUBY.strip_indent
+          expect_offense(<<-RUBY.strip_indent)
             if foo
+            ^^^^^^ Use the return of the conditional for variable assignment and comparison.
               method_call
               bar = 1
             elsif foobar
@@ -1983,14 +1887,12 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
               bar = 3
             end
           RUBY
-          inspect_source(source)
-
-          expect(cop.offenses.size).to eq(1)
         end
 
         it 'registers an offense when multiple assignment is in else' do
-          source = <<-RUBY.strip_indent
+          expect_offense(<<-RUBY.strip_indent)
             if foo
+            ^^^^^^ Use the return of the conditional for variable assignment and comparison.
               method_call
               bar = 1
             elsif foobar
@@ -2001,16 +1903,13 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
               bar = 3
             end
           RUBY
-          inspect_source(source)
-
-          expect(cop.offenses.size).to eq(1)
         end
       end
     end
 
     it 'allows assignment in multiple branches when it is ' \
        'wrapped in a modifier' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         if foo
           bar << 1
           bar << 2
@@ -2019,15 +1918,13 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
           bar << 4 if foobar
         end
       RUBY
-      inspect_source(source)
-
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'registers an offense for multiple assignment when an earlier ' \
        'assignment is is protected by a modifier' do
-      source = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         if foo
+        ^^^^^^ Use the return of the conditional for variable assignment and comparison.
           bar << 1
           bar << 2
         else
@@ -2035,9 +1932,6 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
           bar << 4
         end
       RUBY
-      inspect_source(source)
-
-      expect(cop.messages).to eq([message])
     end
 
     context 'auto-correct' do

--- a/spec/rubocop/cop/style/def_with_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/def_with_parentheses_spec.rb
@@ -4,21 +4,19 @@ RSpec.describe RuboCop::Cop::Style::DefWithParentheses do
   subject(:cop) { described_class.new }
 
   it 'reports an offense for def with empty parens' do
-    src = <<-RUBY.strip_indent
+    expect_offense(<<-RUBY.strip_indent)
       def func()
+              ^ Omit the parentheses in defs when the method doesn't accept any arguments.
       end
     RUBY
-    inspect_source(src)
-    expect(cop.offenses.size).to eq(1)
   end
 
   it 'reports an offense for class def with empty parens' do
-    src = <<-RUBY.strip_indent
+    expect_offense(<<-RUBY.strip_indent)
       def Test.func()
+                   ^ Omit the parentheses in defs when the method doesn't accept any arguments.
       end
     RUBY
-    inspect_source(src)
-    expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts def with arg and parens' do

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -21,16 +21,16 @@ RSpec.describe RuboCop::Cop::Style::Documentation do
 
   it 'does not consider comment followed by empty line to be class ' \
      'documentation' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       # Copyright 2014
       # Some company
 
       class My_Class
+      ^^^^^ Missing top-level class documentation comment.
         def method
         end
       end
     RUBY
-    expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for non-namespace' do
@@ -109,7 +109,7 @@ RSpec.describe RuboCop::Cop::Style::Documentation do
 
   it 'accepts non-empty class with annotation comment followed by other ' \
      'comment' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       # OPTIMIZE: Make this faster.
       # Class comment.
       class My_Class
@@ -117,7 +117,6 @@ RSpec.describe RuboCop::Cop::Style::Documentation do
         end
       end
     RUBY
-    expect(cop.offenses.empty?).to be(true)
   end
 
   it 'accepts non-empty class with comment that ends with an annotation' do
@@ -237,7 +236,7 @@ RSpec.describe RuboCop::Cop::Style::Documentation do
   context 'sparse and trailing comments' do
     %w[class module].each do |keyword|
       it "ignores comments after #{keyword} node end" do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           module TestModule
             # documentation comment
             #{keyword} Test
@@ -246,7 +245,6 @@ RSpec.describe RuboCop::Cop::Style::Documentation do
             end # decorating comment
           end
         RUBY
-        expect(cop.offenses.empty?).to be(true)
       end
 
       it "ignores sparse comments inside #{keyword} node" do
@@ -267,13 +265,12 @@ RSpec.describe RuboCop::Cop::Style::Documentation do
   context 'with # :nodoc:' do
     %w[class module].each do |keyword|
       it "accepts non-namespace #{keyword} without documentation" do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           #{keyword} Test #:nodoc:
             def method
             end
           end
         RUBY
-        expect(cop.offenses.empty?).to be(true)
       end
 
       it "accepts compact-style nested #{keyword} without documentation" do
@@ -300,7 +297,7 @@ RSpec.describe RuboCop::Cop::Style::Documentation do
 
       context 'with `all` modifier' do
         it "accepts nested #{keyword} without documentation" do
-          inspect_source(<<-RUBY.strip_indent)
+          expect_no_offenses(<<-RUBY.strip_indent)
             module A #:nodoc: all
               module B
                 TEST = 20
@@ -310,7 +307,6 @@ RSpec.describe RuboCop::Cop::Style::Documentation do
               end
             end
           RUBY
-          expect(cop.offenses.empty?).to be(true)
         end
       end
     end

--- a/spec/rubocop/cop/style/each_with_object_spec.rb
+++ b/spec/rubocop/cop/style/each_with_object_spec.rb
@@ -25,10 +25,11 @@ RSpec.describe RuboCop::Cop::Style::EachWithObject do
       end
     RUBY
 
-    expect(corrected).to eq(['[1, 2, 3].each_with_object({}) do |i, h|',
-                             '  h[i] = i',
-                             'end',
-                             ''].join("\n"))
+    expect(corrected).to eq(<<-RUBY.strip_indent)
+      [1, 2, 3].each_with_object({}) do |i, h|
+        h[i] = i
+      end
+    RUBY
   end
 
   it 'correctly autocorrects with return value only' do
@@ -38,9 +39,10 @@ RSpec.describe RuboCop::Cop::Style::EachWithObject do
       end
     RUBY
 
-    expect(corrected).to eq(['[1, 2, 3].each_with_object({}) do |i, h|',
-                             'end',
-                             ''].join("\n"))
+    expect(corrected).to eq(<<-RUBY.strip_indent)
+      [1, 2, 3].each_with_object({}) do |i, h|
+      end
+    RUBY
   end
 
   it 'ignores inject and reduce with passed in, but not returned hash' do

--- a/spec/rubocop/cop/style/empty_else_spec.rb
+++ b/spec/rubocop/cop/style/empty_else_spec.rb
@@ -66,15 +66,19 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse do
 
         context 'not using semicolons' do
           let(:source) do
-            ['if a',
-             '  foo',
-             'else',
-             'end'].join("\n")
+            <<-RUBY.strip_indent
+              if a
+                foo
+              else
+              end
+            RUBY
           end
           let(:corrected_source) do
-            ['if a',
-             '  foo',
-             'end'].join("\n")
+            <<-RUBY.strip_indent
+              if a
+                foo
+              end
+            RUBY
           end
 
           it_behaves_like 'offense registration'
@@ -217,21 +221,25 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse do
       context 'with an else-clause containing only the literal nil' do
         context 'when standalone' do
           let(:source) do
-            ['if a',
-             '  foo',
-             'elsif b',
-             '  bar',
-             'else',
-             '  nil',
-             'end'].join("\n")
+            <<-RUBY.strip_indent
+              if a
+                foo
+              elsif b
+                bar
+              else
+                nil
+              end
+            RUBY
           end
 
           let(:corrected_source) do
-            ['if a',
-             '  foo',
-             'elsif b',
-             '  bar',
-             'end'].join("\n")
+            <<-RUBY.strip_indent
+              if a
+                foo
+              elsif b
+                bar
+              end
+            RUBY
           end
 
           it_behaves_like 'offense registration'
@@ -498,31 +506,35 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse do
     end
 
     let(:source) do
-      ['def foo',
-       '  if @params',
-       '    case @params[:x]',
-       '    when :a',
-       '      :b',
-       '    else',
-       '      nil',
-       '    end',
-       '  else',
-       '    :c',
-       '  end',
-       'end'].join("\n")
+      <<-RUBY.strip_indent
+        def foo
+          if @params
+            case @params[:x]
+            when :a
+              :b
+            else
+              nil
+            end
+          else
+            :c
+          end
+        end
+      RUBY
     end
 
     let(:corrected_source) do
-      ['def foo',
-       '  if @params',
-       '    case @params[:x]',
-       '    when :a',
-       '      :b',
-       '    end',
-       '  else',
-       '    :c',
-       '  end',
-       'end'].join("\n")
+      <<-RUBY.strip_indent
+        def foo
+          if @params
+            case @params[:x]
+            when :a
+              :b
+            end
+          else
+            :c
+          end
+        end
+      RUBY
     end
 
     it_behaves_like 'offense registration'

--- a/spec/rubocop/cop/style/encoding_spec.rb
+++ b/spec/rubocop/cop/style/encoding_spec.rb
@@ -4,76 +4,56 @@ RSpec.describe RuboCop::Cop::Style::Encoding, :config do
   subject(:cop) { described_class.new(config) }
 
   it 'registers no offense when no encoding present' do
-    inspect_source('def foo() end')
-
-    expect(cop.offenses.empty?).to be(true)
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def foo() end
+    RUBY
   end
 
   it 'registers no offense when encoding present but not UTF-8' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       # encoding: us-ascii
       def foo() end
     RUBY
-
-    expect(cop.offenses.empty?).to be(true)
   end
 
   it 'registers an offense when encoding present and UTF-8' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       # encoding: utf-8
+      ^^^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
       def foo() end
     RUBY
-
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(
-      ['Unnecessary utf-8 encoding comment.']
-    )
   end
 
   it 'registers an offense when encoding present on 2nd line after shebang' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       #!/usr/bin/env ruby
       # encoding: utf-8
+      ^^^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
       def foo() end
     RUBY
-
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(
-      ['Unnecessary utf-8 encoding comment.']
-    )
   end
 
   it 'registers an offense for vim-style encoding comments' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       # vim:filetype=ruby, fileencoding=utf-8
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
       def foo() end
     RUBY
-
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(
-      ['Unnecessary utf-8 encoding comment.']
-    )
   end
 
   it 'registers no offense when encoding is in the wrong place' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def foo() end
       # encoding: utf-8
     RUBY
-
-    expect(cop.offenses.empty?).to be(true)
   end
 
   it 'registers an offense for encoding inserted by magic_encoding gem' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       # -*- encoding : utf-8 -*-
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
       def foo() 'ä' end
     RUBY
-
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(
-      ['Unnecessary utf-8 encoding comment.']
-    )
   end
 
   context 'auto-correct' do

--- a/spec/rubocop/cop/style/end_block_spec.rb
+++ b/spec/rubocop/cop/style/end_block_spec.rb
@@ -4,8 +4,9 @@ RSpec.describe RuboCop::Cop::Style::EndBlock do
   subject(:cop) { described_class.new }
 
   it 'reports an offense for an END block' do
-    src = 'END { test }'
-    inspect_source(src)
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      END { test }
+      ^^^ Avoid the use of `END` blocks. Use `Kernel#at_exit` instead.
+    RUBY
   end
 end

--- a/spec/rubocop/cop/style/for_spec.rb
+++ b/spec/rubocop/cop/style/for_spec.rb
@@ -7,22 +7,21 @@ RSpec.describe RuboCop::Cop::Style::For, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'each' } }
 
     it 'registers an offense for for' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def func
           for n in [1, 2, 3] do
+          ^^^ Prefer `each` over `for`.
             puts n
           end
         end
       RUBY
-      expect(cop.messages).to eq(['Prefer `each` over `for`.'])
-      expect(cop.highlights).to eq(['for'])
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'for')
     end
 
     it 'registers an offense for opposite + correct style' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def func
           for n in [1, 2, 3] do
+          ^^^ Prefer `each` over `for`.
             puts n
           end
           [1, 2, 3].each do |n|
@@ -30,8 +29,6 @@ RSpec.describe RuboCop::Cop::Style::For, :config do
           end
         end
       RUBY
-      expect(cop.messages).to eq(['Prefer `each` over `for`.'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'accepts multiline each' do
@@ -67,31 +64,28 @@ RSpec.describe RuboCop::Cop::Style::For, :config do
     end
 
     it 'registers an offense for multiline each' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def func
           [1, 2, 3].each do |n|
+                    ^^^^ Prefer `for` over `each`.
             puts n
           end
         end
       RUBY
-      expect(cop.messages).to eq(['Prefer `for` over `each`.'])
-      expect(cop.highlights).to eq(['each'])
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'each')
     end
 
     it 'registers an offense for correct + opposite style' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def func
           for n in [1, 2, 3] do
             puts n
           end
           [1, 2, 3].each do |n|
+                    ^^^^ Prefer `for` over `each`.
             puts n
           end
         end
       RUBY
-      expect(cop.messages).to eq(['Prefer `for` over `each`.'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'accepts single line each' do

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -33,21 +33,19 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for not having a frozen string literal comment ' \
        'on the top line' do
-      inspect_source('puts 1')
-
-      expect(cop.messages)
-        .to eq(['Missing magic comment `# frozen_string_literal: true`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        puts 1
+        ^ Missing magic comment `# frozen_string_literal: true`.
+      RUBY
     end
 
     it 'registers an offense for not having a frozen string literal comment ' \
        'under a shebang' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         #!/usr/bin/env ruby
+        ^ Missing magic comment `# frozen_string_literal: true`.
         puts 1
       RUBY
-
-      expect(cop.messages)
-        .to eq(['Missing magic comment `# frozen_string_literal: true`.'])
     end
 
     it 'accepts a frozen string literal below a shebang comment' do
@@ -68,13 +66,11 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for not having a frozen string literal comment ' \
        'under an encoding comment' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         # encoding: utf-8
+        ^ Missing magic comment `# frozen_string_literal: true`.
         puts 1
       RUBY
-
-      expect(cop.messages)
-        .to eq(['Missing magic comment `# frozen_string_literal: true`.'])
     end
 
     it 'accepts a frozen string literal below an encoding comment' do
@@ -95,14 +91,12 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for not having a frozen string literal comment ' \
        'under a shebang and an encoding comment' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         #!/usr/bin/env ruby
+        ^ Missing magic comment `# frozen_string_literal: true`.
         # encoding: utf-8
         puts 1
       RUBY
-
-      expect(cop.messages)
-        .to eq(['Missing magic comment `# frozen_string_literal: true`.'])
     end
 
     it 'accepts a frozen string literal comment below shebang and encoding ' \

--- a/spec/rubocop/cop/style/global_vars_spec.rb
+++ b/spec/rubocop/cop/style/global_vars_spec.rb
@@ -22,8 +22,9 @@ RSpec.describe RuboCop::Cop::Style::GlobalVars, :config do
 
   described_class::BUILT_IN_VARS.each do |var|
     it "does not register an offense for built-in variable #{var}" do
-      inspect_source("puts #{var}")
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(<<-RUBY.strip_indent)
+        puts #{var}
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -6,32 +6,29 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
 
   shared_examples 'reports offense' do |body|
     it 'reports an offense if method body is if / unless without else' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def func
           if something
+          ^^ Use a guard clause instead of wrapping the code inside a conditional expression.
             #{body}
           end
         end
 
         def func
           unless something
+          ^^^^^^ Use a guard clause instead of wrapping the code inside a conditional expression.
             #{body}
           end
         end
       RUBY
-      expect(cop.offenses.size).to eq(2)
-      expect(cop.offenses.map(&:line).sort).to eq([2, 8])
-      expect(cop.messages)
-        .to eq(['Use a guard clause instead of wrapping ' \
-                'the code inside a conditional expression.'] * 2)
-      expect(cop.highlights).to eq(%w[if unless])
     end
 
     it 'reports an offense if method body ends with if / unless without else' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def func
           test
           if something
+          ^^ Use a guard clause instead of wrapping the code inside a conditional expression.
             #{body}
           end
         end
@@ -39,16 +36,11 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
         def func
           test
           unless something
+          ^^^^^^ Use a guard clause instead of wrapping the code inside a conditional expression.
             #{body}
           end
         end
       RUBY
-      expect(cop.offenses.size).to eq(2)
-      expect(cop.offenses.map(&:line).sort).to eq([3, 10])
-      expect(cop.messages)
-        .to eq(['Use a guard clause instead of wrapping ' \
-                'the code inside a conditional expression.'] * 2)
-      expect(cop.highlights).to eq(%w[if unless])
     end
   end
 
@@ -206,29 +198,25 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
 
   shared_examples 'on if nodes which exit current scope' do |kw|
     it "registers an error with #{kw} in the if branch" do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         if something
+        ^^ Use a guard clause instead of wrapping the code inside a conditional expression.
           #{kw}
         else
           puts "hello"
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Use a guard clause instead of wrapping ' \
-                                  'the code inside a conditional expression.'])
     end
 
     it "registers an error with #{kw} in the else branch" do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         if something
+        ^^ Use a guard clause instead of wrapping the code inside a conditional expression.
          puts "hello"
         else
           #{kw}
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Use a guard clause instead of wrapping ' \
-                                  'the code inside a conditional expression.'])
     end
 
     it "doesn't register an error if condition has multiple lines" do
@@ -243,18 +231,17 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
     end
 
     it "does not report an offense if #{kw} is inside elsif" do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         if something
           a
         elsif something_else
           #{kw}
         end
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it "does not report an offense if #{kw} is inside if..elsif..else..end" do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         if something
           a
         elsif something_else
@@ -263,27 +250,29 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
           #{kw}
         end
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it "doesn't register an error if control flow expr has multiple lines" do
-      inspect_source(['if something',
-                      "  #{kw} 'blah blah blah' \\",
-                      "        'blah blah blah'",
-                      'else',
-                      '  puts "hello"',
-                      'end'])
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(<<-RUBY.strip_indent)
+        if something
+          #{kw} 'blah blah blah' \\
+                'blah blah blah'
+        else
+          puts "hello"
+        end
+      RUBY
     end
 
     it 'registers an error if non-control-flow branch has multiple lines' do
-      inspect_source(['if something',
-                      "  #{kw}",
-                      'else',
-                      '  puts "hello" \\',
-                      '       "blah blah blah"',
-                      'end'])
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        if something
+        ^^ Use a guard clause instead of wrapping the code inside a conditional expression.
+          #{kw}
+        else
+          puts "hello" \\
+               "blah blah blah"
+        end
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/style/if_unless_modifier_of_if_unless_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_of_if_unless_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifierOfIfUnless do
   subject(:cop) { described_class.new }
 
   it 'provides a good error message' do
-    source = 'condition ? then_part : else_part unless external_condition'
-    inspect_source(source)
-    expect(cop.messages)
-      .to eq(['Avoid modifier `unless` after another conditional.'])
+    expect_offense(<<-RUBY.strip_indent)
+      condition ? then_part : else_part unless external_condition
+                                        ^^^^^^ Avoid modifier `unless` after another conditional.
+    RUBY
   end
 
   context 'ternary with modifier' do

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -241,8 +241,7 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier do
       it 'accepts' do
         expect("  #{body} if #{conditional}".length).to eq(81)
 
-        inspect_source(source)
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(source)
       end
     end
   end

--- a/spec/rubocop/cop/style/implicit_runtime_error_spec.rb
+++ b/spec/rubocop/cop/style/implicit_runtime_error_spec.rb
@@ -23,13 +23,13 @@ RSpec.describe RuboCop::Cop::Style::ImplicitRuntimeError do
     end
 
     it "doesn't register an offense for #{method} StandardError, 'message'" do
-      inspect_source("#{method} StandardError, 'message'")
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(<<-RUBY.strip_indent)
+        #{method} StandardError, 'message'
+      RUBY
     end
 
     it "doesn't register an offense for #{method} with no arguments" do
-      inspect_source(method)
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(method)
     end
   end
 end

--- a/spec/rubocop/cop/style/infinite_loop_spec.rb
+++ b/spec/rubocop/cop/style/infinite_loop_spec.rb
@@ -9,25 +9,23 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop do
 
   %w(1 2.0 [1] {}).each do |lit|
     it "registers an offense for a while loop with #{lit} as condition" do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         while #{lit}
+        ^^^^^ Use `Kernel#loop` for infinite loops.
           top
         end
       RUBY
-      expect(cop.messages).to eq(['Use `Kernel#loop` for infinite loops.'])
-      expect(cop.highlights).to eq(['while'])
     end
   end
 
   %w[false nil].each do |lit|
     it "registers an offense for a until loop with #{lit} as condition" do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         until #{lit}
+        ^^^^^ Use `Kernel#loop` for infinite loops.
           top
         end
       RUBY
-      expect(cop.messages).to eq(['Use `Kernel#loop` for infinite loops.'])
-      expect(cop.highlights).to eq(['until'])
     end
   end
 

--- a/spec/rubocop/cop/style/line_end_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/line_end_concatenation_spec.rb
@@ -92,12 +92,10 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
 
   it 'accepts string concat with a return value of method on an interpolated ' \
      'string' do
-    source = <<-RUBY
+    expect_no_offenses(<<-RUBY.strip_indent)
       x3a = 'x' +
         "\#{'a' + "\#{3}"}".reverse
     RUBY
-    inspect_source(source)
-    expect(cop.offenses.empty?).to be(true)
   end
 
   it 'accepts string concat at line end when followed by comment' do

--- a/spec/rubocop/cop/style/method_def_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_def_parentheses_spec.rb
@@ -85,12 +85,10 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
     end
 
     it 'accepts a def with parameters but no parens' do
-      src = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         def func a, b
         end
       RUBY
-      inspect_source(src)
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'reports an offense for opposite + correct' do
@@ -115,12 +113,10 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
     end
 
     it 'accepts a class def with parameters with parens' do
-      src = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         def Test.func a, b
         end
       RUBY
-      inspect_source(src)
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'reports an offense for def with no args and parens' do
@@ -133,12 +129,10 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
     end
 
     it 'accepts def with no args and no parens' do
-      src = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         def func
         end
       RUBY
-      inspect_source(src)
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it 'auto-removes the parens' do

--- a/spec/rubocop/cop/style/multiple_comparison_spec.rb
+++ b/spec/rubocop/cop/style/multiple_comparison_spec.rb
@@ -6,11 +6,12 @@ RSpec.describe RuboCop::Cop::Style::MultipleComparison do
   let(:config) { RuboCop::Config.new }
 
   it 'does not register an offense for comparing an lvar' do
-    inspect_source(['a = "a"',
-                    'if a == "a"',
-                    '  print a',
-                    'end'])
-    expect(cop.offenses.empty?).to be(true)
+    expect_no_offenses(<<-RUBY.strip_indent)
+      a = "a"
+      if a == "a"
+        print a
+      end
+    RUBY
   end
 
   it 'registers an offense when `a` is compared twice' do
@@ -48,61 +49,68 @@ RSpec.describe RuboCop::Cop::Style::MultipleComparison do
   end
 
   it 'does not register an offense for comparing multiple literal strings' do
-    inspect_source(['if "a" == "a" || "a" == "c"',
-                    '  print "a"',
-                    'end'])
-    expect(cop.offenses.empty?).to be(true)
+    expect_no_offenses(<<-RUBY.strip_indent)
+      if "a" == "a" || "a" == "c"
+        print "a"
+      end
+    RUBY
   end
 
   it 'does not register an offense for comparing multiple int literals' do
-    inspect_source(['if 1 == 1 || 1 == 2',
-                    '  print 1',
-                    'end'])
-    expect(cop.offenses.empty?).to be(true)
+    expect_no_offenses(<<-RUBY.strip_indent)
+      if 1 == 1 || 1 == 2
+        print 1
+      end
+    RUBY
   end
 
   it 'does not register an offense for comparing lvars' do
-    inspect_source(['a = "a"',
-                    'b = "b"',
-                    'if a == "a" || b == "b"',
-                    '  print a',
-                    'end'])
-    expect(cop.offenses.empty?).to be(true)
+    expect_no_offenses(<<-RUBY.strip_indent)
+      a = "a"
+      b = "b"
+      if a == "a" || b == "b"
+        print a
+      end
+    RUBY
   end
 
   it 'does not register an offense for comparing lvars when a string is ' \
     'on the lefthand side' do
-    inspect_source(['a = "a"',
-                    'b = "b"',
-                    'if a == "a" || "b" == b',
-                    '  print a',
-                    'end'])
-    expect(cop.offenses.empty?).to be(true)
+    expect_no_offenses(<<-RUBY.strip_indent)
+      a = "a"
+      b = "b"
+      if a == "a" || "b" == b
+        print a
+      end
+    RUBY
   end
 
   it 'does not register an offense for a == b || b == a' do
-    inspect_source(['a = "a"',
-                    'b = "b"',
-                    'if a == b || b == a',
-                    '  print a',
-                    'end'])
-    expect(cop.offenses.empty?).to be(true)
+    expect_no_offenses(<<-RUBY.strip_indent)
+      a = "a"
+      b = "b"
+      if a == b || b == a
+        print a
+      end
+    RUBY
   end
 
   it 'does not register an offense for a duplicated condition' do
-    inspect_source(['a = "a"',
-                    'b = "b"',
-                    'if a == b || a == b',
-                    '  print a',
-                    'end'])
-    expect(cop.offenses.empty?).to be(true)
+    expect_no_offenses(<<-RUBY.strip_indent)
+      a = "a"
+      b = "b"
+      if a == b || a == b
+        print a
+      end
+    RUBY
   end
 
   it 'does not register an offense for Array#include?' do
-    inspect_source(['a = "a"',
-                    'if ["a", "b", "c"].include? a',
-                    '  print a',
-                    'end'])
-    expect(cop.offenses.empty?).to be(true)
+    expect_no_offenses(<<-RUBY.strip_indent)
+      a = "a"
+      if ["a", "b", "c"].include? a
+        print a
+      end
+    RUBY
   end
 end

--- a/spec/rubocop/cop/style/next_spec.rb
+++ b/spec/rubocop/cop/style/next_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe RuboCop::Cop::Style::Next, :config do
     end
 
     it "allows loops with #{condition} being the entire body with else" do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         [].each do |o|
           #{condition} o == 1
             puts o
@@ -289,13 +289,11 @@ RSpec.describe RuboCop::Cop::Style::Next, :config do
           end
         end
       RUBY
-
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it "allows loops with #{condition} with else, nested in another " \
        'condition' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         [].each do |o|
           if foo
             #{condition} o == 1
@@ -306,12 +304,10 @@ RSpec.describe RuboCop::Cop::Style::Next, :config do
           end
         end
       RUBY
-
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it "allows loops with #{condition} with else at the end" do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         [].each do |o|
           puts o
           #{condition} o == 1
@@ -321,8 +317,6 @@ RSpec.describe RuboCop::Cop::Style::Next, :config do
           end
         end
       RUBY
-
-      expect(cop.offenses.empty?).to be(true)
     end
 
     it "reports an offense for #{condition} whose body has 3 lines" do
@@ -346,13 +340,11 @@ RSpec.describe RuboCop::Cop::Style::Next, :config do
       end
 
       it "allows modifier #{condition}" do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           [].each do |o|
             puts o #{condition} o == 1
           end
         RUBY
-
-        expect(cop.offenses.empty?).to be(true)
       end
     end
 
@@ -414,22 +406,27 @@ RSpec.describe RuboCop::Cop::Style::Next, :config do
   end
 
   it 'keeps comments when autocorrecting' do
-    new_source = autocorrect_source(['loop do',
-                                     '  if test # keep me',
-                                     '    # keep me',
-                                     '    something # keep me',
-                                     '    # keep me',
-                                     '    ',
-                                     '  end # keep me',
-                                     'end'])
-    expect(new_source).to eq(['loop do',
-                              '  next unless test # keep me',
-                              '  # keep me',
-                              '  something # keep me',
-                              '  # keep me',
-                              '    ',
-                              ' # keep me',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
+      loop do
+        if test # keep me
+          # keep me
+          something # keep me
+          # keep me
+
+        end # keep me
+      end
+    RUBY
+
+    expect(new_source).to eq(<<-RUBY.strip_indent)
+      loop do
+        next unless test # keep me
+        # keep me
+        something # keep me
+        # keep me
+
+       # keep me
+      end
+    RUBY
   end
 
   it 'handles `then` when autocorrecting' do

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -102,11 +102,10 @@ RSpec.describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
 
   %w[rescue if unless while until].each do |op|
     it "allows parens if the condition node is a modifier #{op} op" do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         if (something #{op} top)
         end
       RUBY
-      expect(cop.offenses.empty?).to be(true)
     end
   end
 

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -48,8 +48,9 @@ RSpec.describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'does not register an offense for other delimiters ' \
        'when containing preferred delimiter characters' do
-      inspect_source('%([string])')
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(<<-RUBY.strip_indent)
+        %([string])
+      RUBY
     end
 
     it 'registers an offense for other delimiters ' \
@@ -73,8 +74,9 @@ RSpec.describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'does not register an offense for other delimiters ' \
        'when containing preferred delimiter characters' do
-      inspect_source('%q([string])')
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(<<-RUBY.strip_indent)
+        %q([string])
+      RUBY
     end
   end
 
@@ -92,8 +94,9 @@ RSpec.describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'does not register an offense for other delimiters ' \
        'when containing preferred delimiter characters' do
-      inspect_source('%Q([string])')
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(<<-RUBY.strip_indent)
+        %Q([string])
+      RUBY
     end
 
     it 'registers an offense for other delimiters ' \
@@ -132,8 +135,7 @@ RSpec.describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'does not register an offense for other delimiters ' \
        'when containing preferred delimiter characters' do
-      inspect_source('%w([some] [words])')
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses('%w([some] [words])')
     end
   end
 
@@ -151,8 +153,7 @@ RSpec.describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'does not register an offense for other delimiters ' \
        'when containing preferred delimiter characters' do
-      inspect_source('%W([some] [words])')
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses('%W([some] [words])')
     end
 
     it 'registers an offense for other delimiters ' \
@@ -176,8 +177,7 @@ RSpec.describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'does not register an offense for other delimiters ' \
        'when containing preferred delimiter characters' do
-      inspect_source('%r([regexp])')
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses('%r([regexp])')
     end
 
     it 'registers an offense for other delimiters ' \
@@ -248,8 +248,7 @@ RSpec.describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'does not register an offense for other delimiters ' \
        'when containing preferred delimiter characters' do
-      inspect_source('%x([command])')
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses('%x([command])')
     end
 
     it 'registers an offense for other delimiters ' \

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -78,25 +78,28 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
 
   it 'auto-corrects source separated by newlines ' \
      'by removing redundant begin blocks' do
-    src = <<-RUBY.strip_margin('|')
-      |  def func
-      |    begin
-      |      foo
-      |      bar
-      |    rescue
-      |      baz
-      |    end
-      |  end
+    src = <<-RUBY.strip_indent
+      def func
+        begin
+          foo
+          bar
+        rescue
+          baz
+        end
+      end
     RUBY
-    result_src = ['  def func',
-                  '    ',
-                  '      foo',
-                  '      bar',
-                  '    rescue',
-                  '      baz',
-                  '    ',
-                  '  end',
-                  ''].join("\n")
+
+    result_src = <<-RUBY.strip_indent
+      def func
+        
+          foo
+          bar
+        rescue
+          baz
+        
+      end
+    RUBY
+
     new_source = autocorrect_source(src)
     expect(new_source).to eq(result_src)
   end
@@ -127,21 +130,23 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
       end
     RUBY
 
-    result_src = ['def method',
-                  '  ',
-                  '    BlockA do |strategy|',
-                  '      foo',
-                  '    end',
-                  '',
-                  '    BlockB do |portfolio|',
-                  '      foo',
-                  '    end',
-                  '',
-                  '  rescue => e # some problem',
-                  '    bar',
-                  '  ',
-                  'end',
-                  ''].join("\n")
+    result_src = <<-RUBY.strip_indent
+      def method
+        
+          BlockA do |strategy|
+            foo
+          end
+
+          BlockB do |portfolio|
+            foo
+          end
+
+        rescue => e # some problem
+          bar
+        
+      end
+    RUBY
+
     new_source = autocorrect_source(src)
     expect(new_source).to eq(result_src)
   end

--- a/spec/rubocop/cop/style/redundant_exception_spec.rb
+++ b/spec/rubocop/cop/style/redundant_exception_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantException do
     end
 
     it "accepts a #{keyword} with RuntimeError if it does not have 2 args" do
-      inspect_source("#{keyword} RuntimeError, msg, caller")
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses("#{keyword} RuntimeError, msg, caller")
     end
 
     it "auto-corrects a #{keyword} RuntimeError by removing RuntimeError" do

--- a/spec/rubocop/cop/style/redundant_freeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_freeze_spec.rb
@@ -29,8 +29,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze do
   shared_examples 'mutable objects' do |o|
     it "allows #{o} with freeze" do
       source = [prefix, "CONST = #{o}.freeze"].compact.join("\n")
-      inspect_source(source)
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(source)
     end
   end
 

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses do
 
   shared_examples 'plausible' do |expr|
     it 'accepts parentheses when arguments are unparenthesized' do
-      inspect_source(expr)
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(expr)
     end
   end
 
@@ -168,8 +167,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses do
 
   it 'accepts parentheses around a method call with unparenthesized ' \
      'arguments' do
-    inspect_source('(a 1, 2) && (1 + 1)')
-    expect(cop.offenses.empty?).to be(true)
+    expect_no_offenses('(a 1, 2) && (1 + 1)')
   end
 
   it 'accepts parentheses inside an irange' do

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -143,14 +143,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf do
 
     it 'accepts a self receiver used to distinguish from an argument' \
       ' when an inner method is defined' do
-      src = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         def foo(bar)
           def inner_method(); end
           puts bar, self.bar
         end
       RUBY
-      inspect_source(src)
-      expect(cop.offenses.empty?).to be(true)
     end
   end
 

--- a/spec/rubocop/cop/style/self_assignment_spec.rb
+++ b/spec/rubocop/cop/style/self_assignment_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe RuboCop::Cop::Style::SelfAssignment do
     end
 
     it "accepts shorthand assignment for #{op} and #{var}" do
-      inspect_source("#{var} #{op}= y")
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses("#{var} #{op}= y")
     end
 
     it "auto-corrects a non-shorthand assignment #{op} and #{var}" do

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -35,9 +35,13 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods do
     end
 
     it 'auto-corrects an empty method' do
-      corrected = autocorrect_source('def x; end')
-      expect(corrected).to eq(['def x; ',
-                               'end'].join("\n"))
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
+        def x; end
+      RUBY
+      expect(corrected).to eq(<<-RUBY.strip_indent)
+        def x; 
+        end
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/style/trailing_body_on_class_spec.rb
+++ b/spec/rubocop/cop/style/trailing_body_on_class_spec.rb
@@ -45,28 +45,40 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnClass do
   end
 
   it 'auto-corrects body after class definition' do
-    corrected = autocorrect_source(['class Foo; body ',
-                                    'end'].join("\n"))
-    expect(corrected).to eq ['class Foo ',
-                             '  body ',
-                             'end'].join("\n")
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
+      class Foo; body 
+      end
+    RUBY
+    expect(corrected).to eq(<<-RUBY.strip_indent)
+      class Foo 
+        body 
+      end
+    RUBY
   end
 
   it 'auto-corrects with comment after body' do
-    corrected = autocorrect_source(['class BarQux; foo # comment',
-                                    'end'].join("\n"))
-    expect(corrected).to eq ['# comment',
-                             'class BarQux ',
-                             '  foo ',
-                             'end'].join("\n")
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
+      class BarQux; foo # comment
+      end
+    RUBY
+    expect(corrected).to eq(<<-RUBY.strip_indent)
+      # comment
+      class BarQux 
+        foo 
+      end
+    RUBY
   end
 
   it 'auto-corrects when there are multiple semicolons' do
-    corrected = autocorrect_source(['class Bar; def bar; end',
-                                    'end'].join("\n"))
-    expect(corrected).to eq ['class Bar ',
-                             '  def bar; end',
-                             'end'].join("\n")
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
+      class Bar; def bar; end
+      end
+    RUBY
+    expect(corrected).to eq(<<-RUBY.strip_indent)
+      class Bar 
+        def bar; end
+      end
+    RUBY
   end
 
   context 'when class is not on first line of processed_source' do

--- a/spec/rubocop/cop/style/trailing_body_on_module_spec.rb
+++ b/spec/rubocop/cop/style/trailing_body_on_module_spec.rb
@@ -46,39 +46,55 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnModule do
   end
 
   it 'auto-corrects body after module definition' do
-    corrected = autocorrect_source(['module Foo extend self ',
-                                    'end'].join("\n"))
-    expect(corrected).to eq ['module Foo ',
-                             '  extend self ',
-                             'end'].join("\n")
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
+      module Foo extend self 
+      end
+    RUBY
+    expect(corrected).to eq(<<-RUBY.strip_indent)
+      module Foo 
+        extend self 
+      end
+    RUBY
   end
 
   it 'auto-corrects with comment after body' do
-    corrected = autocorrect_source(['module BarQux; foo # comment',
-                                    'end'].join("\n"))
-    expect(corrected).to eq ['# comment',
-                             'module BarQux ',
-                             '  foo ',
-                             'end'].join("\n")
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
+      module BarQux; foo # comment
+      end
+    RUBY
+    expect(corrected).to eq(<<-RUBY.strip_indent)
+      # comment
+      module BarQux 
+        foo 
+      end
+    RUBY
   end
 
   it 'auto-corrects when there are multiple semicolons' do
-    corrected = autocorrect_source(['module Bar; def bar; end',
-                                    'end'].join("\n"))
-    expect(corrected).to eq ['module Bar ',
-                             '  def bar; end',
-                             'end'].join("\n")
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
+      module Bar; def bar; end
+      end
+    RUBY
+    expect(corrected).to eq(<<-RUBY.strip_indent)
+      module Bar 
+        def bar; end
+      end
+    RUBY
   end
 
   context 'when module is not on first line of processed_source' do
     it 'auto-correct offense' do
-      corrected = autocorrect_source(['',
-                                      '  module Foo; body ',
-                                      '  end'].join("\n"))
-      expect(corrected).to eq ['',
-                               '  module Foo ',
-                               '    body ',
-                               '  end'].join("\n")
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
+
+        module Foo; body 
+        end
+      RUBY
+      expect(corrected).to eq(<<-RUBY.strip_indent)
+
+        module Foo 
+          body 
+        end
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -27,8 +27,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
     it 'accepts method call without trailing comma with single element hash' \
         ' parameters at the end' do
-      inspect_source('some_method(a: 1)')
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses('some_method(a: 1)')
     end
 
     it 'accepts method call without parameters' do
@@ -94,14 +93,13 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'accepts a method call with ' \
          'hash parameters at the end and no trailing comma' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           some_method(a,
                       b,
                       c: 0,
                       d: 1
                      )
         RUBY
-        expect(cop.offenses.empty?).to be(true)
       end
 
       it 'accepts comma inside a heredoc parameter at the end' do
@@ -139,11 +137,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       context 'when closing bracket is on same line as last value' do
         it 'accepts a method call with Hash as last parameter split on ' \
            'multiple lines' do
-          inspect_source(<<-RUBY.strip_indent)
+          expect_no_offenses(<<-RUBY.strip_indent)
             some_method(a: "b",
                         c: "d")
           RUBY
-          expect(cop.offenses.empty?).to be(true)
         end
       end
 
@@ -172,7 +169,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'accepts trailing comma in a method call with hash' \
          ' parameters at the end' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           some_method(
                         a,
                         b,
@@ -180,31 +177,27 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
                         d: 1,
                      )
         RUBY
-        expect(cop.offenses.empty?).to be(true)
       end
 
       it 'accepts no trailing comma in a method call with a multiline' \
          ' braceless hash at the end with more than one parameter on a line' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           some_method(
                         a,
                         b: 0,
                         c: 0, d: 1
                      )
         RUBY
-        expect(cop.offenses.empty?).to be(true)
       end
 
       it 'accepts a trailing comma in a method call with single ' \
          'line hashes' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           some_method(
            { a: 0, b: 1 },
            { a: 1, b: 0 },
           )
         RUBY
-
-        expect(cop.offenses.empty?).to be(true)
       end
 
       it 'accepts an empty hash being passed as a method argument' do
@@ -288,7 +281,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'accepts trailing comma in a method call with hash' \
          ' parameters at the end' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           some_method(
                         a,
                         b,
@@ -296,36 +289,32 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
                         d: 1,
                      )
         RUBY
-        expect(cop.offenses.empty?).to be(true)
       end
 
       it 'accepts a trailing comma in a method call with ' \
          'a single hash parameter' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           some_method(
                         a: 0,
                         b: 1,
                      )
         RUBY
-        expect(cop.offenses.empty?).to be(true)
       end
 
       it 'accepts a trailing comma in a method call with single ' \
          'line hashes' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           some_method(
            { a: 0, b: 1 },
            { a: 1, b: 0 },
           )
         RUBY
-
-        expect(cop.offenses.empty?).to be(true)
       end
 
       # this is a sad parse error
       it 'accepts no trailing comma in a method call with a block' \
          ' parameter at the end' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           some_method(
                         a,
                         b,
@@ -334,7 +323,6 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
                         &block
                      )
         RUBY
-        expect(cop.offenses.empty?).to be(true)
       end
 
       it 'accepts missing comma after a heredoc' do
@@ -378,12 +366,11 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'accepts a multiline call with arguments on a single line and' \
          ' trailing comma' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           method(
             1, 2,
           )
         RUBY
-        expect(cop.offenses.empty?).to be(true)
       end
     end
   end

--- a/spec/rubocop/cop/style/trailing_comma_in_array_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_array_literal_spec.rb
@@ -270,12 +270,11 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArrayLiteral, :config do
 
       it 'accepts a multiline array with items on a single line and' \
          'trailing comma' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           foo = [
             1, 2,
           ]
         RUBY
-        expect(cop.offenses.empty?).to be(true)
       end
     end
   end

--- a/spec/rubocop/cop/style/trailing_comma_in_hash_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_hash_literal_spec.rb
@@ -275,12 +275,11 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInHashLiteral, :config do
 
       it 'accepts a multiline hash with pairs on a single line and' \
          'trailing comma' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           bar = {
             a: 1001, b: 2020,
           }
         RUBY
-        expect(cop.offenses.empty?).to be(true)
       end
     end
   end

--- a/spec/rubocop/cop/style/trailing_method_end_statement_spec.rb
+++ b/spec/rubocop/cop/style/trailing_method_end_statement_spec.rb
@@ -66,54 +66,74 @@ RSpec.describe RuboCop::Cop::Style::TrailingMethodEndStatement do
   end
 
   it 'auto-corrects trailing end in 2 line method' do
-    corrected = autocorrect_source(['  def some_method',
-                                    '    []; end'].join("\n"))
-    expect(corrected).to eq ['  def some_method',
-                             '    [] ',
-                             '  end'].join("\n")
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
+      def some_method
+        []; end
+    RUBY
+    expect(corrected).to eq(<<-RUBY.strip_indent)
+      def some_method
+        [] 
+        end
+    RUBY
   end
 
   it 'auto-corrects trailing end in 3 line method' do
-    corrected = autocorrect_source(['  def do_this(x)',
-                                    '    y = x + 5',
-                                    '  y / 2; end'].join("\n"))
-    expect(corrected).to eq ['  def do_this(x)',
-                             '    y = x + 5',
-                             '  y / 2 ',
-                             '  end'].join("\n")
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
+      def do_this(x)
+        y = x + 5
+        y / 2; end
+    RUBY
+    expect(corrected).to eq(<<-RUBY.strip_indent)
+      def do_this(x)
+        y = x + 5
+        y / 2 
+        end
+    RUBY
   end
 
   it 'auto-corrects trailing end with comment' do
-    corrected = autocorrect_source(['  def f(x, y)',
-                                    '    process(x)',
-                                    '    process(y) end # comment'].join("\n"))
-    expect(corrected).to eq ['  def f(x, y)',
-                             '    process(x)',
-                             '    process(y) ',
-                             '  end # comment'].join("\n")
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
+      def f(x, y)
+        process(x)
+        process(y) end # comment
+    RUBY
+    expect(corrected).to eq(<<-RUBY.strip_indent)
+      def f(x, y)
+        process(x)
+        process(y) 
+        end # comment
+    RUBY
   end
 
   it 'auto-corrects trailing end on method with block' do
-    corrected = autocorrect_source(['  def d',
-                                    '    block do',
-                                    '      foo',
-                                    '    end end'].join("\n"))
-    expect(corrected).to eq ['  def d',
-                             '    block do',
-                             '      foo',
-                             '    end ',
-                             '  end'].join("\n")
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
+      def d
+        block do
+          foo
+        end end
+    RUBY
+    expect(corrected).to eq(<<-RUBY.strip_indent)
+      def d
+        block do
+          foo
+        end 
+        end
+    RUBY
   end
 
   it 'auto-corrects trailing end for larger example' do
-    corrected = autocorrect_source(['class Foo',
-                                    '  def some_method',
-                                    '    []; end',
-                                    'end'].join("\n"))
-    expect(corrected).to eq ['class Foo',
-                             '  def some_method',
-                             '    [] ',
-                             '  end',
-                             'end'].join("\n")
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
+      class Foo
+        def some_method
+          []; end
+      end
+    RUBY
+    expect(corrected).to eq(<<-RUBY.strip_indent)
+      class Foo
+        def some_method
+          [] 
+        end
+      end
+    RUBY
   end
 end

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe RuboCop::Cop::Team do
 
     it 'returns offenses' do
       expect(offenses.empty?).to be(false)
-      expect(offenses.all? { |o| o.is_a?(RuboCop::Cop::Offense) }).to be_truthy
+      expect(offenses).to all(be_a(RuboCop::Cop::Offense))
     end
 
     context 'when Parser reports non-fatal warning for the file' do

--- a/spec/support/multiline_literal_brace_layout_examples.rb
+++ b/spec/support/multiline_literal_brace_layout_examples.rb
@@ -62,9 +62,7 @@ shared_examples_for 'multiline literal brace layout' do
     let(:cop_config) { { 'EnforcedStyle' => 'same_line' } }
 
     it 'ignores heredocs that could share a last line' do
-      inspect_source(construct(false, a, make_multi(heredoc), true))
-
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(construct(false, a, make_multi(heredoc), true))
     end
 
     it 'detects heredoc structures that are safe to add to' do
@@ -88,15 +86,11 @@ shared_examples_for 'multiline literal brace layout' do
 
     context 'opening brace on same line as first element' do
       it 'allows closing brace on same line as last element' do
-        inspect_source(construct(false, false))
-
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(construct(false, false))
       end
 
       it 'allows closing brace on same line as last multiline element' do
-        inspect_source(construct(false, a, make_multi(multi), false))
-
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(construct(false, a, make_multi(multi), false))
       end
 
       it 'detects closing brace on different line from last element' do
@@ -158,15 +152,11 @@ shared_examples_for 'multiline literal brace layout' do
 
     context 'opening brace on separate line from first element' do
       it 'allows closing brace on separate line from last element' do
-        inspect_source(construct(true, true))
-
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(construct(true, true))
       end
 
       it 'allows closing brace on separate line from last multiline element' do
-        inspect_source(construct(true, a, make_multi(multi), true))
-
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(construct(true, a, make_multi(multi), true))
       end
 
       it 'detects closing brace on same line as last element' do
@@ -193,15 +183,11 @@ shared_examples_for 'multiline literal brace layout' do
 
     context 'opening brace on same line as first element' do
       it 'allows closing brace on different line from last element' do
-        inspect_source(construct(false, true))
-
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(construct(false, true))
       end
 
       it 'allows closing brace on different line from multi-line element' do
-        inspect_source(construct(false, a, make_multi(multi), true))
-
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(construct(false, a, make_multi(multi), true))
       end
 
       it 'detects closing brace on same line as last element' do
@@ -238,15 +224,11 @@ shared_examples_for 'multiline literal brace layout' do
 
     context 'opening brace on separate line from first element' do
       it 'allows closing brace on separate line from last element' do
-        inspect_source(construct(true, true))
-
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(construct(true, true))
       end
 
       it 'allows closing brace on separate line from last multiline element' do
-        inspect_source(construct(true, a, make_multi(multi), true))
-
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(construct(true, a, make_multi(multi), true))
       end
 
       it 'detects closing brace on same line as last element' do
@@ -273,15 +255,11 @@ shared_examples_for 'multiline literal brace layout' do
 
     context 'opening brace on same line as first element' do
       it 'allows closing brace on same line from last element' do
-        inspect_source(construct(false, false))
-
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(construct(false, false))
       end
 
       it 'allows closing brace on same line as multi-line element' do
-        inspect_source(construct(false, a, make_multi(multi), false))
-
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(construct(false, a, make_multi(multi), false))
       end
 
       it 'detects closing brace on different line from last element' do
@@ -354,15 +332,11 @@ shared_examples_for 'multiline literal brace layout' do
 
     context 'opening brace on separate line from first element' do
       it 'allows closing brace on same line as last element' do
-        inspect_source(construct(true, false))
-
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(construct(true, false))
       end
 
       it 'allows closing brace on same line as last multiline element' do
-        inspect_source(construct(true, a, make_multi(multi), false))
-
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(construct(true, a, make_multi(multi), false))
       end
 
       it 'detects closing brace on different line from last element' do


### PR DESCRIPTION
I'm on a mission to clear out our specs a bit. This change does:

 - Introduce `#expect_offense` and `#expect_no_offenses` in many more specs.
 - Replace instances of code examples expressed as arrays of strings with heredocs.
 - Replace usages of `#strip_margin` with `#strip_indent`.

Moving forward I'm planning to:

 - [DAMP](https://stackoverflow.com/a/11837973/1520557)en some of the tests which use loops and shared examples excessively.
 - Extend `#expect_offense` or introduce a similar matcher for auto-correction.
 - Introduce internal investigations for specs.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
