### PR TITLE
Improve some error messages

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -152,7 +152,7 @@ Layout/AccessModifierIndentation:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
-# Make sure all lines containing elements of a hash literal have the same indentation.
+# Make sure all lines containing elements on a hash literal have the same indentation.
 Layout/AlignHash:
   # Alignment of entries using hash rocket as separator. Valid values are:
   #

--- a/config/default.yml
+++ b/config/default.yml
@@ -152,7 +152,7 @@ Layout/AccessModifierIndentation:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
-# Ensure lines containing elements on a hash literal have the same indentation.
+# Ensure lines containing elements of a hash literal have the same indentation.
 Layout/AlignHash:
   # Alignment of entries using hash rocket as separator. Valid values are:
   #

--- a/config/default.yml
+++ b/config/default.yml
@@ -152,7 +152,7 @@ Layout/AccessModifierIndentation:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
-# Align the elements of a hash literal if they span more than one line.
+# Make sure all lines containing elements of a hash literal have the same indentation.
 Layout/AlignHash:
   # Alignment of entries using hash rocket as separator. Valid values are:
   #

--- a/config/default.yml
+++ b/config/default.yml
@@ -152,7 +152,7 @@ Layout/AccessModifierIndentation:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
-# Make sure all lines containing elements on a hash literal have the same indentation.
+# Ensure lines containing elements on a hash literal have the same indentation.
 Layout/AlignHash:
   # Alignment of entries using hash rocket as separator. Valid values are:
   #

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -60,21 +60,21 @@ Layout/AccessModifierIndentation:
 
 Layout/AlignArray:
   Description: >-
-                 Align the elements of an array literal if they span more than
-                 one line.
+                 Make sure all lines containing elements on an array literal have
+                 the same indentation.
   StyleGuide: '#align-multiline-arrays'
   Enabled: true
 
 Layout/AlignHash:
   Description: >-
-                 Align the elements of a hash literal if they span more than
-                 one line.
+                 Make sure all lines containing elements on a hash literal have
+                 the same indentation.
   Enabled: true
 
 Layout/AlignParameters:
   Description: >-
-                 Align the parameters of a method call if they span more
-                 than one line.
+                 Make sure all lines containing parameters on a method call have
+                 the same indentation.
   StyleGuide: '#no-double-indent'
   Enabled: true
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -60,20 +60,20 @@ Layout/AccessModifierIndentation:
 
 Layout/AlignArray:
   Description: >-
-                 Ensure lines containing elements on an array literal have
+                 Ensure lines containing elements of an array literal have
                  the same indentation.
   StyleGuide: '#align-multiline-arrays'
   Enabled: true
 
 Layout/AlignHash:
   Description: >-
-                 Ensure lines containing elements on a hash literal have
+                 Ensure lines containing elements of a hash literal have
                  the same indentation.
   Enabled: true
 
 Layout/AlignParameters:
   Description: >-
-                 Ensure lines containing parameters on a method call have
+                 Ensure lines containing parameters of a method call have
                  the same indentation.
   StyleGuide: '#no-double-indent'
   Enabled: true

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -60,20 +60,20 @@ Layout/AccessModifierIndentation:
 
 Layout/AlignArray:
   Description: >-
-                 Make sure all lines containing elements on an array literal have
+                 Ensure lines containing elements on an array literal have
                  the same indentation.
   StyleGuide: '#align-multiline-arrays'
   Enabled: true
 
 Layout/AlignHash:
   Description: >-
-                 Make sure all lines containing elements on a hash literal have
+                 Ensure lines containing elements on a hash literal have
                  the same indentation.
   Enabled: true
 
 Layout/AlignParameters:
   Description: >-
-                 Make sure all lines containing parameters on a method call have
+                 Ensure lines containing parameters on a method call have
                  the same indentation.
   StyleGuide: '#no-double-indent'
   Enabled: true

--- a/lib/rubocop/cop/layout/align_array.rb
+++ b/lib/rubocop/cop/layout/align_array.rb
@@ -23,7 +23,7 @@ module RuboCop
       class AlignArray < Cop
         include Alignment
 
-        MSG = 'Make sure all lines containing elements on an array literal ' \
+        MSG = 'Ensure lines containing elements on an array literal ' \
               'have the same indentation.'.freeze
 
         def on_array(node)

--- a/lib/rubocop/cop/layout/align_array.rb
+++ b/lib/rubocop/cop/layout/align_array.rb
@@ -23,8 +23,8 @@ module RuboCop
       class AlignArray < Cop
         include Alignment
 
