### PR TITLE
[Fix #6142] Ignore keyword arguments in `Rails/Delegate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [#6192](https://github.com/rubocop-hq/rubocop/issues/6192): Make `Style/RedundantBegin` aware of stabby lambdas. ([@drenmi][])
 * [#6208](https://github.com/rubocop-hq/rubocop/pull/6208): Ignore assignment methods in `Naming/PredicateName`. ([@sunny][])
 * [#6196](https://github.com/rubocop-hq/rubocop/issues/6196): Fix incorrect autocorrect for `Style/EmptyCaseCondition` when using `return` in `when` clause and assigning the return value of `case`. ([@koic][])
+* [#6142](https://github.com/rubocop-hq/rubocop/issues/6142): Ignore keyword arguments in `Rails/Delegate`. ([@sunny][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/delegate.rb
+++ b/lib/rubocop/cop/rails/delegate.rb
@@ -94,8 +94,13 @@ module RuboCop
         def arguments_match?(arg_array, body)
           argument_array = body.arguments
 
-          arg_array == argument_array ||
-            arg_array.map(&:children) == argument_array.map(&:children)
+          return false if arg_array.size != argument_array.size
+
+          arg_array.zip(argument_array).all? do |arg, argument|
+            arg.arg_type? &&
+              argument.lvar_type? &&
+              arg.children == argument.children
+          end
         end
 
         def method_name_matches?(method_name, body)

--- a/spec/rubocop/cop/rails/delegate_spec.rb
+++ b/spec/rubocop/cop/rails/delegate_spec.rb
@@ -77,6 +77,14 @@ RSpec.describe RuboCop::Cop::Rails::Delegate do
     RUBY
   end
 
+  it 'ignores trivial delegate with mismatched keyword arguments' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def fox(foo:)
+        bar.fox(foo)
+      end
+    RUBY
+  end
+
   it 'ignores trivial delegate with other prefix' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def fox_foo


### PR DESCRIPTION
Closes #6142 

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
