### PR TITLE
Drop support for MRI 2.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'
     - 'tmp/**/*'
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.2
 
 Naming/PredicateName:
   # Method define macros for dynamically generated method.

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ dist: trusty
 rvm:
   - jruby-9.2.0.0
   - jruby-head
-  - 2.1.10
   - 2.2.10
   - 2.3.7
   - 2.4.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 * [#6006](https://github.com/bbatsov/rubocop/pull/6006): Remove `rake repl` task. ([@koic][])
 
 ## 0.57.2 (2018-06-12)
+### Changes
+
+* Drop support for MRI 2.1. ([@drenmi][])
 
 ### Bug fixes
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,7 @@ gemspec
 
 gem 'bump', require: false
 gem 'pry'
-# pry-byebug requires MRI 2.2.0 or higher.
-gem 'pry-byebug' if RUBY_ENGINE == 'ruby' && RUBY_VERSION >= '2.2.0'
+gem 'pry-byebug' if RUBY_ENGINE == 'ruby'
 gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.7'
 gem 'rubocop-rspec', '~> 1.26.0'

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You can read a ton more about RuboCop in its [official manual](http://docs.ruboc
 
 RuboCop supports the following Ruby implementations:
 
-* MRI 2.1+
+* MRI 2.2+
 * JRuby 9.0+
 
 The Rails cops support the following versions:

--- a/config/default.yml
+++ b/config/default.yml
@@ -130,7 +130,7 @@ AllCops:
   # followed by the Gemfile.lock or gems.locked file. (Although the Ruby version
   # is specified in the Gemfile or gems.rb file, RuboCop reads the final value
   # from the lock file.) If the Ruby version is still unresolved, RuboCop will
-  # use the oldest officially supported Ruby version (currently Ruby 2.1).
+  # use the oldest officially supported Ruby version (currently Ruby 2.2).
   TargetRubyVersion: ~
   # What version of Rails is the inspected code using?  If a value is specified
   # for TargetRailsVersion then it is used.  Acceptable values are specificed

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -16,10 +16,10 @@ module RuboCop
 
     COMMON_PARAMS = %w[Exclude Include Severity
                        AutoCorrect StyleGuide Details].freeze
-    # 2.1 is the oldest officially supported Ruby version.
-    DEFAULT_RUBY_VERSION = 2.1
-    KNOWN_RUBIES = [2.1, 2.2, 2.3, 2.4, 2.5].freeze
-    OBSOLETE_RUBIES = { 1.9 => '0.50', 2.0 => '0.50' }.freeze
+    # 2.2 is the oldest officially supported Ruby version.
+    DEFAULT_RUBY_VERSION = 2.2
+    KNOWN_RUBIES = [2.2, 2.3, 2.4, 2.5].freeze
+    OBSOLETE_RUBIES = { 1.9 => '0.50', 2.0 => '0.50', 2.1 => '0.58' }.freeze
     RUBY_VERSION_FILENAME = '.ruby-version'.freeze
     DEFAULT_RAILS_VERSION = 5.0
     OBSOLETE_COPS = {

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -176,15 +176,11 @@ module RuboCop
       end
 
       def yaml_safe_load(yaml_code, filename)
-        if YAML.respond_to?(:safe_load) # Ruby 2.1+
-          if defined?(SafeYAML) && SafeYAML.respond_to?(:load)
-            SafeYAML.load(yaml_code, filename,
-                          whitelisted_tags: %w[!ruby/regexp])
-          else
-            YAML.safe_load(yaml_code, [Regexp, Symbol], [], false, filename)
-          end
+        if defined?(SafeYAML) && SafeYAML.respond_to?(:load)
+          SafeYAML.load(yaml_code, filename,
+                        whitelisted_tags: %w[!ruby/regexp])
         else
-          YAML.load(yaml_code, filename) # rubocop:disable Security/YAMLLoad
+          YAML.safe_load(yaml_code, [Regexp, Symbol], [], false, filename)
         end
       end
     end

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -163,12 +163,9 @@ module RuboCop
       [ast, comments, tokens]
     end
 
-    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
+    # rubocop:disable Metrics/MethodLength
     def parser_class(ruby_version)
       case ruby_version
-      when 2.1
-        require 'parser/ruby21'
-        Parser::Ruby21
       when 2.2
         require 'parser/ruby22'
         Parser::Ruby22
@@ -188,7 +185,7 @@ module RuboCop
         raise ArgumentError, "Unknown Ruby version: #{ruby_version.inspect}"
       end
     end
-    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength
+    # rubocop:enable Metrics/MethodLength
 
     def create_parser(ruby_version)
       builder = RuboCop::AST::Builder.new

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -59,10 +59,6 @@ shared_context 'config', :config do
   end
 end
 
-shared_context 'ruby 2.1', :ruby21 do
-  let(:ruby_version) { 2.1 }
-end
-
 shared_context 'ruby 2.2', :ruby22 do
   let(:ruby_version) { 2.2 }
 end

--- a/lib/rubocop/rspec/shared_examples.rb
+++ b/lib/rubocop/rspec/shared_examples.rb
@@ -9,29 +9,6 @@ shared_examples_for 'accepts' do
   end
 end
 
-shared_examples_for 'mimics MRI 2.1' do |grep_mri_warning|
-  if RUBY_ENGINE == 'ruby' && RUBY_VERSION.start_with?('2.1')
-    it "mimics MRI #{RUBY_VERSION} built-in syntax checking" do
-      inspect_source(source)
-      offenses_by_mri = MRISyntaxChecker.offenses_for_source(
-        source, cop.name, grep_mri_warning
-      )
-
-      # Compare objects before comparing counts for clear failure output.
-      cop.offenses.each_with_index do |offense_by_cop, index|
-        offense_by_mri = offenses_by_mri[index]
-        # Exclude column attribute since MRI does not
-        # output column number.
-        %i[severity line cop_name].each do |a|
-          expect(offense_by_cop.send(a)).to eq(offense_by_mri.send(a))
-        end
-      end
-
-      expect(cop.offenses.count).to eq(offenses_by_mri.count)
-    end
-  end
-end
-
 shared_examples_for 'misaligned' do |annotated_source, used_style|
   config_to_allow_offenses = if used_style
                                { 'EnforcedStyleAlignWith' => used_style.to_s }

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.name = 'rubocop'
   s.version = RuboCop::Version::STRING
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.1.0'
+  s.required_ruby_version = '>= 2.2.0'
   s.authors = ['Bozhidar Batsov', 'Jonas Arvidsson', 'Yuji Nakayama']
   s.description = <<-DESCRIPTION
     Automatic Ruby code style checking tool.
@@ -43,8 +43,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('unicode-display_width', '~> 1.0', '>= 1.0.1')
 
   s.add_development_dependency('bundler', '~> 1.3')
-  # TODO: loosen rack dependency once Ruby 2.1.0 support is dropped.
-  # See https://git.io/vxWRB
-  s.add_development_dependency('rack', '>= 1.6.9', '< 2.0')
+  s.add_development_dependency('rack', '>= 2.0')
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1270,7 +1270,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     RUBY
     create_file('.rubocop.yml', <<-YAML.strip_indent)
       AllCops:
-        TargetRubyVersion: 2.1
+        TargetRubyVersion: 2.2
     YAML
     create_file('example.rb', src)
     expect(cli.run(%w[-a -f simple])).to eq(1)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)
     expect($stdout.string)
       .to eq(["#{abs('example.rb')}:3:1: E: Lint/Syntax: unexpected " \
-              'token $end (Using Ruby 2.1 parser; configure using ' \
+              'token $end (Using Ruby 2.2 parser; configure using ' \
               '`TargetRubyVersion` parameter, under `AllCops`)',
               ''].join("\n"))
   end
@@ -1636,7 +1636,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           /\AError: Unknown Ruby version 2.6 found in `TargetRubyVersion`/
         )
         expect($stderr.string.strip).to match(
-          /Supported versions: 2.1, 2.2, 2.3, 2.4, 2.5/
+          /Supported versions: 2.2, 2.3, 2.4, 2.5/
         )
       end
     end
@@ -1658,7 +1658,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         )
 
         expect($stderr.string.strip).to match(
-          /Supported versions: 2.1, 2.2, 2.3, 2.4/
+          /Supported versions: 2.2, 2.3, 2.4/
         )
       end
     end

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -802,7 +802,7 @@ RSpec.describe RuboCop::Config do
 
   describe '#target_ruby_version', :isolated_environment do
     context 'when TargetRubyVersion is set' do