-        MSG = 'Align the elements of an array literal if they span more ' \
-              'than one line.'.freeze
+        MSG = 'Make sure all lines containing elements on an array literal ' \
+              'have the same indentation.'.freeze
 
         def on_array(node)
           check_alignment(node.children)

--- a/lib/rubocop/cop/layout/align_array.rb
+++ b/lib/rubocop/cop/layout/align_array.rb
@@ -3,8 +3,8 @@
 module RuboCop
   module Cop
     module Layout
-      # Here we check if the elements of a multi-line array literal are
-      # aligned.
+      # Here we check if all lines containing elements of a multi-line array
+      # literal have the same indentation.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/layout/align_array.rb
+++ b/lib/rubocop/cop/layout/align_array.rb
@@ -23,7 +23,7 @@ module RuboCop
       class AlignArray < Cop
         include Alignment
 
-        MSG = 'Ensure lines containing elements on an array literal ' \
+        MSG = 'Ensure lines containing elements of an array literal ' \
               'have the same indentation.'.freeze
 
         def on_array(node)

--- a/lib/rubocop/cop/layout/align_hash.rb
+++ b/lib/rubocop/cop/layout/align_hash.rb
@@ -169,7 +169,7 @@ module RuboCop
         include HashAlignment
         include RangeHelp
 
-        MSG = 'Make sure all lines containing elements on a hash literal ' \
+        MSG = 'Ensure lines containing elements on a hash literal ' \
               'have the same indentation.'.freeze
 
         def on_send(node)

--- a/lib/rubocop/cop/layout/align_hash.rb
+++ b/lib/rubocop/cop/layout/align_hash.rb
@@ -169,8 +169,8 @@ module RuboCop
         include HashAlignment
         include RangeHelp
 
-        MSG = 'Align the elements of a hash literal if they span more than ' \
-              'one line.'.freeze
+        MSG = 'Make sure all lines containing elements on a hash literal ' \
+              'have the same indentation.'.freeze
 
         def on_send(node)
           return if double_splat?(node)

--- a/lib/rubocop/cop/layout/align_hash.rb
+++ b/lib/rubocop/cop/layout/align_hash.rb
@@ -169,7 +169,7 @@ module RuboCop
         include HashAlignment
         include RangeHelp
 
-        MSG = 'Ensure lines containing elements on a hash literal ' \
+        MSG = 'Ensure lines containing elements of a hash literal ' \
               'have the same indentation.'.freeze
 
         def on_send(node)

--- a/lib/rubocop/cop/layout/align_parameters.rb
+++ b/lib/rubocop/cop/layout/align_parameters.rb
@@ -3,8 +3,8 @@
 module RuboCop
   module Cop
     module Layout
-      # Here we check if the parameters on a multi-line method call or
-      # definition are aligned.
+      # Here we check if all lines containing parameters of a multi-line method
+      # call or definition have the same indentation.
       #
       # @example EnforcedStyle: with_first_parameter (default)
       #   # good

--- a/lib/rubocop/cop/layout/align_parameters.rb
+++ b/lib/rubocop/cop/layout/align_parameters.rb
@@ -30,7 +30,7 @@ module RuboCop
       class AlignParameters < Cop
         include Alignment
 
-        ALIGN_PARAMS_MSG = 'Make sure all lines containing parameters on a ' \
+        ALIGN_PARAMS_MSG = 'Ensure lines containing parameters on a ' \
           'method %<type>s have the same indentation.'.freeze
 
         FIXED_INDENT_MSG = 'Use one level of indentation for parameters ' \

--- a/lib/rubocop/cop/layout/align_parameters.rb
+++ b/lib/rubocop/cop/layout/align_parameters.rb
@@ -30,8 +30,8 @@ module RuboCop
       class AlignParameters < Cop
         include Alignment
 
-        ALIGN_PARAMS_MSG = 'Align the parameters of a method %<type>s if ' \
-          'they span more than one line.'.freeze
+        ALIGN_PARAMS_MSG = 'Make sure all lines containing parameters on a ' \
+          'method %<type>s have the same indentation.'.freeze
 
         FIXED_INDENT_MSG = 'Use one level of indentation for parameters ' \
           'following the first line of a multi-line method %<type>s.'.freeze

--- a/lib/rubocop/cop/layout/align_parameters.rb
+++ b/lib/rubocop/cop/layout/align_parameters.rb
@@ -30,7 +30,7 @@ module RuboCop
       class AlignParameters < Cop
         include Alignment
 
