### PR TITLE
[Documentation fix] wrong quotation for `||`

### DIFF
--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Style
       # This cop checks for uses of `and` and `or`, and suggests using `&&` and
-      # `|| instead`. It can be configured to check only in conditions, or in
+      # `||` instead. It can be configured to check only in conditions, or in
       # all contexts.
       #
       # @example EnforcedStyle: always (default)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -114,7 +114,7 @@ Enabled by default | Supports autocorrection
 Enabled | Yes
 
 This cop checks for uses of `and` and `or`, and suggests using `&&` and
-`|| instead`. It can be configured to check only in conditions, or in
+`||` instead. It can be configured to check only in conditions, or in
 all contexts.
 
 ### Examples


### PR DESCRIPTION
Fix typo of the comment/manual.

Before: `|| instead`
After:    `||` instead

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
