### PR TITLE
[Fix #6029] Fix false positive for `Lint/ShadowedArgument`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix auto-correct support check for custom cops on --auto-gen-config. ([@r7kamura][])
 * Fix exception that occurs when auto-correcting a modifier if statement in `Style/UnneededCondition`. ([@rrosenblum][])
 * [#6025](https://github.com/bbatsov/rubocop/pull/6025): Fix an incorrect auto-correct for `Lint/UnneededCondition` when using if_branch in `else` branch. ([@koic][])
+* [#6029](https://github.com/bbatsov/rubocop/issues/6029): Fix a false positive for `Lint/ShadowedArgument` when reassigning to splat variable. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/shadowed_argument.rb
+++ b/lib/rubocop/cop/lint/shadowed_argument.rb
@@ -77,9 +77,7 @@ module RuboCop
             next if references.any? do |reference|
               next true if !reference.explicit? && ignore_implicit_references?
 
-              reference_pos = reference.node.source_range.begin_pos
-
-              reference_pos <= assignment_without_usage_pos
+              reference_pos(reference.node) <= assignment_without_usage_pos
             end
 
             yield location_known ? node : argument.declaration_node
@@ -113,6 +111,12 @@ module RuboCop
 
             location_known
           end
+        end
+
+        def reference_pos(node)
+          node = node.parent.masgn_type? ? node.parent : node
+
+          node.source_range.begin_pos
         end
 
         # Check whether the given node is nested into block or conditional.

--- a/spec/rubocop/cop/lint/shadowed_argument_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_argument_spec.rb
@@ -53,6 +53,29 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedArgument, :config do
         end
       end
 
+      context 'when a splat argument is shadowed' do
+        it 'registers an offense' do
+          expect_offense(<<-RUBY.strip_indent)
+            def do_something(*items)
+              *items, last = [42, 42]
+               ^^^^^ Argument `items` was shadowed by a local variable before it was used.
+              puts items
+            end
+          RUBY
+        end
+      end
+
+      context 'when reassigning to splat variable' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            def do_something(*items)
+              *items, last = items
+              puts items
+            end
+          RUBY
+        end
+      end
+
       context 'when binding is used' do
         it 'registers an offense' do
           expect_offense(<<-RUBY.strip_indent)


### PR DESCRIPTION
Fixes #6029.

This PR fixes a false positive for `Lint/ShadowedArgument` when reassigning to splat variable.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
