### PR TITLE
Improve usage of offense matchers and heredocs in specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### Changes
 
 * [#6006](https://github.com/bbatsov/rubocop/pull/6006): Remove `rake repl` task. ([@koic][])
-* [#5990](https://github.com/bbatsov/rubocop/pull/5990):Drop support for MRI 2.1. ([@drenmi][])
+* [#5990](https://github.com/bbatsov/rubocop/pull/5990): Drop support for MRI 2.1. ([@drenmi][])
 
 ## 0.57.2 (2018-06-12)
 

--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -14,10 +14,6 @@ module CopHelper
     Tempfile.open('tmp') { |f| inspect_source(source, f) }
   end
 
-  def inspect_gemfile(source)
-    inspect_source(source, 'Gemfile')
-  end
-
   def inspect_source(source, file = nil)
     if source.is_a?(Array) && source.size == 1
       raise "Don't use an array for a single line of code: #{source}"

--- a/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
+++ b/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
@@ -17,14 +17,8 @@ RSpec.describe RuboCop::Cop::Bundler::DuplicatedGem, :config do
 
   context 'when investigating Gemfiles' do
     context 'and the file is empty' do
-      let(:source) { '' }
-
-      it 'does not raise an error' do
-        expect { inspect_source('gems.rb') }.not_to raise_error
-      end
-
       it 'does not register any offenses' do
-        expect(cop.offenses.empty?).to eq(true)
+        expect_no_offenses('', 'Gemfile')
       end
     end
 
@@ -38,44 +32,25 @@ RSpec.describe RuboCop::Cop::Bundler::DuplicatedGem, :config do
     end
 
     context 'and a gem is duplicated in default group' do
-      let(:source) { <<-GEM }
-        source 'https://rubygems.org'
-        gem 'rubocop'
-        gem 'rubocop'
-      GEM
-
       it 'registers an offense' do
-        inspect_gemfile(source)
-        expect(cop.offenses.size).to eq(1)
-      end
-
-      it "references gem's first occurrence in message" do
-        inspect_gemfile(source)
-        expect(cop.offenses.first.message).to include('2')
-      end
-
-      it 'highlights the duplicate gem' do
-        inspect_gemfile(source)
-        expect(cop.highlights).to eq(["gem 'rubocop'"])
+        expect_offense(<<-GEM, 'Gemfile')
+          source 'https://rubygems.org'
+          gem 'rubocop'
+          gem 'rubocop'
+          ^^^^^^^^^^^^^ Gem `rubocop` requirements already given on line 2 of the Gemfile.
+        GEM
       end
     end
 
     context 'and a duplicated gem is in a git/path/group/platforms block' do
-      let(:source) { <<-GEM }
-        gem 'rubocop'
-        group :development do
-          gem 'rubocop', path: '/path/to/gem'
-        end
-      GEM
-
       it 'registers an offense' do
-        inspect_gemfile(source)
-        expect(cop.offenses.size).to eq(1)
-      end
-
-      it 'highlights the duplicate gem' do
-        inspect_gemfile(source)
-        expect(cop.highlights).to eq(["gem 'rubocop', path: '/path/to/gem'"])
+        expect_offense(<<-GEM, 'Gemfile')
+          gem 'rubocop'
+          group :development do
+            gem 'rubocop', path: '/path/to/gem'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Gem `rubocop` requirements already given on line 1 of the Gemfile.
+          end
+        GEM
       end
     end
   end

--- a/spec/rubocop/cop/bundler/insecure_protocol_source_spec.rb
+++ b/spec/rubocop/cop/bundler/insecure_protocol_source_spec.rb
@@ -29,18 +29,18 @@ RSpec.describe RuboCop::Cop::Bundler::InsecureProtocolSource do
   it 'autocorrects `source :gemcutter`' do
     new_source = autocorrect_source('source :gemcutter')
 
-    expect(new_source).to eq "source 'https://rubygems.org'"
+    expect(new_source).to eq("source 'https://rubygems.org'")
   end
 
   it 'autocorrects `source :rubygems`' do
     new_source = autocorrect_source('source :rubygems')
 
-    expect(new_source).to eq "source 'https://rubygems.org'"
+    expect(new_source).to eq("source 'https://rubygems.org'")
   end
 
   it 'autocorrects `source :rubyforge`' do
     new_source = autocorrect_source('source :rubyforge')
 
-    expect(new_source).to eq "source 'https://rubygems.org'"
+    expect(new_source).to eq("source 'https://rubygems.org'")
   end
 end

--- a/spec/rubocop/cop/gemspec/ordered_dependencies_spec.rb
+++ b/spec/rubocop/cop/gemspec/ordered_dependencies_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RuboCop::Cop::Gemspec::OrderedDependencies, :config do
   end
 
   shared_examples 'ordered dependency' do |add_dependency|
-    context "When #{add_dependency}" do
+    context "when #{add_dependency}" do
       context 'When gems are alphabetically sorted' do
         it 'does not register any offenses' do
           expect_no_offenses(<<-RUBY.strip_indent)
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::Gemspec::OrderedDependencies, :config do
         end
       end
 
-      context 'When gems are not alphabetically sorted' do
+      context 'when gems are not alphabetically sorted' do
         let(:source) { <<-RUBY.strip_indent }
           Gem::Specification.new do |spec|
             spec.#{add_dependency} 'rubocop'
@@ -51,7 +51,7 @@ RSpec.describe RuboCop::Cop::Gemspec::OrderedDependencies, :config do
         end
       end
 
-      context 'When each individual group of line is sorted' do
+      context 'when each individual group of line is sorted' do
         it 'does not register any offenses' do
           expect_no_offenses(<<-RUBY.strip_indent)
             Gem::Specification.new do |spec|
@@ -65,7 +65,7 @@ RSpec.describe RuboCop::Cop::Gemspec::OrderedDependencies, :config do
         end
       end
 
-      context 'When dependency is separated by multiline comment' do
+      context 'when dependency is separated by multiline comment' do
         let(:source) { <<-RUBY.strip_indent }
           Gem::Specification.new do |spec|
             # For code quality
@@ -177,7 +177,7 @@ RSpec.describe RuboCop::Cop::Gemspec::OrderedDependencies, :config do
     RUBY
   end
 
-  context 'When different dependencies are consecutive' do
+  context 'when different dependencies are consecutive' do
     it 'does not register any offenses' do
       expect_no_offenses(<<-RUBY.strip_indent)
         Gem::Specification.new do |spec|

--- a/spec/rubocop/cop/internal_affairs/node_destructuring_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/node_destructuring_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe RuboCop::Cop::InternalAffairs::NodeDestructuring do
 
   context 'when destructuring using `node.children`' do
     it 'registers an offense when receiver is named `node`' do
-      expect_offense(<<-RUBY, 'example_cop.rb')
+      expect_offense(<<-RUBY.strip_indent, 'example_cop.rb')
         lhs, rhs = node.children
         ^^^^^^^^^^^^^^^^^^^^^^^^ Use the methods provided with the node extensions, or destructure the node using `*`.
       RUBY
     end
 
     it 'registers an offense when receiver is named `send_node`' do
-      expect_offense(<<-RUBY, 'example_cop.rb')
+      expect_offense(<<-RUBY.strip_indent, 'example_cop.rb')
         lhs, rhs = send_node.children
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the methods provided with the node extensions, or destructure the node using `*`.
       RUBY
@@ -20,13 +20,13 @@ RSpec.describe RuboCop::Cop::InternalAffairs::NodeDestructuring do
   end
 
   it 'does not register an offense for a predicate node type check' do
-    expect_no_offenses(<<-RUBY, 'example_spec.rb')
+    expect_no_offenses(<<-RUBY.strip_indent, 'example_spec.rb')
       lhs, rhs = *node
     RUBY
   end
 
   it 'does not register an offense when receiver is named `array`' do
-    expect_no_offenses(<<-RUBY, 'example_spec.rb')
+    expect_no_offenses(<<-RUBY.strip_indent, 'example_spec.rb')
       lhs, rhs = array.children
     RUBY
   end

--- a/spec/rubocop/cop/internal_affairs/node_type_predicate_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/node_type_predicate_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe RuboCop::Cop::InternalAffairs::NodeTypePredicate do
 
   context 'comparison node type check' do
     it 'registers an offense' do
-      expect_offense(<<-RUBY, 'example_cop.rb')
-      node.type == :send
-      ^^^^^^^^^^^^^^^^^^ Use `#send_type?` to check node type.
+      expect_offense(<<-RUBY.strip_indent, 'example_cop.rb')
+        node.type == :send
+        ^^^^^^^^^^^^^^^^^^ Use `#send_type?` to check node type.
       RUBY
     end
 
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::NodeTypePredicate do
   end
 
   it 'does not register an offense for a predicate node type check' do
-    expect_no_offenses(<<-RUBY, 'example_spec.rb')
+    expect_no_offenses(<<-RUBY.strip_indent, 'example_spec.rb')
       node.send_type?
     RUBY
   end

--- a/spec/rubocop/cop/internal_affairs/offense_location_keyword_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/offense_location_keyword_spec.rb
@@ -3,24 +3,16 @@
 RSpec.describe RuboCop::Cop::InternalAffairs::OffenseLocationKeyword do
   subject(:cop) { described_class.new }
 
-  shared_examples 'auto-correction' do |name, old_source, new_source|
-    it "auto-corrects #{name}" do
-      corrected_source = autocorrect_source(old_source)
-
-      expect(corrected_source).to eq(new_source)
-    end
-  end
-
   context 'when `node.loc.selector` is passed' do
     it 'registers an offense' do
-      expect_offense(<<-RUBY, 'example_cop.rb')
+      expect_offense(<<-RUBY.strip_indent, 'example_cop.rb')
         add_offense(node, location: node.loc.selector)
                                     ^^^^^^^^^^^^^^^^^ Use `:selector` as the location argument to `#add_offense`.
       RUBY
     end
 
     it 'registers an offense if message argument is passed' do
-      expect_offense(<<-RUBY, 'example_cop.rb')
+      expect_offense(<<-RUBY.strip_indent, 'example_cop.rb')
         add_offense(
           node,
           message: 'message',
@@ -32,28 +24,26 @@ RSpec.describe RuboCop::Cop::InternalAffairs::OffenseLocationKeyword do
   end
 
   it 'does not register an offense when the `loc` is on a child node' do
-    expect_no_offenses(<<-RUBY, 'example_cop.rb')
+    expect_no_offenses(<<-RUBY.strip_indent, 'example_cop.rb')
       add_offense(node, location: node.arguments.loc.selector)
     RUBY
   end
 
   it 'does not register an offense when the `loc` is on a different node' do
-    expect_no_offenses(<<-RUBY, 'example_cop.rb')
+    expect_no_offenses(<<-RUBY.strip_indent, 'example_cop.rb')
       add_offense(node, location: other_node.loc.selector)
     RUBY
   end
 
-  it_behaves_like(
-    'auto-correction',
-    'when there are no other kwargs but location',
-    'add_offense(node, location: node.loc.selector)',
-    'add_offense(node, location: :selector)'
-  )
+  it 'auto-corrects `location` when it is the only keyword' do
+    corrected =
+      autocorrect_source('add_offense(node, location: node.loc.selector)')
 
-  it_behaves_like(
-    'auto-correction',
-    'when there are other kwargs',
-    <<-RUBY,
+    expect(corrected).to eq('add_offense(node, location: :selector)')
+  end
+
+  it 'auto-corrects `location` when there are other keywords' do
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
       add_offense(
         node,
         message: 'foo',
@@ -61,7 +51,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::OffenseLocationKeyword do
         severity: :warning
       )
     RUBY
-    <<-RUBY
+    expect(corrected).to eq(<<-RUBY.strip_indent)
       add_offense(
         node,
         message: 'foo',
@@ -69,5 +59,5 @@ RSpec.describe RuboCop::Cop::InternalAffairs::OffenseLocationKeyword do
         severity: :warning
       )
     RUBY
-  )
+  end
 end

--- a/spec/rubocop/cop/internal_affairs/redundant_location_argument_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/redundant_location_argument_spec.rb
@@ -3,18 +3,10 @@
 RSpec.describe RuboCop::Cop::InternalAffairs::RedundantLocationArgument do
   subject(:cop) { described_class.new }
 
-  shared_examples 'auto-correction' do |name, old_source, new_source|
-    it "auto-corrects #{name}" do
-      corrected_source = autocorrect_source(old_source)
-
-      expect(corrected_source).to eq(new_source)
-    end
-  end
-
   context 'when location argument is passed' do
     context 'when location argument is :expression' do
       it 'registers an offense' do
-        expect_offense(<<-RUBY, 'example_cop.rb')
+        expect_offense(<<-RUBY.strip_indent, 'example_cop.rb')
           add_offense(node, location: :expression)
                             ^^^^^^^^^^^^^^^^^^^^^ Redundant location argument to `#add_offense`.
         RUBY
@@ -22,38 +14,45 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantLocationArgument do
 
       context 'when there is a message argument' do
         it 'registers an offense' do
-          expect_offense(<<-RUBY, 'example_cop.rb')
+          expect_offense(<<-RUBY.strip_indent, 'example_cop.rb')
             add_offense(node, location: :expression, message: 'message')
                               ^^^^^^^^^^^^^^^^^^^^^ Redundant location argument to `#add_offense`.
           RUBY
         end
       end
 
-      it_behaves_like(
-        'auto-correction',
-        'when there is no message argument',
-        'add_offense(node, location: :expression)',
-        'add_offense(node)'
-      )
+      it 'removes default `location` when there are no other keywords' do
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
+          add_offense(node, location: :expression)
+        RUBY
 
-      it_behaves_like(
-        'auto-correction',
-        'when there is a message argument before location',
-        "add_offense(node, message: 'foo', location: :expression)",
-        "add_offense(node, message: 'foo')"
-      )
+        expect(corrected).to eq(<<-RUBY.strip_indent)
+          add_offense(node)
+        RUBY
+      end
 
-      it_behaves_like(
-        'auto-correction',
-        'when there is a message argument after location',
-        "add_offense(node, location: :expression, message: 'foo')",
-        "add_offense(node, message: 'foo')"
-      )
+      it 'removes default `location` when preceded by another keyword' do
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
+          add_offense(node, message: 'foo', location: :expression)
+        RUBY
 
-      it_behaves_like(
-        'auto-correction',
-        'when there are arguments around location',
-        <<-RUBY,
+        expect(corrected).to eq(<<-RUBY.strip_indent)
+          add_offense(node, message: 'foo')
+        RUBY
+      end
+
+      it 'removes default `location` when followed by another keyword' do
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
+          add_offense(node, location: :expression, message: 'foo')
+        RUBY
+
+        expect(corrected).to eq(<<-RUBY.strip_indent)
+          add_offense(node, message: 'foo')
+        RUBY
+      end
+
+      it 'removes default `location` surrounded by other keywords' do
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
           add_offense(
             node,
             severity: :error,
@@ -61,19 +60,20 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantLocationArgument do
             message: 'message'
           )
         RUBY
-        <<-RUBY
+
+        expect(corrected).to eq(<<-RUBY.strip_indent)
           add_offense(
             node,
             severity: :error,
             message: 'message'
           )
         RUBY
-      )
+      end
     end
 
     context 'when location argument does not equal to :expression' do
       it 'does not register an offense' do
-        expect_no_offenses(<<-RUBY, 'example_cop.rb')
+        expect_no_offenses(<<-RUBY.strip_indent, 'example_cop.rb')
           add_offense(node, location: :selector)
         RUBY
       end
@@ -82,7 +82,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantLocationArgument do
 
   context 'when location argument is not passed' do
     it 'does not register an offense' do
-      expect_no_offenses(<<-RUBY, 'example_cop.rb')
+      expect_no_offenses(<<-RUBY.strip_indent, 'example_cop.rb')
         add_offense(node)
       RUBY
     end

--- a/spec/rubocop/cop/internal_affairs/redundant_message_argument_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/redundant_message_argument_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantMessageArgument do
 
   context 'when `MSG` is passed' do
     it 'registers an offense' do
-      expect_offense(<<-RUBY, 'example_cop.rb')
+      expect_offense(<<-RUBY.strip_indent, 'example_cop.rb')
       add_offense(node, message: MSG)
                         ^^^^^^^^^^^^ Redundant message argument to `#add_offense`.
       RUBY
@@ -19,21 +19,21 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantMessageArgument do
   end
 
   it 'does not register an offense when formatted `MSG` is passed' do
-    expect_no_offenses(<<-RUBY, 'example_cop.rb')
+    expect_no_offenses(<<-RUBY.strip_indent, 'example_cop.rb')
       add_offense(node, location: :expression, message: MSG % foo)
     RUBY
   end
 
   context 'when `#message` is passed' do
     it 'registers an offense' do
-      expect_offense(<<-RUBY, 'example_cop.rb')
+      expect_offense(<<-RUBY.strip_indent, 'example_cop.rb')
       add_offense(node, location: :expression, message: message)
                                                ^^^^^^^^^^^^^^^^ Redundant message argument to `#add_offense`.
       RUBY
     end
 
     it 'auto-corrects' do
-      new_source = autocorrect_source(<<-RUBY)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         add_offense(
           node,
           location: :expression,
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantMessageArgument do
         )
       RUBY
 
-      expect(new_source).to eq(<<-RUBY)
+      expect(new_source).to eq(<<-RUBY.strip_indent)
         add_offense(
           node,
           location: :expression,
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantMessageArgument do
   context 'when `#message` with offending node is passed' do
     context 'when message is the only keyword argument' do
       it 'registers an offense' do
-        expect_offense(<<-RUBY, 'example_cop.rb')
+        expect_offense(<<-RUBY.strip_indent, 'example_cop.rb')
           add_offense(node, message: message(node))
                             ^^^^^^^^^^^^^^^^^^^^^^ Redundant message argument to `#add_offense`.
         RUBY
@@ -71,7 +71,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantMessageArgument do
 
     context 'when there are others keyword arguments' do
       it 'registers an offense' do
-        expect_offense(<<-RUBY, 'example_cop.rb')
+        expect_offense(<<-RUBY.strip_indent, 'example_cop.rb')
           add_offense(node,
                       location: :selector,
                       message: message(node),
@@ -100,7 +100,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantMessageArgument do
 
   it 'does not register an offense when `#message` with another node ' \
      ' is passed' do
-    expect_no_offenses(<<-RUBY, 'example_cop.rb')
+    expect_no_offenses(<<-RUBY.strip_indent, 'example_cop.rb')
       add_offense(node, message: message(other_node))
     RUBY
   end

--- a/spec/rubocop/cop/internal_affairs/useless_message_assertion_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/useless_message_assertion_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::UselessMessageAssertion do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for specs that assert using the MSG' do
-    expect_offense(<<-RUBY, 'example_spec.rb')
+    expect_offense(<<-RUBY.strip_indent, 'example_spec.rb')
       it 'uses described_class::MSG to specify the expected message' do
         inspect_source(cop, 'foo')
         expect(cop.messages).to eq([described_class::MSG])
@@ -14,14 +14,14 @@ RSpec.describe RuboCop::Cop::InternalAffairs::UselessMessageAssertion do
   end
 
   it 'registers an offense for described_class::MSG in let' do
-    expect_offense(<<-RUBY, 'example_spec.rb')
+    expect_offense(<<-RUBY.strip_indent, 'example_spec.rb')
       let(:msg) { described_class::MSG }
                   ^^^^^^^^^^^^^^^^^^^^ Do not specify cop behavior using `described_class::MSG`.
     RUBY
   end
 
   it 'does not register an offense for an assertion about the message' do
-    expect_no_offenses(<<-RUBY, 'example_spec.rb')
+    expect_no_offenses(<<-RUBY.strip_indent, 'example_spec.rb')
       it 'has a good message' do
         expect(described_class::MSG).to eq('Good message.')
       end

--- a/spec/rubocop/cop/layout/case_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/case_indentation_spec.rb
@@ -595,9 +595,7 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation do
     end
 
     it "doesn't auto-correct" do
-      expect(autocorrect_source(source))
-        .to eq(source)
-      expect(cop.offenses.map(&:corrected?)).to eq [false]
+      expect(autocorrect_source(source)).to eq(source)
     end
   end
 end

--- a/spec/rubocop/cop/layout/else_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/else_alignment_spec.rb
@@ -51,27 +51,24 @@ RSpec.describe RuboCop::Cop::Layout::ElseAlignment do
 
     describe '#autocorrect' do
       it 'corrects bad alignment' do
-        corrected = autocorrect_source(<<-RUBY.strip_indent)
-            if a1
-              b1
-              elsif a2
-              b2
-          else
-              c
-            end
+        corrected = autocorrect_source(<<-RUBY.strip_margin('|'))
+        |    if a1
+        |      b1
+        |      elsif a2
+        |      b2
+        |  else
+        |      c
+        |    end
         RUBY
-        expect(cop.messages).to eq(['Align `elsif` with `if`.',
-                                    'Align `else` with `if`.'])
-        expect(corrected)
-          .to eq <<-RUBY.strip_margin('|')
-            |  if a1
-            |    b1
-            |  elsif a2
-            |    b2
-            |  else
-            |    c
-            |  end
-          RUBY
+        expect(corrected).to eq(<<-RUBY.strip_margin('|'))
+        |    if a1
+        |      b1
+        |    elsif a2
+        |      b2
+        |    else
+        |      c
+        |    end
+        RUBY
       end
     end
 

--- a/spec/rubocop/cop/layout/first_array_element_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_array_element_line_break_spec.rb
@@ -4,26 +4,22 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
   subject(:cop) { described_class.new }
 
   context 'elements listed on the first line' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'registers an offense' do
+      expect_offense(<<-RUBY.strip_indent)
         a = [:a,
+             ^^ Add a line break before the first element of a multi-line array.
              :b]
       RUBY
     end
 
-    it 'detects the offense' do
-      inspect_source(source)
-
-      expect(cop.offenses.length).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq([':a'])
-    end
-
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(source)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
+        a = [:a,
+             :b]
+      RUBY
       # Alignment for the first element is set by IndentationWidth cop,
       # the rest of the elements should be aligned using the AlignArray cop.
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(corrected).to eq(<<-RUBY.strip_indent)
         a = [
         :a,
              :b]
@@ -32,24 +28,21 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
   end
 
   context 'word arrays' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'detects the offense' do
+      expect_offense(<<-RUBY.strip_indent)
         %w(a b
+           ^ Add a line break before the first element of a multi-line array.
            c d)
       RUBY
     end
 
-    it 'detects the offense' do
-      inspect_source(source)
-
-      expect(cop.offenses.length).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(['a'])
-    end
-
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
+        %w(a b
+           c d)
+      RUBY
+
+      expect(corrected).to eq(<<-RUBY.strip_indent)
         %w(
         a b
            c d)
@@ -58,25 +51,21 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
   end
 
   context 'array nested in a method call' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'registers ans offense' do
+      expect_offense(<<-RUBY.strip_indent)
         method([:foo,
+                ^^^^ Add a line break before the first element of a multi-line array.
                 :bar])
       RUBY
     end
 
-    it 'detects the offense' do
-      inspect_source(source)
-
-      expect(cop.offenses.length).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq([':foo'])
-    end
-
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(source)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
+        method([:foo,
+                :bar])
+      RUBY
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(corrected).to eq(<<-RUBY.strip_indent)
         method([
         :foo,
                 :bar])
@@ -85,66 +74,54 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
   end
 
   context 'masgn implicit arrays' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'detects the offense' do
+      expect_offense(<<-RUBY.strip_indent)
+        a, b,
+        c = 1,
+            ^ Add a line break before the first element of a multi-line array.
+        2, 3
+      RUBY
+    end
+
+    it 'autocorrects the offense' do
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         a, b,
         c = 1,
         2, 3
       RUBY
-    end
 
-    let(:correct_source) do
-      ['a, b,',
-       'c = ',
-       '1,',
-       '2, 3',
-       ''].join("\n")
-    end
-
-    it 'detects the offense' do
-      inspect_source(source)
-
-      expect(cop.offenses.length).to eq(1)
-      expect(cop.offenses.first.line).to eq(2)
-      expect(cop.highlights).to eq(['1'])
-    end
-
-    it 'autocorrects the offense' do
-      new_source = autocorrect_source(source)
-
-      expect(new_source).to eq(correct_source)
+      expect(corrected).to eq(<<-RUBY.strip_indent)
+        a, b,
+        c = 
+        1,
+        2, 3
+      RUBY
     end
   end
 
   context 'send implicit arrays' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'detects the offense' do
+      expect_offense(<<-RUBY.strip_indent)
         a
         .c = 1,
+             ^ Add a line break before the first element of a multi-line array.
         2, 3
       RUBY
     end
 
-    let(:correct_source) do
-      ['a',
-       '.c = ',
-       '1,',
-       '2, 3',
-       ''].join("\n")
-    end
-
-    it 'detects the offense' do
-      inspect_source(source)
-
-      expect(cop.offenses.length).to eq(1)
-      expect(cop.offenses.first.line).to eq(2)
-      expect(cop.highlights).to eq(['1'])
-    end
-
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(source)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        a
+        .c = 1,
+        2, 3
+      RUBY
 
-      expect(new_source).to eq(correct_source)
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        a
+        .c = 
+        1,
+        2, 3
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/layout/first_hash_element_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_hash_element_line_break_spec.rb
@@ -4,58 +4,48 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementLineBreak do
   subject(:cop) { described_class.new }
 
   context 'elements listed on the first line' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'detects the offense' do
+      expect_offense(<<-RUBY.strip_indent)
         a = { a: 1,
-              b: 2}
+              ^^^^ Add a line break before the first element of a multi-line hash.
+              b: 2 }
       RUBY
     end
 
-    it 'detects the offense' do
-      inspect_source(source)
-
-      expect(cop.offenses.length).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(['a: 1'])
-    end
-
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(source)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        a = { a: 1,
+              b: 2 }
+      RUBY
 
-      expect(new_source).to eq([
-        'a = { ',
-        'a: 1,',
-        '      b: 2}',
-        ''
-      ].join("\n"))
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        a = { 
+        a: 1,
+              b: 2 }
+      RUBY
     end
   end
 
   context 'hash nested in a method call' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'detects the offense' do
+      expect_offense(<<-RUBY.strip_indent)
         method({ foo: 1,
+                 ^^^^^^ Add a line break before the first element of a multi-line hash.
                  bar: 2 })
       RUBY
     end
 
-    it 'detects the offense' do
-      inspect_source(source)
-
-      expect(cop.offenses.length).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(['foo: 1'])
-    end
-
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(source)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        method({ foo: 1,
+                 bar: 2 })
+      RUBY
 
-      expect(new_source).to eq([
-        'method({ ',
-        'foo: 1,',
-        '         bar: 2 })',
-        ''
-      ].join("\n"))
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        method({ 
+        foo: 1,
+                 bar: 2 })
+      RUBY
     end
   end
 
@@ -70,7 +60,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementLineBreak do
   it 'ignores implicit hashes in method calls without parens' do
     expect_no_offenses(<<-RUBY.strip_indent)
       method foo: 1,
-       bar:2
+       bar: 2
     RUBY
   end
 
@@ -86,7 +76,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementLineBreak do
     expect_no_offenses(<<-RUBY.strip_indent)
       b = {
         a: 1,
-        b: 2}
+        b: 2 }
     RUBY
   end
 end

--- a/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
@@ -4,23 +4,19 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak do
   subject(:cop) { described_class.new }
 
   context 'args listed on the first line' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'detects the offense' do
+      expect_offense(<<-RUBY.strip_indent)
         foo(bar,
+            ^^^ Add a line break before the first argument of a multi-line method argument list.
           baz)
       RUBY
     end
 
-    it 'detects the offense' do
-      inspect_source(source)
-
-      expect(cop.offenses.length).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(['bar'])
-    end
-
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(source)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        foo(bar,
+          baz)
+      RUBY
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         foo(
@@ -31,23 +27,19 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak do
   end
 
   context 'hash arg spanning multiple lines' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'detects the offense' do
+      expect_offense(<<-RUBY.strip_indent)
         something(3, bar: 1,
+                  ^ Add a line break before the first argument of a multi-line method argument list.
         baz: 2)
       RUBY
     end
 
-    it 'detects the offense' do
-      inspect_source(source)
-
-      expect(cop.offenses.length).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(['3'])
-    end
-
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(source)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        something(3, bar: 1,
+        baz: 2)
+      RUBY
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         something(
@@ -58,23 +50,19 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak do
   end
 
   context 'hash arg without a line break before the first pair' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'detects the offense' do
+      expect_offense(<<-RUBY.strip_indent)
         something(bar: 1,
+                  ^^^^^^ Add a line break before the first argument of a multi-line method argument list.
         baz: 2)
       RUBY
     end
 
-    it 'detects the offense' do
-      inspect_source(source)
-
-      expect(cop.offenses.length).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(['bar: 1'])
-    end
-
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(source)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        something(bar: 1,
+        baz: 2)
+      RUBY
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         something(

--- a/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
@@ -4,25 +4,23 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
   subject(:cop) { described_class.new }
 
   context 'params listed on the first line' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'detects the offense' do
+      expect_offense(<<-RUBY.strip_indent)
         def foo(bar,
+                ^^^ Add a line break before the first parameter of a multi-line method parameter list.
           baz)
           do_something
         end
       RUBY
     end
 
-    it 'detects the offense' do
-      inspect_source(source)
-
-      expect(cop.offenses.length).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(['bar'])
-    end
-
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(source)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        def foo(bar,
+          baz)
+          do_something
+        end
+      RUBY
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         def foo(
@@ -35,25 +33,23 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
   end
 
   context 'params on first line of singleton method' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'detects the offense' do
+      expect_offense(<<-RUBY.strip_indent)
         def self.foo(bar,
+                     ^^^ Add a line break before the first parameter of a multi-line method parameter list.
           baz)
           do_something
         end
       RUBY
     end
 
-    it 'detects the offense' do
-      inspect_source(source)
-
-      expect(cop.offenses.length).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(['bar'])
-    end
-
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(source)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        def self.foo(bar,
+          baz)
+          do_something
+        end
+      RUBY
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         def self.foo(
@@ -95,25 +91,23 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
   end
 
   context 'params with default values' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'detects the offense' do
+      expect_offense(<<-RUBY.strip_indent)
         def foo(bar = [],
+                ^^^^^^^^ Add a line break before the first parameter of a multi-line method parameter list.
           baz = 2)
           do_something
         end
       RUBY
     end
 
-    it 'detects the offense' do
-      inspect_source(source)
-
-      expect(cop.offenses.length).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(['bar = []'])
-    end
-
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(source)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        def foo(bar = [],
+          baz = 2)
+          do_something
+        end
+      RUBY
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         def foo(

--- a/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
@@ -20,46 +20,35 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
       let(:indentation_width) { 2 }
 
       it 'registers an offense for an over-indented first parameter' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           run(
               :foo,
+              ^^^^ Indent the first parameter one step more than the start of the previous line.
               bar: 3
           )
         RUBY
-        expect(cop.messages).to eq(['Indent the first parameter one step ' \
-                                    'more than the start of the ' \
-                                    'previous line.'])
-        expect(cop.highlights).to eq([':foo'])
       end
 
       it 'registers an offense for an under-indented first parameter' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           run(
            :foo,
+           ^^^^ Indent the first parameter one step more than the start of the previous line.
               bar: 3
           )
         RUBY
-        expect(cop.highlights).to eq([':foo'])
       end
 
       it 'registers an offense on lines affected by another offense' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           foo(
            bar(
+           ^^^^ Indent the first parameter one step more than the start of the previous line.
             7
+            ^ Bad indentation of the first parameter.
           )
           )
         RUBY
-
-        expect(cop.highlights).to eq([['bar(',
-                                       '  7',
-                                       ')'].join("\n"),
-                                      '7'])
-
-        expect(cop.messages)
-          .to eq(['Indent the first parameter one step more than ' \
-                  'the start of the previous line.',
-                  'Bad indentation of the first parameter.'])
       end
 
       it 'auto-corrects nested offenses' do
@@ -198,11 +187,11 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
       end
 
       it 'does not view chained call as an outer method call' do
-        expect_no_offenses(<<-'RUBY'.strip_margin('|'))
-          |  A = Regexp.union(
-          |    /[A-Za-z_][A-Za-z\d_]*[!?=]?/,
-          |    *AST::Types::OPERATOR_METHODS.map(&:to_s)
-          |  ).freeze
+        expect_no_offenses(<<-'RUBY'.strip_indent)
+          A = Regexp.union(
+            /[A-Za-z_][A-Za-z\d_]*[!?=]?/,
+            *AST::Types::OPERATOR_METHODS.map(&:to_s)
+          ).freeze
         RUBY
       end
 
@@ -591,11 +580,11 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
       end
 
       it 'does not view chained call as an outer method call' do
-        expect_no_offenses(<<-'RUBY'.strip_margin('|'))
-          |  A = Regexp.union(
-          |        /[A-Za-z_][A-Za-z\d_]*[!?=]?/,
-          |        *AST::Types::OPERATOR_METHODS.map(&:to_s)
-          |      ).freeze
+        expect_no_offenses(<<-'RUBY'.strip_indent)
+          A = Regexp.union(
+                /[A-Za-z_][A-Za-z\d_]*[!?=]?/,
+                *AST::Types::OPERATOR_METHODS.map(&:to_s)
+              ).freeze
         RUBY
       end
 

--- a/spec/rubocop/cop/layout/indent_array_spec.rb
+++ b/spec/rubocop/cop/layout/indent_array_spec.rb
@@ -27,13 +27,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentArray do
     end
 
     it 'registers an offense for incorrectly indented first element' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a << [
          1
+         ^ Use 2 spaces for indentation in an array, relative to the start of the line where the left square bracket is.
         ]
       RUBY
-      expect(cop.highlights).to eq(['1'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'auto-corrects incorrectly indented first element' do

--- a/spec/rubocop/cop/layout/indent_assignment_spec.rb
+++ b/spec/rubocop/cop/layout/indent_assignment_spec.rb
@@ -11,19 +11,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentAssignment, :config do
   end
   let(:cop_indent) { nil } # use indentation with from Layout/IndentationWidth
 
-  let(:message) do
-    'Indent the first line of the right-hand-side of a multi-line assignment.'
-  end
-
   it 'registers an offense for incorrectly indented rhs' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       a =
       if b ; end
+      ^^^^^^^^^^ Indent the first line of the right-hand-side of a multi-line assignment.
     RUBY
-
-    expect(cop.offenses.length).to eq(1)
-    expect(cop.highlights).to eq(['if b ; end'])
-    expect(cop.message).to eq(message)
   end
 
   it 'allows assignments that do not start on a newline' do
@@ -49,15 +42,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentAssignment, :config do
   end
 
   it 'registers an offense for multi-lhs' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       a,
       b =
       if b ; end
+      ^^^^^^^^^^ Indent the first line of the right-hand-side of a multi-line assignment.
     RUBY
-
-    expect(cop.offenses.length).to eq(1)
-    expect(cop.highlights).to eq(['if b ; end'])
-    expect(cop.message).to eq(message)
   end
 
   it 'ignores comparison operators' do

--- a/spec/rubocop/cop/layout/indent_hash_spec.rb
+++ b/spec/rubocop/cop/layout/indent_hash_spec.rb
@@ -54,14 +54,13 @@ RSpec.describe RuboCop::Cop::Layout::IndentHash do
     end
 
     it 'registers an offense for incorrectly indented first pair with :' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a << {
                a: 1,
+               ^^^^ Use 2 spaces for indentation in a hash, relative to the start of the line where the left curly brace is.
              aaa: 222
         }
       RUBY
-      expect(cop.highlights).to eq(['a: 1'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     include_examples 'right brace'
@@ -86,14 +85,13 @@ RSpec.describe RuboCop::Cop::Layout::IndentHash do
     end
 
     it 'registers an offense for incorrectly indented first pair with =>' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a << {
            'a' => 1,
+           ^^^^^^^^ Use 2 spaces for indentation in a hash, relative to the start of the line where the left curly brace is.
          'aaa' => 222
         }
       RUBY
-      expect(cop.highlights).to eq(["'a' => 1"])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     include_examples 'right brace'
@@ -109,13 +107,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentHash do
     end
 
     it 'registers an offense for incorrectly indented first pair' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a << {
          a: 1
+         ^^^^ Use 2 spaces for indentation in a hash, relative to the start of the line where the left curly brace is.
         }
       RUBY
-      expect(cop.highlights).to eq(['a: 1'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'auto-corrects incorrectly indented first pair' do
@@ -146,32 +143,27 @@ RSpec.describe RuboCop::Cop::Layout::IndentHash do
     end
 
     it 'registers an offense for incorrectly indented first pair' do
-      inspect_source(<<-RUBY.strip_margin('|'))
-        |   config.rack_cache = {
-        |   :metastore => "rails:/",
-        |   :entitystore => "rails:/",
-        |   :verbose => false
-        |   }
+      expect_offense(<<-RUBY.strip_indent)
+        config.rack_cache = {
+        :metastore => "rails:/",
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use 2 spaces for indentation in a hash, relative to the start of the line where the left curly brace is.
+        :entitystore => "rails:/",
+        :verbose => false
+        }
       RUBY
-      expect(cop.highlights).to eq([':metastore => "rails:/"'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
   end
 
   context 'when hash is right hand side in assignment' do
     it 'registers an offense for incorrectly indented first pair' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a = {
             a: 1,
+            ^^^^ Use 2 spaces for indentation in a hash, relative to the start of the line where the left curly brace is.
           b: 2,
          c: 3
         }
       RUBY
-      expect(cop.messages)
-        .to eq(['Use 2 spaces for indentation in a hash, relative to the ' \
-                'start of the line where the left curly brace is.'])
-      expect(cop.highlights).to eq(['a: 1'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'auto-corrects incorrectly indented first pair' do
@@ -276,34 +268,23 @@ RSpec.describe RuboCop::Cop::Layout::IndentHash do
         end
 
         it "registers an offense for 'consistent' indentation" do
-          inspect_source(<<-RUBY.strip_indent)
+          expect_offense(<<-RUBY.strip_indent)
             func({
               a: 1
+              ^^^^ Use 2 spaces for indentation in a hash, relative to the first position after the preceding left parenthesis.
             })
+            ^ Indent the right brace the same as the first position after the preceding left parenthesis.
           RUBY
-          expect(cop.messages)
-            .to eq(['Use 2 spaces for indentation in a hash, relative to the' \
-                    ' first position after the preceding left parenthesis.',
-                    'Indent the right brace the same as the first position ' \
-                    'after the preceding left parenthesis.'])
-          expect(cop.config_to_allow_offenses)
-            .to eq('EnforcedStyle' => 'consistent')
         end
 
         it "registers an offense for 'align_braces' indentation" do
-          inspect_source(<<-RUBY.strip_indent)
+          expect_offense(<<-RUBY.strip_indent)
             var = {
                     a: 1
+                    ^^^^ Use 2 spaces for indentation in a hash, relative to the start of the line where the left curly brace is.
                   }
+                  ^ Indent the right brace the same as the start of the line where the left brace is.
           RUBY
-          # since there are no parens, warning message is for 'consistent' style
-          expect(cop.messages)
-            .to eq(['Use 2 spaces for indentation in a hash, relative to the' \
-                    ' start of the line where the left curly brace is.',
-                    'Indent the right brace the same as the start of the ' \
-                    'line where the left brace is.'])
-          expect(cop.config_to_allow_offenses)
-            .to eq('EnforcedStyle' => 'align_braces')
         end
 
         it 'auto-corrects incorrectly indented first pair' do
@@ -361,18 +342,13 @@ RSpec.describe RuboCop::Cop::Layout::IndentHash do
         end
 
         it 'registers an offense for incorrect indentation' do
-          inspect_source(<<-RUBY.strip_indent)
+          expect_offense(<<-RUBY.strip_indent)
             func({
                    a: 1
+                   ^^^^ Use 2 spaces for indentation in a hash, relative to the start of the line where the left curly brace is.
                  })
+                 ^ Indent the right brace the same as the start of the line where the left brace is.
           RUBY
-          expect(cop.messages)
-            .to eq(['Use 2 spaces for indentation in a hash, relative to the' \
-                    ' start of the line where the left curly brace is.',
-                    'Indent the right brace the same as the start of the ' \
-                    'line where the left brace is.'])
-          expect(cop.config_to_allow_offenses)
-            .to eq('EnforcedStyle' => 'special_inside_parentheses')
         end
 
         it 'accepts normal indentation for second argument' do
@@ -402,15 +378,11 @@ RSpec.describe RuboCop::Cop::Layout::IndentHash do
 
       it 'registers an offense for incorrectly indented multi-line hash ' \
          'with braces' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           func x, {
                  a: 1, b: 2 }
+                 ^^^^ Use 2 spaces for indentation in a hash, relative to the start of the line where the left curly brace is.
         RUBY
-        expect(cop.messages)
-          .to eq(['Use 2 spaces for indentation in a hash, relative to the ' \
-                  'start of the line where the left curly brace is.'])
-        expect(cop.highlights).to eq(['a: 1'])
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
     end
   end
@@ -451,17 +423,13 @@ RSpec.describe RuboCop::Cop::Layout::IndentHash do
 
     context "when 'consistent' style is used" do
       it 'registers an offense for incorrect indentation' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           func({
             a: 1
+            ^^^^ Use 2 spaces for indentation in a hash, relative to the position of the opening brace.
           })
+          ^ Indent the right brace the same as the left brace.
         RUBY
-        expect(cop.messages)
-          .to eq(['Use 2 spaces for indentation in a hash, relative to the' \
-                  ' position of the opening brace.',
-                  'Indent the right brace the same as the left brace.'])
-        expect(cop.config_to_allow_offenses)
-          .to eq('EnforcedStyle' => 'consistent')
       end
 
       it 'auto-corrects incorrectly indented first pair' do

--- a/spec/rubocop/cop/layout/indent_heredoc_spec.rb
+++ b/spec/rubocop/cop/layout/indent_heredoc_spec.rb
@@ -121,14 +121,17 @@ RSpec.describe RuboCop::Cop::Layout::IndentHeredoc, :config do
         end
       CORRECTION
 
-      include_examples 'accept', 'not indented but with whitespace, with `-`',
-                       <<-RUBY
-        def foo
-          <<-#{quote}RUBY2#{quote}
-          something
-          RUBY2
-        end
-      RUBY
+      it 'does not reguster an offense when not indented but with ' \
+         'whitespace, with `-`' do
+        expect_no_offenses(<<-RUBY)
+          def foo
+            <<-#{quote}RUBY2#{quote}
+            something
+            RUBY2
+          end
+        RUBY
+      end
+
       include_examples 'accept', 'indented, but with `-`', <<-RUBY
         def foo
           <<-#{quote}RUBY2#{quote}

--- a/spec/rubocop/cop/layout/initial_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/initial_indentation_spec.rb
@@ -3,11 +3,11 @@
 RSpec.describe RuboCop::Cop::Layout::InitialIndentation do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for indented method definition ' do
+  it 'registers an offense for indented method definition' do
     expect_offense(<<-RUBY.strip_margin('|'))
-      |  def f
-      |  ^^^ Indentation of first line in file detected.
-      |  end
+    |  def f
+    |  ^^^ Indentation of first line in file detected.
+    |  end
     RUBY
   end
 
@@ -44,10 +44,10 @@ RSpec.describe RuboCop::Cop::Layout::InitialIndentation do
   end
 
   it 'registers an offense for indented assignment disregarding comment' do
-    expect_offense(<<-RUBY.strip_margin('|'))
-      |   # comment
-      |   x = 1
-      |   ^ Indentation of first line in file detected.
+    expect_offense(<<-RUBY)
+       # comment
+       x = 1
+       ^ Indentation of first line in file detected.
     RUBY
   end
 
@@ -59,23 +59,23 @@ RSpec.describe RuboCop::Cop::Layout::InitialIndentation do
   end
 
   it 'auto-corrects indented method definition' do
-    corrected = autocorrect_source(<<-RUBY.strip_margin('|'))
-      |  def f
-      |  end
-    RUBY
-    expect(corrected).to eq <<-RUBY.strip_indent
+    corrected = autocorrect_source(<<-RUBY)
       def f
-        end
+      end
+    RUBY
+    expect(corrected).to eq(<<-RUBY.strip_indent)
+      def f
+            end
     RUBY
   end
 
   it 'auto-corrects indented assignment but not comment' do
-    corrected = autocorrect_source(<<-RUBY.strip_margin('|'))
-      |  # comment
-      |  x = 1
+    corrected = autocorrect_source(<<-RUBY)
+      # comment
+      x = 1
     RUBY
-    expect(corrected).to eq <<-RUBY.strip_indent
-        # comment
+    expect(corrected).to eq(<<-RUBY.strip_indent)
+            # comment
       x = 1
     RUBY
   end

--- a/spec/rubocop/cop/layout/multiline_assignment_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_assignment_layout_spec.rb
@@ -16,15 +16,11 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
     let(:enforced_style) { 'new_line' }
 
     it 'registers an offense when the rhs is on the same line' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         blarg = if true
+        ^^^^^^^^^^^^^^^ Right hand side of multi-line assignment is on the same line as the assignment operator `=`.
         end
       RUBY
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(["blarg = if true\nend"])
-      expect(cop.messages).to eq([described_class::NEW_LINE_OFFENSE])
     end
 
     it 'auto-corrects offenses' do
@@ -51,15 +47,11 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
       let(:supported_types) { %w[array] }
 
       it 'allows supported types to be configured' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           a, b = 4,
+          ^^^^^^^^^ Right hand side of multi-line assignment is on the same line as the assignment operator `=`.
           5
         RUBY
-
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.offenses.first.line).to eq(1)
-        expect(cop.highlights).to eq(["a, b = 4,\n5"])
-        expect(cop.messages).to eq([described_class::NEW_LINE_OFFENSE])
       end
     end
 
@@ -72,16 +64,12 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
     end
 
     it 'registers an offense for masgn with multi-line lhs' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a,
+        ^^ Right hand side of multi-line assignment is on the same line as the assignment operator `=`.
         b = if foo
         end
       RUBY
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(["a,\nb = if foo\nend"])
-      expect(cop.messages).to eq([described_class::NEW_LINE_OFFENSE])
     end
   end
 
@@ -89,16 +77,12 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
     let(:enforced_style) { 'same_line' }
 
     it 'registers an offense when the rhs is a different line' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         blarg =
+        ^^^^^^^ Right hand side of multi-line assignment is not on the same line as the assignment operator `=`.
         if true
         end
       RUBY
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(["blarg =\nif true\nend"])
-      expect(cop.messages).to eq([described_class::SAME_LINE_OFFENSE])
     end
 
     it 'auto-corrects offenses' do
@@ -126,16 +110,12 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
       let(:supported_types) { %w[array] }
 
       it 'allows supported types to be configured' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           a, b =
+          ^^^^^^ Right hand side of multi-line assignment is not on the same line as the assignment operator `=`.
           4,
           5
         RUBY
-
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.offenses.first.line).to eq(1)
-        expect(cop.highlights).to eq(["a, b =\n4,\n5"])
-        expect(cop.messages).to eq([described_class::SAME_LINE_OFFENSE])
       end
     end
 
@@ -147,17 +127,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
     end
 
     it 'registers an offense for masgn with multi-line lhs' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a,
+        ^^ Right hand side of multi-line assignment is not on the same line as the assignment operator `=`.
         b =
         if foo
         end
       RUBY
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(["a,\nb =\nif foo\nend"])
-      expect(cop.messages).to eq([described_class::SAME_LINE_OFFENSE])
     end
   end
 end

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -3,149 +3,198 @@
 RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
   subject(:cop) { described_class.new(config) }
 
-  shared_examples 'common behavior' do |keyword|
-    context 'bad alignment' do
-      it 'registers an offense when used with begin' do
-        inspect_source(<<-RUBY.strip_indent)
-          begin
-            something
-              #{keyword}
-              error
-          end
-        RUBY
-        expect(cop.messages).to eq(["`#{keyword}` at 3, 4 is not aligned with" \
-                                    ' `end` at 5, 0.'])
-      end
+  it 'accepts the modifier form' do
+    expect_no_offenses('test rescue nil')
+  end
 
-      it 'registers an offense when used with def' do
-        inspect_source(<<-RUBY.strip_indent)
-          def test
-            something
-              #{keyword}
-              error
-          end
-        RUBY
-        expect(cop.messages).to eq(["`#{keyword}` at 3, 4 is not aligned with" \
-                                    ' `end` at 5, 0.'])
+  it 'registers an offense when rescue used with begin' do
+    expect_offense(<<-RUBY.strip_indent)
+      begin
+        something
+          rescue
+          ^^^^^^ `rescue` at 3, 4 is not aligned with `end` at 5, 0.
+          error
       end
+    RUBY
+  end
 
-      it 'registers an offense when used with defs' do
-        inspect_source(<<-RUBY.strip_indent)
-          def Test.test
-            something
-              #{keyword}
-              error
-          end
-        RUBY
-        expect(cop.messages).to eq(["`#{keyword}` at 3, 4 is not aligned with" \
-                                    ' `end` at 5, 0.'])
+  it 'registers an offense when rescue used with def' do
+    expect_offense(<<-RUBY.strip_indent)
+      def test
+        something
+          rescue
+          ^^^^^^ `rescue` at 3, 4 is not aligned with `end` at 5, 0.
+          error
       end
+    RUBY
+  end
 
-      it 'registers an offense when used with class' do
-        inspect_source(<<-RUBY.strip_indent)
-          class C
-            something
-              #{keyword}
-              error
-          end
-        RUBY
-        expect(cop.messages).to eq(["`#{keyword}` at 3, 4 is not aligned with" \
-                                    ' `end` at 5, 0.'])
+  it 'registers an offense when rescue used with defs' do
+    expect_offense(<<-RUBY.strip_indent)
+      def Test.test
+        something
+          rescue
+          ^^^^^^ `rescue` at 3, 4 is not aligned with `end` at 5, 0.
+          error
       end
+    RUBY
+  end
 
-      it 'registers an offense when used with module' do
-        inspect_source(<<-RUBY.strip_indent)
-          module M
-            something
-              #{keyword}
-              error
-          end
-        RUBY
-        expect(cop.messages).to eq(["`#{keyword}` at 3, 4 is not aligned with" \
-                                    ' `end` at 5, 0.'])
+  it 'registers an offense when rescue used with class' do
+    expect_offense(<<-RUBY.strip_indent)
+      class C
+        something
+          rescue
+          ^^^^^^ `rescue` at 3, 4 is not aligned with `end` at 5, 0.
+          error
       end
+    RUBY
+  end
 
-      it 'accepts rescue and ensure on the same line' do
-        inspect_source('begin; puts 1; rescue; ensure; puts 2; end')
-
-        expect(cop.messages.empty?).to be(true)
+  it 'registers an offense when rescue used with module' do
+    expect_offense(<<-RUBY.strip_indent)
+      module M
+        something
+          rescue
+          ^^^^^^ `rescue` at 3, 4 is not aligned with `end` at 5, 0.
+          error
       end
+    RUBY
+  end
 
-      it 'auto-corrects' do
-        corrected = autocorrect_source(<<-RUBY.strip_indent)
-          begin
-            something
-              #{keyword}
-              error
-          end
-        RUBY
-        expect(corrected).to eq(<<-RUBY.strip_indent)
-          begin
-            something
-          #{keyword}
-              error
-          end
-        RUBY
+  it 'registers an offense when ensure used with begin' do
+    expect_offense(<<-RUBY.strip_indent)
+      begin
+        something
+          ensure
+          ^^^^^^ `ensure` at 3, 4 is not aligned with `end` at 5, 0.
+          error
       end
+    RUBY
+  end
+
+  it 'registers an offense when ensure used with def' do
+    expect_offense(<<-RUBY.strip_indent)
+      def test
+        something
+          ensure
+          ^^^^^^ `ensure` at 3, 4 is not aligned with `end` at 5, 0.
+          error
+      end
+    RUBY
+  end
+
+  it 'registers an offense when ensure used with defs' do
+    expect_offense(<<-RUBY.strip_indent)
+      def Test.test
+        something
+          ensure 
+          ^^^^^^ `ensure` at 3, 4 is not aligned with `end` at 5, 0.
+          error
+      end
+    RUBY
+  end
+
+  it 'registers an offense when ensure used with class' do
+    expect_offense(<<-RUBY.strip_indent)
+      class C
+        something
+          ensure
+          ^^^^^^ `ensure` at 3, 4 is not aligned with `end` at 5, 0.
+          error
+      end
+    RUBY
+  end
+
+  it 'registers an offense when ensure used with module' do
+    expect_offense(<<-RUBY.strip_indent)
+      module M
+        something
+          ensure
+          ^^^^^^ `ensure` at 3, 4 is not aligned with `end` at 5, 0.
+          error
+      end
+    RUBY
+  end
+
+  it 'accepts rescue and ensure on the same line' do
+    inspect_source('begin; puts 1; rescue; ensure; puts 2; end')
+
+    expect(cop.messages.empty?).to be(true)
+  end
+
+  it 'auto-corrects' do
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
+      begin
+        something
+          rescue
+          error
+      end
+    RUBY
+    expect(corrected).to eq(<<-RUBY.strip_indent)
+      begin
+        something
+      rescue
+          error
+      end
+    RUBY
+  end
+
+  it 'accepts correctly aligned rescue' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      begin
+        something
+      rescue
+        error
+      end
+    RUBY
+  end
+
+  it 'accepts correctly aligned ensure' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      begin
+        something
+      ensure
+        error
+      end
+    RUBY
+  end
+
+  context '>= Ruby 2.5', :ruby25 do
+    it 'accepts aligned rescue in do-end block' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        [1, 2, 3].each do |el|
+          el.to_s
+        rescue StandardError => _exception
+          next
+        end
+      RUBY
     end
 
-    it 'accepts correct alignment' do
-      inspect_source(['begin',
-                      '  something',
-                      keyword,
-                      '    error',
-                      'end'])
-      expect(cop.messages.empty?).to be(true)
-    end
-
-    context '>= Ruby 2.5', :ruby25 do
-      it "accepts aligned #{keyword} in do-end block" do
-        expect_no_offenses(<<-RUBY.strip_indent)
+    it 'accepts aligned rescue in do-end block in a method' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def foo
           [1, 2, 3].each do |el|
             el.to_s
           rescue StandardError => _exception
             next
           end
-        RUBY
-      end
-
-      it "accepts aligned #{keyword} in do-end block in a method" do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          def foo
-            [1, 2, 3].each do |el|
-              el.to_s
-            rescue StandardError => _exception
-              next
-            end
-          end
-        RUBY
-      end
-
-      it "registers an offense for not aligned #{keyword} in do-end block" do
-        expect_offense(<<-RUBY.strip_indent)
-          def foo
-            [1, 2, 3].each do |el|
-              el.to_s
-          rescue StandardError => _exception
-          ^^^^^^ `rescue` at 4, 0 is not aligned with `end` at 6, 2.
-              next
-            end
-          end
-        RUBY
-      end
+        end
+      RUBY
     end
-  end
 
-  context 'rescue' do
-    it_behaves_like 'common behavior', 'rescue'
-
-    it 'accepts the modifier form' do
-      expect_no_offenses('test rescue nil')
+    it 'registers an offense for not aligned rescue in do-end block' do
+      expect_offense(<<-RUBY.strip_indent)
+        def foo
+          [1, 2, 3].each do |el|
+            el.to_s
+        rescue StandardError => _exception
+        ^^^^^^ `rescue` at 4, 0 is not aligned with `end` at 6, 2.
+            next
+          end
+        end
+      RUBY
     end
-  end
-
-  context 'ensure' do
-    it_behaves_like 'common behavior', 'ensure'
   end
 
   describe 'excluded file' do

--- a/spec/rubocop/cop/layout/space_after_not_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_not_spec.rb
@@ -20,11 +20,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAfterNot do
 
   it 'reports an offense for space after ! with the negated receiver ' \
      'wrapped in parentheses' do
-    inspect_source('! (model)')
-
-    expect(cop.messages)
-      .to eq(['Do not leave space between `!` and its argument.'])
-    expect(cop.highlights).to eq(['! (model)'])
+    expect_offense(<<-RUBY.strip_indent)
+      ! (model)
+      ^^^^^^^^^ Do not leave space between `!` and its argument.
+    RUBY
   end
 
   context 'auto-correct' do

--- a/spec/rubocop/cop/layout/space_around_equals_in_parameter_default_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_equals_in_parameter_default_spec.rb
@@ -7,23 +7,20 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :confi
     let(:cop_config) { { 'EnforcedStyle' => 'space' } }
 
     it 'registers an offense for default value assignment without space' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def f(x, y=0, z= 1)
+                  ^ Surrounding space missing in default value assignment.
+                       ^^ Surrounding space missing in default value assignment.
         end
       RUBY
-      expect(cop.messages)
-        .to eq(['Surrounding space missing in default value assignment.'] * 2)
-      expect(cop.highlights).to eq(['=', '= '])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for assignment empty string without space' do
-      inspect_source(<<-RUBY.strip_indent)
-        def f(x, y="", z=1)
+      expect_offense(<<-RUBY.strip_indent)
+        def f(x, y="")
+                  ^ Surrounding space missing in default value assignment.
         end
       RUBY
-      expect(cop.offenses.size).to eq(2)
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'no_space')
     end
 
     it 'registers an offense for assignment of empty list without space' do
@@ -76,23 +73,21 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :confi
     let(:cop_config) { { 'EnforcedStyle' => 'no_space' } }
 
     it 'registers an offense for default value assignment with space' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def f(x, y = 0, z =1, w= 2)
+                  ^^^ Surrounding space detected in default value assignment.
+                         ^^ Surrounding space detected in default value assignment.
+                               ^^ Surrounding space detected in default value assignment.
         end
       RUBY
-      expect(cop.messages)
-        .to eq(['Surrounding space detected in default value assignment.'] * 3)
-      expect(cop.highlights).to eq([' = ', ' =', '= '])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for assignment empty string with space' do
-      inspect_source(<<-RUBY.strip_indent)
-        def f(x, y = "", z = 1)
+      expect_offense(<<-RUBY.strip_indent)
+        def f(x, y = "")
+                  ^^^ Surrounding space detected in default value assignment.
         end
       RUBY
-      expect(cop.offenses.size).to eq(2)
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'space')
     end
 
     it 'registers an offense for assignment of empty list with space' do

--- a/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
@@ -11,31 +11,28 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
     end
 
     it 'registers an offense for left brace without outer space' do
-      inspect_source('each{ puts }')
-      expect(cop.messages).to eq(['Space missing to the left of {.'])
-      expect(cop.highlights).to eq(['{'])
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'no_space')
+      expect_offense(<<-RUBY.strip_indent)
+        each{ puts }
+            ^ Space missing to the left of {.
+      RUBY
     end
 
     it 'registers an offense for opposite + correct style' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         each{ puts }
+            ^ Space missing to the left of {.
         each { puts }
       RUBY
-      expect(cop.messages).to eq(['Space missing to the left of {.'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for multiline block where left brace has no ' \
        'outer space' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         foo.map{ |a|
+               ^ Space missing to the left of {.
           a.bar.to_s
         }
       RUBY
-      expect(cop.messages).to eq(['Space missing to the left of {.'])
-      expect(cop.highlights).to eq(['{'])
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'no_space')
     end
 
     it 'auto-corrects missing space' do
@@ -48,19 +45,18 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'no_space' } }
 
     it 'registers an offense for braces surrounded by spaces' do
-      inspect_source('each { puts }')
-      expect(cop.messages).to eq(['Space detected to the left of {.'])
-      expect(cop.highlights).to eq([' '])
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'space')
+      expect_offense(<<-RUBY.strip_indent)
+        each { puts }
+            ^ Space detected to the left of {.
+      RUBY
     end
 
     it 'registers an offense for correct + opposite style' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         each{ puts }
         each { puts }
+            ^ Space detected to the left of {.
       RUBY
-      expect(cop.messages).to eq(['Space detected to the left of {.'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'accepts left brace without outer space' do
@@ -81,11 +77,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
     end
 
     it 'registers an offense for empty braces' do
-      inspect_source('-> {}')
-      expect(cop.messages).to eq(['Space detected to the left of {.'])
-      expect(cop.highlights).to eq([' '])
-      expect(cop.config_to_allow_offenses)
-        .to eq('EnforcedStyleForEmptyBraces' => 'space')
+      expect_offense(<<-RUBY.strip_indent)
+        -> {}
+          ^ Space detected to the left of {.
+      RUBY
     end
 
     it 'auto-corrects unwanted space' do
@@ -107,11 +102,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
     end
 
     it 'registers an offense for empty braces' do
-      inspect_source('->{}')
-      expect(cop.messages).to eq(['Space missing to the left of {.'])
-      expect(cop.highlights).to eq(['{'])
-      expect(cop.config_to_allow_offenses)
-        .to eq('EnforcedStyleForEmptyBraces' => 'no_space')
+      expect_offense(<<-RUBY.strip_indent)
+        ->{}
+          ^ Space missing to the left of {.
+      RUBY
     end
 
     it 'auto-corrects missing space' do

--- a/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
@@ -8,14 +8,12 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeFirstArg, :config do
   context 'for method calls without parentheses' do
     it 'registers an offense for method call with two spaces before the ' \
        'first arg' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         something  x
+                 ^^ Put one space between the method name and the first argument.
         a.something  y, z
+                   ^^ Put one space between the method name and the first argument.
       RUBY
-      expect(cop.messages)
-        .to eq(['Put one space between the method name and the first ' \
-                'argument.'] * 2)
-      expect(cop.highlights).to eq(['  ', '  '])
     end
 
     it 'auto-corrects extra space' do

--- a/spec/rubocop/cop/layout/space_before_semicolon_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_semicolon_spec.rb
@@ -32,8 +32,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeSemicolon do
   context 'inside block braces' do
     shared_examples 'common behavior' do
       it 'accepts no space between an opening brace and a semicolon' do
-        inspect_source('test {; }')
-        expect(cop.messages.empty?).to be(true)
+        expect_no_offenses('test {; }')
       end
     end
 
@@ -58,8 +57,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeSemicolon do
 
       it 'registers an offense for a space between an opening brace and a ' \
          'semicolon' do
-        inspect_source('test { ; }')
-        expect(cop.messages).to eq(['Space found before semicolon.'])
+        expect_offense(<<-RUBY.strip_indent)
+          test { ; }
+                ^ Space found before semicolon.
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
@@ -108,35 +108,28 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
   end
 
   it 'registers an offense for left brace without inner space' do
-    inspect_source('each {puts }')
-    expect(cop.messages).to eq(['Space missing inside {.'])
-    expect(cop.highlights).to eq(['p'])
-    expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+    expect_offense(<<-RUBY.strip_indent)
+      each {puts }
+            ^ Space missing inside {.
+    RUBY
   end
 
   it 'registers an offense for right brace without inner space' do
-    inspect_source('each { puts}')
-    expect(cop.messages).to eq(['Space missing inside }.'])
-    expect(cop.highlights).to eq(['}'])
-    expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+    expect_offense(<<-RUBY.strip_indent)
+      each { puts}
+                 ^ Space missing inside }.
+    RUBY
   end
 
   it 'registers offenses for both braces without inner space' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       a {}
       b { }
+         ^ Space inside empty braces detected.
       each {puts}
+            ^ Space missing inside {.
+                ^ Space missing inside }.
     RUBY
-    expect(cop.messages).to eq(['Space inside empty braces detected.',
-                                'Space missing inside {.',
-                                'Space missing inside }.'])
-    expect(cop.highlights).to eq([' ', 'p', '}'])
-
-    # Both correct and incorrect code has been found in relation to
-    # EnforcedStyleForEmptyBraces, but that doesn't matter. EnforcedStyle can
-    # be changed to get rid of the EnforcedStyle offenses.
-    expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
-                                               'no_space')
   end
 
   it 'auto-corrects missing space' do
@@ -151,10 +144,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
       end
 
       it 'registers an offense for left brace without inner space' do
-        inspect_source('each {|x| puts }')
-        expect(cop.messages).to eq(['Space between { and | missing.'])
-        expect(cop.highlights).to eq(['{|'])
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+        expect_offense(<<-RUBY.strip_indent)
+          each {|x| puts }
+               ^^ Space between { and | missing.
+        RUBY
       end
     end
 
@@ -162,20 +155,18 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
       it 'accepts left brace with inner space' do
         expect_no_offenses(<<-RUBY.strip_indent)
           each { |x|
-          puts
+            puts
           }
         RUBY
       end
 
       it 'registers an offense for left brace without inner space' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           each {|x|
-          puts
+               ^^ Space between { and | missing.
+            puts
           }
         RUBY
-        expect(cop.messages).to eq(['Space between { and | missing.'])
-        expect(cop.highlights).to eq(['{|'])
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
 
       it 'auto-corrects missing space' do
@@ -238,10 +229,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
       end
 
       it 'registers an offense for left brace with inner space' do
-        inspect_source('each { |x| puts }')
-        expect(cop.messages).to eq(['Space between { and | detected.'])
-        expect(cop.highlights).to eq([' '])
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+        expect_offense(<<-RUBY.strip_indent)
+          each { |x| puts }
+                ^ Space between { and | detected.
+        RUBY
       end
 
       it 'accepts new lambda syntax' do
@@ -273,26 +264,17 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     end
 
     it 'registers an offense for left brace with inner space' do
-      inspect_source('each { puts}')
-      expect(cop.messages).to eq(['Space inside { detected.'])
-      expect(cop.highlights).to eq([' '])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      expect_offense(<<-RUBY.strip_indent)
+        each { puts}
+              ^ Space inside { detected.
+      RUBY
     end
 
     it 'registers an offense for right brace with inner space' do
-      inspect_source('each {puts  }')
-      expect(cop.messages).to eq(['Space inside } detected.'])
-      expect(cop.highlights).to eq(['  '])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-    end
-
-    it 'registers offenses for both braces with inner space' do
-      inspect_source('each { puts  }')
-      expect(cop.messages).to eq(['Space inside { detected.',
-                                  'Space inside } detected.'])
-      expect(cop.highlights).to eq([' ', '  '])
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
-                                                 'space')
+      expect_offense(<<-RUBY.strip_indent)
+        each {puts }
+                  ^ Space inside } detected.
+      RUBY
     end
 
     it 'accepts left brace without outer space' do
@@ -311,10 +293,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
         end
 
         it 'registers an offense for left brace without inner space' do
-          inspect_source('each {|x| puts}')
-          expect(cop.messages).to eq(['Space between { and | missing.'])
-          expect(cop.highlights).to eq(['{|'])
-          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+          expect_offense(<<-RUBY.strip_indent)
+            each {|x| puts}
+                 ^^ Space between { and | missing.
+          RUBY
         end
 
         it 'accepts new lambda syntax' do
@@ -337,10 +319,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
         end
 
         it 'registers an offense for left brace with inner space' do
-          inspect_source('each { |x| puts}')
-          expect(cop.messages).to eq(['Space between { and | detected.'])
-          expect(cop.highlights).to eq([' '])
-          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+          expect_offense(<<-RUBY.strip_indent)
+            each { |x| puts}
+                  ^ Space between { and | detected.
+          RUBY
         end
 
         it 'accepts new lambda syntax' do

--- a/spec/rubocop/cop/layout/space_inside_range_literal_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_range_literal_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideRangeLiteral do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for space inside .. literal' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       1 .. 2
+      ^^^^^^ Space inside range literal.
       1.. 2
+      ^^^^^ Space inside range literal.
       1 ..2
+      ^^^^^ Space inside range literal.
     RUBY
-    expect(cop.offenses.size).to eq(3)
-    expect(cop.messages)
-      .to eq(['Space inside range literal.'] * 3)
   end
 
   it 'accepts no space inside .. literal' do
@@ -19,14 +19,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideRangeLiteral do
   end
 
   it 'registers an offense for space inside ... literal' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       1 ... 2
+      ^^^^^^^ Space inside range literal.
       1... 2
+      ^^^^^^ Space inside range literal.
       1 ...2
+      ^^^^^^ Space inside range literal.
     RUBY
-    expect(cop.offenses.size).to eq(3)
-    expect(cop.messages)
-      .to eq(['Space inside range literal.'] * 3)
   end
 
   it 'accepts no space inside ... literal' do
@@ -45,20 +45,20 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideRangeLiteral do
   end
 
   it 'registers an offense in multiline range literal with space in it' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       x = 0 ..
+          ^^^^ Space inside range literal.
           10
     RUBY
-    expect(cop.offenses.size).to eq(1)
   end
 
   it 'autocorrects space around .. literal' do
-    corrected = autocorrect_source(['1  .. 2'])
-    expect(corrected).to eq '1..2'
+    corrected = autocorrect_source('1  .. 2')
+    expect(corrected).to eq('1..2')
   end
 
   it 'autocorrects space around ... literal' do
-    corrected = autocorrect_source(['1  ... 2'])
-    expect(corrected).to eq '1...2'
+    corrected = autocorrect_source('1  ... 2')
+    expect(corrected).to eq('1...2')
   end
 end

--- a/spec/rubocop/cop/layout/space_inside_reference_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_reference_brackets_spec.rb
@@ -191,30 +191,29 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
     end
 
     it 'registers multiple offenses in one set of ref brackets' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         b[ 89  ]
+          ^ Do not use space inside reference brackets.
+             ^^ Do not use space inside reference brackets.
       RUBY
-      expect(cop.offenses.size).to eq(2)
-      expect(cop.messages.uniq)
-        .to eq(['Do not use space inside reference brackets.'])
     end
 
     it 'registers multiple offenses for multiple sets of ref brackets' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a[ :key]["foo"  ][   0 ]
+          ^ Do not use space inside reference brackets.
+                      ^^ Do not use space inside reference brackets.
+                          ^^^ Do not use space inside reference brackets.
+                              ^ Do not use space inside reference brackets.
       RUBY
-      expect(cop.offenses.size).to eq(4)
-      expect(cop.messages.uniq)
-        .to eq(['Do not use space inside reference brackets.'])
     end
 
     it 'registers offense in outer ref brackets' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         record[ options[:attribute] ]
+               ^ Do not use space inside reference brackets.
+                                   ^ Do not use space inside reference brackets.
       RUBY
-      expect(cop.offenses.size).to eq(2)
-      expect(cop.messages.uniq)
-        .to eq(['Do not use space inside reference brackets.'])
     end
 
     context 'auto-correct' do

--- a/spec/rubocop/cop/layout/trailing_blank_lines_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_blank_lines_spec.rb
@@ -32,13 +32,23 @@ RSpec.describe RuboCop::Cop::Layout::TrailingBlankLines, :config do
     end
 
     it 'registers an offense for multiple trailing blank lines' do
-      inspect_source(['x = 0', '', '', '', ''])
+      inspect_source(<<-RUBY.strip_indent)
+        x = 0
+
+
+
+      RUBY
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['3 trailing blank lines detected.'])
     end
 
     it 'registers an offense for multiple blank lines in an empty file' do
-      inspect_source(['', '', '', '', ''])
+      inspect_source(<<-RUBY.strip_indent)
+
+
+
+
+      RUBY
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['3 trailing blank lines detected.'])
     end
@@ -81,7 +91,12 @@ RSpec.describe RuboCop::Cop::Layout::TrailingBlankLines, :config do
     end
 
     it 'registers an offense for multiple trailing blank lines' do
-      inspect_source(['x = 0', '', '', '', ''])
+      inspect_source(<<-RUBY.strip_indent)
+        x = 0
+
+
+
+      RUBY
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['3 trailing blank lines instead of 1 detected.'])

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -7,15 +7,17 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods do
 
   shared_examples 'in scope' do |type, opening_line|
     it "registers an offense for duplicate method in #{type}" do
-      inspect_source([opening_line,
-                      '  def some_method',
-                      '    implement 1',
-                      '  end',
-                      '  def some_method',
-                      '    implement 2',
-                      '  end',
-                      'end'])
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        #{opening_line}
+          def some_method
+            implement 1
+          end
+          def some_method
+          ^^^ Method `A#some_method` is defined at both (string):2 and (string):5.
+            implement 2
+          end
+        end
+      RUBY
     end
 
     it "doesn't register an offense for non-duplicate method in #{type}" do
@@ -32,18 +34,17 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods do
     end
 
     it "registers an offense for duplicate class methods in #{type}" do
-      inspect_source([opening_line,
-                      '  def self.some_method',
-                      '    implement 1',
-                      '  end',
-                      '  def self.some_method',
-                      '    implement 2',
-                      '  end',
-                      'end'], 'src.rb')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(
-        ['Method `A.some_method` is defined at both src.rb:2 and src.rb:5.']
-      )
+      expect_offense(<<-RUBY.strip_indent, 'dups.rb')
+        #{opening_line}
+          def self.some_method
+            implement 1
+          end
+          def self.some_method
+          ^^^ Method `A.some_method` is defined at both dups.rb:2 and dups.rb:5.
+            implement 2
+          end
+        end
+      RUBY
     end
 
     it "doesn't register offense for non-duplicate class methods in #{type}" do
@@ -128,40 +129,41 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods do
     end
 
     it "registers 2 offenses for pair of duplicate methods in #{type}" do
-      inspect_source([opening_line,
-                      '  def some_method',
-                      '    implement 1',
-                      '  end',
-                      '  def some_method',
-                      '    implement 2',
-                      '  end',
-                      '  def any_method',
-                      '    implement 1',
-                      '  end',
-                      '  def any_method',
-                      '    implement 2',
-                      '  end',
-                      'end'], 'dups.rb')
-      expect(cop.offenses.size).to eq(2)
-      expect(cop.messages).to contain_exactly(
-        'Method `A#any_method` is defined at both dups.rb:8 and dups.rb:11.',
-        'Method `A#some_method` is defined at both dups.rb:2 and dups.rb:5.'
-      )
+      expect_offense(<<-RUBY.strip_indent, 'dups.rb')
+        #{opening_line}
+          def some_method
+            implement 1
+          end
+          def some_method
+          ^^^ Method `A#some_method` is defined at both dups.rb:2 and dups.rb:5.
+            implement 2
+          end
+          def any_method
+            implement 1
+          end
+          def any_method
+          ^^^ Method `A#any_method` is defined at both dups.rb:8 and dups.rb:11.
+            implement 2
+          end
+        end
+      RUBY
     end
 
     it 'registers an offense for a duplicate instance method in separate ' \
        "#{type} blocks" do
-      inspect_source([opening_line,
-                      '  def some_method',
-                      '    implement 1',
-                      '  end',
-                      'end',
-                      opening_line,
-                      '  def some_method',
-                      '    implement 2',
-                      '  end',
-                      'end'])
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent, 'dups.rb')
+        #{opening_line}
+          def some_method
+            implement 1
+          end
+        end
+        #{opening_line}
+          def some_method
+          ^^^ Method `A#some_method` is defined at both dups.rb:2 and dups.rb:7.
+            implement 2
+          end
+        end
+      RUBY
     end
 
     it 'registers an offense for a duplicate class method in separate ' \

--- a/spec/rubocop/cop/lint/implicit_string_concatenation_spec.rb
+++ b/spec/rubocop/cop/lint/implicit_string_concatenation_spec.rb
@@ -10,15 +10,11 @@ RSpec.describe RuboCop::Cop::Lint::ImplicitStringConcatenation do
   end
 
   context 'on adjacent string literals on the same line' do
-    let(:source) { 'class A; "abc" "def"; end' }
-
     it 'registers an offense' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Combine "abc" and "def" into a single ' \
-                                  'string literal, rather than using ' \
-                                  'implicit string concatenation.'])
-      expect(cop.highlights).to eq(['"abc" "def"'])
+      expect_offense(<<-RUBY.strip_indent)
+        class A; "abc" "def"; end
+                 ^^^^^^^^^^^ Combine "abc" and "def" into a single string literal, rather than using implicit string concatenation.
+      RUBY
     end
   end
 
@@ -34,15 +30,12 @@ RSpec.describe RuboCop::Cop::Lint::ImplicitStringConcatenation do
   end
 
   context 'when the string literals contain newlines' do
-    let(:source) { "def method; 'ab\nc' 'de\nf'; end" }
-
     it 'registers an offense' do
-      inspect_source(source)
+      inspect_source(<<-RUBY.strip_indent)
+        def method; "ab\\nc" "de\\nf"; end
+      RUBY
+
       expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Combine "ab\nc" and "de\nf" into a ' \
-                                  'single string literal, rather than using ' \
-                                  'implicit string concatenation.'])
-      expect(cop.highlights).to eq(["'ab\nc' 'de\nf'"])
     end
   end
 
@@ -53,32 +46,20 @@ RSpec.describe RuboCop::Cop::Lint::ImplicitStringConcatenation do
   end
 
   context 'when inside an array' do
-    let(:source) { 'array = ["abc" "def"]' }
-
     it 'notes that the strings could be separated by a comma instead' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Combine "abc" and "def" into a single ' \
-                                  'string literal, rather than using ' \
-                                  'implicit string concatenation. Or, if they' \
-                                  ' were intended to be separate array ' \
-                                  'elements, separate them with a comma.'])
-      expect(cop.highlights).to eq(['"abc" "def"'])
+      expect_offense(<<-RUBY.strip_indent)
+        array = ["abc" "def"]
+                 ^^^^^^^^^^^ Combine "abc" and "def" into a single string literal, rather than using implicit string concatenation. Or, if they were intended to be separate array elements, separate them with a comma.
+      RUBY
     end
   end
 
   context "when in a method call's argument list" do
-    let(:source) { 'method("abc" "def")' }
-
     it 'notes that the strings could be separated by a comma instead' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Combine "abc" and "def" into a single ' \
-                                  'string literal, rather than using ' \
-                                  'implicit string concatenation. Or, if they' \
-                                  ' were intended to be separate method ' \
-                                  'arguments, separate them with a comma.'])
-      expect(cop.highlights).to eq(['"abc" "def"'])
+      expect_offense(<<-RUBY.strip_indent)
+        method("abc" "def")
+               ^^^^^^^^^^^ Combine "abc" and "def" into a single string literal, rather than using implicit string concatenation. Or, if they were intended to be separate method arguments, separate them with a comma.
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/lint/inherit_exception_spec.rb
+++ b/spec/rubocop/cop/lint/inherit_exception_spec.rb
@@ -3,44 +3,39 @@
 RSpec.describe RuboCop::Cop::Lint::InheritException, :config do
   subject(:cop) { described_class.new(config) }
 
-  shared_examples 'registers an offense' do |message|
-    it 'registers an offense' do
-      inspect_source(source)
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq([message])
-    end
-  end
-
-  shared_examples 'auto-correct' do |expected|
-    it 'auto-corrects' do
-      new_source = autocorrect_source(source)
-
-      expect(new_source).to eq(expected)
-    end
-  end
-
   context 'when class inherits from `Exception`' do
-    let(:source) do
-      'class C < Exception; end'
-    end
-
     context 'with enforced style set to `runtime_error`' do
       let(:cop_config) { { 'EnforcedStyle' => 'runtime_error' } }
 
-      it_behaves_like 'registers an offense',
-                      'Inherit from `RuntimeError` instead of `Exception`.'
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
+          class C < Exception; end
+                    ^^^^^^^^^ Inherit from `RuntimeError` instead of `Exception`.
+        RUBY
+      end
 
-      it_behaves_like 'auto-correct', 'class C < RuntimeError; end'
+      it 'auto-corrects' do
+        corrected = autocorrect_source('class C < Exception; end')
+
+        expect(corrected).to eq('class C < RuntimeError; end')
+      end
     end
 
     context 'with enforced style set to `standard_error`' do
       let(:cop_config) { { 'EnforcedStyle' => 'standard_error' } }
 
-      it_behaves_like 'registers an offense',
-                      'Inherit from `StandardError` instead of `Exception`.'
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
+          class C < Exception; end
+                    ^^^^^^^^^ Inherit from `StandardError` instead of `Exception`.
+        RUBY
+      end
 
-      it_behaves_like 'auto-correct', 'class C < StandardError; end'
+      it 'auto-corrects' do
+        corrected = autocorrect_source('class C < Exception; end')
+
+        expect(corrected).to eq('class C < StandardError; end')
+      end
     end
   end
 end

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -33,15 +33,15 @@ RSpec.describe RuboCop::Cop::Lint::NestedMethodDefinition do
   end
 
   it 'registers an offense for a nested class method definition' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       class Foo
         def self.x
           def self.y
+          ^^^^^^^^^^ Method definitions must not be nested. Use `lambda` instead.
           end
         end
       end
     RUBY
-    expect(cop.offenses.size).to eq(1)
   end
 
   it 'does not register an offense for a lambda definition inside method' do

--- a/spec/rubocop/cop/lint/nested_percent_literal_spec.rb
+++ b/spec/rubocop/cop/lint/nested_percent_literal_spec.rb
@@ -54,13 +54,10 @@ RSpec.describe RuboCop::Cop::Lint::NestedPercentLiteral do
     end
 
     it 'registers offense for nested percent literal' do
-      source = '%W[\xff %W[]]'
-      inspect_source(source)
-
-      expect(cop.messages).to eq(['Within percent literals, nested percent' \
-                                  ' literals do not function and may be' \
-                                  ' unwanted in the result.'])
-      expect(cop.highlights).to eq([source])
+      expect_offense(<<-RUBY.strip_indent)
+        %W[\\xff %W[]]
+        ^^^^^^^^^^^^^ Within percent literals, nested percent literals do not function and may be unwanted in the result.
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/lint/next_without_accumulator_spec.rb
+++ b/spec/rubocop/cop/lint/next_without_accumulator_spec.rb
@@ -4,25 +4,25 @@ RSpec.describe RuboCop::Cop::Lint::NextWithoutAccumulator do
   subject(:cop) { described_class.new }
 
   def code_without_accumulator(method_name)
-    <<-SOURCE
+    <<-RUBY
       (1..4).#{method_name}(0) do |acc, i|
         next if i.odd?
         acc + i
       end
-    SOURCE
+    RUBY
   end
 
   def code_with_accumulator(method_name)
-    <<-SOURCE
+    <<-RUBY
       (1..4).#{method_name}(0) do |acc, i|
         next acc if i.odd?
         acc + i
       end
-    SOURCE
+    RUBY
   end
 
   def code_with_nested_block(method_name)
-    <<-SOURCE
+    <<-RUBY
       [(1..3), (4..6)].#{method_name}(0) do |acc, elems|
         elems.each_with_index do |elem, i|
           next if i == 1
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Lint::NextWithoutAccumulator do
         end
         acc
       end
-    SOURCE
+    RUBY
   end
 
   shared_examples 'reduce/inject' do |reduce_alias|

--- a/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
+++ b/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
@@ -5,99 +5,71 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
 
   context 'when a block argument has same name ' \
           'as an outer scope variable' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'registers an offense' do
+      expect_offense(<<-RUBY.strip_indent)
         def some_method
           foo = 1
           puts foo
           1.times do |foo|
+                      ^^^ Shadowing outer local variable - `foo`.
           end
         end
       RUBY
-    end
-
-    it 'registers an offense' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.message)
-        .to eq('Shadowing outer local variable - `foo`.')
-      expect(cop.offenses.first.line).to eq(4)
     end
   end
 
   context 'when a splat block argument has same name ' \
           'as an outer scope variable' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'registers an offense' do
+      expect_offense(<<-RUBY.strip_indent)
         def some_method
           foo = 1
           puts foo
           1.times do |*foo|
+                      ^^^^ Shadowing outer local variable - `foo`.
           end
         end
       RUBY
-    end
-
-    it 'registers an offense' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.message)
-        .to eq('Shadowing outer local variable - `foo`.')
-      expect(cop.offenses.first.line).to eq(4)
     end
   end
 
   context 'when a block block argument has same name ' \
           'as an outer scope variable' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'registers an offense' do
+      expect_offense(<<-RUBY.strip_indent)
         def some_method
           foo = 1
           puts foo
           proc_taking_block = proc do |&foo|
+                                       ^^^^ Shadowing outer local variable - `foo`.
           end
           proc_taking_block.call do
           end
         end
       RUBY
     end
-
-    it 'registers an offense' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.message)
-        .to eq('Shadowing outer local variable - `foo`.')
-      expect(cop.offenses.first.line).to eq(4)
-    end
   end
 
   context 'when a block local variable has same name ' \
           'as an outer scope variable' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'registers an offense' do
+      expect_offense(<<-RUBY.strip_indent)
         def some_method
           foo = 1
           puts foo
           1.times do |i; foo|
+                         ^^^ Shadowing outer local variable - `foo`.
             puts foo
           end
         end
       RUBY
     end
-
-    it 'registers an offense' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.message)
-        .to eq('Shadowing outer local variable - `foo`.')
-      expect(cop.offenses.first.line).to eq(4)
-    end
   end
 
   context 'when a block argument has different name ' \
           'with outer scope variables' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         def some_method
           foo = 1
           puts foo
@@ -106,13 +78,11 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
         end
       RUBY
     end
-
-    include_examples 'accepts'
   end
 
   context 'when an outer scope variable is reassigned in a block' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         def some_method
           foo = 1
           puts foo
@@ -122,13 +92,11 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
         end
       RUBY
     end
-
-    include_examples 'accepts'
   end
 
   context 'when an outer scope variable is referenced in a block' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         def some_method
           foo = 1
           puts foo
@@ -138,41 +106,35 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
         end
       RUBY
     end
-
-    include_examples 'accepts'
   end
 
   context 'when multiple block arguments have same name "_"' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         def some_method
           1.times do |_, foo, _|
           end
         end
       RUBY
     end
-
-    include_examples 'accepts'
   end
 
   context 'when multiple block arguments have ' \
           'a same name starts with "_"' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         def some_method
           1.times do |_foo, bar, _foo|
           end
         end
       RUBY
     end
-
-    include_examples 'accepts'
   end
 
   context 'when a block argument has same name "_" ' \
           'as outer scope variable "_"' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         def some_method
           _ = 1
           puts _
@@ -181,14 +143,12 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
         end
       RUBY
     end
-
-    include_examples 'accepts'
   end
 
   context 'when a block argument has a same name starts with "_" ' \
           'as an outer scope variable' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         def some_method
           _foo = 1
           puts _foo
@@ -197,14 +157,12 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
         end
       RUBY
     end
-
-    include_examples 'accepts'
   end
 
   context 'when a method argument has same name ' \
           'as an outer scope variable' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         class SomeClass
           foo = 1
           puts foo
@@ -213,7 +171,5 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
         end
       RUBY
     end
-
-    include_examples 'accepts'
   end
 end

--- a/spec/rubocop/cop/lint/unified_integer_spec.rb
+++ b/spec/rubocop/cop/lint/unified_integer_spec.rb
@@ -50,21 +50,21 @@ RSpec.describe RuboCop::Cop::Lint::UnifiedInteger do
 
   context 'when Integer' do
     context 'without any decorations' do
-      let(:source) { '1.is_a?(Integer)' }
-
-      include_examples 'accepts'
+      it 'does not reguster an offense' do
+        expect_no_offenses('1.is_a?(Integer)')
+      end
     end
 
     context 'when explicitly specified as toplevel constant' do
-      let(:source) { '1.is_a?(::Integer)' }
-
-      include_examples 'accepts'
+      it 'does not reguster an offense' do
+        expect_no_offenses('1.is_a?(::Integer)')
+      end
     end
 
     context 'with MyNamespace' do
-      let(:source) { '1.is_a?(MyNamespace::Integer)' }
-
-      include_examples 'accepts'
+      it 'does not reguster an offense' do
+        expect_no_offenses('1.is_a?(MyNamespace::Integer)')
+      end
     end
   end
 end

--- a/spec/rubocop/cop/metrics/block_length_spec.rb
+++ b/spec/rubocop/cop/metrics/block_length_spec.rb
@@ -31,17 +31,14 @@ RSpec.describe RuboCop::Cop::Metrics::BlockLength, :config do
   end
 
   it 'rejects a block with more than 5 lines' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       something do
+      ^^^^^^^^^^^^ Block has too many lines. [3/2]
         a = 1
         a = 2
         a = 3
       end
     RUBY
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.offenses.map(&:line).sort).to eq([1])
-    expect(cop.config_to_allow_offenses).to eq('Max' => 3)
-    expect(cop.messages.first).to eq('Block has too many lines. [3/2]')
   end
 
   it 'reports the correct beginning and end lines' do
@@ -98,20 +95,22 @@ RSpec.describe RuboCop::Cop::Metrics::BlockLength, :config do
   end
 
   it 'rejects brace blocks too' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       something {
+      ^^^^^^^^^^^ Block has too many lines. [3/2]
         a = 1
         a = 2
         a = 3
       }
     RUBY
-    expect(cop.offenses.size).to eq(1)
   end
 
   it 'properly counts nested blocks' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       something do
+      ^^^^^^^^^^^^ Block has too many lines. [6/2]
         something do
+        ^^^^^^^^^^^^ Block has too many lines. [4/2]
           a = 2
           a = 3
           a = 4
@@ -119,8 +118,6 @@ RSpec.describe RuboCop::Cop::Metrics::BlockLength, :config do
         end
       end
     RUBY
-    expect(cop.offenses.size).to eq(2)
-    expect(cop.offenses.map(&:line).sort).to eq([1, 2])
   end
 
   it 'does not count commented lines by default' do
@@ -138,15 +135,14 @@ RSpec.describe RuboCop::Cop::Metrics::BlockLength, :config do
     before { cop_config['CountComments'] = true }
 
     it 'also counts commented lines' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         something do
+        ^^^^^^^^^^^^ Block has too many lines. [3/2]
           a = 1
           #a = 2
           a = 3
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.map(&:line).sort).to eq([1])
     end
   end
 

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -5,25 +5,11 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
 
   let(:cop_config) { { 'Max' => 5, 'CountComments' => false } }
 
-  shared_examples 'reports violation' do |first_line, last_line|
-    it 'rejects a method with more than 5 lines' do
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.map(&:line)).to contain_exactly(first_line)
-      expect(cop.config_to_allow_offenses).to eq('Max' => 6)
-      expect(cop.messages.first).to eq('Method has too many lines. [6/5]')
-    end
-
-    it 'reports the correct beginning and end lines' do
-      offense = cop.offenses.first
-      expect(offense.location.first_line).to eq(first_line)
-      expect(offense.location.last_line).to eq(last_line)
-    end
-  end
-
   context 'when method is an instance method' do
-    before do
-      inspect_source(<<-RUBY.strip_indent)
-        def m()
+    it 'registers an offense' do
+      expect_offense(<<-RUBY.strip_indent)
+        def m
+        ^^^^^ Method has too many lines. [6/5]
           a = 1
           a = 2
           a = 3
@@ -33,14 +19,13 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
         end
       RUBY
     end
-
-    include_examples 'reports violation', 1, 8
   end
 
   context 'when method is defined with `define_method`' do
-    before do
-      inspect_source(<<-RUBY.strip_indent)
+    it 'registers an offense' do
+      expect_offense(<<-RUBY.strip_indent)
         define_method(:m) do
+        ^^^^^^^^^^^^^^^^^^^^ Method has too many lines. [6/5]
           a = 1
           a = 2
           a = 3
@@ -50,14 +35,13 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
         end
       RUBY
     end
-
-    include_examples 'reports violation', 1, 8
   end
 
   context 'when method is a class method' do
-    before do
-      inspect_source(<<-RUBY.strip_indent)
-        def self.m()
+    it 'registers an offense' do
+      expect_offense(<<-RUBY.strip_indent)
+        def self.m
+        ^^^^^^^^^^ Method has too many lines. [6/5]
           a = 1
           a = 2
           a = 3
@@ -67,16 +51,15 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
         end
       RUBY
     end
-
-    include_examples 'reports violation', 1, 8
   end
 
   context 'when method is defined on a singleton class' do
-    before do
-      inspect_source(<<-RUBY.strip_indent)
+    it 'registers an offense' do
+      expect_offense(<<-RUBY.strip_indent)
         class K
           class << self
-            def m()
+            def m
+            ^^^^^ Method has too many lines. [6/5]
               a = 1
               a = 2
               a = 3
@@ -88,13 +71,11 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
         end
       RUBY
     end
-
-    include_examples 'reports violation', 3, 10
   end
 
   it 'accepts a method with less than 5 lines' do
     expect_no_offenses(<<-RUBY.strip_indent)
-      def m()
+      def m
         a = 1
         a = 2
         a = 3
@@ -165,8 +146,9 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
   end
 
   it 'properly counts lines when method ends with block' do
-    inspect_source(<<-RUBY.strip_indent)
-      def m()
+    expect_offense(<<-RUBY.strip_indent)
+      def m
+      ^^^^^ Method has too many lines. [6/5]
         something do
           a = 2
           a = 3
@@ -175,8 +157,6 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
         end
       end
     RUBY
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.offenses.map(&:line).sort).to eq([1])
   end
 
   it 'does not count commented lines by default' do
@@ -196,8 +176,9 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
     before { cop_config['CountComments'] = true }
 
     it 'also counts commented lines' do
-      inspect_source(<<-RUBY.strip_indent)
-        def m()
+      expect_offense(<<-RUBY.strip_indent)
+        def m
+        ^^^^^ Method has too many lines. [6/5]
           a = 1
           #a = 2
           a = 3
@@ -206,8 +187,6 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
           a = 6
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.map(&:line).sort).to eq([1])
     end
   end
 end

--- a/spec/rubocop/cop/metrics/module_length_spec.rb
+++ b/spec/rubocop/cop/metrics/module_length_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe RuboCop::Cop::Metrics::ModuleLength, :config do
   let(:cop_config) { { 'Max' => 5, 'CountComments' => false } }
 
   it 'rejects a module with more than 5 lines' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       module Test
+      ^^^^^^^^^^^ Module has too many lines. [6/5]
         a = 1
         a = 2
         a = 3
@@ -16,9 +17,6 @@ RSpec.describe RuboCop::Cop::Metrics::ModuleLength, :config do
         a = 6
       end
     RUBY
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Module has too many lines. [6/5]'])
-    expect(cop.config_to_allow_offenses).to eq('Max' => 6)
   end
 
   it 'reports the correct beginning and end lines' do
@@ -109,8 +107,9 @@ RSpec.describe RuboCop::Cop::Metrics::ModuleLength, :config do
     end
 
     it 'rejects a module with 6 lines that belong to the module directly' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         module NamespaceModule
+        ^^^^^^^^^^^^^^^^^^^^^^ Module has too many lines. [6/5]
           module TestOne
             a = 1
             a = 2
@@ -133,7 +132,6 @@ RSpec.describe RuboCop::Cop::Metrics::ModuleLength, :config do
           a = 6
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
   end
 
@@ -165,8 +163,9 @@ RSpec.describe RuboCop::Cop::Metrics::ModuleLength, :config do
     end
 
     it 'rejects a module with 6 lines that belong to the module directly' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         module NamespaceModule
+        ^^^^^^^^^^^^^^^^^^^^^^ Module has too many lines. [6/5]
           class TestOne
             a = 1
             a = 2
@@ -189,7 +188,6 @@ RSpec.describe RuboCop::Cop::Metrics::ModuleLength, :config do
           a = 6
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
   end
 
@@ -197,8 +195,9 @@ RSpec.describe RuboCop::Cop::Metrics::ModuleLength, :config do
     before { cop_config['CountComments'] = true }
 
     it 'also counts commented lines' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         module Test
+        ^^^^^^^^^^^ Module has too many lines. [6/5]
           a = 1
           #a = 2
           a = 3
@@ -207,7 +206,6 @@ RSpec.describe RuboCop::Cop::Metrics::ModuleLength, :config do
           a = 6
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
   end
 end

--- a/spec/rubocop/cop/metrics/parameter_lists_spec.rb
+++ b/spec/rubocop/cop/metrics/parameter_lists_spec.rb
@@ -11,15 +11,11 @@ RSpec.describe RuboCop::Cop::Metrics::ParameterLists, :config do
   end
 
   it 'registers an offense for a method def with 5 parameters' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def meth(a, b, c, d, e)
+              ^^^^^^^^^^^^^^^ Avoid parameter lists longer than 4 parameters. [5/4]
       end
     RUBY
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(
-      ['Avoid parameter lists longer than 4 parameters. [5/4]']
-    )
-    expect(cop.config_to_allow_offenses).to eq('Max' => 5)
   end
 
   it 'accepts a method def with 4 parameters' do

--- a/spec/rubocop/cop/metrics/perceived_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/perceived_complexity_spec.rb
@@ -42,19 +42,12 @@ RSpec.describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
     end
 
     it 'registers an offense for an if modifier' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def self.method_name
+        ^^^^^^^^^^^^^^^^^^^^ Perceived complexity for method_name is too high. [2/1]
           call_foo if some_condition
         end
       RUBY
-      expect(cop.messages)
-        .to eq(['Perceived complexity for method_name is too high. [2/1]'])
-      expect(cop.highlights).to eq([<<-RUBY.strip_indent.chomp])
-        def self.method_name
-          call_foo if some_condition
-        end
-      RUBY
-      expect(cop.config_to_allow_offenses).to eq('Max' => 2)
     end
 
     it 'registers an offense for an unless modifier' do
@@ -152,8 +145,9 @@ RSpec.describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
 
     it 'registers an offense for a case/when block without an expression ' \
        'after case' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def method_name
+        ^^^^^^^^^^^^^^^ Perceived complexity for method_name is too high. [3/1]
           case
           when value == 1
             call_foo
@@ -162,10 +156,6 @@ RSpec.describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
           end
         end
       RUBY
-      # Here, the `case` node doesn't count, but each when scores one
-      # complexity point.
-      expect(cop.messages)
-        .to eq(['Perceived complexity for method_name is too high. [3/1]'])
     end
 
     it 'registers an offense for &&' do

--- a/spec/rubocop/cop/naming/binary_operator_parameter_name_spec.rb
+++ b/spec/rubocop/cop/naming/binary_operator_parameter_name_spec.rb
@@ -3,18 +3,25 @@
 RSpec.describe RuboCop::Cop::Naming::BinaryOperatorParameterName do
   subject(:cop) { described_class.new }
 
-  %i[+ eql? equal?].each do |op|
-    it "registers an offense for #{op} with arg not named other" do
-      inspect_source(<<-RUBY.strip_indent)
-        def #{op}(another)
-          another
-        end
-      RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(["When defining the `#{op}` operator, " \
-                'name its argument `other`.'])
-    end
+  it 'registers an offense for `#+` when argument is not named other' do
+    expect_offense(<<-RUBY.strip_indent)
+        def +(foo); end
+              ^^^ When defining the `+` operator, name its argument `other`.
+    RUBY
+  end
+
+  it 'registers an offense for `#eql?` when argument is not named other' do
+    expect_offense(<<-RUBY.strip_indent)
+        def eql?(foo); end
+                 ^^^ When defining the `eql?` operator, name its argument `other`.
+    RUBY
+  end
+
+  it 'registers an offense for `#equal?` when argument is not named other' do
+    expect_offense(<<-RUBY.strip_indent)
+        def equal?(foo); end
+                   ^^^ When defining the `equal?` operator, name its argument `other`.
+    RUBY
   end
 
   it 'works properly even if the argument not surrounded with braces' do

--- a/spec/rubocop/cop/naming/predicate_name_spec.rb
+++ b/spec/rubocop/cop/naming/predicate_name_spec.rb
@@ -9,24 +9,23 @@ RSpec.describe RuboCop::Cop::Naming::PredicateName, :config do
         'NamePrefixBlacklist' => %w[has_ is_] }
     end
 
-    %w[has is].each do |prefix|
-      it 'registers an offense when method name starts with known prefix' do
-        inspect_source(<<-RUBY.strip_indent)
-          def #{prefix}_attr
-            # ...
-          end
-        RUBY
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages).to eq(["Rename `#{prefix}_attr` to `attr?`."])
-        expect(cop.highlights).to eq(["#{prefix}_attr"])
-      end
+    it 'registers an offense when method name starts with "is"' do
+      expect_offense(<<-RUBY.strip_indent)
+        def is_attr; end
+            ^^^^^^^ Rename `is_attr` to `attr?`.
+      RUBY
+    end
+
+    it 'registers an offense when method name starts with "has"' do
+      expect_offense(<<-RUBY.strip_indent)
+        def has_attr; end
+            ^^^^^^^^ Rename `has_attr` to `attr?`.
+      RUBY
     end
 
     it 'accepts method name that starts with unknown prefix' do
       expect_no_offenses(<<-RUBY.strip_indent)
-        def have_attr
-          # ...
-        end
+        def have_attr; end
       RUBY
     end
   end
@@ -36,25 +35,23 @@ RSpec.describe RuboCop::Cop::Naming::PredicateName, :config do
       { 'NamePrefix' => %w[has_ is_], 'NamePrefixBlacklist' => [] }
     end
 
-    %w[has is].each do |prefix|
-      it 'registers an offense when method name starts with known prefix' do
-        inspect_source(<<-RUBY.strip_indent)
-          def #{prefix}_attr
-            # ...
-          end
-        RUBY
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages)
-          .to eq(["Rename `#{prefix}_attr` to `#{prefix}_attr?`."])
-        expect(cop.highlights).to eq(["#{prefix}_attr"])
-      end
+    it 'registers an offense when method name starts with "is"' do
+      expect_offense(<<-RUBY.strip_indent)
+        def is_attr; end
+            ^^^^^^^ Rename `is_attr` to `is_attr?`.
+      RUBY
+    end
+
+    it 'registers an offense when method name starts with "has"' do
+      expect_offense(<<-RUBY.strip_indent)
+        def has_attr; end
+            ^^^^^^^^ Rename `has_attr` to `has_attr?`.
+      RUBY
     end
 
     it 'accepts method name that starts with unknown prefix' do
       expect_no_offenses(<<-RUBY.strip_indent)
-        def have_attr
-          # ...
-        end
+        def have_attr; end
       RUBY
     end
   end
@@ -67,9 +64,7 @@ RSpec.describe RuboCop::Cop::Naming::PredicateName, :config do
 
     it 'accepts method name which is in whitelist' do
       expect_no_offenses(<<-RUBY.strip_indent)
-        def is_a?
-          # ...
-        end
+        def is_a?; end
       RUBY
     end
   end

--- a/spec/rubocop/cop/rails/action_filter_spec.rb
+++ b/spec/rubocop/cop/rails/action_filter_spec.rb
@@ -49,20 +49,17 @@ RSpec.describe RuboCop::Cop::Rails::ActionFilter, :config do
     context 'when using action methods' do
       described_class::FILTER_METHODS.each do |method|
         it "does not register an offense for #{method}" do
-          inspect_source_file("#{method} :name")
-          expect(cop.offenses.size).to eq(0)
+          expect_no_offenses("#{method} :name")
         end
 
         it "does not register an offense for #{method} with block" do
-          inspect_source_file("#{method} { |controller| something }")
-          expect(cop.offenses.size).to eq(0)
+          expect_no_offenses("#{method} { |controller| something }")
         end
       end
 
       described_class::ACTION_METHODS.each do |method|
         it "accepts #{method}" do
-          inspect_source_file("#{method} :something")
-          expect(cop.offenses.empty?).to be(true)
+          expect_no_offenses("#{method} :something")
         end
       end
 
@@ -75,20 +72,17 @@ RSpec.describe RuboCop::Cop::Rails::ActionFilter, :config do
     context 'when using filter methods' do
       described_class::ACTION_METHODS.each do |method|
         it "does not register an offense for #{method}" do
-          inspect_source_file("#{method} :name")
-          expect(cop.offenses.size).to eq(0)
+          expect_no_offenses("#{method} :name")
         end
 
         it "does not register an offense for #{method} with block" do
-          inspect_source_file("#{method} { |controller| something }")
-          expect(cop.offenses.size).to eq(0)
+          expect_no_offenses("#{method} { |controller| something }")
         end
       end
 
       described_class::FILTER_METHODS.each do |method|
         it "accepts #{method}" do
-          inspect_source_file("#{method} :something")
-          expect(cop.offenses.empty?).to be(true)
+          expect_no_offenses("#{method} :something")
         end
       end
 

--- a/spec/rubocop/cop/rails/application_job_spec.rb
+++ b/spec/rubocop/cop/rails/application_job_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::ApplicationJob do
-  let(:msgs) { ['Jobs should subclass `ApplicationJob`.'] }
-
   context 'rails 4', :rails4, :config do
     subject(:cop) { described_class.new(config) }
 
@@ -60,53 +58,50 @@ RSpec.describe RuboCop::Cop::Rails::ApplicationJob do
   context 'rails 5', :rails5 do
     subject(:cop) { described_class.new }
 
-    it 'allows ApplicationJob to be defined' do
+    it 'allows `ApplicationJob` to be defined' do
       expect_no_offenses(<<-RUBY.strip_indent)
-        class ApplicationJob < ActiveJob::Base
-        end
+        class ApplicationJob < ActiveJob::Base; end
       RUBY
     end
 
-    it 'corrects jobs that subclass ActiveJob::Base' do
-      source = "class MyJob < ActiveJob::Base\nend"
-      inspect_source(source)
-      expect(cop.messages).to eq(msgs)
-      expect(cop.highlights).to eq(['ActiveJob::Base'])
-      expect(autocorrect_source(source))
-        .to eq("class MyJob < ApplicationJob\nend")
+    context 'when subclassing `ActiveJob::Base`' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
+          class MyJob < ActiveJob::Base; end
+                        ^^^^^^^^^^^^^^^ Jobs should subclass `ApplicationJob`.
+        RUBY
+      end
+
+      it 'auto-corrects' do
+        expect(autocorrect_source('class MyJob < ActiveJob::Base; end'))
+          .to eq('class MyJob < ApplicationJob; end')
+      end
     end
 
-    it 'corrects single-line class definitions' do
-      source = 'class MyJob < ActiveJob::Base; end'
-      inspect_source(source)
-      expect(cop.messages).to eq(msgs)
-      expect(cop.highlights).to eq(['ActiveJob::Base'])
-      expect(autocorrect_source(source))
-        .to eq('class MyJob < ApplicationJob; end')
+    context 'when subclassing `ActiveJob::Base` in a module namespace' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
+          module Nested
+            class MyJob < ActiveJob::Base; end
+                          ^^^^^^^^^^^^^^^ Jobs should subclass `ApplicationJob`.
+          end
+        RUBY
+      end
     end
 
-    it 'corrects namespaced jobs that subclass ActiveJob::Base' do
-      source = "module Nested\n  class MyJob < ActiveJob::Base\n  end\nend"
-      inspect_source(source)
-      expect(cop.messages).to eq(msgs)
-      expect(cop.highlights).to eq(['ActiveJob::Base'])
-      expect(autocorrect_source(source))
-        .to eq("module Nested\n  class MyJob < ApplicationJob\n  end\nend")
-    end
-
-    it 'corrects jobs defined using nested constants' do
-      source = "class Nested::MyJob < ActiveJob::Base\nend"
-      inspect_source(source)
-      expect(cop.messages).to eq(msgs)
-      expect(cop.highlights).to eq(['ActiveJob::Base'])
-      expect(autocorrect_source(source))
-        .to eq("class Nested::MyJob < ApplicationJob\nend")
+    context 'when subclassing `ActiveJob::Base` in an inline namespace' do
+      it 'corrects jobs defined using nested constants' do
+        expect_offense(<<-RUBY.strip_indent)
+          class Nested::MyJob < ActiveJob::Base; end
+                                ^^^^^^^^^^^^^^^ Jobs should subclass `ApplicationJob`.
+        RUBY
+      end
     end
 
     it 'corrects jobs defined using Class.new' do
       source = 'MyJob = Class.new(ActiveJob::Base)'
       inspect_source(source)
-      expect(cop.messages).to eq(msgs)
+      expect(cop.messages).to eq(['Jobs should subclass `ApplicationJob`.'])
       expect(cop.highlights).to eq(['ActiveJob::Base'])
       expect(autocorrect_source(source))
         .to eq('MyJob = Class.new(ApplicationJob)')
@@ -115,7 +110,7 @@ RSpec.describe RuboCop::Cop::Rails::ApplicationJob do
     it 'corrects nested jobs defined using Class.new' do
       source = 'Nested::MyJob = Class.new(ActiveJob::Base)'
       inspect_source(source)
-      expect(cop.messages).to eq(msgs)
+      expect(cop.messages).to eq(['Jobs should subclass `ApplicationJob`.'])
       expect(cop.highlights).to eq(['ActiveJob::Base'])
       expect(autocorrect_source(source))
         .to eq('Nested::MyJob = Class.new(ApplicationJob)')
@@ -124,7 +119,7 @@ RSpec.describe RuboCop::Cop::Rails::ApplicationJob do
     it 'corrects anonymous jobs' do
       source = 'Class.new(ActiveJob::Base) {}'
       inspect_source(source)
-      expect(cop.messages).to eq(msgs)
+      expect(cop.messages).to eq(['Jobs should subclass `ApplicationJob`.'])
       expect(cop.highlights).to eq(['ActiveJob::Base'])
       expect(autocorrect_source(source))
         .to eq('Class.new(ApplicationJob) {}')

--- a/spec/rubocop/cop/rails/application_record_spec.rb
+++ b/spec/rubocop/cop/rails/application_record_spec.rb
@@ -8,15 +8,13 @@ RSpec.describe RuboCop::Cop::Rails::ApplicationRecord do
 
     it 'allows ApplicationRecord to be defined' do
       expect_no_offenses(<<-RUBY.strip_indent)
-        class ApplicationRecord < ActiveRecord::Base
-        end
+        class ApplicationRecord < ActiveRecord::Base; end
       RUBY
     end
 
     it 'allows models that subclass ActiveRecord::Base' do
       expect_no_offenses(<<-RUBY.strip_indent)
-        class MyModel < ActiveRecord::Base
-        end
+        class MyModel < ActiveRecord::Base; end
       RUBY
     end
 
@@ -27,16 +25,14 @@ RSpec.describe RuboCop::Cop::Rails::ApplicationRecord do
     it 'allows namespaced models that subclass ActiveRecord::Base' do
       expect_no_offenses(<<-RUBY.strip_indent)
         module Nested
-          class MyModel < ActiveRecord::Base
-          end
+          class MyModel < ActiveRecord::Base; end
         end
       RUBY
     end
 
     it 'allows models defined using nested constants' do
       expect_no_offenses(<<-RUBY.strip_indent)
-        class Nested::MyModel < ActiveRecord::Base
-        end
+        class Nested::MyModel < ActiveRecord::Base; end
       RUBY
     end
 

--- a/spec/rubocop/cop/rails/date_spec.rb
+++ b/spec/rubocop/cop/rails/date_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe RuboCop::Cop::Rails::Date, :config do
       end
 
       it "accepts Some::Date.#{day}" do
-        inspect_source("Some::Date.#{day}")
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses("Some::Date.#{day}")
       end
     end
 
@@ -30,13 +29,11 @@ RSpec.describe RuboCop::Cop::Rails::Date, :config do
       end
 
       it "accepts variable named #{method}" do
-        inspect_source("#{method} = 1")
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses("#{method} = 1")
       end
 
       it "accepts variable #{method} as range end" do
-        inspect_source("from_time..#{method}")
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses("from_time..#{method}")
       end
     end
 
@@ -84,8 +81,7 @@ RSpec.describe RuboCop::Cop::Rails::Date, :config do
 
     %w[current yesterday tomorrow].each do |day|
       it "accepts Date.#{day}" do
-        inspect_source("Date.#{day}")
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses("Date.#{day}")
       end
     end
 
@@ -98,8 +94,7 @@ RSpec.describe RuboCop::Cop::Rails::Date, :config do
 
     RuboCop::Cop::Rails::TimeZone::ACCEPTED_METHODS.each do |a_method|
       it "accepts val.to_time.#{a_method}" do
-        inspect_source("val.to_time.#{a_method}")
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses("val.to_time.#{a_method}")
       end
     end
 

--- a/spec/rubocop/cop/rails/enum_uniqueness_spec.rb
+++ b/spec/rubocop/cop/rails/enum_uniqueness_spec.rb
@@ -6,11 +6,10 @@ RSpec.describe RuboCop::Cop::Rails::EnumUniqueness, :config do
   context 'when array syntax is used' do
     context 'with a single duplicated enum value' do
       it 'registers an offense' do
-        inspect_source('enum status: [:active, :archived, :active]')
-
-        msg = 'Duplicate value `:active` found in `status` enum declaration.'
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages).to eq([msg])
+        expect_offense(<<-RUBY.strip_indent)
+          enum status: [:active, :archived, :active]
+                                            ^^^^^^^ Duplicate value `:active` found in `status` enum declaration.
+        RUBY
       end
     end
 
@@ -34,11 +33,10 @@ RSpec.describe RuboCop::Cop::Rails::EnumUniqueness, :config do
   context 'when hash syntax is used' do
     context 'with a single duplicated enum value' do
       it 'registers an offense' do
-        inspect_source('enum status: { active: 0, archived: 0 }')
-
-        msg = 'Duplicate value `0` found in `status` enum declaration.'
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages).to eq([msg])
+        expect_offense(<<-RUBY.strip_indent)
+          enum status: { active: 0, archived: 0 }
+                                              ^ Duplicate value `0` found in `status` enum declaration.
+        RUBY
       end
     end
 

--- a/spec/rubocop/cop/rails/find_by_spec.rb
+++ b/spec/rubocop/cop/rails/find_by_spec.rb
@@ -3,17 +3,19 @@
 RSpec.describe RuboCop::Cop::Rails::FindBy do
   subject(:cop) { described_class.new }
 
-  shared_examples 'registers_offense' do |selector|
-    it "when using where.#{selector}" do
-      inspect_source("User.where(id: x).#{selector}")
-
-      expect(cop.messages)
-        .to eq(["Use `find_by` instead of `where.#{selector}`."])
-    end
+  it 'registers an offense when using `#first`' do
+    expect_offense(<<-RUBY.strip_indent)
+      User.where(id: x).first
+           ^^^^^^^^^^^^^^^^^^ Use `find_by` instead of `where.first`.
+    RUBY
   end
 
-  it_behaves_like('registers_offense', 'first')
-  it_behaves_like('registers_offense', 'take')
+  it 'registers an offense when using `#take`' do
+    expect_offense(<<-RUBY.strip_indent)
+      User.where(id: x).take
+           ^^^^^^^^^^^^^^^^^ Use `find_by` instead of `where.take`.
+    RUBY
+  end
 
   it 'does not register an offense when using find_by' do
     expect_no_offenses('User.find_by(id: x)')

--- a/spec/rubocop/cop/rails/not_null_column_spec.rb
+++ b/spec/rubocop/cop/rails/not_null_column_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe RuboCop::Cop::Rails::NotNullColumn, :config do
     end
 
     context 'with null: false and default' do
-      let(:source) do
-        'add_column :users, :name, :string, null: false, default: ""'
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          add_column :users, :name, :string, null: false, default: ""
+        RUBY
       end
-
-      include_examples 'accepts'
     end
 
     context 'with null: false and default: nil' do
@@ -33,33 +33,35 @@ RSpec.describe RuboCop::Cop::Rails::NotNullColumn, :config do
     end
 
     context 'with null: true' do
-      let(:source) { 'add_column :users, :name, :string, null: true' }
-
-      include_examples 'accepts'
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          add_column :users, :name, :string, null: true
+        RUBY
+      end
     end
 
     context 'without any options' do
-      let(:source) { 'add_column :users, :name, :string' }
-
-      include_examples 'accepts'
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          add_column :users, :name, :string
+        RUBY
+      end
     end
   end
 
   context 'with change_column call' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         add_column :users, :name, :string
         User.update_all(name: "dummy")
         change_column :users, :name, :string, null: false
       RUBY
     end
-
-    include_examples 'accepts'
   end
 
   context 'with create_table call' do
-    let(:source) do
-      <<-RUBY.strip_indent
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         class CreateUsersTable < ActiveRecord::Migration
           def change
             create_table :users do |t|
@@ -70,8 +72,6 @@ RSpec.describe RuboCop::Cop::Rails::NotNullColumn, :config do
         end
       RUBY
     end
-
-    include_examples 'accepts'
   end
 
   context 'with add_reference call' do
@@ -85,17 +85,19 @@ RSpec.describe RuboCop::Cop::Rails::NotNullColumn, :config do
     end
 
     context 'with default option' do
-      let(:source) do
-        'add_reference :products, :category, null: false, default: 1'
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          add_reference :products, :category, null: false, default: 1
+        RUBY
       end
-
-      include_examples 'accepts'
     end
 
     context 'without any options' do
-      let(:source) { 'add_reference :products, :category' }
-
-      include_examples 'accepts'
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          add_reference :products, :category
+        RUBY
+      end
     end
   end
 end

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -17,9 +17,7 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
     let(:code) { code }
 
     it "accepts usages of #{name}" do
-      inspect_source(source)
-
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(code)
     end
   end
 

--- a/spec/rubocop/cop/rails/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/rails/safe_navigation_spec.rb
@@ -5,9 +5,7 @@ RSpec.describe RuboCop::Cop::Rails::SafeNavigation, :config do
 
   shared_examples 'accepts' do |name, code|
     it "accepts usages of #{name}" do
-      inspect_source("[1, 2].#{code}")
-
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses("[1, 2].#{code}")
     end
   end
 

--- a/spec/rubocop/cop/rails/skips_model_validations_spec.rb
+++ b/spec/rubocop/cop/rails/skips_model_validations_spec.rb
@@ -40,8 +40,7 @@ RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
   context 'with methods that require at least an argument' do
     methods_with_arguments.each do |method_name|
       it "doesn't register an offense for `#{method_name}`" do
-        inspect_source("User.#{method_name}")
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses("User.#{method_name}")
       end
     end
   end
@@ -68,8 +67,7 @@ RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
 
     whitelist.each do |method_name|
       it "accepts `#{method_name}`" do
-        inspect_source("User.#{method_name}")
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses("User.#{method_name}")
       end
     end
 

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -60,16 +60,13 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
 
     it 'allows assigning any variable type inside if else' \
       'with multiple assignment' do
-      source = <<-RUBY.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         if foo
           #{variable}, #{variable} = something
         else
           #{variable}, #{variable} = something_else
         end
       RUBY
-      inspect_source(source)
-
-      expect(cop.messages.empty?).to be(true)
     end
 
     it 'allows assigning any variable type inside if else' do

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -27,16 +27,17 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
       let(:cop_config_overrides) { {} }
 
       it 'registers offense for hash rocket syntax when new is possible' do
-        inspect_source('x = { :a => 0 }')
-        expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
-        expect(cop.config_to_allow_offenses)
-          .to eq('EnforcedStyle' => 'hash_rockets')
+        expect_offense(<<-RUBY.strip_indent)
+          x = { :a => 0 }
+                ^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
       end
 
       it 'registers an offense for mixed syntax when new is possible' do
-        inspect_source('x = { :a => 0, b: 1 }')
-        expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+        expect_offense(<<-RUBY.strip_indent)
+          x = { :a => 0, b: 1 }
+                ^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
       end
 
       it 'registers an offense for hash rockets in method calls' do
@@ -201,10 +202,11 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
 
       it 'registers an offense when using hash rockets ' \
         'and no elements have a symbol value' do
-        inspect_source('x = { :a => 1, :b => 2 }')
-        expect(cop.messages)
-          .to eq(['Use the new Ruby 1.9 hash syntax.',
-                  'Use the new Ruby 1.9 hash syntax.'])
+        expect_offense(<<-RUBY.strip_indent)
+          x = { :a => 1, :b => 2 }
+                ^^^^^ Use the new Ruby 1.9 hash syntax.
+                         ^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
       end
 
       it 'registers an offense for hashes with elements on multiple lines' do
@@ -251,15 +253,17 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
     end
 
     it 'registers offense for Ruby 1.9 style' do
-      inspect_source('x = { a: 0 }')
-      expect(cop.messages).to eq(['Use hash rockets syntax.'])
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'ruby19')
+      expect_offense(<<-RUBY.strip_indent)
+        x = { a: 0 }
+              ^^ Use hash rockets syntax.
+      RUBY
     end
 
     it 'registers an offense for mixed syntax' do
-      inspect_source('x = { :a => 0, b: 1 }')
-      expect(cop.messages).to eq(['Use hash rockets syntax.'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      expect_offense(<<-RUBY.strip_indent)
+        x = { a => 0, b: 1 }
+                      ^^ Use hash rockets syntax.
+      RUBY
     end
 
     it 'registers an offense for 1.9 style in method calls' do
@@ -315,16 +319,17 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'registers offense for hash rocket syntax when new is possible' do
-        inspect_source('x = { :a => 0 }')
-        expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
-        expect(cop.config_to_allow_offenses)
-          .to eq('EnforcedStyle' => 'hash_rockets')
+        expect_offense(<<-RUBY.strip_indent)
+          x = { :a => 0 }
+                ^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
       end
 
       it 'registers an offense for mixed syntax when new is possible' do
-        inspect_source('x = { :a => 0, b: 1 }')
-        expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+        expect_offense(<<-RUBY.strip_indent)
+          x = { :a => 0, b: 1 }
+                ^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
       end
 
       it 'accepts new syntax in method calls' do

--- a/spec/rubocop/cop/style/implicit_runtime_error_spec.rb
+++ b/spec/rubocop/cop/style/implicit_runtime_error_spec.rb
@@ -3,33 +3,53 @@
 RSpec.describe RuboCop::Cop::Style::ImplicitRuntimeError do
   subject(:cop) { described_class.new }
 
-  %w[raise fail].each do |method|
-    it "registers an offense for #{method} 'message'" do
-      inspect_source("#{method} 'message'")
-      expect(cop.offenses.size).to eq 1
-      expect(cop.messages).to eq(["Use `#{method}` with an explicit " \
-                                 'exception class and message, rather than ' \
-                                 'just a message.'])
-      expect(cop.highlights).to eq(["#{method} 'message'"])
-    end
+  it 'registers an offense for `raise` without error class' do
+    expect_offense(<<-RUBY.strip_indent)
+      raise 'message'
+      ^^^^^^^^^^^^^^^ Use `raise` with an explicit exception class and message, rather than just a message.
+    RUBY
+  end
 
-    it "registers an offense for #{method} with a multiline string" do
-      inspect_source(["#{method} 'message' \\", "'2nd line'"])
-      expect(cop.offenses.size).to eq 1
-      expect(cop.messages).to eq(["Use `#{method}` with an explicit " \
-                                 'exception class and message, rather than ' \
-                                 'just a message.'])
-      expect(cop.highlights).to eq(["#{method} 'message' \\\n'2nd line'"])
-    end
+  it 'registers an offense for `fail` without error class' do
+    expect_offense(<<-RUBY.strip_indent)
+      fail 'message'
+      ^^^^^^^^^^^^^^ Use `fail` with an explicit exception class and message, rather than just a message.
+    RUBY
+  end
 
-    it "doesn't register an offense for #{method} StandardError, 'message'" do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        #{method} StandardError, 'message'
-      RUBY
-    end
+  it 'registers an offense for `raise` with a multiline string' do
+    expect_offense(<<-RUBY.strip_indent)
+      raise 'message' \\
+      ^^^^^^^^^^^^^^^^^ Use `raise` with an explicit exception class and message, rather than just a message.
+            '2nd line'
+    RUBY
+  end
 
-    it "doesn't register an offense for #{method} with no arguments" do
-      expect_no_offenses(method)
-    end
+  it 'registers an offense for `fail` with a multiline string' do
+    expect_offense(<<-RUBY.strip_indent)
+      fail 'message' \\
+      ^^^^^^^^^^^^^^^^ Use `fail` with an explicit exception class and message, rather than just a message.
+            '2nd line'
+    RUBY
+  end
+
+  it 'does not register an offense for `raise` with an error class' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      raise StandardError, 'message'
+    RUBY
+  end
+
+  it 'does not register an offense for `fail` with an error class' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      fail StandardError, 'message'
+    RUBY
+  end
+
+  it 'does not register an offense for `raise` without arguments' do
+    expect_no_offenses('raise')
+  end
+
+  it 'does not register an offense for `fail` without arguments' do
+    expect_no_offenses('fail')
   end
 end

--- a/spec/rubocop/cop/style/infinite_loop_spec.rb
+++ b/spec/rubocop/cop/style/infinite_loop_spec.rb
@@ -64,30 +64,30 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop do
     end
 
     it "auto-corrects begin-end-#{keyword} with one statement" do
-      new_source = autocorrect_source(<<-RUBY.strip_margin('|'))
-        |  begin # comment 1
-        |    something += 1 # comment 2
-        |  end #{keyword} #{lit} # comment 3
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        begin # comment 1
+          something += 1 # comment 2
+        end #{keyword} #{lit} # comment 3
       RUBY
-      expect(new_source).to eq(<<-RUBY.strip_margin('|'))
-        |  loop do # comment 1
-        |    something += 1 # comment 2
-        |  end # comment 3
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        loop do # comment 1
+          something += 1 # comment 2
+        end # comment 3
       RUBY
     end
 
     it "auto-corrects begin-end-#{keyword} with two statements" do
-      new_source = autocorrect_source(<<-RUBY.strip_margin('|'))
-        | begin
-        |  something += 1
-        |  something_else += 1
-        | end #{keyword} #{lit}
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        begin
+          something += 1
+          something_else += 1
+        end #{keyword} #{lit}
       RUBY
-      expect(new_source).to eq(<<-RUBY.strip_margin('|'))
-        | loop do
-        |  something += 1
-        |  something_else += 1
-        | end
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        loop do
+          something += 1
+          something_else += 1
+        end
       RUBY
     end
 

--- a/spec/rubocop/cop/style/lambda_call_spec.rb
+++ b/spec/rubocop/cop/style/lambda_call_spec.rb
@@ -7,18 +7,18 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'call' } }
 
     it 'registers an offense for x.()' do
-      inspect_source('x.(a, b)')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'braces')
+      expect_offense(<<-RUBY.strip_indent)
+        x.(a, b)
+        ^^^^^^^^ Prefer the use of `lambda.call(...)` over `lambda.(...)`.
+      RUBY
     end
 
     it 'registers an offense for correct + opposite' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         x.call(a, b)
         x.(a, b)
+        ^^^^^^^^ Prefer the use of `lambda.call(...)` over `lambda.(...)`.
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'accepts x.call()' do
@@ -35,18 +35,18 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'braces' } }
 
     it 'registers an offense for x.call()' do
-      inspect_source('x.call(a, b)')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'call')
+      expect_offense(<<-RUBY.strip_indent)
+        x.call(a, b)
+        ^^^^^^^^^^^^ Prefer the use of `lambda.(...)` over `lambda.call(...)`.
+      RUBY
     end
 
     it 'registers an offense for opposite + correct' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         x.call(a, b)
+        ^^^^^^^^^^^^ Prefer the use of `lambda.(...)` over `lambda.call(...)`.
         x.(a, b)
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'accepts x.()' do

--- a/spec/rubocop/cop/style/method_def_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_def_parentheses_spec.rb
@@ -7,35 +7,29 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'require_parentheses' } }
 
     it 'reports an offense for def with parameters but no parens' do
