### PR TITLE
Detect extra array allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#6173](https://github.com/rubocop-hq/rubocop/pull/6173): Add `AllowImplicitReturn` option to `Rails/SaveBang` cop. ([@robotdana][])
 * [#6218](https://github.com/rubocop-hq/rubocop/pull/6218): Add `comparison` style to `Style/NilComparison`. ([@khiav223577][])
 * Add new `Style/MultilineMethodSignature` cop. ([@drenmi][])
+* [#6234](https://github.com/rubocop-hq/rubocop/pull/6234): Add `Performance/ChainArrayAllocation` cop. ([@schneems][])
 
 ### Bug fixes
 
@@ -3540,3 +3541,4 @@
 [@robotdana]: https://github.com/robotdana
 [@bacchir]: https://github.com/bacchir
 [@khiav223577]: https://github.com/khiav223577
+[@schneems]: https://github.com/schneems

--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -54,6 +54,13 @@ Performance/CaseWhenSplat:
   Enabled: false
   AutoCorrect: false
 
+Performance/ChainArrayAllocation:
+  Description: >-
+                  Instead of chaining array methods that allocate new arrays, mutate an
+                  existing array.
+  Reference: 'https://twitter.com/schneems/status/1034123879978029057'
+  Enabled: false
+
 # By default, the rails cops are not run. Override in project or home
 # directory .rubocop.yml files, or by giving the -R/--rails option.
 Rails:

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -381,6 +381,7 @@ require_relative 'rubocop/cop/performance/times_map'
 require_relative 'rubocop/cop/performance/unfreeze_string'
 require_relative 'rubocop/cop/performance/unneeded_sort'
 require_relative 'rubocop/cop/performance/uri_default_parser'
+require_relative 'rubocop/cop/performance/chain_array_allocation'
 
 require_relative 'rubocop/cop/style/access_modifier_declarations'
 require_relative 'rubocop/cop/style/alias'

--- a/lib/rubocop/cop/performance/chain_array_allocation.rb
+++ b/lib/rubocop/cop/performance/chain_array_allocation.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Performance
+      # This cop is used to identify usages of
+      # @example
+      #   # bad
+      #   array = ["a", "b", "c"]
+      #   array.compact.flatten.map { |x| x.downcase }
+      #
+      # Each of these methods (`compact`, `flatten`, `map`) will generate a
+      # new intermediate array that is promptly thrown away. Instead it is
+      # faster to mutate when we know it's safe.
+      #
+      # @example
+      #   # good.
+      #   array = ["a", "b", "c"]
+      #   array.compact!
+      #   array.flatten!
+      #   array.map! { |x| x.downcase }
+      #   array
+      class ChainArrayAllocation < Cop
+        include RangeHelp
+
+        # These methods return a new array but only sometimes. They must be
+        # called with an argument. For example:
+        #
+        #   [1,2].first    # => 1
+        #   [1,2].first(1) # => [1]
+        #
+        RETURN_NEW_ARRAY_WHEN_ARGS = ':first :last :pop :sample :shift '.freeze
+
+        # These methods return a new array only when called without a block.
+        RETURNS_NEW_ARRAY_WHEN_NO_BLOCK = ':zip :product '.freeze
+
+        # These methods ALWAYS return a new array
+        # after they're called it's safe to mutate the the resulting array
+        ALWAYS_RETURNS_NEW_ARRAY = ':* :+ :- :collect :compact :drop '\
+                                   ':drop_while :flatten :map :reject ' \
+                                   ':reverse :rotate :select :shuffle :sort ' \
+                                   ':take :take_while :transpose :uniq ' \
+                                   ':values_at :| '.freeze
+
+        # These methods have a mutation alternative. For example :collect
+        # can be called as :collect!
+        HAS_MUTATION_ALTERNATIVE = ':collect :compact :flatten :map :reject '\
+                                   ':reverse :rotate :select :shuffle :sort '\
+                                   ':uniq '.freeze
+        MSG = 'Use `%<method>s...%<second_method>s!` instead of `%<method>s' \
+              '...%<second_method>s`.'.freeze
+
+        def_node_matcher :flat_map_candidate?, <<-PATTERN
+          {
+            (send (send _ ${#{RETURN_NEW_ARRAY_WHEN_ARGS}} {int lvar ivar cvar gvar}) ${#{HAS_MUTATION_ALTERNATIVE}} $...)
+            (send (block (send _ ${#{ALWAYS_RETURNS_NEW_ARRAY} }) ...) ${#{HAS_MUTATION_ALTERNATIVE}} $...)
+            (send (send _ ${#{ALWAYS_RETURNS_NEW_ARRAY + RETURNS_NEW_ARRAY_WHEN_NO_BLOCK}} ...) ${#{HAS_MUTATION_ALTERNATIVE}} $...)
+          }
+        PATTERN
+
+        def on_send(node)
+          flat_map_candidate?(node) do |fm, sm, _|
+            range = range_between(
+              node.loc.dot.begin_pos,
+              node.source_range.end_pos
+            )
+            add_offense(
+              node,
+              location: range,
+              message: format(MSG, method: fm, second_method: sm)
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -301,6 +301,7 @@ In the following section you find all available cops:
 * [Performance/Caller](cops_performance.md#performancecaller)
 * [Performance/CaseWhenSplat](cops_performance.md#performancecasewhensplat)
 * [Performance/Casecmp](cops_performance.md#performancecasecmp)
+* [Performance/ChainArrayAllocation](cops_performance.md#performancechainarrayallocation)
 * [Performance/CompareWithBlock](cops_performance.md#performancecomparewithblock)
 * [Performance/Count](cops_performance.md#performancecount)
 * [Performance/Detect](cops_performance.md#performancedetect)

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -119,6 +119,37 @@ str.casecmp('ABC').zero?
 
 * [https://github.com/JuanitoFatas/fast-ruby#stringcasecmp-vs-stringdowncase---code](https://github.com/JuanitoFatas/fast-ruby#stringcasecmp-vs-stringdowncase---code)
 
+## Performance/ChainArrayAllocation
+
+Enabled by default | Supports autocorrection
+--- | ---
+Disabled | No
+
+This cop is used to identify usages of
+Each of these methods (`compact`, `flatten`, `map`) will generate a
+new intermediate array that is promptly thrown away. Instead it is
+faster to mutate when we know it's safe.
+
+### Examples
+
+```ruby
+# bad
+array = ["a", "b", "c"]
+array.compact.flatten.map { |x| x.downcase }
+```
+```ruby
+# good.
+array = ["a", "b", "c"]
+array.compact!
+array.flatten!
+array.map! { |x| x.downcase }
+array
+```
+
+### References
+
+* [https://twitter.com/schneems/status/1034123879978029057](https://twitter.com/schneems/status/1034123879978029057)
+
 ## Performance/CompareWithBlock
 
 Enabled by default | Supports autocorrection

--- a/spec/rubocop/cop/performance/chain_array_allocation_spec.rb
+++ b/spec/rubocop/cop/performance/chain_array_allocation_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Performance::ChainArrayAllocation, :config do
+  subject(:cop) { described_class.new(config) }
+
+  def generate_message(method_one, method_two)
+    "Use `#{method_one}...#{method_two}!` instead of `#{method_one}"\
+    "...#{method_two}`."
+  end
+
+  shared_examples 'map_and_flat' do |method, method_two|
+    it "registers an offense when calling #{method}...#{method_two}" do
+      inspect_source("[1, 2, 3, 4].#{method} { |e| [e, e] }.#{method_two}")
+
+      expect(cop.messages)
+        .to eq([generate_message(method, method_two)])
+      expect(cop.highlights).to eq([".#{method_two}"])
+    end
+  end
+
+  describe 'configured to only warn when flattening one level' do
+    it_behaves_like('map_and_flat', 'map', 'flatten')
+  end
+
+  describe 'Methods that require an argument' do
+    it 'first' do
+      # Yes I know this is not valid Ruby
+      inspect_source('[1, 2, 3, 4].first.uniq')
+      expect(cop.messages.empty?).to be(true)
+
+      inspect_source('[1, 2, 3, 4].first(10).uniq')
+      expect(cop.messages.empty?).to be(false)
+      expect(cop.messages)
+        .to eq([generate_message('first', 'uniq')])
+      expect(cop.highlights).to eq(['.uniq'])
+
+      inspect_source('[1, 2, 3, 4].first(variable).uniq')
+      expect(cop.messages.empty?).to be(false)
+      expect(cop.messages)
+        .to eq([generate_message('first', 'uniq')])
+      expect(cop.highlights).to eq(['.uniq'])
+    end
+  end
+
+  describe 'methods that only return an array with no block' do
+    it 'zip' do
+      # Yes I know this is not valid Ruby
+      inspect_source('[1, 2, 3, 4].zip {|f| }.uniq')
+      expect(cop.messages.empty?).to be(true)
+
+      inspect_source('[1, 2, 3, 4].zip.uniq')
+      expect(cop.messages.empty?).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
It is common to chain array methods for example

```
foo.compact.flatten.map { |x| x.downcase! }
```

Each of these methods `compact`, `flatten`, `map` will generate a new intermediate array that is promptly thrown away. Instead it is much faster to mutate when we know there’s a new array generated:

```
a = foo.compact
a.flatten!
a.map { |x| x.downcase! }
a
```

This PR adds a performance cop to detect this case and raise a failure.


Currently this cop does not support auto-correct and i’m not sure it ever can based on the amount of variety that the code changes may require.

This is my first attempt at writing a cop, so please consider this a rough draft. I need some help and guidance in terms of testing.

I’ve already run this against some major libraries and found quite a few optimizations.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
