### PR TITLE
[Fix #4289] Clarify how overriding config hash values works

### DIFF
--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -42,8 +42,21 @@ Settings in the child file (that which inherits) override those in the parent
 
 Configuration parameters that are hashes, for example `PreferredMethods` in
 `Style/CollectionMethods`, are merged with the same parameter in the parent
-configuration. Other types, such as `AllCops` / `Include` (an array), are
-overridden by the child setting.
+configuration. This means that any key-value pairs given in child configuration
+override the same keys in parent configuration. Giving `~`, YAML's
+representation of `nil`, as a value cancels the setting of the corresponding
+key in the parent configuration. For example:
+
+```yaml
+Style/CollectionMethods:
+  Enabled: true
+  PreferredMethods:
+    # No preference for collect, keep all others from default config.
+    collect: ~
+```
+
+Other types, such as `AllCops` / `Include` (an array), are overridden by the
+child setting.
 
 Arrays override because if they were merged, there would be no way to
 remove elements in child files.

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -736,6 +736,22 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       RuboCop::ConfigLoader.default_configuration = nil
     end
 
+    context 'when a value in a hash is overridden with nil' do
+      it 'acts as if the key/value pair was removed' do
+        create_file('.rubocop.yml', <<-YAML.strip_indent)
+          Style/InverseMethods:
+            InverseMethods:
+              :even?: ~
+          Style/CollectionMethods:
+            Enabled: true
+            PreferredMethods:
+              collect: ~
+        YAML
+        create_file('example.rb', 'array.collect { |e| !e.odd? }')
+        expect(cli.run([])).to eq(0)
+      end
+    end
+
     context 'when configured for rails style indentation' do
       it 'accepts rails style indentation' do
         create_file('.rubocop.yml', <<-YAML.strip_indent)


### PR DESCRIPTION
It was not stated in specs or the manual how you can use `nil` values when overriding a configuration parameter value that is a hash.

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.
