### PR TITLE
Fix #3299 Add offense for private_class_method without arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 * [#6006](https://github.com/bbatsov/rubocop/pull/6006): Remove `rake repl` task. ([@koic][])
 * [#5990](https://github.com/bbatsov/rubocop/pull/5990): Drop support for MRI 2.1. ([@drenmi][])
+* [#3299](https://github.com/bbatsov/rubocop/issues/3299): `Lint/UselessAccessModifier` now warns when `private_class_method` is used without arguments. ([@Darhazer][])
 
 ## 0.57.2 (2018-06-12)
 

--- a/spec/rubocop/cop/lint/ineffective_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/ineffective_access_modifier_spec.rb
@@ -49,6 +49,22 @@ RSpec.describe RuboCop::Cop::Lint::IneffectiveAccessModifier do
     end
   end
 
+  context 'when no access modifier is used' do
+    it "doesn't register an offense" do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class C
+          def self.method
+            puts "hi"
+          end
+
+          def self.method2
+            puts "hi"
+          end
+        end
+      RUBY
+    end
+  end
+
   context 'when a `class << self` block is used' do
     it "doesn't register an offense" do
       expect_no_offenses(<<-RUBY.strip_indent)

--- a/spec/rubocop/cop/lint/ineffective_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/ineffective_access_modifier_spec.rb
@@ -34,18 +34,37 @@ RSpec.describe RuboCop::Cop::Lint::IneffectiveAccessModifier do
   end
 
   context 'when `private_class_method` is used' do
-    it "doesn't register an offense" do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        class C
-          private
+    context 'when `private_class_method` contains all private method names' do
+      it "doesn't register an offense" do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          class C
+            private
 
-          def self.method
-            puts "hi"
+            def self.method
+              puts "hi"
+            end
+
+            private_class_method :method
           end
+        RUBY
+      end
+    end
 
-          private_class_method :method
-        end
-      RUBY
+    context 'when `private_class_method` does not contain the method' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
+          class C
+            private
+
+            def self.method2
+            ^^^ `private` (on line 2) does not make singleton methods private. Use `private_class_method` or `private` inside a `class << self` block instead.
+              puts "hi"
+            end
+
+            private_class_method :method
+          end
+        RUBY
+      end
     end
   end
 

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -163,6 +163,21 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier do
     end
   end
 
+  context 'when private_class_method is used without arguments' do
+    it 'registers an offense' do
+      expect_offense(<<-RUBY.strip_indent)
+        class SomeClass
+          private_class_method
+          ^^^^^^^^^^^^^^^^^^^^ Useless `private_class_method` access modifier.
+
+          def self.some_method
+            puts 10
+          end
+        end
+      RUBY
+    end
+  end
+
   context "when using ActiveSupport's `concerning` method" do
     let(:config) do
       RuboCop::Config.new(
@@ -670,7 +685,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier do
       end
 
       it 'registers two offenses when a modifier is inside and outside the ' \
-        ' and no method is defined' do
+        ' block and no method is defined' do
         src = <<-RUBY.strip_indent
           class A
             #{modifier}


### PR DESCRIPTION
* Refactored IneffectiveAccessModifier cop so it doesn't use any instance variables to track current state
* Added more tests to the IneffectiveAccessModifier cop
* The above was done in an attempt to make IneffectiveAccessModifier handle `private_class_method` with no arguments, but I eventually decided that the cop can't handle this reasonably, as it can't guess which methods were meant to be set as private (it may highlight just the first method after private_class_method or all static methods after it?)
* Added offense in `UselessAccessModifier` cop for private_class_method without any arguments, as well as if the class contains only private_class_method call.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
