### PR TITLE
Fix a false positive for `Layout/IndentationWidth`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#6103](https://github.com/rubocop-hq/rubocop/pull/6103): Fix a false positive for `Layout/IndentationWidth` when multiple modifiers are used in a block and a method call is made at end of the block. ([@koic][])
+
 ## 0.58.1 (2018-07-10)
 
 ### Bug fixes

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -325,7 +325,9 @@ module RuboCop
         end
 
         def leftmost_modifier_of(node)
-          node.each_ancestor(:send).to_a.last
+          return node unless node.parent && node.parent.send_type?
+
+          leftmost_modifier_of(node.parent)
         end
       end
     end

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -930,6 +930,40 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
               end
             RUBY
           end
+
+          context 'when multiple modifiers are used in a block and' \
+                  'a method call is made at end of the block' do
+            it 'accepts a correctly aligned body' do
+              expect_no_offenses(<<-RUBY.strip_indent)
+                obj = Class.new do
+                  private def private_property
+                    "That would be great."
+                  end
+                end.new
+              RUBY
+            end
+
+            it 'registers an offense for bad indentation of a def' do
+              expect_offense(<<-RUBY.strip_indent)
+                obj = Class.new do
+                    private def private_property
+                ^^^^ Use 2 (not 4) spaces for indentation.
+                    end
+                end.new
+              RUBY
+            end
+
+            it 'registers an offense for bad indentation of a def body' do
+              expect_offense(<<-RUBY.strip_indent)
+                obj = Class.new do
+                  private def private_property
+                      "That would be great."
+                  ^^^^ Use 2 (not 4) spaces for indentation.
+                  end
+                end.new
+              RUBY
+            end
+          end
         end
       end
 


### PR DESCRIPTION
This PR fixes a false positive for `Layout/IndentationWidth` cop when multiple modifiers are used in a block and a method call is made at end of the block.

This false positive is a regression that was mixed in #5996.

With the change from RuboCop 0.57.1 to 0.57.2, the following code now detects a false positive.

```ruby
obj = Class.new do
  private def private_property
    "That would be great."
  end

  protected def protected_property
    "I believe you have my stapler."
  end
end.new
```

https://github.com/rails/rails/blob/05bef14/actionview/test/template/form_helper/form_with_test.rb#L451-L459

The following is the result of running in rails/rails repo.

```console
% rubocop -V
0.58.1 (using Parser 2.5.1.2, running on ruby 2.5.1 x86_64-darwin17)
% bundle exec rubocop actionview/test/template/form_helper/form_with_test.rb
Inspecting 1 file
C

Offenses:

actionview/test/template/form_helper/form_with_test.rb:453:9: C:
Layout/IndentationWidth: Use 2 (not -2) spaces for indentation.
        "That would be great."
        ^^
actionview/test/template/form_helper/form_with_test.rb:457:9: C:
Layout/IndentationWidth: Use 2 (not -2) spaces for indentation.
        "I believe you have my stapler."
        ^^

1 file inspected, 2 offenses detected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
