### PR TITLE
Changes to how to identify poorly named memoization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#6084](https://github.com/rubocop-hq/rubocop/issues/6084): Fix `Naming/MemoizedInstanceVariableName` cop to allow methods to have leading underscores. ([@kenman345][])
+
 ## 0.58.1 (2018-07-10)
 
 ### Bug fixes
@@ -3473,3 +3477,4 @@
 [@Vasfed]: https://github.com/Vasfed
 [@drn]: https://github.com/drn
 [@maxh]: https://github.com/maxh
+[@kenman345]: https://github.com/kenman345

--- a/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
+++ b/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
@@ -118,7 +118,7 @@ module RuboCop
 
           return false unless valid_leading_underscore?(variable_name)
 
-          variable_name.sub(/\A_/, '') == method_name
+          variable_name.sub(/\A_/, '') == method_name.sub(/\A_/, '')
         end
 
         def message(variable)

--- a/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
+++ b/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
@@ -8,7 +8,7 @@ module RuboCop
       #
       # This cop can be configured with the EnforcedStyleForLeadingUnderscores
       # directive. It can be configured to allow for memoized instance variables
-      # prefixed with an underscore. Prefixing ivars with an undersscore is a
+      # prefixed with an underscore. Prefixing ivars with an underscore is a
       # convention that is used to implicitly indicate that an ivar should not
       # be set or referencd outside of the memoization method.
       #
@@ -18,6 +18,11 @@ module RuboCop
       #   # not `@foo`. This can cause confusion and bugs.
       #   def foo
       #     @something ||= calculate_expensive_thing
+      #   end
+      #
+      #   # good
+      #   def _foo
+      #     @foo ||= calculate_expensive_thing
       #   end
       #
       #   # good
@@ -54,6 +59,11 @@ module RuboCop
       #     @_foo ||= calculate_expensive_thing
       #   end
       #
+      #   # good
+      #   def _foo
+      #     @_foo ||= calculate_expensive_thing
+      #   end
+      #
       # @example EnforcedStyleForLeadingUnderscores :optional
       #   # bad
       #   def foo
@@ -67,6 +77,11 @@ module RuboCop
       #
       #   # good
       #   def foo
+      #     @_foo ||= calculate_expensive_thing
+      #   end
+      #
+      #   # good
+      #   def _foo
       #     @_foo ||= calculate_expensive_thing
       #   end
       class MemoizedInstanceVariableName < Cop

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -292,7 +292,7 @@ does not match the method name.
 
 This cop can be configured with the EnforcedStyleForLeadingUnderscores
 directive. It can be configured to allow for memoized instance variables
-prefixed with an underscore. Prefixing ivars with an undersscore is a
+prefixed with an underscore. Prefixing ivars with an underscore is a
 convention that is used to implicitly indicate that an ivar should not
 be set or referencd outside of the memoization method.
 
@@ -306,6 +306,11 @@ be set or referencd outside of the memoization method.
 # not `@foo`. This can cause confusion and bugs.
 def foo
   @something ||= calculate_expensive_thing
+end
+
+# good
+def _foo
+  @foo ||= calculate_expensive_thing
 end
 
 # good
@@ -343,6 +348,11 @@ end
 def foo
   @_foo ||= calculate_expensive_thing
 end
+
+# good
+def _foo
+  @_foo ||= calculate_expensive_thing
+end
 ```
 #### EnforcedStyleForLeadingUnderscores :optional
 
@@ -359,6 +369,11 @@ end
 
 # good
 def foo
+  @_foo ||= calculate_expensive_thing
+end
+
+# good
+def _foo
   @_foo ||= calculate_expensive_thing
 end
 ```

--- a/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
@@ -95,6 +95,14 @@ RSpec.describe RuboCop::Cop::Naming::MemoizedInstanceVariableName, :config do
         RUBY
       end
 
+      it 'does not registers an offense when method has leading `_`' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          def _foo
+            @foo ||= :foo
+          end
+        RUBY
+      end
+
       context 'memoized variable matches method name during assignment' do
         it 'does not register an offense' do
           expect_no_offenses(<<-RUBY.strip_indent)
@@ -218,6 +226,22 @@ RSpec.describe RuboCop::Cop::Naming::MemoizedInstanceVariableName, :config do
       it 'does not register an offense without a leading underscore' do
         expect_no_offenses(<<-RUBY.strip_indent)
           def x
+            @x ||= :foo
+          end
+        RUBY
+      end
+
+      it 'does not register an offense with a leading `_` for both names' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          def _x
+            @_x ||= :foo
+          end
+        RUBY
+      end
+
+      it 'does not register an offense with a leading `_` for method name' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          def _x
             @x ||= :foo
           end
         RUBY


### PR DESCRIPTION
This adds enhancements to #5843 based on feedback in #6084

With this change, disallowed is the keyword to disallow the use of underscore at the beginning of the variable name of a memoization instance. I originally had the following but determined that this makes enforcing a style in a project much more difficult:
```ruby
when :disallowed
            !variable_name.start_with?('_') || variable_name == method_name 
```

I opted instead to keep that line as is, so that regardless of the method_name and variable_name matching for disalllowed, we are still enforcing the no `_` factor of this cop.

The actual change though is to add the substitution of the `_` at the beginning of a  method_name as well in our comparison.

I considered making it a logical `||` statement with the original code and then `||` with the new line my change makes, but figured its net is that we are still enforcing the same cop. If we wanted to do it this way, then we would be allowing the possibility of a double `__` in the beginning of an ivar that would match to a method that starts with `_`. That seemed like a poor choice since the idea it to ensure they match, not somewhat match.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
