### PR TITLE
Allow `ip` as method parameter in default config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#6116](https://github.com/rubocop-hq/rubocop/pull/6116): Add `ip` to allowed names of `Naming/UncommunicativeMethodParamName` cop in default config. ([@nijikon][])
+
 ### Bug fixes
 
 * [#6103](https://github.com/rubocop-hq/rubocop/pull/6103): Fix a false positive for `Layout/IndentationWidth` when multiple modifiers are used in a block and a method call is made at end of the block. ([@koic][])
@@ -3480,3 +3484,4 @@
 [@drn]: https://github.com/drn
 [@maxh]: https://github.com/maxh
 [@kenman345]: https://github.com/kenman345
+[@nijikon]: https://github.com/nijikon

--- a/config/default.yml
+++ b/config/default.yml
@@ -798,6 +798,7 @@ Naming/UncommunicativeMethodParamName:
     - 'on'
     - in
     - at
+    - ip
   # Blacklisted names that will register an offense
   ForbiddenNames: []
 

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -573,7 +573,7 @@ Name | Default value | Configurable values
 --- | --- | ---
 MinNameLength | `3` | Integer
 AllowNamesEndingInNumbers | `true` | Boolean
-AllowedNames | `io`, `id`, `to`, `by`, `on`, `in`, `at` | Array
+AllowedNames | `io`, `id`, `to`, `by`, `on`, `in`, `at`, `ip` | Array
 ForbiddenNames | `[]` | Array
 
 ## Naming/VariableName


### PR DESCRIPTION
Add `ip` to AllowedNames in default configuration for cop
Naming/UncommunicativeMethodParamName in order to allow name that
is valid and it is pointless to replace it with i.e. `ip_addr`

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
