### PR TITLE
Remove `rake repl` task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 * [#5987](https://github.com/rubocop-hq/rubocop/issues/5987): Suppress errors when using ERB template in Rails/BulkChangeTable. ([@wata727][])
 
+### Changes
+
+* [#6006](https://github.com/bbatsov/rubocop/pull/6006): Remove `rake repl` task. ([@koic][])
+
 ## 0.57.2 (2018-06-12)
 
 ### Bug fixes

--- a/Rakefile
+++ b/Rakefile
@@ -61,16 +61,6 @@ task default: %i[
 require 'yard'
 YARD::Rake::YardocTask.new
 
-desc 'Open a REPL for experimentation'
-task :repl do
-  warn 'DEPRECATION WARNING: `rake repl` is deprecated and ' \
-       'will be removed in RuboCop 0.58.0. Please use `bin/console`.'
-  require 'pry'
-  require 'rubocop'
-  ARGV.clear
-  RuboCop.pry
-end
-
 desc 'Benchmark a cop on given source file/dir'
 task :bench_cop, %i[cop srcpath times] do |_task, args|
   require 'benchmark'


### PR DESCRIPTION
Follow up of #5906.
This PR removes `rake repl` task.

New features have been added to the master branch after RuboCop 0.57.2. So I guess that the minor version will rise and the next version of RuboCop will be 0.58.0.
https://github.com/rubocop-hq/rubocop/blob/38550ff/CHANGELOG.md#master-unreleased

This PR will remove `rake repl` according to the following warning.

```console
% rake repl
DEPRECATION WARNING: `rake repl` is deprecated and will be removed in
RuboCop 0.58.0. Please use `bin/console`.
[1] pry(RuboCop)>
```

In the future development REPL will be unified into `bin/console`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
