### PR TITLE
Remove ascii spec duplication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,6 @@ spec_env: &spec_env
   environment:
     - TASK: "spec"
 
-ascii_spec_env: &ascii_spec_env
-  environment:
-    - TASK: "ascii_spec"
-
 rubocop_env: &rubocop_env
   environment:
     - TASK: "internal_investigation"
@@ -25,11 +21,6 @@ jobs:
     docker:
       - image: circleci/ruby:2.2
     <<: *spec_env
-    <<: *steps
-  ruby-2.2-ascii_spec:
-    docker:
-      - image: circleci/ruby:2.2
-    <<: *ascii_spec_env
     <<: *steps
   ruby-2.2-rubocop:
     docker:
@@ -43,11 +34,6 @@ jobs:
       - image: circleci/ruby:2.3
     <<: *spec_env
     <<: *steps
-  ruby-2.3-ascii_spec:
-    docker:
-      - image: circleci/ruby:2.3
-    <<: *ascii_spec_env
-    <<: *steps
   ruby-2.3-rubocop:
     docker:
       - image: circleci/ruby:2.3
@@ -59,11 +45,6 @@ jobs:
     docker:
       - image: circleci/ruby:2.4
     <<: *spec_env
-    <<: *steps
-  ruby-2.4-ascii_spec:
-    docker:
-      - image: circleci/ruby:2.4
-    <<: *ascii_spec_env
     <<: *steps
   ruby-2.4-rubocop:
     docker:
@@ -77,11 +58,6 @@ jobs:
       - image: circleci/ruby:2.5
     <<: *spec_env
     <<: *steps
-  ruby-2.5-ascii_spec:
-    docker:
-      - image: circleci/ruby:2.5
-    <<: *ascii_spec_env
-    <<: *steps
   ruby-2.5-rubocop:
     docker:
       - image: circleci/ruby:2.5
@@ -94,11 +70,6 @@ jobs:
       - image: circleci/jruby:9.2
     <<: *spec_env
     <<: *steps
-  jruby-9.2-ascii_spec:
-    docker:
-      - image: circleci/jruby:9.2
-    <<: *ascii_spec_env
-    <<: *steps
   jruby-9.2-rubocop:
     docker:
       - image: circleci/jruby:9.2
@@ -110,19 +81,14 @@ workflows:
   build:
     jobs:
       - ruby-2.2-spec
-      - ruby-2.2-ascii_spec
       - ruby-2.2-rubocop
       - ruby-2.3-spec
-      - ruby-2.3-ascii_spec
       - ruby-2.3-rubocop
       - ruby-2.4-spec
-      - ruby-2.4-ascii_spec
       - ruby-2.4-rubocop
       - ruby-2.5-spec
-      - ruby-2.5-ascii_spec
       - ruby-2.5-rubocop
       - jruby-9.2-spec
-      - jruby-9.2-ascii_spec
       - jruby-9.2-rubocop
 
 # Two environment variables are added directly in the CircleCI UI:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ env:
     - TEST_QUEUE_WORKERS=2
   matrix:
     - 'TASK=spec'
-    - 'TASK=ascii_spec'
     - 'TASK=internal_investigation'
 matrix:
   allow_failures:

--- a/Rakefile
+++ b/Rakefile
@@ -21,9 +21,11 @@ task :spec do
   sh('rspec spec/')
 end
 
-desc 'Run RSpec with ASCII encoding'
+desc "Run RSpec's encoding-related specs with ASCII encoding"
 task :ascii_spec do
-  sh('RUBYOPT="$RUBYOPT -E ASCII" rspec spec/')
+  sh('RUBYOPT="$RUBYOPT -E ASCII" rspec ' \
+     'spec/rubocop/config_loader_spec.rb ' \
+     'spec/rubocop/cop/style/string_literals_spec.rb')
 end
 
 desc 'Run test and RuboCop in parallel'
@@ -39,9 +41,11 @@ namespace :parallel do
     sh('rspec-queue spec/')
   end
 
-  desc 'Run RSpec in parallel with ASCII encoding'
+  desc "Run RSpec's encoding-related specs with ASCII encoding in parallel"
   task :ascii_spec do
