### PR TITLE
[Fix #6250] Skip useless access modifier for new method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Don't show "unrecognized parameter" warning for `inherit_mode` parameter to individual cop configurations. ([@maxh][])
 * [#6449](https://github.com/rubocop-hq/rubocop/pull/6449): Fix a false negative for `Layout/IndentationWidth` when setting `EnforcedStyle: rails` of `Layout/IndentationConsistency` and method definition indented to access modifier in a singleton class. ([@koic][])
 * [#6482](https://github.com/rubocop-hq/rubocop/issues/6482): Fix a false positive for `Lint/FormatParameterMismatch` when using (digit)$ flag. ([@koic][])
+* [#6250](https://github.com/rubocop-hq/rubocop/issues/6250): Skip Lint/UselessAccessModifier for `:new` method. ([@tejasbubane][])
 
 ## 0.60.0 (2018-10-26)
 

--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -141,7 +141,13 @@ module RuboCop
 
         def access_modifier?(node)
           node.bare_access_modifier? ||
-            node.method_name == :private_class_method
+            (node.method_name == :private_class_method && new_method?(node))
+        end
+
+        def new_method?(node)
+          return true unless node.arguments.first
+
+          node.arguments.first.value != :new
         end
 
         def check_scope(node)

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -178,6 +178,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier do
     end
   end
 
+  context 'private_class_method with new' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        MyClass = Class.new { private_class_method :new }
+      RUBY
+    end
+  end
+
   context "when using ActiveSupport's `concerning` method" do
     let(:config) do
       RuboCop::Config.new(


### PR DESCRIPTION
Closes https://github.com/rubocop-hq/rubocop/issues/6250

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
