### PR TITLE
[Fix #6305] Fix infinite loop for `Layout/EmptyLinesAroundAccessModifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#6300](https://github.com/rubocop-hq/rubocop/pull/6300): Fix a false positive for `Layout/EmptyLineAfterGuardClause` when guard clause including heredoc. ([@koic][])
 * [#5338](https://github.com/rubocop-hq/rubocop/pull/5338): Move checking of class- and module defining blocks from `Metrics/BlockLength` into the respective length cops. ([@drenmi][])
 * [#2841](https://github.com/rubocop-hq/rubocop/pull/2841): Fix `Style/ZeroLengthPredicate` false positives when inspecting `Tempfile`, `StringIO`, and `File::Stat` objects. ([@drenmi][])
+* [#6305](https://github.com/rubocop-hq/rubocop/pull/6305): Fix infinite loop for `Layout/EmptyLinesAroundAccessModifier` and `Layout/EmptyLinesAroundAccessModifier` when specifying a superclass that breaks the line. ([@koic][])
 
 ## 0.59.1 (2018-09-15)
 

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -137,12 +137,68 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
       RUBY
     end
 
-    it 'accepts missing blank line when at the beginning of class/module' do
+    it 'accepts missing blank line when at the beginning of class' do
       expect_no_offenses(<<-RUBY.strip_indent)
         class Test
           #{access_modifier}
 
           def test; end
+        end
+      RUBY
+    end
+
+    it 'accepts missing blank line when at the beginning of module' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        module Test
+          #{access_modifier}
+
+          def test; end
+        end
+      RUBY
+    end
+
+    it 'accepts missing blank line when at the beginning of sclass' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class << self
+          #{access_modifier}
+
+          def test; end
+        end
+      RUBY
+    end
+
+    it 'accepts missing blank line when specifying a superclass ' \
+       'that breaks the line' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class Foo <
+              Bar
+          #{access_modifier}
+
+          def do_something
+          end
+        end
+      RUBY
+    end
+
+    it 'accepts missing blank line when specifying `self` ' \
+       'that breaks the line' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class <<
+              self
+          #{access_modifier}
+
+          def do_something
+          end
+        end
+      RUBY
+    end
+
+    it 'accepts missing blank line when at the beginning of file' \
+       'when specifying a superclass that breaks the line' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        #{access_modifier}
+
+        def do_something
         end
       RUBY
     end


### PR DESCRIPTION
Fixes #6305.

This is a problem that occurs after #6236.

This PR fixes infinite loop for `Layout/EmptyLinesAroundAccessModifier` and `Layout/EmptyLinesAroundClassBody` when specifying a superclass that breaks the line.

```ruby
class AVerryLongClassNameDoYouLikeIt <
  ItEvenInheritsFromALongClassNameSOINeedToAddALineBrake

  protected

  def foobar
  end
end
```

With this PR, `Layout/EmptyLinesAroundAccessModifier` cop makes aware of the above case that specifying a superclass that breaks the line. This is the same behavior as writing a class definition on a single line.

As a result, `Layout/EmptyLinesAroundAccessModifier` and `Layout/EmptyLinesAroundClassBody` will not conflict with the handling of empty line under the class definition.

This problem was caused by using the regular expression in `EmptyLinesAroundAccessModifier#class_def?` method. This PR will change it to use AST.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
