### PR TITLE
[Fix #6164] Fix incorrect autocorrect for `Style/UnneededCondition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#4115](https://github.com/rubocop-hq/rubocop/issues/4115): Fix false positive for unary operations in `Layout/MultilineOperationIndentation`. ([@jonas054][])
 * [#6127](https://github.com/rubocop-hq/rubocop/issues/6127): Fix an error for `Layout/ClosingParenthesisIndentation` when method arguments are empty with newlines. ([@tatsuyafw][])
 * [#6152](https://github.com/rubocop-hq/rubocop/pull/6152): Fix a false negative for `Layout/AccessModifierIndentation` when using access modifiers with arguments within nested classes. ([@gmalette][])
+* [#6164](https://github.com/rubocop-hq/rubocop/issues/6164): Fix incorrect autocorrect for `Style/UnneededCondition` when using operator method higher precedence than `||`. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/unneeded_condition.rb
+++ b/lib/rubocop/cop/style/unneeded_condition.rb
@@ -50,8 +50,7 @@ module RuboCop
             elsif node.modifier_form?
               corrector.replace(node.source_range, node.if_branch.source)
             else
-              corrected = [node.if_branch.source,
-                           else_source(node.else_branch)].join(' || ')
+              corrected = make_ternary_form(node)
 
               corrector.replace(node.source_range, corrected)
             end
@@ -93,6 +92,17 @@ module RuboCop
           wrap_else = MODIFIER_NODES.include?(else_branch.type) &&
                       else_branch.modifier_form?
           wrap_else ? "(#{else_branch.source})" : else_branch.source
+        end
+
+        def make_ternary_form(node)
+          ternary_form = [node.if_branch.source,
+                          else_source(node.else_branch)].join(' || ')
+
+          if node.parent && node.parent.send_type?
+            "(#{ternary_form})"
+          else
+            ternary_form
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/unneeded_condition_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_condition_spec.rb
@@ -146,6 +146,21 @@ RSpec.describe RuboCop::Cop::Style::UnneededCondition do
 
         expect(new_source).to eq('bar')
       end
+
+      it 'auto-corrects when using `<<` method higher precedence ' \
+         'than `||` operator' do
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+          ary << if foo
+                   foo
+                 else
+                   bar
+                 end
+        RUBY
+
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          ary << (foo || bar)
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #6164.

This PR fixes incorrect autocorrect for `Style/UnneededCondition` when using operator method higher precedence than `||`.

Ruby has higher precedence of operator methods (`<<`, `==`, `+`, others) than `||`.

For example, there is the following Ruby code.

```ruby
ary << if foo
  foo
else
  bar
end
```

Previously, it auto-corrects as follows.

```ruby
ary << foo || bar
```

This code means the following.

```ruby
(ary << foo) || bar
```

This PR fixes to add parentheses when using auto-correct.

```ruby
ary << (foo || bar)
```

This keeps the meaning.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