-      src = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         def func a, b
+                 ^^^^ Use def with parentheses when there are parameters.
         end
       RUBY
-      inspect_source(src)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
-                                                 'require_no_parentheses')
     end
 
     it 'reports an offense for correct + opposite' do
-      src = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         def func(a, b)
         end
         def func a, b
+                 ^^^^ Use def with parentheses when there are parameters.
         end
       RUBY
-      inspect_source(src)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'reports an offense for class def with parameters but no parens' do
-      src = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         def Test.func a, b
+                      ^^^^ Use def with parentheses when there are parameters.
         end
       RUBY
-      inspect_source(src)
-      expect(cop.offenses.size).to eq(1)
     end
 
     it 'accepts def with no args and no parens' do
@@ -74,14 +68,11 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
     # common to require_no_parentheses and
     # require_no_parentheses_except_multiline
     it 'reports an offense for def with parameters with parens' do
-      src = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         def func(a, b)
+                ^^^^^^ Use def without parentheses.
         end
       RUBY
-      inspect_source(src)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
-                                                 'require_parentheses')
     end
 
     it 'accepts a def with parameters but no parens' do
@@ -92,24 +83,21 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
     end
 
     it 'reports an offense for opposite + correct' do
-      src = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         def func(a, b)
+                ^^^^^^ Use def without parentheses.
         end
         def func a, b
         end
       RUBY