-        ALIGN_PARAMS_MSG = 'Ensure lines containing parameters on a ' \
+        ALIGN_PARAMS_MSG = 'Ensure lines containing parameters of a ' \
           'method %<type>s have the same indentation.'.freeze
 
         FIXED_INDENT_MSG = 'Use one level of indentation for parameters ' \

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -59,8 +59,8 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-Here we check if the elements of a multi-line array literal are
-aligned.
+Here we check if all lines containing elements of a multi-line array
+literal have the same indentation.
 
 ### Examples
 
@@ -289,8 +289,8 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-Here we check if the parameters on a multi-line method call or
-definition are aligned.
+Here we check if all lines containing parameters of a multi-line method
+call or definition have the same indentation.
 
 ### Examples
 

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1066,7 +1066,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       example.rb:1:1: C: [Corrected] Style/SignalException: Always use raise to signal exceptions.
       fail NotImplementedError,
       ^^^^
-      example.rb:2:6: C: [Corrected] Layout/AlignParameters: Ensure lines containing parameters on a method call have the same indentation.
+      example.rb:2:6: C: [Corrected] Layout/AlignParameters: Ensure lines containing parameters of a method call have the same indentation.
            'Method should be overridden in child classes'
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1066,7 +1066,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       example.rb:1:1: C: [Corrected] Style/SignalException: Always use raise to signal exceptions.
       fail NotImplementedError,
       ^^^^
-      example.rb:2:6: C: [Corrected] Layout/AlignParameters: Align the parameters of a method call if they span more than one line.
+      example.rb:2:6: C: [Corrected] Layout/AlignParameters: Make sure all lines containing parameters on a method call have the same indentation.
            'Method should be overridden in child classes'
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1066,7 +1066,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       example.rb:1:1: C: [Corrected] Style/SignalException: Always use raise to signal exceptions.
       fail NotImplementedError,
       ^^^^
-      example.rb:2:6: C: [Corrected] Layout/AlignParameters: Make sure all lines containing parameters on a method call have the same indentation.
+      example.rb:2:6: C: [Corrected] Layout/AlignParameters: Ensure lines containing parameters on a method call have the same indentation.
            'Method should be overridden in child classes'
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/spec/rubocop/cop/layout/align_array_spec.rb
+++ b/spec/rubocop/cop/layout/align_array_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe RuboCop::Cop::Layout::AlignArray do
       array = [
         a,
          b,
-         ^ Make sure all lines containing array literal elements have the same indentation.
+         ^ Make sure all lines containing elements on an array literal have the same indentation.
         c,
          d
-         ^ Make sure all lines containing array literal elements have the same indentation.
+         ^ Make sure all lines containing elements on an array literal have the same indentation.
       ]
     RUBY
   end

--- a/spec/rubocop/cop/layout/align_array_spec.rb
+++ b/spec/rubocop/cop/layout/align_array_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe RuboCop::Cop::Layout::AlignArray do
       array = [
         a,
          b,
-         ^ Make sure all lines containing elements on an array literal have the same indentation.
+         ^ Ensure lines containing elements on an array literal have the same indentation.
         c,
          d
-         ^ Make sure all lines containing elements on an array literal have the same indentation.
+         ^ Ensure lines containing elements on an array literal have the same indentation.
       ]
     RUBY
   end

--- a/spec/rubocop/cop/layout/align_array_spec.rb
+++ b/spec/rubocop/cop/layout/align_array_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe RuboCop::Cop::Layout::AlignArray do
       array = [
         a,
          b,
-         ^ Ensure lines containing elements on an array literal have the same indentation.
+         ^ Ensure lines containing elements of an array literal have the same indentation.
         c,
          d
-         ^ Ensure lines containing elements on an array literal have the same indentation.
+         ^ Ensure lines containing elements of an array literal have the same indentation.
       ]
     RUBY
   end

--- a/spec/rubocop/cop/layout/align_array_spec.rb
+++ b/spec/rubocop/cop/layout/align_array_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe RuboCop::Cop::Layout::AlignArray do
       array = [
         a,
          b,
-         ^ Align the elements of an array literal if they span more than one line.
+         ^ Make sure all lines containing array literal elements have the same indentation.
         c,
          d
-         ^ Align the elements of an array literal if they span more than one line.
+         ^ Make sure all lines containing array literal elements have the same indentation.
       ]
     RUBY
   end

--- a/spec/rubocop/cop/layout/align_hash_spec.rb
+++ b/spec/rubocop/cop/layout/align_hash_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         func(a: 0,
           b: 1)
-          ^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
+          ^^^^ Ensure lines containing elements on a hash literal have the same indentation.
       RUBY
     end
 
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         func({a: 0,
           b: 1})
