### PR TITLE
[Fix #6300] Fix a false positive for `Layout/EmptyLineAfterGuardClause`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#6296](https://github.com/rubocop-hq/rubocop/issues/6296): Fix an auto-correct error for `Style/For` when setting `EnforcedStyle: each` and `for` dose not have `do` or semicolon. ([@autopp][])
+* [#6300](https://github.com/rubocop-hq/rubocop/pull/6300): Fix a false positive for `Layout/EmptyLineAfterGuardClause` when guard clause including heredoc. ([@koic][])
 
 ## 0.59.1 (2018-09-15)
 

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -106,6 +106,36 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
+  it 'registers an offense for guard clause followed by empty line' \
+     'when guard clause including heredoc' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def method
+        if truthy
+          raise <<-MSG
+            This is an error.
+          MSG
+        end
+
+        value
+      end
+    RUBY
+  end
+
+  it 'registers an offense for guard clause not followed by empty line' \
+     'when guard clause including heredoc' do
+    expect_offense(<<-RUBY.strip_indent)
+      def method
+        if truthy
+          raise <<-MSG
+            This is an error.
+          MSG
+        end
+        ^^^ Add empty line after guard clause.
+        value
+      end
+    RUBY
+  end
+
   it 'does not register offense for guard clause followed by end' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def foo


### PR DESCRIPTION
Fixes #6300.

This PR fixes a false positive for `Layout/EmptyLineAfterGuardClause` when guard clause including heredoc.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
