### PR TITLE
Exclude `refine` by default on BlockLength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#6006](https://github.com/bbatsov/rubocop/pull/6006): Remove `rake repl` task. ([@koic][])
 * [#5990](https://github.com/bbatsov/rubocop/pull/5990): Drop support for MRI 2.1. ([@drenmi][])
 * [#3299](https://github.com/bbatsov/rubocop/issues/3299): `Lint/UselessAccessModifier` now warns when `private_class_method` is used without arguments. ([@Darhazer][])
+* [#6026](https://github.com/rubocop-hq/rubocop/pull/6026): Exclude `refine` by default from `Metrics/BlockLength` cop. ([@kddeisz][])
 
 ## 0.57.2 (2018-06-12)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1552,7 +1552,10 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   CountComments: false  # count full line comments?
   Max: 25
-  ExcludedMethods: []
+  ExcludedMethods:
+    # By default, exclude the `#refine` method, as it tends to have larger
+    # associated blocks.
+    - refine
 
 Metrics/BlockNesting:
   CountBlocks: false

--- a/manual/cops_metrics.md
+++ b/manual/cops_metrics.md
@@ -37,7 +37,7 @@ Name | Default value | Configurable values
 --- | --- | ---
 CountComments | `false` | Boolean
 Max | `25` | Integer
-ExcludedMethods | `[]` | Array
+ExcludedMethods | `refine` | Array
 
 ## Metrics/BlockNesting
 


### PR DESCRIPTION
Refine blocks necessarily become large as they end up effectively being mini class definitions. Inevitably if you're heavily using refinements you're going to have to shut off `refine` from this cop. This should be a default.