### PR TITLE
[Fix #6036] Make `Rails/BulkChangeTable` aware of string table name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix auto-correct support check for custom cops on --auto-gen-config. ([@r7kamura][])
 * Fix exception that occurs when auto-correcting a modifier if statement in `Style/UnneededCondition`. ([@rrosenblum][])
 * [#6025](https://github.com/bbatsov/rubocop/pull/6025): Fix an incorrect auto-correct for `Lint/UnneededCondition` when using if_branch in `else` branch. ([@koic][])
+* [#6036](https://github.com/rubocop-hq/rubocop/issues/6036): Make `Rails/BulkChangeTable` aware of string table name. ([@wata727][])
 
 ### Changes
 

--- a/lib/rubocop/ast/node/str_node.rb
+++ b/lib/rubocop/ast/node/str_node.rb
@@ -6,6 +6,8 @@ module RuboCop
     # in place of a plain node when the builder constructs the AST, making
     # its methods available to all `str` nodes within RuboCop.
     class StrNode < Node
+      include BasicLiteralNode
+
       def heredoc?
         loc.is_a?(Parser::Source::Map::Heredoc)
       end

--- a/lib/rubocop/cop/rails/bulk_change_table.rb
+++ b/lib/rubocop/cop/rails/bulk_change_table.rb
@@ -168,7 +168,7 @@ module RuboCop
 
         # @param node [RuboCop::AST::SendNode] (send nil? :change_table ...)
         def include_bulk_options?(node)
-          # arguments: [(sym :table) (hash (pair (sym :bulk) _))]
+          # arguments: [{(sym :table)(str "table")} (hash (pair (sym :bulk) _))]
           options = node.arguments[1]
           return false unless options
           options.hash_type? &&
@@ -233,7 +233,7 @@ module RuboCop
 
         # @param node [RuboCop::AST::SendNode]
         def add_offense_for_alter_methods(node)
-          # arguments: [(sym :table) ...]
+          # arguments: [{(sym :table)(str "table")} ...]
           table_name = node.arguments[0].value
           message = format(MSG_FOR_ALTER_METHODS, table: table_name)
           add_offense(node, message: message)
@@ -253,9 +253,11 @@ module RuboCop
 
           # @param new_node [RuboCop::AST::SendNode]
           def process(new_node)
-            # arguments: [(sym :table) ...]
-            table_name = new_node.arguments[0]
-            flush unless @nodes.all? { |node| node.arguments[0] == table_name }
+            # arguments: [{(sym :table)(str "table")} ...]
+            table_name = new_node.arguments[0].value.to_s
+            flush unless @nodes.all? do |node|
+              node.arguments[0].value.to_s == table_name
+            end
             @nodes << new_node
           end
 

--- a/spec/rubocop/cop/rails/bulk_change_table_spec.rb
+++ b/spec/rubocop/cop/rails/bulk_change_table_spec.rb
@@ -333,6 +333,26 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
         end
       RUBY
     end
+
+    it 'register an offense when using string as table name' do
+      expect_offense(<<-RUBY.strip_indent)
+        def change
+          remove_index "users", :name
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ You can use `change_table :users, bulk: true` to combine alter queries.
+          remove_index "users", :address
+        end
+      RUBY
+    end
+
+    it 'register an offense when using mixed style table name' do
+      expect_offense(<<-RUBY.strip_indent)
+        def change
+          remove_index "users", :name
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ You can use `change_table :users, bulk: true` to combine alter queries.
+          remove_index :users, :address
+        end
+      RUBY
+    end
   end
 
   context 'when database is PostgreSQL' do


### PR DESCRIPTION
Fixes #6036

Some ALTER methods accept not only symbols but also strings as table names. Since this cop assumes only symbols, an error will occur if strings are received.

```
$ rubocop _0.57.2_ --only Rails/BulkChangeTable -d db/migrate/test.rb
Scanning /Users/watanabekazuma/workspace/ruby/rubocop/db/migrate/test.rb
An error occurred while Rails/BulkChangeTable cop was inspecting
/Users/watanabekazuma/workspace/ruby/rubocop/db/migrate/test.rb:6:2.
undefined method `value' for s(:str, "api_keys"):RuboCop::AST::StrNode
/Users/watanabekazuma/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.57.2/lib/rubocop/cop/rails/bulk_change_table.rb:235:in `add_offense_for_alter_methods'
/Users/watanabekazuma/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.57.2/lib/rubocop/cop/rails/bulk_change_table.rb:150:in `block in on_def'
/Users/watanabekazuma/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.57.2/lib/rubocop/cop/rails/bulk_change_table.rb:150:in `each'
/Users/watanabekazuma/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.57.2/lib/rubocop/cop/rails/bulk_change_table.rb:150:in `on_def`
```

In order to fix this bug, add `StrNode#value` method. In addition, it fixes the false negative that occurred when using symbols and strings as table names at the same time.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
