### PR TITLE
Add scope methods to `Rails/FindEach` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Changes
 
+* [#6161](https://github.com/rubocop-hq/rubocop/pull/6161): Add scope methods to `Rails/FindEach` cop. Makes the cop also check for the following scopes: `eager_load`, `includes`, `joins`, `left_joins`, `left_outer_joins`, `preload`, `references`, and `unscoped`. ([@repinel][])
 * [#6137](https://github.com/rubocop-hq/rubocop/pull/6137): Allow `db` to allowed names of `Naming/UncommunicativeMethodParamName` cop in default config. ([@mkenyon][])
 
 ## 0.58.2 (2018-07-23)
@@ -3507,3 +3508,4 @@
 [@nijikon]: https://github.com/nijikon
 [@mikeyhew]: https://github.com/mikeyhew
 [@mkenyon]: https://github.com/mkenyon
+[@repinel]: https://github.com/repinel

--- a/lib/rubocop/cop/rails/find_each.rb
+++ b/lib/rubocop/cop/rails/find_each.rb
@@ -15,7 +15,10 @@ module RuboCop
       class FindEach < Cop
         MSG = 'Use `find_each` instead of `each`.'.freeze
 
-        SCOPE_METHODS = %i[all where not].freeze
+        SCOPE_METHODS = %i[
+          all eager_load includes joins left_joins left_outer_joins not preload
+          references unscoped where
+        ].freeze
         IGNORED_METHODS = %i[order limit select].freeze
 
         def on_send(node)

--- a/spec/rubocop/cop/rails/find_each_spec.rb
+++ b/spec/rubocop/cop/rails/find_each_spec.rb
@@ -30,8 +30,16 @@ RSpec.describe RuboCop::Cop::Rails::FindEach do
     end
   end
 
-  it_behaves_like('register_offense', 'where(name: name)')
   it_behaves_like('register_offense', 'all')
+  it_behaves_like('register_offense', 'eager_load(:association_name)')
+  it_behaves_like('register_offense', 'includes(:association_name)')
+  it_behaves_like('register_offense', 'joins(:association_name)')
+  it_behaves_like('register_offense', 'left_joins(:association_name)')
+  it_behaves_like('register_offense', 'left_outer_joins(:association_name)')
+  it_behaves_like('register_offense', 'preload(:association_name)')
+  it_behaves_like('register_offense', 'references(:association_name)')
+  it_behaves_like('register_offense', 'unscoped')
+  it_behaves_like('register_offense', 'where(name: name)')
   it_behaves_like('register_offense', 'where.not(name: name)')
 
   it 'does not register an offense when using find_by' do


### PR DESCRIPTION
Makes the cop check for the following scopes: `includes`, `joins`, `left_outer_joins`, and `unscoped`.

I can add a changelog entry if this looks good.