### PR TITLE
[Fix #5538] Fix false negative in modifier cops when line length cop is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#6330](https://github.com/rubocop-hq/rubocop/issues/6330): Fix an error for `Rails/ReversibleMigration` when using variable assignment. ([@koic][], [@scottmatthewman][])
 * [#6331](https://github.com/rubocop-hq/rubocop/issues/6331): Fix a false positive for `Style/RedundantFreeze` and a false negative for `Style/MutableConstant` when assigning a regexp object to a constant. ([@koic][])
 * [#6334](https://github.com/rubocop-hq/rubocop/pull/6334): Fix a false negative for `Style/RedundantFreeze` when assigning a range object to a constant. ([@koic][])
+* [#5538](https://github.com/rubocop-hq/rubocop/pull/5538): Fix false negatives in modifier cops when line length cop is disabled. ([@drenmi][])
 
 ## 0.59.2 (2018-09-24)
 

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -32,6 +32,8 @@ module RuboCop
       end
 
       def modifier_fits_on_single_line?(node)
+        return true unless max_line_length
+
         modifier_length = length_in_modifier_form(node, node.condition,
                                                   node.body.source_length)
 
@@ -47,6 +49,8 @@ module RuboCop
       end
 
       def max_line_length
+        return unless config.for_cop('Metrics/LineLength')['Enabled']
+
         config.for_cop('Metrics/LineLength')['Max']
       end
 

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier do
   subject(:cop) { described_class.new(config) }
 
   let(:config) do
-    hash = { 'Metrics/LineLength' => { 'Max' => 80 } }
-    RuboCop::Config.new(hash)
+    RuboCop::Config.new('Metrics/LineLength' => { 'Max' => 80 })
   end
 
   context 'multiline if that fits on one line' do
@@ -446,6 +445,26 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier do
       end
 
       it_behaves_like 'with tabs indentation'
+    end
+  end
+
+  context 'when Metrics/LineLength is disabled' do
+    let(:config) do
+      RuboCop::Config.new(
+        'Metrics/LineLength' => {
+          'Enabled' => false,
+          'Max' => 80
+        }
+      )
+    end
+
+    it 'registers an offense even for a long modifier statement' do
+      expect_offense(<<-RUBY.strip_indent)
+        if foo
+        ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+          "This string would make the line longer than eighty characters if combined with the statement." 
+        end
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/while_until_modifier_spec.rb
+++ b/spec/rubocop/cop/style/while_until_modifier_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe RuboCop::Cop::Style::WhileUntilModifier do
   subject(:cop) { described_class.new(config) }
 
   let(:config) do
-    hash = { 'Metrics/LineLength' => { 'Max' => 80 } }
-    RuboCop::Config.new(hash)
+    RuboCop::Config.new('Metrics/LineLength' => { 'Max' => 80 })
   end
 
   it "accepts multiline unless that doesn't fit on one line" do
@@ -107,6 +106,26 @@ RSpec.describe RuboCop::Cop::Style::WhileUntilModifier do
         foo while bar ||
             ^^^^^ Favor modifier `while` usage when having a single-line body.
           baz
+      RUBY
+    end
+  end
+
+  context 'when Metrics/LineLength is disabled' do
+    let(:config) do
+      RuboCop::Config.new(
+        'Metrics/LineLength' => {
+          'Enabled' => false,
+          'Max' => 80
+        }
+      )
+    end
+
+    it 'registers an offense even for a long modifier statement' do
+      expect_offense(<<-RUBY.strip_indent)
+        while foo
+        ^^^^^ Favor modifier `while` usage when having a single-line body.
+          "This string would make the line longer than eighty characters if combined with the statement." 
+        end
       RUBY
     end
   end


### PR DESCRIPTION
When `Metrics/LineLength` is disabled, but has a value for `Max`, these cops would not register offenses for statements that could be turned into long modifiers.

This change fixes that by explicitly checking if `Metrics/LineLength` is enabled before using its value.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
