### PR TITLE
Add `comparison` style to Style/NilComparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#6174](https://github.com/rubocop-hq/rubocop/pull/6174): Add `--display-only-fail-level-offenses` to only output offenses at or above the fail level. ([@robotdana][])
 * Add autocorrect to `Style/For`. ([@rrosenblum][])
 * [#6173](https://github.com/rubocop-hq/rubocop/pull/6173): Add `AllowImplicitReturn` option to `Rails/SaveBang` cop. ([@robotdana][])
+* [#6218](https://github.com/rubocop-hq/rubocop/pull/6218): Add `explicit_comparison` style to Style/NilComparison. ([@khiav223577][])
 
 ### Bug fixes
 
@@ -3532,3 +3533,4 @@
 [@MagedMilad]: https://github.com/MagedMilad
 [@robotdana]: https://github.com/robotdana
 [@bacchir]: https://github.com/bacchir
+[@khiav223577]: https://github.com/khiav223577

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * [#6174](https://github.com/rubocop-hq/rubocop/pull/6174): Add `--display-only-fail-level-offenses` to only output offenses at or above the fail level. ([@robotdana][])
 * Add autocorrect to `Style/For`. ([@rrosenblum][])
 * [#6173](https://github.com/rubocop-hq/rubocop/pull/6173): Add `AllowImplicitReturn` option to `Rails/SaveBang` cop. ([@robotdana][])
-* [#6218](https://github.com/rubocop-hq/rubocop/pull/6218): Add `explicit_comparison` style to Style/NilComparison. ([@khiav223577][])
+* [#6218](https://github.com/rubocop-hq/rubocop/pull/6218): Add `comparison` style to Style/NilComparison. ([@khiav223577][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1248,10 +1248,10 @@ Style/Next:
     - always
 
 Style/NilComparison:
-  EnforcedStyle: predicate_method
+  EnforcedStyle: predicate
   SupportedStyles:
-    - predicate_method
-    - explicit_comparison
+    - predicate
+    - comparison
 
 Style/NonNilCheck:
   # With `IncludeSemanticChanges` set to `true`, this cop reports offenses for

--- a/config/default.yml
+++ b/config/default.yml
@@ -1247,6 +1247,12 @@ Style/Next:
     - skip_modifier_ifs
     - always
 
+Style/NilComparison:
+  EnforcedStyle: predicate_method
+  SupportedStyles:
+    - predicate_method
+    - explicit_comparison
+
 Style/NonNilCheck:
   # With `IncludeSemanticChanges` set to `true`, this cop reports offenses for
   # `!x.nil?` and autocorrects that and `x != nil` to solely `x`, which is

--- a/lib/rubocop/cop/style/nil_comparison.rb
+++ b/lib/rubocop/cop/style/nil_comparison.rb
@@ -6,9 +6,9 @@ module RuboCop
       # This cop checks for comparison of something with nil using `==` and
       # `nil?`.
       #
-      # Supported styles are: predicate_method, explicit_comparison.
+      # Supported styles are: predicate, comparison.
       #
-      # @example EnforcedStyle: predicate_method (default)
+      # @example EnforcedStyle: predicate (default)
       #
       #   # bad
       #   if x == nil
@@ -18,7 +18,7 @@ module RuboCop
       #   if x.nil?
       #   end
       #
-      # @example EnforcedStyle: explicit_comparison
+      # @example EnforcedStyle: comparison
       #
       #   # bad
       #   if x.nil?
@@ -32,7 +32,7 @@ module RuboCop
         include ConfigurableEnforcedStyle
 
         PREDICATE_MSG = 'Prefer the use of the `nil?` predicate.'.freeze
-        EXPLICIT_MSG = 'Prefer the use of the explicit `==` comparison.'.freeze
+        EXPLICIT_MSG = 'Prefer the use of the `==` comparison.'.freeze
 
         def_node_matcher :nil_comparison?, '(send _ {:== :===} nil)'
         def_node_matcher :nil_check?, '(send _ :nil?)'
@@ -44,7 +44,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          new_code = if explicit_comparison?
+          new_code = if prefer_comparison?
                        node.source.sub('.nil?', ' == nil')
                      else
                        node.source.sub(/\s*={2,3}\s*nil/, '.nil?')
@@ -55,19 +55,19 @@ module RuboCop
         private
 
         def message(_node)
-          explicit_comparison? ? EXPLICIT_MSG : PREDICATE_MSG
+          prefer_comparison? ? EXPLICIT_MSG : PREDICATE_MSG
         end
 
         def style_check?(node, &block)
-          if explicit_comparison?
+          if prefer_comparison?
             nil_check?(node, &block)
           else
             nil_comparison?(node, &block)
           end
         end
 
-        def explicit_comparison?
-          style == :explicit_comparison
+        def prefer_comparison?
+          style == :comparison
         end
       end
     end

--- a/lib/rubocop/cop/style/nil_comparison.rb
+++ b/lib/rubocop/cop/style/nil_comparison.rb
@@ -3,9 +3,12 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for comparison of something with nil using ==.
+      # This cop checks for comparison of something with nil using `==` and
+      # `nil?`.
       #
-      # @example
+      # Supported styles are: predicate_method, explicit_comparison.
+      #
+      # @example EnforcedStyle: predicate_method (default)
       #
       #   # bad
       #   if x == nil
@@ -14,20 +17,57 @@ module RuboCop
       #   # good
       #   if x.nil?
       #   end
+      #
+      # @example EnforcedStyle: explicit_comparison
+      #
+      #   # bad
+      #   if x.nil?
+      #   end
+      #
+      #   # good
+      #   if x == nil
+      #   end
+      #
       class NilComparison < Cop
-        MSG = 'Prefer the use of the `nil?` predicate.'.freeze
+        include ConfigurableEnforcedStyle
+
+        PREDICATE_MSG = 'Prefer the use of the `nil?` predicate.'.freeze
+        EXPLICIT_MSG = 'Prefer the use of the explicit `==` comparison.'.freeze
 
         def_node_matcher :nil_comparison?, '(send _ {:== :===} nil)'
+        def_node_matcher :nil_check?, '(send _ :nil?)'
 
         def on_send(node)
-          nil_comparison?(node) do
+          style_check?(node) do
             add_offense(node, location: :selector)
           end
         end
 
         def autocorrect(node)
-          new_code = node.source.sub(/\s*={2,3}\s*nil/, '.nil?')
+          new_code = if explicit_comparison?
+                       node.source.sub('.nil?', ' == nil')
+                     else
+                       node.source.sub(/\s*={2,3}\s*nil/, '.nil?')
+                     end
           ->(corrector) { corrector.replace(node.source_range, new_code) }
+        end
+
+        private
+
+        def message(_node)
+          explicit_comparison? ? EXPLICIT_MSG : PREDICATE_MSG
+        end
+
+        def style_check?(node, &block)
+          if explicit_comparison?
+            nil_check?(node, &block)
+          else
+            nil_comparison?(node, &block)
+          end
+        end
+
+        def explicit_comparison?
+          style == :explicit_comparison
         end
       end
     end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3778,9 +3778,14 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-This cop checks for comparison of something with nil using ==.
+This cop checks for comparison of something with nil using `==` and
+`nil?`.
+
+Supported styles are: predicate_method, explicit_comparison.
 
 ### Examples
+
+#### EnforcedStyle: predicate_method (default)
 
 ```ruby
 # bad
@@ -3791,6 +3796,23 @@ end
 if x.nil?
 end
 ```
+#### EnforcedStyle: explicit_comparison
+
+```ruby
+# bad
+if x.nil?
+end
+
+# good
+if x == nil
+end
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `predicate_method` | `predicate_method`, `explicit_comparison`
 
 ### References
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3781,11 +3781,11 @@ Enabled | Yes
 This cop checks for comparison of something with nil using `==` and
 `nil?`.
 
-Supported styles are: predicate_method, explicit_comparison.
+Supported styles are: predicate, comparison.
 
 ### Examples
 
-#### EnforcedStyle: predicate_method (default)
+#### EnforcedStyle: predicate (default)
 
 ```ruby
 # bad
@@ -3796,7 +3796,7 @@ end
 if x.nil?
 end
 ```
-#### EnforcedStyle: explicit_comparison
+#### EnforcedStyle: comparison
 
 ```ruby
 # bad
@@ -3812,7 +3812,7 @@ end
 
 Name | Default value | Configurable values
 --- | --- | ---
-EnforcedStyle | `predicate_method` | `predicate_method`, `explicit_comparison`
+EnforcedStyle | `predicate` | `predicate`, `comparison`
 
 ### References
 

--- a/spec/rubocop/cop/style/nil_comparison_spec.rb
+++ b/spec/rubocop/cop/style/nil_comparison_spec.rb
@@ -3,8 +3,8 @@
 RSpec.describe RuboCop::Cop::Style::NilComparison, :config do
   subject(:cop) { described_class.new(config) }
 
-  context 'configured with predicate_method preferred' do
-    let(:cop_config) { { 'EnforcedStyle' => 'predicate_method' } }
+  context 'configured with predicate preferred' do
+    let(:cop_config) { { 'EnforcedStyle' => 'predicate' } }
 
     it 'registers an offense for == nil' do
       expect_offense(<<-RUBY.strip_indent)
@@ -31,13 +31,13 @@ RSpec.describe RuboCop::Cop::Style::NilComparison, :config do
     end
   end
 
-  context 'configured with explicit_comparison preferred' do
-    let(:cop_config) { { 'EnforcedStyle' => 'explicit_comparison' } }
+  context 'configured with comparison preferred' do
+    let(:cop_config) { { 'EnforcedStyle' => 'comparison' } }
 
     it 'registers an offense for nil?' do
       expect_offense(<<-RUBY.strip_indent)
         x.nil?
-          ^^^^ Prefer the use of the explicit `==` comparison.
+          ^^^^ Prefer the use of the `==` comparison.
       RUBY
     end
 

--- a/spec/rubocop/cop/style/nil_comparison_spec.rb
+++ b/spec/rubocop/cop/style/nil_comparison_spec.rb
@@ -1,29 +1,49 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Style::NilComparison do
-  subject(:cop) { described_class.new }
+RSpec.describe RuboCop::Cop::Style::NilComparison, :config do
+  subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense for == nil' do
-    expect_offense(<<-RUBY.strip_indent)
-      x == nil
-        ^^ Prefer the use of the `nil?` predicate.
-    RUBY
+  context 'configured with predicate_method preferred' do
+    let(:cop_config) { { 'EnforcedStyle' => 'predicate_method' } }
+
+    it 'registers an offense for == nil' do
+      expect_offense(<<-RUBY.strip_indent)
+        x == nil
+          ^^ Prefer the use of the `nil?` predicate.
+      RUBY
+    end
+
+    it 'registers an offense for === nil' do
+      expect_offense(<<-RUBY.strip_indent)
+        x === nil
+          ^^^ Prefer the use of the `nil?` predicate.
+      RUBY
+    end
+
+    it 'autocorrects by replacing == nil with .nil?' do
+      corrected = autocorrect_source('x == nil')
+      expect(corrected).to eq 'x.nil?'
+    end
+
+    it 'autocorrects by replacing === nil with .nil?' do
+      corrected = autocorrect_source('x === nil')
+      expect(corrected).to eq 'x.nil?'
+    end
   end
 
-  it 'registers an offense for === nil' do
-    expect_offense(<<-RUBY.strip_indent)
-      x === nil
-        ^^^ Prefer the use of the `nil?` predicate.
-    RUBY
-  end
+  context 'configured with explicit_comparison preferred' do
+    let(:cop_config) { { 'EnforcedStyle' => 'explicit_comparison' } }
 
-  it 'autocorrects by replacing == nil with .nil?' do
-    corrected = autocorrect_source('x == nil')
-    expect(corrected).to eq 'x.nil?'
-  end
+    it 'registers an offense for nil?' do
+      expect_offense(<<-RUBY.strip_indent)
+        x.nil?
+          ^^^^ Prefer the use of the explicit `==` comparison.
+      RUBY
+    end
 
-  it 'autocorrects by replacing === nil with .nil?' do
-    corrected = autocorrect_source('x === nil')
-    expect(corrected).to eq 'x.nil?'
+    it 'autocorrects by replacing.nil? with == nil' do
+      corrected = autocorrect_source('x.nil?')
+      expect(corrected).to eq 'x == nil'
+    end
   end
 end


### PR DESCRIPTION
## Summary

This PR add a new style for Style/NilComparison. It allows developers to choose which style they  prefer (`nil?` or `== nil`).

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