-      inspect_source(src)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'reports an offense for class def with parameters with parens' do
-      src = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         def Test.func(a, b)
+                     ^^^^^^ Use def without parentheses.
         end
       RUBY
-      inspect_source(src)
-      expect(cop.offenses.size).to eq(1)
     end
 
     it 'accepts a class def with parameters with parens' do
@@ -120,12 +108,11 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
     end
 
     it 'reports an offense for def with no args and parens' do
-      src = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         def func()
+                ^^ Use def without parentheses.
         end
       RUBY
-      inspect_source(src)
-      expect(cop.offenses.size).to eq(1)
     end
 
     it 'accepts def with no args and no parens' do
@@ -163,17 +150,15 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
 
     context 'when args span multiple lines' do
       it 'reports an offense for correct + opposite' do
-        src = <<-RUBY.strip_indent
+        expect_offense(<<-RUBY.strip_indent)
           def func(a,
                    b)
           end
           def func a,
+                   ^^ Use def with parentheses when there are parameters.
                    b
           end
         RUBY
-        inspect_source(src)
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
 
       it 'auto-adds required parens to argument lists on multiple lines' do

--- a/spec/rubocop/cop/style/missing_else_spec.rb
+++ b/spec/rubocop/cop/style/missing_else_spec.rb
@@ -233,13 +233,6 @@ RSpec.describe RuboCop::Cop::Style::MissingElse do
 
       context 'with no else-clause' do
         it 'registers an offense' do