-    sh('RUBYOPT="$RUBYOPT -E ASCII" rspec-queue spec/')
+    sh('RUBYOPT="$RUBYOPT -E ASCII" rspec-queue ' \
+       'spec/rubocop/config_loader_spec.rb ' \
+       'spec/rubocop/cop/style/string_literals_spec.rb')
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -16,8 +16,15 @@ require 'rubocop/rake_task'
 
 Dir['tasks/**/*.rake'].each { |t| load t }
 
-RSpec::Core::RakeTask.new(:spec)
-RSpec::Core::RakeTask.new(:ascii_spec) { |t| t.ruby_opts = '-E ASCII' }
+desc 'Run RSpec'
+task :spec do
+  sh('rspec spec/')
+end
+
+desc 'Run RSpec with ASCII encoding'
+task :ascii_spec do
+  sh('RUBYOPT="$RUBYOPT -E ASCII" rspec spec/')
+end
 
 desc 'Run test and RuboCop in parallel'
 task parallel: %i[

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,10 @@ require 'rubocop/rake_task'
 Dir['tasks/**/*.rake'].each { |t| load t }
 
 desc 'Run RSpec'
-task :spec do
+task spec: %i[default_spec ascii_spec]
+
+desc 'Run default RSpec'
+task :default_spec do
   sh('rspec spec/')
 end
 
@@ -31,14 +34,17 @@ end
 desc 'Run test and RuboCop in parallel'
 task parallel: %i[
   documentation_syntax_check generate_cops_documentation
-  parallel:spec parallel:ascii_spec
+  parallel:spec
   internal_investigation
 ]
 
 namespace :parallel do
   desc 'Run RSpec in parallel'
-  task :spec do
-    sh('rspec-queue spec/')
+  task spec: %i[default_spec ascii_spec]
+
+  desc 'Run default RSpec in parallel'
+  task :default_spec do
+    sh('rspec spec/')
   end
 
   desc "Run RSpec's encoding-related specs with ASCII encoding in parallel"
@@ -65,7 +71,7 @@ end
 
 task default: %i[
   documentation_syntax_check generate_cops_documentation
-  spec ascii_spec
+  spec
   internal_investigation
 ]
 

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ require 'rubocop/rake_task'
 
 Dir['tasks/**/*.rake'].each { |t| load t }
 
-RSpec::Core::RakeTask.new(:spec) { |t| t.ruby_opts = '-E UTF-8' }
+RSpec::Core::RakeTask.new(:spec)
 RSpec::Core::RakeTask.new(:ascii_spec) { |t| t.ruby_opts = '-E ASCII' }
 
 desc 'Run test and RuboCop in parallel'

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -169,7 +169,7 @@ module RuboCop
       # stderr. Care is taken to use the standard OS exit code for a "file not
       # found" error.
       def read_file(absolute_path)
-        IO.read(absolute_path, encoding: Encoding::UTF_8)
+        IO.read(absolute_path)
       rescue Errno::ENOENT
         raise ConfigNotFoundError,
               "Configuration file not found: #{absolute_path}"

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -98,7 +98,7 @@ module RuboCop
       end
 
       def to_string_literal(string)
-        if needs_escaping?(string) && compatible_external_encoding_for?(string)
+        if needs_escaping?(string)
           string.inspect
         else
           "'#{string.gsub('\\') { '\\\\' }}'"
@@ -132,13 +132,6 @@ module RuboCop
         @tokens[node.object_id] = processed_source.tokens.select do |token|
           token.end_pos <= end_pos && token.begin_pos >= begin_pos
         end
-      end
-
-      private
-
-      def compatible_external_encoding_for?(src)
-        src = src.dup if RUBY_VERSION < '2.3' || RUBY_ENGINE == 'jruby'
-        src.force_encoding(Encoding.default_external).valid_encoding?
       end
     end
   end


### PR DESCRIPTION
This is a follow up to https://github.com/rubocop-hq/rubocop/pull/6220#issuecomment-416057213. With these changes, the `ascii_spec` task goes down from ~50 seconds to ~2 seconds.

I intentionally added https://github.com/rubocop-hq/rubocop/commit/0451970f16c40825acf5a95c83f52c6edfb2c2ab temporarily to prove that these specs are actually preventing regressions, so are worth keeping.
 
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
