### PR TITLE
Rename offence to offense in documentation and specs

### DIFF
--- a/lib/rubocop/cop/style/class_vars.rb
+++ b/lib/rubocop/cop/style/class_vars.rb
@@ -26,7 +26,7 @@ module RuboCop
       #
       #   class A
       #     def test
-      #       @@test # you can access class variable without offence
+      #       @@test # you can access class variable without offense
       #     end
       #   end
       #

--- a/lib/rubocop/cop/style/method_def_parentheses.rb
+++ b/lib/rubocop/cop/style/method_def_parentheses.rb
@@ -60,8 +60,8 @@ module RuboCop
       #
       # @example EnforcedStyle: require_no_parentheses_except_multiline
       #   # The `require_no_parentheses_except_multiline` style prefers no
-      #   # parantheses when method definition arguments fit on single line,
-      #   # but prefers parantheses when arguments span multiple lines.
+      #   # parentheses when method definition arguments fit on single line,
+      #   # but prefers parentheses when arguments span multiple lines.
       #
       #   # bad
       #   def bar(num1, num2)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -696,7 +696,7 @@ end
 
 class A
   def test
-    @@test # you can access class variable without offence
+    @@test # you can access class variable without offense
   end
 end
 ```
@@ -2923,8 +2923,8 @@ end
 
 ```ruby
 # The `require_no_parentheses_except_multiline` style prefers no
-# parantheses when method definition arguments fit on single line,
-# but prefers parantheses when arguments span multiple lines.
+# parentheses when method definition arguments fit on single line,
+# but prefers parentheses when arguments span multiple lines.
 
 # bad
 def bar(num1, num2)

--- a/spec/rubocop/cop/layout/closing_heredoc_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/closing_heredoc_indentation_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe RuboCop::Cop::Layout::ClosingHeredocIndentation do
     RUBY
   end
 
-  it 'registers an offence for bad indentation of a closing heredoc' do
+  it 'registers an offense for bad indentation of a closing heredoc' do
     expect_offense(<<-RUBY.strip_indent)
       class Test
         def foo

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'registers offence when guard clause is before `begin`' do
+  it 'registers offense when guard clause is before `begin`' do
     expect_offense(<<-RUBY.strip_indent)
       def foo
         return another_object if something_different?
@@ -72,7 +72,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offence for modifier if' do
+  it 'does not register offense for modifier if' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def foo
         foo += 1 if need_add?
@@ -81,7 +81,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offence for guard clause followed by end' do
+  it 'does not register offense for guard clause followed by end' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def foo
         if something?
@@ -91,7 +91,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offence for guard clause inside oneliner block' do
+  it 'does not register offense for guard clause inside oneliner block' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def foo
         object.tap { |obj| return another_object if something? }
@@ -100,7 +100,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offence for multiple guard clauses' do
+  it 'does not register offense for multiple guard clauses' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def foo
         return another_object if something?
@@ -112,7 +112,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offence if next line is end' do
+  it 'does not register offense if next line is end' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def foo
         return another_object if something_different?
@@ -120,7 +120,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offence when guard clause is before `rescue`' do
+  it 'does not register offense when guard clause is before `rescue`' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def foo
         begin
@@ -132,7 +132,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offence when guard clause is before `ensure`' do
+  it 'does not register offense when guard clause is before `ensure`' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def foo
         begin
@@ -144,7 +144,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offence when guard clause is before `rescue`-`else`' do
+  it 'does not register offense when guard clause is before `rescue`-`else`' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def foo
         begin
@@ -158,7 +158,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offence when guard clause is before `else`' do
+  it 'does not register offense when guard clause is before `else`' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def foo
         if cond
@@ -170,7 +170,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offence when guard clause is before `elsif`' do
+  it 'does not register offense when guard clause is before `elsif`' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def foo
         if cond
@@ -182,7 +182,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offence when guard clause is after single line ' \
+  it 'does not register offense when guard clause is after single line ' \
      'heredoc' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def foo
@@ -195,7 +195,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offence when guard clause is after multiline heredoc' do
+  it 'does not register offense when guard clause is after multiline heredoc' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def foo
         raise ArgumentError, <<-MSG unless path
@@ -209,7 +209,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'registers an offence for methods starting with end_' do
+  it 'registers an offense for methods starting with end_' do
     expect_offense(<<-RUBY.strip_indent)
       def foo
         next unless need_next?
@@ -219,7 +219,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'autocorrects offence' do
+  it 'autocorrects offense' do
     new_source = autocorrect_source(<<-RUBY.strip_indent)
       def foo
         next if foo?