-          inspect_source('if cond; foo end')
-          msg = ['`if` condition requires an `else`-clause with `nil` in it.']
-          expect(cop.messages)
-            .to eq(msg)
-        end
-
-        it 'highlights' do
           expect_offense(<<-RUBY.strip_indent)
             if cond; foo end
             ^^^^^^^^^^^^^^^^ `if` condition requires an `else`-clause with `nil` in it.
@@ -269,10 +262,10 @@ RSpec.describe RuboCop::Cop::Style::MissingElse do
 
       context 'with no else-clause' do
         it 'registers an offense' do
-          inspect_source('unless cond; foo end')
-          msg = ['`if` condition requires an `else`-clause with `nil` in it.']
-          expect(cop.messages)
-            .to eq(msg)
+          expect_offense(<<-RUBY.strip_indent)
+            unless cond; foo end
+            ^^^^^^^^^^^^^^^^^^^^ `if` condition requires an `else`-clause with `nil` in it.
+          RUBY
         end
       end
     end
@@ -298,10 +291,10 @@ RSpec.describe RuboCop::Cop::Style::MissingElse do
 
       context 'with no else-clause' do
         it 'registers an offense' do
-          inspect_source('case v; when a; foo; when b; bar; end')
-          msg = ['`case` condition requires an `else`-clause with `nil` in it.']
-          expect(cop.messages)
-            .to eq(msg)
+          expect_offense(<<-RUBY.strip_indent)
+            case v; when a; foo; when b; bar; end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `case` condition requires an `else`-clause with `nil` in it.
+          RUBY
         end
       end
     end

