### PR TITLE
 Refactor DocumentationMethod spec to use expect_offense helper

### DIFF
--- a/lib/rubocop/rspec/shared_examples.rb
+++ b/lib/rubocop/rspec/shared_examples.rb
@@ -2,13 +2,6 @@
 
 # `cop` and `source` must be declared with #let.
 
-shared_examples_for 'accepts' do
-  it 'accepts' do
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
-  end
-end
-
 shared_examples_for 'misaligned' do |annotated_source, used_style|
   config_to_allow_offenses = if used_style
                                { 'EnforcedStyleAlignWith' => used_style.to_s }

--- a/spec/rubocop/cop/layout/indent_heredoc_spec.rb
+++ b/spec/rubocop/cop/layout/indent_heredoc_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentHeredoc, :config do
         end
       CORRECTION
 
-      it 'does not reguster an offense when not indented but with ' \
+      it 'does not register an offense when not indented but with ' \
          'whitespace, with `-`' do
         expect_no_offenses(<<-RUBY)
           def foo

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -61,8 +61,6 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
     end
 
     context 'with receiver' do
-      let(:source) { '' }
-
       it 'registers an offense' do
         expect_offense(<<-RUBY.strip_indent)
           Foo.some_method a { |el| puts el }

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -11,16 +11,16 @@ RSpec.describe RuboCop::Cop::Lint::NestedMethodDefinition do
   end
 
   it 'registers an offense for a nested singleton method definition' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       class Foo
       end
       foo = Foo.new
       def foo.bar
         def baz
+        ^^^^^^^ Method definitions must not be nested. Use `lambda` instead.
         end
       end
     RUBY
-    expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for a nested method definition inside lambda' do

--- a/spec/rubocop/cop/lint/unified_integer_spec.rb
+++ b/spec/rubocop/cop/lint/unified_integer_spec.rb
@@ -38,9 +38,9 @@ RSpec.describe RuboCop::Cop::Lint::UnifiedInteger do
       end
 
       context 'with MyNamespace' do
-        let(:source) { "1.is_a?(MyNamespace::#{klass})" }
-
-        include_examples 'accepts'
+        it 'does not register an offense' do
+          expect_no_offenses("1.is_a?(MyNamespace::#{klass})")
+        end
       end
     end
   end
@@ -50,19 +50,19 @@ RSpec.describe RuboCop::Cop::Lint::UnifiedInteger do
 
   context 'when Integer' do
     context 'without any decorations' do
-      it 'does not reguster an offense' do
+      it 'does not register an offense' do
         expect_no_offenses('1.is_a?(Integer)')
       end
     end
 
     context 'when explicitly specified as toplevel constant' do
-      it 'does not reguster an offense' do
+      it 'does not register an offense' do
         expect_no_offenses('1.is_a?(::Integer)')
       end
     end
 
     context 'with MyNamespace' do
-      it 'does not reguster an offense' do
+      it 'does not register an offense' do
         expect_no_offenses('1.is_a?(MyNamespace::Integer)')
       end
     end

--- a/spec/rubocop/cop/metrics/line_length_spec.rb
+++ b/spec/rubocop/cop/metrics/line_length_spec.rb
@@ -197,20 +197,11 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
     let(:cop_config) { { 'Max' => 80, 'AllowURI' => false } }
 
     context 'and all the excessive characters are part of an URL' do
-      let(:source) { <<-RUBY }
-        # See: https://github.com/rubocop-hq/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c
-      RUBY
-
       it 'registers an offense for the line' do
-        inspect_source(source)
-        expect(cop.offenses.size).to eq(1)
-      end
-
-      it 'highlights excessive characters' do
-        inspect_source(source)
-        expect(cop.highlights).to eq(
-          ['061837309890f04ab08c']
-        )
+        expect_offense(<<-RUBY)
+          # See: https://github.com/rubocop-hq/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c
+                                                                                ^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [102/80]
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/naming/heredoc_delimiter_case_spec.rb
+++ b/spec/rubocop/cop/naming/heredoc_delimiter_case_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe RuboCop::Cop::Naming::HeredocDelimiterCase, :config do
     end
 
     context 'with a non-interpolated heredoc' do
-      it 'does not reguster an offense with a lowercase delimiter' do
+      it 'does not register an offense with a lowercase delimiter' do
         expect_no_offenses(<<-RUBY.strip_indent)
           <<-'sql'
             foo

--- a/spec/rubocop/cop/rails/output_safety_spec.rb
+++ b/spec/rubocop/cop/rails/output_safety_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe RuboCop::Cop::Rails::OutputSafety do
       expect_no_offenses('raw')
     end
 
