### PR TITLE
Fix incorrect autocorrect for `Style/UnneededCondition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#5966](https://github.com/bbatsov/rubocop/issues/5966): Fix a false positive for `Layout/ClosingHeredocIndentation` when heredoc content is outdented compared to the closing. ([@koic][])
 * Fix auto-correct support check for custom cops on --auto-gen-config. ([@r7kamura][])
 * Fix exception that occurs when auto-correcting a modifier if statement in `Style/UnneededCondition`. ([@rrosenblum][])
+* [#6025](https://github.com/bbatsov/rubocop/pull/6025): Fix an incorrect auto-correct for `Lint/UnneededCondition` when using if_branch in `else` branch. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/unneeded_condition.rb
+++ b/lib/rubocop/cop/style/unneeded_condition.rb
@@ -37,7 +37,9 @@ module RuboCop
         UNNEEDED_CONDITION = 'This condition is not needed.'.freeze
 
         def on_if(node)
+          return if node.elsif_conditional?
           return unless offense?(node)
+
           add_offense(node, location: range_of_offense(node))
         end
 
@@ -72,15 +74,19 @@ module RuboCop
         end
 
         def offense?(node)
-          return false if node.elsif_conditional?
-
           condition, if_branch, else_branch = *node
+
+          return false if use_if_branch?(else_branch)
 
           condition == if_branch && !node.elsif? && (
             node.ternary? ||
             !else_branch.instance_of?(AST::Node) ||
             else_branch.single_line?
           )
+        end
+
+        def use_if_branch?(else_branch)
+          else_branch && else_branch.if_type?
         end
 
         def else_source(else_branch)

--- a/spec/rubocop/cop/style/unneeded_condition_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_condition_spec.rb
@@ -72,6 +72,18 @@ RSpec.describe RuboCop::Cop::Style::UnneededCondition do
           RUBY
         end
       end
+
+      context 'when using ternary if in `else` branch' do
+        it 'registers no offense' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            if a
+              a
+            else
+              b ? c : d
+            end
+          RUBY
+        end
+      end
     end
 
     describe '#autocorrection' do


### PR DESCRIPTION
## Summary

Follow up of https://github.com/rubocop-hq/rubocop/issues/6013#issuecomment-398243569.
(This fixes a part reported at #6013.)

This PR fixes the following incorrect auto-correct.

```
% cat example.rb
if a
  a
else
  b ? c : d
end
% rubocop example.rb --only Style/UnneededCondition -a
```

### Expected behavior

```ruby
a || (b ? c : d)
```

### Actual behavior

```ruby
a || b ? c : d
```

I'm not sure whether it is easy to read nested conditional expressions as one liner.
So, this PR will not detect offenses, it does not auto-correct.

In any case, it is not good to break the code with auto-correct.

## Other Information

In order to suppress the following offense, product code has been refactored slightly.

```console
C: Metrics/CyclomaticComplexity: Cyclomatic complexity for offense? is
too high. [7/6]
        def offense?(node) ...
        ^^^^^^^^^^^^^^^^^^
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
