### PR TITLE
Move inspection of class- and module definition block length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#6263](https://github.com/rubocop-hq/rubocop/issues/6263): Fix an error `Layout/EmptyLineAfterGuardClause` when guard clause is after heredoc including string interpolation. ([@koic][])
 * [#6281](https://github.com/rubocop-hq/rubocop/pull/6281): Fix false negative in `Style/MultilineMethodSignature`. ([@drenmi][])
 * [#6264](https://github.com/rubocop-hq/rubocop/issues/6264): Fix an incorrect autocorrect for `Layout/EmptyLineAfterGuardClause` cop when `if` condition is after heredoc. ([@koic][])
+* [#5338](https://github.com/rubocop-hq/rubocop/pull/5338): Move checking of class- and module defining blocks from `Metrics/BlockLength` into the respective length cops. ([@drenmi][])
 
 ### Changes
 

--- a/lib/rubocop/cop/metrics/block_length.rb
+++ b/lib/rubocop/cop/metrics/block_length.rb
@@ -14,6 +14,7 @@ module RuboCop
 
         def on_block(node)
           return if excluded_method?(node)
+          return if node.class_constructor?
 
           check_code_length(node)
         end

--- a/lib/rubocop/cop/metrics/class_length.rb
+++ b/lib/rubocop/cop/metrics/class_length.rb
@@ -13,7 +13,17 @@ module RuboCop
           check_code_length(node)
         end
 
+        def on_casgn(node)
+          class_definition?(node) do
+            check_code_length(node)
+          end
+        end
+
         private
+
+        def_node_matcher :class_definition?, <<-PATTERN
+          (casgn nil? _ (block (send (const nil? :Class) :new) ...))
+        PATTERN
 
         def message(length, max_length)
           format('Class has too many lines. [%<length>d/%<max>d]',

--- a/lib/rubocop/cop/metrics/module_length.rb
+++ b/lib/rubocop/cop/metrics/module_length.rb
@@ -13,7 +13,17 @@ module RuboCop
           check_code_length(node)
         end
 
+        def on_casgn(node)
+          module_definition?(node) do
+            check_code_length(node)
+          end
+        end
+
         private
+
+        def_node_matcher :module_definition?, <<-PATTERN
+          (casgn nil? _ (block (send (const nil? :Module) :new) ...))
+        PATTERN
 
         def message(length, max_length)
           format('Module has too many lines. [%<length>d/%<max>d]',

--- a/lib/rubocop/cop/mixin/code_length.rb
+++ b/lib/rubocop/cop/mixin/code_length.rb
@@ -18,9 +18,13 @@ module RuboCop
 
       def check_code_length(node)
         length = code_length(node)
+
         return unless length > max_length
 
-        add_offense(node, message: message(length, max_length)) do
+        location = node.casgn_type? ? :name : :expression
+
+        add_offense(node, location: location,
+                          message: message(length, max_length)) do
           self.max = length
         end
       end

--- a/spec/rubocop/cop/metrics/block_length_spec.rb
+++ b/spec/rubocop/cop/metrics/block_length_spec.rb
@@ -131,6 +131,36 @@ RSpec.describe RuboCop::Cop::Metrics::BlockLength, :config do
     RUBY
   end
 
+  context 'when defining a class' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        Class.new do
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      RUBY
+    end
+  end
+
+  context 'when defining a module' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        Module.new do
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      RUBY
+    end
+  end
+
   context 'when CountComments is enabled' do
     before { cop_config['CountComments'] = true }
 

--- a/spec/rubocop/cop/metrics/class_length_spec.rb
+++ b/spec/rubocop/cop/metrics/class_length_spec.rb
@@ -153,4 +153,20 @@ RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
       RUBY
     end
   end
+
+  context 'when inspecting a class defined with Class.new' do
+    it 'registers an offense' do
+      expect_offense(<<-RUBY.strip_indent)
+        Foo = Class.new do
+        ^^^ Class has too many lines. [6/5]
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/metrics/module_length_spec.rb
+++ b/spec/rubocop/cop/metrics/module_length_spec.rb
@@ -208,4 +208,20 @@ RSpec.describe RuboCop::Cop::Metrics::ModuleLength, :config do
       RUBY
     end
   end
+
+  context 'when inspecting a class defined with Module.new' do
+    it 'registers an offense' do
+      expect_offense(<<-RUBY.strip_indent)
+        Foo = Module.new do
+        ^^^ Module has too many lines. [6/5]
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Prior to this change, classes and modules defined using `Class.new` and `Module.new` were subject to inspection by `Metrics/BlockLength`.

After this change, such class definitions are checked by `Metrics/ClassLength`, and module definitions by `Metrics/ModuleLength`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