-    it 'does not reguster an offense with more than one argument' do
+    it 'does not register an offense with more than one argument' do
       expect_no_offenses('raw(one, two)')
     end
 

--- a/spec/rubocop/cop/style/documentation_method_spec.rb
+++ b/spec/rubocop/cop/style/documentation_method_spec.rb
@@ -3,29 +3,6 @@
 RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
   subject(:cop) { described_class.new(config) }
 
-  before do
-    inspect_source(source)
-  end
-
-  shared_examples 'code with offense' do |code|
-    context "when checking #{code}" do
-      let(:source) { code }
-
-      it 'registers an offense' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages).to eq([message])
-      end
-    end
-  end
-
-  shared_examples 'code without offense' do |code|
-    let(:source) { code }
-
-    it 'does not register an offense' do
-      expect(cop.offenses.empty?).to be(true)
-    end
-  end
-
   let(:require_for_non_public_methods) { false }
 
   let(:config) do
@@ -39,344 +16,443 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
     )
   end
 
-  let(:message) { 'Missing method documentation comment.' }
-
   context 'when declaring methods outside a class' do
     context 'without documentation comment' do
       context 'when method is public' do
-        it_behaves_like 'code with offense', <<-CODE
-                        def foo
-                          puts 'bar'
-                        end
-        CODE
+        it 'registers an offense' do
+          expect_offense(<<-CODE.strip_indent)
+            def foo
+            ^^^^^^^ Missing method documentation comment.
+              puts 'bar'
+            end
+          CODE
+        end
 
-        it_behaves_like 'code with offense',
-                        'def method; end'
+        it 'registers an offense with `end` on the same line' do
+          expect_offense(<<-CODE.strip_indent)
+            def method; end
+            ^^^^^^^^^^^^^^^ Missing method documentation comment.
+          CODE
+        end
       end
 
       context 'when method is private' do
-        it_behaves_like 'code without offense', <<-CODE
-                        private
+        it 'does not register an offense' do
+          expect_no_offenses(<<-CODE.strip_indent)
+            private
 
-                        def foo
-                          puts 'bar'
-                        end
-        CODE
+            def foo
+              puts 'bar'
+            end
+          CODE
+        end
 
-        it_behaves_like 'code without offense', <<-CODE
-                        private
+        it 'does not register an offense with `end` on the same line' do
+          expect_no_offenses(<<-CODE.strip_indent)
+            private
 
-                        def foo; end
-        CODE
+            def foo; end
+          CODE
+        end
 
-        it_behaves_like 'code without offense', <<-CODE
-                        private def foo
-                          puts 'bar'
-                        end
-        CODE
+        it 'does not register an offense with inline `private`' do
+          expect_no_offenses(<<-CODE.strip_indent)
+            private def foo
+              puts 'bar'
+            end
+          CODE
+        end
 
-        it_behaves_like 'code without offense',
-                        'private def method; end'
+        it 'does not register an offense with inline `private` and `end`' do
+          expect_no_offenses('private def method; end')
+        end
 
         context 'when required for non-public methods' do
           let(:require_for_non_public_methods) { true }
 
-          it_behaves_like 'code with offense', <<-CODE
-                          private
+          it 'registers an offense' do
+            expect_offense(<<-CODE.strip_indent)
+              private
 
-                          def foo
-                            puts 'bar'
-                          end
-          CODE
+              def foo
+              ^^^^^^^ Missing method documentation comment.
+                puts 'bar'
+              end
+            CODE
+          end
 
-          it_behaves_like 'code with offense', <<-CODE
-                          private
+          it 'registers an offense with `end` on the same line' do
+            expect_offense(<<-CODE.strip_indent)
+              private
 
-                          def foo; end
-          CODE
+              def foo; end
+              ^^^^^^^^^^^^ Missing method documentation comment.
+            CODE
+          end
 
-          it_behaves_like 'code with offense', <<-CODE
-                          private def foo
-                            puts 'bar'
-                          end
-          CODE
+          it 'registers an offense with inline `private`' do
+            expect_offense(<<-CODE.strip_indent)
+              private def foo
+                      ^^^^^^^ Missing method documentation comment.
+                puts 'bar'
+              end
+            CODE
+          end
 
-          it_behaves_like 'code with offense',
-                          'private def method; end'
+          it 'registers an offense with inline `private` and `end`' do
+            expect_offense(<<-CODE.strip_indent)
+              private def method; end
+                      ^^^^^^^^^^^^^^^ Missing method documentation comment.
+            CODE
+          end
         end
       end
 
       context 'when method is protected' do
-        it_behaves_like 'code without offense', <<-CODE
-                        protected
+        it 'does not register an offense' do
+          expect_no_offenses(<<-CODE.strip_indent)
+            protected
 
