### PR TITLE
Add missing example for Style EndBlock documentation

### DIFF
--- a/lib/rubocop/cop/style/end_block.rb
+++ b/lib/rubocop/cop/style/end_block.rb
@@ -4,6 +4,14 @@ module RuboCop
   module Cop
     module Style
       # This cop checks for END blocks.
+      #
+      # @example
+      #   # bad
+      #   END { puts 'Goodbye!' }
+      #
+      #   # good
+      #   at_exit { puts 'Goodbye!' }
+      #
       class EndBlock < Cop
         MSG = 'Avoid the use of `END` blocks. ' \
               'Use `Kernel#at_exit` instead.'.freeze

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1695,6 +1695,16 @@ Enabled | No
 
 This cop checks for END blocks.
 
+### Examples
+
+```ruby
+# bad
+END { puts 'Goodbye!' }
+
+# good
+at_exit { puts 'Goodbye!' }
+```
+
 ### References
 
 * [https://github.com/rubocop-hq/ruby-style-guide#no-END-blocks](https://github.com/rubocop-hq/ruby-style-guide#no-END-blocks)


### PR DESCRIPTION
Missing example for Style/EndBlock documentation.
Related to: #3808

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages]
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

