### PR TITLE
Modify tests to not allow arrays for the source

### DIFF
--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -15,9 +15,6 @@ module CopHelper
   end
 
   def inspect_source(source, file = nil)
-    if source.is_a?(Array) && source.size == 1
-      raise "Don't use an array for a single line of code: #{source}"
-    end
     RuboCop::Formatter::DisabledConfigFormatter.config_to_allow_offenses = {}
     RuboCop::Formatter::DisabledConfigFormatter.detected_styles = {}
     processed_source = parse_source(source, file)
@@ -26,8 +23,6 @@ module CopHelper
   end
 
   def parse_source(source, file = nil)
-    source = source.join($RS) if source.is_a?(Array)
-
     if file && file.respond_to?(:write)
       file.write(source)
       file.rewind

--- a/lib/rubocop/rspec/shared_examples.rb
+++ b/lib/rubocop/rspec/shared_examples.rb
@@ -42,8 +42,7 @@ shared_examples_for 'aligned' do |alignment_base, arg, end_kw, name|
   name ||= alignment_base
   name = name.gsub(/\n/, ' <newline>')
   it "accepts matching #{name} ... end" do
-    inspect_source(["#{alignment_base} #{arg}",
-                    end_kw])
+    inspect_source("#{alignment_base} #{arg}\n#{end_kw}")
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::CommentConfig do
         '# rubocop:enable FlatMap',
         '# rubocop:disable RSpec/Example',
         '# rubocop:disable Custom2/Number9'                  # 48
-      ]
+      ].join("\n")
     end
 
     def disabled_lines_of_cop(cop)

--- a/spec/rubocop/cop/commissioner_spec.rb
+++ b/spec/rubocop/cop/commissioner_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::Commissioner do
       allow(cop).to receive(:offenses).and_return([1])
 
       commissioner = described_class.new([cop], [])
-      source = []
+      source = ''
       processed_source = parse_source(source)
 
       expect(commissioner.investigate(processed_source)).to eq [1]
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::Commissioner do
         cops.each(&:as_null_object)
 
         commissioner = described_class.new(cops, [])
-        source = []
+        source = ''
         processed_source = parse_source(source)
 
         expect(commissioner.investigate(processed_source)).to eq %w[foo baz]
@@ -37,7 +37,11 @@ RSpec.describe RuboCop::Cop::Commissioner do
       expect(cop).to receive(:on_def)
 
       commissioner = described_class.new([cop], [])
-      source = ['def method', '1', 'end']
+      source = <<-RUBY.strip_indent
+        def method
+        1
+        end
+      RUBY
       processed_source = parse_source(source)
 
       commissioner.investigate(processed_source)
@@ -45,7 +49,7 @@ RSpec.describe RuboCop::Cop::Commissioner do
 
     it 'passes the input params to all cops/forces that implement their own' \
        ' #investigate method' do
-      source = []
+      source = ''
       processed_source = parse_source(source)
       expect(cop).to receive(:investigate).with(processed_source)
       expect(force).to receive(:investigate).with(processed_source)
@@ -59,7 +63,11 @@ RSpec.describe RuboCop::Cop::Commissioner do
       allow(cop).to receive(:on_int) { raise RuntimeError }
 
       commissioner = described_class.new([cop], [])
-      source = ['def method', '1', 'end']
+      source = <<-RUBY.strip_indent
+        def method
+        1
+        end
+      RUBY
       processed_source = parse_source(source)
 
       commissioner.investigate(processed_source)
@@ -77,7 +85,11 @@ RSpec.describe RuboCop::Cop::Commissioner do
         allow(cop).to receive(:on_int) { raise RuntimeError }
 
         commissioner = described_class.new([cop], [], raise_error: true)
-        source = ['def method', '1', 'end']
+        source = <<-RUBY.strip_indent
+          def method
+          1
+          end
+        RUBY
         processed_source = parse_source(source)
 
         expect do

--- a/spec/rubocop/cop/layout/align_hash_spec.rb
+++ b/spec/rubocop/cop/layout/align_hash_spec.rb
@@ -517,16 +517,18 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
 
     it "doesn't break code by moving long keys too far left" do
       # regression test; see GH issue 2582
-      new_source = autocorrect_source(['{',
-                                       '  sjtjo: sjtjo,',
-                                       '  too_ono_ilitjion_tofotono_o: ' \
-                                       'too_ono_ilitjion_tofotono_o,',
-                                       '}'])
-      expect(new_source).to eq(['{',
-                                '  sjtjo: sjtjo,',
-                                'too_ono_ilitjion_tofotono_o: ' \
-                                'too_ono_ilitjion_tofotono_o,',
-                                '}'].join("\n"))
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        {
+          sjtjo: sjtjo,
+          too_ono_ilitjion_tofotono_o: too_ono_ilitjion_tofotono_o,
+        }
+      RUBY
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        {
+          sjtjo: sjtjo,
+        too_ono_ilitjion_tofotono_o: too_ono_ilitjion_tofotono_o,
+        }
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
@@ -19,12 +19,10 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundMethodBody do
   # two cops registering offense for the line with only spaces would cause
   # havoc in auto-correction.
   it 'accepts method body starting with a line with spaces' do
-    expect_no_offenses([
-                         'def some_method',
-                         '  ',
-                         '  do_something',
-                         'end'
-                       ])
+    expect_no_offenses(['def some_method',
+                        '  ',
+                        '  do_something',
+                        'end'].join("\n"))
   end
 
   it 'autocorrects method body starting with a blank' do

--- a/spec/rubocop/cop/layout/end_of_line_spec.rb
+++ b/spec/rubocop/cop/layout/end_of_line_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
   shared_examples 'iso-8859-15' do |eol|
     it 'can inspect non-UTF-8 encoded source with proper encoding comment' do
       inspect_source_file(["# coding: ISO-8859-15#{eol}",
-                           "# Euro symbol: \xa4#{eol}"])
+                           "# Euro symbol: \xa4#{eol}"].join("\n"))
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
     end
 
     it 'registers an offense for an incorrect EOL' do
-      inspect_source_file(['x=0', '', "y=1\r"])
+      inspect_source_file(['x=0', '', "y=1\r"].join("\n"))
       expect(cop.messages).to eq(messages)
       expect(cop.offenses.map(&:line))
         .to eq([RuboCop::Platform.windows? ? 1 : 3])
@@ -40,13 +40,13 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
     include_examples 'all configurations'
 
     it 'registers an offense for CR+LF' do
-      inspect_source_file(['x=0', '', "y=1\r"])
+      inspect_source_file(['x=0', '', "y=1\r"].join("\n"))
       expect(cop.messages).to eq(messages)
       expect(cop.offenses.map(&:line)).to eq([1])
     end
 
     it 'highlights the whole offending line' do
-      inspect_source_file(['x=0', '', "y=1\r"])
+      inspect_source_file(['x=0', '', "y=1\r"].join("\n"))
       expect(cop.highlights).to eq(["x=0\n"])
     end
 
@@ -112,13 +112,13 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
     include_examples 'all configurations'
 
     it 'registers an offense for CR+LF' do
-      inspect_source_file(['x=0', '', "y=1\r"])
+      inspect_source_file(['x=0', '', "y=1\r"].join("\n"))
       expect(cop.messages).to eq(['Carriage return character detected.'])
       expect(cop.offenses.map(&:line)).to eq([3])
     end
 
     it 'highlights the whole offending line' do
-      inspect_source_file(['x=0', '', "y=1\r"])
+      inspect_source_file(['x=0', '', "y=1\r"].join("\n"))
       expect(cop.highlights).to eq(["y=1\r"])
     end
 

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
 
     it 'ignores trailing whitespace' do
       expect_no_offenses(['      class Benchmarker < Performer     ',
-                          '      end'])
+                          '      end'].join("\n"))
     end
 
     it 'registers an offense on class inheritance' do

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -317,7 +317,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
                                           '    y',
                                           ' ',
                                           'rescue',
