### PR TITLE
Support `{a,b}` glob patterns in PathUtil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changes
 
+### New features
+
+* [#6105](https://github.com/rubocop-hq/rubocop/issues/6105): Support `{a,b}` file name globs in `Exclude` and `Include` config. ([@mikeyhew][])
+
 * [#6116](https://github.com/rubocop-hq/rubocop/pull/6116): Add `ip` to allowed names of `Naming/UncommunicativeMethodParamName` cop in default config. ([@nijikon][])
 
 ### Bug fixes
@@ -3485,3 +3489,5 @@
 [@maxh]: https://github.com/maxh
 [@kenman345]: https://github.com/kenman345
 [@nijikon]: https://github.com/nijikon
+[@mikeyhew]: https://github.com/mikeyhew
+[@kenman345]: https://github.com/kenman345

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -36,7 +36,7 @@ module RuboCop
     def match_path?(pattern, path)
       case pattern
       when String
-        File.fnmatch?(pattern, path, File::FNM_PATHNAME)
+        File.fnmatch?(pattern, path, File::FNM_PATHNAME | File::FNM_EXTGLOB)
       when Regexp
         begin
           path =~ pattern

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -218,6 +218,7 @@ AllCops:
     - 'db/**/*'
     - 'config/**/*'
     - 'script/**/*'
+    - 'bin/{rails,rake}'
     - !ruby/regexp /old_and_unused\.rb$/
 
 # other configuration

--- a/spec/rubocop/path_util_spec.rb
+++ b/spec/rubocop/path_util_spec.rb
@@ -85,6 +85,12 @@ RSpec.describe RuboCop::PathUtil do
         .to be(true)
       expect(described_class.match_path?('**/.*',
                                          'dir/.hidden_file')).to be(true)
+
+      expect(described_class.match_path?('c{at,ub}s', 'cats')).to be(true)
+      expect(described_class.match_path?('c{at,ub}s', 'cubs')).to be(true)
+      expect(described_class.match_path?('c{at,ub}s', 'gorillas')).to be(false)
+      expect(described_class.match_path?('**/*.{rb,txt}', 'dir/foo.txt'))
+        .to be(true)
     end
 
     it 'matches regexps' do


### PR DESCRIPTION
@jonas054 well that was pretty easy! Do the docs need to be updated at all for this?

Fixes #6105 

Pass the `FNM_EXTGLOB` flag to `File.fnmatch?` in
`PathUtil#match_path?`. This adds support for `{a,b}` patterns in
`Exclude`, `Include` and related configuration.

---

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
