### PR TITLE
Doc: Code review SaaS SideCI was renamed to Sider

### DIFF
--- a/manual/automated_code_review.md
+++ b/manual/automated_code_review.md
@@ -16,7 +16,7 @@ Codacy is free for open source, and it provides RuboCop analysis out-of-the-box.
 [Hound](https://houndci.com/) comments on style violations in GitHub pull requests, allowing you and your team to better review and maintain a clean codebase.
 It is open source software.
 
-### SideCI
+### Sider
 
-[SideCI](https://sideci.com) improves your team's productivity by automating code analysis.
+[Sider](https://sider.review) improves your team's productivity by automating code analysis.
 It supports Auto-correction.


### PR DESCRIPTION
According [their website](https://sider.review) & [blog](https://blog.sideci.com/sideci-announcing-new-name-sider-481047359195), the service was renamed few weeks ago.

Because this is a minor doc change, so I thought it's okay to removed todos included in PR template. Let me know if there's any concern. Thanks!

P.S. Just noticed [a good interview for RuboCop on their blog](https://blog.sideci.com/interview-with-bozhidar-batsov-99b049b6fd6a) 😉