-                                          'end'])
+                                          'end'].join("\n"))
 
           expect(corrected).to eq ['def x',
                                    '  y',

--- a/spec/rubocop/cop/layout/multiline_hash_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_hash_brace_layout_spec.rb
@@ -26,7 +26,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineHashBraceLayout, :config do
     let(:a) { 'a: 1' }
     let(:b) { 'b: 2' }
     let(:multi_prefix) { 'b: ' }
-    let(:multi) { ['[', '1', ']'] }
+    let(:multi) do
+      <<-RUBY.strip_indent.chomp
+        [
+        1
+        ]
+      RUBY
+    end
   end
 
   include_examples 'multiline literal brace layout trailing comma' do

--- a/spec/rubocop/cop/layout/space_inside_string_interpolation_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_string_interpolation_spec.rb
@@ -4,17 +4,19 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
   subject(:cop) { described_class.new(config) }
 
   let(:irregular_source) do
-    ['"#{ var}"',
-     '"#{var }"',
-     '"#{   var   }"',
-     '"#{var	}"',
-     '"#{	var	}"',
-     '"#{	var}"',
-     '"#{ 	 var 	 	}"']
+    <<-'RUBY'.strip_indent.chomp
+      "#{ var}"
+      "#{var }"
+      "#{   var   }"
+      "#{var	}"
+      "#{	var	}"
+      "#{	var}"
+      "#{ 	 var 	 	}"
+    RUBY
   end
 
   shared_examples 'ill-formatted string interpolations' do
-    let(:source_length) { source.class == String ? 1 : source.length }
+    let(:source_length) { source.count("\n") + 1 }
 
     it 'registers an offense for any irregular spacing inside the braces' do
       inspect_source(source)
@@ -50,8 +52,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
 
     context 'for well-formatted string interpolations' do
       let(:source) do
-        ['"Variable is    #{var}      "',
-         '"  Variable is  #{var}"']
+        <<-'RUBY'.strip_indent.chomp
+          "Variable is    #{var}      "
+          "  Variable is  #{var}"
+        RUBY
       end
 
       it 'does not register an offense for excess literal spacing' do
@@ -63,7 +67,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
 
       it 'does not correct valid string interpolations' do
         new_source = autocorrect_source(source)
-        expect(new_source).to eq(source.join("\n"))
+        expect(new_source).to eq(source)
       end
     end
 
@@ -94,8 +98,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
 
     context 'for well-formatted string interpolations' do
       let(:source) do
-        ['"Variable is    #{ var }      "',
-         '"  Variable is  #{ var }"']
+        <<-'RUBY'.strip_indent.chomp
+          "Variable is    #{ var }      "
+          "  Variable is  #{ var }"
+        RUBY
       end
 
       it 'does not register an offense for excess literal spacing' do
@@ -107,7 +113,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
 
       it 'does not correct valid string interpolations' do
         new_source = autocorrect_source(source)
-        expect(new_source).to eq(source.join("\n"))
+        expect(new_source).to eq(source)
       end
     end
 

--- a/spec/rubocop/cop/layout/tab_spec.rb
+++ b/spec/rubocop/cop/layout/tab_spec.rb
@@ -61,22 +61,22 @@ RSpec.describe RuboCop::Cop::Layout::Tab do
   end
 
   it 'auto-corrects a line indented with tab' do
-    new_source = autocorrect_source(["\tx = 0"])
+    new_source = autocorrect_source("\tx = 0")
     expect(new_source).to eq('  x = 0')
   end
 
   it 'auto-corrects a line indented with multiple tabs' do
-    new_source = autocorrect_source(["\t\t\tx = 0"])
+    new_source = autocorrect_source("\t\t\tx = 0")
     expect(new_source).to eq('      x = 0')
   end
 
   it 'auto-corrects a line indented with mixed whitespace' do
-    new_source = autocorrect_source([" \tx = 0"])
+    new_source = autocorrect_source(" \tx = 0")
     expect(new_source).to eq('   x = 0')
   end
 
   it 'auto-corrects a line with tab in a string indented with tab' do
-    new_source = autocorrect_source(["\t(x = \"\t\")"])
+    new_source = autocorrect_source("\t(x = \"\t\")")
     expect(new_source).to eq("  (x = \"\t\")")
   end
 

--- a/spec/rubocop/cop/layout/trailing_blank_lines_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_blank_lines_spec.rb
@@ -67,17 +67,31 @@ RSpec.describe RuboCop::Cop::Layout::TrailingBlankLines, :config do
     end
 
     it 'auto-corrects unwanted blank lines' do
-      new_source = autocorrect_source(['x = 0', '', '', '', ''])
-      expect(new_source).to eq(['x = 0', ''].join("\n"))
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        x = 0
+
+
+
+
+      RUBY
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        x = 0
+      RUBY
     end
 
     it 'auto-corrects unwanted blank lines in an empty file' do
-      new_source = autocorrect_source(['', '', '', '', ''])
-      expect(new_source).to eq(['', ''].join("\n"))
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+
+
+
+
+
+      RUBY
+      expect(new_source).to eq("\n")
     end
 
     it 'auto-corrects even if some lines have space' do
-      new_source = autocorrect_source(['x = 0', '', '  ', '', ''])
+      new_source = autocorrect_source(['x = 0', '', '  ', '', ''].join("\n"))
       expect(new_source).to eq(['x = 0', ''].join("\n"))
     end
   end
@@ -86,7 +100,10 @@ RSpec.describe RuboCop::Cop::Layout::TrailingBlankLines, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'final_blank_line' } }
 
     it 'registers an offense for final newline' do
-      inspect_source(['x = 0', ''])
+      inspect_source(<<-RUBY.strip_indent)
+        x = 0
+      RUBY
+
       expect(cop.messages).to eq(['Trailing blank line missing.'])
     end
 
@@ -103,7 +120,12 @@ RSpec.describe RuboCop::Cop::Layout::TrailingBlankLines, :config do
     end
 
     it 'registers an offense for multiple blank lines in an empty file' do
-      inspect_source(['', '', '', '', ''])
+      inspect_source(<<-RUBY.strip_indent)
+
+
+
+
+      RUBY
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['3 trailing blank lines instead of 1 detected.'])
@@ -119,23 +141,49 @@ RSpec.describe RuboCop::Cop::Layout::TrailingBlankLines, :config do
     end
 
     it 'auto-corrects unwanted blank lines' do
-      new_source = autocorrect_source(['x = 0', '', '', '', ''])
-      expect(new_source).to eq(['x = 0', '', ''].join("\n"))
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        x = 0
+
+
+
+
+      RUBY
+
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        x = 0
+
+      RUBY
     end
 
     it 'auto-corrects unwanted blank lines in an empty file' do
-      new_source = autocorrect_source(['', '', '', '', ''])
-      expect(new_source).to eq(['', '', ''].join("\n"))
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+
+
+
+
+      RUBY
+      expect(new_source).to eq(<<-RUBY)
+
+
+      RUBY
     end
 
     it 'auto-corrects missing blank line' do
-      new_source = autocorrect_source(['x = 0', ''])
-      expect(new_source).to eq(['x = 0', '', ''].join("\n"))
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        x = 0
+      RUBY
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        x = 0
+
+      RUBY
     end
 
     it 'auto-corrects missing newline' do
-      new_source = autocorrect_source(['x = 0'])
-      expect(new_source).to eq(['x = 0', '', ''].join("\n"))
+      new_source = autocorrect_source('x = 0')
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        x = 0
+
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
   it 'registers an offense for trailing whitespace in a heredoc string' do
     inspect_source(['x = <<RUBY',
                     '  Hi   ',
-                    'RUBY'])
+                    'RUBY'].join("\n"))
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -31,7 +31,7 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
     inspect_source(["x = 0\t",
                     ' ',
                     '__END__',
-                    "x = 0\t"])
+                    "x = 0\t"].join("\n"))
     expect(cop.offenses.map(&:line)).to eq([1, 2])
   end
 
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
                     '=begin',
                     '__END__',
                     '=end',
-                    "x = 0\t"])
+                    "x = 0\t"].join("\n"))
     expect(cop.offenses.map(&:line)).to eq([1, 5])
   end
 
@@ -49,7 +49,7 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
                     '__END__',
                     "x2 = 0\t",
                     'RUBY',
