### PR TITLE
Fix Layout/AccessModifierIndentation to stop finding offense in access modifiers with params in nested classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#6132](https://github.com/rubocop-hq/rubocop/issues/6132): Fix a false negative for `Naming/FileName` when `Include` of `AllCops` is the default setting. ([@koic][])
 * [#4115](https://github.com/rubocop-hq/rubocop/issues/4115): Fix false positive for unary operations in `Layout/MultilineOperationIndentation`. ([@jonas054][])
 * [#6127](https://github.com/rubocop-hq/rubocop/issues/6127): Fix an error for `Layout/ClosingParenthesisIndentation` when method arguments are empty with newlines. ([@tatsuyafw][])
+* [#6152](https://github.com/rubocop-hq/rubocop/pull/6152): Fix a false negative for `Layout/AccessModifierIndentation` when using access modifiers with arguments within nested classes. ([@gmalette][])
 
 ### Changes
 
@@ -3509,3 +3510,4 @@
 [@mikeyhew]: https://github.com/mikeyhew
 [@mkenyon]: https://github.com/mkenyon
 [@repinel]: https://github.com/repinel
+[@gmalette]: https://github.com/gmalette

--- a/lib/rubocop/cop/layout/access_modifier_indentation.rb
+++ b/lib/rubocop/cop/layout/access_modifier_indentation.rb
@@ -66,6 +66,7 @@ module RuboCop
 
         def check_body(body, node)
           return if body.nil? # Empty class etc.
+          return if body.module_type? || body.class_type? || body.sclass_type?
 
           modifiers = body.each_child_node(:send).select(&:access_modifier?)
           class_column = node.source_range.column

--- a/lib/rubocop/cop/layout/access_modifier_indentation.rb
+++ b/lib/rubocop/cop/layout/access_modifier_indentation.rb
@@ -66,7 +66,7 @@ module RuboCop
 
         def check_body(body, node)
           return if body.nil? # Empty class etc.
-          return if body.module_type? || body.class_type? || body.sclass_type?
+          return unless body.begin_type?
 
           modifiers = body.each_child_node(:send).select(&:access_modifier?)
           class_column = node.source_range.column

--- a/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
@@ -198,6 +198,32 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
       RUBY
     end
 
+    it 'accepts indented access modifiers with arguments in nested classes' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class A
+          module Test
+            private :test
+          end
+        end
+      RUBY
+
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class A
+          class Test
+            private :test
+          end
+        end
+      RUBY
+
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class A
+          class << self
+            private :test
+          end
+        end
+      RUBY
+    end
+
     it 'auto-corrects incorrectly indented access modifiers' do
       corrected = autocorrect_source(<<-RUBY.strip_indent)
         class Test


### PR DESCRIPTION
Rubocop previously incorrectly found errors in access modifiers when they were used
for parameters to specify methods to change visibility, but only when
the class was nested.

```ruby
class A
  module Test
    private :foo
  end
end
```

This commit removes the offenses for these.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] ~~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
