### PR TITLE
[Fix #4301] Turn off autocorrect for `Rails/RelativeDateConstant` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#6137](https://github.com/rubocop-hq/rubocop/pull/6137): Allow `db` to allowed names of `Naming/UncommunicativeMethodParamName` cop in default config. ([@mkenyon][])
 * Update the highlighting of `Lint/DuplicateMethods` to include the method name. ([@rrosenblum][])
 * [#6057](https://github.com/rubocop-hq/rubocop/issues/6057): Return 0 when running `rubocop --auto-gen-conf` if the todo file is successfully created even if there are offenses. ([@MagedMilad][])
+* [#4301](https://github.com/rubocop-hq/rubocop/issues/4301): Turn off autocorrect for `Rails/RelativeDateConstant` by default. ([@koic][])
 
 ## 0.58.2 (2018-07-23)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1804,6 +1804,9 @@ Rails/RefuteMethods:
   Include:
     - '**/test/**/*'
 
+Rails/RelativeDateConstant:
+  AutoCorrect: false
+
 Rails/RequestReferer:
   EnforcedStyle: referer
   SupportedStyles:

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1487,6 +1487,12 @@ class SomeClass
 end
 ```
 
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AutoCorrect | `false` | Boolean
+
 ## Rails/RequestReferer
 
 Enabled by default | Supports autocorrection


### PR DESCRIPTION
Fixes #4301.

Turn off autocorrect for `Rails/RelativeDateConstant` by default.
It is difficult to automatically fix together the code that uses that constant.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