-                    "x3 = 0\t"])
+                    "x3 = 0\t"].join("\n"))
     expect(cop.offenses.map(&:line)).to eq([1, 3, 5])
   end
 
@@ -60,7 +60,7 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
                     '=end',
                     "x2 = 0\t",
                     'RUBY',
-                    "x3 = 0\t"])
+                    "x3 = 0\t"].join("\n"))
     expect(cop.offenses.map(&:line)).to eq([1, 2, 5, 7])
   end
 
@@ -70,7 +70,7 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
 
   it 'auto-corrects unwanted space' do
     new_source = autocorrect_source(['x = 0 ',
-                                     "x = 0\t"])
+                                     "x = 0\t"].join("\n"))
     expect(new_source).to eq(['x = 0',
                               'x = 0'].join("\n"))
   end
@@ -81,13 +81,13 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
     it 'accepts trailing whitespace in a heredoc string' do
       expect_no_offenses(['x = <<RUBY',
                           '  Hi   ',
-                          'RUBY'])
+                          'RUBY'].join("\n"))
     end
 
     it 'registers an offence for trailing whitespace at the heredoc begin' do
       inspect_source(['x = <<RUBY ',
                       '  Hi   ',
-                      'RUBY'])
+                      'RUBY'].join("\n"))
       expect(cop.offenses.size).to eq(1)
     end
   end

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -5,23 +5,41 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
 
   include_examples 'debugger', 'debugger', 'debugger'
   include_examples 'debugger', 'byebug', 'byebug'
-  include_examples 'debugger', 'pry binding', %w[binding.pry binding.remote_pry
-                                                 binding.pry_remote]
+  include_examples 'debugger', 'pry binding',
+                   'binding.pry'
+  include_examples 'debugger', 'pry binding',
+                   'binding.remote_pry'
+  include_examples 'debugger', 'pry binding',
+                   'binding.pry_remote'
   include_examples 'debugger',
-                   'capybara debug method', %w[save_and_open_page
-                                               save_and_open_screenshot
-                                               save_screenshot]
+                   'capybara debug method',
+                   'save_and_open_page'
+  include_examples 'debugger',
+                   'capybara debug method',
+                   'save_and_open_screenshot'
+  include_examples 'debugger',
+                   'capybara debug method',
+                   'save_screenshot'
   include_examples 'debugger', 'debugger with an argument', 'debugger foo'
   include_examples 'debugger', 'byebug with an argument', 'byebug foo'
   include_examples 'debugger',
-                   'pry binding with an argument', ['binding.pry foo',
-                                                    'binding.remote_pry foo',
-                                                    'binding.pry_remote foo']
+                   'pry binding with an argument',
+                   'binding.pry foo'
+  include_examples 'debugger',
+                   'pry binding with an argument',
+                   'binding.remote_pry foo'
+  include_examples 'debugger',
+                   'pry binding with an argument',
+                   'binding.pry_remote foo'
   include_examples 'debugger',
                    'capybara debug method with an argument',
-                   ['save_and_open_page foo',
-                    'save_and_open_screenshot foo',
-                    'save_screenshot foo']
+                   'save_and_open_page foo'
+  include_examples 'debugger',
+                   'capybara debug method with an argument',
+                   'save_and_open_screenshot foo'
+  include_examples 'debugger',
+                   'capybara debug method with an argument',
+                   'save_screenshot foo'
   include_examples 'non-debugger', 'a non-pry binding', 'binding.pirate'
 
   include_examples 'debugger', 'debugger with Kernel', 'Kernel.debugger'

--- a/spec/rubocop/cop/lint/string_conversion_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/string_conversion_in_interpolation_spec.rb
@@ -37,12 +37,12 @@ RSpec.describe RuboCop::Cop::Lint::StringConversionInInterpolation do
   end
 
   it 'autocorrects by removing the redundant to_s' do
-    corrected = autocorrect_source(['"some #{something.to_s}"'])
+    corrected = autocorrect_source('"some #{something.to_s}"')
     expect(corrected).to eq '"some #{something}"'
   end
 
   it 'autocorrects implicit receiver by replacing to_s with self' do
-    corrected = autocorrect_source(['"some #{to_s}"'])
+    corrected = autocorrect_source('"some #{to_s}"')
     expect(corrected).to eq '"some #{self}"'
   end
 end

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -60,17 +60,21 @@ RSpec.describe RuboCop::Cop::Lint::Void do
 
   %w[var @var @@var VAR $var].each do |var|
     it "registers an offense for void var #{var} if not on last line" do
-      inspect_source(["#{var} = 5",
-                      var,
-                      'top'])
+      inspect_source(<<-RUBY.strip_indent)
+                       #{var} = 5
+                       #{var}
+                       top
+      RUBY
       expect(cop.offenses.size).to eq(1)
     end
   end
 
   %w(1 2.0 :test /test/ [1] {}).each do |lit|
     it "registers an offense for void lit #{lit} if not on last line" do
-      inspect_source([lit,
-                      'top'])
+      inspect_source(<<-RUBY.strip_indent)
+                        #{lit}
+                        top
+      RUBY
       expect(cop.offenses.size).to eq(1)
     end
   end

--- a/spec/rubocop/cop/metrics/abc_size_spec.rb
+++ b/spec/rubocop/cop/metrics/abc_size_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
 
         inspect_source(['def method_name',
                         *code,
-                        'end'])
+                        'end'].join("\n"))
         expect(cop.messages)
           .to eq(['Assignment Branch Condition size for method_name is too ' \
                   "high. [#{presentation}]"])

--- a/spec/rubocop/cop/metrics/line_length_spec.rb
+++ b/spec/rubocop/cop/metrics/line_length_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
   it 'registers an offense for long line before __END__ but not after' do
     inspect_source(['#' * 150,
                     '__END__',
-                    '#' * 200])
+                    '#' * 200].join("\n"))
     expect(cop.messages).to eq(['Line is too long. [150/80]'])
   end
 

--- a/spec/rubocop/cop/rails/read_write_attribute_spec.rb
+++ b/spec/rubocop/cop/rails/read_write_attribute_spec.rb
@@ -60,15 +60,14 @@ RSpec.describe RuboCop::Cop::Rails::ReadWriteAttribute do
       end
 
       it 'autocorrects multiline' do
-        source = [
-          'write_attribute(',
-          ':attr, ',
-          '(',
-          "'test_' + postfix",
-          ').to_sym',
-          ')',
-          ''
-        ]
+        source = <<-RUBY.strip_indent
+          write_attribute(
+          :attr,
+          (
+          'test_' + postfix
+          ).to_sym
+          )
+        RUBY
         corrected_source = <<-RUBY.strip_indent
           self[:attr] = (
           'test_' + postfix

--- a/spec/rubocop/cop/rails/request_referer_spec.rb
+++ b/spec/rubocop/cop/rails/request_referer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::Rails::RequestReferer, :config do
     end
 
     it 'autocorrects referrer with referer' do
-      corrected = autocorrect_source(['puts request.referrer'])
+      corrected = autocorrect_source('puts request.referrer')
       expect(corrected).to eq 'puts request.referer'
     end
   end
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Rails::RequestReferer, :config do
     end
 
     it 'autocorrects referer with referrer' do
-      corrected = autocorrect_source(['puts request.referer'])
+      corrected = autocorrect_source('puts request.referer')
       expect(corrected).to eq 'puts request.referrer'
     end
   end

--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -193,15 +193,21 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang do
     end
 
     it "when using #{method} as last method call" do
-      expect_no_offenses(['def foo', "object.#{method}", 'end'])
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def foo
+          object.#{method}
+        end
+      RUBY
     end
 
     # Bug: https://github.com/rubocop-hq/rubocop/issues/4264
     it 'when using the assigned variable as value in a hash' do
-      inspect_source(['def foo',
-                      "  foo = Foo.#{method}",
-                      '  render json: foo',
-                      'end'])
+      inspect_source(<<-RUBY.strip_indent)
+        def foo
+          foo = Foo.#{method}
+          render json: foo
+        end
+      RUBY
       if pass
         expect(cop.offenses.empty?).to be(true)
       else

--- a/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
+++ b/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
@@ -26,11 +26,11 @@ RSpec.describe RuboCop::Cop::Rails::UniqBeforePluck, :config do
 
     it_behaves_like 'UniqBeforePluck cop', method,
                     ['Model.pluck(:id)',
-                     "  .#{method}"], :correct
+                     "  .#{method}"].join("\n"), :correct
 
     it_behaves_like 'UniqBeforePluck cop', method,
                     ['Model.pluck(:id).',
-                     "  #{method}"], :correct
+                     "  #{method}"].join("\n"), :correct
 
     context "#{method} before pluck" do
       it_behaves_like 'UniqBeforePluck cop', method,