-                        def foo
-                          puts 'bar'
-                        end
-        CODE
+            def foo
+              puts 'bar'
+            end
+          CODE
+        end
 
-        it_behaves_like 'code without offense', <<-CODE
-                          protected def foo
-                            puts 'bar'
-                          end
-        CODE
+        it 'does not register an offense with inline `protected`' do
+          expect_no_offenses(<<-CODE.strip_indent)
+            protected def foo
+              puts 'bar'
+            end
+          CODE
+        end
 
         context 'when required for non-public methods' do
           let(:require_for_non_public_methods) { true }
 
-          it_behaves_like 'code with offense', <<-CODE
-                          protected
+          it 'registers an offense' do
+            expect_offense(<<-CODE.strip_indent)
+              protected
 
-                          def foo
-                            puts 'bar'
-                          end
-          CODE
+              def foo
+              ^^^^^^^ Missing method documentation comment.
+                puts 'bar'
+              end
+            CODE
+          end
 
-          it_behaves_like 'code with offense', <<-CODE
-                          protected def foo
-                            puts 'bar'
-                          end
-          CODE
+          it 'registers an offense with inline `protected`' do
+            expect_offense(<<-CODE.strip_indent)
+              protected def foo
+                        ^^^^^^^ Missing method documentation comment.
+                puts 'bar'
+              end
+            CODE
+          end
         end
       end
     end
 
     context 'with documentation comment' do
-      it_behaves_like 'code without offense', <<-CODE
-                      # Documentation
-                      def foo
-                        puts 'bar'
-                      end
-      CODE
+      it 'does not register an offense' do
+        expect_no_offenses(<<-CODE.strip_indent)
+          # Documentation
+          def foo
+            puts 'bar'
+          end
+        CODE
+      end
 
-      it_behaves_like 'code without offense', <<-CODE
-                      # Documentation
-                      def foo; end
-      CODE
+      it 'does not register an offense with `end` on the same line' do
+        expect_no_offenses(<<-CODE.strip_indent)
+          # Documentation
+          def foo; end
+        CODE
+      end
     end
 
     context 'with both public and private methods' do
-      it_behaves_like 'code with offense', <<-CODE
-                      def foo
-                        puts 'bar'
-                      end
+      context 'when the public method has no documentation' do
+        it 'registers an offense' do
+          expect_offense(<<-CODE.strip_indent)
+            def foo
+            ^^^^^^^ Missing method documentation comment.
+              puts 'bar'
+            end
 
-                      private
+            private
 
-                      def baz
-                        puts 'bar'
-                      end
-      CODE
+            def baz
+              puts 'bar'
+            end
+          CODE
+        end
+      end
 
-      it_behaves_like 'code without offense', <<-CODE
-                      # Documentation
-                      def foo
-                        puts 'bar'
-                      end
+      context 'when the public method has documentation' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<-CODE.strip_indent)
+            # Documentation
+            def foo
+              puts 'bar'
+            end
 
-                      private
+            private
 
-                      def baz
-                        puts 'bar'
-                      end
-      CODE
+            def baz
+              puts 'bar'
+            end
+          CODE
+        end
+      end
 
       context 'when required for non-public methods' do
         let(:require_for_non_public_methods) { true }
 
-        it_behaves_like 'code with offense', <<-CODE
-                        # Documentation
-                        def foo
-                          puts 'bar'
-                        end
+        it 'registers an offense' do
+          expect_offense(<<-CODE.strip_indent)
+            # Documentation
+            def foo
+              puts 'bar'
+            end
 
-                        private
+            private
 
-                        def baz
-                          puts 'bar'
-                        end
-        CODE
+            def baz
+            ^^^^^^^ Missing method documentation comment.
+              puts 'bar'
+            end
+          CODE
+        end
       end
     end
 
     context 'when declaring methods in a class' do
       context 'without documentation comment' do
         context 'wheh method is public' do
-          it_behaves_like 'code with offense', <<-CODE
-                          class Foo
-                            def bar
-                              puts 'baz'
-                            end
-                          end
-          CODE
+          it 'registers an offense' do
+            expect_offense(<<-CODE.strip_indent)
+              class Foo
+                def bar
+                ^^^^^^^ Missing method documentation comment.
+                  puts 'baz'
+                end
+              end
+            CODE
+          end
 
-          it_behaves_like 'code with offense', <<-CODE
-                          class Foo
-                            def method; end
-                          end
-          CODE
+          it 'registers an offense with `end` on the same line' do
+            expect_offense(<<-CODE.strip_indent)
+              class Foo
+                def method; end
+                ^^^^^^^^^^^^^^^ Missing method documentation comment.
+              end
+            CODE
+          end
         end
 
         context 'when method is private' do
