### PR TITLE
Add `URI#open` example to `Security/Open`

### DIFF
--- a/lib/rubocop/cop/security/open.rb
+++ b/lib/rubocop/cop/security/open.rb
@@ -4,11 +4,12 @@ module RuboCop
   module Cop
     module Security
       # This cop checks for the use of `Kernel#open`.
+      #
       # `Kernel#open` enables not only file access but also process invocation
-      # by prefixing a pipe symbol (e.g., `open("| ls")`).  So, it may lead to
+      # by prefixing a pipe symbol (e.g., `open("| ls")`). So, it may lead to
       # a serious security risk by using variable input to the argument of
-      # `Kernel#open`.  It would be better to use `File.open` or `IO.popen`
-      # explicitly.
+      # `Kernel#open`. It would be better to use `File.open`, `IO.popen` or
+      # `URI#open` explicitly.
       #
       # @example
       #   # bad
@@ -17,6 +18,7 @@ module RuboCop
       #   # good
       #   File.open(something)
       #   IO.popen(something)
+      #   URI.parse(something).open
       class Open < Cop
         MSG = 'The use of `Kernel#open` is a serious security risk.'.freeze
 

--- a/manual/cops_security.md
+++ b/manual/cops_security.md
@@ -90,11 +90,12 @@ Enabled by default | Supports autocorrection
 Enabled | No
 
 This cop checks for the use of `Kernel#open`.
+
 `Kernel#open` enables not only file access but also process invocation
-by prefixing a pipe symbol (e.g., `open("| ls")`).  So, it may lead to
+by prefixing a pipe symbol (e.g., `open("| ls")`). So, it may lead to
 a serious security risk by using variable input to the argument of
-`Kernel#open`.  It would be better to use `File.open` or `IO.popen`
-explicitly.
+`Kernel#open`. It would be better to use `File.open`, `IO.popen` or
+`URI#open` explicitly.
 
 ### Examples
 
@@ -105,6 +106,7 @@ open(something)
 # good
 File.open(something)
 IO.popen(something)
+URI.parse(something).open
 ```
 
 ## Security/YAMLLoad


### PR DESCRIPTION
Mention `URI#open` inside `Security/Open`'s documentation since it's a common usage of using `open()` on links thanks to `open-uri`.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
