### PR TITLE
Add `bin/setup` script to bin dir

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install


### PR DESCRIPTION
Currently, A Gem made with `bundle gem <gem-name>` provides `bin/setup` command and `bin/console` command.
https://github.com/bundler/bundler/tree/v1.16.2/lib/bundler/templates/newgem/bin

`bin/setup` command is for setting up development.
RuboCop requires only the `bundle install` setup, so there may be not much merit. However, developers trying to participate in a new development may first think of `bin/setup`.

Although I'm not sure the frequency of the aspect to be used, but I opened this PR because `bin/setup` command may be able to help First step.

Related PR #5906.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