-          it_behaves_like 'code without offense', <<-CODE
-                          class Foo
-                            private
+          it 'does not register an offense' do
+            expect_no_offenses(<<-CODE.strip_indent)
+              class Foo
+                private
 
-                            def bar
-                              puts 'baz'
-                            end
-                          end
-          CODE
+                def bar
+                  puts 'baz'
+                end
+              end
+            CODE
+          end
 
-          it_behaves_like 'code without offense', <<-CODE
-                          class Foo
-                            private def bar
-                              puts 'baz'
-                            end
-                          end
-          CODE
+          it 'does not register an offense with inline `private`' do
+            expect_no_offenses(<<-CODE.strip_indent)
+              class Foo
+                private def bar
+                  puts 'baz'
+                end
+              end
+            CODE
+          end
 
-          it_behaves_like 'code without offense', <<-CODE
-                          class Foo
-                            private
+          it 'does not register an offense with `end` on the same line' do
+            expect_no_offenses(<<-CODE.strip_indent)
+              class Foo
+                private
 
-                            def bar; end
-                          end
-          CODE
+                def bar; end
+              end
+            CODE
+          end
 
-          it_behaves_like 'code without offense', <<-CODE
-                          class Foo
-                            private def bar; end
-                          end
-          CODE
+          it 'does not register an offense with inline `private` and `end`' do
+            expect_no_offenses(<<-CODE.strip_indent)
+              class Foo
+                private def bar; end
+              end
+            CODE
+          end
 
           context 'when required for non-public methods' do
             let(:require_for_non_public_methods) { true }
 
-            it_behaves_like 'code with offense', <<-CODE
-                            class Foo
-                              private
+            it 'registers an offense' do
+              expect_offense(<<-CODE.strip_indent)
+                class Foo
+                  private
 
-                              def bar
-                                puts 'baz'
-                              end
-                            end
-            CODE
+                  def bar
+                  ^^^^^^^ Missing method documentation comment.
+                    puts 'baz'
+                  end
+                end
+              CODE
+            end
 
-            it_behaves_like 'code with offense', <<-CODE
-                            class Foo
-                              private def bar
-                                puts 'baz'
-                              end
-                            end
-            CODE
+            it 'registers an offense witn inline `private`' do
+              expect_offense(<<-CODE.strip_indent)
+                class Foo
+                  private def bar
+                          ^^^^^^^ Missing method documentation comment.
+                    puts 'baz'
+                  end
+                end
+              CODE
+            end
 
-            it_behaves_like 'code with offense', <<-CODE
-                            class Foo
-                              private
+            it 'registers an offense with `end` on the same line' do
+              expect_offense(<<-CODE.strip_indent)
+                class Foo
+                  private
 
-                              def bar; end
-                            end
-            CODE
+                  def bar; end
+                  ^^^^^^^^^^^^ Missing method documentation comment.
+                end
+              CODE
+            end
 
-            it_behaves_like 'code with offense', <<-CODE
-                            class Foo
-                              private def bar; end
-                            end
-            CODE
+            it 'registers an offense with inline `private` and `end`' do
+              expect_offense(<<-CODE.strip_indent)
+                class Foo
+                  private def bar; end
+                          ^^^^^^^^^^^^ Missing method documentation comment.
+                end
+              CODE
+            end
           end
         end
       end
 
       context 'with documentation comment' do
         context 'when method is public' do
-          it_behaves_like 'code without offense', <<-CODE
-                          class Foo
-                            # Documentation
-                            def bar
-                              puts 'baz'
-                            end
-                          end
-          CODE
+          it 'does not register an offense' do
+            expect_no_offenses(<<-CODE)
+              class Foo
+                # Documentation
+                def bar
+                  puts 'baz'
+                end
+              end
+            CODE
+          end
 
-          it_behaves_like 'code without offense', <<-CODE
-                          class Foo
-                            # Documentation
-                            def bar; end
-                          end
-          CODE
+          it 'does not register an offense with `end` on the same line' do
+            expect_no_offenses(<<-CODE.strip_indent)
+              class Foo
+                # Documentation
+                def bar; end
+              end
+            CODE
+          end
         end
       end
 
       context 'with annotation comment' do
-        it_behaves_like 'code with offense', <<-CODE
-                        class Foo
-                          # FIXME: offense
-                          def bar
-                            puts 'baz'
-                          end
-                        end
-        CODE
+        it 'registers an offense' do
+          expect_offense(<<-CODE.strip_indent)
+            class Foo
+              # FIXME: offense
+              def bar
+              ^^^^^^^ Missing method documentation comment.
+                puts 'baz'
+              end
+            end
+          CODE
+        end
       end
 
       context 'with directive comment' do
