### PR TITLE
Remove unneeded $stderr capturing

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -54,7 +54,6 @@ RSpec/ExpectOutput:
     - 'spec/rubocop/formatter/disabled_config_formatter_spec.rb'
     - 'spec/rubocop/formatter/formatter_set_spec.rb'
     - 'spec/rubocop/options_spec.rb'
-    - 'spec/rubocop/path_util_spec.rb'
     - 'spec/rubocop/rake_task_spec.rb'
     - 'spec/rubocop/result_cache_spec.rb'
     - 'spec/rubocop/target_finder_spec.rb'

--- a/spec/rubocop/path_util_spec.rb
+++ b/spec/rubocop/path_util_spec.rb
@@ -34,21 +34,16 @@ RSpec.describe RuboCop::PathUtil do
       create_empty_file('dir/sub/file')
       create_empty_file('dir/.hidden/file')
       create_empty_file('dir/.hidden_file')
-      $stderr = StringIO.new
     end
-
-    after { $stderr = STDERR }
 
     it 'does not match dir/** for file in hidden dir' do
       expect(described_class.match_path?('dir/**', 'dir/.hidden/file'))
         .to be(false)
-      expect($stderr.string).to eq('')
     end
 
     it 'matches dir/** for hidden file' do
       expect(described_class.match_path?('dir/**', 'dir/.hidden_file'))
         .to be(true)
-      expect($stderr.string).to eq('')
     end
 
     it 'does not match file in a subdirectory' do


### PR DESCRIPTION
Back in the day, `PathUtil` would issue a deprecation warning, which this spec was expecting *not* to trigger (see 5df9ffbaa95e78734fa52c9367b4aeae957385d9). The deprecation warning was removed in 797ba0296da8983753148adfdd7982d8d41f5a15

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
