### PR TITLE
Change URL of rubocop-emacs repo

### DIFF
--- a/manual/integration_with_other_tools.md
+++ b/manual/integration_with_other_tools.md
@@ -2,7 +2,7 @@
 
 ### Emacs
 
-[rubocop.el](https://github.com/bbatsov/rubocop-emacs) is a simple
+[rubocop.el](https://github.com/rubocop-hq/rubocop-emacs) is a simple
 Emacs interface for RuboCop. It allows you to run RuboCop inside Emacs
 and quickly jump between problems in your code.
 


### PR DESCRIPTION
Follow up of #5935 and #6044.

rubocop-emacs repo has been moved from bbatsov/rubocop-emacs to rubocop-hq/rubocop-emacs.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
