### PR TITLE
Refactor corrector specs and check for correct range source

### DIFF
--- a/spec/rubocop/cop/corrector_spec.rb
+++ b/spec/rubocop/cop/corrector_spec.rb
@@ -2,56 +2,105 @@
 
 RSpec.describe RuboCop::Cop::Corrector do
   describe '#rewrite' do
-    it 'allows removal of a range' do
-      source = 'true and false'
-      processed_source = parse_source(source)
+    let(:source) do
+      <<-RUBY.strip_indent.strip
+        true and false
+      RUBY
+    end
+    let(:processed_source) { parse_source(source) }
+    let(:node) { processed_source.ast }
+    let(:operator) { node.loc.operator }
 
-      correction = lambda do |corrector|
-        node = processed_source.ast
-        corrector.remove(node.loc.operator)
+    def do_rewrite(corrections = nil, &block)
+      corrections ||= block
+      corrections = [corrections] unless corrections.is_a? Array
+      unless corrections.all? { |c| c.is_a?(Proc) }
+        raise 'Corrections should be a proc, block or an array of procs'
       end
+      described_class.new(processed_source.buffer, corrections).rewrite
+    end
 
-      corrector = described_class.new(processed_source.buffer, [correction])
-      expect(corrector.rewrite).to eq 'true  false'
+    matcher :rewrite_to do |expected|
+      supports_block_expectations
+      attr_accessor :result
+      match { |corrections| (self.result = do_rewrite corrections) == expected }
+
+      failure_message do
+        "expected to rewrite to #{expected.inspect}, but got #{result.inspect}"
+      end
+      failure_message_when_negated do
+        "expected not to rewrite to #{expected.inspect}, but did"
+      end
+    end
+
+    it 'allows removal of a range' do
+      expect { |corr| corr.remove(operator) }.to rewrite_to 'true  false'
     end
 
     it 'allows insertion before a source range' do
-      source = 'true and false'
-      processed_source = parse_source(source)
-
-      correction = lambda do |corrector|
-        node = processed_source.ast
-        corrector.insert_before(node.loc.operator, ';nil ')
-      end
-
-      corrector = described_class.new(processed_source.buffer, [correction])
-      expect(corrector.rewrite).to eq 'true ;nil and false'
+      expect do |corrector|
+        corrector.insert_before(operator, ';nil ')
+      end.to rewrite_to 'true ;nil and false'
     end
 
     it 'allows insertion after a source range' do
-      source = 'true and false'
-      processed_source = parse_source(source)
-
-      correction = lambda do |corrector|
-        node = processed_source.ast
-        corrector.insert_after(node.loc.operator, ' nil;')
-      end
-
-      corrector = described_class.new(processed_source.buffer, [correction])
-      expect(corrector.rewrite).to eq 'true and nil; false'
+      expect do |corrector|
+        corrector.insert_after(operator, ' nil;')
+      end.to rewrite_to 'true and nil; false'
     end
 
     it 'allows replacement of a range' do
-      source = 'true and false'
-      processed_source = parse_source(source)
+      expect { |c| c.replace(operator, 'or') }.to rewrite_to 'true or false'
+    end
 
-      correction = lambda do |corrector|
-        node = processed_source.ast
-        corrector.replace(node.loc.operator, 'or')
+    it 'allows removal of characters preceding range' do
+      expect do |corrector|
+        corrector.remove_preceding(operator, 2)
+      end.to rewrite_to 'truand false'
+    end
+
+    it 'allows removal of characters from range beginning' do
+      expect do |corrector|
+        corrector.remove_leading(operator, 2)
+      end.to rewrite_to 'true d false'
+    end
+
+    it 'allows removal of characters fron range ending' do
+      expect do |corrector|
+        corrector.remove_trailing(operator, 2)
+      end.to rewrite_to 'true a false'
+    end
+
+    context 'when range is from incorrect source' do
+      let(:other_source) { parse_source(source) }
+      let(:op_other) do
+        Parser::Source::Range.new(other_source.buffer, 0, 2)
+      end
+      let(:op_string) do
+        Parser::Source::Range.new(processed_source.raw_source, 0, 2)
       end
 
-      corrector = described_class.new(processed_source.buffer, [correction])
-      expect(corrector.rewrite).to eq 'true or false'
+      {
+        remove: nil,
+        insert_before: ['1'],
+        insert_after: ['1'],
+        replace: ['1'],
+        remove_preceding: [2],
+        remove_leading: [2],
+        remove_trailing: [2]
+      }.each_pair do |method, params|
+        it "raises exception from #{method}" do
+          expect do
+            do_rewrite { |corr| corr.public_send(method, op_string, *params) }
+          end.to raise_exception 'Corrector expected range source buffer to be'\
+                                 ' a Parser::Source::Buffer, but got String'
+          expect do
+            do_rewrite { |corr| corr.public_send(method, op_other, *params) }
+          end.to raise_exception(
+            /^Correction target buffer \d+ name:"\(string\)" is not current/
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This makes tests for `Corrector` more readable and adds a check to try to prevent issues like #6035, (follow-up to #6049)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] (n/a) Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
