### PR TITLE
[Fix #6088] Fix an error for `Layout/MultilineAssignmentLayout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Fix `Style/RedundantParentheses` with hash literal as first argument to `super`. ([@maxh][])
 * [#6086](https://github.com/bbatsov/rubocop/issues/6086): Fix an error for `Gemspec/OrderedDependencies` when using method call to gem names in gemspec. ([@koic][])
+* [#6088](https://github.com/bbatsov/rubocop/issues/6088): Fix an error for `Layout/MultilineAssignmentLayout` cop when using multi-line block defines on separate lines. ([@koic][])
 
 ## 0.58.0 (2018-07-07)
 

--- a/lib/rubocop/cop/layout/multiline_assignment_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_assignment_layout.rb
@@ -43,10 +43,15 @@ module RuboCop
           'on the same line as the assignment operator `=`.'.freeze
 
         def check_assignment(node, rhs)
+          return if node.send_type?
           return unless rhs
           return unless supported_types.include?(rhs.type)
           return if rhs.first_line == rhs.last_line
 
+          check_by_enforced_style(node, rhs)
+        end
+
+        def check_by_enforced_style(node, rhs)
           case style
           when :new_line
             check_new_line_offense(node, rhs)

--- a/spec/rubocop/cop/layout/multiline_assignment_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_assignment_layout_spec.rb
@@ -71,6 +71,46 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
         end
       RUBY
     end
+
+    context 'when supported types is block' do
+      let(:supported_types) { %w[block] }
+
+      it 'registers an offense when multi-line assignments ' \
+         'using block definition is on the same line' do
+        expect_offense(<<-RUBY.strip_indent)
+          lambda = -> {
+          ^^^^^^^^^^^^^ Right hand side of multi-line assignment is on the same line as the assignment operator `=`.
+            puts 'hello'
+          }
+        RUBY
+      end
+
+      it 'allows multi-line assignments when using block definition ' \
+         'on separate lines' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          lambda =
+            -> {
+              puts 'hello'
+            }
+        RUBY
+      end
+
+      it 'allows multi-line block defines on separate lines' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          default_scope -> {
+            where(foo: "bar")
+          }
+        RUBY
+      end
+
+      it 'allows multi-line assignments when using shovel operator' do
+        expect_no_offenses(<<-'RUBY'.strip_indent)
+          foo << items.map do |item|
+            "#{item}!"
+          end
+        RUBY
+      end
+    end
   end
 
   context 'same_line style' do
@@ -134,6 +174,46 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
         if foo
         end
       RUBY
+    end
+
+    context 'when supported types is block' do
+      let(:supported_types) { %w[block] }
+
+      it 'allows when multi-line assignments using block definition ' \
+         'is on the same line' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          lambda = -> {
+            puts 'hello'
+          }
+        RUBY
+      end
+
+      it 'registers an offense when multi-line assignments ' \
+         'using block definition on separate lines' do
+        expect_offense(<<-RUBY.strip_indent)
+          lambda =
+          ^^^^^^^^ Right hand side of multi-line assignment is not on the same line as the assignment operator `=`.
+            -> {
+              puts 'hello'
+            }
+        RUBY
+      end
+
+      it 'allows multi-line block defines on separate lines' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          default_scope -> {
+            where(foo: "bar")
+          }
+        RUBY
+      end
+
+      it 'allows multi-line assignments when using shovel operator' do
+        expect_no_offenses(<<-'RUBY'.strip_indent)
+          foo << items.map do |item|
+            "#{item}!"
+          end
+        RUBY
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #6088.

This PR fixes an error for `Layout/MultilineAssignmentLayout` cop when using multi-line block defines on separate lines.

```console
% cat example.rb
default_scope -> {
  where(foo: "bar")
}
% rubocop example.rb --only Layout/MultilineAssignmentLayout
Inspecting 1 file
An error occurred while Layout/MultilineAssignmentLayout cop was
inspecting /private/tmp/example.rb:1:0.
To see the complete backtrace run rubocop -d.
.

1 file inspected, no offenses detected

1 error occurred:
An error occurred while Layout/MultilineAssignmentLayout cop was
inspecting /private/tmp/example.rb:1:0.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop-hq/rubocop/issues

Mention the following information in the issue report:
0.58.0 (using Parser 2.5.1.0, running on ruby 2.6.0 x86_64-darwin17)
```

The following case will also be fixed by this PR.

```ruby
foo << items.map do |item|
  "#{item}!"
end
```

This issue caused by removing `return unless node.setter_method?` from `on_send`.
https://github.com/rubocop-hq/rubocop/pull/6073/files#diff-a608d920f9037d90d3ca7aead6d41a1dL14

Test cases with `block` in `supported_types` option was missing, so This PR added and fixed it.
https://github.com/rubocop-hq/rubocop/blob/v0.58.0/config/default.yml#L481

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
