### PR TITLE
Ignore assignment methods in `Naming/PredicateName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#6022](https://github.com/rubocop-hq/rubocop/issues/6022): Fix `Layout/MultilineHashBraceLayout` and `Layout/MultilineArrayBraceLayout` auto-correct syntax error when there is a comment on the last element. ([@bacchir][])
 * [#6175](https://github.com/rubocop-hq/rubocop/issues/6175): Fix `Style/BracesAroundHashParameters` auto-correct syntax error when there is a trailing comma. ([@bacchir][])
 * [#6192](https://github.com/rubocop-hq/rubocop/issues/6192): Make `Style/RedundantBegin` aware of stabby lambdas. ([@drenmi][])
+* [#6208](https://github.com/rubocop-hq/rubocop/pull/6208): Ignore assignment methods in `Naming/PredicateName`. ([@sunny][])
 
 ### Changes
 

--- a/lib/rubocop/cop/naming/predicate_name.rb
+++ b/lib/rubocop/cop/naming/predicate_name.rb
@@ -63,6 +63,7 @@ module RuboCop
         def allowed_method_name?(method_name, prefix)
           !method_name.start_with?(prefix) ||
             method_name == expected_name(method_name, prefix) ||
+            method_name.end_with?('=') ||
             predicate_whitelist.include?(method_name)
         end
 

--- a/spec/rubocop/cop/naming/predicate_name_spec.rb
+++ b/spec/rubocop/cop/naming/predicate_name_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe RuboCop::Cop::Naming::PredicateName, :config do
         def have_attr; end
       RUBY
     end
+
+    it 'accepts method name that is an assignment' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def is_hello=; end
+      RUBY
+    end
   end
 
   context 'without blacklisted prefixes' do


### PR DESCRIPTION
Having:

```rb
def is_possible=(value)
  # … 
end
```

Produces an offense with this suggestion:

```
Naming/PredicateName: Rename `is_hello=` to `hello=?`.
```

This PR ignores methods ending in `=` in `Naming/PredicateName` since `hello=?` or `hello?=` both produce syntax errors in Ruby.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
