### PR TITLE
[Fix #5951] Prevent Style/MethodCallWithArgsParentheses from raising an error in some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#5965](https://github.com/bbatsov/rubocop/issues/5965): Prevent `Layout/ClosingHeredocIndentation` from raising an error on heredocs containing only a newline. ([@drenmi][])
 * Prevent a crash in `Layout/IndentationConsistency` cop triggered by an empty expression string interpolation. ([@alexander-lazarov][])
+* [#5951](https://github.com/bbatsov/rubocop/issues/5951): Prevent `Style/MethodCallWithArgsParentheses` from raising an error in certain cases. ([@drenmi][])
 
 ## 0.57.1 (2018-06-07)
 

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -467,7 +467,7 @@ module RuboCop
       end
 
       def parenthesized_call?
-        loc.begin && loc.begin.is?('(')
+        loc.respond_to?(:begin) && loc.begin && loc.begin.is?('(')
       end
 
       def chained?

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -91,7 +91,8 @@ module RuboCop
         end
 
         def args_parenthesized?(node)
-          return false unless node.arguments.length == 1
+          return false unless node.arguments.one?
+
           node.arguments.first.parenthesized_call?
         end
       end

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -175,6 +175,34 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
     RUBY
   end
 
+  it 'auto-corrects calls where the argument node is a constant' do
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
+      def my_method
+        raise NotImplementedError
+      end
+    RUBY
+
+    expect(new_source).to eq(<<-RUBY.strip_indent)
+      def my_method
+        raise(NotImplementedError)
+      end
+    RUBY
+  end
+
+  it 'auto-corrects calls where the argument node is a number' do
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
+      def my_method
+        sleep 1
+      end
+    RUBY
+
+    expect(new_source).to eq(<<-RUBY.strip_indent)
+      def my_method
+        sleep(1)
+      end
+    RUBY
+  end
+
   it 'ignores method listed in IgnoredMethods' do
     expect_no_offenses('puts :test')
   end


### PR DESCRIPTION
This cop would raise an error when auto-correcting certain constructs, such as:

```ruby
def foo
  sleep 1
end
```

This was happening because some of the Parser source maps are missing the `begin` keyword.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
