### PR TITLE
Fix `AllowURI` option for `Metrics/LineLength` cop with disabled `Layut/Tab` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#6266](https://github.com/rubocop-hq/rubocop/issues/6266): Run `Rails/HasManyOrHasOneDependent` only for `ActiveRecord` class. ([@tejasbubane][])
 * [#6296](https://github.com/rubocop-hq/rubocop/issues/6296): Fix an auto-correct error for `Style/For` when setting `EnforcedStyle: each` and `for` dose not have `do` or semicolon. ([@autopp][])
 * [#6300](https://github.com/rubocop-hq/rubocop/pull/6300): Fix a false positive for `Layout/EmptyLineAfterGuardClause` when guard clause including heredoc. ([@koic][])
+* [#6287](https://github.com/rubocop-hq/rubocop/pull/6287): Fix `AllowURI` option for `Metrics/LineLength` cop with disabled `Layut/Tab` cop. ([@AlexWayfer][])
 
 ## 0.59.1 (2018-09-15)
 

--- a/lib/rubocop/cop/metrics/line_length.rb
+++ b/lib/rubocop/cop/metrics/line_length.rb
@@ -123,8 +123,8 @@ module RuboCop
 
         def allowed_uri_position?(line, uri_range)
           uri_range.begin < max &&
-            (uri_range.end == line_length(line) ||
-             uri_range.end == line_length(line) - 1)
+            (uri_range.end == line.length ||
+             uri_range.end == line.length - 1)
         end
 
         def find_excessive_uri_range(line)

--- a/spec/rubocop/cop/metrics/line_length_spec.rb
+++ b/spec/rubocop/cop/metrics/line_length_spec.rb
@@ -393,7 +393,15 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
       it_behaves_like 'with tabs indentation'
 
       it "accepts a line that's including URI" do
-        expect_no_offenses("\thttps://github.com/rubocop-hq/rubocop")
+        expect_no_offenses("\t\t# https://github.com/rubocop-hq/rubocop")
+      end
+
+      it "accepts a line that's including URI with text" do
+        expect_no_offenses("\t\t# See https://github.com/rubocop-hq/rubocop")
+      end
+
+      it "accepts a line that's including URI in quotes with text" do
+        expect_no_offenses("\t\t# See 'https://github.com/rubocop-hq/rubocop'")
       end
     end
   end


### PR DESCRIPTION
I'm not sure that `line.length - 1` is correct check for #5361, but I also don't know how to make it better.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