--- a/spec/rubocop/cop/style/alias_spec.rb
+++ b/spec/rubocop/cop/style/alias_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe RuboCop::Cop::Style::Alias, :config do
     end
 
     it 'autocorrects alias with symbol args' do
-      corrected = autocorrect_source(['alias :ala :bala'])
+      corrected = autocorrect_source('alias :ala :bala')
       expect(corrected).to eq 'alias ala bala'
     end
 

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
 
     it 'accepts one empty hash parameter with whitespace' do
       expect_no_offenses(['where(  {     ',
-                          " }\t   )  "])
+                          " }\t   )  "].join("\n"))
     end
   end
 
@@ -89,51 +89,51 @@ RSpec.describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
   shared_examples 'no_braces and context_dependent auto-corrections' do
     it 'corrects one non-hash parameter followed by a hash parameter with ' \
        'braces' do
-      corrected = autocorrect_source(['where(1, { y: 2 })'])
+      corrected = autocorrect_source('where(1, { y: 2 })')
       expect(corrected).to eq('where(1, y: 2)')
     end
 
     it 'corrects one object method hash parameter with braces' do
-      corrected = autocorrect_source(['x.func({ y: "z" })'])
+      corrected = autocorrect_source('x.func({ y: "z" })')
       expect(corrected).to eq('x.func(y: "z")')
     end
 
     it 'corrects one hash parameter with braces' do
-      corrected = autocorrect_source(['where({ x: 1 })'])
+      corrected = autocorrect_source('where({ x: 1 })')
       expect(corrected).to eq('where(x: 1)')
     end
 
     it 'corrects one hash parameter with braces and whitespace' do
       corrected = autocorrect_source(['where(  ',
-                                      ' { x: 1 }   )'])
+                                      ' { x: 1 }   )'].join("\n"))
       expect(corrected).to eq(['where(  ',
                                ' x: 1   )'].join("\n"))
     end
 
     it 'corrects one hash parameter with braces and multiple keys' do
-      corrected = autocorrect_source(['where({ x: 1, foo: "bar" })'])
+      corrected = autocorrect_source('where({ x: 1, foo: "bar" })')
       expect(corrected).to eq('where(x: 1, foo: "bar")')
     end
 
     it 'corrects one hash parameter with braces and extra leading whitespace' do
-      corrected = autocorrect_source(['where({   x: 1, y: 2 })'])
+      corrected = autocorrect_source('where({   x: 1, y: 2 })')
       expect(corrected).to eq('where(x: 1, y: 2)')
     end
 
     it 'corrects one hash parameter with braces and extra trailing ' \
        'whitespace' do
-      corrected = autocorrect_source(['where({ x: 1, y: 2   })'])
+      corrected = autocorrect_source('where({ x: 1, y: 2   })')
       expect(corrected).to eq('where(x: 1, y: 2)')
     end
 
     it 'corrects one hash parameter with braces and a trailing comma' do
-      corrected = autocorrect_source(['where({ x: 1, y: 2, })'])
+      corrected = autocorrect_source('where({ x: 1, y: 2, })')
       expect(corrected).to eq('where(x: 1, y: 2)')
     end
 
     it 'corrects one hash parameter with braces and trailing comma and ' \
        'whitespace' do
-      corrected = autocorrect_source(['where({ x: 1, y: 2,   })'])
+      corrected = autocorrect_source('where({ x: 1, y: 2,   })')
       expect(corrected).to eq('where(x: 1, y: 2)')
     end
 
@@ -298,12 +298,12 @@ RSpec.describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       include_examples 'no_braces and context_dependent auto-corrections'
 
       it 'corrects one hash parameter with braces' do
-        corrected = autocorrect_source(['where(1, { x: 1 })'])
+        corrected = autocorrect_source('where(1, { x: 1 })')
         expect(corrected).to eq('where(1, x: 1)')
       end
 
       it 'corrects two hash parameters with braces' do
-        corrected = autocorrect_source(['where(1, { x: 1 }, { y: 2 })'])
+        corrected = autocorrect_source('where(1, { x: 1 }, { y: 2 })')
         expect(corrected).to eq('where(1, { x: 1 }, y: 2)')
       end
 
@@ -359,12 +359,12 @@ RSpec.describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       include_examples 'no_braces and context_dependent auto-corrections'
 
       it 'corrects one hash parameter with braces and one without' do
-        corrected = autocorrect_source(['where(1, { x: 1 }, y: 2)'])
+        corrected = autocorrect_source('where(1, { x: 1 }, y: 2)')
         expect(corrected).to eq('where(1, { x: 1 }, {y: 2})')
       end
 
       it 'corrects one hash parameter with braces' do
-        corrected = autocorrect_source(['where(1, { x: 1 })'])
+        corrected = autocorrect_source('where(1, { x: 1 })')
         expect(corrected).to eq('where(1, x: 1)')
       end
     end
@@ -419,17 +419,17 @@ RSpec.describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
 
     describe '#autocorrect' do
       it 'corrects one hash parameter without braces' do
-        corrected = autocorrect_source(['where(x: "y")'])
+        corrected = autocorrect_source('where(x: "y")')
         expect(corrected).to eq('where({x: "y"})')
       end
 
       it 'corrects one hash parameter with multiple keys and without braces' do
-        corrected = autocorrect_source(['where(x: "y", foo: "bar")'])
+        corrected = autocorrect_source('where(x: "y", foo: "bar")')
         expect(corrected).to eq('where({x: "y", foo: "bar"})')
       end
 
       it 'corrects one hash parameter without braces with one hash value' do
-        corrected = autocorrect_source(['where(x: { "y" => "z" })'])
+        corrected = autocorrect_source('where(x: { "y" => "z" })')
         expect(corrected).to eq('where({x: { "y" => "z" }})')
       end
     end

--- a/spec/rubocop/cop/style/class_check_spec.rb
+++ b/spec/rubocop/cop/style/class_check_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::Style::ClassCheck, :config do
     end
 
     it 'auto-corrects kind_of? to is_a?' do
-      corrected = autocorrect_source(['x.kind_of? y'])
+      corrected = autocorrect_source('x.kind_of? y')
       expect(corrected).to eq 'x.is_a? y'
     end
   end
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Style::ClassCheck, :config do
     end
 
     it 'auto-corrects is_a? to kind_of?' do
-      corrected = autocorrect_source(['x.is_a? y'])
+      corrected = autocorrect_source('x.is_a? y')
       expect(corrected).to eq 'x.kind_of? y'
     end
   end

--- a/spec/rubocop/cop/style/command_literal_spec.rb
+++ b/spec/rubocop/cop/style/command_literal_spec.rb
@@ -121,10 +121,12 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
 
     describe 'a multi-line ` string with backticks' do
       let(:source) do
-        ['foo = `',
-         '  echo \`ls\`',
-         '  echo \`ls -l\`',
-         '`']
+        <<-RUBY.strip_indent
+          foo = `
+            echo \`ls\`
+            echo \`ls -l\`
+          `
+        RUBY
       end
 
       it 'registers an offense' do
@@ -139,7 +141,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
 
       it 'cannot auto-correct' do
         new_source = autocorrect_source(source)
-        expect(new_source).to eq(source.join("\n"))
+        expect(new_source).to eq(source)
       end
 
       describe 'when configured to allow inner backticks' do
@@ -198,10 +200,12 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
 
     describe 'a multi-line %x string without backticks' do
       let(:source) do
