### PR TITLE
Suppress backtrace when usage of `rubocop` command is incorrect

### DIFF
--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -39,7 +39,7 @@ module RuboCop
       act_on_options
       apply_default_formatter
       execute_runners(paths)
-    rescue RuboCop::ConfigNotFoundError => e
+    rescue ConfigNotFoundError, IncorrectCopNameError, OptionArgumentError => e
       warn e.message
       STATUS_ERROR
     rescue RuboCop::Error => e
@@ -47,9 +47,6 @@ module RuboCop
       STATUS_ERROR
     rescue Finished
       STATUS_SUCCESS
-    rescue IncorrectCopNameError => e
-      warn e.message
-      STATUS_ERROR
     rescue OptionParser::InvalidOption => e
       warn e.message
       warn 'For usage information, use --help'
@@ -128,9 +125,9 @@ module RuboCop
     def validate_options_vs_config
       if @options[:parallel] &&
          !@config_store.for(Dir.pwd).for_all_cops['UseCache']
-        raise ArgumentError, '-P/--parallel uses caching to speed up ' \
-                             'execution, so combining with AllCops: ' \
-                             'UseCache: false is not allowed.'
+        raise OptionArgumentError, '-P/--parallel uses caching to speed up ' \
+                                   'execution, so combining with AllCops: ' \
+                                   'UseCache: false is not allowed.'
       end
     end
 

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -142,26 +142,26 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       it 'rejects using -v with -V' do
         msg = 'Incompatible cli options: [:version, :verbose_version]'
         expect { options.parse %w[-vV] }
-          .to raise_error(ArgumentError, msg)
+          .to raise_error(RuboCop::OptionArgumentError, msg)
       end
 
       it 'rejects using -v with --show-cops' do
         msg = 'Incompatible cli options: [:version, :show_cops]'
         expect { options.parse %w[-v --show-cops] }
-          .to raise_error(ArgumentError, msg)
+          .to raise_error(RuboCop::OptionArgumentError, msg)
       end
 
       it 'rejects using -V with --show-cops' do
         msg = 'Incompatible cli options: [:verbose_version, :show_cops]'
         expect { options.parse %w[-V --show-cops] }
-          .to raise_error(ArgumentError, msg)
+          .to raise_error(RuboCop::OptionArgumentError, msg)
       end
 
       it 'mentions all incompatible options when more than two are used' do
         msg = 'Incompatible cli options: [:version, :verbose_version,' \
               ' :show_cops]'
         expect { options.parse %w[-vV --show-cops] }
-          .to raise_error(ArgumentError, msg)
+          .to raise_error(RuboCop::OptionArgumentError, msg)
       end
     end
 
@@ -171,7 +171,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
           msg = ['-P/--parallel uses caching to speed up execution, so ',
                  'combining with --cache false is not allowed.'].join
           expect { options.parse %w[--parallel --cache false] }
-            .to raise_error(ArgumentError, msg)
+            .to raise_error(RuboCop::OptionArgumentError, msg)
         end
       end
 
@@ -179,7 +179,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
         it 'fails with an error message' do
           msg = '-P/--parallel can not be combined with --auto-correct.'
           expect { options.parse %w[--parallel --auto-correct] }
-            .to raise_error(ArgumentError, msg)
+            .to raise_error(RuboCop::OptionArgumentError, msg)
         end
       end
 
@@ -189,7 +189,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                 '--auto-gen-config needs a non-cached run, so they cannot be ' \
                 'combined.'
           expect { options.parse %w[--parallel --auto-gen-config] }
-            .to raise_error(ArgumentError, msg)
+            .to raise_error(RuboCop::OptionArgumentError, msg)
         end
       end
 
@@ -197,7 +197,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
         it 'fails with an error message' do
           msg = '-P/--parallel can not be combined with -F/--fail-fast.'
           expect { options.parse %w[--parallel --fail-fast] }
-            .to raise_error(ArgumentError, msg)
+            .to raise_error(RuboCop::OptionArgumentError, msg)
         end
       end
     end
@@ -247,7 +247,8 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       end
 
       it 'fails if unrecognized argument is given' do
-        expect { options.parse %w[--cache maybe] }.to raise_error(ArgumentError)
+        expect { options.parse %w[--cache maybe] }
+          .to raise_error(RuboCop::OptionArgumentError)
       end
 
       it 'accepts true as argument' do
@@ -277,7 +278,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
 
       it 'fails if given without --auto-gen-config' do
         expect { options.parse %w[--exclude-limit 10] }
-          .to raise_error(ArgumentError)
+          .to raise_error(RuboCop::OptionArgumentError)
       end
     end
 
@@ -306,7 +307,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
 
       it 'fails if more than one path is given' do
         expect { options.parse %w[--stdin foo bar] }
-          .to raise_error(ArgumentError)
+          .to raise_error(RuboCop::OptionArgumentError)
       end
     end
   end


### PR DESCRIPTION
Related to #4819.

This PR suppresses the display when usage of `rubocop` command is incorrect. I think that it is more user-friendly for end users if there is no backtrace.

The following is an example of omitting backtrace.

## Before

```console
% rubocop  --auto-correct --parallel
-P/--parallel can not be combined with --auto-correct.
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.57.2/lib/rubocop/options.rb:290:in
`block in validate_parallel'
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.57.2/lib/rubocop/options.rb:290:in
`each'
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.57.2/lib/rubocop/options.rb:290:in
`validate_parallel'
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.57.2/lib/rubocop/options.rb:254:in
`validate_compatibility'
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.57.2/lib/rubocop/options.rb:23:in
`parse'
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.57.2/lib/rubocop/cli.rb:37:in
`run'
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.57.2/exe/rubocop:13:in
`block in <top (required)>'
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/2.5.0/benchmark.rb:308:in
`realtime'
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.57.2/exe/rubocop:12:in
`<top (required)>'
/Users/koic/.rbenv/versions/2.5.1/bin/rubocop:23:in `load'
/Users/koic/.rbenv/versions/2.5.1/bin/rubocop:23:in `<main>'
```

## After

```console
% rubocop  --auto-correct --parallel
-P/--parallel can not be combined with --auto-correct.
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
