### PR TITLE
[Fix #6281] Fix false negative for Style/MultilineMethodSignature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#6242](https://github.com/rubocop-hq/rubocop/pull/6242): Fix `Style/EmptyCaseCondition` auto-correction removes comment between `case` and first `when`. ([@koic][])
 * [#6261](https://github.com/rubocop-hq/rubocop/pull/6261): Fix undefined method error for `Style/RedundantBegin` when calling `super` with a block. ([@eitoball][])
 * [#6263](https://github.com/rubocop-hq/rubocop/issues/6263): Fix an error `Layout/EmptyLineAfterGuardClause` when guard clause is after heredoc including string interpolation. ([@koic][])
+* [#6281](https://github.com/rubocop-hq/rubocop/pull/6281): Fix false negative in `Style/MultilineMethodSignature`. ([@drenmi][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/multiline_method_signature.rb
+++ b/lib/rubocop/cop/style/multiline_method_signature.rb
@@ -22,6 +22,7 @@ module RuboCop
         MSG = 'Avoid multi-line method signatures.'.freeze
 
         def on_def(node)
+          return unless node.arguments?
           return if opening_line(node) == closing_line(node)
           return if correction_exceeds_max_line_length?(node)
 
@@ -36,11 +37,7 @@ module RuboCop
         end
 
         def closing_line(node)
-          if node.arguments?
-            node.arguments.last_line
-          else
-            node.first_line
-          end
+          node.arguments.last_line
         end
 
         def correction_exceeds_max_line_length?(node)
@@ -52,8 +49,7 @@ module RuboCop
         end
 
         def definition_width(node)
-          node.loc.expression.source.squeeze.length -
-            node.loc.end.source.length
+          node.source_range.begin.join(node.arguments.source_range.end).length
         end
 
         def max_line_length

--- a/spec/rubocop/cop/style/multiline_method_signature_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_signature_spec.rb
@@ -113,5 +113,23 @@ RSpec.describe RuboCop::Cop::Style::MultilineMethodSignature, :config do
         RUBY
       end
     end
+
+    context 'when correction would not exceed maximum line length' do
+      let(:other_cops) do
+        {
+          'Metrics/LineLength' => { 'Max' => 25 }
+        }
+      end
+
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
+          def foo(bar,
+          ^^^^^^^^^^^^ Avoid multi-line method signatures.
+                  baz)
+            qux.qux
+          end
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
This cop would take the body of the method definition into account when estimating the single line length of the signature, which is clearly wrong. This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
