### PR TITLE
Move SendNode#stabby_lambda? to MethodDispatchNode#lambda_literal?

### DIFF
--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module AST
     # Common functionality for nodes that are a kind of method dispatch:
-    # `send`, `csend`, `super`, `zsuper`, `yield`
+    # `send`, `csend`, `super`, `zsuper`, `yield`, `defined?`
     module MethodDispatchNode
       extend NodePattern::Macros
       include MethodIdentifierPredicates
@@ -161,6 +161,25 @@ module RuboCop
       def def_modifier?
         send_type? &&
           [self, *each_descendant(:send)].any?(&:adjacent_def_modifier?)
+      end
+
+      # Checks whether this is a lambda. Some versions of parser parses
+      # non-literal lambdas as a method send.
+      #
+      # @return [Boolean] whether this method is a lambda
+      def lambda?
+        block_literal? && command?(:lambda)
+      end
+
+      # Checks whether this is a lambda literal (stabby lambda.)
+      #
+      # @example
+      #
+      #   -> (foo) { bar }
+      #
+      # @return [Boolean] whether this method is a lambda literal
+      def lambda_literal?
+        block_literal? && loc.expression && loc.expression.source == '->'
       end
 
       private

--- a/lib/rubocop/ast/node/send_node.rb
+++ b/lib/rubocop/ast/node/send_node.rb
@@ -8,21 +8,6 @@ module RuboCop
     class SendNode < Node
       include ParameterizedNode
       include MethodDispatchNode
-
-      # Checks whether this is a lambda. Some versions of parser parses
-      # non-literal lambdas as a method send.
-      #
-      # @return [Boolean] whether this method is a lambda
-      def lambda?
-        block_literal? && method?(:lambda)
-      end
-
-      # Checks whether this is a stabby lambda. e.g. `-> () {}`
-      #
-      # @return [Boolean] whether this method is a stabby lambda
-      def stabby_lambda?
-        loc.selector && loc.selector.source == '->'
-      end
     end
   end
 end

--- a/lib/rubocop/cop/style/empty_block_parameter.rb
+++ b/lib/rubocop/cop/style/empty_block_parameter.rb
@@ -29,7 +29,7 @@ module RuboCop
 
         def on_block(node)
           send_node = node.send_node
-          check(node) unless send_node.send_type? && send_node.stabby_lambda?
+          check(node) unless send_node.send_type? && send_node.lambda_literal?
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/style/empty_lambda_parameter.rb
+++ b/lib/rubocop/cop/style/empty_lambda_parameter.rb
@@ -26,7 +26,7 @@ module RuboCop
           send_node = node.send_node
           return unless send_node.send_type?
 
-          check(node) if node.send_node.stabby_lambda?
+          check(node) if node.send_node.lambda_literal?
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -65,10 +65,7 @@ module RuboCop
         def on_block(node)
           return if target_ruby_version < 2.5
 
-          send_node = node.send_node
-          # send_node is either SendNode or SuperNode, only SendNode
-          # could be a lambda.
-          return if send_node.send_type? && send_node.stabby_lambda?
+          return if node.send_node.lambda_literal?
           return if node.braces?
 
           check(node)

--- a/lib/rubocop/cop/style/stabby_lambda_parentheses.rb
+++ b/lib/rubocop/cop/style/stabby_lambda_parentheses.rb
@@ -30,7 +30,7 @@ module RuboCop
           return unless redundant_parentheses?(node) ||
                         missing_parentheses?(node)
 
-          add_offense(node.parent.arguments)
+          add_offense(node.block_node.arguments)
         end
 
         def autocorrect(node)
@@ -57,7 +57,7 @@ module RuboCop
 
         def missing_parentheses_corrector(node)
           lambda do |corrector|
-            args_loc = node.parent.arguments.source_range
+            args_loc = node.loc.expression
 
             corrector.insert_before(args_loc, '(')
             corrector.insert_after(args_loc, ')')
@@ -66,7 +66,7 @@ module RuboCop
 
         def unwanted_parentheses_corrector(node)
           lambda do |corrector|
-            args_loc = node.parent.arguments.loc
+            args_loc = node.loc
 
             corrector.replace(args_loc.begin, '')
             corrector.remove(args_loc.end)
@@ -74,11 +74,11 @@ module RuboCop
         end
 
         def stabby_lambda_with_args?(node)
-          node.stabby_lambda? && node.parent.arguments?
+          node.lambda_literal? && node.block_node.arguments?
         end
 
         def parentheses?(node)
-          node.parent.arguments.loc.begin
+          node.block_node.arguments.loc.begin
         end
       end
     end

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -1153,6 +1153,13 @@ RSpec.describe RuboCop::AST::SendNode do
       it { expect(send_node.lambda?).to be_truthy }
     end
 
+    context 'with a method named lambda in a class' do
+      let(:source) { 'foo.lambda { |bar| baz }' }
+      let(:send_node) { parse_source(source).ast.send_node }
+
+      it { expect(send_node.lambda?).to be_falsey }
+    end
+
     context 'with a stabby lambda method' do
       let(:source) { '-> (foo) { do_something(foo) }' }
       let(:send_node) { parse_source(source).ast.send_node }
@@ -1172,14 +1179,14 @@ RSpec.describe RuboCop::AST::SendNode do
       let(:send_node) { parse_source(source).ast.send_node }
       let(:source) { '-> (foo) { do_something(foo) }' }
 
-      it { expect(send_node.stabby_lambda?).to be(true) }
+      it { expect(send_node.lambda_literal?).to be(true) }
     end
 
     context 'with a lambda method' do
       let(:send_node) { parse_source(source).ast.send_node }
       let(:source) { 'lambda { |foo| bar(foo) }' }
 
-      it { expect(send_node.stabby_lambda?).to be(false) }
+      it { expect(send_node.lambda_literal?).to be(false) }
     end
 
     context 'with a non-lambda method' do


### PR DESCRIPTION
Following up on [this discussion](https://github.com/rubocop-hq/rubocop/pull/6269#issuecomment-420164664).

This change moves `SendNode#stabby_lambda?` to `MethodDispatchNode`.

This change lets us treat method dispatch nodes (`send`, `super`, `yield`, etc.) polymorphically, which saves us from type errors and type checking when working with blocks.

It also renames the method to `#lambda_literal?`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
