### PR TITLE
Improve warning check

### DIFF
--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -191,7 +191,9 @@ RSpec.describe 'RuboCop Project', type: :feature do
 
   describe 'requiring all of `lib` with verbose warnings enabled' do
     it 'emits no warnings' do
-      whitelisted = ->(line) { line =~ /warning: private attribute\?$/ }
+      whitelisted = lambda do |line|
+        line =~ /warning: private attribute\?$/ && RUBY_VERSION < '2.3'
+      end
 
       warnings = `ruby -Ilib -w -W2 lib/rubocop.rb 2>&1`
                  .lines

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -191,14 +191,14 @@ RSpec.describe 'RuboCop Project', type: :feature do
 
   describe 'requiring all of `lib` with verbose warnings enabled' do
     it 'emits no warnings' do
-      whitelisted = lambda do |line|
+      allowed = lambda do |line|
         line =~ /warning: private attribute\?$/ && RUBY_VERSION < '2.3'
       end
 
       warnings = `ruby -Ilib -w -W2 lib/rubocop.rb 2>&1`
                  .lines
                  .grep(%r{/lib/rubocop}) # ignore warnings from dependencies
-                 .reject(&whitelisted)
+                 .reject(&allowed)
       expect(warnings.empty?).to be(true)
     end
   end


### PR DESCRIPTION
Just a minimal improvement to I found out when working on something unrelated. The warning is apparently 2.2 specific, so once we drop support for that, the exclusion can be dropped. The explicit check makes it easier that we don't forget to drop the exclusion when the time to drop ruby 2.2 comes. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
