### PR TITLE
[Fix #6264] Fix an incorrect autocorrect for `Layout/EmptyLineAfterGuardClause`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#6261](https://github.com/rubocop-hq/rubocop/pull/6261): Fix undefined method error for `Style/RedundantBegin` when calling `super` with a block. ([@eitoball][])
 * [#6263](https://github.com/rubocop-hq/rubocop/issues/6263): Fix an error `Layout/EmptyLineAfterGuardClause` when guard clause is after heredoc including string interpolation. ([@koic][])
 * [#6281](https://github.com/rubocop-hq/rubocop/pull/6281): Fix false negative in `Style/MultilineMethodSignature`. ([@drenmi][])
+* [#6264](https://github.com/rubocop-hq/rubocop/issues/6264): Fix an incorrect autocorrect for `Layout/EmptyLineAfterGuardClause` cop when `if` condition is after heredoc. ([@koic][])
 
 ### Changes
 

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'registers an offense for next guard clause not followed by empty line' do
+  it 'registers an offense for `next` guard clause not followed by ' \
+     'empty line' do
     expect_offense(<<-RUBY.strip_indent)
       def foo
         next unless need_next?
@@ -37,11 +38,24 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'registers an offense for next guard clause not followed by empty line ' \
-     'when guard clause is after heredoc' do
+  it 'registers an offense for `raise` guard clause not followed by ' \
+     'empty line when `unless` condition is after heredoc' do
     expect_offense(<<-RUBY.strip_indent)
       def foo
         raise ArgumentError, <<-MSG unless path
+          Must be called with mount point
+        MSG
+      ^^^^^ Add empty line after guard clause.
+        bar
+      end
+    RUBY
+  end
+
+  it 'registers an offense for `raise` guard clause not followed ' \
+     'by empty line when `if` condition is after heredoc' do
+    expect_offense(<<-RUBY.strip_indent)
+      def foo
+        raise ArgumentError, <<-MSG if path
           Must be called with mount point
         MSG
       ^^^^^ Add empty line after guard clause.
@@ -61,8 +75,8 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'registers an offense for next guard clause not followed by empty line ' \
-     'when guard clause is after condition without method invocation' do
+  it 'registers an offense for `raise` guard clause not followed by empty ' \
+     'line when guard clause is after condition without method invocation' do
     expect_no_offenses(<<-'RUBY'.strip_indent)
       def foo
         raise unless $1 == o
@@ -72,8 +86,8 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'registers an offense for next guard clause not followed by empty line ' \
-     'when guard clause is after method call with argument' do
+  it 'registers an offense for `raise` guard clause not followed by ' \
+     'empty line when guard clause is after method call with argument' do
     expect_offense(<<-'RUBY'.strip_indent)
       def foo
         raise SerializationError.new("Unsupported argument type: #{argument.class.name}") unless serializer
@@ -98,6 +112,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
         if something?
           return
         end
+      end
+    RUBY
+  end
+
+  it 'does not register offense when using guard clause is after `raise`' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def foo
+        raise ArgumentError, 'HTTP redirect too deep' if limit.zero?
+
+        foobar
       end
     RUBY
   end
@@ -262,6 +286,27 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
         next if foo? # This is foo
 
         foobar
+      end
+    RUBY
+  end
+
+  it 'correctly autocorrects offense when guard clause is after heredoc' do
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
+      def foo
+        raise(<<-FAIL) if true
+          boop
+        FAIL
+        1
+      end
+    RUBY
+
+    expect(new_source).to eq(<<-RUBY.strip_indent)
+      def foo
+        raise(<<-FAIL) if true
+          boop
+        FAIL
+
+        1
       end
     RUBY
   end


### PR DESCRIPTION
Fixes #6264.

This PR fixes an incorrect auto-correct for `Layout/EmptyLineAfterGuardClause` cop when `if` condition is after heredoc.

This problem included two problems of auto-correct related to heredoc and false positives of `if` condition.

So this PR fixes the following auto-correct.

```ruby
raise(<<-FAIL) if true
  boop
FAIL
1
```

The following is the result of auto-correct.

## Before

```ruby
raise(<<-FAIL) if true

  boop
FAIL
1
```

## After

```ruby
raise(<<-FAIL) if true
  boop
FAIL

1
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
