### PR TITLE
[Fix #6052] Fix a false positive for `Style/SymbolProc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#5467](https://github.com/bbatsov/rubocop/issues/5467): Fix a false negative for `Style/MultipleComparison` when multiple comparison is not part of a conditional. ([@koic][])
 * [#6042](https://github.com/rubocop-hq/rubocop/pull/6042): Fix `Lint/RedundantWithObject` error on missing parameter to `each_with_object`. ([@Vasfed][])
 * [#6056](https://github.com/rubocop-hq/rubocop/pull/6056): Support string timestamps in `Rails/CreateTableWithTimestamps` cop. ([@drn][])
+* [#6052](https://github.com/rubocop-hq/rubocop/issues/6052): Fix a false positive for `Style/SymbolProc` when using  block with adding a comma after the sole argument. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -22,7 +22,7 @@ module RuboCop
         def_node_matcher :symbol_proc?, <<-PATTERN
           (block
             ${(send ...) (super ...) zsuper}
-            (args (arg _var))
+            $(args (arg _var))
             (send (lvar _var) $_))
         PATTERN
 
@@ -31,7 +31,7 @@ module RuboCop
         end
 
         def on_block(node)
-          symbol_proc?(node) do |send_or_super, method|
+          symbol_proc?(node) do |send_or_super, block_args, method|
             block_method_name = resolve_block_method_name(send_or_super)
 
             # TODO: Rails-specific handling that we should probably make
@@ -40,6 +40,8 @@ module RuboCop
             return if proc_node?(send_or_super)
             return if %i[lambda proc].include?(block_method_name)
             return if ignored_method?(block_method_name)
+            return if block_args.children.size == 1 &&
+                      block_args.source.include?(',')
 
             offense(node, method, block_method_name)
           end

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -64,6 +64,10 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
     expect_no_offenses('something { |*x| x.first }')
   end
 
+  it 'accepts block with adding a comma after the sole argument' do
+    expect_no_offenses('something { |x,| x.first }')
+  end
+
   context 'when the method has arguments' do
     let(:source) { 'method(one, 2) { |x| x.test }' }
 


### PR DESCRIPTION
Fixes #6052.

This PR fixes a false positive for `Style/SymbolProc` when using block with adding a comma after the sole argument.

The following ASTs are the same.

```console
% bin/console
[1] pry(RuboCop)> RuboCop::ProcessedSource.new('h.sort_by { |i,| i.foo }', RUBY_VERSION.to_f).ast
=> s(:block,
  s(:send,
    s(:send, nil, :h), :sort_by),
  s(:args,
    s(:arg, :i)),
  s(:send,
    s(:lvar, :i), :foo))
[2] pry(RuboCop)> RuboCop::ProcessedSource.new('h.sort_by { |i| i.foo }', RUBY_VERSION.to_f).ast
=> s(:block,
  s(:send,
    s(:send, nil, :h), :sort_by),
  s(:args,
    s(:arg, :i)),
  s(:send,
    s(:lvar, :i), :foo))
```

So this implementation of PR uses `source` to decide whether to separate arguments with a comma.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
