### PR TITLE
Remove Node#method_name in favour of node extensions

### DIFF
--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -297,10 +297,6 @@ module RuboCop
         {(send $_ ...) (block (send $_ ...) ...)}
       PATTERN
 
-      def_node_matcher :method_name, <<-PATTERN
-        {(send _ $_ ...) (block (send _ $_ ...) ...)}
-      PATTERN
-
       # Note: for masgn, #asgn_rhs will be an array node
       def_node_matcher :asgn_rhs, '[assignment? (... $_)]'
       def_node_matcher :str_content, '(str $_)'
@@ -360,11 +356,6 @@ module RuboCop
         source_length.zero?
       end
 
-      def asgn_method_call?
-        !COMPARISON_OPERATORS.include?(method_name) &&
-          method_name.to_s.end_with?('='.freeze)
-      end
-
       def arithmetic_operation?
         ARITHMETIC_OPERATORS.include?(method_name)
       end
@@ -376,7 +367,7 @@ module RuboCop
       def_node_matcher :shorthand_asgn?, '{op_asgn or_asgn and_asgn}'
 
       def_node_matcher :assignment?, <<-PATTERN
-        {equals_asgn? shorthand_asgn? asgn_method_call?}
+        {equals_asgn? shorthand_asgn?}
       PATTERN
 
       # Some cops treat the shovel operator as a kind of assignment.

--- a/lib/rubocop/ast/node/block_node.rb
+++ b/lib/rubocop/ast/node/block_node.rb
@@ -32,6 +32,13 @@ module RuboCop
         node_parts[2]
       end
 
+      # The name of the dispatched method as a symbol.
+      #
+      # @return [Symbol] the name of the dispatched method
+      def method_name
+        send_node.method_name
+      end
+
       # Checks whether this block takes any arguments.
       #
       # @return [Boolean] whether this `block` node takes any arguments
@@ -101,7 +108,7 @@ module RuboCop
       #
       # @return [Boolean] whether the `block` node body is a void context
       def void_context?
-        VOID_CONTEXT_METHODS.include?(send_node.method_name)
+        VOID_CONTEXT_METHODS.include?(method_name)
       end
     end
   end

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -80,6 +80,7 @@ module RuboCop
       def setter_method?
         loc.respond_to?(:operator) && loc.operator
       end
+      alias assignment? setter_method?
 
       # Checks whether the dispatched method uses a dot to connect the
       # receiver and the method name.

--- a/lib/rubocop/cop/mixin/safe_assignment.rb
+++ b/lib/rubocop/cop/mixin/safe_assignment.rb
@@ -11,8 +11,9 @@ module RuboCop
       private
 
       def_node_matcher :empty_condition?, '(begin)'
+      def_node_matcher :setter_method?, '[(send ...) setter_method?]'
       def_node_matcher :safe_assignment?,
-                       '(begin {equals_asgn? asgn_method_call?})'
+                       '(begin {equals_asgn? #setter_method?})'
 
       def safe_assignment_allowed?
         cop_config['AllowSafeAssignment']

--- a/lib/rubocop/cop/performance/size.rb
+++ b/lib/rubocop/cop/performance/size.rb
@@ -55,15 +55,21 @@ module RuboCop
         end
 
         def array?(node)
+          return true if node.array_type?
+          return false unless node.send_type?
+
           _, constant = *node.receiver
 
-          node.array_type? || constant == :Array || node.method_name == :to_a
+          constant == :Array || node.method_name == :to_a
         end
 
         def hash?(node)
+          return true if node.hash_type?
+          return false unless node.send_type?
+
           _, constant = *node.receiver
 
-          node.hash_type? || constant == :Hash || node.method_name == :to_h
+          constant == :Hash || node.method_name == :to_h
         end
       end
     end

--- a/lib/rubocop/cop/rails/save_bang.rb
+++ b/lib/rubocop/cop/rails/save_bang.rb
@@ -105,7 +105,8 @@ module RuboCop
 
         def check_assignment(assignment)
           node = right_assignment_node(assignment)
-          return unless node
+
+          return unless node && node.send_type?
           return unless persist_method?(node, CREATE_PERSIST_METHODS)
           return if persisted_referenced?(assignment)
 
@@ -141,8 +142,10 @@ module RuboCop
 
         def right_assignment_node(assignment)
           node = assignment.node.child_nodes.first
+
           return node unless node && node.block_type?
-          node.child_nodes.first
+
+          node.send_node
         end
 
         def persisted_referenced?(assignment)

--- a/lib/rubocop/cop/style/format_string_token.rb
+++ b/lib/rubocop/cop/style/format_string_token.rb
@@ -69,7 +69,7 @@ module RuboCop
         private
 
         def includes_format_methods?(node)
-          node.each_ancestor.any? do |ancestor|
+          node.each_ancestor(:send).any? do |ancestor|
             FORMAT_STRING_METHODS.include?(ancestor.method_name)
           end
         end

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -54,8 +54,8 @@ module RuboCop
         }.freeze
 
         def on_send(node)
-          return if node.ancestors.any? do |ancestor|
-            ignored_method? ancestor.method_name
+          return if node.each_ancestor(:send, :block).any? do |ancestor|
+            ignored_method?(ancestor.method_name)
           end
 
           numeric, replacement = check(node)

--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -1,38 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::AST::Node do
-  describe '#asgn_method_call?' do
-    it 'does not match ==' do
-      parsed = parse_source('Object.new == value')
-      expect(parsed.ast.asgn_method_call?).to be(false)
-    end
-
-    it 'does not match !=' do
-      parsed = parse_source('Object.new != value')
-      expect(parsed.ast.asgn_method_call?).to be(false)
-    end
-
-    it 'does not match <=' do
-      parsed = parse_source('Object.new <= value')
-      expect(parsed.ast.asgn_method_call?).to be(false)
-    end
-
-    it 'does not match >=' do
-      parsed = parse_source('Object.new >= value')
-      expect(parsed.ast.asgn_method_call?).to be(false)
-    end
-
-    it 'does not match ===' do
-      parsed = parse_source('Object.new === value')
-      expect(parsed.ast.asgn_method_call?).to be(false)
-    end
-
-    it 'matches =' do
-      parsed = parse_source('Object.new = value')
-      expect(parsed.ast.asgn_method_call?).to be(true)
-    end
-  end
-
   describe '#value_used?' do
     let(:node) { RuboCop::ProcessedSource.new(src, ruby_version).ast }
 


### PR DESCRIPTION
Previously, some of the cops were relying on a top level method on `Node` to get the method name for `send` nodes. This meant we had some recursive calls that were frivolously asking for the method name of other node types, e.g. `hash` and `array`, where this does not have meaning.

This change untangles and removes `Node#method_name` and makes the affected cops more diligent about knowing on which node types they are operating.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