-        ['foo = %x(',
-         '  ls',
-         '  ls -l',
-         ')']
+        <<-RUBY.strip_indent
+          foo = %x(
+            ls
+            ls -l
+          )
+        RUBY
       end
 
       it 'registers an offense' do
@@ -216,16 +220,23 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
 
       it 'auto-corrects' do
         new_source = autocorrect_source(source)
-        expect(new_source).to eq("foo = `\n  ls\n  ls -l\n`")
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          foo = `
+            ls
+            ls -l
+          `
+        RUBY
       end
     end
 
     describe 'a multi-line %x string with backticks' do
       let(:source) do
-        ['foo = %x(',
-         '  echo `ls`',
-         '  echo `ls -l`',
-         ')']
+        <<-RUBY.strip_indent
+          foo = %x(
+            echo `ls`
+            echo `ls -l`
+          )
+        RUBY
       end
 
       it 'is accepted' do
@@ -252,7 +263,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
 
         it 'cannot auto-correct' do
           new_source = autocorrect_source(source)
-          expect(new_source).to eq(source.join("\n"))
+          expect(new_source).to eq(source)
         end
       end
     end
@@ -295,10 +306,12 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
 
     describe 'a multi-line ` string without backticks' do
       let(:source) do
-        ['foo = `',
-         '  ls',
-         '  ls -l',
-         '`']
+        <<-RUBY.strip_indent
+          foo = `
+            ls
+            ls -l
+          `
+        RUBY
       end
 
       it 'registers an offense' do
@@ -313,16 +326,23 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
 
       it 'auto-corrects' do
         new_source = autocorrect_source(source)
-        expect(new_source).to eq("foo = %x(\n  ls\n  ls -l\n)")
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          foo = %x(
+            ls
+            ls -l
+          )
+        RUBY
       end
     end
 
     describe 'a multi-line ` string with backticks' do
       let(:source) do
-        ['foo = `',
-         '  echo \`ls\`',
-         '  echo \`ls -l\`',
-         '`']
+        <<-'RUBY'.strip_indent
+          foo = `
+            echo \`ls\`
+            echo \`ls -l\`
+          `
+        RUBY
       end
 
       it 'registers an offense' do
@@ -337,7 +357,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
 
       it 'cannot auto-correct' do
         new_source = autocorrect_source(source)
-        expect(new_source).to eq(source.join("\n"))
+        expect(new_source).to eq(source)
       end
     end
 
@@ -411,10 +431,12 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
 
     describe 'a multi-line ` string without backticks' do
       let(:source) do
-        ['foo = `',
-         '  ls',
-         '  ls -l',
-         '`']
+        <<-'RUBY'.strip_indent
+          foo = `
+            ls
+            ls -l
+          `
+        RUBY
       end
 
       it 'registers an offense' do
@@ -429,16 +451,23 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
 
       it 'auto-corrects' do
         new_source = autocorrect_source(source)
-        expect(new_source).to eq("foo = %x(\n  ls\n  ls -l\n)")
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          foo = %x(
+            ls
+            ls -l
+          )
+        RUBY
       end
     end
 
     describe 'a multi-line ` string with backticks' do
       let(:source) do
-        ['foo = `',
-         '  echo \`ls\`',
-         '  echo \`ls -l\`',
-         '`']
+        <<-'RUBY'.strip_indent
+          foo = `
+            echo \`ls\`
+            echo \`ls -l\`
+          `
+        RUBY
       end
 
       it 'registers an offense' do
@@ -453,7 +482,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
 
       it 'cannot auto-correct' do
         new_source = autocorrect_source(source)
-        expect(new_source).to eq(source.join("\n"))
+        expect(new_source).to eq(source)
       end
     end
 

--- a/spec/rubocop/cop/style/empty_method_spec.rb
+++ b/spec/rubocop/cop/style/empty_method_spec.rb
@@ -69,17 +69,21 @@ RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
 
     context 'with a non-empty instance method definition' do
       it_behaves_like 'code without offense',
-                      ['def foo',
-                       '  bar',
-                       'end']
+                      <<-RUBY.strip_indent
+                        def foo
+                          bar
+                        end
+                      RUBY
 
       it_behaves_like 'code without offense',
                       'def foo; bar; end'
 
       it_behaves_like 'code without offense',
-                      ['def foo',
-                       '  # bar',
-                       'end']
+                      <<-RUBY.strip_indent
+                        def foo
+                          # bar
+                        end
+                      RUBY
     end
 
     context 'with an empty class method definition' do
@@ -105,17 +109,21 @@ RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
 
     context 'with a non-empty class method definition' do
       it_behaves_like 'code without offense',
-                      ['def self.foo',
-                       '  bar',
-                       'end']
+                      <<-RUBY.strip_indent
+                        def self.foo
+                          bar
+                        end
+                      RUBY
 
       it_behaves_like 'code without offense',
                       'def self.foo; bar; end'
 
       it_behaves_like 'code without offense',
-                      ['def self.foo',
-                       '  # bar',
-                       'end']
+                      <<-RUBY.strip_indent
+                        def self.foo
+                          # bar
+                        end
+                      RUBY
     end
   end
 
@@ -144,17 +152,21 @@ RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
 
     context 'with a non-empty instance method definition' do
       it_behaves_like 'code without offense',
-                      ['def foo',
-                       '  bar',
-                       'end']
+                      <<-RUBY.strip_indent
+                        def foo
+                          bar
+                        end
+                      RUBY
 
       it_behaves_like 'code without offense',
                       'def foo; bar; end'
 
       it_behaves_like 'code without offense',
-                      ['def foo',
-                       '  # bar',
-                       'end']
+                      <<-RUBY.strip_indent
+                        def foo
+                          # bar
+                        end
+                      RUBY
     end
 
     context 'with an empty class method definition' do
@@ -175,17 +187,21 @@ RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
 
     context 'with a non-empty class method definition' do
       it_behaves_like 'code without offense',
-                      ['def self.foo',
-                       '  bar',
-                       'end']
+                      <<-RUBY.strip_indent
+                        def self.foo
+                          bar
+                        end
+                      RUBY
 
       it_behaves_like 'code without offense',
                       'def self.foo; bar; end'
 
       it_behaves_like 'code without offense',
-                      ['def self.foo',
-                       '  # bar',
-                       'end']
+                      <<-RUBY.strip_indent
+                        def self.foo
+                          # bar
+                        end
+                      RUBY
     end
 
     context 'when method is nested in class scope' do

--- a/spec/rubocop/cop/style/format_string_token_spec.rb
+++ b/spec/rubocop/cop/style/format_string_token_spec.rb
@@ -19,11 +19,11 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
       let(:enforced_style) { name }
 
       it "registers offenses for #{bad_style1}" do
-        inspect_source([
-                         '<<-HEREDOC',
-                         "foo #{good} + bar #{bad_style1}",
-                         'HEREDOC'
-                       ])
+        inspect_source(<<-RUBY.strip_indent)
+          <<-HEREDOC
+          foo #{good} + bar #{bad_style1}
+          HEREDOC
+        RUBY
 
         expect(cop.highlights).to eql([bad_style1])
       end

--- a/spec/rubocop/cop/style/lambda_call_spec.rb
+++ b/spec/rubocop/cop/style/lambda_call_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
     end
 
     it 'auto-corrects x.() to x.call()' do
-      new_source = autocorrect_source(['a.(x)'])
+      new_source = autocorrect_source('a.(x)')
       expect(new_source).to eq('a.call(x)')
     end
   end
@@ -58,17 +58,17 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
     end
 
     it 'auto-corrects x.call() to x.()' do
-      new_source = autocorrect_source(['a.call(x)'])
+      new_source = autocorrect_source('a.call(x)')
       expect(new_source).to eq('a.(x)')
     end
 
     it 'auto-corrects x.call to x.()' do
-      new_source = autocorrect_source(['a.call'])
+      new_source = autocorrect_source('a.call')
       expect(new_source).to eq('a.()')
     end
 
     it 'auto-corrects x.call asdf, x123 to x.(asdf, x123)' do
