### PR TITLE
[Fix #6240] Fix an error for `Style/WordArray`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#6208](https://github.com/rubocop-hq/rubocop/pull/6208): Ignore assignment methods in `Naming/PredicateName`. ([@sunny][])
 * [#6196](https://github.com/rubocop-hq/rubocop/issues/6196): Fix incorrect autocorrect for `Style/EmptyCaseCondition` when using `return` in `when` clause and assigning the return value of `case`. ([@koic][])
 * [#6142](https://github.com/rubocop-hq/rubocop/issues/6142): Ignore keyword arguments in `Rails/Delegate`. ([@sunny][])
+* [#6240](https://github.com/rubocop-hq/rubocop/issues/6240): Fix an auto-correct error for `Style/WordArray` when setting `EnforcedStyle: brackets` and using string interpolation in `%W` literal. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -81,11 +81,23 @@ module RuboCop
         end
 
         def correct_bracketed(node)
-          words = node.children.map { |w| to_string_literal(w.children[0]) }
+          words = node.children.map do |word|
+            if word.dstr_type?
+              string_literal = to_string_literal(word.source)
+
+              trim_string_interporation_escape_character(string_literal)
+            else
+              to_string_literal(word.children[0])
+            end
+          end
 
           lambda do |corrector|
             corrector.replace(node.source_range, "[#{words.join(', ')}]")
           end
+        end
+
+        def trim_string_interporation_escape_character(str)
+          str.gsub(/\\\#{(.*?)\}/) { "\#{#{Regexp.last_match(1)}}" }
         end
       end
     end

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -251,6 +251,12 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       expect(new_source).to eq('["\n", "\t", "\b", "\v", "\f"]')
     end
 
+    it 'autocorrects a %W() array which uses string interpolation' do
+      new_source = autocorrect_source('%W(#{foo}bar baz)')
+
+      expect(new_source).to eq('["#{foo}bar", \'baz\']')
+    end
+
     it "doesn't fail on strings which are not valid UTF-8" do
       # Regression test, see GH issue 2671
       expect_no_offenses(<<-'RUBY'.strip_indent)


### PR DESCRIPTION
Fixes #6240.

This PR fixes an auto-correct error for `Style/WordArray` when setting `EnforcedStyle: brackets` and using string interpolation in `%W` literal.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
