### PR TITLE
[Fix #6124] Fix `Style/IfUnlessModifier` cop for disabled `Layout/Tab` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 * [#4115](https://github.com/rubocop-hq/rubocop/issues/4115): Fix false positive for unary operations in `Layout/MultilineOperationIndentation`. ([@jonas054][])
 * [#6127](https://github.com/rubocop-hq/rubocop/issues/6127): Fix an error for `Layout/ClosingParenthesisIndentation` when method arguments are empty with newlines. ([@tatsuyafw][])
 * [#6152](https://github.com/rubocop-hq/rubocop/pull/6152): Fix a false negative for `Layout/AccessModifierIndentation` when using access modifiers with arguments within nested classes. ([@gmalette][])
+* [#6124](https://github.com/rubocop-hq/rubocop/issues/6124): Fix `Style/IfUnlessModifier` cop for disabled `Layout/Tab` cop when there is no `IndentationWidth` config. ([@AlexWayfer][])
+* [#6133](https://github.com/rubocop-hq/rubocop/pull/6133): Fix `AllowURI` option of `Metrics/LineLength` cop for files with tabs indentation. ([@AlexWayfer][])
 
 ### Changes
 

--- a/lib/rubocop/cop/metrics/line_length.rb
+++ b/lib/rubocop/cop/metrics/line_length.rb
@@ -76,7 +76,7 @@ module RuboCop
           excessive_position = if uri_range && uri_range.begin < max
                                  uri_range.end
                                else
-                                 max
+                                 highligh_start(line)
                                end
 
           source_range(processed_source.buffer, index + 1,

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -52,7 +52,11 @@ module RuboCop
 
       def indentation_multiplier
         return 1 if config.for_cop('Layout/Tab')['Enabled']
-        config.for_cop('Layout/Tab')['IndentationWidth']
+        default_configuration = RuboCop::ConfigLoader.default_configuration
+        config.for_cop('Layout/Tab')['IndentationWidth'] ||
+          config.for_cop('Layout/IndentationWidth')['Width'] ||
+          default_configuration.for_cop('Layout/Tab')['IndentationWidth'] ||
+          default_configuration.for_cop('Layout/IndentationWidth')['Width']
       end
     end
   end


### PR DESCRIPTION
When there is no `IndentationWidth` config.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
