### PR TITLE
Self contained CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,15 +8,15 @@ steps: &steps
 
 spec_env: &spec_env
   environment:
-    - TASK: "spec"
+    TASK: "spec"
 
 ascii_spec_env: &ascii_spec_env
   environment:
-    - TASK: "ascii_spec"
+    TASK: "ascii_spec"
 
 rubocop_env: &rubocop_env
   environment:
-    - TASK: "internal_investigation"
+    TASK: "internal_investigation"
 
 jobs:
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,17 +6,30 @@ steps: &steps
     - run: bundle install
     - run: bash .travis.sh
 
+common_env: &common_env
+  # By default we have 2 CPUs and 4GB ram available
+  # https://circleci.com/docs/2.0/configuration-reference/#resource_class
+  JRUBY_OPTS: "--debug -J-Xmn1024m -J-Xms2048m -J-Xmx2048m"
+
+  # CircleCI container has two cores, but Ruby can see 32 cores. So we
+  # configure test-queue.
+  # See https://github.com/tmm1/test-queue#environment-variables
+  TEST_QUEUE_WORKERS: 2
+
 spec_env: &spec_env
   environment:
     TASK: "spec"
+    <<: *common_env
 
 ascii_spec_env: &ascii_spec_env
   environment:
     TASK: "ascii_spec"
+    <<: *common_env
 
 rubocop_env: &rubocop_env
   environment:
     TASK: "internal_investigation"
+    <<: *common_env
 
 jobs:
 
@@ -124,15 +137,3 @@ workflows:
       - jruby-9.2-spec
       - jruby-9.2-ascii_spec
       - jruby-9.2-rubocop
-
-# Two environment variables are added directly in the CircleCI UI:
-# https://circleci.com/gh/rubocop-hq/rubocop/edit#env-vars
-#
-# By default we have 2 CPUs and 4GB ram available
-# https://circleci.com/docs/2.0/configuration-reference/#resource_class
-# JRUBY_OPTS="--debug -J-Xmn1024m -J-Xms2048m -J-Xmx2048m"
-#
-# CircleCI container has two cores, but Ruby can see 32 cores. So we
-# configure test-queue.
-# See https://github.com/tmm1/test-queue#environment-variables
-# TEST_QUEUE_WORKERS=2


### PR DESCRIPTION
This PR makes the CircleCI config self-contained, so it doesn't depend on repo configuration that must be set in CircleCI UI.

As you can [see](https://circleci.com/gh/deivid-rodriguez/rubocop/1205), as opposed to #6220, build now uses two workers instead of 32.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
