### PR TITLE
[Fix #6115] Fix a false positive for `Lint/OrderedMagicComments`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#6103](https://github.com/rubocop-hq/rubocop/pull/6103): Fix a false positive for `Layout/IndentationWidth` when multiple modifiers are used in a block and a method call is made at end of the block. ([@koic][])
 * [#6084](https://github.com/rubocop-hq/rubocop/issues/6084): Fix `Naming/MemoizedInstanceVariableName` cop to allow methods to have leading underscores. ([@kenman345][])
 * [#6098](https://github.com/rubocop-hq/rubocop/issues/6098): Fix an error for `Layout/ClassStructure` when there is a comment in the macro method to be auto-correct. ([@koic][])
+* [#6115](https://github.com/rubocop-hq/rubocop/issues/6115): Fix a false positive for `Lint/OrderedMagicComments` when using `{ encoding: Encoding::SJIS }` hash object after `frozen_string_literal` magic comment. ([@koic][])
 
 ## 0.58.1 (2018-07-10)
 

--- a/lib/rubocop/cop/mixin/frozen_string_literal.rb
+++ b/lib/rubocop/cop/mixin/frozen_string_literal.rb
@@ -34,7 +34,13 @@ module RuboCop
       end
 
       def leading_comment_lines
-        processed_source[0..2].compact
+        comments = processed_source.comments
+
+        comments.each_with_object([]) do |comment, leading_comments|
+          next if comment.loc.line > 3
+
+          leading_comments << comment.text
+        end
       end
     end
   end

--- a/lib/rubocop/magic_comment.rb
+++ b/lib/rubocop/magic_comment.rb
@@ -190,7 +190,7 @@ module RuboCop
     class SimpleComment < MagicComment
       # Match `encoding` or `coding`
       def encoding
-        extract(/\#* \b(?:en)?coding: (#{TOKEN})/i)
+        extract(/\A\#.*\b(?:en)?coding: (#{TOKEN})/i)
       end
 
       private

--- a/lib/rubocop/magic_comment.rb
+++ b/lib/rubocop/magic_comment.rb
@@ -190,7 +190,7 @@ module RuboCop
     class SimpleComment < MagicComment
       # Match `encoding` or `coding`
       def encoding
-        extract(/\A\#.*\b(?:en)?coding: (#{TOKEN})/i)
+        extract(/\A\s*\#.*\b(?:en)?coding: (#{TOKEN})/i)
       end
 
       private
@@ -203,7 +203,7 @@ module RuboCop
       # Case-insensitive and dashes/underscores are acceptable.
       # @see https://git.io/vM7Mg
       def extract_frozen_string_literal
-        extract(/\A#\s*frozen[_-]string[_-]literal:\s*(#{TOKEN})\s*\z/i)
+        extract(/\A\s*#\s*frozen[_-]string[_-]literal:\s*(#{TOKEN})\s*\z/i)
       end
     end
   end

--- a/spec/rubocop/cop/lint/ordered_magic_comments_spec.rb
+++ b/spec/rubocop/cop/lint/ordered_magic_comments_spec.rb
@@ -70,6 +70,17 @@ RSpec.describe RuboCop::Cop::Lint::OrderedMagicComments, :config do
     RUBY
   end
 
+  it 'does not register an offense when using ' \
+     '`encoding: Encoding::SJIS` Hash notation after' \
+     '`frozen_string_literal` magic comment' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      # frozen_string_literal: true
+
+      x = { encoding: Encoding::SJIS }
+      puts x
+    RUBY
+  end
+
   it 'autocorrects ordered magic comments' do
     new_source = autocorrect_source(<<-RUBY.strip_indent)
       # frozen_string_literal: true

--- a/spec/rubocop/magic_comment_spec.rb
+++ b/spec/rubocop/magic_comment_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe RuboCop::MagicComment do
                    encoding: 'utf-8'
 
   include_examples 'magic comment',
+                   '    # coding: utf-8',
+                   encoding: 'utf-8'
+
+  include_examples 'magic comment',
                    '# incoding: utf-8'
 
   include_examples 'magic comment',
@@ -43,6 +47,10 @@ RSpec.describe RuboCop::MagicComment do
 
   include_examples 'magic comment',
                    '# frozen_string_literal: true',
+                   frozen_string_literal: true
+
+  include_examples 'magic comment',
+                   '    # frozen_string_literal: true',
                    frozen_string_literal: true
 
   include_examples 'magic comment',


### PR DESCRIPTION
Fixes #6115.

This PR fixes a false positive for `Lint/OrderedMagicComments` when using `encoding: Encoding::SJIS` Hash notation after `frozen_string_literal` magic comment.

There was a false positive to misunderstanding the following Hash notation as an encoding magic comment.

```ruby
# frozen_string_literal: true

x = { encoding: Encoding::SJIS }
puts x
```

This PR changes the pattern match of the magic encoding comment so that beginning of line always starts with `#`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