--- a/spec/rubocop/cop/style/module_function_spec.rb
+++ b/spec/rubocop/cop/style/module_function_spec.rb
@@ -25,13 +25,13 @@ RSpec.describe RuboCop::Cop::Style::ModuleFunction, :config do
     end
 
     it 'auto-corrects `extend self` to `module_function`' do
-      source = <<-RUBY.strip_indent
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         module Foo
           extend self
           def test; end
         end
       RUBY
-      corrected = autocorrect_source(source)
+
       expect(corrected).to eq <<-RUBY.strip_indent
         module Foo
           module_function
@@ -64,13 +64,13 @@ RSpec.describe RuboCop::Cop::Style::ModuleFunction, :config do
     end
 
     it 'auto-corrects `module_function` to `extend self`' do
-      source = <<-RUBY.strip_indent
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         module Foo
           module_function
           def test; end
         end
       RUBY
-      corrected = autocorrect_source(source)
+
       expect(corrected).to eq <<-RUBY.strip_indent
         module Foo
           extend self

--- a/spec/rubocop/cop/style/multiline_if_modifier_spec.rb
+++ b/spec/rubocop/cop/style/multiline_if_modifier_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe RuboCop::Cop::Style::MultilineIfModifier do
 
   shared_examples 'no offense' do
     it 'does not register an offense' do