-        it_behaves_like 'code with offense', <<-CODE
-                        class Foo
-                          # rubocop:disable Style/For
-                          def bar
-                            puts 'baz'
-                          end
-                        end
-        CODE
+        it 'registers an offense' do
+          expect_offense(<<-CODE.strip_indent)
+            class Foo
+              # rubocop:disable Style/For
+              def bar
+              ^^^^^^^ Missing method documentation comment.
+                puts 'baz'
+              end
+            end
+          CODE
+        end
       end
 
       context 'with both public and private methods' do
-        it_behaves_like 'code with offense', <<-CODE
-                        class Foo
-                          def bar
-                            puts 'baz'
-                          end
+        context 'when the public method has no documentation' do
+          it 'registers an offense' do
+            expect_offense(<<-CODE.strip_indent)
+              class Foo
+                def bar
+                ^^^^^^^ Missing method documentation comment.
+                  puts 'baz'
+                end
 
-                          private
+                private
 
-                          def baz
-                            puts 'baz'
-                          end
-                        end
-        CODE
+                def baz
+                  puts 'baz'
+                end
+              end
+            CODE
+          end
+        end
 
-        it_behaves_like 'code without offense', <<-CODE
-                        class Foo
-                          # Documentation
-                          def bar
-                            puts 'baz'
-                          end
+        context 'when the public method has documentation' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<-CODE.strip_indent)
+              class Foo
+                # Documentation
+                def bar
+                  puts 'baz'
+                end
 
-                          private
+                private
 
-                          def baz
-                            puts 'baz'
-                          end
-                        end
-        CODE
+                def baz
+                  puts 'baz'
+                end
+              end
+            CODE
+          end
+        end
 
         context 'when required for non-public methods' do
           let(:require_for_non_public_methods) { true }
 
-          it_behaves_like 'code with offense', <<-CODE
-                          class Foo
-                            # Documentation
-                            def bar
-                              puts 'baz'
-                            end
+          it 'registers an offense' do
+            expect_offense(<<-CODE.strip_indent)
+              class Foo
+                # Documentation
+                def bar
+                  puts 'baz'
+                end
 
-                            private
+                private
 
-                            def baz
-                              puts 'baz'
-                            end
-                          end
-          CODE
+                def baz
+                ^^^^^^^ Missing method documentation comment.
+                  puts 'baz'
+                end
+              end
+            CODE
+          end
         end
       end
     end
@@ -384,344 +460,428 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
     context 'when declaring methods in a module' do
       context 'without documentation comment' do
         context 'wheh method is public' do
-          it_behaves_like 'code with offense', <<-CODE
-                           module Foo
-                             def bar
-                               puts 'baz'
-                             end
-                           end
-          CODE
+          it 'registers an offense' do
+            expect_offense(<<-CODE.strip_indent)
+              module Foo
+                def bar
+                ^^^^^^^ Missing method documentation comment.
+                  puts 'baz'
+                end
+              end
+            CODE
+          end
 
-          it_behaves_like 'code with offense', <<-CODE
-                          module Foo
-                            def method; end
-                          end
-          CODE
+          it 'registers an offense with `end` on the same line' do
+            expect_offense(<<-CODE.strip_indent)
+              module Foo
+                def method; end
+                ^^^^^^^^^^^^^^^ Missing method documentation comment.
+              end
+            CODE
+          end
         end
 
         context 'when method is private' do
-          it_behaves_like 'code without offense', <<-CODE
-                          module Foo
-                            private
+          it 'does not register an offense' do
+            expect_no_offenses(<<-CODE.strip_indent)
+              module Foo
+                private
 
-                            def bar
-                              puts 'baz'
-                            end
-                          end
-          CODE
+                def bar
+                  puts 'baz'
+                end
+              end
+            CODE
+          end
 
-          it_behaves_like 'code without offense', <<-CODE
-                          module Foo
-                            private def bar
-                              puts 'baz'
-                            end
-                          end
-          CODE
+          it 'does not register an offense with inline `private`' do
+            expect_no_offenses(<<-CODE.strip_indent)
+              module Foo
+                private def bar
+                  puts 'baz'
+                end
+              end
+            CODE
+          end
 
-          it_behaves_like 'code without offense', <<-CODE
-                          module Foo
-                            private
+          it 'does not register an offense with `end` on the same line' do
+            expect_no_offenses(<<-CODE.strip_indent)
+              module Foo
+                private
 
-                            def bar; end
-                          end
-          CODE
+                def bar; end
+              end
+            CODE
+          end
 
-          it_behaves_like 'code without offense', <<-CODE
-                          module Foo
-                            private def bar; end
-                          end
-          CODE
+          it 'does not register an offense with inline `private` and `end`' do
+            expect_no_offenses(<<-CODE.strip_indent)
+              module Foo
+                private def bar; end
+              end
+            CODE
+          end
 
           context 'when required for non-public methods' do
             let(:require_for_non_public_methods) { true }
 
