### PR TITLE
Remove `pwd` from cache key

### DIFF
--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -84,7 +84,6 @@ module RuboCop
                         relevant_options_digest(options),
                         file_checksum(file, config_store))
       @cached_data = CachedData.new(file)
-      @pwd = Dir.pwd
     end
 
     def valid?
@@ -136,7 +135,7 @@ module RuboCop
       digester = Digest::MD5.new
       mode = File.stat(file).mode
       digester.update(
-        "#{@pwd}#{file}#{mode}#{config_store.for(file).signature}"
+        "#{file}#{mode}#{config_store.for(file).signature}"
       )
       digester.file(file)
       digester.hexdigest


### PR DESCRIPTION
Problem
===

The cache key does not include `Dir.pwd` unexpectedly.
Because `file_chechsum` method is called before initializing `@pwd`. So `@pwd` is always nil.

Solution
====

Remove `@pwd` from cache key. Because `@pwd` is meaningless.
The `file` argument is always full path, so it includes `@pwd`.

Note
===

This patch does not include CHANGELOG. Because this patch does not change behaviour of RuboCop.




-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
