### PR TITLE
Testing ABCSize#complexity

### DIFF
--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -330,6 +330,7 @@ require_relative 'rubocop/cop/lint/void'
 
 require_relative 'rubocop/cop/metrics/cyclomatic_complexity'
 # relies on cyclomatic_complexity
+require_relative 'rubocop/cop/metrics/utils/abc_size_calculator'
 require_relative 'rubocop/cop/metrics/abc_size'
 require_relative 'rubocop/cop/metrics/block_length'
 require_relative 'rubocop/cop/metrics/block_nesting'

--- a/lib/rubocop/cop/metrics/abc_size.rb
+++ b/lib/rubocop/cop/metrics/abc_size.rb
@@ -11,27 +11,11 @@ module RuboCop
 
         MSG = 'Assignment Branch Condition size for %<method>s is too high. ' \
               '[%<complexity>.4g/%<max>.4g]'.freeze
-        BRANCH_NODES = %i[send csend].freeze
-        CONDITION_NODES = CyclomaticComplexity::COUNTED_NODES.freeze
 
         private
 
         def complexity(node)
-          assignment = 0
-          branch = 0
-          condition = 0
-
-          node.each_node do |child|
-            if child.assignment?
-              assignment += 1
-            elsif BRANCH_NODES.include?(child.type)
-              branch += 1
-            elsif CONDITION_NODES.include?(child.type)
-              condition += 1
-            end
-          end
-
-          Math.sqrt(assignment**2 + branch**2 + condition**2).round(2)
+          Utils::AbcSizeCalculator.calculate(node)
         end
       end
     end

--- a/lib/rubocop/cop/metrics/utils/abc_size_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/abc_size_calculator.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Metrics
+      module Utils
+        # > ABC is .. a software size metric .. computed by counting the number
+        # > of assignments, branches and conditions for a section of code.
+        # > http://c2.com/cgi/wiki?AbcMetric
+        #
+        # We separate the *calculator* from the *cop* so that the calculation,
+        # the formula itself, is easier to test.
+        module AbcSizeCalculator
+          # > Branch -- an explicit forward program branch out of scope -- a
+          # > function call, class method call ..
+          # > http://c2.com/cgi/wiki?AbcMetric
+          BRANCH_NODES = %i[send csend].freeze
+
+          # > Condition -- a logical/Boolean test, == != <= >= < > else case
+          # > default try catch ? and unary conditionals.
+          # > http://c2.com/cgi/wiki?AbcMetric
+          CONDITION_NODES = CyclomaticComplexity::COUNTED_NODES.freeze
+
+          def self.calculate(node)
+            assignment = 0
+            branch = 0
+            condition = 0
+
+            node.each_node do |child|
+              if child.assignment?
+                assignment += 1
+              elsif BRANCH_NODES.include?(child.type)
+                branch += 1
+              elsif CONDITION_NODES.include?(child.type)
+                condition += 1
+              end
+            end
+
+            Math.sqrt(assignment**2 + branch**2 + condition**2).round(2)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/metrics/utils/abc_size_calculator_spec.rb
+++ b/spec/rubocop/cop/metrics/utils/abc_size_calculator_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Metrics::Utils::AbcSizeCalculator do
+  describe '#calculate' do
+    context '0 assignments, 3 branches, 0 conditions' do
+      it 'returns 3' do
+        node = parse_source(<<-RUBY.strip_indent).ast
+          def method_name
+            return x, y, z
+          end
+        RUBY
+        expect(described_class.calculate(node)).to be_within(0.001).of(3)
+      end
+    end
+
+    context '2 assignments, 6 branches, 2 conditions' do
+      it 'returns 6.63' do
+        node = parse_source(<<-RUBY.strip_indent).ast
+          def method_name
+            a = b ? c : d
+            e = f ? g : h
+          end
+        RUBY
+        expect(described_class.calculate(node)).to be_within(0.001).of(6.63)
+      end
+    end
+
+    context '2 assignments, 8 branches, 3 conditions' do
+      it 'returns 8.77' do
+        node = parse_source(<<-RUBY.strip_indent).ast
+          def method_name
+            a = b ? c : d
+            if a
+              a
+            else
+              e = f ? g : h
+
+              # The * and - are counted as branches because they are parsed as
+              # `send` nodes. YARV might optimize them, but to `parser` they
+              # are methods.
+              e * 2.4 - 781.0
+            end
+          end
+        RUBY
+        expect(described_class.calculate(node)).to be_within(0.001).of(8.77)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I think it is useful to test the #complexity method in isolation, in addition
to the existing unit tests for the cop as a whole.

Also, I think these tests serve as better *examples* of the ABC formula.

Of course, #complexity is a private method, and some purists say that we
should not *ever* send a private method, even for the good of testing. But,
I find that stance extreme and take a more utilitarian view. I try to avoid
sending private methods in production code, but it doesn't bother me at all
in tests. That's just my opinion.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [N/A] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
