### PR TITLE
[Fix #5181] Change the path pattern to match the hidden file

### DIFF
--- a/.travis.rb
+++ b/.travis.rb
@@ -3,6 +3,7 @@
 require 'English'
 require 'benchmark'
 
+# A module for continuous integration.
 module RubocopTravis
   class << self
     def run
@@ -23,7 +24,8 @@ module RubocopTravis
     # Running YARD under jruby crashes so skip checking the manual.
     def documentation
       return if jruby?
-      sh!('bundle exec rake documentation_syntax_check generate_cops_documentation')
+      sh!('bundle exec rake documentation_syntax_check ' \
+          'generate_cops_documentation')
     end
 
     def jruby?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Update the highlighting of `Lint/DuplicateMethods` to include the method name. ([@rrosenblum][])
 * [#6057](https://github.com/rubocop-hq/rubocop/issues/6057): Return 0 when running `rubocop --auto-gen-conf` if the todo file is successfully created even if there are offenses. ([@MagedMilad][])
 * [#4301](https://github.com/rubocop-hq/rubocop/issues/4301): Turn off autocorrect for `Rails/RelativeDateConstant` by default. ([@koic][])
+* [#4832](https://github.com/rubocop-hq/rubocop/issues/4832): Change the path pattern (`*`) to match the hidden file. ([@koic][])
 
 ## 0.58.2 (2018-07-23)
 

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -36,7 +36,8 @@ module RuboCop
     def match_path?(pattern, path)
       case pattern
       when String
-        File.fnmatch?(pattern, path, File::FNM_PATHNAME | File::FNM_EXTGLOB)
+        File.fnmatch?(pattern, path, File::FNM_PATHNAME | File::FNM_EXTGLOB) ||
+          hidden_file_in_not_hidden_dir?(pattern, path)
       when Regexp
         begin
           path =~ pattern
@@ -58,6 +59,19 @@ module RuboCop
 
     def self.reset_pwd
       @pwd = nil
+    end
+
+    def hidden_file_in_not_hidden_dir?(pattern, path)
+      File.fnmatch?(
+        pattern, path,
+        File::FNM_PATHNAME | File::FNM_EXTGLOB | File::FNM_DOTMATCH
+      ) && File.basename(path).start_with?('.') && !hidden_dir?(path)
+    end
+
+    def hidden_dir?(path)
+      File.dirname(path).split(File::SEPARATOR).any? do |dir|
+        dir.start_with?('.')
+      end
     end
   end
 end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -984,17 +984,21 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       create_file('file.rb', 'x=0') # Included by default
       create_file('example', 'x=0')
       create_file('regexp', 'x=0')
+      create_file('vendor/bundle/ruby/2.4.0/gems/backports-3.6.8/.irbrc', 'x=0')
       create_file('.dot1/file.rb', 'x=0') # Hidden but explicitly included
       create_file('.dot2/file.rb', 'x=0') # Hidden, excluded by default
       create_file('.dot3/file.rake', 'x=0') # Hidden, not included by wildcard
       create_file('.rubocop.yml', <<-YAML.strip_indent)
         AllCops:
           Include:
+            - "**/.irbrc"
             - example
             - "**/*.rb"
             - "**/*.rake"
             - !ruby/regexp /regexp$/
             - .dot1/**/*
+          Exclude:
+            - vendor/bundle/**/*
       YAML
       expect(cli.run(%w[--format files])).to eq(1)
       expect($stderr.string).to eq('')

--- a/spec/rubocop/path_util_spec.rb
+++ b/spec/rubocop/path_util_spec.rb
@@ -45,9 +45,9 @@ RSpec.describe RuboCop::PathUtil do
       expect($stderr.string).to eq('')
     end
 
-    it 'does not match dir/** for hidden file' do
+    it 'matches dir/** for hidden file' do
       expect(described_class.match_path?('dir/**', 'dir/.hidden_file'))
-        .to be(false)
+        .to be(true)
       expect($stderr.string).to eq('')
     end
 
@@ -78,7 +78,7 @@ RSpec.describe RuboCop::PathUtil do
       expect(described_class.match_path?('**/*',
                                          'dir/.hidden/file')).to be(false)
       expect(described_class.match_path?('**/*',
-                                         'dir/.hidden_file')).to be(false)
+                                         'dir/.hidden_file')).to be(true)
       expect(described_class.match_path?('**/.*/*', 'dir/.hidden/file'))
         .to be(true)
       expect(described_class.match_path?('**/.*',


### PR DESCRIPTION
Fixes #5181.
Fixes #4832.

This PR changes the path pattern (`*`) to match the hidden file.

This PR resolves the following problem.

```console
AllCops:
  Exclude:
    - 'vendor/bundle/**/*'
```

The above .rubocop.yml setting is expected to cover hidden files as well. However, there is a problem that offenses occur with hidden files.

```console
vendor/bundle/ruby/2.4.0/gems/backports-3.6.8/.irbrc:1:1: C:
Style/SpecialGlobalVars: Prefer $LOAD_PATH over $:.
$:.unshift "./lib"
^^

(snip)
```

This PR solves this problem by including hidden files in the path match target.

And This PR only changes behavior to hidden files.

As resolved in #1401, #1656, hidden directories keep their previous behavior.
So hidden files in the hidden directory don't match.

Probably it will be an intuitive path match to users.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
