### PR TITLE
Drop min target Ruby version from `Lint/UnneededRequireStatement`

### DIFF
--- a/lib/rubocop/cop/lint/unneeded_require_statement.rb
+++ b/lib/rubocop/cop/lint/unneeded_require_statement.rb
@@ -22,10 +22,7 @@ module RuboCop
       #   # good
       #   require 'unloaded_feature'
       class UnneededRequireStatement < Cop
-        extend TargetRubyVersion
         include RangeHelp
-
-        minimum_target_ruby_version 2.2
 
         MSG = 'Remove unnecessary `require` statement.'.freeze
 


### PR DESCRIPTION
Fowllow up of #5990.

Since RuboCop 0.58.0 drops support for MRI 2.1.

This PR drops minimum target Ruby version from `Lint/UnneededRequireStatement`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
