### PR TITLE
[Fix #6242] Fix an incorrect autocorrect for `Style/EmptyCaseCondition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#6256](https://github.com/rubocop-hq/rubocop/pull/6256): Fix false positive for `Naming/FileName` when investigating dotfiles. ([@sinsoku][])
+* [#6242](https://github.com/rubocop-hq/rubocop/pull/6242): Fix `Style/EmptyCaseCondition` auto-correction removes comment between `case` and first `when`. ([@koic][])
 
 ## 0.59.0 (2018-09-09)
 

--- a/lib/rubocop/cop/style/empty_case_condition.rb
+++ b/lib/rubocop/cop/style/empty_case_condition.rb
@@ -67,9 +67,8 @@ module RuboCop
         private
 
         def correct_case_when(corrector, case_node, when_nodes)
-          case_range = case_node.loc.keyword.join(when_nodes.first.loc.keyword)
-
-          corrector.replace(case_range, 'if')
+          remove_case_node(corrector, case_node)
+          corrector.replace(when_nodes.first.loc.keyword, 'if')
 
           when_nodes[1..-1].each do |when_node|
             corrector.replace(when_node.loc.keyword, 'elsif')
@@ -87,6 +86,14 @@ module RuboCop
 
             corrector.replace(range, conditions.map(&:source).join(' || '))
           end
+        end
+
+        def remove_case_node(corrector, case_node)
+          range = range_by_whole_lines(
+            case_node.loc.keyword, include_final_newline: true
+          )
+
+          corrector.remove(range)
         end
       end
     end

--- a/spec/rubocop/cop/style/empty_case_condition_spec.rb
+++ b/spec/rubocop/cop/style/empty_case_condition_spec.rb
@@ -53,6 +53,41 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition do
       it_behaves_like 'detect/correct empty case, accept non-empty case'
     end
 
+    context 'with multiple when branches and an `else` with code comments' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          case
+          # condition a
+          when 1 == 2
+            foo
+          # condition b
+          when 1 == 1
+            bar
+          # condition c
+          else
+            baz
+          end
+        RUBY
+      end
+
+      let(:corrected_source) do
+        <<-RUBY.strip_indent
+          # condition a
+          if 1 == 2
+            foo
+          # condition b
+          elsif 1 == 1
+            bar
+          # condition c
+          else
+            baz
+          end
+        RUBY
+      end
+
+      it_behaves_like 'detect/correct empty case, accept non-empty case'
+    end
+
     context 'with multiple when branches and no else' do
       let(:source) do
         <<-RUBY.strip_indent


### PR DESCRIPTION
Fixes #6242.

This PR fixes `Style/EmptyCaseCondition` auto-correction removes comment between `case` and first `when`.

This change keeps the following source code comment.

```ruby
def foo
  case
  # when bar ...
  when bar
    2
  end
end
```

The following is the result of auto-correct.

## Before

```ruby
def foo
  if bar
    2
  end
end
```

## After

```ruby
def foo
  # when bar ...
  if bar
    2
  end
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
