### PR TITLE
Add AllowImplicitReturn option to Rails/SaveBang cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#6109](https://github.com/rubocop-hq/rubocop/pull/6109): Add new `Bundler/GemComment` cop. ([@sunny][])
 * [#6148](https://github.com/rubocop-hq/rubocop/pull/6148): Add `IgnoredMethods` option to `Style/NumericPredicate` cop. ([@AlexWayfer][])
 * [#6174](https://github.com/rubocop-hq/rubocop/pull/6174): Add `--display-only-fail-level-offenses` to only output offenses at or above the fail level. ([@robotdana][])
+* [#6173](https://github.com/rubocop-hq/rubocop/pull/6173): Add `AllowImplicitReturn` option to `Rails/SaveBang` cop. ([@robotdana][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1824,6 +1824,9 @@ Rails/SafeNavigation:
   # implement the intended method. `try` will not raise an exception for this.
   ConvertTry: false
 
+Rails/SaveBang:
+  AllowImplicitReturn: true
+
 Rails/ScopeArgs:
   Include:
     - app/models/**/*.rb

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1731,12 +1731,18 @@ This cop identifies possible cases where Active Record save! or related
 should be used instead of save because the model might have failed to
 save and an exception is better than unhandled failure.
 
-This will ignore calls that return a boolean for success if the result
-is assigned to a variable or used as the condition in an if/unless
-statement.  It will also ignore calls that return a model assigned to a
-variable that has a call to `persisted?`. Finally, it will ignore any
-call with more than 2 arguments as that is likely not an Active Record
-call or a Model.update(id, attributes) call.
+This will allow:
+- update or save calls, assigned to a variable,
+  or used as a condition in an if/unless/case statement.
+- create calls, assigned to a variable that then has a
+  call to `persisted?`.
+- calls if the result is explicitly returned from methods and blocks,
+  or provided as arguments.
+- calls whose signature doesn't look like an ActiveRecord
+  persistence method.
+
+By default it will also allow implicit returns from methods and blocks.
+that behavior can be turned off with `AllowImplicitReturn: false`.
 
 ### Examples
 
@@ -1760,7 +1766,47 @@ user = User.find_or_create_by(name: 'Joe')
 unless user.persisted?
   # ...
 end
+
+def save_user
+  return user.save
+end
 ```
+#### AllowImplicitReturn: true (default)
+
+```ruby
+# good
+users.each { |u| u.save }
+
+def save_user
+  user.save
+end
+```
+#### AllowImplicitReturn: false
+
+```ruby
+# bad
+users.each { |u| u.save }
+def save_user
+  user.save
+end
+
+# good
+users.each { |u| u.save! }
+
+def save_user
+  user.save!
+end
+
+def save_user
+  return user.save
+end
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AllowImplicitReturn | `true` | Boolean
 
 ### References
 

--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -43,11 +43,11 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
     end
   end
 
-  shared_examples 'checks_variable_return_use_offense' do |method, pass|
+  shared_examples 'checks_variable_return_use_offense' do |method, update|
     it "when assigning the return value of #{method}" do
       inspect_source("x = object.#{method}\n")
 
-      if pass
+      if update
         expect(cop.messages.empty?).to be(true)
       else
         expect(cop.messages)
@@ -62,7 +62,7 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
                           "  obj.name = 'Tom'\n" \
                           'end')
 
-      if pass
+      if update
         expect(cop.messages.empty?).to be(true)
       else
         expect(cop.messages)
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
     it "when using #{method} with if" do
       inspect_source("if object.#{method}; something; end")
 
-      if pass
+      if update
         expect(cop.messages.empty?).to be(true)
       else
         expect(cop.messages)
@@ -86,7 +86,7 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
     it "when using #{method} with negated if" do
       inspect_source("if !object.#{method}; something; end")
 
-      if pass
+      if update
         expect(cop.messages.empty?).to be(true)
       else
         expect(cop.messages)
@@ -100,7 +100,7 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
           something
         end
       RUBY
-      if pass
+      if update
         expect(cop.messages.empty?).to be(true)
       else
         expect(cop.messages)
@@ -111,7 +111,7 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
     it "when using #{method} with oneline if" do
       inspect_source("something if object.#{method}")
 
-      if pass
+      if update
         expect(cop.messages.empty?).to be(true)
       else
         expect(cop.messages)
@@ -122,7 +122,7 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
     it "when using #{method} with oneline if and multiple conditional" do
       inspect_source("something if false || object.#{method}")
 
-      if pass
+      if update
         expect(cop.messages.empty?).to be(true)
       else
         expect(cop.messages)
@@ -140,7 +140,7 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
         end
       RUBY
 
-      if pass
+      if update
         expect(cop.messages.empty?).to be(true)
       else
         expect(cop.messages)
@@ -151,7 +151,7 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
     it "when using #{method} with '&&'" do
       inspect_source("object.#{method} && false")
 
-      if pass
+      if update
         expect(cop.messages.empty?).to be(true)
       else
         expect(cop.messages)
@@ -162,7 +162,7 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
     it "when using #{method} with 'and'" do
       inspect_source("object.#{method} and false")
 
-      if pass
+      if update
         expect(cop.messages.empty?).to be(true)
       else
         expect(cop.messages)
@@ -173,7 +173,7 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
     it "when using #{method} with '||'" do
       inspect_source("object.#{method} || false")
 
-      if pass
+      if update
         expect(cop.messages.empty?).to be(true)
       else
         expect(cop.messages)
@@ -192,7 +192,7 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
     it "when using #{method} with 'or'" do
       inspect_source("object.#{method} or false")
 
-      if pass
+      if update
         expect(cop.messages.empty?).to be(true)
       else
         expect(cop.messages)
@@ -250,7 +250,7 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
           render json: foo
         end
       RUBY
-      if pass
+      if update
         expect(cop.offenses.empty?).to be(true)
       else
         expect(cop.offenses.size).to eq(1)
@@ -258,7 +258,7 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
     end
   end
 
-  shared_examples 'check_implicit_return' do |method, pass|
+  shared_examples 'check_implicit_return' do |method, allow_implicit_return|
     it "when using #{method} as last method call" do
       inspect_source(<<-RUBY.strip_indent)
         def foo
@@ -266,7 +266,7 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
         end
       RUBY
 
-      if pass
+      if allow_implicit_return
         expect(cop.offenses.empty?).to be true
       else
         expect(cop.messages)
@@ -282,7 +282,7 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
         end
       RUBY
 
-      if pass
+      if allow_implicit_return
         expect(cop.offenses.empty?).to be true
       else
         expect(cop.messages)


### PR DESCRIPTION
Often the return value of a method is ignored, it's just the last line of a controller.
Or (because the check did more than it said it did) the last line of a block.

By adding this switch I noticed I needed to explicitly check for hash assignment & passing to a method,
so I narrowed what last_call_of_method? does, closer to what it says it's doing. (and renamed it implicit_return?)

I named this AllowImplicitReturn, because I feel like you're already expressing intent with explicit returns. I also added a check for explicit returns

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
