### PR TITLE
[Fix #6330] Fix an error for `Rails/ReversibleMigration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#6330](https://github.com/rubocop-hq/rubocop/issues/6330): Fix an error for `Rails/ReversibleMigration` when using variable assignment. ([@koic][], [@scottmatthewman][])
+
 ## 0.59.2 (2018-09-24)
 
 ### Bug fixes

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -246,6 +246,8 @@ module RuboCop
         end
 
         def check_change_table_offense(receiver, node)
+          return unless node.send_type?
+
           method_name = node.method_name
           return if receiver != node.receiver &&
                     !IRREVERSIBLE_CHANGE_TABLE_CALLS.include?(method_name)

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -61,6 +61,18 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
     RUBY
   end
 
+  context 'when using variable assignment' do
+    it_behaves_like 'accepts', 'create_table', <<-RUBY
+      def change
+        change_table :invoices do |t|
+          decimals_params = {precision: 10, scale: 2}
+
+          t.decimal :total_discount, decimals_params
+        end
+      end
+    RUBY
+  end
+
   context 'within #reversible' do
     it_behaves_like 'accepts', 'execute', <<-RUBY
       reversible do |dir|


### PR DESCRIPTION
Fixes #6330 and follow up of #6198.

This PR fixes an error for `Rails/ReversibleMigration` when using variable assignment.

Cc @scottmatthewman 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
