### PR TITLE
[Fix #6138] Skip block local variables in Lint/ShadowedArgument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#6124](https://github.com/rubocop-hq/rubocop/issues/6124): Fix `Style/IfUnlessModifier` cop for disabled `Layout/Tab` cop when there is no `IndentationWidth` config. ([@AlexWayfer][])
 * [#6133](https://github.com/rubocop-hq/rubocop/pull/6133): Fix `AllowURI` option of `Metrics/LineLength` cop for files with tabs indentation. ([@AlexWayfer][])
 * [#6164](https://github.com/rubocop-hq/rubocop/issues/6164): Fix incorrect autocorrect for `Style/UnneededCondition` when using operator method higher precedence than `||`. ([@koic][])
+* [#6138](https://github.com/rubocop-hq/rubocop/issues/6138): Fix a false positive for assigning a block local variable in `Lint/ShadowedArgument`. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/shadowed_argument.rb
+++ b/lib/rubocop/cop/lint/shadowed_argument.rb
@@ -83,6 +83,9 @@ module RuboCop
 
         def check_argument(argument)
           return unless argument.method_argument? || argument.block_argument?
+          # Block local variables, i.e., variables declared after ; inside
+          # |...| aren't really arguments.
+          return if argument.explicit_block_local_variable?
 
           shadowing_assignment(argument) do |node|
             message = format(MSG, argument: argument.name)

--- a/spec/rubocop/cop/lint/shadowed_argument_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_argument_spec.rb
@@ -416,6 +416,19 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedArgument, :config do
   end
 
   describe 'block argument shadowing' do
+    context 'when a block local variable is assigned but no argument is' \
+            ' shadowed' do
+      it 'accepts' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          numbers = [1, 2, 3]
+          numbers.each do |i; j|
+            j = i * 2
+            puts j
+          end
+        RUBY
+      end
+    end
+
     context 'when a single argument is shadowed' do
       it 'registers an offense' do
         expect_offense(<<-RUBY.strip_indent)


### PR DESCRIPTION
Block local variables are not arguments. They aren't used to pass values into the block, so they can't be shadowed.

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.