### PR TITLE
[Fix #5987] Suppress errors when using ERB template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * [#5843](https://github.com/bbatsov/rubocop/issues/5843): Add configuration options to `Naming/MemoizedInstanceVariableName` cop to allow leading underscores. ([@leklund][])
 * [#5843](https://github.com/bbatsov/rubocop/issues/5843): Add `EnforcedStyleForLeadingUnderscores` to `Naming/MemoizedInstanceVariableName` cop to allow leading underscores. ([@leklund][])
 
+### Bug fixes
+
+* [#5987](https://github.com/rubocop-hq/rubocop/issues/5987): Suppress errors when using ERB template in Rails/BulkChangeTable. ([@wata727][])
+
 ## 0.57.2 (2018-06-12)
 
 ### Bug fixes

--- a/lib/rubocop/cop/rails/bulk_change_table.rb
+++ b/lib/rubocop/cop/rails/bulk_change_table.rb
@@ -76,7 +76,7 @@ module RuboCop
         MYSQL = 'mysql'.freeze
         POSTGRESQL = 'postgresql'.freeze
 
-        MIGRATIION_METHODS = %i[change up down].freeze
+        MIGRATION_METHODS = %i[change up down].freeze
 
         COMBINABLE_TRANSFORMATIONS = %i[
           primary_key
@@ -134,7 +134,7 @@ module RuboCop
 
         def on_def(node)
           return unless support_bulk_alter?
-          return unless MIGRATIION_METHODS.include?(node.method_name)
+          return unless MIGRATION_METHODS.include?(node.method_name)
           return unless node.body
 
           recorder = AlterMethodsRecorder.new

--- a/lib/rubocop/cop/rails/bulk_change_table.rb
+++ b/lib/rubocop/cop/rails/bulk_change_table.rb
@@ -196,6 +196,8 @@ module RuboCop
           config = yaml['development']
           return nil unless config.is_a?(Hash)
           config
+        rescue Psych::SyntaxError
+          nil
         end
 
         def support_bulk_alter?

--- a/spec/rubocop/cop/rails/bulk_change_table_spec.rb
+++ b/spec/rubocop/cop/rails/bulk_change_table_spec.rb
@@ -357,6 +357,8 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
   end
 
   context 'when `database.yml` is exists' do
+    let(:yaml) {}
+
     before do
       allow(File).to receive(:exist?)
         .with('config/database.yml')
@@ -388,6 +390,16 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
       end
 
       it_behaves_like 'offense for postgresql'
+    end
+
+    context 'invalid (e.g. ERB)' do
+      before do
+        allow(YAML).to receive(:load_file).with('config/database.yml') do
+          YAML.parse('pool: <%= Rails.env.production? ? 10 : 5 %>')
+        end
+      end
+
+      it_behaves_like 'no offense'
     end
   end
 end


### PR DESCRIPTION
Fixes #5987

Rails/BulkChangeTable cop raise an error when `database.yml` contains the syntax of ERB.

In this case, catches the error and treats `database.yml` as empty.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
