### PR TITLE
Fix a false negative for `Rails/HasManyOrHasOneDependent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* [#6266](https://github.com/rubocop-hq/rubocop/issues/6266): Run `Rails/HasManyOrHasOneDependent` only for `ActiveRecord` class. ([@tejasbubane][])
+* [#6266](https://github.com/rubocop-hq/rubocop/issues/6266): Fix a false positive for `Rails/HasManyOrHasOneDependent` when using associations of Active Resource. ([@tejasbubane][], [@koic][])
 * [#6296](https://github.com/rubocop-hq/rubocop/issues/6296): Fix an auto-correct error for `Style/For` when setting `EnforcedStyle: each` and `for` dose not have `do` or semicolon. ([@autopp][])
 * [#6300](https://github.com/rubocop-hq/rubocop/pull/6300): Fix a false positive for `Layout/EmptyLineAfterGuardClause` when guard clause including heredoc. ([@koic][])
 * [#6287](https://github.com/rubocop-hq/rubocop/pull/6287): Fix `AllowURI` option for `Metrics/LineLength` cop with disabled `Layut/Tab` cop. ([@AlexWayfer][])


### PR DESCRIPTION
Follow up of https://github.com/rubocop-hq/rubocop/issues/6266#issuecomment-422651337.

This PR fixes a false negative for `Rails/HasManyOrHasOneDependent` when using the following mix-in case.

```ruby
module Foo
  extend ActiveSupport::Concern

  included do
    has_many :bazs # 0.59.1 emits offense for this line
  end
end

class Bar < ApplicationRecord
  include Foo
end
```

In #6298, only subclasses of `AactiveRecord::Base` or `ApplicationRecord` were scoped. But in that approach false negatives occur in the above case.
This PR changes the approach to solve the issue #6266 by skipping it in case of subclass of `ActiveResource::Base`.

Also, this PR integrates a series of change log entry which has not yet been released for the fixing of #6266.

Cc @tejasbubane @yskkin 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
