### PR TITLE
Update UncommunicativeMethodParamName Whitelist

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -799,6 +799,8 @@ Naming/UncommunicativeMethodParamName:
     - at
     - ip
     - db
+    - as
+    - no
   # Blacklisted names that will register an offense
   ForbiddenNames: []
 


### PR DESCRIPTION
Added 'no' and 'as' to AllowedNames as additional common 2 letter parameter names
