### PR TITLE
Change offense message of `Layout/SpaceInLambdaLiteral`

### DIFF
--- a/lib/rubocop/cop/layout/space_in_lambda_literal.rb
+++ b/lib/rubocop/cop/layout/space_in_lambda_literal.rb
@@ -3,8 +3,8 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks for spaces between -> and opening parameter
-      # parenthesis in lambda literals.
+      # This cop checks for spaces between `->` and opening parameter
+      # parenthesis (`(`) in lambda literals.
       #
       # @example EnforcedStyle: require_no_space (default)
       #     # bad
@@ -24,20 +24,21 @@ module RuboCop
         include RangeHelp
 
         ARROW = '->'.freeze
-        MSG_REQUIRE_SPACE = 'Use a space between `->` and opening ' \
-                            'parenthesis in lambda literals'.freeze
-        MSG_REQUIRE_NO_SPACE = 'Do not use spaces between `->` and opening ' \
-                               'parenthesis in lambda literals'.freeze
+        MSG_REQUIRE_SPACE = 'Use a space between `->` and ' \
+                            '`(` in lambda literals.'.freeze
+        MSG_REQUIRE_NO_SPACE = 'Do not use spaces between `->` and ' \
+                               '`(` in lambda literals.'.freeze
 
         def on_send(node)
           return unless arrow_lambda_with_args?(node)
+
           if style == :require_space && !space_after_arrow?(node)
             add_offense(node,
-                        location: node.parent.loc.expression,
+                        location: range_of_offense(node),
                         message: MSG_REQUIRE_SPACE)
           elsif style == :require_no_space && space_after_arrow?(node)
             add_offense(node,
-                        location: node.parent.loc.expression,
+                        location: range_of_offense(node),
                         message: MSG_REQUIRE_NO_SPACE)
           end
         end
@@ -79,6 +80,13 @@ module RuboCop
           arrow = lambda_node.parent.children[0]
           parentheses = lambda_node.parent.children[1]
           parentheses.source_range.begin_pos - arrow.source_range.end_pos > 0
+        end
+
+        def range_of_offense(node)
+          range_between(
+            node.parent.loc.expression.begin_pos,
+            node.parent.arguments.loc.expression.end_pos
+          )
         end
       end
     end

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -3738,8 +3738,8 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-This cop checks for spaces between -> and opening parameter
-parenthesis in lambda literals.
+This cop checks for spaces between `->` and opening parameter
+parenthesis (`(`) in lambda literals.
 
 ### Examples
 

--- a/spec/rubocop/cop/layout/space_in_lambda_literal_spec.rb
+++ b/spec/rubocop/cop/layout/space_in_lambda_literal_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     it 'registers an offense for no space between -> and (' do
       expect_offense(<<-RUBY.strip_indent)
         a = ->(b, c) { b + c }
-            ^^^^^^^^^^^^^^^^^^ Use a space between `->` and opening parenthesis in lambda literals
+            ^^^^^^^^ Use a space between `->` and `(` in lambda literals.
       RUBY
     end
 
@@ -33,22 +33,22 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     it 'registers an offense for no space in the inner nested lambda' do
       expect_offense(<<-RUBY.strip_indent)
         a = -> (b = ->(c) {}, d) { b + d }
-                    ^^^^^^^^ Use a space between `->` and opening parenthesis in lambda literals
+                    ^^^^^ Use a space between `->` and `(` in lambda literals.
       RUBY
     end
 
     it 'registers an offense for no space in the outer nested lambda' do
       expect_offense(<<-RUBY.strip_indent)
         a = ->(b = -> (c) {}, d) { b + d }
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a space between `->` and opening parenthesis in lambda literals
+            ^^^^^^^^^^^^^^^^^^^^ Use a space between `->` and `(` in lambda literals.
       RUBY
     end
 
     it 'registers an offense for no space in both lambdas when nested' do
       expect_offense(<<-RUBY.strip_indent)
         a = ->(b = ->(c) {}, d) { b + d }
-                   ^^^^^^^^ Use a space between `->` and opening parenthesis in lambda literals
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a space between `->` and opening parenthesis in lambda literals
+                   ^^^^^ Use a space between `->` and `(` in lambda literals.
+            ^^^^^^^^^^^^^^^^^^^ Use a space between `->` and `(` in lambda literals.
       RUBY
     end
 
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     it 'registers an offense for a space between -> and (' do
       expect_offense(<<-RUBY.strip_indent)
         a = -> (b, c) { b + c }
-            ^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and opening parenthesis in lambda literals
+            ^^^^^^^^^ Do not use spaces between `->` and `(` in lambda literals.
       RUBY
     end
 
@@ -107,29 +107,29 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     it 'registers an offense for spaces between -> and (' do
       expect_offense(<<-RUBY.strip_indent)
         a = ->   (b, c) { b + c }
-            ^^^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and opening parenthesis in lambda literals
+            ^^^^^^^^^^^ Do not use spaces between `->` and `(` in lambda literals.
       RUBY
     end
 
     it 'registers an offense for a space in the inner nested lambda' do
       expect_offense(<<-RUBY.strip_indent)
         a = ->(b = -> (c) {}, d) { b + d }
-                   ^^^^^^^^^ Do not use spaces between `->` and opening parenthesis in lambda literals
+                   ^^^^^^ Do not use spaces between `->` and `(` in lambda literals.
       RUBY
     end
 
     it 'registers an offense for a space in the outer nested lambda' do
       expect_offense(<<-RUBY.strip_indent)
         a = -> (b = ->(c) {}, d) { b + d }
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and opening parenthesis in lambda literals
+            ^^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and `(` in lambda literals.
       RUBY
     end
 
     it 'registers two offenses for a space in both lambdas when nested' do
       expect_offense(<<-RUBY.strip_indent)
         a = -> (b = -> (c) {}, d) { b + d }
-                    ^^^^^^^^^ Do not use spaces between `->` and opening parenthesis in lambda literals
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and opening parenthesis in lambda literals
+                    ^^^^^^ Do not use spaces between `->` and `(` in lambda literals.
+            ^^^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and `(` in lambda literals.
       RUBY
     end
 


### PR DESCRIPTION
Follow up of https://github.com/rubocop-hq/rubocop/pull/6167#issuecomment-414213956.

This PR changes offense message of `Layout/SpaceInLambdaLiteral` cop.

The following is an example.

```console
% cat example.rb
a = -> (x, y) { x + y }
```

## Before

```console
% rubocop example.rb --only Layout/SpaceInLambdaLiteral
Inspecting 1 file
C

Offenses:

example.rb:1:5: C: Layout/SpaceInLambdaLiteral: Do not use spaces
between -> and opening brace in lambda literals
a = -> (x, y) { x + y }
    ^^^^^^^^^^^^^^^^^^^
```

## After

```console
% rubocop example.rb --only Layout/SpaceInLambdaLiteral
Inspecting 1 file
C

Offenses:

example.rb:1:5: C: Layout/SpaceInLambdaLiteral: Do not use spaces
between -> and opening ( in lambda literals
a = -> (x, y) { x + y }
    ^^^^^^^^^

1 file inspected, 1 offense detected
```

This change clarifies the target of offenses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
