### PR TITLE
Don't stop execution if cache directory is not writable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 ### Changes
 
 * [#6286](https://github.com/rubocop-hq/rubocop/pull/6286): Allow exclusion of certain methods for `Metrics/MethodLength`. ([@akanoi][])
+* [#6321](https://github.com/rubocop-hq/rubocop/pull/6321): Fix run of RuboCop when cache directory is not writable. ([@Kevinrob][])
 
 ## 0.59.1 (2018-09-15)
 
@@ -3620,3 +3621,4 @@
 [@autopp]: https://github.com/autopp
 [@lukasz-wojcik]: https://github.com/lukasz-wojcik
 [@albaer]: https://github.com/albaer
+[@Kevinrob]: https://github.com/Kevinrob

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -97,7 +97,15 @@ module RuboCop
 
     def save(offenses)
       dir = File.dirname(@path)
-      FileUtils.mkdir_p(dir)
+
+      begin
+        FileUtils.mkdir_p(dir)
+      rescue Errno::EACCES => e
+        warn "Couldn't create cache directory. Continuing without cache."\
+             "\n  #{e.message}"
+        return
+      end
+
       preliminary_path = "#{@path}_#{rand(1_000_000_000)}"
       # RuboCop must be in control of where its cached data is stored. A
       # symbolic link anywhere in the cache directory tree can be an

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -223,6 +223,14 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
         cache.save(offenses)
       end
     end
+
+    context 'when the @path is not writable' do
+      let(:cache_root) { '/permission_denied_dir' }
+
+      it 'doesn\'t raise an exception' do
+        expect { cache.save([]) }.not_to raise_error
+      end
+    end
   end
 
   describe '.cleanup' do


### PR DESCRIPTION
I run into a situation where $HOME was `/` and `Rubocop` won't run because the cache directory was not writable.  
Cache issues should not stopping this awesome program from running.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
