### PR TITLE
[Fix #6007] Fix false positive in Style/IfUnlessModifier when using named capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#5338](https://github.com/rubocop-hq/rubocop/pull/5338): Move checking of class- and module defining blocks from `Metrics/BlockLength` into the respective length cops. ([@drenmi][])
 * [#2841](https://github.com/rubocop-hq/rubocop/pull/2841): Fix `Style/ZeroLengthPredicate` false positives when inspecting `Tempfile`, `StringIO`, and `File::Stat` objects. ([@drenmi][])
 * [#6305](https://github.com/rubocop-hq/rubocop/pull/6305): Fix infinite loop for `Layout/EmptyLinesAroundAccessModifier` and `Layout/EmptyLinesAroundAccessModifier` when specifying a superclass that breaks the line. ([@koic][])
+* [#6007](https://github.com/rubocop-hq/rubocop/pull/6007): Fix false positive in `Style/IfUnlessModifier` when using named capture. ([@drenmi][])
 
 ## 0.59.1 (2018-09-15)
 

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -31,8 +31,11 @@ module RuboCop
         ASSIGNMENT_TYPES = %i[lvasgn casgn cvasgn
                               gvasgn ivasgn masgn].freeze
 
+        NAMED_CAPTURE = /\?<.+>/
+
         def on_if(node)
           return unless eligible_node?(node)
+          return if named_capture_in_condition?(node)
 
           add_offense(node, location: :keyword,
                             message: format(MSG, keyword: node.keyword))
@@ -45,6 +48,10 @@ module RuboCop
         end
 
         private
+
+        def named_capture_in_condition?(node)
+          node.condition.match_with_lvasgn_type?
+        end
 
         def eligible_node?(node)
           !non_eligible_if?(node) && !node.chained? &&

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -349,6 +349,16 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier do
     end
   end
 
+  context 'with a named regexp capture on the LHS' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        if /(?<foo>\d)/ =~ "bar"
+          foo
+        end
+      RUBY
+    end
+  end
+
   context 'with disabled Layout/Tab cop' do
     shared_examples 'with tabs indentation' do
       let(:source) do


### PR DESCRIPTION
When using a named capture in the condition, which is subsequently used in one of the conditional branches, the modifier form will not work:

```ruby
def qux(bar)
  if /(?<baz>.+)/ =~ "hello"
    baz 
  end
end

qux("hello")
#=> "hello"

def foo(bar)
  baz if /(?<baz>.+)/ =~ "hello"
end

foo("hello")
#=> NameError (undefined local variable or method `baz')
```

This change makes the cop ignore conditions like this to avoid breaking code.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