-      inspect_source(source)
-      expect(cop.messages.empty?).to be(true)
+      expect_no_offenses(source)
     end
   end
 

--- a/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
@@ -5,30 +5,28 @@ RSpec.describe RuboCop::Cop::Style::MultilineTernaryOperator do
 
   it 'registers offense when the if branch and the else branch are ' \
      'on a separate line from the condition' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       a = cond ?
+          ^^^^^^ Avoid multi-line ternary operators, use `if` or `unless` instead.
         b : c
     RUBY
-    expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense when the false branch is on a separate line' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       a = cond ? b :
+          ^^^^^^^^^^ Avoid multi-line ternary operators, use `if` or `unless` instead.
           c
     RUBY
-
-    expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense when everything is on a separate line' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       a = cond ?
+          ^^^^^^ Avoid multi-line ternary operators, use `if` or `unless` instead.
           b :
           c
     RUBY
-
-    expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts a single line ternary operator expression' do

--- a/spec/rubocop/cop/style/multiple_comparison_spec.rb
+++ b/spec/rubocop/cop/style/multiple_comparison_spec.rb
@@ -15,37 +15,45 @@ RSpec.describe RuboCop::Cop::Style::MultipleComparison do
   end
 
   it 'registers an offense when `a` is compared twice' do
