### PR TITLE
[Fix #2841] Reduce Style/ZeroLengthPredicate false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#6272](https://github.com/rubocop-hq/rubocop/pull/6272): Make `Lint/UnreachableCode` detect `exit`, `exit!` and `abort`. ([@hoshinotsuyoshi][])
 * [#6295](https://github.com/rubocop-hq/rubocop/pull/6295): Exclude `#===` from `Naming/BinaryOperatorParameterName`. ([@zverok][])
 * Add `+` to allowed file names of `Naming/FileName`. ([@yensaki][])
+* [#2841](https://github.com/rubocop-hq/rubocop/pull/2841): Fix `Style/ZeroLengthPredicate` false positives when inspecting `Tempfile`, `StringIO`, and `File::Stat` objects. ([@drenmi][])
 
 ## 0.59.0 (2018-09-09)
 

--- a/lib/rubocop/cop/style/zero_length_predicate.rb
+++ b/lib/rubocop/cop/style/zero_length_predicate.rb
@@ -50,6 +50,8 @@ module RuboCop
 
           lhs, opr, rhs = zero_length_predicate
 
+          return if non_polymorphic_collection?(node)
+
           add_offense(
             node,
             message: format(ZERO_MSG, lhs: lhs, opr: opr, rhs: rhs)
@@ -62,6 +64,8 @@ module RuboCop
           return unless nonzero_length_predicate
 
           lhs, opr, rhs = nonzero_length_predicate
+
+          return if non_polymorphic_collection?(node)
 
           add_offense(
             node,
@@ -98,6 +102,14 @@ module RuboCop
         def_node_matcher :other_receiver, <<-PATTERN
           {(send (send $_ _) _ _)
            (send _ _ (send $_ _))}
+        PATTERN
+
+        # Some collection like objects in the Ruby standard library
+        # implement `#size`, but not `#empty`. We ignore those to
+        # reduce false positives.
+        def_node_matcher :non_polymorphic_collection?, <<-PATTERN
+          {(send (send (send (const nil? :File) :stat _) ...) ...)
+           (send (send (send (const nil? {:Tempfile :StringIO}) {:new :open} ...) ...) ...)}
         PATTERN
       end
     end

--- a/spec/rubocop/cop/style/zero_length_predicate_spec.rb
+++ b/spec/rubocop/cop/style/zero_length_predicate_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe RuboCop::Cop::Style::ZeroLengthPredicate do
   subject(:cop) { described_class.new }
 
+  let(:source) { '' }
+
   before do
     inspect_source(source)
   end
@@ -151,5 +153,39 @@ RSpec.describe RuboCop::Cop::Style::ZeroLengthPredicate do
 
     it_behaves_like 'code without offense', '0 != size'
     it_behaves_like 'code without offense', '0 != length'
+  end
+
+  context 'when inspecting a File::Stat object' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        File.stat(foo).size == 0
+      RUBY
+    end
+  end
+
+  context 'when inspecting a StringIO object' do
+    context 'when initialized with a string' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          StringIO.new('foo').size == 0
+        RUBY
+      end
+    end
+
+    context 'when initialized without arguments' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          StringIO.new.size == 0
+        RUBY
+      end
+    end
+  end
+
+  context 'when inspecting a Tempfile object' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        Tempfile.new('foo').size == 0
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Some collection like classes in the Ruby standard library implement `#size` but not `#empty`. This change has the cop ignore known cases with `Tempfile`, `StringIO`, and `File::Stat` objects to reduce false positives.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
