### PR TITLE
Fix an error when executing default rake task with `SpecRunner`

### DIFF
--- a/tasks/spec_runner.rake
+++ b/tasks/spec_runner.rake
@@ -11,9 +11,12 @@ module RuboCop
   # The specs will be run in parallel if the system implements `fork`.
   # If ENV['COVERAGE'] is truthy, code coverage will be measured.
   class SpecRunner
-    def initialize(encoding: 'UTF-8')
-      @previous_encoding = Encoding.default_external
-      @temporary_encoding = encoding
+    def initialize(external_encoding: 'UTF-8', internal_encoding: nil)
+      @previous_external_encoding = Encoding.default_external
+      @previous_internal_encoding = Encoding.default_internal
+
+      @temporary_external_encoding = external_encoding
+      @temporary_internal_encoding = internal_encoding
     end
 
     def run_specs
@@ -30,10 +33,12 @@ module RuboCop
     private
 
     def with_encoding
-      Encoding.default_external = @temporary_encoding
+      Encoding.default_external = @temporary_external_encoding
+      Encoding.default_internal = @temporary_internal_encoding
       yield
     ensure
-      Encoding.default_external = @previous_encoding
+      Encoding.default_external = @previous_external_encoding
+      Encoding.default_internal = @previous_internal_encoding
     end
 
     def parallel_runner_klass
@@ -104,7 +109,7 @@ end
 
 desc 'Run RSpec code examples with ASCII encoding'
 task :ascii_spec do
-  RuboCop::SpecRunner.new(encoding: 'ASCII').run_specs
+  RuboCop::SpecRunner.new(external_encoding: 'ASCII').run_specs
 end
 
 namespace :parallel do


### PR DESCRIPTION
Related PR is #6255.

This PR fixes the following `default` rake task error.

```console
% cd path/to/rubocop/repo
% bundle exec rake

  (snip)

  Encoding::InvalidByteSequenceError:
    "\xA4" on UTF-8
```

In actually some `Encoding::InvalidByteSequenceError` and `Encoding::UndefinedConversionError` occur.

These errors does not occur when executing `spec` rake task only (i.e. `bundle exec rake spec`).
On the other hand, these errors occur when `spec` rake task is executed after `yard_for_generate_documentation` rake task (e.g. `bundle exec rake`).

Run `spec` rake task only, then `Encoding.default_internal` is `nil`.
On the other hand, When `spec` rake task is executed after `yard_for_generate_documentation` rake task, then `Encoding.default_internal` will be `UTF-8`.

This PR sets the value of `Encoding.default_internal` to `nil` as same as executing `spec` rake task only. And this will have the same behavior as CircleCI.
https://github.com/rubocop-hq/rubocop/blob/f9001b98ecda4b0dd113682dbb1543e8a06c15e8/.circleci/config.yml#L23

Unfortunately, I have not found an essential cause.
However, when developing RuboCop I think that it is inconvenient without this patch because I'm doing comprehensive final confirmation using the `default` rake task.

The reproduction environment as below.

```console
% ruby -v
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin17]
```

Cc @bquorning 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