-    inspect_source(['a = "a"',
-                    'if a == "a" || a == "b"',
-                    '  print a',
-                    'end'])
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      a = "a"
+      if a == "a" || a == "b"
+      ^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
+        print a
+      end
+    RUBY
   end
 
   it 'registers an offense when `a` is compared three times' do
-    inspect_source(['a = "a"',
-                    'if a == "a" || a == "b" || a == "c"',
-                    '  print a',
-                    'end'])
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      a = "a"
+      if a == "a" || a == "b" || a == "c"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
+        print a
+      end
+    RUBY
   end
 
   it 'registers an offense when `a` is compared three times on the right ' \
     'hand side' do
-    inspect_source(['a = "a"',
-                    'if "a" == a || "b" == a || "c" == a',
-                    '  print a',
-                    'end'])
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      a = "a"
+      if "a" == a || "b" == a || "c" == a
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
+        print a
+      end
+    RUBY
   end
 
   it 'registers an offense when `a` is compared three times, once on the ' \
     'righthand side' do
-    inspect_source(['a = "a"',
-                    'if a == "a" || "b" == a || a == "c"',
-                    '  print a',
-                    'end'])
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      a = "a"
+      if a == "a" || "b" == a || a == "c"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
+        print a
+      end
+    RUBY
   end
 
   it 'does not register an offense for comparing multiple literal strings' do

--- a/spec/rubocop/cop/style/negated_if_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_spec.rb
@@ -13,41 +13,36 @@ RSpec.describe RuboCop::Cop::Style::NegatedIf do
 
   describe 'with “both” style' do
     it 'registers an offense for if with exclamation point condition' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         if !a_condition
+        ^^^^^^^^^^^^^^^ Favor `unless` over `if` for negative conditions.
           some_method
         end
         some_method if !a_condition
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Favor `unless` over `if` for negative conditions.
       RUBY
-      expect(cop.messages).to eq(
-        ['Favor `unless` over `if` for negative ' \
-         'conditions.'] * 2
-      )
     end
 
     it 'registers an offense for unless with exclamation point condition' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         unless !a_condition
+        ^^^^^^^^^^^^^^^^^^^ Favor `if` over `unless` for negative conditions.
           some_method
         end
         some_method unless !a_condition
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Favor `if` over `unless` for negative conditions.
       RUBY
-      expect(cop.messages).to eq(['Favor `if` over `unless` for negative ' \
-                                  'conditions.'] * 2)
     end
 
     it 'registers an offense for if with "not" condition' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         if not a_condition
+        ^^^^^^^^^^^^^^^^^^ Favor `unless` over `if` for negative conditions.
           some_method
         end
         some_method if not a_condition
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Favor `unless` over `if` for negative conditions.
       RUBY
-      expect(cop.messages).to eq(
-        ['Favor `unless` over `if` for negative ' \
-         'conditions.'] * 2
-      )
-      expect(cop.offenses.map(&:line)).to eq([1, 4])
     end
 
     it 'accepts an if/else with negative condition' do
@@ -145,14 +140,11 @@ RSpec.describe RuboCop::Cop::Style::NegatedIf do
     end
 
     it 'registers an offence for prefix' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         if !foo
+        ^^^^^^^ Favor `unless` over `if` for negative conditions.
         end
       RUBY
-
-      expect(cop.messages).to eq(
-        ['Favor `unless` over `if` for negative conditions.']
-      )
     end
 
     it 'does not register an offence for postfix' do

--- a/spec/rubocop/cop/style/negated_while_spec.rb
+++ b/spec/rubocop/cop/style/negated_while_spec.rb
@@ -4,39 +4,36 @@ RSpec.describe RuboCop::Cop::Style::NegatedWhile do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for while with exclamation point condition' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       while !a_condition
+      ^^^^^^^^^^^^^^^^^^ Favor `until` over `while` for negative conditions.
         some_method
       end
       some_method while !a_condition
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Favor `until` over `while` for negative conditions.
     RUBY
-    expect(cop.messages).to eq(
-      ['Favor `until` over `while` for negative conditions.'] * 2
-    )
   end
 
   it 'registers an offense for until with exclamation point condition' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       until !a_condition
+      ^^^^^^^^^^^^^^^^^^ Favor `while` over `until` for negative conditions.
         some_method
       end
       some_method until !a_condition
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Favor `while` over `until` for negative conditions.
     RUBY
-    expect(cop.messages)
-      .to eq(['Favor `while` over `until` for negative conditions.'] * 2)
   end
 
   it 'registers an offense for while with "not" condition' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       while (not a_condition)
+      ^^^^^^^^^^^^^^^^^^^^^^^ Favor `until` over `while` for negative conditions.
         some_method
       end
       some_method while not a_condition
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Favor `until` over `while` for negative conditions.
     RUBY
-    expect(cop.messages).to eq(
-      ['Favor `until` over `while` for negative conditions.'] * 2
-    )
-    expect(cop.offenses.map(&:line)).to eq([1, 4])
   end
 
   it 'accepts a while where only part of the condition is negated' do

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -6,15 +6,17 @@ RSpec.describe RuboCop::Cop::Style::NumericLiterals, :config do
   let(:cop_config) { { 'MinDigits' => 5 } }
 
   it 'registers an offense for a long undelimited integer' do
-    inspect_source('a = 12345')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.config_to_allow_offenses).to eq('MinDigits' => 6)
+    expect_offense(<<-RUBY.strip_indent)
+      a = 12345
+          ^^^^^ Use underscores(_) as decimal mark and separate every 3 digits with them.
+    RUBY
   end
 
   it 'registers an offense for a float with a long undelimited integer part' do
-    inspect_source('a = 123456.789')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.config_to_allow_offenses).to eq('MinDigits' => 7)
+    expect_offense(<<-RUBY.strip_indent)
+      a = 123456.789
+          ^^^^^^^^^^ Use underscores(_) as decimal mark and separate every 3 digits with them.
+    RUBY
   end
 
   it 'accepts integers with less than three places at the end' do
@@ -97,12 +99,10 @@ RSpec.describe RuboCop::Cop::Style::NumericLiterals, :config do
     end
 
     it 'registers an offense for an integer with misplaced underscore' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a = 123_456_78_90_00
-        b = 81_92
+            ^^^^^^^^^^^^^^^^ Use underscores(_) as decimal mark and separate every 3 digits with them.
       RUBY
-      expect(cop.offenses.size).to eq(2)
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
   end
 end

--- a/spec/rubocop/cop/style/one_line_conditional_spec.rb
+++ b/spec/rubocop/cop/style/one_line_conditional_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional do
 
   shared_examples 'no offense' do
     it 'does not register an offense' do
-      inspect_source(source)
-      expect(cop.messages.empty?).to be(true)
+      expect_no_offenses(source)
     end
   end
 

--- a/spec/rubocop/cop/style/optional_arguments_spec.rb
+++ b/spec/rubocop/cop/style/optional_arguments_spec.rb
@@ -9,24 +9,21 @@ RSpec.describe RuboCop::Cop::Style::OptionalArguments do
 
   it 'registers an offense when an optional argument is followed by a ' \
      'required argument' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def foo(a = 1, b)
