### PR TITLE
Add SemVer compatibility badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Coverage Status](https://img.shields.io/codeclimate/coverage/github/bbatsov/rubocop.svg)](https://codeclimate.com/github/bbatsov/rubocop)
 [![Code Climate](https://codeclimate.com/github/bbatsov/rubocop/badges/gpa.svg)](https://codeclimate.com/github/bbatsov/rubocop)
 [![Inline docs](http://inch-ci.org/github/bbatsov/rubocop.svg)](http://inch-ci.org/github/bbatsov/rubocop)
+[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=rubocop&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=rubocop&package-manager=bundler&version-scheme=semver)
 
 [![Patreon](https://img.shields.io/badge/patreon-donate-orange.svg)](https://www.patreon.com/bbatsov)
 [![Liberapay](https://liberapay.com/assets/widgets/donate.svg)](https://liberapay.com/bbatsov/donate)


### PR DESCRIPTION
First up, thanks for rubocop - I genuinely don't know what I'd do without it. As a solo developer it is totally invaluable for keeping my code maintainable.

In preparation for rubocop's glorious 1.0.0-ing, I put together this badge showing how compatible each release is. It shows SemVer compliance in the main badge (so currently just says "pre-1.0.0") but if you click it you can see how compatible each update was (as well as an explanation of how it's calculated):

[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=rubocop&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=rubocop&package-manager=bundler&version-scheme=semver)

The scores for individual version updates are pretty interesting: you can see what a good job has been done of keeping new cops / breaking changes out of patch releases:

![image](https://user-images.githubusercontent.com/1144873/41498537-30d132c8-713e-11e8-9dc3-41ea7e2d5099.png)

Any feedback super appreciated - I put this together based on Dependabot's data (we do a *lot* of rubocop updates) and just want to make it useful. If there's anything you'd change please just let me know.