### PR TITLE
WIP: Extend Cop metadata #5978

### DIFF
--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -17,6 +17,7 @@ require_relative 'rubocop/version'
 
 require_relative 'rubocop/path_util'
 require_relative 'rubocop/file_finder'
+require_relative 'rubocop/cop_finder'
 require_relative 'rubocop/platform'
 require_relative 'rubocop/string_util'
 require_relative 'rubocop/name_similarity'

--- a/lib/rubocop/cop_finder.rb
+++ b/lib/rubocop/cop_finder.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'pathname'
+
+module RuboCop
+  # Common methods for finding files.
+  class CopFinder
+    RELEASE_PATH = 'relnotes'.freeze
+    IGNORED_FOLDERS = %w[. ..].freeze
+    COP_NAME_PATTERN = /`(.*?)`/
+    VERSION_PATTERN = /\d+(\.\d+)*/
+    COP_ADDED_PATTERN = /^(?=.*\bnew\b)(?=.*\bcop\b).*$/i
+
+    attr_reader :registry
+
+    def initialize
+      @registry = Cop::Cop.registry
+    end
+
+    def cops_with_version_added
+      cops_with_version(regex_pattern: COP_ADDED_PATTERN)
+    end
+
+    def cops_with_version(regex_pattern:)
+      {}.tap do |cops_with_version|
+        release_notes = (Dir.entries(RELEASE_PATH) - IGNORED_FOLDERS)
+        release_notes.each do |relnote|
+          version = relnote[VERSION_PATTERN]
+          found_cops = search_in_relnote(relnote: relnote,
+                                         regex_pattern: regex_pattern)
+
+          found_cops.each do |found_cop|
+            qualified_cop_name = registry.qualified_cop_name(found_cop, Dir.pwd)
+            next unless registry.contains_cop_matching?(qualified_cop_name)
+
+            cops_with_version[qualified_cop_name] = version
+          end
+        end
+      end
+    end
+
+    def search_in_relnote(relnote:, regex_pattern:)
+      relnotes = File.readlines(File.join(RELEASE_PATH, relnote))
+
+      [].tap do |found_cops|
+        relnotes.grep(regex_pattern).each do |line|
+          found_cops << line[COP_NAME_PATTERN, 1]
+        end
+      end.compact
+    end
+  end
+end


### PR DESCRIPTION
This PR is intended to extend the cop metadata as described in this issue https://github.com/rubocop-hq/rubocop/issues/5978. Currently only the empty VersionAdded meta data is added here, the others meta data fields will follow. However, I would like to clarify once whether my implementation corresponds to this as it is intended. And whether I should continue or what I should change or improve.

### ToDo

* [x] Add VersionAdded - the RuboCop version in which it was added 
  * [ ] Fill VersionAdded 
* [ ] Add VersionChanged - the RuboCop version in which it was changed in a user-impacting way (new config, updated defaults, etc)
* [ ] Add VersionRemoved - the RuboCop version in which the cop was removed for whatever reason.
* [ ] Add Safe (true/false) - indicates whether the cop can yield false positives (by design) or not.
* [ ] Add SafeAutoCorrect (true/false) - indicates whether the auto-correct the cop does is safe (equivalent) by design.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