-      new_source = autocorrect_source(['a.call asdf, x123'])
+      new_source = autocorrect_source('a.call asdf, x123')
       expect(new_source).to eq('a.(asdf, x123)')
     end
   end

--- a/spec/rubocop/cop/style/line_end_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/line_end_concatenation_spec.rb
@@ -66,10 +66,12 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
 
   it 'registers multiple offenses when there are chained concatenations' \
      'combined with << calls' do
-    inspect_source(['top = "test#{x}" <<',
-                    '"top" +',
-                    '"foo" <<',
-                    '"bar"'])
+    inspect_source(<<-'RUBY'.strip_indent)
+      top = "test#{x}" <<
+      "top" +
+      "foo" <<
+      "bar"
+    RUBY
     expect(cop.offenses.size).to eq(3)
   end
 
@@ -140,51 +142,74 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
   end
 
   it 'autocorrects in the simple case by replacing + with \\' do
-    corrected = autocorrect_source(['top = "test" +',
-                                    '"top"'])
-    expect(corrected).to eq ['top = "test" \\', '"top"'].join("\n")
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
+      top = "test" + 
+      "top"
+    RUBY
+    expect(corrected).to eq(<<-RUBY.strip_indent)
+      top = "test" \\
+      "top"
+    RUBY
   end
 
   # The "central auto-correction engine" can't handle intermediate states where
   # the code has syntax errors, so it's important to fix the trailing
   # whitespace in this cop.
   it 'autocorrects a + with trailing whitespace to \\' do
-    corrected = autocorrect_source(['top = "test" + ',
-                                    '"top"'])
-    expect(corrected).to eq ['top = "test" \\', '"top"'].join("\n")
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
+      top = "test" +
+      "top"
+    RUBY
+    expect(corrected).to eq(<<-RUBY.strip_indent)
+      top = "test" \\
+      "top"
+    RUBY
   end
 
   it 'autocorrects a + with \\ to just \\' do
-    corrected = autocorrect_source(['top = "test" + \\',
-                                    '"top"'])
-    expect(corrected).to eq ['top = "test" \\', '"top"'].join("\n")
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
+      top = "test" + \\
+      "top"
+    RUBY
+    expect(corrected).to eq(<<-RUBY.strip_indent)
+      top = "test" \\
+      "top"
+    RUBY
   end
 
   it 'autocorrects for chained concatenations and << calls' do
-    corrected = autocorrect_source(['top = "test#{x}" <<',
-                                    '"top" +',
-                                    '"ubertop" <<',
-                                    '"foo"'])
+    corrected = autocorrect_source(<<-'RUBY'.strip_indent)
+      top = "test#{x}" <<
+      "top" +
+      "ubertop" <<
+      "foo"
+    RUBY
 
-    expect(corrected).to eq ['top = "test#{x}" \\',
-                             '"top" \\',
-                             '"ubertop" \\',
-                             '"foo"'].join("\n")
+    expect(corrected).to eq(<<-'RUBY'.strip_indent)
+      top = "test#{x}" \
+      "top" \
+      "ubertop" \
+      "foo"
+    RUBY
   end
 
   it 'autocorrects only the lines that should be autocorrected' do
-    corrected = autocorrect_source(['top = "test#{x}" <<',
-                                    '"top" + # comment',
-                                    '"foo" +',
-                                    '"bar" +',
-                                    '%(baz) +',
-                                    '"qux"'])
+    corrected = autocorrect_source(<<-'RUBY'.strip_indent)
+      top = "test#{x}" <<
+      "top" + # comment
+      "foo" +
+      "bar" +
+      %(baz) +
+      "qux"
+    RUBY
 
-    expect(corrected).to eq ['top = "test#{x}" \\',
-                             '"top" + # comment',
-                             '"foo" \\',
-                             '"bar" +',
-                             '%(baz) +',
-                             '"qux"'].join("\n")
+    expect(corrected).to eq(<<-'RUBY'.strip_indent)
+      top = "test#{x}" \
+      "top" + # comment
+      "foo" \
+      "bar" +
+      %(baz) +
+      "qux"
+    RUBY
   end
 end

--- a/spec/rubocop/cop/style/multiline_if_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_if_then_spec.rb
@@ -14,20 +14,24 @@ RSpec.describe RuboCop::Cop::Style::MultilineIfThen do
   end
 
   it 'registers an offense for then in multiline if' do
-    inspect_source(['if cond then',
-                    'end',
-                    "if cond then\t",
-                    'end',
-                    'if cond then  ',
-                    'end',
-                    'if cond',
-                    'then',
-                    'end',
-                    'if cond then # bad',
-                    'end'])
-    expect(cop.offenses.map(&:line)).to eq([1, 3, 5, 8, 10])
-    expect(cop.highlights).to eq(['then'] * 5)
-    expect(cop.messages).to eq(['Do not use `then` for multi-line `if`.'] * 5)
+    expect_offense(<<-RUBY.strip_indent)
+      if cond then
+              ^^^^ Do not use `then` for multi-line `if`.
+      end
+      if cond then\t
+              ^^^^ Do not use `then` for multi-line `if`.
+      end
+      if cond then
+              ^^^^ Do not use `then` for multi-line `if`.
+      end
+      if cond
+      then
+      ^^^^ Do not use `then` for multi-line `if`.
+      end
+      if cond then # bad
+              ^^^^ Do not use `then` for multi-line `if`.
+      end
+    RUBY
   end
 
   it 'registers an offense for then in multiline elsif' do

--- a/spec/rubocop/cop/style/numeric_literal_prefix_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literal_prefix_spec.rb
@@ -28,12 +28,12 @@ RSpec.describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
       end
 
       it 'autocorrects an octal literal starting with 0' do
-        corrected = autocorrect_source(['a = 01234'])
+        corrected = autocorrect_source('a = 01234')
         expect(corrected).to eq('a = 0o1234')
       end
 
       it 'autocorrects an octal literal starting with 0O' do
-        corrected = autocorrect_source(['b(0O1234, a)'])
+        corrected = autocorrect_source('b(0O1234, a)')
         expect(corrected).to eq('b(0o1234, a)')
       end
     end
@@ -71,7 +71,7 @@ RSpec.describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
       end
 
       it 'does not autocorrect an octal literal starting with 0' do
-        corrected = autocorrect_source(['b(01234, a)'])
+        corrected = autocorrect_source('b(01234, a)')
         expect(corrected).to eq 'b(01234, a)'
       end
     end
@@ -92,7 +92,7 @@ RSpec.describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
     end
 
     it 'autocorrects literals with uppercase prefix' do
-      corrected = autocorrect_source(['a = 0XAB'])
+      corrected = autocorrect_source('a = 0XAB')
       expect(corrected).to eq 'a = 0xAB'
     end
   end
@@ -112,7 +112,7 @@ RSpec.describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
     end
 
     it 'autocorrects literals with uppercase prefix' do
-      corrected = autocorrect_source(['a = 0B1010'])
+      corrected = autocorrect_source('a = 0B1010')
       expect(corrected).to eq 'a = 0b1010'
     end
   end
@@ -132,13 +132,23 @@ RSpec.describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
     end
 
     it 'autocorrects literals with prefix' do
-      corrected = autocorrect_source(['a = 0d1234', 'b(0D1990)'])
-      expect(corrected).to eq "a = 1234\nb(1990)"
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
+        a = 0d1234
+        b(0D1990)
+      RUBY
+      expect(corrected).to eq(<<-RUBY.strip_indent)
+        a = 1234
+        b(1990)
+      RUBY
     end
 
     it 'does not autocorrect literals with no prefix' do
-      corrected = autocorrect_source(['a = 1234', 'b(1990)'])
-      expect(corrected).to eq "a = 1234\nb(1990)"
+      source = <<-RUBY.strip_indent
+        a = 1234
+        b(1990)
+      RUBY
+      corrected = autocorrect_source(source)
+      expect(corrected).to eq(source)
     end
   end
 end

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -66,27 +66,27 @@ RSpec.describe RuboCop::Cop::Style::NumericLiterals, :config do
   end
 
   it 'autocorrects a long integer offense' do
