### PR TITLE
Restore tests for Ruby 2.1 or higher

### DIFF
--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -70,6 +70,17 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
       end
     end
 
+    context 'when a required keyword argument is unused' do
+      it 'registers an offense but does not suggest underscore-prefix' do
+        expect_offense(<<-RUBY.strip_indent)
+          def self.some_method(foo, bar:)
+                                    ^^^ Unused method argument - `bar`.
+            puts foo
+          end
+        RUBY
+      end
+    end
+
     context 'when an optional keyword argument is unused' do
       it 'registers an offense but does not suggest underscore-prefix' do
         expect_offense(<<-RUBY.strip_indent)

--- a/spec/rubocop/cop/metrics/parameter_lists_spec.rb
+++ b/spec/rubocop/cop/metrics/parameter_lists_spec.rb
@@ -56,5 +56,12 @@ RSpec.describe RuboCop::Cop::Metrics::ParameterLists, :config do
         end
       RUBY
     end
+
+    it 'does not count keyword arguments without default values' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def meth(a, b, c, d:, e:)
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Follow up of https://github.com/rubocop-hq/rubocop/pull/5990/files#r200832453 and https://github.com/rubocop-hq/rubocop/pull/5990/files#r200832468

This PR restores tests that keyword arguments without defaults were introduced in Ruby 2.1.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
