### PR TITLE
Test Ruby release candidates on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,29 @@ jobs:
     steps:
       *rubocop_steps
 
+  # Latest MRI release candidate
+  ruby-rc-spec:
+    docker:
+      - image: circleci/ruby:rc
+    environment:
+      <<: *common_env
+    steps:
+      *spec_steps
+  ruby-rc-ascii_spec:
+    docker:
+      - image: circleci/ruby:rc
+    environment:
+      <<: *common_env
+    steps:
+      *ascii_spec_steps
+  ruby-rc-rubocop:
+    docker:
+      - image: circleci/ruby:rc
+    environment:
+      <<: *common_env
+    steps:
+      *rubocop_steps
+
   # JRuby 9.2
   jruby-9.2-spec:
     docker:
@@ -217,6 +240,11 @@ workflows:
             - cc-setup
       - ruby-2.5-ascii_spec
       - ruby-2.5-rubocop
+      - ruby-rc-spec:
+          requires:
+            - cc-setup
+      - ruby-rc-ascii_spec
+      - ruby-rc-rubocop
       - jruby-9.2-spec:
           requires:
             - cc-setup


### PR DESCRIPTION
It's not the latest nightly build, and no RC image is available for JRuby, but perhaps the MRI Release Candidate offers enough coverage that we can drop ruby-head and jruby-head from .travis.yml

The RC builds should be “allowed failures” (if we enable “Require status checks to pass before merging” on master branch.)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
