### PR TITLE
Allow string timestamps in CreateTableWithTimestamps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#6036](https://github.com/rubocop-hq/rubocop/issues/6036): Make `Rails/BulkChangeTable` aware of string table name. ([@wata727][])
 * [#5467](https://github.com/bbatsov/rubocop/issues/5467): Fix a false negative for `Style/MultipleComparison` when multiple comparison is not part of a conditional. ([@koic][])
 * [#6042](https://github.com/rubocop-hq/rubocop/pull/6042): Fix `Lint/RedundantWithObject` error on missing parameter to `each_with_object`. ([@Vasfed][])
+* [#6056](https://github.com/rubocop-hq/rubocop/pull/6056): Support string timestamps in `Rails/CreateTableWithTimestamps` cop. ([@drn][])
 
 ### Changes
 
@@ -3451,3 +3452,4 @@
 [@alexander-lazarov]: https://github.com/alexander-lazarov
 [@r7kamura]: https://github.com/r7kamura
 [@Vasfed]: https://github.com/Vasfed
+[@drn]: https://github.com/drn

--- a/lib/rubocop/cop/rails/create_table_with_timestamps.rb
+++ b/lib/rubocop/cop/rails/create_table_with_timestamps.rb
@@ -59,7 +59,9 @@ module RuboCop
         PATTERN
 
         def_node_search :created_at_or_updated_at_included?, <<-PATTERN
-          (send _var :datetime (sym {:created_at :updated_at}) ...)
+          (send _var :datetime
+            {(sym {:created_at :updated_at})(str {"created_at" "updated_at"})}
+            ...)
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/rails/create_table_with_timestamps_spec.rb
+++ b/spec/rubocop/cop/rails/create_table_with_timestamps_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe RuboCop::Cop::Rails::CreateTableWithTimestamps do
     RUBY
   end
 
-  it 'does not register an offense when including created_at in block' do
+  it 'does not register an offense when including :created_at in block' do
     expect_no_offenses <<-RUBY
       create_table :users do |t|
         t.string :name
@@ -83,13 +83,35 @@ RSpec.describe RuboCop::Cop::Rails::CreateTableWithTimestamps do
     RUBY
   end
 
-  it 'does not register an offense when including updated_at in block' do
+  it "does not register an offense when including 'created_at' in block" do
+    expect_no_offenses <<-RUBY
+      create_table :users do |t|
+        t.string :name
+        t.string :email
+
+        t.datetime 'created_at', default: -> { 'CURRENT_TIMESTAMP' }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when including :updated_at in block' do
     expect_no_offenses <<-RUBY
       create_table :users do |t|
         t.string :name
         t.string :email
 
         t.datetime :updated_at, default: -> { 'CURRENT_TIMESTAMP' }
+      end
+    RUBY
+  end
+
+  it "does not register an offense when including 'updated_at' in block" do
+    expect_no_offenses <<-RUBY
+      create_table :users do |t|
+        t.string :name
+        t.string :email
+
+        t.datetime 'updated_at', default: -> { 'CURRENT_TIMESTAMP' }
       end
     RUBY
   end


### PR DESCRIPTION
This change makes it so that this cop does not fail when using strings for timestamp column names:

    create_table :users do |t|
      t.datetime 'updated_at'
    end

This is useful when squashing migrations by duplicating the schema.rb, as the rails-generated schema uses string timestamps.

I'm pretty new to working with ASTs, so I couldn't figure out how to combine sym / str in the same `def_node_search`. Happy to adjust if there's a better way to do this. EDIT: thanks for the info @koic! 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.