### PR TITLE
[Fix #6175] BracesAroundHashParameters syntax error with trailing comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#6164](https://github.com/rubocop-hq/rubocop/issues/6164): Fix incorrect autocorrect for `Style/UnneededCondition` when using operator method higher precedence than `||`. ([@koic][])
 * [#6138](https://github.com/rubocop-hq/rubocop/issues/6138): Fix a false positive for assigning a block local variable in `Lint/ShadowedArgument`. ([@jonas054][])
 * [#6022](https://github.com/rubocop-hq/rubocop/issues/6022): Fix `Layout/MultilineHashBraceLayout` and `Layout/MultilineArrayBraceLayout` auto-correct syntax error when there is a comment on the last element. ([@bacchir][])
+* [#6175](https://github.com/rubocop-hq/rubocop/issues/6175): Fix `Style/BracesAroundHashParameters` auto-correct syntax error when there is a trailing comma. ([@bacchir][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -127,13 +127,12 @@ module RuboCop
         end
 
         def remove_braces_with_whitespace(corrector, node, space)
-          right_brace_and_space = right_brace_and_space(node.loc.end, space)
-
           if node.multiline?
             remove_braces_with_range(corrector,
                                      left_whole_line_range(node.loc.begin),
                                      right_whole_line_range(node.loc.end))
           else
+            right_brace_and_space = right_brace_and_space(node.loc.end, space)
             left_brace_and_space = left_brace_and_space(node.loc.begin, space)
             remove_braces_with_range(corrector,
                                      left_brace_and_space,
@@ -155,7 +154,7 @@ module RuboCop
         end
 
         def right_whole_line_range(loc_end)
-          if range_by_whole_lines(loc_end).source.strip == '}'
+          if range_by_whole_lines(loc_end).source.strip =~ /}\s*,?\z/
             range_by_whole_lines(loc_end, include_final_newline: true)
           else
             loc_end

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -328,6 +328,29 @@ RSpec.describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
         )
         RUBY
       end
+
+      it 'corrects parameters with braces & trailing comma' do
+        corrected = autocorrect_source('foo(1, { x: 1, y: 2, },)')
+        expect(corrected).to eq('foo(1, x: 1, y: 2,)')
+      end
+
+      it 'corrects hash multiline parameters with braces & trailing comma' do
+        src = <<-RUBY.strip_indent
+        foo(
+          {
+            foo: 1,
+            bar: 2,
+          } ,
+        )
+        RUBY
+        corrected = autocorrect_source(src)
+        expect(corrected).to eq(<<-RUBY.strip_indent)
+        foo(
+            foo: 1,
+            bar: 2,
+        )
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
See [#6175](https://github.com/rubocop-hq/rubocop/issues/6175)

Fixes `Style/BracesAroundHashParameters` auto-correct syntax error when there's a trailing comma after the hash. My approach to solve this is detecting the trailing comma before correcting and removing it together with the right curly brace (the same way it does with trailing spaces).

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