-            it_behaves_like 'code with offense', <<-CODE
-                            module Foo
-                              private
+            it 'registers an offense' do
+              expect_offense(<<-CODE.strip_indent)
+                module Foo
+                  private
 
-                              def bar
-                                puts 'baz'
-                              end
-                            end
-            CODE
+                  def bar
+                  ^^^^^^^ Missing method documentation comment.
+                    puts 'baz'
+                  end
+                end
+              CODE
+            end
 
-            it_behaves_like 'code with offense', <<-CODE
-                            module Foo
-                              private def bar
-                                puts 'baz'
-                              end
-                            end
-            CODE
+            it 'registers an offense with inline `private`' do
+              expect_offense(<<-CODE.strip_indent)
+                module Foo
+                  private def bar
+                          ^^^^^^^ Missing method documentation comment.
+                    puts 'baz'
+                  end
+                end
+              CODE
+            end
 
-            it_behaves_like 'code with offense', <<-CODE
-                            module Foo
-                              private
+            it 'registers an offense with `end` on the same line' do
+              expect_offense(<<-CODE.strip_indent)
+                module Foo
+                  private
 
-                              def bar; end
-                            end
-            CODE
+                  def bar; end
+                  ^^^^^^^^^^^^ Missing method documentation comment.
+                end
+              CODE
+            end
 
-            it_behaves_like 'code with offense', <<-CODE
-                            module Foo
-                              private def bar; end
-                            end
-            CODE
+            it 'registers an offense with inline `private` and `end`' do
+              expect_offense(<<-CODE.strip_indent)
+                module Foo
+                  private def bar; end
+                          ^^^^^^^^^^^^ Missing method documentation comment.
+                end
+              CODE
+            end
           end
         end
       end
 
       context 'with documentation comment' do
         context 'when method is public' do
-          it_behaves_like 'code without offense', <<-CODE
-                          module Foo
-                            # Documentation
-                            def bar
-                              puts 'baz'
-                            end
-                          end
-          CODE
+          it 'does not register an offense' do
+            expect_no_offenses(<<-CODE.strip_indent)
+              module Foo
+                # Documentation
+                def bar
+                  puts 'baz'
+                end
+              end
+            CODE
+          end
 
-          it_behaves_like 'code without offense', <<-CODE
-                          module Foo
-                            # Documentation
-                            def bar; end
-                          end
-          CODE
+          it 'does not register an offense with `end` on the same line' do
+            expect_no_offenses(<<-CODE.strip_indent)
+              module Foo
+                # Documentation
+                def bar; end
+              end
+            CODE
+          end
         end
       end
 
       context 'with both public and private methods' do
-        it_behaves_like 'code with offense', <<-CODE
-                        module Foo
-                          def bar
-                            puts 'baz'
-                          end
+        context 'when the public method has no documentation' do
+          it 'registers an offense' do
+            expect_offense(<<-CODE.strip_indent)
+              module Foo
+                def bar
+                ^^^^^^^ Missing method documentation comment.
+                  puts 'baz'
+                end
 
-                          private
+                private
 
-                          def baz
-                            puts 'baz'
-                          end
-                        end
-        CODE
+                def baz
+                  puts 'baz'
+                end
+              end
+            CODE
+          end
+        end
 
-        it_behaves_like 'code without offense', <<-CODE
-                        module Foo
-                          # Documentation
-                          def bar
-                            puts 'baz'
-                          end
+        context 'when the public method has documentation' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<-CODE.strip_indent)
+              module Foo
+                # Documentation
+                def bar
+                  puts 'baz'
+                end
 
-                          private
+                private
 
-                          def baz
-                            puts 'baz'
-                          end
-                        end
-        CODE
+                def baz
+                  puts 'baz'
+                end
+              end
+            CODE
+          end
+        end
 
         context 'when required for non-public methods' do
           let(:require_for_non_public_methods) { true }
 
-          it_behaves_like 'code with offense', <<-CODE
-                          module Foo
-                            # Documentation
-                            def bar
-                              puts 'baz'
-                            end
+          it 'registers an offense' do
+            expect_offense(<<-CODE.strip_indent)
+              module Foo
+                # Documentation
+                def bar
+                  puts 'baz'
+                end
 
-                            private
+                private
 
-                            def baz
-                              puts 'baz'
-                            end
-                          end
-          CODE
+                def baz
+                ^^^^^^^ Missing method documentation comment.
+                  puts 'baz'
+                end
+              end
+            CODE
+          end
         end
       end
     end
 
     context 'when declaring methods for class instance' do
       context 'without documentation comment' do
