### PR TITLE
Disable CaseWhenSplat by default and tweak messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [#4301](https://github.com/rubocop-hq/rubocop/issues/4301): Turn off autocorrect for `Rails/RelativeDateConstant` by default. ([@koic][])
 * [#4832](https://github.com/rubocop-hq/rubocop/issues/4832): Change the path pattern (`*`) to match the hidden file. ([@koic][])
 * `Style/For` now highlights the entire statement rather than just the keyword. ([@rrosenblum][])
+* Disable `Performance/CaseWhenSplat` and its auto-correction by default. ([@rrosenblum][])
 
 ## 0.58.2 (2018-07-23)
 

--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -51,6 +51,13 @@ Lint/NumberConversion:
   Description: 'Checks unsafe usage of number conversion methods.'
   Enabled: false
 
+Performance/CaseWhenSplat:
+  Description: >-
+                  Place `when` conditions that use splat at the end
+                  of the list of `when` branches.
+  Enabled: false
+  AutoCorrect: false
+
 # By default, the rails cops are not run. Override in project or home
 # directory .rubocop.yml files, or by giving the -R/--rails option.
 Rails:

--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -53,8 +53,8 @@ Lint/NumberConversion:
 
 Performance/CaseWhenSplat:
   Description: >-
-                  Place `when` conditions that use splat at the end
-                  of the list of `when` branches.
+                 Reordering `when` conditions with a splat to the end
+                 of the `when` branches can improve performance.
   Enabled: false
   AutoCorrect: false
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -921,12 +921,6 @@ Performance/Caller:
              Use `caller(n..n)` instead of `caller`.
   Enabled: true
 
-Performance/CaseWhenSplat:
-  Description: >-
-                  Place `when` conditions that use splat at the end
-                  of the list of `when` branches.
-  Enabled: true
-
 Performance/Casecmp:
   Description: >-
              Use `casecmp` rather than `downcase ==`, `upcase ==`, `== downcase`, or `== upcase`..

--- a/lib/rubocop/cop/performance/case_when_splat.rb
+++ b/lib/rubocop/cop/performance/case_when_splat.rb
@@ -3,16 +3,19 @@
 module RuboCop
   module Cop
     module Performance
-      # Place `when` conditions that use splat at the end
-      # of the list of `when` branches.
+      # Reordering `when` conditions with a splat to the end
+      # of the `when` branches can improve performance.
       #
       # Ruby has to allocate memory for the splat expansion every time
       # that the `case` `when` statement is run. Since Ruby does not support
       # fall through inside of `case` `when`, like some other languages do,
-      # the order of the `when` branches does not matter. By placing any
+      # the order of the `when` branches should not matter. By placing any
       # splat expansions at the end of the list of `when` branches we will
       # reduce the number of times that memory has to be allocated for
-      # the expansion.
+      # the expansion. The exception to this is if multiple of your `when`
+      # conditions can be true for any given condition. A likely scenario for
+      # this defining a higher level when condition to override a condition
+      # that is inside of the splat expansion.
       #
       # This is not a guaranteed performance improvement. If the data being
       # processed by the `case` condition is normalized in a manner that favors
@@ -54,9 +57,10 @@ module RuboCop
         include Alignment
         include RangeHelp
 
-        MSG = 'Place `when` conditions with a splat ' \
-              'at the end of the `when` branches.'.freeze
-        ARRAY_MSG = 'Do not expand array literals in `when` conditions.'.freeze
+        MSG = 'Reordering `when` conditions with a splat to the end ' \
+          'of the `when` branches can improve performance.'.freeze
+        ARRAY_MSG = 'Pass the contents of array literals ' \
+          'directly to `when` conditions.'.freeze
 
         def on_case(case_node)
           when_conditions = case_node.when_branches.flat_map(&:conditions)

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -31,16 +31,19 @@ Enabled by default | Supports autocorrection
 --- | ---
 Disabled | Yes
 
-Place `when` conditions that use splat at the end
-of the list of `when` branches.
+Reordering `when` conditions with a splat to the end
+of the `when` branches can improve performance.
 
 Ruby has to allocate memory for the splat expansion every time
 that the `case` `when` statement is run. Since Ruby does not support
 fall through inside of `case` `when`, like some other languages do,
-the order of the `when` branches does not matter. By placing any
+the order of the `when` branches should not matter. By placing any
 splat expansions at the end of the list of `when` branches we will
 reduce the number of times that memory has to be allocated for
-the expansion.
+the expansion. The exception to this is if multiple of your `when`
+conditions can be true for any given condition. A likely scenario for
+this defining a higher level when condition to override a condition
+that is inside of the splat expansion.
 
 This is not a guaranteed performance improvement. If the data being
 processed by the `case` condition is normalized in a manner that favors

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -29,7 +29,7 @@ caller_locations(1..1).first
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | Yes
+Disabled | Yes
 
 Place `when` conditions that use splat at the end
 of the list of `when` branches.
@@ -81,6 +81,12 @@ when 5
   baz
 end
 ```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AutoCorrect | `false` | Boolean
 
 ## Performance/Casecmp
 

--- a/spec/rubocop/cop/performance/case_when_splat_spec.rb
+++ b/spec/rubocop/cop/performance/case_when_splat_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
     expect_offense(<<-RUBY.strip_indent)
       case foo
       when *cond
-      ^^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
+      ^^^^^^^^^^ Reordering `when` conditions with a splat to the end of the `when` branches can improve performance.
         bar
       when 4
         foobar
@@ -60,7 +60,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
     expect_offense(<<-RUBY.strip_indent)
       case foo
       when *baz
-      ^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
+      ^^^^^^^^^ Reordering `when` conditions with a splat to the end of the `when` branches can improve performance.
         bar
       when 4
         foobar
@@ -72,7 +72,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
     expect_offense(<<-RUBY.strip_indent)
       case foo
       when *cond then bar
-      ^^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
+      ^^^^^^^^^^ Reordering `when` conditions with a splat to the end of the `when` branches can improve performance.
       when 4 then baz
       end
     RUBY
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
     expect_offense(<<-RUBY.strip_indent)
       case foo
       when *Foo, Bar
-      ^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
+      ^^^^^^^^^ Reordering `when` conditions with a splat to the end of the `when` branches can improve performance.
         nil
       end
     RUBY
@@ -93,10 +93,10 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
     expect_offense(<<-RUBY.strip_indent)
       case foo
       when *cond1
-      ^^^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
+      ^^^^^^^^^^^ Reordering `when` conditions with a splat to the end of the `when` branches can improve performance.
         bar
       when *cond2
-      ^^^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
+      ^^^^^^^^^^^ Reordering `when` conditions with a splat to the end of the `when` branches can improve performance.
         doo
       when 4
         foobar
@@ -110,12 +110,12 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
     expect_offense(<<-RUBY.strip_indent)
       case foo
       when *cond1
-      ^^^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
+      ^^^^^^^^^^^ Reordering `when` conditions with a splat to the end of the `when` branches can improve performance.
         bar
       when 8
         barfoo
       when *SOME_CONSTANT
-      ^^^^^^^^^^^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
+      ^^^^^^^^^^^^^^^^^^^ Reordering `when` conditions with a splat to the end of the `when` branches can improve performance.
         doo
       when 4
         foobar
@@ -129,12 +129,12 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
     expect_offense(<<-RUBY.strip_indent)
       case foo
       when *cond1
-      ^^^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
+      ^^^^^^^^^^^ Reordering `when` conditions with a splat to the end of the `when` branches can improve performance.
         bar
       when 8
         barfoo
       when *cond2
-      ^^^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
+      ^^^^^^^^^^^ Reordering `when` conditions with a splat to the end of the `when` branches can improve performance.
         doo
       when 4
         foobar
@@ -173,7 +173,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
     expect_offense(<<-RUBY.strip_indent)
       case foo
       when *cond
-      ^^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
+      ^^^^^^^^^^ Reordering `when` conditions with a splat to the end of the `when` branches can improve performance.
         bar
       when *[1, 2]
         baz
@@ -185,7 +185,7 @@ RSpec.describe RuboCop::Cop::Performance::CaseWhenSplat do
     expect_offense(<<-RUBY.strip_indent)
       case foo
       when cond1, *cond2
-      ^^^^^^^^^^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
+      ^^^^^^^^^^^^^^^^^^ Reordering `when` conditions with a splat to the end of the `when` branches can improve performance.
         bar
       when cond3
         baz


### PR DESCRIPTION
This is in response to https://github.com/rubocop-hq/rubocop/pull/6163. Rather than removing the cop entirely, I rather disable it, and its auto-correction, by default. While the check isn't 100% accurate because of the limitations of static code analysis, I still believe the check that is being performed can provide value.