### PR TITLE
Add `--fail-level-output` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#6109](https://github.com/rubocop-hq/rubocop/pull/6109): Add new `Bundler/GemComment` cop. ([@sunny][])
 * [#6148](https://github.com/rubocop-hq/rubocop/pull/6148): Add `IgnoredMethods` option to `Style/NumericPredicate` cop. ([@AlexWayfer][])
+* [#6174](https://github.com/rubocop-hq/rubocop/pull/6174): Add `--display-only-fail-level-offenses` to only output offenses at or above the fail level. ([@robotdana][])
 
 ### Bug fixes
 
@@ -3519,3 +3520,4 @@
 [@repinel]: https://github.com/repinel
 [@gmalette]: https://github.com/gmalette
 [@MagedMilad]: https://github.com/MagedMilad
+[@robotdana]: https://github.com/robotdana

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -136,6 +136,7 @@ module RuboCop
              table) do |severity|
         @options[:fail_level] = severity
       end
+      option(opts, '--display-only-fail-level-offenses')
     end
 
     def add_flags_with_optional_args(opts)
@@ -251,6 +252,11 @@ module RuboCop
       unless boolean_or_empty_cache?
         raise OptionArgumentError, '-C/--cache argument must be true or false'
       end
+
+      if display_only_fail_level_offenses_with_autocorrect?
+        raise OptionArgumentError, '--autocorrect can not be used with ' \
+          '--display-only-fail-level-offenses'
+      end
       validate_auto_gen_config
       validate_parallel
 
@@ -302,6 +308,10 @@ module RuboCop
       @options.key?(:only) &&
         (@options[:only] & %w[Lint/UnneededCopDisableDirective
                               UnneededCopDisableDirective]).any?
+    end
+
+    def display_only_fail_level_offenses_with_autocorrect?
+      @options[:display_only_fail_level_offenses] && @options[:autocorrect]
     end
 
     def except_syntax?
@@ -378,6 +388,9 @@ module RuboCop
                              'if no format is specified.'],
       fail_level:           ['Minimum severity (A/R/C/W/E/F) for exit',
                              'with error code.'],
+      display_only_fail_level_offenses:
+                            ['Only output offense messages at',
+                             'the specified --fail-level or above'],
       show_cops:            ['Shows the given cops, or all cops by',
                              'default, and their configurations for the',
                              'current directory.'],

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -98,6 +98,9 @@ module RuboCop
       file_started(file)
 
       offenses = file_offenses(file)
+      if @options[:display_only_fail_level_offenses]
+        offenses = offenses.select { |o| considered_failure?(o) }
+      end
       formatter_set.file_finished(file, offenses)
       offenses
     rescue InfiniteCorrectionLoop => e

--- a/manual/basic_usage.md
+++ b/manual/basic_usage.md
@@ -81,6 +81,7 @@ Command flag                    | Description
 `--exclude-limit`               | Limit how many individual files `--auto-gen-config` can list in `Exclude` parameters, default is 15.
 `--show-cops`                   | Shows available cops and their configuration.
 `--fail-level`                  | Minimum [severity](#severity) for exit with error code. Full severity name or upper case initial can be given. Normally, auto-corrected offenses are ignored. Use `A` or `autocorrect` if you'd like them to trigger failure.
+`--display-only-fail-level-offenses`           | Only output offense messages at the specified `--fail-level` or above
 `-s/--stdin`                    | Pipe source from STDIN. This is useful for editor integration.
 `--[no-]color`                  | Force color output on or off.
 `--parallel`                    | Use available CPUs to execute inspection in parallel.

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -82,6 +82,9 @@ RSpec.describe RuboCop::Options, :isolated_environment do
               -r, --require FILE               Require Ruby file.
                   --fail-level SEVERITY        Minimum severity (A/R/C/W/E/F) for exit
                                                with error code.
+                  --display-only-fail-level-offenses
+                                               Only output offense messages at
+                                               the specified --fail-level or above
                   --show-cops [COP1,COP2,...]  Shows the given cops, or all cops by
                                                default, and their configurations for the
                                                current directory.


### PR DESCRIPTION
Intended for having CI run across a codebase, and only fail at a certain level
And provide output for only the cops causing CI failure, without a spam of e.g.
refactor offenses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