+              ^^^^^ Optional arguments should appear at the end of the argument list.
       end
     RUBY
-
-    expect(cop.messages).to eq([message])
-    expect(cop.highlights).to eq(['a = 1'])
   end
 
   it 'registers an offense for each optional argument when multiple ' \
      'optional arguments are followed by a required argument' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def foo(a = 1, b = 2, c)
+              ^^^^^ Optional arguments should appear at the end of the argument list.
+                     ^^^^^ Optional arguments should appear at the end of the argument list.
       end
     RUBY
-
-    expect(cop.messages).to eq([message, message])
-    expect(cop.highlights).to eq(['a = 1', 'b = 2'])
   end
 
   it 'allows methods without arguments' do
@@ -84,13 +81,11 @@ RSpec.describe RuboCop::Cop::Style::OptionalArguments do
     context 'required params' do
       it 'registers an offense for optional arguments that come before ' \
          'required arguments where there are name arguments' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           def foo(a = 1, b, c:, d: 4)
+                  ^^^^^ Optional arguments should appear at the end of the argument list.
           end
         RUBY
-
-        expect(cop.messages).to eq([message])
-        expect(cop.highlights).to eq(['a = 1'])
       end
 
       it 'allows optional arguments before required named arguments' do
@@ -102,12 +97,10 @@ RSpec.describe RuboCop::Cop::Style::OptionalArguments do
 
       it 'allows optional arguments to come before a mix of required and ' \
          'optional named argument' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           def foo(a = 1, b:, c: 3)
           end
         RUBY
-
-        expect(cop.messages.empty?).to be(true)
       end
     end
   end

--- a/spec/rubocop/cop/style/or_assignment_spec.rb
+++ b/spec/rubocop/cop/style/or_assignment_spec.rb
@@ -58,59 +58,47 @@ RSpec.describe RuboCop::Cop::Style::OrAssignment do
 
   context 'when using var = if var; var; else; something; end' do
     it 'registers an offense with normal variables' do
-      code = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         foo = if foo
+        ^^^^^^^^^^^^ Use the double pipe equals operator `||=` instead.
                 foo
               else
                 'default'
               end
       RUBY
-      inspect_source(code)
-      expect(cop.highlights).to eq([code.strip])
-      expect(cop.messages)
-        .to eq(['Use the double pipe equals operator `||=` instead.'])
     end
 
     it 'registers an offense with instance variables' do
-      code = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         @foo = if @foo
+        ^^^^^^^^^^^^^^ Use the double pipe equals operator `||=` instead.
                  @foo
                else
                  'default'
                end
       RUBY
-      inspect_source(code)
-      expect(cop.highlights).to eq([code.strip])
-      expect(cop.messages)
-        .to eq(['Use the double pipe equals operator `||=` instead.'])
     end
 
     it 'registers an offense with class variables' do
-      code = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         @@foo = if @@foo
+        ^^^^^^^^^^^^^^^^ Use the double pipe equals operator `||=` instead.
                   @@foo
                 else
                   'default'
                 end
       RUBY
-      inspect_source(code)
-      expect(cop.highlights).to eq([code.strip])
-      expect(cop.messages)
-        .to eq(['Use the double pipe equals operator `||=` instead.'])
     end
 
     it 'registers an offense with global variables' do
-      code = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         $foo = if $foo
+        ^^^^^^^^^^^^^^ Use the double pipe equals operator `||=` instead.
                  $foo
                else
                  'default'
                end
       RUBY
-      inspect_source(code)
-      expect(cop.highlights).to eq([code.strip])
-      expect(cop.messages)
-        .to eq(['Use the double pipe equals operator `||=` instead.'])
     end
 
     it 'autocorrects normal variables to `var ||= something`' do
@@ -228,67 +216,43 @@ RSpec.describe RuboCop::Cop::Style::OrAssignment do
 
   context 'when using unless var; var = something; end' do
     it 'registers an offense for normal variables' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         foo = nil
         unless foo
+        ^^^^^^^^^^ Use the double pipe equals operator `||=` instead.
           foo = 'default'
         end
       RUBY
-      expect(cop.highlights).to eq([<<-RUBY.strip_indent.strip])
-        unless foo
-          foo = 'default'
-        end
-      RUBY
-      expect(cop.messages)
-        .to eq(['Use the double pipe equals operator `||=` instead.'])
     end
 
     it 'registers an offense for instance variables' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         @foo = nil
         unless @foo
+        ^^^^^^^^^^^ Use the double pipe equals operator `||=` instead.
           @foo = 'default'
         end
       RUBY
-      expect(cop.highlights).to eq([<<-RUBY.strip_indent.strip])
-        unless @foo
-          @foo = 'default'
-        end
-      RUBY
-      expect(cop.messages)
-        .to eq(['Use the double pipe equals operator `||=` instead.'])
     end
 
     it 'registers an offense for class variables' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         @@foo = nil
         unless @@foo
+        ^^^^^^^^^^^^ Use the double pipe equals operator `||=` instead.
           @@foo = 'default'
         end
       RUBY
-      expect(cop.highlights).to eq([<<-RUBY.strip_indent.strip])
-        unless @@foo
-          @@foo = 'default'
-        end
-      RUBY
-      expect(cop.messages)
-        .to eq(['Use the double pipe equals operator `||=` instead.'])
     end
 
     it 'registers an offense for global variables' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         $foo = nil
         unless $foo
+        ^^^^^^^^^^^ Use the double pipe equals operator `||=` instead.
           $foo = 'default'
         end
       RUBY
-      expect(cop.highlights).to eq([<<-RUBY.strip_indent.strip])
-        unless $foo
-          $foo = 'default'
-        end
-      RUBY
-      expect(cop.messages)
-        .to eq(['Use the double pipe equals operator `||=` instead.'])
     end
 
     it 'autocorrects normal variables to `var ||= something`' do

--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -51,9 +51,7 @@ RSpec.describe RuboCop::Cop::Style::ParallelAssignment, :config do
 
   shared_examples('allowed') do |source|
     it "allows assignment of: #{source.gsub(/\s*\n\s*/, '; ')}" do
-      inspect_source(source)
-
-      expect(cop.messages.empty?).to be(true)
+      expect_no_offenses(source)
     end
   end
 

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -6,26 +6,30 @@ RSpec.describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
   let(:cop_config) { { 'AllowSafeAssignment' => true } }
 
   it 'registers an offense for parentheses around condition' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       if (x > 10)
+         ^^^^^^^^ Don't use parentheses around the condition of an `if`.
       elsif (x < 3)
+            ^^^^^^^ Don't use parentheses around the condition of an `elsif`.
       end
       unless (x > 10)
+             ^^^^^^^^ Don't use parentheses around the condition of an `unless`.
       end
       while (x > 10)
+            ^^^^^^^^ Don't use parentheses around the condition of a `while`.
       end
       until (x > 10)
+            ^^^^^^^^ Don't use parentheses around the condition of an `until`.
       end
       x += 1 if (x < 10)
+                ^^^^^^^^ Don't use parentheses around the condition of an `if`.
       x += 1 unless (x < 10)
+                    ^^^^^^^^ Don't use parentheses around the condition of an `unless`.
       x += 1 until (x < 10)
+                   ^^^^^^^^ Don't use parentheses around the condition of an `until`.
       x += 1 while (x < 10)
+                   ^^^^^^^^ Don't use parentheses around the condition of a `while`.
     RUBY
-    expect(cop.offenses.size).to eq(9)
-    expect(cop.messages.first)
-      .to eq("Don't use parentheses around the condition of an `if`.")
-    expect(cop.messages.last)
-      .to eq("Don't use parentheses around the condition of a `while`.")
   end
 
   it 'accepts parentheses if there is no space between the keyword and (.' do
@@ -158,20 +162,20 @@ RSpec.describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
 
     it 'does not accept variable assignment in condition surrounded with ' \
        'parentheses' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         if (test = 10)
+           ^^^^^^^^^^^ Don't use parentheses around the condition of an `if`.
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
 
     it 'does not accept element assignment in condition surrounded with ' \
        'parentheses' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         if (test[0] = 10)
+           ^^^^^^^^^^^^^^ Don't use parentheses around the condition of an `if`.
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
   end
 

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
 
     context 'with a raise with 2 args' do
       it 'reports an offense' do
-        inspect_source('raise RuntimeError, msg')
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.config_to_allow_offenses)
-          .to eq('EnforcedStyle' => 'exploded')
+        expect_offense(<<-RUBY.strip_indent)
+          raise RuntimeError, msg
+          ^^^^^^^^^^^^^^^^^^^^^^^ Provide an exception object as an argument to `raise`.
+        RUBY
       end
 
       it 'auto-corrects to compact style' do
@@ -22,17 +22,14 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
 
     context 'with correct + opposite' do
       it 'reports an offense' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           if a
             raise RuntimeError, msg
+            ^^^^^^^^^^^^^^^^^^^^^^^ Provide an exception object as an argument to `raise`.
           else
             raise Ex.new(msg)
           end
         RUBY
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages)
-          .to eq(['Provide an exception object as an argument to `raise`.'])
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
 
       it 'auto-corrects to compact style' do

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -4,37 +4,36 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
   subject(:cop) { described_class.new(config) }
 
   it 'reports an offense for single line def with redundant begin block' do
-    src = '  def func; begin; x; y; rescue; z end end'
-    inspect_source(src)
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      def func; begin; x; y; rescue; z end; end
+                ^^^^^ Redundant `begin` block detected.
+    RUBY
   end
 
   it 'reports an offense for def with redundant begin block' do
-    src = <<-RUBY.strip_indent
+    expect_offense(<<-RUBY.strip_indent)
       def func
         begin
+        ^^^^^ Redundant `begin` block detected.
           ala
         rescue => e
           bala
         end
       end
     RUBY
-    inspect_source(src)
-    expect(cop.offenses.size).to eq(1)
   end
 
   it 'reports an offense for defs with redundant begin block' do
-    src = <<-RUBY.strip_indent
+    expect_offense(<<-RUBY.strip_indent)
       def Test.func
         begin
+        ^^^^^ Redundant `begin` block detected.
           ala
         rescue => e
           bala
         end
       end
     RUBY
-    inspect_source(src)
-    expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts a def with required begin block' do

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -6,49 +6,45 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
   let(:cop_config) { { 'AllowMultipleReturnValues' => false } }
 
   it 'reports an offense for def with only a return' do
-    src = <<-RUBY.strip_indent
+    expect_offense(<<-RUBY.strip_indent)
       def func
         return something
+        ^^^^^^ Redundant `return` detected.
       ensure
         2
       end
     RUBY
-    inspect_source(src)
-    expect(cop.offenses.size).to eq(1)
   end
 
   it 'reports an offense for defs with only a return' do
-    src = <<-RUBY.strip_indent
+    expect_offense(<<-RUBY.strip_indent)
       def Test.func
         return something
+        ^^^^^^ Redundant `return` detected.
       end
     RUBY
-    inspect_source(src)
-    expect(cop.offenses.size).to eq(1)
   end
 
   it 'reports an offense for def ending with return' do
-    src = <<-RUBY.strip_indent
+    expect_offense(<<-RUBY.strip_indent)
       def func
         one
         two
         return something
+        ^^^^^^ Redundant `return` detected.
       end
     RUBY
-    inspect_source(src)
-    expect(cop.offenses.size).to eq(1)
   end
 
   it 'reports an offense for defs ending with return' do
-    src = <<-RUBY.strip_indent
+    expect_offense(<<-RUBY.strip_indent)
       def self.func
         one
         two
         return something
+        ^^^^^^ Redundant `return` detected.
       end
     RUBY
-    inspect_source(src)
-    expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts return in a non-final position' do
@@ -133,52 +129,39 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
 
   context 'when multi-value returns are not allowed' do
     it 'reports an offense for def with only a return' do
-      src = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         def func
           return something, test
+          ^^^^^^ Redundant `return` detected. To return multiple values, use an array.
         end
       RUBY
-      inspect_source(src)
-      expect(cop.offenses.size).to eq(1)
     end
 
     it 'reports an offense for defs with only a return' do
-      src = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         def Test.func
           return something, test
+          ^^^^^^ Redundant `return` detected. To return multiple values, use an array.
         end
       RUBY
-      inspect_source(src)
-      expect(cop.offenses.size).to eq(1)
     end
 
     it 'reports an offense for def ending with return' do
-      src = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         def func
           one
           two
           return something, test
+          ^^^^^^ Redundant `return` detected. To return multiple values, use an array.
         end
       RUBY
-      inspect_source(src)
-      expect(cop.offenses.size).to eq(1)
     end
 
     it 'reports an offense for defs ending with return' do
-      src = <<-RUBY.strip_indent
+      expect_offense(<<-RUBY.strip_indent)
         def self.func
           one
           two
-          return something, test
-        end
-      RUBY
-      inspect_source(src)
-      expect(cop.offenses.size).to eq(1)
-    end
-
-    it 'registers a helpful message for defs with multiple returns' do
-      expect_offense(<<-RUBY.strip_indent)
-        def func
           return something, test
           ^^^^^^ Redundant `return` detected. To return multiple values, use an array.
         end

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -4,9 +4,10 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf do
   subject(:cop) { described_class.new }
 
   it 'reports an offense a self receiver on an rvalue' do
-    src = 'a = self.b'
-    inspect_source(src)
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      a = self.b
+          ^^^^^^ Redundant `self` detected.
+    RUBY
   end
 
   it 'does not report an offense when receiver and lvalue have the same name' do
@@ -199,9 +200,10 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf do
   end
 
   it 'reports an offence a self receiver of .call' do
-    src = 'self.call'
-    inspect_source(src)
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      self.call
+      ^^^^^^^^^ Redundant `self` detected.
+    RUBY
   end
 
   it 'auto-corrects by removing redundant self' do

--- a/spec/rubocop/cop/style/signal_exception_spec.rb
+++ b/spec/rubocop/cop/style/signal_exception_spec.rb
@@ -117,17 +117,15 @@ RSpec.describe RuboCop::Cop::Style::SignalException, :config do
 
     it 'registers an offense for `raise` and `fail` with `Kernel` as ' \
        'explicit receiver' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def test
           Kernel.raise
+                 ^^^^^ Use `fail` instead of `raise` to signal exceptions.
         rescue Exception
           Kernel.fail
+                 ^^^^ Use `raise` instead of `fail` to rethrow exceptions.
         end
       RUBY
-      expect(cop.offenses.size).to eq(2)
-      expect(cop.messages)
-        .to eq(['Use `fail` instead of `raise` to signal exceptions.',
-                'Use `raise` instead of `fail` to rethrow exceptions.'])
     end
 
     it 'registers an offense for raise not in a begin/rescue/end' do
@@ -142,32 +140,30 @@ RSpec.describe RuboCop::Cop::Style::SignalException, :config do
     end
 
     it 'registers one offense for each raise' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         cop.stub(:on_def) { raise RuntimeError }
+                            ^^^^^ Use `fail` instead of `raise` to signal exceptions.
         cop.stub(:on_def) { raise RuntimeError }
+                            ^^^^^ Use `fail` instead of `raise` to signal exceptions.
       RUBY
-      expect(cop.offenses.size).to eq(2)
-      expect(cop.messages)
-        .to eq(['Use `fail` instead of `raise` to signal exceptions.'] * 2)
     end
 
     it 'is not confused by nested begin/rescue' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         begin
           raise
+          ^^^^^ Use `fail` instead of `raise` to signal exceptions.
           begin
             raise
+            ^^^^^ Use `fail` instead of `raise` to signal exceptions.
           rescue
             fail
+            ^^^^ Use `raise` instead of `fail` to rethrow exceptions.
           end
         rescue Exception
           #do nothing
         end
       RUBY
-      expect(cop.offenses.size).to eq(3)
-      expect(cop.messages)
-        .to eq(['Use `fail` instead of `raise` to signal exceptions.'] * 2 +
-               ['Use `raise` instead of `fail` to rethrow exceptions.'])
     end
 
     it 'auto-corrects raise to fail when appropriate' do

--- a/spec/rubocop/cop/style/single_line_block_params_spec.rb
+++ b/spec/rubocop/cop/style/single_line_block_params_spec.rb
@@ -10,21 +10,24 @@ RSpec.describe RuboCop::Cop::Style::SingleLineBlockParams, :config do
   end
 
   it 'finds wrong argument names in calls with different syntax' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def m
         [0, 1].reduce { |c, d| c + d }
+                        ^^^^^^ Name `reduce` block params `|a, e|`.
         [0, 1].reduce{ |c, d| c + d }
+                       ^^^^^^ Name `reduce` block params `|a, e|`.
         [0, 1].reduce(5) { |c, d| c + d }
+                           ^^^^^^ Name `reduce` block params `|a, e|`.
         [0, 1].reduce(5){ |c, d| c + d }
+                          ^^^^^^ Name `reduce` block params `|a, e|`.
         [0, 1].reduce (5) { |c, d| c + d }
+                            ^^^^^^ Name `reduce` block params `|a, e|`.
         [0, 1].reduce(5) { |c, d| c + d }
+                           ^^^^^^ Name `reduce` block params `|a, e|`.
         ala.test { |x, z| bala }
+                   ^^^^^^ Name `test` block params `|x, y|`.
       end
     RUBY
-    expect(cop.offenses.size).to eq(7)
-    expect(cop.offenses.map(&:line).sort).to eq((2..8).to_a)
-    expect(cop.messages.first)
-      .to eq('Name `reduce` block params `|a, e|`.')
   end
 
   it 'allows calls with proper argument names' do

--- a/spec/rubocop/cop/style/string_methods_spec.rb
+++ b/spec/rubocop/cop/style/string_methods_spec.rb
@@ -5,15 +5,15 @@ RSpec.describe RuboCop::Cop::Style::StringMethods, :config do
 
   let(:cop_config) { { 'intern' => 'to_sym' } }
 
-  let(:source) { "'something'.intern" }
-  let(:corrected) { autocorrect_source(source) }
-
   it 'registers an offense' do
-    inspect_source(source)
+    expect_offense(<<-RUBY.strip_indent)
+      'something'.intern
+                  ^^^^^^ Prefer `to_sym` over `intern`.
+    RUBY
+  end
 
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Prefer `to_sym` over `intern`.'])
-    expect(cop.highlights).to eq(%w[intern])
+  it 'auto-corrects' do
+    corrected = autocorrect_source("'something'.intern")
 
     expect(corrected).to eq("'something'.to_sym")
   end

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
     end
 
     it 'registers an offense for arrays of symbols' do
-      inspect_source('[:one, :two, :three]')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Use `%i` or `%I` for an array of symbols.'])
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'brackets')
+      expect_offense(<<-RUBY.strip_indent)
+        [:one, :two, :three]
+        ^^^^^^^^^^^^^^^^^^^^ Use `%i` or `%I` for an array of symbols.
+      RUBY
     end
 
     it 'autocorrects arrays of symbols' do
@@ -87,8 +87,6 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
         %i(a b c d)
       RUBY
 
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Use `%i` or `%I` for an array of symbols.'])
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'percent',
                                                  'MinSize' => 4)
     end
@@ -98,8 +96,7 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
         [:one, :two, :three]
         %i(a b)
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Use `%i` or `%I` for an array of symbols.'])
+
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'registers an offense for arrays of single quoted strings' do
-      inspect_source("['one', 'two', 'three']")
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Use `%w` or `%W` for an array of words.'])
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'brackets')
+      expect_offense(<<-RUBY.strip_indent)
+        ['one', 'two', 'three']
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+      RUBY
     end
 
     it 'registers an offense for arrays of double quoted strings' do
@@ -182,8 +182,7 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
         ['one', 'two', 'three']
         %w(a b c d)
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Use `%w` or `%W` for an array of words.'])
+
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'percent',
                                                  'MinSize' => 4)
     end
@@ -193,8 +192,7 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
         ['one', 'two', 'three']
         %w(a b)
       RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Use `%w` or `%W` for an array of words.'])
+
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 


### PR DESCRIPTION
Another pass of the same treatment as in #5982.

- Introduce `#expect_offense` and `#expect_no_offenses` in many more specs.
- Replace instances of code examples expressed as arrays of strings with heredocs.
- Replace usages of `#strip_margin` with `#strip_indent`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
