### PR TITLE
Allow `db` to allowed names of `Naming/UncommunicativeMethodParamName` cop in default config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#6137](https://github.com/rubocop-hq/rubocop/pull/6137): Allow `db` to allowed names of `Naming/UncommunicativeMethodParamName` cop in default config. ([@mkenyon][])
+
 ## 0.58.2 (2018-07-23)
 
 ### Changes
@@ -3491,3 +3495,4 @@
 [@kenman345]: https://github.com/kenman345
 [@nijikon]: https://github.com/nijikon
 [@mikeyhew]: https://github.com/mikeyhew
+[@mkenyon]: https://github.com/mkenyon

--- a/config/default.yml
+++ b/config/default.yml
@@ -798,6 +798,7 @@ Naming/UncommunicativeMethodParamName:
     - in
     - at
     - ip
+    - db
   # Blacklisted names that will register an offense
   ForbiddenNames: []
 

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -573,7 +573,7 @@ Name | Default value | Configurable values
 --- | --- | ---
 MinNameLength | `3` | Integer
 AllowNamesEndingInNumbers | `true` | Boolean
-AllowedNames | `io`, `id`, `to`, `by`, `on`, `in`, `at`, `ip` | Array
+AllowedNames | `io`, `id`, `to`, `by`, `on`, `in`, `at`, `ip`, `db` | Array
 ForbiddenNames | `[]` | Array
 
 ## Naming/VariableName


### PR DESCRIPTION
Add `db` to AllowedNames in default configuration for cop
Naming/UncommunicativeMethodParamName in order to allow talking about or
configuring a particular database.

I think that using the shorter `db` is unambiguous while still being descriptive, rather than writing out `database`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
