### PR TITLE
Remove redundant tests for `RuboCop::PathUtil`

### DIFF
--- a/spec/rubocop/path_util_spec.rb
+++ b/spec/rubocop/path_util_spec.rb
@@ -67,8 +67,6 @@ RSpec.describe RuboCop::PathUtil do
 
     it 'matches glob expressions' do
       expect(described_class.match_path?('dir/*', 'dir/file')).to be(true)
-      expect(described_class.match_path?('dir/*/*',
-                                         'dir/sub/file')).to be(true)
       expect(described_class.match_path?('dir/**/*',
                                          'dir/sub/file')).to be(true)
       expect(described_class.match_path?('dir/**/*', 'dir/file')).to be(true)


### PR DESCRIPTION
The following tests are the same.

- https://github.com/rubocop-hq/rubocop/blob/v0.58.2/spec/rubocop/path_util_spec.rb#L70-L73

This PR removes one duplicate.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