@@ -238,7 +238,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'correctly autocorrects offence with comment on same line' do
+  it 'correctly autocorrects offense with comment on same line' do
     new_source = autocorrect_source(<<-RUBY.strip_indent)
       def foo
         next if foo? # This is foo

--- a/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
         RUBY
       end
 
-      it 'registers offence for namespace body starting with a blank' do
+      it 'registers offense for namespace body starting with a blank' do
         inspect_source(<<-RUBY.strip_indent)
           class Parent
 
@@ -178,7 +178,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
         expect(cop.messages).to eq([extra_begin])
       end
 
-      it 'registers offence for namespace body ending with a blank' do
+      it 'registers offense for namespace body ending with a blank' do
         inspect_source(<<-RUBY.strip_indent)
           class Parent
             class Child
@@ -192,7 +192,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
         expect(cop.messages).to eq([extra_end])
       end
 
-      it 'registers offences for namespaced class body not starting '\
+      it 'registers offenses for namespaced class body not starting '\
           'with a blank' do
         inspect_source(<<-RUBY.strip_indent)
           class Parent
@@ -205,7 +205,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
         expect(cop.messages).to eq([missing_begin])
       end
 
-      it 'registers offences for namespaced class body not ending '\
+      it 'registers offenses for namespaced class body not ending '\
           'with a blank' do
         inspect_source(<<-RUBY.strip_indent)
           class Parent
@@ -251,7 +251,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
         RUBY
       end
 
-      it 'registers offence for namespace body starting with a blank' do
+      it 'registers offense for namespace body starting with a blank' do
         inspect_source(<<-RUBY.strip_indent)
           class Parent
 
@@ -263,7 +263,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
         expect(cop.messages).to eq([extra_begin])
       end
 
-      it 'registers offence for namespace body ending with a blank' do
+      it 'registers offense for namespace body ending with a blank' do
         inspect_source(<<-RUBY.strip_indent)
           class Parent
             module Child
@@ -294,7 +294,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
         RUBY
       end
 
-      it 'registers offences for namespace body starting '\
+      it 'registers offenses for namespace body starting '\
         'and ending without a blank' do
         inspect_source(<<-RUBY.strip_indent)
           class Parent

--- a/spec/rubocop/cop/layout/empty_lines_around_module_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_module_body_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
         RUBY
       end
 
-      it 'registers offence for namespace body starting with a blank' do
+      it 'registers offense for namespace body starting with a blank' do
         inspect_source(<<-RUBY.strip_indent)
           module Parent
 
@@ -128,7 +128,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
         expect(cop.messages).to eq([extra_begin])
       end
 
-      it 'registers offence for namespace body ending with a blank' do
+      it 'registers offense for namespace body ending with a blank' do
         inspect_source(<<-RUBY.strip_indent)
           module Parent
             module Child
@@ -142,7 +142,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
         expect(cop.messages).to eq([extra_end])
       end
 
-      it 'registers offences for namespaced module body not starting '\
+      it 'registers offenses for namespaced module body not starting '\
           'with a blank' do
         inspect_source(<<-RUBY.strip_indent)
           module Parent
@@ -155,7 +155,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
         expect(cop.messages).to eq([missing_begin])
       end
 
-      it 'registers offences for namespaced module body not ending '\
+      it 'registers offenses for namespaced module body not ending '\
           'with a blank' do
         inspect_source(<<-RUBY.strip_indent)
           module Parent
@@ -201,7 +201,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
         RUBY
       end
 
-      it 'registers offence for namespace body starting with a blank' do
+      it 'registers offense for namespace body starting with a blank' do
         inspect_source(<<-RUBY.strip_indent)
           module Parent
 
@@ -213,7 +213,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
         expect(cop.messages).to eq([extra_begin])
       end
 
-      it 'registers offence for namespace body ending with a blank' do
+      it 'registers offense for namespace body ending with a blank' do
         inspect_source(<<-RUBY.strip_indent)
           module Parent
             class SomeClass
@@ -244,7 +244,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
         RUBY
       end
 
-      it 'registers offences for namespace body starting '\
+      it 'registers offenses for namespace body starting '\
         'and ending without a blank' do
         inspect_source(<<-RUBY.strip_indent)
           module Parent

--- a/spec/rubocop/cop/layout/leading_blank_lines_spec.rb
+++ b/spec/rubocop/cop/layout/leading_blank_lines_spec.rb
@@ -121,14 +121,14 @@ RSpec.describe RuboCop::Cop::Layout::LeadingBlankLines, :config do
       end
 
       it 'does not invoke conflicts with other cops' do