-          ^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
+          ^^^^ Ensure lines containing elements on a hash literal have the same indentation.
       RUBY
     end
   end
@@ -103,7 +103,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         func({a: 0,
           b: 1})
-          ^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
+          ^^^^ Ensure lines containing elements on a hash literal have the same indentation.
       RUBY
     end
   end
@@ -119,7 +119,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         func(a: 0,
           b: 1)
-          ^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
+          ^^^^ Ensure lines containing elements on a hash literal have the same indentation.
       RUBY
     end
 
@@ -137,12 +137,12 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash1 = {
           a: 0,
            bb: 1
-           ^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
+           ^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
         }
         hash2 = {
           'ccc' => 2,
          'dddd'  =>  2
-         ^^^^^^^^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
+         ^^^^^^^^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
         }
       RUBY
     end
@@ -151,7 +151,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         hash = { a: 1, b: 2,
                 c: 3 }
-                ^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
+                ^^^^ Ensure lines containing elements on a hash literal have the same indentation.
       RUBY
     end
 
@@ -173,7 +173,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash = {
             'a' => 0,
           'bbb' => 1
-          ^^^^^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
+          ^^^^^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
         }
       RUBY
     end
@@ -183,7 +183,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         expect_offense(<<-RUBY.strip_indent)
           func(a: 0,
             b: 1)
-            ^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
+            ^^^^ Ensure lines containing elements on a hash literal have the same indentation.
         RUBY
       end
 
@@ -191,7 +191,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         expect_offense(<<-RUBY.strip_indent)
           func(a: 0,
              bbb: 1)
-             ^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
+             ^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
         RUBY
       end
 
@@ -351,13 +351,13 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         hash1 = {
           'a'   =>  0,
-          ^^^^^^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
+          ^^^^^^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
           'bbb' => 1
         }
         hash2 = {
           a:   0,
           bbb:1
-          ^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
+          ^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
         }
       RUBY
     end
@@ -366,15 +366,15 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         hash1 = {
           'a'   =>  0,
-          ^^^^^^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
+          ^^^^^^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
          'bbb'  =>  1
-         ^^^^^^^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
+         ^^^^^^^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
         }
         hash2 = {
            a:  0,
-           ^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
+           ^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
           bbb: 1
-          ^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
+          ^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
         }
       RUBY
     end
@@ -384,7 +384,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash = {
           'a'   => 0,
           'bbb'  => 1
-          ^^^^^^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
+          ^^^^^^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
         }
       RUBY
     end
@@ -471,7 +471,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash = {
             'a' =>  0,
           'bbb' => 1
-          ^^^^^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
+          ^^^^^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
         }
       RUBY
     end
@@ -481,7 +481,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash = {
             'a'  => 0,
           'bbb' =>  1
-          ^^^^^^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
+          ^^^^^^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
         }
       RUBY
     end
@@ -545,12 +545,12 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash1 = {
           a:   0,
           bbb: 1
-          ^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
+          ^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
         }
         hash2 = {
             'a' => 0,
           'bbb' => 1
-          ^^^^^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
+          ^^^^^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
         }
       RUBY
     end

--- a/spec/rubocop/cop/layout/align_hash_spec.rb
+++ b/spec/rubocop/cop/layout/align_hash_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         func(a: 0,
           b: 1)
-          ^^^^ Ensure lines containing elements on a hash literal have the same indentation.
+          ^^^^ Ensure lines containing elements of a hash literal have the same indentation.
       RUBY
     end
 
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         func({a: 0,
           b: 1})
-          ^^^^ Ensure lines containing elements on a hash literal have the same indentation.
+          ^^^^ Ensure lines containing elements of a hash literal have the same indentation.
       RUBY
     end
   end
@@ -103,7 +103,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         func({a: 0,
           b: 1})
-          ^^^^ Ensure lines containing elements on a hash literal have the same indentation.
+          ^^^^ Ensure lines containing elements of a hash literal have the same indentation.
       RUBY
     end
   end
@@ -119,7 +119,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         func(a: 0,
           b: 1)
-          ^^^^ Ensure lines containing elements on a hash literal have the same indentation.
+          ^^^^ Ensure lines containing elements of a hash literal have the same indentation.
       RUBY
     end
 
@@ -137,12 +137,12 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash1 = {
           a: 0,
            bb: 1
-           ^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
+           ^^^^^ Ensure lines containing elements of a hash literal have the same indentation.
         }
         hash2 = {
           'ccc' => 2,
          'dddd'  =>  2
-         ^^^^^^^^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
+         ^^^^^^^^^^^^^ Ensure lines containing elements of a hash literal have the same indentation.
         }
       RUBY
     end
