### PR TITLE
Remove redundant Include of config.ru in default.yml

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -42,7 +42,6 @@ AllCops:
     - '**/.irbrc'
     - '**/.pryrc'
     - '**/buildfile'
-    - '**/config.ru'
     - '**/Appraisals'
     - '**/Berksfile'
     - '**/Brewfile'


### PR DESCRIPTION
We `Include` `**/*.ru` so there is no need to also `Include` `config.ru`.

-----------------

* [x] Wrote [good commit messages][1].
* [N/A] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [N/A] Added tests.
* [N/A] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
