### PR TITLE
correct dead links in the basic usage documentation

### DIFF
--- a/manual/basic_usage.md
+++ b/manual/basic_usage.md
@@ -69,7 +69,7 @@ Command flag                    | Description
 `-c/--config`                   | Run with specified config file.
 `-f/--format`                   | Choose a formatter.
 `-o/--out`                      | Write output to a file instead of STDOUT.
-`-r/--require`                  | Require Ruby file (see [Loading Extensions](#loading-extensions)).
+`-r/--require`                  | Require Ruby file (see [Loading Extensions](extensions.md#loading-extensions)).
 `-R/--rails`                    | Run extra Rails cops.
 `-l/--lint`                     | Run only lint cops.
 `-a/--auto-correct`             | Auto-correct certain offenses. *Note:* Experimental - use with caution.
@@ -80,7 +80,7 @@ Command flag                    | Description
 `--no-auto-gen-timestamp`       | Don't include the date and time when --auto-gen-config was run in the config file it generates
 `--exclude-limit`               | Limit how many individual files `--auto-gen-config` can list in `Exclude` parameters, default is 15.
 `--show-cops`                   | Shows available cops and their configuration.
-`--fail-level`                  | Minimum [severity](#severity) for exit with error code. Full severity name or upper case initial can be given. Normally, auto-corrected offenses are ignored. Use `A` or `autocorrect` if you'd like them to trigger failure.
+`--fail-level`                  | Minimum [severity](configuration.md#severity) for exit with error code. Full severity name or upper case initial can be given. Normally, auto-corrected offenses are ignored. Use `A` or `autocorrect` if you'd like them to trigger failure.
 `--display-only-fail-level-offenses`           | Only output offense messages at the specified `--fail-level` or above
 `-s/--stdin`                    | Pipe source from STDIN. This is useful for editor integration.
 `--[no-]color`                  | Force color output on or off.


### PR DESCRIPTION
I was setting up `rubocop` on something this morning and found a pair of dead links in the documentation, so I figured I'd pay it forward and update them. This corrects some references in `basic_usage.md` that point to what's now in different documentation files.

I THINK this is in line with the contributing guidelines (and since there's not really a programming change there's no need for a changelog entry? I think) but if I guessed wrong, apologies!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [na] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [na] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
