### PR TITLE
[Fix #6035] Fix `Layout/LeadingBlankLines` autocorrection conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Fix exception that occurs when auto-correcting a modifier if statement in `Style/UnneededCondition`. ([@rrosenblum][])
 * [#6025](https://github.com/bbatsov/rubocop/pull/6025): Fix an incorrect auto-correct for `Lint/UnneededCondition` when using if_branch in `else` branch. ([@koic][])
 * [#6029](https://github.com/bbatsov/rubocop/issues/6029): Fix a false positive for `Lint/ShadowedArgument` when reassigning to splat variable. ([@koic][])
+* [#6035](https://github.com/rubocop-hq/rubocop/issues/6035): Fix error on autocorrection when `Layout/LeadingBlankLines` is the first cop to act. ([@Vasfed][])
 * [#6036](https://github.com/rubocop-hq/rubocop/issues/6036): Make `Rails/BulkChangeTable` aware of string table name. ([@wata727][])
 * [#5467](https://github.com/bbatsov/rubocop/issues/5467): Fix a false negative for `Style/MultipleComparison` when multiple comparison is not part of a conditional. ([@koic][])
 * [#6042](https://github.com/rubocop-hq/rubocop/pull/6042): Fix `Lint/RedundantWithObject` error on missing parameter to `each_with_object`. ([@Vasfed][])

--- a/lib/rubocop/cop/layout/leading_blank_lines.rb
+++ b/lib/rubocop/cop/layout/leading_blank_lines.rb
@@ -39,7 +39,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          range = Parser::Source::Range.new(processed_source.raw_source,
+          range = Parser::Source::Range.new(processed_source.buffer,
                                             0,
                                             node.begin_pos)
 

--- a/spec/rubocop/cop/layout/leading_blank_lines_spec.rb
+++ b/spec/rubocop/cop/layout/leading_blank_lines_spec.rb
@@ -104,5 +104,37 @@ RSpec.describe RuboCop::Cop::Layout::LeadingBlankLines, :config do
         end
       RUBY
     end
+
+    context 'in collaboration' do
+      let(:config) do
+        RuboCop::Config.new('Layout/SpaceAroundEqualsInParameterDefault' => {
+                              'SupportedStyles' => [:space],
+                              'EnforcedStyle' => :space
+                            })
+      end
+      let(:cops) do
+        cop_classes = [
+          described_class,
+          ::RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault
+        ]
+        ::RuboCop::Cop::Registry.new(cop_classes)
+      end
+
+      it 'does not invoke conflicts with other cops' do
+        source_with_offences = <<-RUBY.strip_indent
+
+          def bar(arg =1); end
+        RUBY
+
+        options = { auto_correct: true, stdin: true }
+        team = RuboCop::Cop::Team.new(cops, config, options)
+        team.inspect_file(parse_source(source_with_offences, nil))
+        new_source = options[:stdin]
+
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          def bar(arg = 1); end
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes #6035.
Autocorrect of `Layout/LeadingBlankLines` constructed `Parser::Source::Range` from `raw_source` string instead of `buffer` which led to comparison error.

-----------------

Before submitting the PR make sure the following are checked:

* [v] Wrote [good commit messages][1].
* [v] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [v] Feature branch is up-to-date with `master` (if not - rebase it).
* [v] Squashed related commits together.
* [v] Added tests.
* [v] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [v] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [v] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
