### PR TITLE
[Fix #6196] Fix incorrect autocorrect for `Style/EmptyCaseCondition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#6175](https://github.com/rubocop-hq/rubocop/issues/6175): Fix `Style/BracesAroundHashParameters` auto-correct syntax error when there is a trailing comma. ([@bacchir][])
 * [#6192](https://github.com/rubocop-hq/rubocop/issues/6192): Make `Style/RedundantBegin` aware of stabby lambdas. ([@drenmi][])
 * [#6208](https://github.com/rubocop-hq/rubocop/pull/6208): Ignore assignment methods in `Naming/PredicateName`. ([@sunny][])
+* [#6196](https://github.com/rubocop-hq/rubocop/issues/6196): Fix incorrect autocorrect for `Style/EmptyCaseCondition` when using `return` in `when` clause and assigning the return value of `case`. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/empty_case_condition.rb
+++ b/lib/rubocop/cop/style/empty_case_condition.rb
@@ -43,6 +43,13 @@ module RuboCop
 
         def on_case(case_node)
           return if case_node.condition
+          return if case_node.when_branches.any? do |when_branch|
+            when_branch.each_descendant.any?(&:return_type?)
+          end
+          if (else_branch = case_node.else_branch)
+            return if else_branch.return_type? ||
+                      else_branch.each_descendant.any?(&:return_type?)
+          end
 
           add_offense(case_node, location: :keyword)
         end

--- a/spec/rubocop/cop/style/empty_case_condition_spec.rb
+++ b/spec/rubocop/cop/style/empty_case_condition_spec.rb
@@ -194,5 +194,61 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition do
 
       it_behaves_like 'detect/correct empty case, accept non-empty case'
     end
+
+    context 'when using `return` in `when` clause and ' \
+            'assigning the return value of `case`' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          v = case
+              when x.a
+                1
+              when x.b
+                return 2
+              end
+        RUBY
+      end
+    end
+
+    context 'when using `return ... if` in `when` clause and ' \
+            'assigning the return value of `case`' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          v = case
+              when x.a
+                1
+              when x.b
+                return 2 if foo
+              end
+        RUBY
+      end
+    end
+
+    context 'when using `return` in `else` clause and ' \
+            'assigning the return value of `case`' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          v = case
+              when x.a
+                1
+              else
+                return 2
+              end
+        RUBY
+      end
+    end
+
+    context 'when using `return ... if` in `else` clause and ' \
+            'assigning the return value of `case`' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          v = case
+              when x.a
+                1
+              else
+                return 2 if foo
+              end
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #6196.

This PR fixes an incorrect autocorrect for `Style/EmptyCaseCondition` when using `return` in `when` clause and assigning the return value of `case`.

The following code returns `2`.

```ruby
def foo
  v = case
      when true
        return 2
      end
end

p foo # => 2
```

The following code raises "void value expression" error.

```ruby
def bar
  v = if true
        return 2
      end
end

bar # => hoge.rb:4: void value expression
```

I think that it is difficult to keep compatibility with auto-correct.
Therefore this PR changes the above case to false negative.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