@@ -151,7 +151,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         hash = { a: 1, b: 2,
                 c: 3 }
-                ^^^^ Ensure lines containing elements on a hash literal have the same indentation.
+                ^^^^ Ensure lines containing elements of a hash literal have the same indentation.
       RUBY
     end
 
@@ -173,7 +173,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash = {
             'a' => 0,
           'bbb' => 1
-          ^^^^^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
+          ^^^^^^^^^^ Ensure lines containing elements of a hash literal have the same indentation.
         }
       RUBY
     end
@@ -183,7 +183,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         expect_offense(<<-RUBY.strip_indent)
           func(a: 0,
             b: 1)
-            ^^^^ Ensure lines containing elements on a hash literal have the same indentation.
+            ^^^^ Ensure lines containing elements of a hash literal have the same indentation.
         RUBY
       end
 
@@ -191,7 +191,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         expect_offense(<<-RUBY.strip_indent)
           func(a: 0,
              bbb: 1)
-             ^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
+             ^^^^^^ Ensure lines containing elements of a hash literal have the same indentation.
         RUBY
       end
 
@@ -351,13 +351,13 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         hash1 = {
           'a'   =>  0,
-          ^^^^^^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
+          ^^^^^^^^^^^ Ensure lines containing elements of a hash literal have the same indentation.
           'bbb' => 1
         }
         hash2 = {
           a:   0,
           bbb:1
-          ^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
+          ^^^^^ Ensure lines containing elements of a hash literal have the same indentation.
         }
       RUBY
     end
@@ -366,15 +366,15 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         hash1 = {
           'a'   =>  0,
-          ^^^^^^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
+          ^^^^^^^^^^^ Ensure lines containing elements of a hash literal have the same indentation.
          'bbb'  =>  1
-         ^^^^^^^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
+         ^^^^^^^^^^^^ Ensure lines containing elements of a hash literal have the same indentation.
         }
         hash2 = {
            a:  0,
-           ^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
+           ^^^^^ Ensure lines containing elements of a hash literal have the same indentation.
           bbb: 1
-          ^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
+          ^^^^^^ Ensure lines containing elements of a hash literal have the same indentation.
         }
       RUBY
     end
@@ -384,7 +384,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash = {
           'a'   => 0,
           'bbb'  => 1
-          ^^^^^^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
+          ^^^^^^^^^^^ Ensure lines containing elements of a hash literal have the same indentation.
         }
       RUBY
     end
@@ -471,7 +471,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash = {
             'a' =>  0,
           'bbb' => 1
-          ^^^^^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
+          ^^^^^^^^^^ Ensure lines containing elements of a hash literal have the same indentation.
         }
       RUBY
     end
@@ -481,7 +481,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash = {
             'a'  => 0,
           'bbb' =>  1
-          ^^^^^^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
+          ^^^^^^^^^^^ Ensure lines containing elements of a hash literal have the same indentation.
         }
       RUBY
     end
@@ -545,12 +545,12 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash1 = {
           a:   0,
           bbb: 1
-          ^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
+          ^^^^^^ Ensure lines containing elements of a hash literal have the same indentation.
         }
         hash2 = {
             'a' => 0,
           'bbb' => 1
-          ^^^^^^^^^^ Ensure lines containing elements on a hash literal have the same indentation.
+          ^^^^^^^^^^ Ensure lines containing elements of a hash literal have the same indentation.
         }
       RUBY
     end

--- a/spec/rubocop/cop/layout/align_hash_spec.rb
+++ b/spec/rubocop/cop/layout/align_hash_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         func(a: 0,
           b: 1)
-          ^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
       RUBY
     end
 
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         func({a: 0,
           b: 1})
-          ^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
       RUBY
     end
   end
@@ -103,7 +103,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         func({a: 0,
           b: 1})
-          ^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
       RUBY
     end
   end
@@ -119,7 +119,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         func(a: 0,
           b: 1)
-          ^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
       RUBY
     end
 
@@ -137,12 +137,12 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash1 = {
           a: 0,
            bb: 1
-           ^^^^^ Align the elements of a hash literal if they span more than one line.
+           ^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
         }
         hash2 = {
           'ccc' => 2,
          'dddd'  =>  2
-         ^^^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+         ^^^^^^^^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
         }
       RUBY
     end
@@ -151,7 +151,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         hash = { a: 1, b: 2,
                 c: 3 }
-                ^^^^ Align the elements of a hash literal if they span more than one line.
+                ^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
       RUBY
     end
 
