### PR TITLE
Fix exception when auto-correcting Style/UnneededCondition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#4878](https://github.com/rubocop-hq/rubocop/issues/4878): Fix false positive in `Layout/IndentationWidth` when multiple modifiers and def are on the same line. ([@tatsuyafw][])
 * [#5966](https://github.com/bbatsov/rubocop/issues/5966): Fix a false positive for `Layout/ClosingHeredocIndentation` when heredoc content is outdented compared to the closing. ([@koic][])
 * Fix auto-correct support check for custom cops on --auto-gen-config. ([@r7kamura][])
+* Fix exception that occurs when auto-correcting a modifier if statement in `Style/UnneededCondition`. ([@rrosenblum][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/unneeded_condition.rb
+++ b/lib/rubocop/cop/style/unneeded_condition.rb
@@ -34,6 +34,7 @@ module RuboCop
         include RangeHelp
 
         MSG = 'Use double pipes `||` instead.'.freeze
+        UNNEEDED_CONDITION = 'This condition is not needed.'.freeze
 
         def on_if(node)
           return unless offense?(node)
@@ -44,6 +45,8 @@ module RuboCop
           lambda do |corrector|
             if node.ternary?
               corrector.replace(range_of_offense(node), '||')
+            elsif node.modifier_form?
+              corrector.replace(node.source_range, node.if_branch.source)
             else
               corrected = [node.if_branch.source,
                            else_source(node.else_branch)].join(' || ')
@@ -54,6 +57,14 @@ module RuboCop
         end
 
         private
+
+        def message(node)
+          if node.modifier_form?
+            UNNEEDED_CONDITION
+          else
+            MSG
+          end
+        end
 
         def range_of_offense(node)
           return :expression unless node.ternary?

--- a/spec/rubocop/cop/style/unneeded_condition_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_condition_spec.rb
@@ -63,6 +63,15 @@ RSpec.describe RuboCop::Cop::Style::UnneededCondition do
           RUBY
         end
       end
+
+      context 'when using modifier if' do
+        it 'registers an offense' do
+          expect_offense(<<-RUBY.strip_indent)
+            bar if bar
+            ^^^^^^^^^^ This condition is not needed.
+          RUBY
+        end
+      end
     end
 
     describe '#autocorrection' do
@@ -118,6 +127,12 @@ RSpec.describe RuboCop::Cop::Style::UnneededCondition do
         expect(new_source).to eq(<<-RUBY.strip_indent)
           b || (c while d)
         RUBY
+      end
+
+      it 'auto-corrects modifer if statements' do
+        new_source = autocorrect_source('bar if bar')
+
+        expect(new_source).to eq('bar')
       end
     end
   end


### PR DESCRIPTION
It seemed a bit odd to me that this would register an offense in the first place, but it does follow all of the rules. An alternative solution would be to not register an offense for modifier if statements.