### PR TITLE
[Fix #6127] Fix an error for `Layout/ClosingParenthesisIndentation` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * [#6132](https://github.com/rubocop-hq/rubocop/issues/6132): Fix a false negative for `Naming/FileName` when `Include` of `AllCops` is the default setting. ([@koic][])
 * [#4115](https://github.com/rubocop-hq/rubocop/issues/4115): Fix false positive for unary operations in `Layout/MultilineOperationIndentation`. ([@jonas054][])
+* [#6127](https://github.com/rubocop-hq/rubocop/issues/6127): Fix an error for `Layout/ClosingParenthesisIndentation` when method arguments are empty with newlines. ([@tatsuyafw][])
 
 ### Changes
 

--- a/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
@@ -63,10 +63,6 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
         RUBY
       end
 
-      it 'accepts empty ()' do
-        expect_no_offenses('some_method()')
-      end
-
       it 'accepts a correctly indented )' do
         expect_no_offenses(<<-RUBY.strip_indent)
           some_method(a,
@@ -97,6 +93,26 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
           b =
             some_method(a,
                        )
+        RUBY
+      end
+    end
+
+    context 'without arguments' do
+      it 'accepts empty ()' do
+        expect_no_offenses('some_method()')
+      end
+
+      it 'can handle indentation up against the left edge' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          some_method(
+          )
+        RUBY
+      end
+
+      it 'accepts a correctly aligned ) against (' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          some_method(
+                     )
         RUBY
       end
     end
@@ -197,11 +213,6 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
                            )
         RUBY
       end
-
-      it 'accepts empty ()' do
-        expect_no_offenses('foo = some_method()')
-      end
-
       it 'accepts a correctly indented )' do
         expect_no_offenses(<<-RUBY.strip_indent)
           foo = some_method(a,
@@ -232,6 +243,41 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
           b =
             some_method(a,
                        )
+        RUBY
+      end
+    end
+
+    context 'without arguments' do
+      it 'accepts empty ()' do
+        expect_no_offenses('foo = some_method()')
+      end
+
+      it 'accepts a correctly aligned ) against (' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo = some_method(
+                           )
+        RUBY
+      end
+
+      it 'can handle indentation up against the left edge' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo = some_method(
+          )
+        RUBY
+      end
+
+      it 'can handle indentation up against the method' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo = some_method(
+                )
+        RUBY
+      end
+
+      it 'registers an offense for misaligned )' do
+        expect_offense(<<-RUBY.strip_indent)
+          foo = some_method(
+            )
+            ^ Indent `)` to column 0 (not 2)
         RUBY
       end
     end


### PR DESCRIPTION
Fixes #6127

`Layout/ClosingParenthesisIndentation` cop threw an error when method arguments are empty and a right paren started in newlines like the following code:

```ruby
# foo.rb
def foo
  something(
  )
end
```

```console
$ rubocop --only 'Layout/ClosingParenthesisIndentation' foo.rb
Inspecting 1 file
An error occurred while Layout/ClosingParenthesisIndentation cop was inspecting /Users/hoshino/src/github.com/tatsuyafw/rubocop/foo.rb:2:2.
To see the complete backtrace run rubocop -d.
.

1 file inspected, no offenses detected

1 error occurred:
An error occurred while Layout/ClosingParenthesisIndentation cop was inspecting /Users/hoshino/src/github.com/tatsuyafw/rubocop/foo.rb:2:2.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop-hq/rubocop/issues

Mention the following information in the issue report:
0.58.2 (using Parser 2.5.1.2, running on ruby 2.5.1 x86_64-darwin17)
$
```

This change fixes the above error.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
