### PR TITLE
[Fix #2743] Support << besides = in EndAlignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#6042](https://github.com/rubocop-hq/rubocop/pull/6042): Fix `Lint/RedundantWithObject` error on missing parameter to `each_with_object`. ([@Vasfed][])
 * [#6056](https://github.com/rubocop-hq/rubocop/pull/6056): Support string timestamps in `Rails/CreateTableWithTimestamps` cop. ([@drn][])
 * [#6052](https://github.com/rubocop-hq/rubocop/issues/6052): Fix a false positive for `Style/SymbolProc` when using  block with adding a comma after the sole argument. ([@koic][])
+* [#2743](https://github.com/rubocop-hq/rubocop/issues/2743): Support `<<` as a kind of assignment operator in `Layout/EndAlignment`. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -379,6 +379,11 @@ module RuboCop
         {equals_asgn? shorthand_asgn? asgn_method_call?}
       PATTERN
 
+      # Some cops treat the shovel operator as a kind of assignment.
+      def_node_matcher :assignment_or_similar?, <<-PATTERN
+        {assignment? (send _recv :<< ...)}
+      PATTERN
+
       def literal?
         LITERALS.include?(type)
       end

--- a/lib/rubocop/cop/layout/end_alignment.rb
+++ b/lib/rubocop/cop/layout/end_alignment.rb
@@ -162,7 +162,7 @@ module RuboCop
         def alignment_node_for_variable_style(node)
           return node.parent if node.case_type? && node.argument?
 
-          assignment = node.ancestors.find(&:assignment?)
+          assignment = node.ancestors.find(&:assignment_or_similar?)
           if assignment && !line_break_before_keyword?(assignment.source_range,
                                                        node)
             assignment

--- a/lib/rubocop/cop/mixin/check_assignment.rb
+++ b/lib/rubocop/cop/mixin/check_assignment.rb
@@ -11,8 +11,6 @@ module RuboCop
       end
 
       def on_send(node)
-        return unless node.setter_method?
-
         rhs = extract_rhs(node)
 
         return unless rhs

--- a/spec/rubocop/cop/layout/end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/end_alignment_spec.rb
@@ -372,6 +372,10 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
         var = until test
         end
         ^^^ `end` at 2, 0 is not aligned with `until` at 1, 6.
+
+        var << until test
+        end
+        ^^^ `end` at 2, 0 is not aligned with `until` at 1, 7.
       RUBY
 
       include_examples 'aligned', 'var = if',     'test',     '      end'
@@ -379,6 +383,8 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
       include_examples 'aligned', 'var = while',  'test',     '      end'
       include_examples 'aligned', 'var = until',  'test',     '      end'
       include_examples 'aligned', 'var = case',   'a when b', '      end'
+
+      include_examples 'aligned', 'var[0] = case', 'a when b', '         end'
     end
 
     context 'when EnforcedStyleAlignWith is variable' do
@@ -386,6 +392,7 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
         { 'EnforcedStyleAlignWith' => 'variable', 'AutoCorrect' => true }
       end
 
+      include_examples 'aligned', 'var << if',    'test',     'end'
       include_examples 'aligned', 'var = if',     'test',     'end'
       include_examples 'aligned', 'var = unless', 'test',     'end'
       include_examples 'aligned', 'var = while',  'test',     'end'
@@ -411,6 +418,22 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
         var = until test
               end
               ^^^ `end` at 2, 6 is not aligned with `var = until` at 1, 0.
+
+        var << if test
+               end
+               ^^^ `end` at 2, 7 is not aligned with `var << if` at 1, 0.
+
+        var << unless test
+               end
+               ^^^ `end` at 2, 7 is not aligned with `var << unless` at 1, 0.
+
+        var[x] = while test
+                 end
+                 ^^^ `end` at 2, 9 is not aligned with `var[x] = while` at 1, 0.
+
+        var << until test
+               end
+               ^^^ `end` at 2, 7 is not aligned with `var << until` at 1, 0.
       RUBY
 
       # If there's a line break after = we align with the keyword even if the
@@ -496,6 +519,30 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
         h[k] = if test
                end
                ^^^ `end` at 2, 7 is not aligned with `h[k] = if` at 1, 0.
+
+        var << case a when b
+               end
+               ^^^ `end` at 2, 7 is not aligned with `var << case` at 1, 0.
+
+        @var << if test
+                end
+                ^^^ `end` at 2, 8 is not aligned with `@var << if` at 1, 0.
+
+        @@var << if test
+                 end
+                 ^^^ `end` at 2, 9 is not aligned with `@@var << if` at 1, 0.
+
+        $var << if test
+                end
+                ^^^ `end` at 2, 8 is not aligned with `$var << if` at 1, 0.
+
+        CNST << if test
+                end
+                ^^^ `end` at 2, 8 is not aligned with `CNST << if` at 1, 0.
+
+        h[k] << if test
+                end
+                ^^^ `end` at 2, 8 is not aligned with `h[k] << if` at 1, 0.
       RUBY
 
       include_examples 'misaligned', <<-RUBY, false
@@ -531,6 +578,26 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
       var = case a when b
             end
             ^^^ `end` at 2, 6 is not aligned with `var = case a when b` at 1, 0.
+
+      var << if test
+             end
+             ^^^ `end` at 2, 7 is not aligned with `var << if test` at 1, 0.
+
+      var << unless test
+             end
+             ^^^ `end` at 2, 7 is not aligned with `var << unless test` at 1, 0.
+
+      var << while test
+             end
+             ^^^ `end` at 2, 7 is not aligned with `var << while test` at 1, 0.
+
+      var << until test
+             end
+             ^^^ `end` at 2, 7 is not aligned with `var << until test` at 1, 0.
+
+      var << case a when b
+             end
+             ^^^ `end` at 2, 7 is not aligned with `var << case a when b` at 1, 0.
     RUBY
 
     include_examples 'misaligned', <<-RUBY, false
@@ -543,6 +610,7 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
     include_examples 'aligned', 'var = if',     'test',     'end'
     include_examples 'aligned', 'var = unless', 'test',     'end'
     include_examples 'aligned', 'var = while',  'test',     'end'
+    include_examples 'aligned', 'var << while', 'test',     'end'
     include_examples 'aligned', 'var = until',  'test',     'end'
     include_examples 'aligned', 'var = case',   'a when b', 'end'
 


### PR DESCRIPTION
The `variable` and `start_of_line` values for the `EnforcedStyleAlignWith` configuration parameter now supports not only `=`, but also `<<` as a kind of assignment operator.

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.