### PR TITLE
Fix `Lint/RedundantWithObject` error on missing argument to *with_object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#6029](https://github.com/bbatsov/rubocop/issues/6029): Fix a false positive for `Lint/ShadowedArgument` when reassigning to splat variable. ([@koic][])
 * [#6036](https://github.com/rubocop-hq/rubocop/issues/6036): Make `Rails/BulkChangeTable` aware of string table name. ([@wata727][])
 * [#5467](https://github.com/bbatsov/rubocop/issues/5467): Fix a false negative for `Style/MultipleComparison` when multiple comparison is not part of a conditional. ([@koic][])
+* [#6042](https://github.com/rubocop-hq/rubocop/pull/6042): Fix `Lint/RedundantWithObject` error on missing parameter to `each_with_object`. ([@Vasfed][])
 
 ### Changes
 
@@ -3449,3 +3450,4 @@
 [@tatsuyafw]: https://github.com/tatsuyafw
 [@alexander-lazarov]: https://github.com/alexander-lazarov
 [@r7kamura]: https://github.com/r7kamura
+[@Vasfed]: https://github.com/Vasfed

--- a/lib/rubocop/cop/lint/redundant_with_object.rb
+++ b/lib/rubocop/cop/lint/redundant_with_object.rb
@@ -36,7 +36,7 @@ module RuboCop
         def_node_matcher :redundant_with_object?, <<-PATTERN
           (block
             $(send _ {:each_with_object :with_object}
-              (_))
+              _)
             (args
               (arg _))
             ...)

--- a/spec/rubocop/cop/lint/redundant_with_object_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_with_object_spec.rb
@@ -74,4 +74,14 @@ RSpec.describe RuboCop::Cop::Lint::RedundantWithObject do
   it 'an object is used as a block argument' do
     expect_no_offenses('ary.each_with_object([]) { |v, o| v; o }')
   end
+
+  context 'when missing argument to `each_with_object`' do
+    it 'does not register an offense when block has 2 arguments' do
+      expect_no_offenses('ary.each_with_object { |v, o| v; o }')
+    end
+
+    it 'does not register an offense when block has 1 argument' do
+      expect_no_offenses('ary.each_with_object { |v| v }')
+    end
+  end
 end


### PR DESCRIPTION
When a user has missing argument to `each_with_object` in their code - rubocop fails with
```
An error occurred while Lint/RedundantWithObject cop was inspecting (filename)
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
```
and `undefined method 'children' for nil:NilClass` in backtrace.

This PR makes matcher in corresponding cop more permissive thus fixing the error.

-----------------

Before submitting the PR make sure the following are checked:

* [v] Wrote [good commit messages][1].
* [n/a] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [v] Feature branch is up-to-date with `master` (if not - rebase it).
* [v] Squashed related commits together.
* [v] Added tests.
* [n/a] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [b] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [v] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