-    corrected = autocorrect_source(['a = 123456'])
+    corrected = autocorrect_source('a = 123456')
     expect(corrected).to eq 'a = 123_456'
   end
 
   it 'autocorrects an integer with misplaced underscore' do
-    corrected = autocorrect_source(['a = 123_456_78_90_00'])
+    corrected = autocorrect_source('a = 123_456_78_90_00')
     expect(corrected).to eq 'a = 123_456_789_000'
   end
 
   it 'autocorrects negative numbers' do
-    corrected = autocorrect_source(['a = -123456'])
+    corrected = autocorrect_source('a = -123456')
     expect(corrected).to eq 'a = -123_456'
   end
 
   it 'autocorrects floating-point numbers' do
-    corrected = autocorrect_source(['a = 123456.78'])
+    corrected = autocorrect_source('a = 123456.78')
     expect(corrected).to eq 'a = 123_456.78'
   end
 
   it 'autocorrects negative floating-point numbers' do
-    corrected = autocorrect_source(['a = -123456.78'])
+    corrected = autocorrect_source('a = -123456.78')
     expect(corrected).to eq 'a = -123_456.78'
   end
 

--- a/spec/rubocop/cop/style/proc_spec.rb
+++ b/spec/rubocop/cop/style/proc_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::Style::Proc do
   end
 
   it 'auto-corrects Proc.new to proc' do
-    corrected = autocorrect_source(['Proc.new { test }'])
+    corrected = autocorrect_source('Proc.new { test }')
     expect(corrected).to eq 'proc { test }'
   end
 end

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
       it 'does not auto-correct to compact style' do
         initial_source = 'raise RuntimeError, msg, caller'
 
-        new_source = autocorrect_source([initial_source])
+        new_source = autocorrect_source(initial_source)
         expect(new_source).to eq(initial_source)
       end
     end
@@ -91,7 +91,7 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
         end
 
         it 'auto-corrects to exploded style' do
-          new_source = autocorrect_source(['raise Ex.new(msg)'])
+          new_source = autocorrect_source('raise Ex.new(msg)')
           expect(new_source).to eq('raise Ex, msg')
         end
       end
@@ -108,7 +108,7 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
         end
 
         it 'auto-corrects to exploded style' do
-          new_source = autocorrect_source(['raise Ex.new'])
+          new_source = autocorrect_source('raise Ex.new')
           expect(new_source).to eq('raise Ex')
         end
       end

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -93,10 +93,12 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
 
     describe 'a multi-line `//` regex with slashes' do
       let(:source) do
-        ['foo = /',
-         '  https?:\/\/',
-         '  example\.com',
-         '/x']
+        <<-'RUBY'.strip_indent
+          foo = /
+            https?:\/\/
+            example\.com
+          /x
+        RUBY
       end
 
       it 'registers an offense' do
@@ -106,7 +108,7 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
 
       it 'cannot auto-correct' do
         new_source = autocorrect_source(source)
-        expect(new_source).to eq(source.join("\n"))
+        expect(new_source).to eq(source)
       end
 
       describe 'when configured to allow inner slashes' do
@@ -165,10 +167,12 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
 
     describe 'a multi-line %r regex without slashes' do
       let(:source) do
-        ['foo = %r{',
-         '  foo',
-         '  bar',
-         '}x']
+        <<-'RUBY'.strip_indent.chomp
+          foo = %r{
+            foo
+            bar
+          }x
+        RUBY
       end
 
       it 'registers an offense' do
@@ -184,10 +188,12 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
 
     describe 'a multi-line %r regex with slashes' do
       let(:source) do
-        ['foo = %r{',
-         '  https?://',
-         '  example\.com',
-         '}x']
+        <<-'RUBY'.strip_indent
+          foo = %r{
+            https?://
+            example\.com
+          }x
+        RUBY
       end
 
       it 'is accepted' do
@@ -209,7 +215,7 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
 
         it 'cannot auto-correct' do
           new_source = autocorrect_source(source)
-          expect(new_source).to eq(source.join("\n"))
+          expect(new_source).to eq(source)
         end
       end
     end
@@ -252,10 +258,12 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
 
     describe 'a multi-line `//` regex without slashes' do
       let(:source) do
-        ['foo = /',
-         '  foo',
-         '  bar',
-         '/x']
+        <<-'RUBY'.strip_indent.chomp
+          foo = /
+            foo
+            bar
+          /x
+        RUBY
       end
 
       it 'registers an offense' do
@@ -271,10 +279,12 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
 
     describe 'a multi-line `//` regex with slashes' do
       let(:source) do
-        ['foo = /',
-         '  https?:\/\/',
-         '  example\.com',
-         '/x']
+        <<-'RUBY'.strip_indent
+          foo = /
+            https?:\/\/
+            example\.com
+          /x
+        RUBY
       end
 
       it 'registers an offense' do
@@ -284,7 +294,7 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
 
       it 'cannot auto-correct' do
         new_source = autocorrect_source(source)
-        expect(new_source).to eq(source.join("\n"))
+        expect(new_source).to eq(source)
       end
     end
 
@@ -358,10 +368,12 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
 
     describe 'a multi-line `//` regex without slashes' do
       let(:source) do
-        ['foo = /',
-         '  foo',
-         '  bar',
-         '/x']
+        <<-'RUBY'.strip_indent.chomp
+          foo = /
+            foo
+            bar
+          /x
+        RUBY
       end
 
       it 'registers an offense' do
@@ -377,10 +389,12 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
 
     describe 'a multi-line `//` regex with slashes' do
       let(:source) do
-        ['foo = /',
-         '  https?:\/\/',
-         '  example\.com',
-         '/x']
+        <<-'RUBY'.strip_indent
+          foo = /
+            https?:\/\/
+            example\.com
+          /x
+        RUBY
       end
 
       it 'registers an offense' do
@@ -390,7 +404,7 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
 
       it 'cannot auto-correct' do
         new_source = autocorrect_source(source)
-        expect(new_source).to eq(source.join("\n"))
+        expect(new_source).to eq(source)
       end
     end
 

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods do
   end
 
   it 'auto-corrects def with semicolon after method name' do
-    corrected = autocorrect_source(['  def some_method; body end # Cmnt'])
+    corrected = autocorrect_source('  def some_method; body end # Cmnt')
     expect(corrected).to eq ['  # Cmnt',
                              '  def some_method; ',
                              '    body ',
@@ -81,28 +81,28 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods do
   end
 
   it 'auto-corrects defs with parentheses after method name' do
-    corrected = autocorrect_source(['  def self.some_method() body end'])
+    corrected = autocorrect_source('  def self.some_method() body end')
     expect(corrected).to eq ['  def self.some_method() ',
                              '    body ',
                              '  end'].join("\n")
   end
 
   it 'auto-corrects def with argument in parentheses' do
-    corrected = autocorrect_source(['  def some_method(arg) body end'])
+    corrected = autocorrect_source('  def some_method(arg) body end')
     expect(corrected).to eq ['  def some_method(arg) ',
                              '    body ',
                              '  end'].join("\n")
   end
 
   it 'auto-corrects def with argument and no parentheses' do
-    corrected = autocorrect_source(['  def some_method arg; body end'])
+    corrected = autocorrect_source('  def some_method arg; body end')
     expect(corrected).to eq ['  def some_method arg; ',
                              '    body ',
                              '  end'].join("\n")
   end
 
   it 'auto-corrects def with semicolon before end' do
-    corrected = autocorrect_source(['  def some_method; b1; b2; end'])
+    corrected = autocorrect_source('  def some_method; b1; b2; end')
     expect(corrected).to eq ['  def some_method; ',
                              '    b1; ',
                              '    b2; ',

--- a/spec/rubocop/cop/style/stabby_lambda_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/stabby_lambda_parentheses_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::Style::StabbyLambdaParentheses, :config do
     end
 
     it 'autocorrects when a stabby lambda has no parentheses' do
-      corrected = autocorrect_source(['->a,b,c { a + b + c }'])
+      corrected = autocorrect_source('->a,b,c { a + b + c }')
       expect(corrected).to eq '->(a,b,c) { a + b + c }'
     end
   end
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Cop::Style::StabbyLambdaParentheses, :config do
     end
 
     it 'autocorrects when a stabby lambda does not parentheses' do
-      corrected = autocorrect_source(['->(a,b,c) { a + b + c }'])
+      corrected = autocorrect_source('->(a,b,c) { a + b + c }')
       expect(corrected).to eq '->a,b,c { a + b + c }'
     end
   end

--- a/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
 
     it 'registers an offense for double quotes within embedded expression in ' \
        'a heredoc string' do
-      src = ['<<RUBY',
-             '#{"A"}',
-             'RUBY']
-      inspect_source(src)
-      expect(cop.messages)
-        .to eq(['Prefer single-quoted strings inside interpolations.'])
+      expect_offense(<<-'SOURCE'.strip_indent)
+        <<RUBY
+        #{"A"}
+          ^^^ Prefer single-quoted strings inside interpolations.
+        RUBY
+      SOURCE
     end
 
     it 'accepts double quotes on a static string' do
@@ -73,12 +73,12 @@ RSpec.describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
 
     it 'registers an offense for single quotes within embedded expression in ' \
        'a heredoc string' do
-      src = ['<<RUBY',
-             '#{\'A\'}',
-             'RUBY']
-      inspect_source(src)
-      expect(cop.messages)
-        .to eq(['Prefer double-quoted strings inside interpolations.'])
+      expect_offense(<<-'SOURCE'.strip_indent)
+        <<RUBY
+        #{'A'}
+          ^^^ Prefer double-quoted strings inside interpolations.
+        RUBY
+      SOURCE
     end
   end
 

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -7,14 +7,16 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'single_quotes' } }
 
     it 'registers offense for double quotes when single quotes suffice' do
