### PR TITLE
Make Lint/UnreachableCode detect 'exit', 'exit!' and 'abort'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * [#6256](https://github.com/rubocop-hq/rubocop/pull/6256): Fix false positive for `Naming/FileName` when investigating dotfiles. ([@sinsoku][])
 * [#6242](https://github.com/rubocop-hq/rubocop/pull/6242): Fix `Style/EmptyCaseCondition` auto-correction removes comment between `case` and first `when`. ([@koic][])
 
+### Changes
+
+* [#6272](https://github.com/rubocop-hq/rubocop/pull/6272): Make `Lint/UnreachableCode` detect `exit`, `exit!` and `abort`. ([@hoshinotsuyoshi][])
+
 ## 0.59.0 (2018-09-09)
 
 ### New features

--- a/lib/rubocop/cop/lint/unreachable_code.rb
+++ b/lib/rubocop/cop/lint/unreachable_code.rb
@@ -56,7 +56,7 @@ module RuboCop
             return next break retry redo
             (send
              {nil? (const {nil? cbase} :Kernel)}
-             {:raise :fail :throw}
+             {:raise :fail :throw :exit :exit! :abort}
              ...)
           }
         PATTERN

--- a/spec/rubocop/cop/lint/unreachable_code_spec.rb
+++ b/spec/rubocop/cop/lint/unreachable_code_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RuboCop::Cop::Lint::UnreachableCode do
     head + body + tail
   end
 
-  %w[return next break retry redo throw raise fail].each do |t|
+  %w[return next break retry redo throw raise fail exit exit! abort].each do |t|
     it "registers an offense for `#{t}` before other statements" do
       expect_offense(wrap(<<-RUBY))
         #{t}


### PR DESCRIPTION
I think it is reasonable that Lint/UnreachableCode detects 'exit', 'exit!' and 'abort'

```ruby
def foo
  exit
  puts 'hello' # unreachable, but rubocop 0.59.0 does not add offence
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
