### PR TITLE
[Fix #6296] Fix an auto-correct error for `Style/For`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#6296](https://github.com/rubocop-hq/rubocop/issues/6296): Fix an auto-correct error for `Style/For` when setting `EnforcedStyle: each` and `for` dose not have `do` or semicolon. ([@autopp][])
+
 ## 0.59.1 (2018-09-15)
 
 ### Bug fixes
@@ -3571,3 +3575,4 @@
 [@ShockwaveNN]: https://github.com/ShockwaveNN
 [@Knack]: https://github.com/Knack
 [@yensaki]: https://github.com/yensaki
+[@autopp]: https://github.com/autopp

--- a/lib/rubocop/cop/style/for.rb
+++ b/lib/rubocop/cop/style/for.rb
@@ -99,7 +99,9 @@ module RuboCop
 
         def autocorrect_to_each(node)
           item, enumerable = deconstruct_for(node)
-          replacement_range = replacement_range(node, node.loc.begin.end_pos)
+          loc_begin = node.loc.begin
+          end_pos = loc_begin ? loc_begin.end_pos : enumerable.loc.end.end_pos
+          replacement_range = replacement_range(node, end_pos)
           correction = "#{enumerable.source}.each do |#{item.source}|"
 
           ->(corrector) { corrector.replace(replacement_range, correction) }

--- a/spec/rubocop/cop/style/for_spec.rb
+++ b/spec/rubocop/cop/style/for_spec.rb
@@ -67,6 +67,24 @@ RSpec.describe RuboCop::Cop::Style::For, :config do
           end
         RUBY
       end
+
+      it 'changes for that dose not have do or semicolon to each' do
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+          def func
+            for n in [1, 2, 3]
+              puts n
+            end
+          end
+        RUBY
+
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          def func
+            [1, 2, 3].each do |n|
+              puts n
+            end
+          end
+        RUBY
+      end
     end
 
     it 'accepts multiline each' do


### PR DESCRIPTION
This PR fixes #6296.

Auto-correction of `Style/For` raises `NoMethodError`when `EnforcedStyle` is `each` and `for` loop dose not have `do` or semicolon.

This is due to `begin` of the node's location becoming `nil`.
So, in such a case, `end_pos` of the enumeration target is set to the end of the replacement range.

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
