### PR TITLE
Fix false positive for `Naming/FileName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#6256](https://github.com/rubocop-hq/rubocop/pull/6256): Fix false positive for `Naming/FileName` when investigating dotfiles. ([@sinsoku][])
+
 ## 0.59.0 (2018-09-09)
 
 ### New features

--- a/lib/rubocop/cop/naming/file_name.rb
+++ b/lib/rubocop/cop/naming/file_name.rb
@@ -91,6 +91,7 @@ module RuboCop
         end
 
         def filename_good?(basename)
+          basename = basename.sub(/^\./, '')
           basename = basename.sub(/\.[^\.]+$/, '')
           basename =~ (regex || SNAKE_CASE)
         end

--- a/spec/rubocop/cop/naming/file_name_spec.rb
+++ b/spec/rubocop/cop/naming/file_name_spec.rb
@@ -358,4 +358,12 @@ RSpec.describe RuboCop::Cop::Naming::FileName do
       expect(cop.offenses.empty?).to be(true)
     end
   end
+
+  context 'with dotfiles' do
+    let(:filename) { '.pryrc' }
+
+    it 'does not report an offense' do
+      expect(cop.offenses.empty?).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
The code before the change made dotfiles an empty string, so the cop
registered an offense that files are not snake_case.

```ruby
'.pryrc'.sub(/\.[^\.]+$/, '')
#=> ""
basename =~ (regex || SNAKE_CASE)
#=> nil
```

This commit fixes the false positive.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
