### PR TITLE
Fix markdown for UnneededSplatExpansion lint

### DIFF
--- a/lib/rubocop/cop/lint/unneeded_splat_expansion.rb
+++ b/lib/rubocop/cop/lint/unneeded_splat_expansion.rb
@@ -44,7 +44,7 @@ module RuboCop
       #   end
       #
       #   case foo
-      #   when *[1, 2, 3]
+      #   when 1, 2, 3
       #     bar
       #   else
       #     baz

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -2122,7 +2122,7 @@ rescue StandardError, ApplicationError
 end
 
 case foo
-when *[1, 2, 3]
+when 1, 2, 3
   bar
 else
   baz


### PR DESCRIPTION
In regards to the Lint/UnneededSplatExpansion cop the final example provided under 'good' section is a repeat of example provided under 'bad' and is assumed to be a mistake.