### PR TITLE
[Fix #6266] Run HasManyOrHasOneDependent only for ActiveRecord class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* [#6266](https://github.com/rubocop-hq/rubocop/issues/6266): Run `Rails/HasManyOrHasOneDependent` only for `ActiveRecord` class. ([@tejasbubane][])
 * [#6296](https://github.com/rubocop-hq/rubocop/issues/6296): Fix an auto-correct error for `Style/For` when setting `EnforcedStyle: each` and `for` dose not have `do` or semicolon. ([@autopp][])
 * [#6300](https://github.com/rubocop-hq/rubocop/pull/6300): Fix a false positive for `Layout/EmptyLineAfterGuardClause` when guard clause including heredoc. ([@koic][])
 

--- a/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
+++ b/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
@@ -23,6 +23,11 @@ module RuboCop
       class HasManyOrHasOneDependent < Cop
         MSG = 'Specify a `:dependent` option.'.freeze
 
+        def_node_matcher :activerecord_class, <<-PATTERN
+          {(const nil? :ApplicationRecord)
+           (const (const nil? :ActiveRecord) :Base)}
+        PATTERN
+
         def_node_matcher :association_without_options?, <<-PATTERN
           (send nil? {:has_many :has_one} _)
         PATTERN
@@ -46,7 +51,18 @@ module RuboCop
             (args) ...)
         PATTERN
 
-        def on_send(node)
+        def on_class(node)
+          _class_name, base_class, body = *node.children
+
+          activerecord_class(base_class) do
+            check_offsenses(body)
+            body.each_descendant(:send) do |n|
+              check_offsenses(n)
+            end
+          end
+        end
+
+        def check_offsenses(node)
           unless association_without_options?(node)
             return if valid_options?(association_with_options?(node))
           end

--- a/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
+++ b/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent do
   context 'has_one' do
     it 'registers an offense when not specifying any options' do
       expect_offense(<<-RUBY.strip_indent)
-        class Person
+        class Person < ApplicationRecord
           has_one :foo
           ^^^^^^^ Specify a `:dependent` option.
         end
@@ -15,7 +15,7 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent do
 
     it 'registers an offense when missing an explicit `:dependent` strategy' do
       expect_offense(<<-RUBY.strip_indent)
-        class Person
+        class Person < ApplicationRecord
           has_one :foo, class_name: 'bar'
           ^^^^^^^ Specify a `:dependent` option.
         end
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent do
 
     it 'does not register an offense when specifying `:dependent` strategy' do
       expect_no_offenses(<<-RUBY.strip_indent)
-        class Person
+        class Person < ApplicationRecord
           has_one :foo, dependent: :destroy
         end
       RUBY
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent do
     context 'with :through option' do
       it 'does not register an offense for non-nil value' do
         expect_no_offenses(<<-RUBY.strip_indent)
-          class Person
+          class Person < ApplicationRecord
             has_one :foo, through: :bar
           end
         RUBY
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent do
 
       it 'registers an offense for nil value' do
         expect_offense(<<-RUBY.strip_indent)
-        class Person
+        class Person < ApplicationRecord
           has_one :foo, through: nil
           ^^^^^^^ Specify a `:dependent` option.
         end
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent do
     context 'with_options dependent: :destroy' do
       it 'does not register an offense' do
         expect_no_offenses(<<-RUBY.strip_indent)
-          class Person
+          class Person < ApplicationRecord
             with_options dependent: :destroy do
               has_one :foo
             end
@@ -62,7 +62,7 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent do
 
       it 'does not register an offense for using `class_name` option' do
         expect_no_offenses(<<-RUBY.strip_indent)
-          class Person
+          class Person < ApplicationRecord
             with_options dependent: :destroy do
               has_one :foo, class_name: 'Foo'
             end
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent do
   context 'has_many' do
     it 'registers an offense when not specifying any options' do
       expect_offense(<<-RUBY.strip_indent)
-        class Person
+        class Person < ApplicationRecord
           has_many :foo
           ^^^^^^^^ Specify a `:dependent` option.
         end
@@ -84,7 +84,7 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent do
 
     it 'registers an offense when missing an explicit `:dependent` strategy' do
       expect_offense(<<-RUBY.strip_indent)
-        class Person
+        class Person < ApplicationRecord
           has_many :foo, class_name: 'bar'
           ^^^^^^^^ Specify a `:dependent` option.
         end
@@ -102,7 +102,7 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent do
 
       it 'registers an offense for nil value' do
         expect_offense(<<-RUBY.strip_indent)
-        class Person
+        class Person < ApplicationRecord
           has_many :foo, through: nil
           ^^^^^^^^ Specify a `:dependent` option.
         end
@@ -113,7 +113,7 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent do
     context 'Surrounded `with_options` block' do
       it 'registers an offense when `dependent: :destroy` is not present' do
         expect_offense(<<-RUBY.strip_indent)
-          class Person
+          class Person < ApplicationRecord
             with_options through: nil do
               has_many :foo
               ^^^^^^^^ Specify a `:dependent` option.
@@ -124,7 +124,7 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent do
 
       it "doesn't register an offense for `with_options dependent: :destroy`" do
         expect_no_offenses(<<-RUBY.strip_indent)
-          class Person
+          class Person < ApplicationRecord
             with_options dependent: :destroy do
               has_many :foo
             end
@@ -136,7 +136,7 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent do
         it "doesn't register an offense for " \
            '`with_options dependent: :destroy`' do
           expect_no_offenses(<<-RUBY.strip_indent)
-            class Person
+            class Person < ApplicationRecord
               with_options dependent: :destroy do
                 has_many :foo
                 has_many :bar
@@ -160,6 +160,33 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent do
           end
         RUBY
       end
+    end
+  end
+
+  context 'base-class check' do
+    it 'runs the cop for ActiveRecord::Base class' do
+      expect_offense(<<-RUBY.strip_indent)
+        class Person < ActiveRecord::Base
+          has_one :foo
+          ^^^^^^^ Specify a `:dependent` option.
+        end
+      RUBY
+    end
+
+    it 'does not run the cop for ActiveResource class' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class Person < ActiveResource
+          has_one :foo
+        end
+      RUBY
+    end
+
+    it 'does not run the cop no base-class' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class Person
+          has_one :foo
+        end
+      RUBY
     end
   end
 end


### PR DESCRIPTION
Closes: https://github.com/rubocop-hq/rubocop/issues/6266

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