-        source_with_offences = <<-RUBY.strip_indent
+        source_with_offenses = <<-RUBY.strip_indent
 
           def bar(arg =1); end
         RUBY
 
         options = { auto_correct: true, stdin: true }
         team = RuboCop::Cop::Team.new(cops, config, options)
-        team.inspect_file(parse_source(source_with_offences, nil))
+        team.inspect_file(parse_source(source_with_offenses, nil))
         new_source = options[:stdin]
 
         expect(new_source).to eq(<<-RUBY.strip_indent)

--- a/spec/rubocop/cop/layout/space_after_colon_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_colon_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAfterColon do
     RUBY
   end
 
-  it 'registers an offence if an keyword optional argument has no space' do
+  it 'registers an offense if an keyword optional argument has no space' do
     expect_offense(<<-RUBY.strip_indent)
       def m(var:1, other_var: 2)
                ^ Space missing after colon.

--- a/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
                           'RUBY'].join("\n"))
     end
 
-    it 'registers an offence for trailing whitespace at the heredoc begin' do
+    it 'registers an offense for trailing whitespace at the heredoc begin' do
       inspect_source(['x = <<RUBY ',
                       '  Hi   ',
                       'RUBY'].join("\n"))

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -253,11 +253,11 @@ RSpec.describe RuboCop::Cop::Lint::FormatParameterMismatch do
   end
 
   context 'with wildcard' do
-    it 'does not register an offence for width' do
+    it 'does not register an offense for width' do
       expect_no_offenses('format("%*d", 10, 3)')
     end
 
-    it 'does not register an offence for precision' do
+    it 'does not register an offense for precision' do
       expect_no_offenses('format("%.*f", 2, 20.19)')
     end
 

--- a/spec/rubocop/cop/lint/percent_string_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_string_array_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe RuboCop::Cop::Lint::PercentStringArray do
   end
 
   context 'with invalid byte sequence in UTF-8' do
-    it 'add an offences if tokens contain quotes' do
+    it 'add an offense if tokens contain quotes' do
       expect_offense(<<-RUBY)
         %W("a\\255\\255")
         ^^^^^^^^^^^^^^^ Within `%w`/`%W`, quotes and ',' are unnecessary and may be unwanted in the resulting strings.

--- a/spec/rubocop/cop/lint/unified_integer_spec.rb
+++ b/spec/rubocop/cop/lint/unified_integer_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe RuboCop::Cop::Lint::UnifiedInteger do
 
   let(:config) { RuboCop::Config.new }
 
-  shared_examples 'registers an offence' do |klass|
+  shared_examples 'registers an offense' do |klass|
     context "when #{klass}" do
       context 'without any decorations' do
         let(:source) { "1.is_a?(#{klass})" }
 
-        it 'registers an offence' do
+        it 'registers an offense' do
           inspect_source(source)
           expect(cop.offenses.size).to eq(1)
           expect(cop.messages).to eq(["Use `Integer` instead of `#{klass}`."])
@@ -25,7 +25,7 @@ RSpec.describe RuboCop::Cop::Lint::UnifiedInteger do
       context 'when explicitly specified as toplevel constant' do
         let(:source) { "1.is_a?(::#{klass})" }
 
-        it 'registers an offence' do
+        it 'registers an offense' do
           inspect_source(source)
           expect(cop.offenses.size).to eq(1)
           expect(cop.messages).to eq(["Use `Integer` instead of `#{klass}`."])
@@ -45,8 +45,8 @@ RSpec.describe RuboCop::Cop::Lint::UnifiedInteger do
     end
   end
 
-  include_examples 'registers an offence', 'Fixnum'
-  include_examples 'registers an offence', 'Bignum'
+  include_examples 'registers an offense', 'Fixnum'
+  include_examples 'registers an offense', 'Bignum'
 
   context 'when Integer' do
     context 'without any decorations' do

--- a/spec/rubocop/cop/lint/unneeded_cop_enable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/unneeded_cop_enable_directive_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::Cop::Lint::UnneededCopEnableDirective do
     end
 
     context 'when at least one cop was disabled' do
-      it 'does not register offence' do
+      it 'does not register offense' do
         expect_no_offenses(<<-RUBY.strip_indent)
         # rubocop:disable Metrics/LineLength
         foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo

--- a/spec/rubocop/cop/metrics/line_length_spec.rb
+++ b/spec/rubocop/cop/metrics/line_length_spec.rb
@@ -166,23 +166,23 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
 
       let(:source) { <<-RUBY }
         foo(<<-DOC, <<-SQL, <<-FOO)
-          1st offence: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          1st offense: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
           \#{<<-OK}
-            no offence (whitelisted): Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            no offense (whitelisted): Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
           OK
