### PR TITLE
Move `ContextCreatingMethods` and `MethodCreatingMethods` to default.yml

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1654,6 +1654,10 @@ Lint/UnusedMethodArgument:
   AllowUnusedKeywordArguments: false
   IgnoreEmptyMethods: true
 
+Lint/UselessAccessModifier:
+  ContextCreatingMethods: []
+  MethodCreatingMethods: []
+
 Lint/Void:
   CheckForMethodsWithNoSideEffects: false
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -761,8 +761,6 @@ Lint/UriRegexp:
 Lint/UselessAccessModifier:
   Description: 'Checks for useless access modifiers.'
   Enabled: true
-  ContextCreatingMethods: []
-  MethodCreatingMethods: []
 
 Lint/UselessAssignment:
   Description: 'Checks for useless assignment to a local variable.'


### PR DESCRIPTION
This PR is a change similar to #5271 and #5349.

Cop configs are grouped in config/default.yml.
This PR unified the setting place by moving those configs of `Lint/UselessAccessModifier` cop from config/enabled.yml to config/default.yml.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
