### PR TITLE
[Fix 6071] Fix MethodCallWithArgsParentheses when args are method calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* [#6071](https://github.com/bbatsov/rubocop/issues/6071): Fix auto-correct `Style/MethodCallWithArgsParentheses` when arguments are method calls. ([@maxh][])
 * Fix `Style/RedundantParentheses` with hash literal as first argument to `super`. ([@maxh][])
 * [#6086](https://github.com/bbatsov/rubocop/issues/6086): Fix an error for `Gemspec/OrderedDependencies` when using method call to gem names in gemspec. ([@koic][])
 

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -93,7 +93,8 @@ module RuboCop
         def args_parenthesized?(node)
           return false unless node.arguments.one?
 
-          node.arguments.first.parenthesized_call?
+          first_node = node.arguments.first
+          first_node.begin_type? && first_node.parenthesized_call?
         end
       end
     end

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -175,6 +175,34 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
     RUBY
   end
 
+  it 'auto-corrects calls where arg is method call' do
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
+      def my_method
+        foo bar.baz(abc, xyz)
+      end
+    RUBY
+
+    expect(new_source).to eq(<<-RUBY.strip_indent)
+      def my_method
+        foo(bar.baz(abc, xyz))
+      end
+    RUBY
+  end
+
+  it 'auto-corrects calls where multiple args are method calls' do
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
+      def my_method
+        foo bar.baz(abc, xyz), foo(baz)
+      end
+    RUBY
+
+    expect(new_source).to eq(<<-RUBY.strip_indent)
+      def my_method
+        foo(bar.baz(abc, xyz), foo(baz))
+      end
+    RUBY
+  end
+
   it 'auto-corrects calls where the argument node is a constant' do
     new_source = autocorrect_source(<<-RUBY.strip_indent)
       def my_method


### PR DESCRIPTION
Fixes https://github.com/rubocop-hq/rubocop/issues/6071 by making `Style/MethodCallWithArgsParentheses` properly support methods whose arguments are (the results of) other parenthesized method calls.

Currently, `foo bar.baz(1)` autocorrects `foo(ar.baz(1)`. Note the `bar` => `ar` corruption and the omission of the closing parenthesis.

With this fix, `foo bar.baz(1)` autocorrects to `foo(bar.baz(1))`. 

I believe this bug was introduced by https://github.com/rubocop-hq/rubocop/commit/da75dc817f6ca3d3d5381dcc80fa1ec3e01c5508#diff-64ff5170af84da7f10ed1d4756b06b1c.