### PR TITLE
[Fix #6086] Fix an error for `Gemspec/OrderedDependencies`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#6086](https://github.com/bbatsov/rubocop/issues/6086): Fix an error for `Gemspec/OrderedDependencies` when using method call to gem names in gemspec. ([@koic][])
+
 ## 0.58.0 (2018-07-07)
 
 ### New features

--- a/lib/rubocop/cop/mixin/ordered_gem_node.rb
+++ b/lib/rubocop/cop/mixin/ordered_gem_node.rb
@@ -37,7 +37,15 @@ module RuboCop
       end
 
       def gem_name(declaration_node)
-        declaration_node.first_argument.str_content
+        gem_node = declaration_node.first_argument
+
+        find_gem_name(gem_node)
+      end
+
+      def find_gem_name(gem_node)
+        return gem_node.str_content if gem_node.str_type?
+
+        find_gem_name(gem_node.receiver)
       end
 
       def treat_comments_as_separators

--- a/spec/rubocop/cop/gemspec/ordered_dependencies_spec.rb
+++ b/spec/rubocop/cop/gemspec/ordered_dependencies_spec.rb
@@ -187,4 +187,15 @@ RSpec.describe RuboCop::Cop::Gemspec::OrderedDependencies, :config do
       RUBY
     end
   end
+
+  context 'When using method call to gem names' do
+    it 'does not register any offenses' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        Gem::Specification.new do |spec|
+          spec.add_dependency         'rubocop'.freeze
+          spec.add_runtime_dependency 'rspec'.freeze
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #6086.

This PR fixes an error for `Gemspec/OrderedDependencies` when using method call to gem names in gemspec.

The following is reproduction steps.

```console
% cat /tmp/foo.gemspec
Gem::Specification.new do |spec|
  spec.add_development_dependency 'rspec'.freeze
  spec.add_development_dependency 'rubocop'.freeze
end
% rubocop foo.gemspec --only Gemspec/OrderedDependencies -d
For /private/tmp: configuration from
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.58.0/config/default.yml
Inheriting configuration from
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.58.0/config/enabled.yml
Inheriting configuration from
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.58.0/config/disabled.yml
Inspecting 1 file
Scanning /private/tmp/foo.gemspec
An error occurred while Gemspec/OrderedDependencies cop was inspecting
/private/tmp/foo.gemspec.
undefined method `downcase' for nil:NilClass

(snip)

/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.58.0/exe/rubocop:12:in
`<top (required)>'
/Users/koic/.rbenv/versions/2.5.1/bin/rubocop:23:in `load'
/Users/koic/.rbenv/versions/2.5.1/bin/rubocop:23:in `<main>'
.

1 file inspected, no offenses detected

1 error occurred:
An error occurred while Gemspec/OrderedDependencies cop was inspecting
/private/tmp/foo.gemspec.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop-hq/rubocop/issues

Mention the following information in the issue report:
0.58.0 (using Parser 2.5.1.0, running on ruby 2.5.1 x86_64-darwin17)
Finished in 0.43951499997638166 seconds
```

This PR considers the case to be called in the method chain for
the gem name as follows.

```ruby
spec.add_development_dependency 'foo'.bar.baz
```

In this case, the gem name will be resolved searching recursively.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
