### PR TITLE
add specs for MemoizedInstanceVariableName

### DIFF
--- a/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
@@ -103,6 +103,15 @@ RSpec.describe RuboCop::Cop::Naming::MemoizedInstanceVariableName, :config do
         RUBY
       end
 
+      it 'does not register an offense with a leading `_` for both names' do
+        pending
+        expect_no_offenses(<<-RUBY.strip_indent)
+          def _foo
+            @_foo ||= :foo
+          end
+        RUBY
+      end
+
       context 'memoized variable matches method name during assignment' do
         it 'does not register an offense' do
           expect_no_offenses(<<-RUBY.strip_indent)
@@ -207,6 +216,14 @@ RSpec.describe RuboCop::Cop::Naming::MemoizedInstanceVariableName, :config do
         @_my_var ||= :foo
         ^^^^^^^^ Memoized variable `@_my_var` does not match method name `foo`. Use `@_foo` instead.
       end
+      RUBY
+    end
+
+    it 'does not register an offense with a leading `_` for both names' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def _foo
+          @_foo ||= :foo
+        end
       RUBY
     end
   end


### PR DESCRIPTION
Add a regression test for `Naming/MemoizedInstanceVariableName` with `EnforcedStyleForLeadingUnderscores: disallowed`, see https://github.com/rubocop-hq/rubocop/issues/6084#issuecomment-407370135 and the following comments.

The [manual](https://github.com/rubocop-hq/rubocop/blob/4ed9aab2b2ba8f1a004c58e5765940540742623d/manual/cops_naming.md#namingmemoizedinstancevariablename) says that it is ok if method name and variable name are the same, but thats not the case if the both are starting with a `_`.

With rubocop `0.57.2` this offence didn't happen.