### PR TITLE
Update Performance/Sample to register offenses when shuffle is followed with at or slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#5973](https://github.com/bbatsov/rubocop/issues/5973): Add new `Style/IpAddresses` cop. ([@dvandersluis][])
 * [#5843](https://github.com/bbatsov/rubocop/issues/5843): Add configuration options to `Naming/MemoizedInstanceVariableName` cop to allow leading underscores. ([@leklund][])
 * [#5843](https://github.com/bbatsov/rubocop/issues/5843): Add `EnforcedStyleForLeadingUnderscores` to `Naming/MemoizedInstanceVariableName` cop to allow leading underscores. ([@leklund][])
+* `Performance/Sample` will now register an offense when using `shuffle` followed by `at` or `slice`. ([@rrosenblum][])
 
 ### Bug fixes
 

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -693,6 +693,8 @@ and `shuffle[]` and change them to use `sample` instead.
 [1, 2, 3].shuffle.first
 [1, 2, 3].shuffle.first(2)
 [1, 2, 3].shuffle.last
+[2, 1, 3].shuffle.at(0)
+[2, 1, 3].shuffle.slice(0)
 [1, 2, 3].shuffle[2]
 [1, 2, 3].shuffle[0, 2]    # sample(2) will do the same
 [1, 2, 3].shuffle[0..2]    # sample(3) will do the same

--- a/spec/rubocop/cop/performance/sample_spec.rb
+++ b/spec/rubocop/cop/performance/sample_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe RuboCop::Cop::Performance::Sample do
   it_behaves_like('offense', 'shuffle.first', 'sample')
   it_behaves_like('offense', 'shuffle.last', 'sample')
   it_behaves_like('offense', 'shuffle[0]', 'sample')
+  it_behaves_like('offense', 'shuffle[-1]', 'sample')
   it_behaves_like('offense', 'shuffle[0, 3]', 'sample(3)')
   it_behaves_like('offense', 'shuffle[0..3]', 'sample(4)')
   it_behaves_like('offense', 'shuffle[0...3]', 'sample(3)')
@@ -34,6 +35,13 @@ RSpec.describe RuboCop::Cop::Performance::Sample do
   it_behaves_like('offense', 'shuffle.last(3)', 'sample(3)')
   it_behaves_like('offense', 'shuffle.first(foo)', 'sample(foo)')
   it_behaves_like('offense', 'shuffle.last(bar)', 'sample(bar)')
+  it_behaves_like('offense', 'shuffle.at(0)', 'sample')
+  it_behaves_like('offense', 'shuffle.at(-1)', 'sample')
+  it_behaves_like('offense', 'shuffle.slice(0)', 'sample')
+  it_behaves_like('offense', 'shuffle.slice(-1)', 'sample')
+  it_behaves_like('offense', 'shuffle.slice(0, 3)', 'sample(3)')
+  it_behaves_like('offense', 'shuffle.slice(0..3)', 'sample(4)')
+  it_behaves_like('offense', 'shuffle.slice(0...3)', 'sample(3)')
   it_behaves_like('offense', 'shuffle(random: Random.new).first',
                   'sample(random: Random.new)')
   it_behaves_like('offense', 'shuffle(random: Random.new).first(2)',
@@ -45,14 +53,28 @@ RSpec.describe RuboCop::Cop::Performance::Sample do
 
   it_behaves_like('accepts', 'sample')
   it_behaves_like('accepts', 'shuffle')
-  it_behaves_like('accepts', 'shuffle[2]')            # nil if coll.size < 3
-  it_behaves_like('accepts', 'shuffle[3, 3]')         # nil if coll.size < 3
-  it_behaves_like('accepts', 'shuffle[2..3]')         # empty if coll.size < 3
-  it_behaves_like('accepts', 'shuffle[2..-3]')        # can't compute range size
-  it_behaves_like('accepts', 'shuffle[foo..3]')       # can't compute range size
-  it_behaves_like('accepts', 'shuffle[-4..-3]')       # nil if coll.size < 3
-  it_behaves_like('accepts', 'shuffle[foo]')          # foo could be a Range
-  it_behaves_like('accepts', 'shuffle[foo, 3]')       # nil if coll.size < foo
+  it_behaves_like('accepts', 'shuffle.at(2)')          # nil if coll.size < 3
+  it_behaves_like('accepts', 'shuffle.at(foo)')
+  it_behaves_like('accepts', 'shuffle.slice(2)')       # nil if coll.size < 3
+  it_behaves_like('accepts', 'shuffle.slice(3, 3)')    # nil if coll.size < 3
+  it_behaves_like('accepts', 'shuffle.slice(2..3)')    # empty if coll.size < 3
+  it_behaves_like('accepts',
+                  'shuffle.slice(2..-3)')   # can't compute range size
+  it_behaves_like('accepts',
+                  'shuffle.slice(foo..3)')  # can't compute range size
+  it_behaves_like('accepts', 'shuffle.slice(-4..-3)')  # nil if coll.size < 3
+  it_behaves_like('accepts', 'shuffle.slice(foo)')     # foo could be a Range
+  it_behaves_like('accepts', 'shuffle.slice(foo, 3)')  # nil if coll.size < foo
+  it_behaves_like('accepts', 'shuffle.slice(foo..bar)')
+  it_behaves_like('accepts', 'shuffle.slice(foo, bar)')
+  it_behaves_like('accepts', 'shuffle[2]')           # nil if coll.size < 3
+  it_behaves_like('accepts', 'shuffle[3, 3]')        # nil if coll.size < 3
+  it_behaves_like('accepts', 'shuffle[2..3]')        # empty if coll.size < 3
+  it_behaves_like('accepts', 'shuffle[2..-3]')       # can't compute range size
+  it_behaves_like('accepts', 'shuffle[foo..3]')      # can't compute range size
+  it_behaves_like('accepts', 'shuffle[-4..-3]')      # nil if coll.size < 3
+  it_behaves_like('accepts', 'shuffle[foo]')         # foo could be a Range
+  it_behaves_like('accepts', 'shuffle[foo, 3]')      # nil if coll.size < foo
   it_behaves_like('accepts', 'shuffle[foo..bar]')
   it_behaves_like('accepts', 'shuffle[foo, bar]')
   it_behaves_like('accepts', 'shuffle(random: Random.new)')


### PR DESCRIPTION
A few of the recent Performance cops have support for `at` and `slice`. This adds the same support to `Performance/Sample`.