### PR TITLE
Make `Style/AccessModifierDeclarations` disabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [#5990](https://github.com/bbatsov/rubocop/pull/5990): Drop support for MRI 2.1. ([@drenmi][])
 * [#3299](https://github.com/bbatsov/rubocop/issues/3299): `Lint/UselessAccessModifier` now warns when `private_class_method` is used without arguments. ([@Darhazer][])
 * [#6026](https://github.com/rubocop-hq/rubocop/pull/6026): Exclude `refine` by default from `Metrics/BlockLength` cop. ([@kddeisz][])
+* [#6066](https://github.com/rubocop-hq/rubocop/pull/6066): Make `Style/AccessModifierDeclarations` disabled by default. ([@wata727][])
 
 ## 0.57.2 (2018-06-12)
 

--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -52,6 +52,10 @@ Rails/SaveBang:
   StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#save-bang'
   Enabled: false
 
+Style/AccessModifierDeclarations:
+  Description: 'Checks style of how access modifiers are used.'
+  Enabled: false
+
 Style/AutoResourceCleanup:
   Description: 'Suggests the usage of an auto resource cleanup version of a method (if available).'
   Enabled: false

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1336,10 +1336,6 @@ Security/YAMLLoad:
 
 #################### Style ###############################
 
-Style/AccessModifierDeclarations:
-  Description: 'Checks style of how access modifiers are used.'
-  Enabled: true
-
 Style/Alias:
   Description: 'Use alias instead of alias_method.'
   StyleGuide: '#alias-method'

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -91,7 +91,7 @@ module RuboCop
         @mutable_attributes.frozen?
       end
 
-      protected :parent= # rubocop:disable Style/AccessModifierDeclarations
+      protected :parent=
 
       # Override `AST::Node#updated` so that `AST::Processor` does not try to
       # mutate our ASTs. Since we keep references from children to parents and
@@ -321,9 +321,7 @@ module RuboCop
          (casgn $_ $_        (send (const nil? {:Class :Module}) :new ...))
          (casgn $_ $_ (block (send (const nil? {:Class :Module}) :new ...) ...))}
       PATTERN
-      # rubocop:disable Style/AccessModifierDeclarations
       private :defined_module0
-      # rubocop:enable Style/AccessModifierDeclarations
 
       def defined_module
         namespace, name = *defined_module0

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4,7 +4,7 @@
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | No
+Disabled | No
 
 Access modifiers should be declared to apply to a group of methods
 or inline before each method, depending on configuration.


### PR DESCRIPTION
Follow up of #5953, #6032

I think it is too difficult to enforce `group` (default) style by default because it doesn't work for some methods.

For example, `def_delegator` doesn't work when using `group` style:

```ruby
require 'forwardable'

class Cat
  def meow
    puts "Meow!"
  end
end

class CatCage
  extend Forwardable

  def initialize(cat)
    @cat = cat
  end

  private

  def_delegator :@cat, :meow
end
```

```
[8] pry(main)> CatCage.new(Cat.new).meow
Meow!
=> nil
```

This is because `def_delegator` defines a method by `self.module_eval`. Forcing group styles by default may be misleading for the above problems.

Maybe it is needed to add such methods to the whitelist and exclude them from inspection, but it seems to be difficult for me.

First of all, I think it should make this cop disabled by default and help users confused by this cop. WDYT? @brandonweiss

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
