### PR TITLE
Fix Style/DateTime cop not detecting to_datetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug fixes
 
+* [#6140](https://github.com/rubocop-hq/rubocop/pull/6140): Fix `Style/DateTime` not detecting `#to_datetime`. It can be configured to allow this. ([@bdewater][])
 * [#6132](https://github.com/rubocop-hq/rubocop/issues/6132): Fix a false negative for `Naming/FileName` when `Include` of `AllCops` is the default setting. ([@koic][])
 * [#4115](https://github.com/rubocop-hq/rubocop/issues/4115): Fix false positive for unary operations in `Layout/MultilineOperationIndentation`. ([@jonas054][])
 * [#6127](https://github.com/rubocop-hq/rubocop/issues/6127): Fix an error for `Layout/ClosingParenthesisIndentation` when method arguments are empty with newlines. ([@tatsuyafw][])

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1463,6 +1463,7 @@ Style/DateTime:
   Description: 'Use Date or Time over DateTime.'
   StyleGuide: '#date--time'
   Enabled: true
+  AllowCoercion: false
 
 Style/DefWithParentheses:
   Description: 'Use def with parentheses when there are arguments.'

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1140,6 +1140,30 @@ Date.iso8601('2016-06-29')
 # good - uses `DateTime` with start argument for historical date
 DateTime.iso8601('1751-04-23', Date::ENGLAND)
 ```
+#### AllowCoercion: false (default)
+
+```ruby
+# bad - coerces to `DateTime`
+something.to_datetime
+
+# good - coerces to `Time`
+something.to_time
+```
+#### AllowCoercion: true
+
+```ruby
+# good
+something.to_datetime
+
+# good
+something.to_time
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AllowCoercion | `false` | Boolean
 
 ### References
 

--- a/spec/rubocop/cop/style/date_time_spec.rb
+++ b/spec/rubocop/cop/style/date_time_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Style::DateTime do
-  subject(:cop) { described_class.new }
+RSpec.describe RuboCop::Cop::Style::DateTime, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:cop_config) { { 'AllowCoercion' => false } }
 
   it 'registers an offense when using DateTime for current time' do
     expect_offense(<<-RUBY.strip_indent)
@@ -38,5 +40,24 @@ RSpec.describe RuboCop::Cop::Style::DateTime do
 
   it 'does not register an offense when using DateTime in another namespace' do
     expect_no_offenses('Icalendar::Values::DateTime.new(start_at)')
+  end
+
+  describe 'when configured to not allow #to_datetime' do
+    before { cop_config['AllowCoercion'] = false }
+
+    it 'registers an offense' do
+      expect_offense(<<-RUBY.strip_indent)
+        thing.to_datetime
+        ^^^^^^^^^^^^^^^^^ Do not use #to_datetime.
+      RUBY
+    end
+  end
+
+  describe 'when configured to allow #to_datetime' do
+    before { cop_config['AllowCoercion'] = true }
+
+    it 'does not register an offense' do
+      expect_no_offenses('thing.to_datetime')
+    end
   end
 end


### PR DESCRIPTION
Does what the title says. During a PR review I noticed somebody suggesting `Time.parse(x).to_datetime` as a workaround for this cop. Given that there are legitimate usecases for DateTime, I figured it made sense to make it configurable.

Edit: I noticed this has been brought up before. This PR closes https://github.com/rubocop-hq/rubocop/issues/6058

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.