### PR TITLE
[Fix #5966] Fix a false positive for `Layout/ClosingHeredocIndentation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug fixes
 
 * [#5987](https://github.com/rubocop-hq/rubocop/issues/5987): Suppress errors when using ERB template in Rails/BulkChangeTable. ([@wata727][])
+* [#5966](https://github.com/bbatsov/rubocop/issues/5966): Fix a false positive for `Layout/ClosingHeredocIndentation` when heredoc content is outdented compared to the closing. ([@koic][])
 
 ## 0.57.2 (2018-06-12)
 

--- a/lib/rubocop/cop/layout/closing_heredoc_indentation.rb
+++ b/lib/rubocop/cop/layout/closing_heredoc_indentation.rb
@@ -55,13 +55,9 @@ module RuboCop
                   'beginning of method definition.'.freeze
 
         def on_heredoc(node)
-          return if heredoc_type(node) == SIMPLE_HEREDOC
-
-          if empty_heredoc?(node) ||
-             contents_indentation(node) >= closing_indentation(node)
-            return if opening_indentation(node) == closing_indentation(node)
-            return if argument_indentation_correct?(node)
-          end
+          return if heredoc_type(node) == SIMPLE_HEREDOC ||
+                    opening_indentation(node) == closing_indentation(node) ||
+                    argument_indentation_correct?(node)
 
           add_offense(node, location: :heredoc_end)
         end

--- a/spec/rubocop/cop/layout/closing_heredoc_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/closing_heredoc_indentation_spec.rb
@@ -72,6 +72,18 @@ RSpec.describe RuboCop::Cop::Layout::ClosingHeredocIndentation do
     RUBY
   end
 
+  it 'accepts correctly indented closing heredoc when ' \
+     'heredoc contents is before closing heredoc' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      include_examples :offense,
+                       <<-EOS
+                         foo
+        bar
+                         baz
+                       EOS
+    RUBY
+  end
+
   it 'registers an offence for bad indentation of a closing heredoc' do
     expect_offense(<<-RUBY.strip_indent)
       class Test
@@ -82,19 +94,6 @@ RSpec.describe RuboCop::Cop::Layout::ClosingHeredocIndentation do
       ^^^^^ `SQL` is not aligned with `<<-SQL`.
         end
       end
-    RUBY
-  end
-
-  it 'registers correctly indented closing heredoc when ' \
-     'heredoc contents is before closing heredoc' do
-    expect_offense(<<-RUBY.strip_indent)
-      include_examples :offense,
-                       <<-EOS
-                         foo
-        bar
-                         baz
-                       EOS
-      ^^^^^^^^^^^^^^^^^^^^ `EOS` is not aligned with `<<-EOS` or beginning of method definition.
     RUBY
   end
 


### PR DESCRIPTION
Fixes #5966.

This PR fixes the following false positive.

```ruby
def f
  puts <<-STR
 There's one space before this line
  STR
end
```

Originally, the reason for adding this rule was that codes using squiggly heredoc (,`strip_indent` and `strip_heredoc`) was oddly changed by auto-correct.
https://github.com/rubocop-hq/rubocop/pull/5557#discussion_r169883584

However, as indicated in this issue, I didn't consider case for simple heredoc that without `strip_heredoc` or` strip_indent`.

This PR will change the rule changed in #5943.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
