### PR TITLE
[Fix #6331] Fix a false positive for `Style/RedundantFreeze`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#6330](https://github.com/rubocop-hq/rubocop/issues/6330): Fix an error for `Rails/ReversibleMigration` when using variable assignment. ([@koic][], [@scottmatthewman][])
+* [#6331](https://github.com/rubocop-hq/rubocop/issues/6331): Fix a false positive for `Style/RedundantFreeze` and a false negative for `Style/MutableConstant` when assigning a regexp object to a constant. ([@koic][])
 
 ## 0.59.2 (2018-09-24)
 

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -33,7 +33,8 @@ module RuboCop
       COMPOSITE_LITERALS = %i[dstr xstr dsym array hash irange
                               erange regexp].freeze
       BASIC_LITERALS = (LITERALS - COMPOSITE_LITERALS).freeze
-      MUTABLE_LITERALS = %i[str dstr xstr array hash].freeze
+      MUTABLE_LITERALS = %i[str dstr xstr array hash
+                            regexp].freeze
       IMMUTABLE_LITERALS = (LITERALS - MUTABLE_LITERALS).freeze
 
       VARIABLES = %i[ivar gvar cvar lvar].freeze

--- a/lib/rubocop/cop/generator/require_file_injector.rb
+++ b/lib/rubocop/cop/generator/require_file_injector.rb
@@ -7,7 +7,7 @@ module RuboCop
       # It looks for other directives that require files in the same (cop)
       # namespace and injects the provided one in alpha
       class RequireFileInjector
-        REQUIRE_PATH = /require_relative ['"](.+)['"]/
+        REQUIRE_PATH = /require_relative ['"](.+)['"]/.freeze
 
         def initialize(source_path:, root_file_path:, output: $stdout)
           @source_path = Pathname(source_path)

--- a/lib/rubocop/cop/layout/empty_line_after_magic_comment.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_magic_comment.rb
@@ -24,7 +24,7 @@ module RuboCop
         include RangeHelp
 
         MSG = 'Add an empty line after magic comments.'.freeze
-        BLANK_LINE = /\A\s*\z/
+        BLANK_LINE = /\A\s*\z/.freeze
 
         def investigate(source)
           return unless source.ast &&

--- a/lib/rubocop/cop/layout/space_inside_array_percent_literal.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_percent_literal.rb
@@ -18,7 +18,7 @@ module RuboCop
 
         MSG = 'Use only a single space inside array percent literal.'.freeze
         MULTIPLE_SPACES_BETWEEN_ITEMS_REGEX =
-          /(?:[\S&&[^\\]](?:\\ )*)( {2,})(?=\S)/
+          /(?:[\S&&[^\\]](?:\\ )*)( {2,})(?=\S)/.freeze
 
         def on_array(node)
           process(node, '%i', '%I', '%w', '%W')

--- a/lib/rubocop/cop/layout/space_inside_percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/layout/space_inside_percent_literal_delimiters.rb
@@ -21,8 +21,8 @@ module RuboCop
         include PercentLiteral
 
         MSG = 'Do not use spaces inside percent literal delimiters.'.freeze
-        BEGIN_REGEX = /\A( +)/
-        END_REGEX = /(?<!\\)( +)\z/
+        BEGIN_REGEX = /\A( +)/.freeze
+        END_REGEX = /(?<!\\)( +)\z/.freeze
 
         def on_array(node)
           process(node, '%i', '%I', '%w', '%W')

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -23,14 +23,14 @@ module RuboCop
         MSG = "Number of arguments (%<arg_num>i) to `%<method>s` doesn't " \
               'match the number of fields (%<field_num>i).'.freeze
         FIELD_REGEX =
-          /(%(([\s#+-0\*]*)(\d*)?(\.\d+)?[bBdiouxXeEfgGaAcps]|%))/
-        NAMED_FIELD_REGEX = /%\{[_a-zA-Z][_a-zA-Z]+\}/
+          /(%(([\s#+-0\*]*)(\d*)?(\.\d+)?[bBdiouxXeEfgGaAcps]|%))/.freeze
+        NAMED_FIELD_REGEX = /%\{[_a-zA-Z][_a-zA-Z]+\}/.freeze
         KERNEL = 'Kernel'.freeze
         SHOVEL = '<<'.freeze
         PERCENT = '%'.freeze
         PERCENT_PERCENT = '%%'.freeze
         STRING_TYPES = %i[str dstr].freeze
-        NAMED_INTERPOLATION = /%(?:<\w+>|\{\w+\})/
+        NAMED_INTERPOLATION = /%(?:<\w+>|\{\w+\})/.freeze
 
         def on_send(node)
           return unless offending_node?(node)

--- a/lib/rubocop/cop/lint/percent_string_array.rb
+++ b/lib/rubocop/cop/lint/percent_string_array.rb
@@ -24,8 +24,8 @@ module RuboCop
         include PercentLiteral
 
         QUOTES_AND_COMMAS = [/,$/, /^'.*'$/, /^".*"$/].freeze
-        LEADING_QUOTE = /^['"]/
-        TRAILING_QUOTE = /['"]?,?$/
+        LEADING_QUOTE = /^['"]/.freeze
+        TRAILING_QUOTE = /['"]?,?$/.freeze
 
         MSG = "Within `%w`/`%W`, quotes and ',' are unnecessary and may be " \
           'unwanted in the resulting strings.'.freeze

--- a/lib/rubocop/cop/mixin/heredoc.rb
+++ b/lib/rubocop/cop/mixin/heredoc.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     # Common functionality for working with heredoc strings.
     module Heredoc
-      OPENING_DELIMITER = /(<<[~-]?)['"`]?([^'"`]+)['"`]?/
+      OPENING_DELIMITER = /(<<[~-]?)['"`]?([^'"`]+)['"`]?/.freeze
 
       def on_str(node)
         return unless node.heredoc?

--- a/lib/rubocop/cop/naming/constant_name.rb
+++ b/lib/rubocop/cop/naming/constant_name.rb
@@ -21,7 +21,7 @@ module RuboCop
         MSG = 'Use SCREAMING_SNAKE_CASE for constants.'.freeze
         # Use POSIX character classes, so we allow accented characters rather
         # than just standard ASCII characters
-        SNAKE_CASE = /^[[:digit:][:upper:]_]+$/
+        SNAKE_CASE = /^[[:digit:][:upper:]_]+$/.freeze
 
         def_node_matcher :class_or_struct_return_method?, <<-PATTERN
           (send

--- a/lib/rubocop/cop/naming/file_name.rb
+++ b/lib/rubocop/cop/naming/file_name.rb
@@ -33,7 +33,7 @@ module RuboCop
                             'called `%<namespace>s`.'.freeze
         MSG_REGEX = '`%<basename>s` should match `%<regex>s`.'.freeze
 
-        SNAKE_CASE = /^[\da-z_.?!]+$/
+        SNAKE_CASE = /^[\da-z_.?!]+$/.freeze
 
         def investigate(processed_source)
           file_path = processed_source.file_path

--- a/lib/rubocop/cop/performance/string_replacement.rb
+++ b/lib/rubocop/cop/performance/string_replacement.rb
@@ -22,7 +22,7 @@ module RuboCop
         include RangeHelp
 
         MSG = 'Use `%<prefer>s` instead of `%<current>s`.'.freeze
-        DETERMINISTIC_REGEX = /\A(?:#{LITERAL_REGEX})+\Z/
+        DETERMINISTIC_REGEX = /\A(?:#{LITERAL_REGEX})+\Z/.freeze
         DELETE = 'delete'.freeze
         TR = 'tr'.freeze
         BANG = '!'.freeze

--- a/lib/rubocop/cop/rails/dynamic_find_by.rb
+++ b/lib/rubocop/cop/rails/dynamic_find_by.rb
@@ -27,7 +27,7 @@ module RuboCop
       #   User.find_by!(email: email)
       class DynamicFindBy < Cop
         MSG = 'Use `%<static_name>s` instead of dynamic `%<method>s`.'.freeze
-        METHOD_PATTERN = /^find_by_(.+?)(!)?$/
+        METHOD_PATTERN = /^find_by_(.+?)(!)?$/.freeze
 
         def on_send(node)
           method_name = node.method_name.to_s

--- a/lib/rubocop/cop/style/encoding.rb
+++ b/lib/rubocop/cop/style/encoding.rb
@@ -13,7 +13,7 @@ module RuboCop
         include RangeHelp
 
         MSG_UNNECESSARY = 'Unnecessary utf-8 encoding comment.'.freeze
-        ENCODING_PATTERN = /#.*coding\s?[:=]\s?(?:UTF|utf)-8/
+        ENCODING_PATTERN = /#.*coding\s?[:=]\s?(?:UTF|utf)-8/.freeze
         SHEBANG = '#!'.freeze
 
         def investigate(processed_source)

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -31,7 +31,7 @@ module RuboCop
         ASSIGNMENT_TYPES = %i[lvasgn casgn cvasgn
                               gvasgn ivasgn masgn].freeze
 
-        NAMED_CAPTURE = /\?<.+>/
+        NAMED_CAPTURE = /\?<.+>/.freeze
 
         def on_if(node)
           return unless eligible_node?(node)

--- a/lib/rubocop/cop/style/infinite_loop.rb
+++ b/lib/rubocop/cop/style/infinite_loop.rb
@@ -16,7 +16,7 @@ module RuboCop
       #     work
       #   end
       class InfiniteLoop < Cop
-        LEADING_SPACE = /\A(\s*)/
+        LEADING_SPACE = /\A(\s*)/.freeze
 
         MSG = 'Use `Kernel#loop` for infinite loops.'.freeze
 

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -35,7 +35,7 @@ module RuboCop
         CLASS_COMPARISON_METHODS = %i[<= >= < >].freeze
         EQUALITY_METHODS = %i[== != =~ !~ <= >= < >].freeze
         NEGATED_EQUALITY_METHODS = %i[!= !~].freeze
-        CAMEL_CASE = /[A-Z]+[a-z]+/
+        CAMEL_CASE = /[A-Z]+[a-z]+/.freeze
 
         def_node_matcher :inverse_candidate?, <<-PATTERN
           {

--- a/lib/rubocop/cop/style/multiline_if_then.rb
+++ b/lib/rubocop/cop/style/multiline_if_then.rb
@@ -20,7 +20,7 @@ module RuboCop
         include OnNormalIfUnless
         include RangeHelp
 
-        NON_MODIFIER_THEN = /then\s*(#.*)?$/
+        NON_MODIFIER_THEN = /then\s*(#.*)?$/.freeze
 
         MSG = 'Do not use `then` for multi-line `%<keyword>s`.'.freeze
 

--- a/lib/rubocop/cop/style/numeric_literal_prefix.rb
+++ b/lib/rubocop/cop/style/numeric_literal_prefix.rb
@@ -36,11 +36,11 @@ module RuboCop
       class NumericLiteralPrefix < Cop
         include IntegerNode
 
-        OCTAL_ZERO_ONLY_REGEX = /^0[Oo][0-7]+$/
-        OCTAL_REGEX = /^0O?[0-7]+$/
-        HEX_REGEX = /^0X[0-9A-F]+$/
-        BINARY_REGEX = /^0B[01]+$/
-        DECIMAL_REGEX = /^0[dD][0-9]+$/
+        OCTAL_ZERO_ONLY_REGEX = /^0[Oo][0-7]+$/.freeze
+        OCTAL_REGEX = /^0O?[0-7]+$/.freeze
+        HEX_REGEX = /^0X[0-9A-F]+$/.freeze
+        BINARY_REGEX = /^0B[01]+$/.freeze
+        DECIMAL_REGEX = /^0[dD][0-9]+$/.freeze
 
         OCTAL_ZERO_ONLY_MSG = 'Use 0 for octal literals.'.freeze
         OCTAL_MSG = 'Use 0o for octal literals.'.freeze

--- a/lib/rubocop/cop/style/unneeded_percent_q.rb
+++ b/lib/rubocop/cop/style/unneeded_percent_q.rb
@@ -27,8 +27,8 @@ module RuboCop
         EMPTY = ''.freeze
         PERCENT_Q = '%q'.freeze
         PERCENT_CAPITAL_Q = '%Q'.freeze
-        STRING_INTERPOLATION_REGEXP = /#\{.+}/
-        ESCAPED_NON_BACKSLASH = /\\[^\\]/
+        STRING_INTERPOLATION_REGEXP = /#\{.+}/.freeze
+        ESCAPED_NON_BACKSLASH = /\\[^\\]/.freeze
 
         def on_dstr(node)
           return unless string_literal?(node)

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -25,7 +25,8 @@ module RuboCop
 
       # Match literal regex characters, not including anchors, character
       # classes, alternatives, groups, repetitions, references, etc
-      LITERAL_REGEX = /[\w\s\-,"'!#%&<>=;:`~]|\\[^AbBdDgGhHkpPRwWXsSzZ0-9]/
+      LITERAL_REGEX =
+        /[\w\s\-,"'!#%&<>=;:`~]|\\[^AbBdDgGhHkpPRwWXsSzZ0-9]/.freeze
 
       module_function
 

--- a/lib/rubocop/magic_comment.rb
+++ b/lib/rubocop/magic_comment.rb
@@ -6,7 +6,7 @@ module RuboCop
   # @abstract parent of three different magic comment handlers
   class MagicComment
     # @see https://git.io/vMC1C IRB's pattern for matching magic comment tokens
-    TOKEN = /[[:alnum:]\-_]+/
+    TOKEN = /[[:alnum:]\-_]+/.freeze
 
     # Detect magic comment format and pass it to the appropriate wrapper.
     #
@@ -129,7 +129,7 @@ module RuboCop
     # @see https://www.gnu.org/software/emacs/manual/html_node/emacs/Specify-Coding.html
     # @see https://git.io/vMCXh Emacs handling in Ruby's parse.y
     class EmacsComment < EditorComment
-      FORMAT    = /\-\*\-(.+)\-\*\-/
+      FORMAT    = /\-\*\-(.+)\-\*\-/.freeze
       SEPARATOR = ';'.freeze
       OPERATOR  = ':'.freeze
 
@@ -153,7 +153,7 @@ module RuboCop
     #
     #   comment.encoding # => 'ascii-8bit'
     class VimComment < EditorComment
-      FORMAT    = /#\s*vim:\s*(.+)/
+      FORMAT    = /#\s*vim:\s*(.+)/.freeze
       SEPARATOR = ', '.freeze
       OPERATOR  = '='.freeze
 

--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -96,27 +96,27 @@ module RuboCop
     # @private
     # Builds Ruby code which implements a pattern
     class Compiler
-      SYMBOL       = %r{:(?:[\w+@*/?!<>=~|%^-]+|\[\]=?)}
-      IDENTIFIER   = /[a-zA-Z_-]/
-      META         = /\(|\)|\{|\}|\[|\]|\$\.\.\.|\$|!|\^|\.\.\./
-      NUMBER       = /-?\d+(?:\.\d+)?/
-      STRING       = /".+?"/
-      METHOD_NAME  = /\#?#{IDENTIFIER}+[\!\?]?\(?/
-      PARAM_NUMBER = /%\d*/
+      SYMBOL       = %r{:(?:[\w+@*/?!<>=~|%^-]+|\[\]=?)}.freeze
+      IDENTIFIER   = /[a-zA-Z_-]/.freeze
+      META         = /\(|\)|\{|\}|\[|\]|\$\.\.\.|\$|!|\^|\.\.\./.freeze
+      NUMBER       = /-?\d+(?:\.\d+)?/.freeze
+      STRING       = /".+?"/.freeze
+      METHOD_NAME  = /\#?#{IDENTIFIER}+[\!\?]?\(?/.freeze
+      PARAM_NUMBER = /%\d*/.freeze
 
-      SEPARATORS = /[\s]+/
+      SEPARATORS = /[\s]+/.freeze
       TOKENS     = Regexp.union(META, PARAM_NUMBER, NUMBER,
                                 METHOD_NAME, SYMBOL, STRING)
 
-      TOKEN = /\G(?:#{SEPARATORS}|#{TOKENS}|.)/
+      TOKEN = /\G(?:#{SEPARATORS}|#{TOKENS}|.)/.freeze
 
-      NODE      = /\A#{IDENTIFIER}+\Z/
-      PREDICATE = /\A#{IDENTIFIER}+\?\(?\Z/
-      WILDCARD  = /\A_#{IDENTIFIER}*\Z/
-      FUNCALL   = /\A\##{METHOD_NAME}/
-      LITERAL   = /\A(?:#{SYMBOL}|#{NUMBER}|#{STRING})\Z/
-      PARAM     = /\A#{PARAM_NUMBER}\Z/
-      CLOSING   = /\A(?:\)|\}|\])\Z/
+      NODE      = /\A#{IDENTIFIER}+\Z/.freeze
+      PREDICATE = /\A#{IDENTIFIER}+\?\(?\Z/.freeze
+      WILDCARD  = /\A_#{IDENTIFIER}*\Z/.freeze
+      FUNCALL   = /\A\##{METHOD_NAME}/.freeze
+      LITERAL   = /\A(?:#{SYMBOL}|#{NUMBER}|#{STRING})\Z/.freeze
+      PARAM     = /\A#{PARAM_NUMBER}\Z/.freeze
+      CLOSING   = /\A(?:\)|\}|\])\Z/.freeze
 
       attr_reader :match_code
 

--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -65,7 +65,7 @@ module RuboCop
 
       # Parsed representation of code annotated with the `^^^ Message` style
       class AnnotatedSource
-        ANNOTATION_PATTERN = /\A\s*\^+ /
+        ANNOTATION_PATTERN = /\A\s*\^+ /.freeze
 
         # @param annotated_source [String] string passed to the matchers
         #

--- a/lib/rubocop/string_interpreter.rb
+++ b/lib/rubocop/string_interpreter.rb
@@ -16,7 +16,7 @@ module RuboCop
                             u[0-9a-fA-F]{4}   |   # unicode char escape
                             u\{[^}]*\}        |   # extended unicode escape
                             .                     # any other escaped char
-                          )/x
+                          )/x.freeze
     class << self
       def interpret(string)
         # We currently don't handle \cx, \C-x, and \M-x

--- a/spec/rubocop/cop/style/redundant_freeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_freeze_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze do
   it_behaves_like 'immutable objects', '1.5'
   it_behaves_like 'immutable objects', ':sym'
   it_behaves_like 'immutable objects', ':""'
-  it_behaves_like 'immutable objects', '/./'
   it_behaves_like 'immutable objects', '1..5'
 
   shared_examples 'mutable objects' do |o|
@@ -37,6 +36,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze do
   it_behaves_like 'mutable objects', '{ a: 1, b: 2 }'
   it_behaves_like 'mutable objects', "'str'"
   it_behaves_like 'mutable objects', '"top#{1 + 2}"'
+  it_behaves_like 'mutable objects', '/./'
 
   it 'allows .freeze on  method call' do
     expect_no_offenses('TOP_TEST = Something.new.freeze')


### PR DESCRIPTION
Fixes #6331.

This PR fixes a false positive for `Style/RedundantFreeze` when assigning a regexp object to a constant.

The following is a reproduction procedure.

```console
% cat example.rb
CONSTANT = /regexp/.freeze
% rubocop example.rb --only Style/RedundantFreeze
Inspecting 1 file
C

Offenses:

example.rb:1:12: C: Style/RedundantFreeze: Do not freeze immutable
objects, as freezing them has no effect.
CONSTANT = /regexp/.freeze
           ^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```

A regexp object is a mutable object.

```console
% ruby -ve 'p(/regexp/.frozen?)'
ruby 2.2.10p489 (2018-03-28 revision 63023) [x86_64-darwin17]
false
% ruby -ve 'p(/regexp/.frozen?)'
ruby 2.3.7p456 (2018-03-28 revision 63024) [x86_64-darwin17]
false
% ruby -ve 'p(/regexp/.frozen?)'
ruby 2.4.4p296 (2018-03-28 revision 63013) [x86_64-darwin17]
false
% ruby -ve 'p(/regexp/.frozen?)'
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin17]
false
```

However, this false positive was caused by not including regexp object as a mutable object in `RuboCop::AST::Node::MUTABLE_LITERALS`.

This PR fixes this problem and applies auto-correct for the following new offenses.

```console
lib/rubocop/string_interpreter.rb:12:27: C: Style/MutableConstant:
Freeze mutable objects assigned to constants.
    STRING_ESCAPE_REGEX = /\\(?: ...
                          ^^^^^^
```

This was a false negative of `Style/MutableConstant`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
