### PR TITLE
Work in progress: Code Climate with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,26 @@ jobs:
     <<: *rubocop_env
     <<: *steps
 
+  code-climate:
+    docker:
+      - image: circleci/ruby:2.5
+    environment:
+      CC_TEST_REPORTER_ID: a11b66bfbb1acdf220d5cb317b2e945a986fd85adebe29a76d411ad6d74ec31f
+    steps:
+      - checkout
+      - run: bundle install
+      - run:
+          name: Setup Code Climate test-reporter
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
+      - run:
+          name: Run specs
+          command: |
+            ./cc-test-reporter before-build
+            rake report_coverage
+            ./cc-test-reporter after-build --exit-code $?
+
 workflows:
   version: 2
   build:
@@ -144,3 +164,4 @@ workflows:
       - jruby-9.2-spec
       - jruby-9.2-ascii_spec
       - jruby-9.2-rubocop
+      - code-climate

--- a/.travis.sh
+++ b/.travis.sh
@@ -4,7 +4,6 @@ set -eo pipefail
 
 run() {
   run_main_task
-  report_coverage
   documentation
   check_requiring_libraries
 }
@@ -28,12 +27,6 @@ is_jruby() {
 
 is_master() {
   [ "$TRAVIS_BRANCH" = 'master' ] && [ "$TRAVIS_PULL_REQUEST" = 'false' ]
-}
-
-report_coverage() {
-  if is_test && is_master; then
-    logged bundle exec codeclimate-test-reporter
-  fi
 }
 
 run_main_task() {

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem 'test-queue'
 gem 'yard', '~> 0.9'
 
 group :test do
-  gem 'codeclimate-test-reporter', '~> 1.0', require: false
   gem 'safe_yaml', require: false
   gem 'webmock', require: false
 end

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 [![Travis Status](https://travis-ci.org/rubocop-hq/rubocop.svg?branch=master)](https://travis-ci.org/rubocop-hq/rubocop)
 [![CircleCI Status](https://circleci.com/gh/rubocop-hq/rubocop/tree/master.svg?style=svg)](https://circleci.com/gh/rubocop-hq/rubocop/tree/master)
 [![AppVeyor Status](https://ci.appveyor.com/api/projects/status/sj3ye7n5690d0nvg?svg=true)](https://ci.appveyor.com/project/bbatsov/rubocop)
-[![Coverage Status](https://img.shields.io/codeclimate/coverage/github/bbatsov/rubocop.svg)](https://codeclimate.com/github/bbatsov/rubocop)
-[![Code Climate](https://codeclimate.com/github/bbatsov/rubocop/badges/gpa.svg)](https://codeclimate.com/github/bbatsov/rubocop)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/ad6e76460499c8c99697/test_coverage)](https://codeclimate.com/github/bbatsov/rubocop/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/ad6e76460499c8c99697/maintainability)](https://codeclimate.com/github/bbatsov/rubocop/maintainability)
 [![Inline docs](http://inch-ci.org/github/bbatsov/rubocop.svg)](http://inch-ci.org/github/bbatsov/rubocop)
 [![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=rubocop&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=rubocop&package-manager=bundler&version-scheme=semver)
 

--- a/Rakefile
+++ b/Rakefile
@@ -38,6 +38,13 @@ namespace :parallel do
   end
 end
 
+desc 'Run RSpec with code coverage on CI, only on master branch'
+task :report_coverage do
+  return if ENV['CIRCLE_BRANCH'] != 'master'
+
+  Rake::Task['coverage'].execute
+end
+
 desc 'Run RSpec with code coverage'
 task :coverage do
   ENV['COVERAGE'] = 'true'

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-on_master = ENV['TRAVIS_BRANCH'] == 'master' &&
-            ENV['TRAVIS_PULL_REQUEST'] == 'false'
-if on_master || ENV['COVERAGE']
+if ENV['COVERAGE']
   require 'simplecov'
   SimpleCov.add_filter '/spec/'
   SimpleCov.add_filter '/vendor/bundle/'


### PR DESCRIPTION
Before, reporting to Code Climate was only done from Travis, due to us checking for `TRAVIS_BRANCH` and `TRAVIS_PULL_REQUEST` environment variables.

Now, Travis doesn't report to Code Climate, while CircleCI runs the new Rake task `report_coverage` which will only run on the master branch.

See also the similar pull request on rubocop-rspec: https://github.com/rubocop-hq/rubocop-rspec/pull/574

/cc @deivid-rodriguez 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