@@ -173,7 +173,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash = {
             'a' => 0,
           'bbb' => 1
-          ^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
         }
       RUBY
     end
@@ -183,7 +183,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         expect_offense(<<-RUBY.strip_indent)
           func(a: 0,
             b: 1)
-            ^^^^ Align the elements of a hash literal if they span more than one line.
+            ^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
         RUBY
       end
 
@@ -191,7 +191,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         expect_offense(<<-RUBY.strip_indent)
           func(a: 0,
              bbb: 1)
-             ^^^^^^ Align the elements of a hash literal if they span more than one line.
+             ^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
         RUBY
       end
 
@@ -351,13 +351,13 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         hash1 = {
           'a'   =>  0,
-          ^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
           'bbb' => 1
         }
         hash2 = {
           a:   0,
           bbb:1
-          ^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
         }
       RUBY
     end
@@ -366,15 +366,15 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         hash1 = {
           'a'   =>  0,
-          ^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
          'bbb'  =>  1
-         ^^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+         ^^^^^^^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
         }
         hash2 = {
            a:  0,
-           ^^^^^ Align the elements of a hash literal if they span more than one line.
+           ^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
           bbb: 1
-          ^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
         }
       RUBY
     end
@@ -384,7 +384,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash = {
           'a'   => 0,
           'bbb'  => 1
-          ^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
         }
       RUBY
     end
@@ -471,7 +471,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash = {
             'a' =>  0,
           'bbb' => 1
-          ^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
         }
       RUBY
     end
@@ -481,7 +481,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash = {
             'a'  => 0,
           'bbb' =>  1
-          ^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
         }
       RUBY
     end
@@ -545,12 +545,12 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash1 = {
           a:   0,
           bbb: 1
-          ^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
         }
         hash2 = {
             'a' => 0,
           'bbb' => 1
-          ^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
         }
       RUBY
     end

--- a/spec/rubocop/cop/layout/align_hash_spec.rb
+++ b/spec/rubocop/cop/layout/align_hash_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         func(a: 0,
           b: 1)
-          ^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
+          ^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
       RUBY
     end
 
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         func({a: 0,
           b: 1})
-          ^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
+          ^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
       RUBY
     end
   end
@@ -103,7 +103,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         func({a: 0,
           b: 1})
-          ^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
+          ^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
       RUBY
     end
   end
@@ -119,7 +119,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         func(a: 0,
           b: 1)
-          ^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
+          ^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
       RUBY
     end
 
@@ -137,12 +137,12 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash1 = {
           a: 0,
            bb: 1
-           ^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
+           ^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
         }
         hash2 = {
           'ccc' => 2,
          'dddd'  =>  2
-         ^^^^^^^^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
+         ^^^^^^^^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
         }
       RUBY
     end
@@ -151,7 +151,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         hash = { a: 1, b: 2,
                 c: 3 }
-                ^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
+                ^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
       RUBY
     end
 
@@ -173,7 +173,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash = {
             'a' => 0,
           'bbb' => 1
-          ^^^^^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
+          ^^^^^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
         }
       RUBY
     end
@@ -183,7 +183,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         expect_offense(<<-RUBY.strip_indent)
           func(a: 0,
             b: 1)
-            ^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
+            ^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
         RUBY
       end
 
@@ -191,7 +191,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         expect_offense(<<-RUBY.strip_indent)
           func(a: 0,
              bbb: 1)
-             ^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
+             ^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
         RUBY
       end
 
@@ -351,13 +351,13 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         hash1 = {
           'a'   =>  0,
-          ^^^^^^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
+          ^^^^^^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
           'bbb' => 1
         }
         hash2 = {
           a:   0,
           bbb:1
-          ^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
+          ^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
         }
       RUBY
     end
@@ -366,15 +366,15 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       expect_offense(<<-RUBY.strip_indent)
         hash1 = {
           'a'   =>  0,
-          ^^^^^^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
+          ^^^^^^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
          'bbb'  =>  1
-         ^^^^^^^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
+         ^^^^^^^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
         }
         hash2 = {
            a:  0,
-           ^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
+           ^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
           bbb: 1
-          ^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
+          ^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
         }
       RUBY
     end
@@ -384,7 +384,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash = {
           'a'   => 0,
           'bbb'  => 1
-          ^^^^^^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
+          ^^^^^^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
         }
       RUBY
     end
@@ -471,7 +471,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash = {
             'a' =>  0,
           'bbb' => 1
-          ^^^^^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
+          ^^^^^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
         }
       RUBY
     end
