### PR TITLE
[Fix #5467] Fix a false negative for `Style/MultipleComparison`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#6025](https://github.com/bbatsov/rubocop/pull/6025): Fix an incorrect auto-correct for `Lint/UnneededCondition` when using if_branch in `else` branch. ([@koic][])
 * [#6029](https://github.com/bbatsov/rubocop/issues/6029): Fix a false positive for `Lint/ShadowedArgument` when reassigning to splat variable. ([@koic][])
 * [#6036](https://github.com/rubocop-hq/rubocop/issues/6036): Make `Rails/BulkChangeTable` aware of string table name. ([@wata727][])
+* [#5467](https://github.com/bbatsov/rubocop/issues/5467): Fix a false negative for `Style/MultipleComparison` when multiple comparison is not part of a conditional. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/multiple_comparison.rb
+++ b/lib/rubocop/cop/style/multiple_comparison.rb
@@ -18,8 +18,12 @@ module RuboCop
         MSG = 'Avoid comparing a variable with multiple items ' \
           'in a conditional, use `Array#include?` instead.'.freeze
 
-        def on_if(node)
-          return unless nested_variable_comparison?(node.condition)
+        def on_or(node)
+          root_of_or_node = root_of_or_node(node)
+
+          return unless node == root_of_or_node
+          return unless nested_variable_comparison?(root_of_or_node)
+
           add_offense(node)
         end
 
@@ -70,6 +74,16 @@ module RuboCop
 
         def comparison?(node)
           simple_comparison?(node) || nested_comparison?(node)
+        end
+
+        def root_of_or_node(or_node)
+          return or_node unless or_node.parent
+
+          if or_node.parent.or_type?
+            root_of_or_node(or_node.parent)
+          else
+            or_node
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/multiple_comparison_spec.rb
+++ b/spec/rubocop/cop/style/multiple_comparison_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::Style::MultipleComparison do
     expect_offense(<<-RUBY.strip_indent)
       a = "a"
       if a == "a" || a == "b"
-      ^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
+         ^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
         print a
       end
     RUBY
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::Style::MultipleComparison do
     expect_offense(<<-RUBY.strip_indent)
       a = "a"
       if a == "a" || a == "b" || a == "c"
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
         print a
       end
     RUBY
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::Cop::Style::MultipleComparison do
     expect_offense(<<-RUBY.strip_indent)
       a = "a"
       if "a" == a || "b" == a || "c" == a
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
         print a
       end
     RUBY
@@ -50,8 +50,18 @@ RSpec.describe RuboCop::Cop::Style::MultipleComparison do
     expect_offense(<<-RUBY.strip_indent)
       a = "a"
       if a == "a" || "b" == a || a == "c"
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
         print a
+      end
+    RUBY
+  end
+
+  it 'registers an offense when multiple comparison is not ' \
+     'part of a conditional' do
+    expect_offense(<<-RUBY.strip_indent)
+      def foo(x)
+        x == 1 || x == 2 || x == 3
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
       end
     RUBY
   end


### PR DESCRIPTION
Fixes #5467.

This PR fixes a false negative for `Style/MultipleComparison` when multiple comparison is not part of a conditional.

The following is a false negative example of issue.

```ruby
def foo(x)
  x == 1 || x == 2 || x == 3
end
```

In addition, this PR will change the offense range as follows.

```diff
  a = "a"
  if a == "a" || a == "b"
- ^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple
  items in a conditional, use `Array#include?` instead.
+    ^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple
  items in a conditional, use `Array#include?` instead.
    print a
  end
```

Since `if` statements are not subject to replace with `Array#include?`, this change will result in a strict offense range.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
