### PR TITLE
Add a Strict mode to Style/MutableConstants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 * [#6704](https://github.com/rubocop-hq/rubocop/pull/6704): Add new `Rails/ReflectionClassName` cop. ([@Bhacaz][])
 * [#6643](https://github.com/rubocop-hq/rubocop/pull/6643): Support `AllowParenthesesInCamelCaseMethod` option on `Style/MethodCallWithArgsParentheses` `omit_parentheses`. ([@dazuma][])
+* Add an experimental strict mode to `Style/MutableConstant` that will freeze all constants, rather than just literals. ([@rrosenblum][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -3549,6 +3549,17 @@ Style/MutableConstant:
   Description: 'Do not assign mutable objects to constants.'
   Enabled: true
   VersionAdded: '0.34'
+  VersionChanged: '0.65'
+  EnforcedStyle: literals
+  SupportedStyles:
+    # literals: freeze literals assigned to constants
+    # strict: freeze all constants
+    # Strict mode is considered an experimental feature. It has not been updated
+    # with an exhaustive list of all methods that will produce frozen objects so
+    # there is a decent chance of getting some false positives. Luckily, there is
+    # no harm in freezing an already frozen object.
+    - literals
+    - strict
 
 Style/NegatedIf:
   Description: >-

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -6,7 +6,15 @@ module RuboCop
       # This cop checks whether some constant value isn't a
       # mutable literal (e.g. array or hash).
       #
-      # @example
+      # Strict mode can be used to freeze all constants, rather than
+      # just literals.
+      # Strict mode is considered an experimental feature. It has not been
+      # updated with an exhaustive list of all methods that will produce
+      # frozen objects so there is a decent chance of getting some false
+      # positives. Luckily, there is no harm in freezing an already
+      # frozen object.
+      #
+      # @example EnforcedStyle: literals (default)
       #   # bad
       #   CONST = [1, 2, 3]
       #
@@ -15,10 +23,36 @@ module RuboCop
       #
       #   # good
       #   CONST = <<~TESTING.freeze
-      #   This is a heredoc
+      #     This is a heredoc
       #   TESTING
+      #
+      #   # good
+      #   CONST = Something.new
+      #
+      #
+      # @example EnforcedStyle: strict
+      #   # bad
+      #   CONST = Something.new
+      #
+      #   # bad
+      #   CONST = Struct.new do
+      #     def foo
+      #       puts 1
+      #     end
+      #   end
+      #
+      #   # good
+      #   CONST = Something.new.freeze
+      #
+      #   # good
+      #   CONST = Struct.new do
+      #     def foo
+      #       puts 1
+      #     end
+      #   end.freeze
       class MutableConstant < Cop
         include FrozenStringLiteral
+        include ConfigurableEnforcedStyle
 
         MSG = 'Freeze mutable objects assigned to constants.'.freeze
 
@@ -39,24 +73,41 @@ module RuboCop
           expr = node.source_range
 
           lambda do |corrector|
-            if node.array_type? && !node.bracketed?
+            splat_value = splat_value(node)
+            if splat_value
+              correct_splat_expansion(corrector, expr, splat_value)
+            elsif node.array_type? && !node.bracketed?
               corrector.insert_before(expr, '[')
-              corrector.insert_after(expr, '].freeze')
-            elsif node.irange_type? || node.erange_type?
+              corrector.insert_after(expr, ']')
+            elsif requires_parentheses?(node)
               corrector.insert_before(expr, '(')
-              corrector.insert_after(expr, ').freeze')
-            else
-              corrector.insert_after(expr, '.freeze')
+              corrector.insert_after(expr, ')')
             end
+
+            corrector.insert_after(expr, '.freeze')
           end
         end
 
         private
 
         def on_assignment(value)
-          range_enclosed_in_parentheses = range_enclosed_in_parentheses?(value)
+          if style == :strict
+            strict_check(value)
+          else
+            check(value)
+          end
+        end
 
-          value = splat_value(value) if splat_value(value)
+        def strict_check(value)
+          return if immutable_literal?(value)
+          return if operation_produces_immutable_object?(value)
+          return if frozen_string_literal?(value)
+
+          add_offense(value)
+        end
+
+        def check(value)
+          range_enclosed_in_parentheses = range_enclosed_in_parentheses?(value)
 
           return unless mutable_literal?(value) ||
                         range_enclosed_in_parentheses
@@ -70,8 +121,49 @@ module RuboCop
           value && value.mutable_literal?
         end
 
+        def immutable_literal?(node)
+          node.nil? || node.immutable_literal?
+        end
+
+        def frozen_string_literal?(node)
+          FROZEN_STRING_LITERAL_TYPES.include?(node.type) &&
+            frozen_string_literals_enabled?
+        end
+
+        def requires_parentheses?(node)
+          node.irange_type? ||
+            node.erange_type? ||
+            (node.send_type? && node.loc.dot.nil?)
+        end
+
+        def correct_splat_expansion(corrector, expr, splat_value)
+          if range_enclosed_in_parentheses?(splat_value)
+            corrector.replace(expr, "#{splat_value.source}.to_a")
+          else
+            corrector.replace(expr, "(#{splat_value.source}).to_a")
+          end
+        end
+
         def_node_matcher :splat_value, <<-PATTERN
           (array (splat $_))
+        PATTERN
+
+        # Some of these patterns may not actually return an immutable object,
+        # but we want to consider them immutable for this cop.
+        def_node_matcher :operation_produces_immutable_object?, <<-PATTERN
+          {
+            (const _ _)
+            (send (const nil? :Struct) :new ...)
+            (block (send (const nil? :Struct) :new ...) ...)
+            (send _ :freeze)
+            (send {float int} {:+ :- :* :** :/ :% :<<} _)
+            (send _ {:+ :- :* :** :/ :%} {float int})
+            (send _ {:== :=== :!= :<= :>= :< :>} _)
+            (send (const nil? :ENV) :[] _)
+            (or (send (const nil? :ENV) :[] _) _)
+            (send _ {:count :length :size} ...)
+            (block (send _ {:count :length :size} ...) ...)
+          }
         PATTERN
 
         def_node_matcher :range_enclosed_in_parentheses?, <<-PATTERN

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3630,12 +3630,22 @@ foo if ['a', 'b', 'c'].include?(a)
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.34 | -
+Enabled | Yes | Yes  | 0.34 | 0.65
 
 This cop checks whether some constant value isn't a
 mutable literal (e.g. array or hash).
 
+Strict mode can be used to freeze all constants, rather than
+just literals.
+Strict mode is considered an experimental feature. It has not been
+updated with an exhaustive list of all methods that will produce
+frozen objects so there is a decent chance of getting some false
+positives. Luckily, there is no harm in freezing an already
+frozen object.
+
 ### Examples
+
+#### EnforcedStyle: literals (default)
 
 ```ruby
 # bad
@@ -3646,9 +3656,41 @@ CONST = [1, 2, 3].freeze
 
 # good
 CONST = <<~TESTING.freeze
-This is a heredoc
+  This is a heredoc
 TESTING
+
+# good
+CONST = Something.new
 ```
+#### EnforcedStyle: strict
+
+```ruby
+# bad
+CONST = Something.new
+
+# bad
+CONST = Struct.new do
+  def foo
+    puts 1
+  end
+end
+
+# good
+CONST = Something.new.freeze
+
+# good
+CONST = Struct.new do
+  def foo
+    puts 1
+  end
+end.freeze
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `literals` | `literals`, `strict`
 
 ## Style/NegatedIf
 

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Style::MutableConstant do
-  subject(:cop) { described_class.new }
+RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
+  subject(:cop) { described_class.new(config) }
 
   let(:prefix) { nil }
 
@@ -35,11 +35,6 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant do
     end
   end
 
-  it_behaves_like 'mutable objects', '[1, 2, 3]'
-  it_behaves_like 'mutable objects', '{ a: 1, b: 2 }'
-  it_behaves_like 'mutable objects', "'str'"
-  it_behaves_like 'mutable objects', '"top#{1 + 2}"'
-
   shared_examples 'immutable objects' do |o|
     it "allows #{o} to be assigned to a constant" do
       source = [prefix, "CONST = #{o}"].compact.join("\n")
@@ -52,78 +47,123 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant do
     end
   end
 
-  it_behaves_like 'immutable objects', '1'
-  it_behaves_like 'immutable objects', '1.5'
-  it_behaves_like 'immutable objects', ':sym'
+  context 'Strict: false' do
+    let(:cop_config) { { 'EnforcedStyle' => 'literals' } }
 
-  it 'allows method call assignments' do
-    expect_no_offenses('TOP_TEST = Something.new')
-  end
+    it_behaves_like 'mutable objects', '[1, 2, 3]'
+    it_behaves_like 'mutable objects', '%w(a b c)'
+    it_behaves_like 'mutable objects', '{ a: 1, b: 2 }'
+    it_behaves_like 'mutable objects', "'str'"
+    it_behaves_like 'mutable objects', '"top#{1 + 2}"'
 
-  context 'when performing a splat assignment' do
-    it 'allows an immutable value' do
-      expect_no_offenses('FOO = *(1...10)')
+    it_behaves_like 'immutable objects', '1'
+    it_behaves_like 'immutable objects', '1.5'
+    it_behaves_like 'immutable objects', ':sym'
+    it_behaves_like 'immutable objects', 'FOO + BAR'
+    it_behaves_like 'immutable objects', 'FOO - BAR'
+    it_behaves_like 'immutable objects', "'foo' + 'bar'"
+    it_behaves_like 'immutable objects', "ENV['foo']"
+
+    it 'allows method call assignments' do
+      expect_no_offenses('TOP_TEST = Something.new')
     end
 
-    it 'allows a frozen array value' do
-      expect_no_offenses('FOO = *[1...10].freeze')
+    context 'splat expansion' do
+      context 'expansion of a range' do
+        it 'registers an offense' do
+          expect_offense(<<-RUBY.strip_indent)
+            FOO = *1..10
+                  ^^^^^^ Freeze mutable objects assigned to constants.
+          RUBY
+        end
+
+        it 'correct to use to_a.freeze' do
+          new_source = autocorrect_source('FOO = *1..10')
+
+          expect(new_source).to eq('FOO = (1..10).to_a.freeze')
+        end
+
+        context 'with parentheses' do
+          it 'registers an offense' do
+            expect_offense(<<-RUBY.strip_indent)
+              FOO = *(1..10)
+                    ^^^^^^^^ Freeze mutable objects assigned to constants.
+            RUBY
+          end
+
+          it 'correct to use to_a.freeze' do
+            new_source = autocorrect_source('FOO = *(1..10)')
+
+            expect(new_source).to eq('FOO = (1..10).to_a.freeze')
+          end
+        end
+      end
     end
 
-    it 'registers an offense for a mutable value' do
-      source = 'BAR = *[1, 2, 3]'
+    context 'when assigning an array without brackets' do
+      it 'adds brackets when auto-correcting' do
+        new_source = autocorrect_source('XXX = YYY, ZZZ')
+        expect(new_source).to eq 'XXX = [YYY, ZZZ].freeze'
+      end
 
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-
-      corrected = autocorrect_source(source)
-
-      expect(corrected).to eq('BAR = *[1, 2, 3].freeze')
-    end
-  end
-
-  context 'when assigning an array without brackets' do
-    it 'adds brackets when auto-correcting' do
-      new_source = autocorrect_source('XXX = YYY, ZZZ')
-      expect(new_source).to eq 'XXX = [YYY, ZZZ].freeze'
+      it 'does not add brackets to %w() arrays' do
+        new_source = autocorrect_source('XXX = %w(YYY ZZZ)')
+        expect(new_source).to eq 'XXX = %w(YYY ZZZ).freeze'
+      end
     end
 
-    it 'does not add brackets to %w() arrays' do
-      new_source = autocorrect_source('XXX = %w(YYY ZZZ)')
-      expect(new_source).to eq 'XXX = %w(YYY ZZZ).freeze'
-    end
-  end
+    context 'when assigning a range (irange) without parenthesis' do
+      it 'adds parenthesis when auto-correcting' do
+        new_source = autocorrect_source('XXX = 1..99')
+        expect(new_source).to eq 'XXX = (1..99).freeze'
+      end
 
-  context 'when assigning a range (irange) without parenthesis' do
-    it 'adds parenthesis when auto-correcting' do
-      new_source = autocorrect_source('XXX = 1..99')
-      expect(new_source).to eq 'XXX = (1..99).freeze'
-    end
-
-    it 'does not add parenthesis to range enclosed in parentheses' do
-      new_source = autocorrect_source('XXX = (1..99)')
-      expect(new_source).to eq 'XXX = (1..99).freeze'
-    end
-  end
-
-  context 'when assigning a range (erange) without parenthesis' do
-    it 'adds parenthesis when auto-correcting' do
-      new_source = autocorrect_source('XXX = 1...99')
-      expect(new_source).to eq 'XXX = (1...99).freeze'
+      it 'does not add parenthesis to range enclosed in parentheses' do
+        new_source = autocorrect_source('XXX = (1..99)')
+        expect(new_source).to eq 'XXX = (1..99).freeze'
+      end
     end
 
-    it 'does not add parenthesis to range enclosed in parentheses' do
-      new_source = autocorrect_source('XXX = (1...99)')
-      expect(new_source).to eq 'XXX = (1...99).freeze'
-    end
-  end
+    context 'when assigning a range (erange) without parenthesis' do
+      it 'adds parenthesis when auto-correcting' do
+        new_source = autocorrect_source('XXX = 1...99')
+        expect(new_source).to eq 'XXX = (1...99).freeze'
+      end
 
-  context 'when the constant is a frozen string literal' do
-    if RuboCop::Config::KNOWN_RUBIES.include?(3.0)
-      context 'when the target ruby version >= 3.0' do
-        let(:ruby_version) { 3.0 }
+      it 'does not add parenthesis to range enclosed in parentheses' do
+        new_source = autocorrect_source('XXX = (1...99)')
+        expect(new_source).to eq 'XXX = (1...99).freeze'
+      end
+    end
+
+    context 'when the constant is a frozen string literal' do
+      if RuboCop::Config::KNOWN_RUBIES.include?(3.0)
+        context 'when the target ruby version >= 3.0' do
+          let(:ruby_version) { 3.0 }
+
+          context 'when the frozen string literal comment is missing' do
+            it_behaves_like 'immutable objects', '"#{a}"'
+          end
+
+          context 'when the frozen string literal comment is true' do
+            let(:prefix) { '# frozen_string_literal: true' }
+
+            it_behaves_like 'immutable objects', '"#{a}"'
+          end
+
+          context 'when the frozen string literal comment is false' do
+            let(:prefix) { '# frozen_string_literal: false' }
+
+            it_behaves_like 'immutable objects', '"#{a}"'
+          end
+        end
+      end
+
+      context 'when the target ruby version >= 2.3' do
+        let(:ruby_version) { 2.3 }
 
         context 'when the frozen string literal comment is missing' do
-          it_behaves_like 'immutable objects', '"#{a}"'
+          it_behaves_like 'mutable objects', '"#{a}"'
         end
 
         context 'when the frozen string literal comment is true' do
@@ -135,9 +175,221 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant do
         context 'when the frozen string literal comment is false' do
           let(:prefix) { '# frozen_string_literal: false' }
 
-          it_behaves_like 'immutable objects', '"#{a}"'
+          it_behaves_like 'mutable objects', '"#{a}"'
         end
       end
+    end
+  end
+
+  context 'Strict: true' do
+    let(:cop_config) { { 'EnforcedStyle' => 'strict' } }
+
+    it_behaves_like 'mutable objects', '[1, 2, 3]'
+    it_behaves_like 'mutable objects', '%w(a b c)'
+    it_behaves_like 'mutable objects', '{ a: 1, b: 2 }'
+    it_behaves_like 'mutable objects', "'str'"
+    it_behaves_like 'mutable objects', '"top#{1 + 2}"'
+    it_behaves_like 'mutable objects', 'Something.new'
+
+    it_behaves_like 'immutable objects', '1'
+    it_behaves_like 'immutable objects', '1.5'
+    it_behaves_like 'immutable objects', ':sym'
+    it_behaves_like 'immutable objects', "ENV['foo']"
+    it_behaves_like 'immutable objects', 'OTHER_CONST'
+    it_behaves_like 'immutable objects', 'Namespace::OTHER_CONST'
+    it_behaves_like 'immutable objects', 'Struct.new'
+    it_behaves_like 'immutable objects', 'Struct.new(:a, :b)'
+    it_behaves_like 'immutable objects', <<-RUBY.strip_indent
+      Struct.new(:node) do
+        def assignment?
+          true
+        end
+      end
+    RUBY
+
+    it 'allows calls to freeze' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        CONST = [1].freeze
+      RUBY
+    end
+
+    context 'splat expansion' do
+      context 'expansion of a range' do
+        it 'registers an offense' do
+          expect_offense(<<-RUBY.strip_indent)
+            FOO = *1..10
+                  ^^^^^^ Freeze mutable objects assigned to constants.
+          RUBY
+        end
+
+        it 'correct to use to_a.freeze' do
+          new_source = autocorrect_source('FOO = *1..10')
+
+          expect(new_source).to eq('FOO = (1..10).to_a.freeze')
+        end
+
+        context 'with parentheses' do
+          it 'registers an offense' do
+            expect_offense(<<-RUBY.strip_indent)
+              FOO = *(1..10)
+                    ^^^^^^^^ Freeze mutable objects assigned to constants.
+            RUBY
+          end
+
+          it 'correct to use to_a.freeze' do
+            new_source = autocorrect_source('FOO = *(1..10)')
+
+            expect(new_source).to eq('FOO = (1..10).to_a.freeze')
+          end
+        end
+      end
+    end
+
+    context 'when assigning with an operator' do
+      shared_examples 'operator methods' do |o|
+        it 'registers an offense' do
+          inspect_source("CONST = FOO #{o} BAR")
+
+          expect(cop.offenses.size).to eq(1)
+          expect(cop.highlights).to eq(["FOO #{o} BAR"])
+        end
+
+        it 'corrects by wrapping in parentheses and calling freeze' do
+          new_source = autocorrect_source(<<-RUBY.strip_indent)
+            CONST = FOO #{o} BAR
+          RUBY
+
+          expect(new_source).to eq(<<-RUBY.strip_indent)
+            CONST = (FOO #{o} BAR).freeze
+          RUBY
+        end
+      end
+
+      it_behaves_like 'operator methods', '+'
+      it_behaves_like 'operator methods', '-'
+      it_behaves_like 'operator methods', '*'
+      it_behaves_like 'operator methods', '/'
+      it_behaves_like 'operator methods', '%'
+      it_behaves_like 'operator methods', '**'
+    end
+
+    context 'when assigning with multiple operator calls' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
+          FOO = [1].freeze
+          BAR = [2].freeze
+          BAZ = [3].freeze
+          CONST = FOO + BAR + BAZ
+                  ^^^^^^^^^^^^^^^ Freeze mutable objects assigned to constants.
+        RUBY
+      end
+
+      it 'corrects by wrapping in parens and calling freeze' do
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+          FOO = [1].freeze
+          BAR = [2].freeze
+          BAZ = [3].freeze
+          CONST = FOO + BAR + BAZ
+        RUBY
+
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          FOO = [1].freeze
+          BAR = [2].freeze
+          BAZ = [3].freeze
+          CONST = (FOO + BAR + BAZ).freeze
+        RUBY
+      end
+    end
+
+    context 'methods and operators that produce frozen objects' do
+      it 'accepts assigning to an environment variable with a fallback' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          CONST = ENV['foo'] || 'foo'
+        RUBY
+      end
+
+      it 'accepts operating on a constant and an interger' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          CONST = FOO + 2
+        RUBY
+      end
+
+      it 'accepts operating on multiple integers' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          CONST = 1 + 2
+        RUBY
+      end
+
+      it 'accepts operating on a constant and a float' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          CONST = FOO + 2.1
+        RUBY
+      end
+
+      it 'accepts operating on multiple floats' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          CONST = 1.2 + 2.1
+        RUBY
+      end
+
+      it 'accepts comparison operators' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          CONST = FOO == BAR
+        RUBY
+      end
+
+      it 'accepts checking fixed size' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          CONST = 'foo'.count
+          CONST = 'foo'.count('f')
+          CONST = [1, 2, 3].count { |n| n > 2 }
+          CONST = [1, 2, 3].count(2) { |n| n > 2 }
+          CONST = 'foo'.length
+          CONST = 'foo'.size
+        RUBY
+      end
+    end
+
+    context 'operators that produce unfrozen objects' do
+      it 'registers an offense when operating on a constant and a string' do
+        expect_offense(<<-RUBY.strip_indent)
+          CONST = FOO + 'bar'
+                  ^^^^^^^^^^^ Freeze mutable objects assigned to constants.
+        RUBY
+      end
+
+      it 'registers an offense when operating on multiple strings' do
+        expect_offense(<<-RUBY.strip_indent)
+          CONST = 'foo' + 'bar' + 'baz'
+                  ^^^^^^^^^^^^^^^^^^^^^ Freeze mutable objects assigned to constants.
+        RUBY
+      end
+    end
+
+    context 'when assigning an array without brackets' do
+      it 'adds brackets when auto-correcting' do
+        new_source = autocorrect_source('XXX = YYY, ZZZ')
+        expect(new_source).to eq 'XXX = [YYY, ZZZ].freeze'
+      end
+
+      it 'does not add brackets to %w() arrays' do
+        new_source = autocorrect_source('XXX = %w(YYY ZZZ)')
+        expect(new_source).to eq 'XXX = %w(YYY ZZZ).freeze'
+      end
+    end
+
+    it 'freezes a heredoc' do
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        FOO = <<-HERE
+          SOMETHING
+        HERE
+      RUBY
+
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        FOO = <<-HERE.freeze
+          SOMETHING
+        HERE
+      RUBY
     end
 
     context 'when the target ruby version >= 2.3' do


### PR DESCRIPTION
This has been something that I have wanted to do for a while. Right now, we only freeze literals that are assigned to constants. This leaves many constants unfrozen and therefore potentially unsafe.

I consider this to be experimental functionality. I'm not sure how many other people would be interested in this feature. I think I have all of the main use cases covered. I am trying to account for any edge cases now. 

Something interesting that I learned from this is that concatenating frozen strings produces an unfrozen string.