### PR TITLE
Set JRUBY_OPTS only for on JRuby builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,12 @@ steps: &steps
     - run: bundle install
     - run: bash .travis.sh
 
-common_env: &common_env
+jruby_env: &jruby_env
   # By default we have 2 CPUs and 4GB ram available
   # https://circleci.com/docs/2.0/configuration-reference/#resource_class
   JRUBY_OPTS: "--debug -J-Xmn1024m -J-Xms2048m -J-Xmx2048m"
 
+common_env: &common_env
   # CircleCI container has two cores, but Ruby can see 32 cores. So we
   # configure test-queue.
   # See https://github.com/tmm1/test-queue#environment-variables
@@ -105,16 +106,22 @@ jobs:
   jruby-9.2-spec:
     docker:
       - image: circleci/jruby:9.2
+        environment:
+          <<: *jruby_env
     <<: *spec_env
     <<: *steps
   jruby-9.2-ascii_spec:
     docker:
       - image: circleci/jruby:9.2
+        environment:
+          <<: *jruby_env
     <<: *ascii_spec_env
     <<: *steps
   jruby-9.2-rubocop:
     docker:
       - image: circleci/jruby:9.2
+        environment:
+          <<: *jruby_env
     <<: *rubocop_env
     <<: *steps
 


### PR DESCRIPTION
Instead of setting the `JRUBY_OPTS` environment variable in all build jobs, let’s just set it on the jobs that need them.

Please note that this applies ONLY to CircleCI builds. On Travis, the `JRUBY_OPTS` ENV variable will still be set for all builds. For detecting if a job is running on JRuby on CircleCI, you can test if `ENV['CIRCLECI']` is `true` *and* `ENV['JRUBY_OPTS']` is set.

Relevant documentation from CircleCI: https://circleci.com/docs/2.0/env-vars/

/cc @deivid-rodriguez 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
