### PR TITLE
Add AllowedReceivers to SaveBang

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1826,6 +1826,7 @@ Rails/SafeNavigation:
 
 Rails/SaveBang:
   AllowImplicitReturn: true
+  AllowedReceivers: []
 
 Rails/ScopeArgs:
   Include:

--- a/lib/rubocop/cop/rails/save_bang.rb
+++ b/lib/rubocop/cop/rails/save_bang.rb
@@ -20,6 +20,9 @@ module RuboCop
       # By default it will also allow implicit returns from methods and blocks.
       # that behavior can be turned off with `AllowImplicitReturn: false`.
       #
+      # You can permit receivers that are giving false positives with
+      # `AllowedReceivers: []`
+      #
       # @example
       #
       #   # bad
@@ -73,6 +76,26 @@ module RuboCop
       #   def save_user
       #     return user.save
       #   end
+      #
+      # @example AllowedReceivers: ['merchant.customers', 'Service::Mailer']
+      #
+      #   # bad
+      #   merchant.create
+      #   customers.builder.save
+      #   Mailer.create
+      #
+      #   module Service::Mailer
+      #     self.create
+      #   end
+      #
+      #   # good
+      #   merchant.customers.create
+      #   MerchantService.merchant.customers.destroy
+      #   Service::Mailer.update(message: 'Message')
+      #   ::Service::Mailer.update
+      #   Services::Service::Mailer.update(message: 'Message')
+      #   Service::Mailer::update
+      #
       class SaveBang < Cop
         include NegativeConditional
 
@@ -203,6 +226,45 @@ module RuboCop
             single_negative?(condition)
         end
 
+        def allowed_receiver?(node)
+          return false unless node.receiver
+          return false unless cop_config['AllowedReceivers']
+          cop_config['AllowedReceivers'].any? do |allowed_receiver|
+            receiver_chain_matches?(node, allowed_receiver)
+          end
+        end
+
+        def receiver_chain_matches?(node, allowed_receiver)
+          allowed_receiver.split('.').reverse.all? do |receiver_part|
+            node = node.receiver
+            return false unless node
+            if node.variable?
+              node.node_parts.first == receiver_part.to_sym
+            elsif node.send_type?
+              node.method_name == receiver_part.to_sym
+            elsif node.const_type?
+              const_matches?(node.const_name, receiver_part)
+            end
+          end
+        end
+
+        # Const == Const
+        # ::Const == ::Const
+        # ::Const == Const
+        # Const == ::Const
+        # NameSpace::Const == Const
+        # NameSpace::Const == NameSpace::Const
+        # NameSpace::Const != ::Const
+        # Const != NameSpace::Const
+        def const_matches?(const, allowed_const)
+          parts = allowed_const.split('::').reverse.zip(
+            const.split('::').reverse
+          )
+          parts.all? do |(allowed_part, const_part)|
+            allowed_part == const_part.to_s
+          end
+        end
+
         def implicit_return?(node)
           return false unless cop_config['AllowImplicitReturn']
           node = assignable_node(node)
@@ -226,7 +288,9 @@ module RuboCop
         end
 
         def persist_method?(node, methods = PERSIST_METHODS)
-          methods.include?(node.method_name) && expected_signature?(node)
+          methods.include?(node.method_name) &&
+            expected_signature?(node) &&
+            !allowed_receiver?(node)
         end
 
         # Check argument signature as no arguments or one hash

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1744,6 +1744,9 @@ This will allow:
 By default it will also allow implicit returns from methods and blocks.
 that behavior can be turned off with `AllowImplicitReturn: false`.
 
+You can permit receivers that are giving false positives with
+`AllowedReceivers: []`
+
 ### Examples
 
 ```ruby
@@ -1801,12 +1804,33 @@ def save_user
   return user.save
 end
 ```
+#### AllowedReceivers: ['merchant.customers', 'Service::Mailer']
+
+```ruby
+# bad
+merchant.create
+customers.builder.save
+Mailer.create
+
+module Service::Mailer
+  self.create
+end
+
+# good
+merchant.customers.create
+MerchantService.merchant.customers.destroy
+Service::Mailer.update(message: 'Message')
+::Service::Mailer.update
+Services::Service::Mailer.update(message: 'Message')
+Service::Mailer::update
+```
 
 ### Configurable attributes
 
 Name | Default value | Configurable values
 --- | --- | ---
 AllowImplicitReturn | `true` | Boolean
+AllowedReceivers | `[]` | Array
 
 ### References
 


### PR DESCRIPTION
Reducing the number of possible false positives makes a cop more useful, and lets us be more confident about running it. In the case of SaveBang, a lot of the false positives will have known receivers, in our codebase the receivers that cause false positives for save bang include braintree customers and elastic search indexes, which we can whitelist like: 
```
braintree_gateway.customer
Braintree::Customer
es.indices
```

We could disable the check for these lines in place, but since it's not terribly difficult to get the computer to do it for us, and juniors feel uncomfortable disabling cops... I think this would be a good addition to the SaveBang cop

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/