### PR TITLE
Exclude === from BinaryOperatorParameterName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Changes
 
 * [#6272](https://github.com/rubocop-hq/rubocop/pull/6272): Make `Lint/UnreachableCode` detect `exit`, `exit!` and `abort`. ([@hoshinotsuyoshi][])
+* [#6295](https://github.com/rubocop-hq/rubocop/pull/6295): Exclude `#===` from `Naming/BinaryOperatorParameterName`. ([@zverok][])
 * Add `+` to allowed file names of `Naming/FileName`. ([@yensaki][])
 
 ## 0.59.0 (2018-09-09)

--- a/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
+++ b/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
@@ -18,7 +18,7 @@ module RuboCop
               'name its argument `other`.'.freeze
 
         OP_LIKE_METHODS = %i[eql? equal?].freeze
-        BLACKLISTED = %i[+@ -@ [] []= << `].freeze
+        BLACKLISTED = %i[+@ -@ [] []= << === `].freeze
 
         def_node_matcher :op_method_candidate?, <<-PATTERN
           (def [#op_method? $_] (args $(arg [!:other !:_other])) _)

--- a/spec/rubocop/cop/naming/binary_operator_parameter_name_spec.rb
+++ b/spec/rubocop/cop/naming/binary_operator_parameter_name_spec.rb
@@ -73,6 +73,14 @@ RSpec.describe RuboCop::Cop::Naming::BinaryOperatorParameterName do
     RUBY
   end
 
+  it 'does not register an offense for ===' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def ===(string)
+        string
+      end
+    RUBY
+  end
+
   it 'does not register an offense for non binary operators' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def -@; end


### PR DESCRIPTION
Reason: relationship between left and right operands of `#===` are not symmetric (operands), they are matcher/matchee, and typically `other` is not an appropriate name for matchee.

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* ~[ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