-          2nd offence: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          2nd offense: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
         DOC
-          no offence (whitelisted): Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          no offense (whitelisted): Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
           \#{<<-XXX}
-            no offence (nested inside whitelisted): Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            no offense (nested inside whitelisted): Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
           XXX
-          no offence (whitelisted): Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          no offense (whitelisted): Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
         SQL
-          3rd offence: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          3rd offense: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
           \#{<<-SQL}
-            no offence (whitelisted): Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            no offense (whitelisted): Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
           SQL
-          4th offence: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          4th offense: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
         FOO
       RUBY
 

--- a/spec/rubocop/cop/rails/active_support_aliases_spec.rb
+++ b/spec/rubocop/cop/rails/active_support_aliases_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RuboCop::Cop::Rails::ActiveSupportAliases do
 
   describe 'String' do
     describe '#starts_with?' do
-      it 'is registered as an offence' do
+      it 'is registered as an offense' do
         expect_offense(<<-RUBY.strip_indent)
           'some_string'.starts_with?('prefix')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `start_with?` instead of `starts_with?`.
@@ -51,7 +51,7 @@ RSpec.describe RuboCop::Cop::Rails::ActiveSupportAliases do
 
   describe 'Array' do
     describe '#append' do
-      it 'is registered as an offence' do
+      it 'is registered as an offense' do
         expect_offense(<<-RUBY.strip_indent)
           [1, 'a', 3].append('element')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `<<` instead of `append`.
@@ -72,7 +72,7 @@ RSpec.describe RuboCop::Cop::Rails::ActiveSupportAliases do
     end
 
     describe '#prepend' do
-      it 'is registered as an offence' do
+      it 'is registered as an offense' do
         expect_offense(<<-RUBY.strip_indent)
           [1, 'a', 3].prepend('element')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `unshift` instead of `prepend`.

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe RuboCop::Cop::Style::Documentation do
     RUBY
   end
 
-  it 'registers an offence for compact-style nested module' do
+  it 'registers an offense for compact-style nested module' do
     expect_offense(<<-RUBY.strip_indent)
       module A::B
       ^^^^^^ Missing top-level module documentation comment.
@@ -222,7 +222,7 @@ RSpec.describe RuboCop::Cop::Style::Documentation do
     RUBY
   end
 
-  it 'registers an offence for compact-style nested class' do
+  it 'registers an offense for compact-style nested class' do
     expect_offense(<<-RUBY.strip_indent)
       class A::B
       ^^^^^ Missing top-level class documentation comment.

--- a/spec/rubocop/cop/style/negated_if_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe RuboCop::Cop::Style::NegatedIf do
       described_class.new(config)
     end
 
-    it 'registers an offence for prefix' do
+    it 'registers an offense for prefix' do
       expect_offense(<<-RUBY.strip_indent)
         if !foo
         ^^^^^^^ Favor `unless` over `if` for negative conditions.
@@ -147,7 +147,7 @@ RSpec.describe RuboCop::Cop::Style::NegatedIf do
       RUBY
     end
 
-    it 'does not register an offence for postfix' do
+    it 'does not register an offense for postfix' do
       expect_no_offenses('foo if !bar')
     end
 
@@ -176,14 +176,14 @@ RSpec.describe RuboCop::Cop::Style::NegatedIf do
       described_class.new(config)
     end
 
-    it 'registers an offence for postfix' do
+    it 'registers an offense for postfix' do
       expect_offense(<<-RUBY.strip_indent)
         foo if !bar
         ^^^^^^^^^^^ Favor `unless` over `if` for negative conditions.
       RUBY
     end
 
-    it 'does not register an offence for prefix' do
+    it 'does not register an offense for prefix' do
       expect_no_offenses(<<-RUBY.strip_indent)
         if !foo
         end

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
       RUBY
     end
 
-    it 'registers an offence for paranthesses in single line condition' do
+    it 'registers an offense for parentheses in single line condition' do
       expect_offense(<<-RUBY.strip_indent)
         if (x > 3 && x < 10)
            ^^^^^^^^^^^^^^^^^ Don't use parentheses around the condition of an `if`.

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf do
     expect_no_offenses('self.()')
   end
 
-  it 'reports an offence a self receiver of .call' do
+  it 'reports an offense a self receiver of .call' do
     expect_offense(<<-RUBY.strip_indent)
       self.call
       ^^^^^^^^^ Redundant `self` detected.


### PR DESCRIPTION
Since `offense` is used throughout the codebase instead of `offence`, harmonize its usage in documentation and specs.

Also renames `parantheses` and `paranthesses` to `parentheses`.

I did not change the CHANGELOG entries, though, I think they should keep their original spelling.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