@@ -481,7 +481,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash = {
             'a'  => 0,
           'bbb' =>  1
-          ^^^^^^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
+          ^^^^^^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
         }
       RUBY
     end
@@ -545,12 +545,12 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         hash1 = {
           a:   0,
           bbb: 1
-          ^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
+          ^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
         }
         hash2 = {
             'a' => 0,
           'bbb' => 1
-          ^^^^^^^^^^ Make sure all lines containing elements of a hash literal have the same indentation.
+          ^^^^^^^^^^ Make sure all lines containing elements on a hash literal have the same indentation.
         }
       RUBY
     end

--- a/spec/rubocop/cop/layout/align_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/align_parameters_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
       expect_offense(<<-RUBY.strip_indent)
         function(a,
           if b then c else d end)
-          ^^^^^^^^^^^^^^^^^^^^^^ Make sure all lines containing parameters on a method call have the same indentation.
+          ^^^^^^^^^^^^^^^^^^^^^^ Ensure lines containing parameters on a method call have the same indentation.
       RUBY
     end
 
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
       expect_offense(<<-RUBY.strip_indent)
         function(a,
             if b then c else d end)
-            ^^^^^^^^^^^^^^^^^^^^^^ Make sure all lines containing parameters on a method call have the same indentation.
+            ^^^^^^^^^^^^^^^^^^^^^^ Ensure lines containing parameters on a method call have the same indentation.
       RUBY
     end
 
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
               c)
         func2(a,
              *b,
-             ^^ Make sure all lines containing parameters on a method call have the same indentation.
+             ^^ Ensure lines containing parameters on a method call have the same indentation.
               c)
         func3(*a)
       RUBY
@@ -85,7 +85,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
       expect_offense(<<-RUBY.strip_indent)
         func1(a,
              b,)
-             ^ Make sure all lines containing parameters on a method call have the same indentation.
+             ^ Ensure lines containing parameters on a method call have the same indentation.
       RUBY
     end
 
@@ -223,7 +223,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
         expect_offense(<<-RUBY.strip_indent)
           def method(a,
             b)
-            ^ Make sure all lines containing parameters on a method definition have the same indentation.
+            ^ Ensure lines containing parameters on a method definition have the same indentation.
           end
         RUBY
       end
@@ -232,7 +232,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
         expect_offense(<<-RUBY.strip_indent)
           def method(a,
               b)
-              ^ Make sure all lines containing parameters on a method definition have the same indentation.
+              ^ Ensure lines containing parameters on a method definition have the same indentation.
           end
         RUBY
       end
@@ -272,7 +272,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
         expect_offense(<<-RUBY.strip_indent)
           def func2(a,
                    *b,
-                   ^^ Make sure all lines containing parameters on a method definition have the same indentation.
+                   ^^ Ensure lines containing parameters on a method definition have the same indentation.
                     c)
           end
         RUBY
@@ -296,7 +296,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
           expect_offense(<<-RUBY.strip_indent)
             def self.method(a,
               b)
-              ^ Make sure all lines containing parameters on a method definition have the same indentation.
+              ^ Ensure lines containing parameters on a method definition have the same indentation.
             end
           RUBY
         end

--- a/spec/rubocop/cop/layout/align_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/align_parameters_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
       expect_offense(<<-RUBY.strip_indent)
         function(a,
           if b then c else d end)
-          ^^^^^^^^^^^^^^^^^^^^^^ Ensure lines containing parameters on a method call have the same indentation.
+          ^^^^^^^^^^^^^^^^^^^^^^ Ensure lines containing parameters of a method call have the same indentation.
       RUBY
     end
 
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
       expect_offense(<<-RUBY.strip_indent)
         function(a,
             if b then c else d end)
-            ^^^^^^^^^^^^^^^^^^^^^^ Ensure lines containing parameters on a method call have the same indentation.
+            ^^^^^^^^^^^^^^^^^^^^^^ Ensure lines containing parameters of a method call have the same indentation.
       RUBY
     end
 
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
               c)
         func2(a,
              *b,
-             ^^ Ensure lines containing parameters on a method call have the same indentation.
+             ^^ Ensure lines containing parameters of a method call have the same indentation.
               c)
         func3(*a)
       RUBY
@@ -85,7 +85,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
       expect_offense(<<-RUBY.strip_indent)
         func1(a,
              b,)
-             ^ Ensure lines containing parameters on a method call have the same indentation.
+             ^ Ensure lines containing parameters of a method call have the same indentation.
       RUBY
     end
 
@@ -223,7 +223,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
         expect_offense(<<-RUBY.strip_indent)
           def method(a,
             b)
