### PR TITLE
[Fix #6100] Fix a false positive in `Naming/ConstantName` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#6100](https://github.com/rubocop-hq/rubocop/issues/6100): Fix a false positive in `Naming/ConstantName` cop when rhs is a conditional expression. ([@tatsuyafw][])
+
 ## 0.62.0 (2019-01-01)
 
 ### New features

--- a/lib/rubocop/ast/node/if_node.rb
+++ b/lib/rubocop/ast/node/if_node.rb
@@ -141,6 +141,35 @@ module RuboCop
 
         [condition, true_branch, false_branch]
       end
+
+      # Returns an array of all the branches in the conditional statement.
+      #
+      # @return [Array<Node>] an array of branch nodes
+      def branches
+        branches = [if_branch]
+
+        return branches unless else_branch
+
+        other_branches = if elsif_conditional?
+                           else_branch.branches
+                         else
+                           [else_branch]
+                         end
+        branches.concat(other_branches)
+      end
+
+      # Calls the given block for each branch node in the conditional statement.
+      # If no block is given, an `Enumerator` is returned.
+      #
+      # @return [self] if a block is given
+      # @return [Enumerator] if no block is given
+      def each_branch
+        return branches.to_enum(__method__) unless block_given?
+
+        branches.each do |branch|
+          yield branch
+        end
+      end
     end
   end
 end

--- a/lib/rubocop/cop/naming/constant_name.rb
+++ b/lib/rubocop/cop/naming/constant_name.rb
@@ -54,12 +54,21 @@ module RuboCop
         def allowed_assignment?(value)
           value && %i[block const casgn].include?(value.type) ||
             allowed_method_call_on_rhs?(value) ||
-            class_or_struct_return_method?(value)
+            class_or_struct_return_method?(value) ||
+            allowed_conditional_expression_on_rhs?(value)
         end
 
         def allowed_method_call_on_rhs?(node)
           node && node.send_type? &&
             (node.receiver.nil? || !node.receiver.literal?)
+        end
+
+        def allowed_conditional_expression_on_rhs?(node)
+          node && node.if_type? && contains_contant?(node)
+        end
+
+        def contains_contant?(node)
+          node.branches.any?(&:const_type?)
         end
       end
     end

--- a/spec/rubocop/ast/if_node_spec.rb
+++ b/spec/rubocop/ast/if_node_spec.rb
@@ -425,4 +425,71 @@ RSpec.describe RuboCop::AST::IfNode do
       it { expect(if_node.else_branch.int_type?).to be(true) }
     end
   end
+
+  describe '#branches' do
+    context 'with an if statement' do
+      let(:source) { 'if foo?; :bar; end' }
+
+      it { expect(if_node.branches.size).to eq(1) }
+      it { expect(if_node.branches).to all(be_literal) }
+    end
+
+    context 'with an unless statement' do
+      let(:source) { 'unless foo?; :bar; end' }
+
+      it { expect(if_node.branches.size).to eq(1) }
+      it { expect(if_node.branches).to all(be_literal) }
+    end
+
+    context 'with an else statement' do
+      let(:source) do
+        ['if foo?',
+         '  1',
+         'else',
+         '  2',
+         'end'].join("\n")
+      end
+
+      it { expect(if_node.branches.size).to eq(2) }
+      it { expect(if_node.branches).to all(be_literal) }
+    end
+
+    context 'with an elsif statement' do
+      let(:source) do
+        ['if foo?',
+         '  1',
+         'elsif bar?',
+         '  2',
+         'else',
+         '  3',
+         'end'].join("\n")
+      end
+
+      it { expect(if_node.branches.size).to eq(3) }
+      it { expect(if_node.branches).to all(be_literal) }
+    end
+  end
+
+  describe '#each_branch' do
+    let(:source) do
+      ['if foo?',
+       '  1',
+       'elsif bar?',
+       '  2',
+       'else',
+       '  3',
+       'end'].join("\n")
+    end
+
+    context 'when not passed a block' do
+      it { expect(if_node.each_branch.is_a?(Enumerator)).to be(true) }
+    end
+
+    context 'when passed a block' do
+      it 'yields all the branches' do
+        expect { |b| if_node.each_branch(&b) }
+          .to yield_successive_args(*if_node.branches)
+      end
+    end
+  end
 end

--- a/spec/rubocop/cop/naming/constant_name_spec.rb
+++ b/spec/rubocop/cop/naming/constant_name_spec.rb
@@ -109,4 +109,27 @@ RSpec.describe RuboCop::Cop::Naming::ConstantName do
          ^^^^^^^ Use SCREAMING_SNAKE_CASE for constants.
     RUBY
   end
+
+  context 'when a rhs is a conditional expression' do
+    context 'when conditional branches contain only constants' do
+      it 'does not check names' do
+        expect_no_offenses('Investigation = if true then Foo else Bar end')
+      end
+    end
+
+    context 'when conditional branches contain a value other than a constant' do
+      it 'does not check names' do
+        expect_no_offenses('Investigation = if true then "foo" else Bar end')
+      end
+    end
+
+    context 'when conditional branches contain only string values' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
+          TopCase = if true then 'foo' else 'bar' end
+          ^^^^^^^ Use SCREAMING_SNAKE_CASE for constants.
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #6100.

This cop would register an offense when rhs is a conditional expression like the following code:

```ruby
# foo.rb
Lol = if true then Foo else Bar end
```

```sh
$ rubocop --only Naming/ConstantName foo.rb
Inspecting 1 file
C

Offenses:

foo.rb:1:1: C: Naming/ConstantName: Use SCREAMING_SNAKE_CASE for constants.
Lol = if true then Foo else Bar end
^^^

1 file inspected, 1 offense detected
$
```

But the docs [say](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/ConstantName)

> To avoid false positives, it ignores cases in which we cannot know for certain the type of value that would be assigned to a constant.

This PR fixes the false positive.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
