### PR TITLE
Add a link to Awesome Code into the documentation

### DIFF
--- a/manual/automated_code_review.md
+++ b/manual/automated_code_review.md
@@ -24,3 +24,7 @@ It is open source software.
 
 [Sider](https://sider.review) improves your team's productivity by automating code analysis.
 It supports Auto-correction.
+
+### Awesome Code
+
+[Awesome Code](https://awesomecode.io) improves your code readability by git push or sending pull requests, with one click or even fully automated. It's an online `rubocop -a` service.


### PR DESCRIPTION
I develop Awesome Code https://awesomecode.io to make rubocop autocorrection easier to use, just with one click or even fully automated.

I added Awesome Code section into rubocop documentation.