### PR TITLE
[Fix #6079] Update a docmentatin to `Lint/ShadowedArgument` cop

### DIFF
--- a/lib/rubocop/cop/lint/shadowed_argument.rb
+++ b/lib/rubocop/cop/lint/shadowed_argument.rb
@@ -5,10 +5,13 @@ module RuboCop
     module Lint
       # This cop checks for shadowed arguments.
       #
+      # This cop has `IgnoreImplicitReferences` configuration option.
+      # It means argument shadowing is used in order to pass parameters
+      # to zero arity `super` when `IgnoreImplicitReferences` is `true`.
+      #
       # @example
       #
       #   # bad
-      #
       #   do_something do |foo|
       #     foo = 42
       #     puts foo
@@ -18,11 +21,8 @@ module RuboCop
       #     foo = 42
       #     puts foo
       #   end
-      #
-      # @example
       #
       #   # good
-      #
       #   do_something do |foo|
       #     foo = foo + 42
       #     puts foo
@@ -36,6 +36,33 @@ module RuboCop
       #   def do_something(foo)
       #     puts foo
       #   end
+      #
+      # @example IgnoreImplicitReferences: false (default)
+      #
+      #   # bad
+      #   def do_something(foo)
+      #     foo = 42
+      #     super
+      #   end
+      #
+      #   def do_something(foo)
+      #     foo = super
+      #     bar
+      #   end
+      #
+      # @example IgnoreImplicitReferences: true
+      #
+      #   # good
+      #   def do_something(foo)
+      #     foo = 42
+      #     super
+      #   end
+      #
+      #   def do_something(foo)
+      #     foo = super
+      #     bar
+      #   end
+      #
       class ShadowedArgument < Cop
         MSG = 'Argument `%<argument>s` was shadowed by a local variable ' \
               'before it was used.'.freeze

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1769,11 +1769,14 @@ Enabled | No
 
 This cop checks for shadowed arguments.
 
+This cop has `IgnoreImplicitReferences` configuration option.
+It means argument shadowing is used in order to pass parameters
+to zero arity `super` when `IgnoreImplicitReferences` is `true`.
+
 ### Examples
 
 ```ruby
 # bad
-
 do_something do |foo|
   foo = 42
   puts foo
@@ -1781,24 +1784,50 @@ end
 
 def do_something(foo)
   foo = 42
+  puts foo
+end
+
+# good
+do_something do |foo|
+  foo = foo + 42
+  puts foo
+end
+
+def do_something(foo)
+  foo = foo + 42
+  puts foo
+end
+
+def do_something(foo)
   puts foo
 end
 ```
+#### IgnoreImplicitReferences: false (default)
+
+```ruby
+# bad
+def do_something(foo)
+  foo = 42
+  super
+end
+
+def do_something(foo)
+  foo = super
+  bar
+end
+```
+#### IgnoreImplicitReferences: true
+
 ```ruby
 # good
-
-do_something do |foo|
-  foo = foo + 42
-  puts foo
+def do_something(foo)
+  foo = 42
+  super
 end
 
 def do_something(foo)
-  foo = foo + 42
-  puts foo
-end
-
-def do_something(foo)
-  puts foo
+  foo = super
+  bar
 end
 ```
 

--- a/spec/rubocop/cop/lint/shadowed_argument_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_argument_spec.rb
@@ -28,6 +28,18 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedArgument, :config do
           RUBY
         end
 
+        context 'when argument was shadowed by zsuper' do
+          it 'registers an offense' do
+            expect_offense(<<-RUBY.strip_indent)
+              def select_fields(query, current_time)
+                query = super
+                ^^^^^^^^^^^^^ Argument `query` was shadowed by a local variable before it was used.
+                query.select('*')
+              end
+            RUBY
+          end
+        end
+
         context 'when IgnoreImplicitReferences config option is set to true' do
           let(:cop_config) { { 'IgnoreImplicitReferences' => true } }
 
@@ -38,6 +50,17 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedArgument, :config do
                 super
               end
             RUBY
+          end
+
+          context 'when argument was shadowed by zsuper' do
+            it 'does not register an offense' do
+              expect_no_offenses(<<-RUBY.strip_indent)
+                def select_fields(query, current_time)
+                  query = super
+                  query.select('*')
+                end
+              RUBY
+            end
           end
         end
       end


### PR DESCRIPTION
Closes #6079.

This PR adds a docmentatin of `IgnoreImplicitReferences` configuration option to `Lint/ShadowedArgument` cop.

It also adds some test cases.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
