### PR TITLE
[Fix #6192] Make Style/RedundantBegin cop aware of stabby lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#6138](https://github.com/rubocop-hq/rubocop/issues/6138): Fix a false positive for assigning a block local variable in `Lint/ShadowedArgument`. ([@jonas054][])
 * [#6022](https://github.com/rubocop-hq/rubocop/issues/6022): Fix `Layout/MultilineHashBraceLayout` and `Layout/MultilineArrayBraceLayout` auto-correct syntax error when there is a comment on the last element. ([@bacchir][])
 * [#6175](https://github.com/rubocop-hq/rubocop/issues/6175): Fix `Style/BracesAroundHashParameters` auto-correct syntax error when there is a trailing comma. ([@bacchir][])
+* [#6192](https://github.com/rubocop-hq/rubocop/issues/6192): Make `Style/RedundantBegin` aware of stabby lambdas. ([@drenmi][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -44,6 +44,16 @@ module RuboCop
       #   rescue => ex
       #     anything
       #   end
+      #
+      #   # good
+      #   # Stabby lambdas don't support implicit `begin` in `do-end` blocks.
+      #   -> do
+      #     begin
+      #       foo
+      #     rescue Bar
+      #       baz
+      #     end
+      #   end
       class RedundantBegin < Cop
         MSG = 'Redundant `begin` block detected.'.freeze
 
@@ -54,7 +64,10 @@ module RuboCop
 
         def on_block(node)
           return if target_ruby_version < 2.5
+
+          return if node.send_node.stabby_lambda?
           return if node.braces?
+
           check(node)
         end
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4547,6 +4547,16 @@ do_something do
 rescue => ex
   anything
 end
+
+# good
+# Stabby lambdas don't support implicit `begin` in `do-end` blocks.
+-> do
+  begin
+    foo
+  rescue Bar
+    baz
+  end
+end
 ```
 
 ### References

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -223,5 +223,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
         end
       RUBY
     end
+
+    it 'accepts a stabby lambda with a begin-end' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        -> do
+          begin
+            foo
+          rescue => e
+            bar
+          end
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Stabby lambda blocks don't support the implicit rescue syntax.

```ruby
-> do
  foo
rescue Bar
  baz
end
#=> SyntaxError (unexpected keyword_rescue)
```

This change makes the cop ignore such cases.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
