### PR TITLE
Restyle example formatting for `Layout/FirstParameterIndentation`

### DIFF
--- a/lib/rubocop/cop/layout/first_parameter_indentation.rb
+++ b/lib/rubocop/cop/layout/first_parameter_indentation.rb
@@ -2,6 +2,7 @@
 
 module RuboCop
   module Cop
+    # rubocop:disable Metrics/LineLength
     module Layout
       # This cop checks the indentation of the first parameter in a method call.
       # Parameters after the first one are checked by Layout/AlignParameters,
@@ -31,7 +32,9 @@ module RuboCop
       #   nested_first_param),
       #   second_param
       #
-      #   # Style: consistent
+      # @example EnforcedStyle: consistent
+      #   # The first parameter should always be indented one step more than the
+      #   # preceding line.
       #
       #   # good
       #   some_method(
@@ -55,7 +58,9 @@ module RuboCop
       #     nested_first_param),
       #   second_param
       #
-      #   # Style: consistent_relative_to_receiver
+      # @example EnforcedStyle: consistent_relative_to_receiver
+      #   # The first parameter should always be indented one level relative to
+      #   # the parent that is receiving the parameter
       #
       #   # good
       #   some_method(
@@ -79,7 +84,11 @@ module RuboCop
       #                 nested_first_param),
       #   second_params
       #
-      #   # Style: special_for_inner_method_call
+      # @example EnforcedStyle: special_for_inner_method_call
+      #   # The first parameter should normally be indented one step more than
+      #   # the preceding line, but if it's a parameter for a method call that
+      #   # is itself a parameter in a method call, then the inner parameter
+      #   # should be indented relative to the inner method.
       #
       #   # good
       #   some_method(
@@ -103,7 +112,10 @@ module RuboCop
       #                 nested_first_param),
       #   second_param
       #
-      #   # Style: special_for_inner_method_call_in_parentheses
+      # @example EnforcedStyle: special_for_inner_method_call_in_parentheses (default)
+      #   # Same as `special_for_inner_method_call` except that the special rule
+      #   # only applies if the outer method call encloses its arguments in
+      #   # parentheses.
       #
       #   # good
       #   some_method(
@@ -128,6 +140,7 @@ module RuboCop
       #   second_param
       #
       class FirstParameterIndentation < Cop
+        # rubocop:enable Metrics/LineLength
         include Alignment
         include ConfigurableEnforcedStyle
         include RangeHelp

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -1922,8 +1922,12 @@ second_param)
 some_method nested_call(
 nested_first_param),
 second_param
+```
+#### EnforcedStyle: consistent
 
-# Style: consistent
+```ruby
+# The first parameter should always be indented one step more than the
+# preceding line.
 
 # good
 some_method(
@@ -1946,8 +1950,12 @@ second_param)
 some_method nested_call(
   nested_first_param),
 second_param
+```
+#### EnforcedStyle: consistent_relative_to_receiver
 
-# Style: consistent_relative_to_receiver
+```ruby
+# The first parameter should always be indented one level relative to
+# the parent that is receiving the parameter
 
 # good
 some_method(
@@ -1970,8 +1978,14 @@ second_param)
 some_method nested_call(
               nested_first_param),
 second_params
+```
+#### EnforcedStyle: special_for_inner_method_call
 
-# Style: special_for_inner_method_call
+```ruby
+# The first parameter should normally be indented one step more than
+# the preceding line, but if it's a parameter for a method call that
+# is itself a parameter in a method call, then the inner parameter
+# should be indented relative to the inner method.
 
 # good
 some_method(
@@ -1994,8 +2008,13 @@ second_param)
 some_method nested_call(
               nested_first_param),
 second_param
+```
+#### EnforcedStyle: special_for_inner_method_call_in_parentheses (default)
 
-# Style: special_for_inner_method_call_in_parentheses
+```ruby
+# Same as `special_for_inner_method_call` except that the special rule
+# only applies if the outer method call encloses its arguments in
+# parentheses.
 
 # good
 some_method(


### PR DESCRIPTION
Follow up of https://github.com/rubocop-hq/rubocop/pull/4880#issuecomment-338499947 and #5699.

This commit is a change of document format for `Layout/FirstParameterIndentation` cop.

This PR uses `# rubocop:disable Metrics/LineLength` because line length of the following line exceeds 80.

```diff
+      # @example EnforcedStyle: special_for_inner_method_call_in_parentheses (default)
```

Descriptions of `EnforcedStyle` are quoted from default.yml.
https://github.com/rubocop-hq/rubocop/blob/v0.57.1/config/default.yml#L365-L381

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
