### PR TITLE
Add missing examples for RangeInclude and Style Encoding cops

### DIFF
--- a/lib/rubocop/cop/performance/range_include.rb
+++ b/lib/rubocop/cop/performance/range_include.rb
@@ -9,11 +9,17 @@ module RuboCop
       # end points of the `Range`. In a great majority of cases, this is what
       # is wanted.
       #
-      # Here is an example of a case where `Range#cover?` may not provide the
-      # desired result:
+      # @example
+      #   # bad
+      #   ('a'..'z').include?('b') # => true
       #
-      #     ('a'..'z').cover?('yellow') # => true
+      #   # good
+      #   ('a'..'z').cover?('b') # => true
       #
+      #   # Example of a case where `Range#cover?` may not provide
+      #   # the desired result:
+      #
+      #   ('a'..'z').cover?('yellow') # => true
       class RangeInclude < Cop
         MSG = 'Use `Range#cover?` instead of `Range#include?`.'.freeze
 

--- a/lib/rubocop/cop/style/encoding.rb
+++ b/lib/rubocop/cop/style/encoding.rb
@@ -4,6 +4,11 @@ module RuboCop
   module Cop
     module Style
       # This cop checks ensures source files have no utf-8 encoding comments.
+      # @example
+      #   # bad
+      #   # encoding: UTF-8
+      #   # coding: UTF-8
+      #   # -*- coding: UTF-8 -*-
       class Encoding < Cop
         include RangeHelp
 

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -450,10 +450,20 @@ item in a `Range` to see if a specified item is there. In contrast,
 end points of the `Range`. In a great majority of cases, this is what
 is wanted.
 
-Here is an example of a case where `Range#cover?` may not provide the
-desired result:
+### Examples
 
-    ('a'..'z').cover?('yellow') # => true
+```ruby
+# bad
+('a'..'z').include?('b') # => true
+
+# good
+('a'..'z').cover?('b') # => true
+
+# Example of a case where `Range#cover?` may not provide
+# the desired result:
+
+('a'..'z').cover?('yellow') # => true
+```
 
 ### References
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1683,6 +1683,15 @@ Enabled | Yes
 
 This cop checks ensures source files have no utf-8 encoding comments.
 
+### Examples
+
+```ruby
+# bad
+# encoding: UTF-8
+# coding: UTF-8
+# -*- coding: UTF-8 -*-
+```
+
 ### References
 
 * [https://github.com/rubocop-hq/ruby-style-guide#utf-8](https://github.com/rubocop-hq/ruby-style-guide#utf-8)


### PR DESCRIPTION
Missing examples for RangeInclude and Style/Encoding cops
Related to: #3808

-----------------
Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages]
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