-            ^ Ensure lines containing parameters on a method definition have the same indentation.
+            ^ Ensure lines containing parameters of a method definition have the same indentation.
           end
         RUBY
       end
@@ -232,7 +232,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
         expect_offense(<<-RUBY.strip_indent)
           def method(a,
               b)
-              ^ Ensure lines containing parameters on a method definition have the same indentation.
+              ^ Ensure lines containing parameters of a method definition have the same indentation.
           end
         RUBY
       end
@@ -272,7 +272,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
         expect_offense(<<-RUBY.strip_indent)
           def func2(a,
                    *b,
-                   ^^ Ensure lines containing parameters on a method definition have the same indentation.
+                   ^^ Ensure lines containing parameters of a method definition have the same indentation.
                     c)
           end
         RUBY
@@ -296,7 +296,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
           expect_offense(<<-RUBY.strip_indent)
             def self.method(a,
               b)
-              ^ Ensure lines containing parameters on a method definition have the same indentation.
+              ^ Ensure lines containing parameters of a method definition have the same indentation.
             end
           RUBY
         end

--- a/spec/rubocop/cop/layout/align_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/align_parameters_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
       expect_offense(<<-RUBY.strip_indent)
         function(a,
           if b then c else d end)
-          ^^^^^^^^^^^^^^^^^^^^^^ Align the parameters of a method call if they span more than one line.
+          ^^^^^^^^^^^^^^^^^^^^^^ Make sure all lines containing parameters on a method call have the same indentation.
       RUBY
     end
 
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
       expect_offense(<<-RUBY.strip_indent)
         function(a,
             if b then c else d end)
-            ^^^^^^^^^^^^^^^^^^^^^^ Align the parameters of a method call if they span more than one line.
+            ^^^^^^^^^^^^^^^^^^^^^^ Make sure all lines containing parameters on a method call have the same indentation.
       RUBY
     end
 
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
               c)
         func2(a,
              *b,
-             ^^ Align the parameters of a method call if they span more than one line.
+             ^^ Make sure all lines containing parameters on a method call have the same indentation.
               c)
         func3(*a)
       RUBY
@@ -85,7 +85,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
       expect_offense(<<-RUBY.strip_indent)
         func1(a,
              b,)
-             ^ Align the parameters of a method call if they span more than one line.
+             ^ Make sure all lines containing parameters on a method call have the same indentation.
       RUBY
     end
 
@@ -223,7 +223,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
         expect_offense(<<-RUBY.strip_indent)
           def method(a,
             b)
-            ^ Align the parameters of a method definition if they span more than one line.
+            ^ Make sure all lines containing parameters on a method definition have the same indentation.
           end
         RUBY
       end
@@ -232,7 +232,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
         expect_offense(<<-RUBY.strip_indent)
           def method(a,
               b)
-              ^ Align the parameters of a method definition if they span more than one line.
+              ^ Make sure all lines containing parameters on a method definition have the same indentation.
           end
         RUBY
       end
@@ -272,7 +272,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
         expect_offense(<<-RUBY.strip_indent)
           def func2(a,
                    *b,
-                   ^^ Align the parameters of a method definition if they span more than one line.
+                   ^^ Make sure all lines containing parameters on a method definition have the same indentation.
                     c)
           end
         RUBY
@@ -296,7 +296,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
           expect_offense(<<-RUBY.strip_indent)
             def self.method(a,
               b)
-              ^ Align the parameters of a method definition if they span more than one line.
+              ^ Make sure all lines containing parameters on a method definition have the same indentation.
             end
           RUBY
         end

--- a/spec/rubocop/cop/lint/number_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/number_conversion_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion do
       RUBY
     end
 
-    it 'when `#to_i` called on a variable on a array' do
+    it 'when `#to_i` called on a variable on an array' do
       expect_offense(<<-RUBY.strip_indent)
         args = [1,2,3]
         args[0].to_i


### PR DESCRIPTION
These are some changes I made a while ago, but forgot to PR.

The idea is to make some error messages less ambiguous. Not sure if many people may have been confounded by the previous wording like me, but I feel the new wording leaves no room for misinterpretation?

Quoting one of my comments in https://github.com/rubocop-hq/rubocop/issues/5184 for the rationale:

> The thing is the message is not refering to "line alignment" but to "parameter alignment", that's what I find confusing since as I see it whereas lines are aligned (they have the same number of leading whitespace), parameters are not (they are distanced differently to the beginning of the line).

> That's why I think "Make sure all lines containing the parameters of a method call have the same indentation" or something along those lines would be more clear. At least I wouldn't have got wrong expectations about what this cop should do.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