-        it_behaves_like 'code with offense', <<-CODE
-                        class Foo; end
+        it 'registers an offense' do
+          expect_offense(<<-CODE.strip_indent)
+            class Foo; end
 
-                        foo = Foo.new
+            foo = Foo.new
 
-                        def foo.bar
-                          puts 'baz'
-                        end
-        CODE
+            def foo.bar
+            ^^^^^^^^^^^ Missing method documentation comment.
+              puts 'baz'
+            end
+          CODE
+        end
 
-        it_behaves_like 'code with offense', <<-CODE
-                        class Foo; end
+        it 'registers an offense with `end` on the same line' do
+          expect_offense(<<-CODE.strip_indent)
+            class Foo; end
 
-                        foo = Foo.new
+            foo = Foo.new
 
-                        def foo.bar; end
-        CODE
+            def foo.bar; end
+            ^^^^^^^^^^^^^^^^ Missing method documentation comment.
+          CODE
+        end
       end
 
       context 'with documentation comment' do
-        it_behaves_like 'code without offense', <<-CODE
-                        class Foo; end
+        it 'does not register an offense' do
+          expect_no_offenses(<<-CODE.strip_indent)
+            class Foo; end
 
-                        foo = Foo.new
+            foo = Foo.new
 
-                        # Documentation
-                        def foo.bar
-                          puts 'baz'
-                        end
-        CODE
+            # Documentation
+            def foo.bar
+              puts 'baz'
+            end
+          CODE
+        end
 
-        it_behaves_like 'code without offense', <<-CODE
-                        class Foo; end
+        it 'does not register an offense with `end` on the same line' do
+          expect_no_offenses(<<-CODE.strip_indent)
+            class Foo; end
 
-                        foo = Foo.new
+            foo = Foo.new
 
-                        # Documentation
-                        def foo.bar; end
-        CODE
+            # Documentation
+            def foo.bar; end
+          CODE
+        end
 
         context 'when method is private' do
-          it_behaves_like 'code without offense', <<-CODE
-                          class Foo; end
+          it 'does not register an offense with `end` on the same line' do
+            expect_no_offenses(<<-CODE.strip_indent)
+              class Foo; end
 
-                          foo = Foo.bar
+              foo = Foo.bar
 
-                          private
+              private
 
-                          def foo.bar; end
-          CODE
+              def foo.bar; end
+            CODE
+          end
 
-          it_behaves_like 'code without offense', <<-CODE
-                          class Foo; end
+          it 'does not register an offense' do
+            expect_no_offenses(<<-CODE.strip_indent)
+              class Foo; end
 
-                          foo = Foo.new
+              foo = Foo.new
 
-                          private
+              private
 
-                          def foo.bar
-                            puts 'baz'
-                          end
-          CODE
+              def foo.bar
+                puts 'baz'
+              end
+            CODE
+          end
 
-          it_behaves_like 'code without offense', <<-CODE
-                          class Foo; end
+          it 'does not register an offense with inline `private` and `end`' do
+            expect_no_offenses(<<-CODE.strip_indent)
+              class Foo; end
 
-                          foo = Foo.new
+              foo = Foo.new
 
-                          private def foo.bar; end
-          CODE
+              private def foo.bar; end
+            CODE
+          end
 
-          it_behaves_like 'code without offense', <<-CODE
-                          class Foo; end
+          it 'does not register an offense with inline `private`' do
+            expect_no_offenses(<<-CODE.strip_indent)
+              class Foo; end
 
-                          foo = Foo.new
+              foo = Foo.new
 
-                          private def foo.bar
-                            puts 'baz'
-                          end
-          CODE
+              private def foo.bar
+                puts 'baz'
+              end
+            CODE
+          end
 
           context 'when required for non-public methods' do
             let(:require_for_non_public_methods) { true }
 
-            it_behaves_like 'code with offense', <<-CODE
-                            class Foo; end
+            it 'registers an offense with `end` on the same line' do
+              expect_offense(<<-CODE.strip_indent)
+                class Foo; end
 
-                            foo = Foo.bar
+                foo = Foo.bar
 
-                            private
+                private
 
-                            def foo.bar; end
-            CODE
+                def foo.bar; end
+                ^^^^^^^^^^^^^^^^ Missing method documentation comment.
+              CODE
+            end
 
-            it_behaves_like 'code with offense', <<-CODE
-                            class Foo; end
+            it 'registers an offense' do
+              expect_offense(<<-CODE.strip_indent)
+                class Foo; end
 
-                            foo = Foo.new
+                foo = Foo.new
 
-                            private
+                private
 
