### PR TITLE
[FIX #5949] Added more details in EnsureReturn cop message in order to make it clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Changes
 
+* [#5949](https://github.com/rubocop-hq/rubocop/issues/5949): Lint/EnsureReturn cop - why ensure must not return. ([@andriymosin][])
 * [#6006](https://github.com/bbatsov/rubocop/pull/6006): Remove `rake repl` task. ([@koic][])
 * [#5990](https://github.com/bbatsov/rubocop/pull/5990): Drop support for MRI 2.1. ([@drenmi][])
 * [#3299](https://github.com/bbatsov/rubocop/issues/3299): `Lint/UselessAccessModifier` now warns when `private_class_method` is used without arguments. ([@Darhazer][])

--- a/lib/rubocop/cop/lint/ensure_return.rb
+++ b/lib/rubocop/cop/lint/ensure_return.rb
@@ -26,7 +26,9 @@ module RuboCop
       #     do_something_else
       #   end
       class EnsureReturn < Cop
-        MSG = 'Do not return from an `ensure` block.'.freeze
+        MSG = 'Do not return from an `ensure` block, it changes the control ' \
+              'flow as if a `rescue Exception` clause was in place before ' \
+              'the `ensure` clause.'.freeze
 
         def on_ensure(node)
           ensure_body = node.body

--- a/spec/rubocop/cop/lint/ensure_return_spec.rb
+++ b/spec/rubocop/cop/lint/ensure_return_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Cop::Lint::EnsureReturn do
       ensure
         file.close
         return
-        ^^^^^^ Do not return from an `ensure` block.
+        ^^^^^^ Do not return from an `ensure` block, it changes the control flow as if a `rescue Exception` clause was in place before the `ensure` clause.
       end
     RUBY
   end


### PR DESCRIPTION
Based on [this discussion](https://github.com/rubocop-hq/rubocop/issues/5949) I decided to add more details in EnsureReturn cop's message to make it clear why you should avoid the use of such practice

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
