### PR TITLE
Fix `Style/RedundantParentheses` with hash literal as first argument to `super`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
++### Bug fixes
+
+* Fix `Style/RedundantParentheses` with hash literal as first argument to `super`. ([@maxh][])
+
 ## 0.58.0 (2018-07-07)
 
 ### New features
@@ -3461,3 +3465,4 @@
 [@r7kamura]: https://github.com/r7kamura
 [@Vasfed]: https://github.com/Vasfed
 [@drn]: https://github.com/drn
+[@maxh]: https://github.com/maxh

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -190,8 +190,16 @@ module RuboCop
           args.one? && args.first.begin_type?
         end
 
-        def_node_matcher :first_argument?, <<-PATTERN
+        def first_argument?(node)
+          first_send_argument?(node) || first_super_argument?(node)
+        end
+
+        def_node_matcher :first_send_argument?, <<-PATTERN
           ^(send _ _ equal?(%0) ...)
+        PATTERN
+
+        def_node_matcher :first_super_argument?, <<-PATTERN
+          ^(super equal?(%0) ...)
         PATTERN
 
         def call_chain_starts_with_int?(begin_node, send_node)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -250,4 +250,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses do
       end
     RUBY
   end
+
+  it 'accepts parentheses in super call with hash' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      super ({
+        foo: bar,
+      })
+    RUBY
+  end
 end


### PR DESCRIPTION
Currently, `Style/RedundantParentheses` finds an offense in `super ({foo: bar})` but not `baz ({foo: bar})`because its internal `hash_literal_as_first_arg` doesn't account for super invocations. This PR adds support for the `super` case.

I couldn't figure out how to write one `def_node_matcher` that covers both cases -- not sure if that's preferable.