### PR TITLE
Layout/AlignArray with fixed indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#6109](https://github.com/rubocop-hq/rubocop/pull/6109): Add new `Bundler/GemComment` cop. ([@sunny][])
 * [#6148](https://github.com/rubocop-hq/rubocop/pull/6148): Add `IgnoredMethods` option to `Style/NumericPredicate` cop. ([@AlexWayfer][])
 * [#6174](https://github.com/rubocop-hq/rubocop/pull/6174): Add `--display-only-fail-level-offenses` to only output offenses at or above the fail level. ([@robotdana][])
+* Add `EnforcedStyle: with_fixed_indentation` to Layout/AlignArray. ([@robotdana][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -152,6 +152,28 @@ Layout/AccessModifierIndentation:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
+Layout/AlignArray:
+  # Alignment of values in multi-line arrays.
+  #
+  # The `with_first_value` style aligns the following lines along the same
+  # column as the first value.
+  #
+  #     array = [a,
+  #              b]
+  #
+  # The `with_fixed_indentation` style aligns the following lines with one
+  # level of indentation relative to the start of the line with the array.
+  #
+  #     array = [a,
+  #       b]
+  EnforcedStyle: with_first_value
+  SupportedStyles:
+    - with_first_value
+    - with_fixed_indentation
+  # By default, the indentation width from Layout/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
 # Align the elements of a hash literal if they span more than one line.
 Layout/AlignHash:
   # Alignment of entries using hash rocket as separator. Valid values are:

--- a/lib/rubocop/cop/layout/align_array.rb
+++ b/lib/rubocop/cop/layout/align_array.rb
@@ -6,7 +6,7 @@ module RuboCop
       # Here we check if the elements of a multi-line array literal are
       # aligned.
       #
-      # @example
+      # @example EnforcedStyle: with_first_value (default)
       #   # bad
       #   a = [1, 2, 3,
       #     4, 5, 6]
@@ -20,18 +20,61 @@ module RuboCop
       #   a = ['run',
       #        'forrest',
       #        'run']
+      #
+      # @example EnforcedStyle: with_fixed_alignment
+      #   # bad
+      #   a = [1, 2, 3,
+      #        4, 5, 6]
+      #   array = ['run',
+      #        'forrest',
+      #        'run']
+      #
+      #   # good
+      #   a = [1, 2, 3,
+      #     4, 5, 6]
+      #   a = ['run',
+      #     'forrest',
+      #     'run']
       class AlignArray < Cop
         include Alignment
 
-        MSG = 'Align the elements of an array literal if they span more ' \
-              'than one line.'.freeze
+        ALIGN_VALUES_MSG = 'Align the elements of an array literal if they ' \
+                           'span more than one line.'.freeze
+
+        FIXED_INDENT_MSG = 'Use one level of indentation for values ' \
+                           'following the first line of a multi-line array.'
+                           .freeze
 
         def on_array(node)
-          check_alignment(node.children)
+          return if node.children.empty?
+          check_alignment(node.children, base_column(node, node.children))
+        end
+
+        def message(_node)
+          fixed_indentation? ? FIXED_INDENT_MSG : ALIGN_VALUES_MSG
         end
 
         def autocorrect(node)
           AlignmentCorrector.correct(processed_source, node, column_delta)
+        end
+
+        def fixed_indentation?
+          cop_config['EnforcedStyle'] == 'with_fixed_indentation'
+        end
+
+        def base_column(node, args)
+          if fixed_indentation?
+            lineno = target_array_lineno(node)
+            line = node.source_range.source_buffer.source_line(lineno)
+            indentation_of_line = /\S.*/.match(line).begin(0)
+            indentation_of_line + configured_indentation_width
+          else
+            display_column(args.first.source_range)
+          end
+        end
+
+        def target_array_lineno(node)
+          node.loc.expression.line
         end
       end
     end

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -64,6 +64,8 @@ aligned.
 
 ### Examples
 
+#### EnforcedStyle: with_first_value (default)
+
 ```ruby
 # bad
 a = [1, 2, 3,
@@ -79,6 +81,30 @@ a = ['run',
      'forrest',
      'run']
 ```
+#### EnforcedStyle: with_fixed_alignment
+
+```ruby
+# bad
+a = [1, 2, 3,
+     4, 5, 6]
+array = ['run',
+     'forrest',
+     'run']
+
+# good
+a = [1, 2, 3,
+  4, 5, 6]
+a = ['run',
+  'forrest',
+  'run']
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `with_first_value` | `with_first_value`, `with_fixed_indentation`
+IndentationWidth | `<none>` | Integer
 
 ### References
 

--- a/spec/rubocop/cop/layout/align_array_spec.rb
+++ b/spec/rubocop/cop/layout/align_array_spec.rb
@@ -1,147 +1,343 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::AlignArray do
-  subject(:cop) { described_class.new }
+  subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense for misaligned array elements' do
-    expect_offense(<<-RUBY.strip_indent)
-      array = [
-        a,
-         b,
-         ^ Align the elements of an array literal if they span more than one line.
-        c,
+  let(:config) do
+    RuboCop::Config.new('Layout/AlignArray' => cop_config,
+                        'Layout/IndentationWidth' => {
+                          'Width' => indentation_width
+                        })
+  end
+  let(:indentation_width) { 2 }
+
+  context 'aligned with first value' do
+    let(:cop_config) do
+      { 'EnforcedStyle' => 'with_first_value' }
+    end
+
+    it 'registers an offense for misaligned array elements' do
+      expect_offense(<<-RUBY.strip_indent)
+        array = [
+          a,
+           b,
+           ^ Align the elements of an array literal if they span more than one line.
+          c,
+           d
+           ^ Align the elements of an array literal if they span more than one line.
+        ]
+      RUBY
+    end
+
+    it 'accepts aligned array keys' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        array = [
+          a,
+          b,
+          c,
+          d
+        ]
+      RUBY
+    end
+
+    it 'accepts single line array' do
+      expect_no_offenses('array = [ a, b ]')
+    end
+
+    it 'accepts several elements per line' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        array = [ a, b,
+                  c, d ]
+      RUBY
+    end
+
+    it 'accepts aligned array with fullwidth characters' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        puts 'Ｒｕｂｙ', [ a,
+                           b ]
+      RUBY
+    end
+
+    it 'auto-corrects alignment' do
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        array = [
+          a,
+           b,
+          c,
          d
-         ^ Align the elements of an array literal if they span more than one line.
-      ]
-    RUBY
-  end
+        ]
+      RUBY
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        array = [
+          a,
+          b,
+          c,
+          d
+        ]
+      RUBY
+    end
 
-  it 'accepts aligned array keys' do
-    expect_no_offenses(<<-RUBY.strip_indent)
-      array = [
-        a,
-        b,
-        c,
-        d
-      ]
-    RUBY
-  end
+    it 'does not auto-correct array within array with too much indentation' do
+      original_source = <<-RUBY.strip_indent
+        [:l1,
+          [:l2,
 
-  it 'accepts single line array' do
-    expect_no_offenses('array = [ a, b ]')
-  end
+            [:l3,
+             [:l4]]]]
+      RUBY
+      new_source = autocorrect_source(original_source)
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        [:l1,
+         [:l2,
 
-  it 'accepts several elements per line' do
-    expect_no_offenses(<<-RUBY.strip_indent)
-      array = [ a, b,
-                c, d ]
-    RUBY
-  end
+           [:l3,
+            [:l4]]]]
+      RUBY
+    end
 
-  it 'accepts aligned array with fullwidth characters' do
-    expect_no_offenses(<<-RUBY.strip_indent)
-      puts 'Ｒｕｂｙ', [ a,
-                         b ]
-    RUBY
-  end
-
-  it 'auto-corrects alignment' do
-    new_source = autocorrect_source(<<-RUBY.strip_indent)
-      array = [
-        a,
-         b,
-        c,
-       d
-      ]
-    RUBY
-    expect(new_source).to eq(<<-RUBY.strip_indent)
-      array = [
-        a,
-        b,
-        c,
-        d
-      ]
-    RUBY
-  end
-
-  it 'does not auto-correct array within array with too much indentation' do
-    original_source = <<-RUBY.strip_indent
-      [:l1,
+    it 'does not auto-correct array within array with too little indentation' do
+      original_source = <<-RUBY.strip_indent
+        [:l1,
         [:l2,
 
           [:l3,
            [:l4]]]]
-    RUBY
-    new_source = autocorrect_source(original_source)
-    expect(new_source).to eq(<<-RUBY.strip_indent)
-      [:l1,
-       [:l2,
+      RUBY
+      new_source = autocorrect_source(original_source)
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        [:l1,
+         [:l2,
 
-         [:l3,
-          [:l4]]]]
-    RUBY
+           [:l3,
+            [:l4]]]]
+      RUBY
+    end
+
+    it 'auto-corrects only elements that begin a line' do
+      original_source = <<-RUBY.strip_indent
+        array = [:bar, {
+                 whiz: 2, bang: 3 }, option: 3]
+      RUBY
+      new_source = autocorrect_source(original_source)
+      expect(new_source).to eq(original_source)
+    end
+
+    it 'does not indent heredoc strings in autocorrect' do
+      original_source = <<-RUBY.strip_indent
+        var = [
+               { :type => 'something',
+                 :sql => <<EOF
+        Select something
+        from atable
+        EOF
+               },
+              { :type => 'something',
+                :sql => <<EOF
+        Select something
+        from atable
+        EOF
+              }
+        ]
+      RUBY
+      new_source = autocorrect_source(original_source)
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        var = [
+               { :type => 'something',
+                 :sql => <<EOF
+        Select something
+        from atable
+        EOF
+               },
+               { :type => 'something',
+                 :sql => <<EOF
+        Select something
+        from atable
+        EOF
+               }
+        ]
+      RUBY
+    end
   end
 
-  it 'does not auto-correct array within array with too little indentation' do
-    original_source = <<-RUBY.strip_indent
-      [:l1,
-      [:l2,
+  context 'aligned with fixed indentation' do
+    let(:cop_config) do
+      {
+        'EnforcedStyle' => 'with_fixed_indentation'
+      }
+    end
 
-        [:l3,
-         [:l4]]]]
-    RUBY
-    new_source = autocorrect_source(original_source)
-    expect(new_source).to eq(<<-RUBY.strip_indent)
-      [:l1,
-       [:l2,
+    let(:correct_source) do
+      <<-RUBY.strip_indent
+        ['a', 'b',
+          'c',
+          'd']
+      RUBY
+    end
 
-         [:l3,
-          [:l4]]]]
-    RUBY
-  end
+    it 'does not autocorrect correct source' do
+      expect(autocorrect_source(correct_source))
+        .to eq(correct_source)
+    end
 
-  it 'auto-corrects only elements that begin a line' do
-    original_source = <<-RUBY.strip_indent
-      array = [:bar, {
-               whiz: 2, bang: 3 }, option: 3]
-    RUBY
-    new_source = autocorrect_source(original_source)
-    expect(new_source).to eq(original_source)
-  end
+    it 'autocorrects by outdenting when indented too far' do
+      original_source = <<-RUBY.strip_indent
+        ['a', 'b',
+              'c',
+              'd']
+      RUBY
 
-  it 'does not indent heredoc strings in autocorrect' do
-    original_source = <<-RUBY.strip_indent
-      var = [
-             { :type => 'something',
-               :sql => <<EOF
-      Select something
-      from atable
-      EOF
-             },
-            { :type => 'something',
-              :sql => <<EOF
-      Select something
-      from atable
-      EOF
-            }
-      ]
-    RUBY
-    new_source = autocorrect_source(original_source)
-    expect(new_source).to eq(<<-RUBY.strip_indent)
-      var = [
-             { :type => 'something',
-               :sql => <<EOF
-      Select something
-      from atable
-      EOF
-             },
-             { :type => 'something',
-               :sql => <<EOF
-      Select something
-      from atable
-      EOF
-             }
-      ]
-    RUBY
+      expect(autocorrect_source(original_source))
+        .to eq(correct_source)
+    end
+
+    it 'autocorrects by indenting when not indented' do
+      original_source = <<-RUBY.strip_indent
+        ['a', 'b',
+        'c',
+        'd']
+      RUBY
+
+      expect(autocorrect_source(original_source))
+        .to eq(correct_source)
+    end
+
+    it 'autocorrects when first line is indented' do
+      original_source = <<-RUBY.strip_margin('|')
+        |  ['a', 'b',
+        |  'c',
+        |  'd']
+      RUBY
+
+      correct_source = <<-RUBY.strip_margin('|')
+        |  ['a', 'b',
+        |    'c',
+        |    'd']
+      RUBY
+
+      expect(autocorrect_source(original_source))
+        .to eq(correct_source)
+    end
+
+    it "doesn't get confused by splat" do
+      expect_offense(<<-RUBY.strip_indent)
+        [a,
+         *b,
+         ^^ Use one level of indentation for values following the first line of a multi-line array.
+          c,
+        ]
+      RUBY
+    end
+
+    context 'multi-line method calls' do
+      it 'can handle existing indentation from multi-line method calls' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+           something
+             .method_name(['a',
+               'b'])
+        RUBY
+      end
+
+      it 'registers offenses for double indentation from relevant method' do
+        expect_offense(<<-RUBY.strip_indent)
+           something
+             .method_name(['a',
+             'b'])
+             ^^^ Use one level of indentation for values following the first line of a multi-line array.
+        RUBY
+      end
+    end
+
+    context 'assigned arrays' do
+      context 'with IndentationWidth:Width set to 4' do
+        let(:indentation_width) { 4 }
+
+        it 'accepts the first parameter being on a new row' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+             assigned_value = [
+                 a,
+                 b,
+                 c
+             ]
+          RUBY
+        end
+
+        it 'accepts the first parameter being on bracket row' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+             assigned_value = [a,
+                 b,
+                 c
+             ]
+          RUBY
+        end
+
+        it 'autocorrects even when first argument is in wrong position' do
+          original_source = <<-RUBY.strip_margin('|')
+            | assigned_value = [
+            |         a,
+            |            b,
+            |                    c
+            | ]
+          RUBY
+
+          correct_source = <<-RUBY.strip_margin('|')
+            | assigned_value = [
+            |     a,
+            |     b,
+            |     c
+            | ]
+          RUBY
+
+          expect(autocorrect_source(original_source))
+            .to eq(correct_source)
+        end
+      end
+
+      context 'with Layout/AlignArray:IndentationWidth set to 4' do
+        let(:config) do
+          RuboCop::Config.new('Layout/AlignArray' =>
+                              cop_config.merge('IndentationWidth' => 4))
+        end
+
+        it 'accepts the first parameter being on a new row' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+             assigned_value = [
+                 a,
+                 b,
+                 c
+             ]
+          RUBY
+        end
+
+        it 'accepts the first parameter being on bracket row' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+             assigned_value = [a,
+                 b,
+                 c
+             ]
+          RUBY
+        end
+
+        it 'autocorrects even when first argument is in wrong position' do
+          original_source = <<-RUBY.strip_margin('|')
+            | assigned_value = [
+            |         a,
+            |            b,
+            |                    c
+            | ]
+          RUBY
+
+          correct_source = <<-RUBY.strip_margin('|')
+            | assigned_value = [
+            |     a,
+            |     b,
+            |     c
+            | ]
+          RUBY
+
+          expect(autocorrect_source(original_source))
+            .to eq(correct_source)
+        end
+      end
+    end
   end
 end

--- a/spec/rubocop/cop/layout/align_array_spec.rb
+++ b/spec/rubocop/cop/layout/align_array_spec.rb
@@ -58,6 +58,10 @@ RSpec.describe RuboCop::Cop::Layout::AlignArray do
       RUBY
     end
 
+    it 'accepts empty array' do
+      expect_no_offenses('[]')
+    end
+
     it 'auto-corrects alignment' do
       new_source = autocorrect_source(<<-RUBY.strip_indent)
         array = [


### PR DESCRIPTION
Adds `EnforcedStyle:with_fixed_indentation` to `Layout/AlignArray`

This works very similarly to the `EnforcedStyle` of `Layout/AlignParameters`

so this would pass when both of those have `with_fixed_indentation` set
```
array = ['this', 'that', 
  'other']

method('this', 'that',
  'other')
```

I intended to also do this for multi-line hashes too, but there's a lot more going on there, so lets see if this is ok first

---

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