-                            def foo.bar
-                              puts 'baz'
-                            end
-            CODE
+                def foo.bar
+                ^^^^^^^^^^^ Missing method documentation comment.
+                  puts 'baz'
+                end
+              CODE
+            end
 
-            it_behaves_like 'code with offense', <<-CODE
-                            class Foo; end
+            it 'registers an offense with inline `private` and `end`' do
+              expect_offense(<<-CODE.strip_indent)
+                class Foo; end
 
-                            foo = Foo.new
+                foo = Foo.new
 
-                            private def foo.bar; end
-            CODE
+                private def foo.bar; end
+                        ^^^^^^^^^^^^^^^^ Missing method documentation comment.
+              CODE
+            end
 
-            it_behaves_like 'code with offense', <<-CODE
-                            class Foo; end
+            it 'registers an offense with inline `private`' do
+              expect_offense(<<-CODE.strip_indent)
+                class Foo; end
 
-                            foo = Foo.new
+                foo = Foo.new
 
-                            private def foo.bar
-                              puts 'baz'
-                            end
-            CODE
+                private def foo.bar
+                        ^^^^^^^^^^^ Missing method documentation comment.
+                  puts 'baz'
+                end
+              CODE
+            end
           end
         end
 
         context 'with both public and private methods' do
-          it_behaves_like 'code with offense', <<-CODE
-                          class Foo; end
+          context 'when the public method has no documentation' do
+            it 'registers an offense' do
+              expect_offense(<<-CODE.strip_indent)
+                class Foo; end
 
-                          foo = Foo.new
+                foo = Foo.new
 
-                          def foo.bar
-                            puts 'baz'
-                          end
+                def foo.bar
+                ^^^^^^^^^^^ Missing method documentation comment.
+                  puts 'baz'
+                end
 
-                          private
+                private
 
-                          def foo.baz
-                            puts 'baz'
-                          end
-          CODE
+                def foo.baz
+                  puts 'baz'
+                end
+              CODE
+            end
+          end
 
-          it_behaves_like 'code without offense', <<-CODE
-                          class Foo; end
+          context 'when the public method has documentation' do
+            it 'does not register an offense' do
+              expect_no_offenses(<<-CODE.strip_indent)
+                class Foo; end
 
-                          foo = Foo.new
+                foo = Foo.new
 
-                          # Documentation
-                          def foo.bar
-                            puts 'baz'
-                          end
+                # Documentation
+                def foo.bar
+                  puts 'baz'
+                end
 
-                          private
+                private
 
-                          def foo.baz
-                            puts 'baz'
-                          end
-          CODE
+                def foo.baz
+                  puts 'baz'
+                end
+              CODE
+            end
+          end
 
           context 'when required for non-public methods' do
             let(:require_for_non_public_methods) { true }
 
-            it_behaves_like 'code with offense', <<-CODE
-                          class Foo; end
+            it 'registers an offense' do
+              expect_offense(<<-CODE.strip_indent)
+                class Foo; end
 
-                          foo = Foo.new
+                foo = Foo.new
 
-                          # Documentation
-                          def foo.bar
-                            puts 'baz'
-                          end
+                # Documentation
+                def foo.bar
+                  puts 'baz'
+                end
 
-                          private
+                private
 
-                          def foo.baz
-                            puts 'baz'
-                          end
-            CODE
+                def foo.baz
+                ^^^^^^^^^^^ Missing method documentation comment.
+                  puts 'baz'
+                end
+              CODE
+            end
           end
         end
       end

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -114,14 +114,14 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
 
     context 'with opposite + correct' do
       it 'reports an offense for opposite + correct' do
-        inspect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           if a
             raise RuntimeError, msg
           else
             raise Ex.new(msg)
+            ^^^^^^^^^^^^^^^^^ Provide an exception class and message as arguments to `raise`.
           end
         RUBY
-        expect(cop.offenses.size).to eq(1)
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
 

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -245,8 +245,10 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'flags single quotes with plain # (not #@var or #{interpolation}' do
-      inspect_source("a = 'blah #'")
-      expect(cop.offenses.size).to be 1
+      expect_offense(<<-RUBY.strip_indent)
+        a = 'blah #'
+            ^^^^^^^^ Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
+      RUBY
     end
 
     it 'accepts single quotes at the start of regexp literals' do

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -114,15 +114,14 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'registers an offense for an array with comments outside of it' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         [
+        ^ Use `%w` or `%W` for an array of words.
         "foo",
         "bar",
         "baz"
         ] # test
       RUBY
-
-      expect(cop.offenses.size).to eq(1)
     end
 
     it 'auto-corrects an array of words' do


### PR DESCRIPTION
 `+`  some minor improvements in other specs:
* Fixed few typos
* removed shared example that is no longer used
* Added expect_offense in one example in line_length_spec
