### PR TITLE
[Fix #6311] Prevent Style/Semicolon from breaking on single line if-then-else in assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#2841](https://github.com/rubocop-hq/rubocop/pull/2841): Fix `Style/ZeroLengthPredicate` false positives when inspecting `Tempfile`, `StringIO`, and `File::Stat` objects. ([@drenmi][])
 * [#6305](https://github.com/rubocop-hq/rubocop/pull/6305): Fix infinite loop for `Layout/EmptyLinesAroundAccessModifier` and `Layout/EmptyLinesAroundAccessModifier` when specifying a superclass that breaks the line. ([@koic][])
 * [#6007](https://github.com/rubocop-hq/rubocop/pull/6007): Fix false positive in `Style/IfUnlessModifier` when using named capture. ([@drenmi][])
+* [#6311](https://github.com/rubocop-hq/rubocop/pull/6311): Prevent `Style/Semicolon` from breaking on single line if-then-else in assignment. ([@drenmi][])
 
 ## 0.59.1 (2018-09-15)
 

--- a/lib/rubocop/cop/style/semicolon.rb
+++ b/lib/rubocop/cop/style/semicolon.rb
@@ -39,14 +39,18 @@ module RuboCop
           exprs_lines = exprs.map { |e| e.source_range.line }
           lines = exprs_lines.group_by { |i| i }
 
-          # every line with more than 1 expression on it is an offense
           lines.each do |line, expr_on_line|
+            # Every line with more than one expression on it is a
+            # potential offense
             next unless expr_on_line.size > 1
 
             # TODO: Find the correct position of the semicolon. We don't know
             # if the first semicolon on the line is a separator of
             # expressions. It's just a guess.
             column = @processed_source[line - 1].index(';')
+
+            next unless column
+
             convention_on(line, column, false)
           end
         end

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -105,6 +105,16 @@ RSpec.describe RuboCop::Cop::Style::Semicolon, :config do
       RUBY
   end
 
+  context 'with a multi-expression line without a semicolon' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def foo
+          bar = baz if qux else quux
+        end
+      RUBY
+    end
+  end
+
   context 'when AllowAsExpressionSeparator is true' do
     let(:cop_config) { { 'AllowAsExpressionSeparator' => true } }
 


### PR DESCRIPTION
This cop was making the assumption that all multi-expression lines would have a semicolon on them, but it turns out that there are cases where this is not true, e.g.:

```ruby
def foo
  bar = baz if qux else quux
end
```

This change asserts that there is an actual semicolon before attempting to register an offense.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
