### PR TITLE
Fix an error for `Rails/HasManyOrHasOneDependent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#2841](https://github.com/rubocop-hq/rubocop/pull/2841): Fix `Style/ZeroLengthPredicate` false positives when inspecting `Tempfile`, `StringIO`, and `File::Stat` objects. ([@drenmi][])
 * [#6305](https://github.com/rubocop-hq/rubocop/pull/6305): Fix infinite loop for `Layout/EmptyLinesAroundAccessModifier` and `Layout/EmptyLinesAroundAccessModifier` when specifying a superclass that breaks the line. ([@koic][])
 * [#6007](https://github.com/rubocop-hq/rubocop/pull/6007): Fix false positive in `Style/IfUnlessModifier` when using named capture. ([@drenmi][])
+* [#6315](https://github.com/rubocop-hq/rubocop/pull/6315): Fix an error for `Rails/HasManyOrHasOneDependent` when an Active Record model does not have any relations. ([@koic][])
 
 ## 0.59.1 (2018-09-15)
 

--- a/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
+++ b/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
@@ -54,6 +54,8 @@ module RuboCop
         def on_class(node)
           _class_name, base_class, body = *node.children
 
+          return if body.nil?
+
           activerecord_class(base_class) do
             check_offsenses(body)
             body.each_descendant(:send) do |n|

--- a/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
+++ b/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
@@ -189,4 +189,13 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent do
       RUBY
     end
   end
+
+  context 'when an Active Record model does not have any relations' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class Person < ApplicationRecord
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes an error for `Rails/HasManyOrHasOneDependent` when an Active Record model does not have any relations.

The reproduction procedure is as follows.

```console
% cat app/models/person.rb
class Person < ApplicationRecord
end

% rubocop app/models/person.rb -R --only Rails/HasManyOrHasOneDependent -d
For /private/tmp: configuration from
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.59.1/config/default.yml
Inheriting configuration from
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.59.1/config/enabled.yml
Inheriting configuration from
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.59.1/config/disabled.yml
Inspecting 1 file
Scanning /private/tmp/app/models/person.rb
An error occurred while Rails/HasManyOrHasOneDependent cop was
inspecting /private/tmp/app/models/person.rb:1:0.
undefined method `each_descendant' for nil:NilClass
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.59.1/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb:59:in `block in on_class'
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.59.1/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb:28:in `activerecord_class'
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.59.1/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb:57:in `on_class'
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.59.1/lib/rubocop/cop/commissioner.rb:58:in
`block (2 levels) in trigger_responding_cops'
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.59.1/lib/rubocop/cop/commissioner.rb:106:in
`with_cop_error_handling'
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.59.1/lib/rubocop/cop/commissioner.rb:57:in
`block in trigger_responding_cops'

(snip)

1 file inspected, no offenses detected

1 error occurred:
An error occurred while Rails/HasManyOrHasOneDependent cop was
inspecting /private/tmp/app/models/person.rb:1:0.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop-hq/rubocop/issues

Mention the following information in the issue report:
0.59.1 (using Parser 2.5.1.2, running on ruby 2.5.1 x86_64-darwin17)
```

This error is a regression by #6298.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
