### PR TITLE
[Fix #6316] Fix auto-correct for `Style/For` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#6305](https://github.com/rubocop-hq/rubocop/pull/6305): Fix infinite loop for `Layout/EmptyLinesAroundAccessModifier` and `Layout/EmptyLinesAroundAccessModifier` when specifying a superclass that breaks the line. ([@koic][])
 * [#6007](https://github.com/rubocop-hq/rubocop/pull/6007): Fix false positive in `Style/IfUnlessModifier` when using named capture. ([@drenmi][])
 * [#6315](https://github.com/rubocop-hq/rubocop/pull/6315): Fix an error for `Rails/HasManyOrHasOneDependent` when an Active Record model does not have any relations. ([@koic][])
+* [#6316](https://github.com/rubocop-hq/rubocop/issues/6316): Fix an auto-correct error for `Style/For` when setting `EnforcedStyle: each` with range provided to the `for` loop without a `do` keyword or semicolon and without enclosing parenthesis. ([@lukasz-wojcik][])
 
 ## 0.59.1 (2018-09-15)
 
@@ -3586,3 +3587,4 @@
 [@yensaki]: https://github.com/yensaki
 [@ryanhageman]: https://github.com/ryanhageman
 [@autopp]: https://github.com/autopp
+[@lukasz-wojcik]: https://github.com/lukasz-wojcik

--- a/spec/rubocop/cop/style/for_spec.rb
+++ b/spec/rubocop/cop/style/for_spec.rb
@@ -50,6 +50,68 @@ RSpec.describe RuboCop::Cop::Style::For, :config do
         RUBY
       end
 
+      context 'with range' do
+        let(:expected_each_with_range) do
+          <<-RUBY.strip_indent
+            def func
+              (1...value).each do |n|
+                puts n
+              end
+            end
+          RUBY
+        end
+
+        it 'changes for to each' do
+          new_source = autocorrect_source(<<-RUBY.strip_indent)
+            def func
+              for n in (1...value) do
+                puts n
+              end
+            end
+          RUBY
+
+          expect(new_source).to eq(expected_each_with_range)
+        end
+
+        it 'changes for that does not have do or semicolon to each' do
+          new_source = autocorrect_source(<<-RUBY.strip_indent)
+            def func
+              for n in (1...value)
+                puts n
+              end
+            end
+          RUBY
+
+          expect(new_source).to eq(expected_each_with_range)
+        end
+
+        context 'without parentheses' do
+          it 'changes for to each' do
+            new_source = autocorrect_source(<<-RUBY.strip_indent)
+              def func
+                for n in 1...value do
+                  puts n
+                end
+              end
+            RUBY
+
+            expect(new_source).to eq(expected_each_with_range)
+          end
+
+          it 'changes for that does not have do or semicolon to each' do
+            new_source = autocorrect_source(<<-RUBY.strip_indent)
+              def func
+                for n in 1...value
+                  puts n
+                end
+              end
+            RUBY
+
+            expect(new_source).to eq(expected_each_with_range)
+          end
+        end
+      end
+
       it 'corrects a tuple of items' do
         new_source = autocorrect_source(<<-RUBY.strip_indent)
           def func
@@ -68,7 +130,7 @@ RSpec.describe RuboCop::Cop::Style::For, :config do
         RUBY
       end
 
-      it 'changes for that dose not have do or semicolon to each' do
+      it 'changes for that does not have do or semicolon to each' do
         new_source = autocorrect_source(<<-RUBY.strip_indent)
           def func
             for n in [1, 2, 3]


### PR DESCRIPTION
Fixes #6316 

It also makes sure that when the range is provided with or  without an enclosing parenthesis the resulting auto correction to `each` will generate a valid code. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