-      inspect_source(['s = "abc"',
-                      'x = "a\\\\b"',
-                      'y ="\\\\b"',
-                      'z = "a\\\\"'])
-      expect(cop.highlights).to eq(['"abc"',
-                                    '"a\\\\b"',
-                                    '"\\\\b"',
-                                    '"a\\\\"'])
+      expect_offense(<<-'RUBY'.strip_indent)
+        s = "abc"
+            ^^^^^ Prefer single-quoted strings when you don't need string interpolation or special symbols.
+        x = "a\\b"
+            ^^^^^^ Prefer single-quoted strings when you don't need string interpolation or special symbols.
+        y ="\\b"
+           ^^^^^ Prefer single-quoted strings when you don't need string interpolation or special symbols.
+        z = "a\\"
+            ^^^^^ Prefer single-quoted strings when you don't need string interpolation or special symbols.
+      RUBY
       expect(cop.messages)
         .to eq(["Prefer single-quoted strings when you don't need " \
                 'string interpolation or special symbols.'] * 4)
@@ -114,9 +116,11 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'detects unneeded double quotes within concatenated string' do
-      src = ['"#{x}" \\', '"y"']
-      inspect_source(src)
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-'RUBY'.strip_indent)
+        "#{x}" \
+        "y"
+        ^^^ Prefer single-quoted strings when you don't need string interpolation or special symbols.
+      RUBY
     end
 
     it 'can handle a built-in constant parsed as string' do

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -85,18 +85,18 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
   end
 
   it 'autocorrects alias with symbols as proc' do
-    corrected = autocorrect_source(['coll.map { |s| s.upcase }'])
+    corrected = autocorrect_source('coll.map { |s| s.upcase }')
     expect(corrected).to eq 'coll.map(&:upcase)'
   end
 
   it 'autocorrects multiple aliases with symbols as proc' do
-    corrected = autocorrect_source(['coll.map { |s| s.upcase }' \
-                                         '.map { |s| s.downcase }'])
+    corrected = autocorrect_source('coll.map { |s| s.upcase }' \
+                                   '.map { |s| s.downcase }')
     expect(corrected).to eq 'coll.map(&:upcase).map(&:downcase)'
   end
 
   it 'auto-corrects correctly when there are no arguments in parentheses' do
-    corrected = autocorrect_source(['coll.map(   ) { |s| s.upcase }'])
+    corrected = autocorrect_source('coll.map(   ) { |s| s.upcase }')
     expect(corrected).to eq 'coll.map(&:upcase)'
   end
 

--- a/spec/rubocop/cop/style/unneeded_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_interpolation_spec.rb
@@ -136,22 +136,22 @@ RSpec.describe RuboCop::Cop::Style::UnneededInterpolation do
   end
 
   it 'autocorrects "#{1 + 1; 2 + 2}"' do
-    corrected = autocorrect_source(['"#{1 + 1; 2 + 2}"'])
+    corrected = autocorrect_source('"#{1 + 1; 2 + 2}"')
     expect(corrected).to eq '(1 + 1; 2 + 2).to_s'
   end
 
   it 'autocorrects "#@var"' do
-    corrected = autocorrect_source(['"#@var"'])
+    corrected = autocorrect_source('"#@var"')
     expect(corrected).to eq '@var.to_s'
   end
 
   it 'autocorrects "#{var}"' do
-    corrected = autocorrect_source(['var = 1; "#{var}"'])
+    corrected = autocorrect_source('var = 1; "#{var}"')
     expect(corrected).to eq 'var = 1; var.to_s'
   end
 
   it 'autocorrects "#{@var}"' do
-    corrected = autocorrect_source(['"#{@var}"'])
+    corrected = autocorrect_source('"#{@var}"')
     expect(corrected).to eq '@var.to_s'
   end
 end

--- a/spec/rubocop/cop/style/variable_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/variable_interpolation_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe RuboCop::Cop::Style::VariableInterpolation do
   end
 
   it 'autocorrects by adding the missing {}' do
-    corrected = autocorrect_source(['"some #@var"'])
+    corrected = autocorrect_source('"some #@var"')
     expect(corrected).to eq '"some #{@var}"'
   end
 end

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -141,10 +141,14 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'keeps the line breaks in place after auto-correct' do
-      new_source = autocorrect_source(["['one',",
-                                       "'two', 'three']"])
-      expect(new_source).to eq(['%w(one',
-                                'two three)'].join("\n"))
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        ['one',
+        'two', 'three']
+      RUBY
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        %w(one
+        two three)
+      RUBY
     end
 
     it 'auto-corrects an array of words in multiple lines' do

--- a/spec/support/multiline_literal_brace_layout_trailing_comma_examples.rb
+++ b/spec/support/multiline_literal_brace_layout_trailing_comma_examples.rb
@@ -14,10 +14,12 @@ shared_examples_for 'multiline literal brace layout trailing comma' do
     context 'opening brace on same line as first element' do
       context 'last element has a trailing comma' do
         it 'autocorrects closing brace on different line from last element' do
-          new_source = autocorrect_source(["#{prefix}#{open}#{a}, # a",
-                                           "#{b}, # b",
-                                           close,
-                                           suffix])
+          new_source = autocorrect_source(<<-RUBY.strip_indent.chomp)
+            #{prefix}#{open}#{a}, # a
+            #{b}, # b
+            #{close}
+            #{suffix}
+          RUBY
 
           expect(new_source)
             .to eq("#{prefix}#{open}#{a}, # a\n#{b},#{close} # b\n#{suffix}")
@@ -32,10 +34,12 @@ shared_examples_for 'multiline literal brace layout trailing comma' do
     context 'opening brace on same line as first element' do
       context 'last element has a trailing comma' do
         it 'autocorrects closing brace on different line as last element' do
-          new_source = autocorrect_source(["#{prefix}#{open}#{a}, # a",
-                                           "#{b}, # b",
-                                           close,
-                                           suffix])
+          new_source = autocorrect_source(<<-RUBY.strip_indent.chomp)
+            #{prefix}#{open}#{a}, # a
+            #{b}, # b
+            #{close}
+            #{suffix}
+          RUBY
 
           expect(new_source)
             .to eq("#{prefix}#{open}#{a}, # a\n#{b},#{close} # b\n#{suffix}")


### PR DESCRIPTION
Since we started using heredocs for most of the code examples, using arrays has felt obsolete.