### PR TITLE
[Fix #6089] Make `Rails/BulkChangeTable` aware of variable table name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Fix `Style/RedundantParentheses` with hash literal as first argument to `super`. ([@maxh][])
 * [#6086](https://github.com/bbatsov/rubocop/issues/6086): Fix an error for `Gemspec/OrderedDependencies` when using method call to gem names in gemspec. ([@koic][])
+* [#6089](https://github.com/rubocop-hq/rubocop/issues/6089): Make `Rails/BulkChangeTable` aware of variable table name. ([@wata727][])
 
 ## 0.58.0 (2018-07-07)
 

--- a/spec/rubocop/cop/rails/bulk_change_table_spec.rb
+++ b/spec/rubocop/cop/rails/bulk_change_table_spec.rb
@@ -353,6 +353,16 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense when using variables as table name' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def change
+          %w[owners members].each do |table|
+            add_column table, :name, :string, null: false
+          end
+        end
+      RUBY
+    end
   end
 
   context 'when database is PostgreSQL' do


### PR DESCRIPTION
Fixes #6089

The following error is occurred when using variables as table name:

```
NoMethodError:
       undefined method `value' for s(:lvar, :table):RuboCop::AST::Node
     # ./lib/rubocop/cop/rails/bulk_change_table.rb:258:in `process'
     # ./lib/rubocop/cop/rails/bulk_change_table.rb:144:in `block in on_def'
     # ./lib/rubocop/ast/node.rb:185:in `block in each_child_node'
     # ./lib/rubocop/ast/node.rb:183:in `each'
     # ./lib/rubocop/ast/node.rb:183:in `each_child_node'
     # ./lib/rubocop/cop/rails/bulk_change_table.rb:142:in `on_def'
     # ./lib/rubocop/cop/commissioner.rb:57:in `block (2 levels) in trigger_responding_cops'
     # ./lib/rubocop/cop/commissioner.rb:105:in `with_cop_error_handling'
     # ./lib/rubocop/cop/commissioner.rb:56:in `block in trigger_responding_cops'
     # ./lib/rubocop/cop/commissioner.rb:55:in `each'
     # ./lib/rubocop/cop/commissioner.rb:55:in `trigger_responding_cops'
     # ./lib/rubocop/cop/commissioner.rb:33:in `block (2 levels) in <class:Commissioner>'
     # ./lib/rubocop/ast/traversal.rb:12:in `walk'
     # ./lib/rubocop/cop/commissioner.rb:45:in `investigate'
     # ./lib/rubocop/rspec/cop_helper.rb:71:in `_investigate'
     # ./lib/rubocop/rspec/cop_helper.rb:25:in `inspect_source'
     # ./lib/rubocop/rspec/expect_offense.rb:61:in `expect_no_offenses'
     # ./spec/rubocop/cop/rails/bulk_change_table_spec.rb:358:in `block (3 levels) in <top (required)>'
```

This problem occurs because the table name is not a literal node. It is very difficult to interpolate variables, so in that case, this cop ignores such nodes.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
