### PR TITLE
Only check method_name on nodes that define it

### DIFF
--- a/lib/rubocop/cop/rails/find_each.rb
+++ b/lib/rubocop/cop/rails/find_each.rb
@@ -22,7 +22,9 @@ module RuboCop
         IGNORED_METHODS = %i[order limit select].freeze
 
         def on_send(node)
-          return unless node.receiver && node.method?(:each)
+          return unless node.receiver &&
+                        node.receiver.send_type? &&
+                        node.method?(:each)
 
           return unless SCOPE_METHODS.include?(node.receiver.method_name)
           return if method_chain(node).any? { |m| ignored_by_find_each?(m) }

--- a/spec/rubocop/cop/rails/find_each_spec.rb
+++ b/spec/rubocop/cop/rails/find_each_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe RuboCop::Cop::Rails::FindEach do
   it_behaves_like('register_offense', 'where(name: name)')
   it_behaves_like('register_offense', 'where.not(name: name)')
 
+  it 'does not register an offense when called on a constant' do
+    expect_no_offenses('FOO.each { |u| u.x }')
+  end
+
   it 'does not register an offense when using find_by' do
     expect_no_offenses('User.all.find_each { |u| u.x }')
   end


### PR DESCRIPTION
#6198 Removed the generic `#method_name` matcher from `Node`.

cc/ @Darhazer 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
