### PR TITLE
[Fix #6067] Prevent auto-correct error for `Performance/InefficientHashSearch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#6056](https://github.com/rubocop-hq/rubocop/pull/6056): Support string timestamps in `Rails/CreateTableWithTimestamps` cop. ([@drn][])
 * [#6052](https://github.com/rubocop-hq/rubocop/issues/6052): Fix a false positive for `Style/SymbolProc` when using  block with adding a comma after the sole argument. ([@koic][])
 * [#2743](https://github.com/rubocop-hq/rubocop/issues/2743): Support `<<` as a kind of assignment operator in `Layout/EndAlignment`. ([@jonas054][])
+* [#6067](https://github.com/rubocop-hq/rubocop/issues/6067): Prevent auto-correct error for `Performance/InefficientHashSearch` when a method by itself and `include?` method are method chaining. ([@koic][])
 
 ### Changes
 

--- a/spec/rubocop/cop/performance/inefficient_hash_search_spec.rb
+++ b/spec/rubocop/cop/performance/inefficient_hash_search_spec.rb
@@ -47,6 +47,15 @@ RSpec.describe RuboCop::Cop::Performance::InefficientHashSearch do
       RUBY
     end
 
+    it 'does not register an offense when `keys` method defined by itself ' \
+       'and `include?` method are method chaining' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def my_include?(key)
+          keys.include?(key)
+        end
+      RUBY
+    end
+
     describe 'autocorrect' do
       context 'when using `keys.include?`' do
         it 'corrects to `key?` or `has_key?`' do


### PR DESCRIPTION
Fixes #6067.

This PR prevents an auto-correct error for `Performance/InefficientHashSearch` when a method defined by itself and `include?` method are method chaining.

Essentially, static analysis targeted by RuboCop does not know the type determined at run-time.

So, this implementation may be false negative if it defines method itself.

```ruby
def keys
  # When delegation instead of an array,
  # it does not know the type until run-time.
  []
end

def my_include?(key)
  keys.include?(key)
end
```

If the above `keys` method defined by itself will return a Hash, it will be false negative, so there is room for improvement in the future.

The aim of this change is to make it more valuable to prevent auto-correct error than false negative.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
