### PR TITLE
Fix auto-correct support check for custom cops on --auto-gen-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * [#5987](https://github.com/rubocop-hq/rubocop/issues/5987): Suppress errors when using ERB template in Rails/BulkChangeTable. ([@wata727][])
 * [#5966](https://github.com/bbatsov/rubocop/issues/5966): Fix a false positive for `Layout/ClosingHeredocIndentation` when heredoc content is outdented compared to the closing. ([@koic][])
+* Fix auto-correct support check for custom cops on --auto-gen-config. ([@r7kamura][])
 
 ### Changes
 
@@ -3437,3 +3438,4 @@
 [@sunny]: https://github.com/sunny
 [@tatsuyafw]: https://github.com/tatsuyafw
 [@alexander-lazarov]: https://github.com/alexander-lazarov
+[@r7kamura]: https://github.com/r7kamura

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -23,8 +23,9 @@ module RuboCop
     # Registry that tracks all cops by their badge and department.
     class Registry
       def initialize(cops = [])
-        @registry    = {}
+        @registry = {}
         @departments = {}
+        @cops_by_cop_name = Hash.new { |hash, key| hash[key] = [] }
 
         cops.each { |cop| enlist(cop) }
       end
@@ -33,6 +34,7 @@ module RuboCop
         @registry[cop.badge] = cop
         @departments[cop.department] ||= []
         @departments[cop.department] << cop
+        @cops_by_cop_name[cop.cop_name] << cop
       end
 
       # @return [Array<Symbol>] list of departments for current cops.
@@ -102,8 +104,9 @@ module RuboCop
         end
       end
 
+      # @return [Hash{String => Array<Class>}]
       def to_h
-        cops.group_by(&:cop_name)
+        @cops_by_cop_name
       end
 
       def cops
@@ -140,6 +143,12 @@ module RuboCop
 
       def each(&block)
         cops.each(&block)
+      end
+
+      # @param [String] cop_name
+      # @return [Class, nil]
+      def find_by_cop_name(cop_name)
+        @cops_by_cop_name[cop_name].first
       end
 
       private

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -18,8 +18,6 @@ module RuboCop
       @config_to_allow_offenses = {}
       @detected_styles = {}
 
-      COPS = Cop::Cop.registry.to_h
-
       class << self
         attr_accessor :config_to_allow_offenses, :detected_styles
       end
@@ -101,7 +99,9 @@ module RuboCop
         if @show_offense_counts
           output_buffer.puts "# Offense count: #{offense_count}"
         end
-        if COPS[cop_name] && COPS[cop_name].first.new.support_autocorrect?
+
+        cop_class = Cop::Cop.registry.find_by_cop_name(cop_name)
+        if cop_class && cop_class.new.support_autocorrect?
           output_buffer.puts '# Cop supports --auto-correct.'
         end
 

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -242,4 +242,46 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
       expect(output.string).to eq(heading)
     end
   end
+
+  context 'with auto-correct supported cop' do
+    before do
+      module Test
+        class Cop3 < ::RuboCop::Cop::Cop
+          def autocorrect
+            # Dummy method to respond to #support_autocorrect?
+          end
+        end
+      end
+
+      formatter.started(['test_auto_correct.rb'])
+      formatter.file_started('test_auto_correct.rb', {})
+      formatter.file_finished('test_auto_correct.rb', offenses)
+      formatter.finished(['test_auto_correct.rb'])
+    end
+
+    let(:expected_rubocop_todo) do
+      [heading,
+       '# Offense count: 1',
+       '# Cop supports --auto-correct.',
+       'Test/Cop3:',
+       '  Exclude:',
+       "    - 'test_auto_correct.rb'",
+       ''].join("\n")
+    end
+
+    let(:offenses) do
+      [
+        RuboCop::Cop::Offense.new(
+          :convention,
+          location,
+          'message',
+          'Test/Cop3'
+        )
+      ]
+    end
+
+    it 'adds a comment about --auto-correct option' do
+      expect(output.string).to eq(expected_rubocop_todo)
+    end
+  end
 end


### PR DESCRIPTION
Although some cops defined in rubocop-rspec support auto-correct mechanism, no `"# Cop supports --auto-correct."` messages will be written into .rubocop_todo.yml.

This is because the result of `RuboCop::Cop::Cop.registry.to_h` is being cached at the time `Rubocop::Formatter::DisabledConfigFormatter::COPS` is defined.

This commit resolves it by removing the intermediate cache.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] ~~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~~
    * No issue found about this PR.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