-      let(:ruby_version) { 2.1 }
+      let(:ruby_version) { 2.2 }
 
       let(:hash) do
         {

--- a/spec/rubocop/cop/layout/def_end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/def_end_alignment_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::Layout::DefEndAlignment, :config do
     include_examples 'aligned', 'def',       'test',       'end'
     include_examples 'aligned', 'def',       'Test.test',  'end', 'defs'
 
-    context 'in ruby 2.1 or later' do
+    context 'in ruby 2.2 or later' do
       include_examples 'aligned', 'foo def', 'test', 'end'
       include_examples 'aligned', 'foo bar def', 'test', 'end'
 
@@ -88,7 +88,7 @@ RSpec.describe RuboCop::Cop::Layout::DefEndAlignment, :config do
     include_examples 'aligned', 'def', 'test',      'end'
     include_examples 'aligned', 'def', 'Test.test', 'end', 'defs'
 
-    context 'in ruby 2.1 or later' do
+    context 'in ruby 2.2 or later' do
       include_examples('aligned',
                        'foo def', 'test',
                        '    end')

--- a/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
+++ b/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
@@ -23,8 +23,6 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
         .to eq('Shadowing outer local variable - `foo`.')
       expect(cop.offenses.first.line).to eq(4)
     end
-
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a splat block argument has same name ' \
@@ -47,8 +45,6 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
         .to eq('Shadowing outer local variable - `foo`.')
       expect(cop.offenses.first.line).to eq(4)
     end
-
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a block block argument has same name ' \
@@ -73,8 +69,6 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
         .to eq('Shadowing outer local variable - `foo`.')
       expect(cop.offenses.first.line).to eq(4)
     end
-
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a block local variable has same name ' \
@@ -98,8 +92,6 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
         .to eq('Shadowing outer local variable - `foo`.')
       expect(cop.offenses.first.line).to eq(4)
     end
-
-    include_examples 'mimics MRI 2.1', 'shadowing'
   end
 
   context 'when a block argument has different name ' \
@@ -116,7 +108,6 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when an outer scope variable is reassigned in a block' do
@@ -133,7 +124,6 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when an outer scope variable is referenced in a block' do
@@ -150,7 +140,6 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when multiple block arguments have same name "_"' do
@@ -164,7 +153,6 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when multiple block arguments have ' \
@@ -179,7 +167,6 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a block argument has same name "_" ' \
@@ -196,7 +183,6 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a block argument has a same name starts with "_" ' \
@@ -213,7 +199,6 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a method argument has same name ' \
@@ -230,6 +215,5 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 end

--- a/spec/rubocop/cop/lint/unneeded_require_statement_spec.rb
+++ b/spec/rubocop/cop/lint/unneeded_require_statement_spec.rb
@@ -3,31 +3,21 @@
 RSpec.describe RuboCop::Cop::Lint::UnneededRequireStatement, :config do
   subject(:cop) { described_class.new(config) }
 
-  context 'target ruby version < 2.2', :ruby21 do
-    it "does not registers an offense when using `require 'enumerator'`" do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        require 'enumerator'
-      RUBY
-    end
+  it "registers an offense when using `require 'enumerator'`" do
+    expect_offense(<<-RUBY.strip_indent)
+      require 'enumerator'
+      ^^^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+    RUBY
   end
 
-  context 'target ruby version >= 2.2', :ruby22 do
-    it "registers an offense when using `require 'enumerator'`" do
-      expect_offense(<<-RUBY.strip_indent)
-        require 'enumerator'
-        ^^^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
-      RUBY
-    end
+  it 'autocorrects remove unnecessary require statement' do
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
+      require 'enumerator'
+      require 'uri'
+    RUBY
 
-    it 'autocorrects remove unnecessary require statement' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
-        require 'enumerator'
-        require 'uri'
-      RUBY
-
-      expect(new_source).to eq(<<-RUBY.strip_indent)
-        require 'uri'
-      RUBY
-    end
+    expect(new_source).to eq(<<-RUBY.strip_indent)
+      require 'uri'
+    RUBY
   end
 end

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -70,17 +70,6 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
       end
     end
 
-    context 'when a required keyword argument is unused', ruby: 2.1 do
-      it 'registers an offense but does not suggest underscore-prefix' do
-        expect_offense(<<-RUBY.strip_indent)
-          def self.some_method(foo, bar:)
-                                    ^^^ Unused method argument - `bar`.
-            puts foo
-          end
-        RUBY
-      end
-    end
-
     context 'when an optional keyword argument is unused' do
       it 'registers an offense but does not suggest underscore-prefix' do
         expect_offense(<<-RUBY.strip_indent)

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -123,17 +123,15 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier do
     end
   end
 
-  if RUBY_ENGINE == 'ruby' && RUBY_VERSION.start_with?('2.1')
-    context 'ruby 2.1 style modifiers' do
-      it 'does not register an offense' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          class SomeClass
-            private def some_method
-              puts 10
-            end
+  context 'when using inline modifiers' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class SomeClass
+          private def some_method
+            puts 10
           end
-        RUBY
-      end
+        end
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -26,8 +26,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
       expect(cop.offenses.first.line).to eq(5)
       expect(cop.highlights).to eq(['foo'])
     end
-
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is assigned and unreferenced ' \
@@ -54,8 +52,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
       expect(cop.offenses.first.line).to eq(5)
       expect(cop.highlights).to eq(['foo'])
     end
-
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is assigned and unreferenced ' \
@@ -83,8 +79,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
       expect(cop.offenses.first.line).to eq(6)
       expect(cop.highlights).to eq(['foo'])
     end
-
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is assigned and unreferenced in a class' do
@@ -110,8 +104,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
       expect(cop.offenses.first.line).to eq(5)
       expect(cop.highlights).to eq(['foo'])
     end
-
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is assigned and unreferenced in a class ' \
@@ -139,8 +131,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
       expect(cop.offenses.first.line).to eq(6)
       expect(cop.highlights).to eq(['foo'])
     end
-
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is assigned and unreferenced ' \
@@ -168,8 +158,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
       expect(cop.offenses.first.line).to eq(6)
       expect(cop.highlights).to eq(['foo'])
     end
-
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is assigned and unreferenced in a module' do
@@ -195,8 +183,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
       expect(cop.offenses.first.line).to eq(5)
       expect(cop.highlights).to eq(['foo'])
     end
-
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is assigned and unreferenced in top level' do
@@ -216,8 +202,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
       expect(cop.offenses.first.line).to eq(1)
       expect(cop.highlights).to eq(['foo'])
     end
-
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is assigned with operator assignment ' \
@@ -331,7 +315,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a referenced variable is reassigned in a block' do
@@ -348,7 +331,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a block local variable is declared but not assigned' do
@@ -400,8 +382,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
       expect(cop.offenses.first.line).to eq(3)
       expect(cop.highlights).to eq(['foo'])
     end
-
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is reassigned at the end of loop body ' \
@@ -423,7 +403,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is reassigned at the end of loop body ' \
@@ -445,7 +424,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a setter is invoked with operator assignment in loop body' do
@@ -462,7 +440,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context "when a variable is reassigned in loop body but won't " \
@@ -564,8 +541,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
       expect(cop.offenses.first.line).to eq(3)
       expect(cop.highlights).to eq(['foo'])
     end
-
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a unreferenced variable is reassigned in same branch ' \
@@ -610,7 +585,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is reassigned in a loop' do
@@ -727,7 +701,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is reassigned in single branch if ' \
@@ -919,7 +892,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is assigned in branch of modifier if ' \
@@ -955,7 +927,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a unreferenced variable is reassigned ' \
@@ -993,7 +964,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is reassigned ' \
@@ -1009,7 +979,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is reassigned ' \
@@ -1025,7 +994,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is reassigned ' \
@@ -1041,7 +1009,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is reassigned with binary operator ' \
@@ -1078,7 +1045,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is assigned with ||= ' \
@@ -1147,8 +1113,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
       expect(cop.offenses.first.line).to eq(2)
       expect(cop.highlights).to eq(['bar'])
     end
-
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is reassigned with multiple assignment ' \
@@ -1164,7 +1128,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is assigned in loop body ' \
@@ -1179,7 +1142,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is assigned in loop body ' \
@@ -1194,7 +1156,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is assigned ' \
@@ -1218,8 +1179,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
       expect(cop.offenses.first.line).to eq(3)
       expect(cop.highlights).to eq(['foo'])
     end
-
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is assigned in main body of begin, rescue ' \
@@ -1242,7 +1201,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is reassigned multiple times ' \
@@ -1264,7 +1222,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is reassigned multiple times ' \
@@ -1284,7 +1241,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is reassigned multiple times ' \
@@ -1304,7 +1260,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is reassigned multiple times in rescue ' \
@@ -1407,7 +1362,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is assigned with operator assignment ' \
@@ -1426,7 +1380,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is assigned ' \
@@ -1497,7 +1450,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a local variable is unreferenced ' \
@@ -1519,8 +1471,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
       expect(cop.offenses.first.line).to eq(2)
       expect(cop.highlights).to eq(['foo'])
     end
-
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a method argument is reassigned ' \
@@ -1556,8 +1506,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
         .to eq('Useless assignment to variable - `foo`.')
       expect(cop.offenses.first.line).to eq(1)
     end
-
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a named capture is unreferenced ' \
@@ -1592,7 +1540,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is referenced ' \
@@ -1624,7 +1571,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is shadowed by a block argument ' \
@@ -1648,8 +1594,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
       expect(cop.offenses.first.line).to eq(2)
       expect(cop.highlights).to eq(['foo'])
     end
-
-    include_examples 'mimics MRI 2.1', 'unused variable'
   end
 
   context 'when a variable is not used and the name starts with _' do
@@ -1664,7 +1608,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a method argument is not used' do
@@ -1676,7 +1619,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when an optional method argument is not used' do
@@ -1688,7 +1630,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a block method argument is not used' do
@@ -1700,7 +1641,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a splat method argument is not used' do
@@ -1712,7 +1652,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a optional keyword method argument is not used' do
@@ -1724,7 +1663,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a keyword splat method argument is used' do
@@ -1737,7 +1675,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a keyword splat method argument is not used' do
@@ -1749,7 +1686,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when an anonymous keyword splat method argument is defined' do
@@ -1761,7 +1697,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a block argument is not used' do
@@ -1773,7 +1708,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when there is only one AST node and it is unused variable' do
@@ -1789,8 +1723,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
       expect(cop.offenses.first.line).to eq(1)
       expect(cop.highlights).to eq(['foo'])
     end
-
-    include_examples 'mimics MRI 2.1'
   end
 
   context 'when a variable is assigned ' \
@@ -1805,7 +1737,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
       end
 
       include_examples 'accepts'
-      include_examples 'mimics MRI 2.1'
     end
 
     context 'and the variable is not used' do
@@ -1824,8 +1755,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
         expect(cop.offenses.first.line).to eq(1)
         expect(cop.highlights).to eq(['foo'])
       end
-
-      include_examples 'mimics MRI 2.1'
     end
   end
 
@@ -1840,7 +1769,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     include_examples 'accepts'
-    include_examples 'mimics MRI 2.1'
   end
 
   # regression test, from problem in Locatable

--- a/spec/rubocop/cop/metrics/parameter_lists_spec.rb
+++ b/spec/rubocop/cop/metrics/parameter_lists_spec.rb
@@ -60,12 +60,5 @@ RSpec.describe RuboCop::Cop::Metrics::ParameterLists, :config do
         end
       RUBY
     end
-
-    it 'does not count keyword arguments without default values', ruby: 2.1 do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        def meth(a, b, c, d:, e:)
-        end
-      RUBY
-    end
   end
 end

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -54,24 +54,16 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         expect_no_offenses('{}')
       end
 
-      context 'ruby < 2.2', :ruby21 do
-        it 'accepts hash rockets when symbol keys have string in them' do
-          expect_no_offenses('x = { :"string" => 0 }')
-        end
+      it 'registers an offense when symbol keys have strings in them' do
+        expect_offense(<<-RUBY.strip_indent)
+          x = { :"string" => 0 }
+                ^^^^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
       end
 
-      context 'ruby >= 2.2', :ruby22 do
-        it 'registers an offense when symbol keys have strings in them' do
-          expect_offense(<<-RUBY.strip_indent)
-            x = { :"string" => 0 }
-                  ^^^^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
-          RUBY
-        end
-
-        it 'preserves quotes during autocorrection' do
-          new_source = autocorrect_source("{ :'&&' => foo }")
-          expect(new_source).to eq("{ '&&': foo }")
-        end
+      it 'preserves quotes during autocorrection' do
+        new_source = autocorrect_source("{ :'&&' => foo }")
+        expect(new_source).to eq("{ '&&': foo }")
       end
 
       context 'if PreferHashRocketsForNonAlnumEndingSymbols is false' do
@@ -360,60 +352,25 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
 
-      context 'ruby < 2.2', :ruby21 do
-        it 'accepts hash rockets when keys have whitespaces in them' do
-          expect_no_offenses('x = { :"t o" => 0, :b => 1 }')
-        end
-
-        it 'registers an offense when keys have whitespaces and mix styles' do
-          inspect_source('x = { :"t o" => 0, b: 1 }')
-          expect(cop.messages).to eq(["Don't mix styles in the same hash."])
-          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-        end
-
-        it 'accepts hash rockets when keys have special symbols in them' do
-          expect_no_offenses('x = { :"\\tab" => 1, :b => 1 }')
-        end
-
-        it 'registers an offense when keys have special symbols and '\
-          'mix styles' do
-          inspect_source('x = { :"\tab" => 1, b: 1 }')
-          expect(cop.messages).to eq(["Don't mix styles in the same hash."])
-          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-        end
-
-        it 'accepts hash rockets when keys start with a digit' do
-          expect_no_offenses('x = { :"1" => 1, :b => 1 }')
-        end
-
-        it 'registers an offense when keys start with a digit and mix styles' do
-          inspect_source('x = { :"1" => 1, b: 1 }')
-          expect(cop.messages).to eq(["Don't mix styles in the same hash."])
-          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-        end
+      it 'registers an offense when keys have whitespaces in them' do
+        expect_offense(<<-RUBY.strip_indent)
+          x = { :"t o" => 0 }
+                ^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
       end
 
-      context 'ruby >= 2.2', :ruby22 do
-        it 'registers an offense when keys have whitespaces in them' do
-          expect_offense(<<-RUBY.strip_indent)
-            x = { :"t o" => 0 }
-                  ^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
-          RUBY
-        end
+      it 'registers an offense when keys have special symbols in them' do
+        expect_offense(<<-'RUBY'.strip_indent)
+          x = { :"\tab" => 1 }
+                ^^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
+      end
 
-        it 'registers an offense when keys have special symbols in them' do
-          expect_offense(<<-'RUBY'.strip_indent)
-            x = { :"\tab" => 1 }
-                  ^^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
-          RUBY
-        end
-
-        it 'registers an offense when keys start with a digit' do
-          expect_offense(<<-RUBY.strip_indent)
-            x = { :"1" => 1 }
-                  ^^^^^^^ Use the new Ruby 1.9 hash syntax.
-          RUBY
-        end
+      it 'registers an offense when keys start with a digit' do
+        expect_offense(<<-RUBY.strip_indent)
+          x = { :"1" => 1 }
+                ^^^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
       end
 
       it 'auto-corrects old to new style' do
@@ -506,60 +463,25 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
 
-      context 'ruby < 2.2', :ruby21 do
-        it 'accepts hash rockets when keys have whitespaces in them' do
-          expect_no_offenses('x = { :"t o" => 0, :b => 1 }')
-        end
-
-        it 'registers an offense when keys have whitespaces and mix styles' do
-          inspect_source('x = { :"t o" => 0, b: 1 }')
-          expect(cop.messages).to eq(["Don't mix styles in the same hash."])
-          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-        end
-
-        it 'accepts hash rockets when keys have special symbols in them' do
-          expect_no_offenses('x = { :"\\tab" => 1, :b => 1 }')
-        end
-
-        it 'registers an offense when keys have special symbols and ' \
-          'mix styles' do
-          inspect_source('x = { :"\tab" => 1, b: 1 }')
-          expect(cop.messages).to eq(["Don't mix styles in the same hash."])
-          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-        end
-
-        it 'accepts hash rockets when keys start with a digit' do
-          expect_no_offenses('x = { :"1" => 1, :b => 1 }')
-        end
-
-        it 'registers an offense when keys start with a digit and mix styles' do
-          inspect_source('x = { :"1" => 1, b: 1 }')
-          expect(cop.messages).to eq(["Don't mix styles in the same hash."])
-          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-        end
+      it 'registers an offense when keys have whitespaces in them' do
+        expect_offense(<<-RUBY.strip_indent)
+          x = { :"t o" => 0 }
+                ^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
       end
 
-      context 'ruby >= 2.2', :ruby22 do
-        it 'registers an offense when keys have whitespaces in them' do
-          expect_offense(<<-RUBY.strip_indent)
-            x = { :"t o" => 0 }
-                  ^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
-          RUBY
-        end
+      it 'registers an offense when keys have special symbols in them' do
+        expect_offense(<<-'RUBY'.strip_indent)
+          x = { :"\tab" => 1 }
+                ^^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
+      end
 
-        it 'registers an offense when keys have special symbols in them' do
-          expect_offense(<<-'RUBY'.strip_indent)
-            x = { :"\tab" => 1 }
-                  ^^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
-          RUBY
-        end
-
-        it 'registers an offense when keys start with a digit' do
-          expect_offense(<<-RUBY.strip_indent)
-            x = { :"1" => 1 }
-                  ^^^^^^^ Use the new Ruby 1.9 hash syntax.
-          RUBY
-        end
+      it 'registers an offense when keys start with a digit' do
+        expect_offense(<<-RUBY.strip_indent)
+          x = { :"1" => 1 }
+                ^^^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
       end
 
       it 'auto-corrects old to new style' do


### PR DESCRIPTION
MRI 2.1 has been [EOL](https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/) for over one year. Time to drop official support? 🙂 

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
