### PR TITLE
Allow to exclude methods from `Metrics/MethodLength`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Allow exclusion of certain methods for `Metrics/MethodLength`. ([@akanoi][])
+* [#6286](https://github.com/rubocop-hq/rubocop/pull/6286)Allow exclusion of certain methods for `Metrics/MethodLength`. ([@akanoi][])
 * [#6267](https://github.com/rubocop-hq/rubocop/pull/6267): Fix undefined method 'method_name' for `Rails/FindEach`. ([@Knack][])
 * [#6256](https://github.com/rubocop-hq/rubocop/pull/6256): Fix false positive for `Naming/FileName` when investigating dotfiles. ([@sinsoku][])
 * [#6242](https://github.com/rubocop-hq/rubocop/pull/6242): Fix `Style/EmptyCaseCondition` auto-correction removes comment between `case` and first `when`. ([@koic][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* [#6286](https://github.com/rubocop-hq/rubocop/pull/6286)Allow exclusion of certain methods for `Metrics/MethodLength`. ([@akanoi][])
+* [#6286](https://github.com/rubocop-hq/rubocop/pull/6286): Allow exclusion of certain methods for `Metrics/MethodLength`. ([@akanoi][])
 * [#6267](https://github.com/rubocop-hq/rubocop/pull/6267): Fix undefined method 'method_name' for `Rails/FindEach`. ([@Knack][])
 * [#6256](https://github.com/rubocop-hq/rubocop/pull/6256): Fix false positive for `Naming/FileName` when investigating dotfiles. ([@sinsoku][])
 * [#6242](https://github.com/rubocop-hq/rubocop/pull/6242): Fix `Style/EmptyCaseCondition` auto-correction removes comment between `case` and first `when`. ([@koic][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* Allow exclusion of certain methods for `Metrics/MethodLength`. ([@akanoi][])
 * [#6267](https://github.com/rubocop-hq/rubocop/pull/6267): Fix undefined method 'method_name' for `Rails/FindEach`. ([@Knack][])
 * [#6256](https://github.com/rubocop-hq/rubocop/pull/6256): Fix false positive for `Naming/FileName` when investigating dotfiles. ([@sinsoku][])
 * [#6242](https://github.com/rubocop-hq/rubocop/pull/6242): Fix `Style/EmptyCaseCondition` auto-correction removes comment between `case` and first `when`. ([@koic][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3565,3 +3565,4 @@
 [@schneems]: https://github.com/schneems
 [@ShockwaveNN]: https://github.com/ShockwaveNN
 [@Knack]: https://github.com/Knack
+[@akanoi]: https://github.com/akanoi

--- a/config/default.yml
+++ b/config/default.yml
@@ -1597,6 +1597,7 @@ Metrics/LineLength:
 Metrics/MethodLength:
   CountComments: false  # count full line comments?
   Max: 10
+  ExcludedMethods: []
 
 Metrics/ModuleLength:
   CountComments: false  # count full line comments?

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -12,17 +12,20 @@ module RuboCop
         LABEL = 'Method'.freeze
 
         def on_def(node)
-          return if cop_config['ExcludedMethods'].include?(String(node.method_name))
+          excluded_methods = cop_config['ExcludedMethods']
+          return if excluded_methods.include?(String(node.method_name))
+
           check_code_length(node)
         end
         alias on_defs on_def
 
         def on_block(node)
           return unless node.send_node.method_name == :define_method
+
           check_code_length(node)
         end
 
-	private
+        private
 
         def cop_label
           LABEL

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -12,17 +12,31 @@ module RuboCop
         LABEL = 'Method'.freeze
 
         def on_def(node)
+          return if excluded_method?(node)
+          
           check_code_length(node)
         end
         alias on_defs on_def
 
         def on_block(node)
           return unless node.send_node.method_name == :define_method
-
+          
           check_code_length(node)
         end
 
         private
+
+        def excluded_method?(node)
+          node_method = String(node.method_name)
+
+          excluded_methods.any? do |method|
+            method == node_method
+          end
+        end
+
+        def excluded_methods
+          cop_config['ExcludedMethods'] || []
+        end
 
         def cop_label
           LABEL

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -12,7 +12,7 @@ module RuboCop
         LABEL = 'Method'.freeze
 
         def on_def(node)
-          return if excluded_methods.include?(String(node.method_name))
+          return if cop_config['ExcludedMethods'].include?(String(node.method_name))
           check_code_length(node)
         end
         alias on_defs on_def
@@ -22,11 +22,7 @@ module RuboCop
           check_code_length(node)
         end
 
-        private
-
-        def excluded_methods
-          cop_config['ExcludedMethods'] || []
-        end
+	private
 
         def cop_label
           LABEL

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -12,7 +12,7 @@ module RuboCop
         LABEL = 'Method'.freeze
 
         def on_def(node)
-          return if excluded_method?(node)
+          return if excluded_methods.include?(String(node.method_name))
           
           check_code_length(node)
         end
@@ -25,14 +25,6 @@ module RuboCop
         end
 
         private
-
-        def excluded_method?(node)
-          node_method = String(node.method_name)
-
-          excluded_methods.any? do |method|
-            method == node_method
-          end
-        end
 
         def excluded_methods
           cop_config['ExcludedMethods'] || []

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -13,14 +13,12 @@ module RuboCop
 
         def on_def(node)
           return if excluded_methods.include?(String(node.method_name))
-          
           check_code_length(node)
         end
         alias on_defs on_def
 
         def on_block(node)
           return unless node.send_node.method_name == :define_method
-          
           check_code_length(node)
         end
 

--- a/manual/cops_metrics.md
+++ b/manual/cops_metrics.md
@@ -147,6 +147,7 @@ Name | Default value | Configurable values
 --- | --- | ---
 CountComments | `false` | Boolean
 Max | `10` | Integer
+ExcludedMethods | `[]` | Array
 
 ### References
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -468,7 +468,7 @@ RSpec.describe RuboCop::ConfigLoader do
               'Enabled' => true,
               'CountComments' => false,
               'Max' => 5,
-              "ExcludedMethods" => []
+              'ExcludedMethods' => []
             }
           )
         expect do

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -467,7 +467,8 @@ RSpec.describe RuboCop::ConfigLoader do
               'StyleGuide' => '#short-methods',
               'Enabled' => true,
               'CountComments' => false,
-              'Max' => 5
+              'Max' => 5,
+              "ExcludedMethods" => []
             }
           )
         expect do

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -189,4 +189,35 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
       RUBY
     end
   end
+
+  context 'when ExcludedMethods is enabled' do
+    before { cop_config['ExcludedMethods'] = ['foo'] }
+
+    it 'still rejects other methods with more than 5 lines' do
+      expect_offense(<<-RUBY.strip_indent)
+        def m 
+        ^^^^^^ Method has too many lines. [6/5]
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      RUBY
+    end
+
+    it 'accepts the foo method with more than 5 lines' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def foo
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
     end
   end
 
-  context 'when ExcludedMethods is enabled' do
+  context 'when method is defined in `ExcludedMethods`' do
     before { cop_config['ExcludedMethods'] = ['foo'] }
 
     it 'still rejects other methods with more than 5 lines' do


### PR DESCRIPTION
The idea is to enable you to exclude from the `Metrics/MethodLength` the methods in the config.

When you need to test a few scripts and know that they have methods with a lot of lines, it's inconvenient to add exceptions at the source code level.


-----------------
Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
