### PR TITLE
Correct space warning on lambda literal

### DIFF
--- a/lib/rubocop/cop/layout/space_in_lambda_literal.rb
+++ b/lib/rubocop/cop/layout/space_in_lambda_literal.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Layout
       # This cop checks for spaces between -> and opening parameter
-      # brace in lambda literals.
+      # parenthesis in lambda literals.
       #
       # @example EnforcedStyle: require_no_space (default)
       #     # bad
@@ -24,10 +24,10 @@ module RuboCop
         include RangeHelp
 
         ARROW = '->'.freeze
-        MSG_REQUIRE_SPACE = 'Use a space between `->` and opening brace ' \
-                            'in lambda literals'.freeze
+        MSG_REQUIRE_SPACE = 'Use a space between `->` and opening ' \
+                            'parenthesis in lambda literals'.freeze
         MSG_REQUIRE_NO_SPACE = 'Do not use spaces between `->` and opening ' \
-                               'brace in lambda literals'.freeze
+                               'parenthesis in lambda literals'.freeze
 
         def on_send(node)
           return unless arrow_lambda_with_args?(node)

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -3739,7 +3739,7 @@ Enabled by default | Supports autocorrection
 Enabled | Yes
 
 This cop checks for spaces between -> and opening parameter
-brace in lambda literals.
+parenthesis in lambda literals.
 
 ### Examples
 

--- a/spec/rubocop/cop/layout/space_in_lambda_literal_spec.rb
+++ b/spec/rubocop/cop/layout/space_in_lambda_literal_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     it 'registers an offense for no space between -> and (' do
       expect_offense(<<-RUBY.strip_indent)
         a = ->(b, c) { b + c }
-            ^^^^^^^^^^^^^^^^^^ Use a space between `->` and opening brace in lambda literals
+            ^^^^^^^^^^^^^^^^^^ Use a space between `->` and opening parenthesis in lambda literals
       RUBY
     end
 
@@ -33,22 +33,22 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     it 'registers an offense for no space in the inner nested lambda' do
       expect_offense(<<-RUBY.strip_indent)
         a = -> (b = ->(c) {}, d) { b + d }
-                    ^^^^^^^^ Use a space between `->` and opening brace in lambda literals
+                    ^^^^^^^^ Use a space between `->` and opening parenthesis in lambda literals
       RUBY
     end
 
     it 'registers an offense for no space in the outer nested lambda' do
       expect_offense(<<-RUBY.strip_indent)
         a = ->(b = -> (c) {}, d) { b + d }
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a space between `->` and opening brace in lambda literals
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a space between `->` and opening parenthesis in lambda literals
       RUBY
     end
 
     it 'registers an offense for no space in both lambdas when nested' do
       expect_offense(<<-RUBY.strip_indent)
         a = ->(b = ->(c) {}, d) { b + d }
-                   ^^^^^^^^ Use a space between `->` and opening brace in lambda literals
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a space between `->` and opening brace in lambda literals
+                   ^^^^^^^^ Use a space between `->` and opening parenthesis in lambda literals
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a space between `->` and opening parenthesis in lambda literals
       RUBY
     end
 
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     it 'registers an offense for a space between -> and (' do
       expect_offense(<<-RUBY.strip_indent)
         a = -> (b, c) { b + c }
-            ^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and opening brace in lambda literals
+            ^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and opening parenthesis in lambda literals
       RUBY
     end
 
@@ -107,29 +107,29 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     it 'registers an offense for spaces between -> and (' do
       expect_offense(<<-RUBY.strip_indent)
         a = ->   (b, c) { b + c }
-            ^^^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and opening brace in lambda literals
+            ^^^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and opening parenthesis in lambda literals
       RUBY
     end
 
     it 'registers an offense for a space in the inner nested lambda' do
       expect_offense(<<-RUBY.strip_indent)
         a = ->(b = -> (c) {}, d) { b + d }
-                   ^^^^^^^^^ Do not use spaces between `->` and opening brace in lambda literals
+                   ^^^^^^^^^ Do not use spaces between `->` and opening parenthesis in lambda literals
       RUBY
     end
 
     it 'registers an offense for a space in the outer nested lambda' do
       expect_offense(<<-RUBY.strip_indent)
         a = -> (b = ->(c) {}, d) { b + d }
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and opening brace in lambda literals
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and opening parenthesis in lambda literals
       RUBY
     end
 
     it 'registers two offenses for a space in both lambdas when nested' do
       expect_offense(<<-RUBY.strip_indent)
         a = -> (b = -> (c) {}, d) { b + d }
-                    ^^^^^^^^^ Do not use spaces between `->` and opening brace in lambda literals
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and opening brace in lambda literals
+                    ^^^^^^^^^ Do not use spaces between `->` and opening parenthesis in lambda literals
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and opening parenthesis in lambda literals
       RUBY
     end
 


### PR DESCRIPTION
The error message in this check is a bit confusing because it says that a space is required before the first brace `{` but what it actually means is a space is required before the first parenthesis `(`.