### PR TITLE
Add IncludedMacros config option to MethodCallWithArgsParentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### New features
 
 * [#6126](https://github.com/rubocop-hq/rubocop/pull/6126): Add an experimental strict mode to `Style/MutableConstant` that will freeze all constants, rather than just literals. ([@rrosenblum][])
+* Add `IncludedMacros` to `Style/MethodCallWithArgsParentheses` to allow including specific macros when `IgnoreMacros` is true. ([@maxh][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
 module RuboCop
   module Cop
     module Style
@@ -8,7 +9,11 @@ module RuboCop
       #
       # In the default style (require_parentheses), macro methods are ignored.
       # Additional methods can be added to the `IgnoredMethods` list. This
-      # option is valid only in the default style.
+      # option is valid only in the default style. Macros can be included by
+      # either setting `IgnoreMacros` to false or adding specific macros to
+      # the `IncludedMacros` list. If a method is listed in both
+      # `IncludedMacros` and `IgnoredMethods`, then the latter takes
+      # precedence (that is, the method is ignored).
       #
       # In the alternative style (omit_parentheses), there are three additional
       # options.
@@ -206,11 +211,17 @@ module RuboCop
         end
 
         def eligible_for_parentheses_omission?(node)
-          node.operator_method? || node.setter_method? || ignore_macros?(node)
+          node.operator_method? || node.setter_method? || ignored_macro?(node)
         end
 
-        def ignore_macros?(node)
-          cop_config['IgnoreMacros'] && node.macro?
+        def included_macros_list
+          cop_config.fetch('IncludedMacros', []).map(&:to_sym)
+        end
+
+        def ignored_macro?(node)
+          cop_config['IgnoreMacros'] &&
+            node.macro? &&
+            !included_macros_list.include?(node.method_name)
         end
 
         def args_begin(node)
@@ -354,3 +365,4 @@ module RuboCop
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2769,7 +2769,11 @@ method calls containing parameters.
 
 In the default style (require_parentheses), macro methods are ignored.
 Additional methods can be added to the `IgnoredMethods` list. This
-option is valid only in the default style.
+option is valid only in the default style. Macros can be included by
+either setting `IgnoreMacros` to false or adding specific macros to
+the `IncludedMacros` list. If a method is listed in both
+`IncludedMacros` and `IgnoredMethods`, then the latter takes
+precedence (that is, the method is ignored).
 
 In the alternative style (omit_parentheses), there are three additional
 options.


### PR DESCRIPTION
Add `IncludedMacros` to `Style/MethodCallWithArgsParentheses` to allow including specific macros when `IgnoreMacros` is true.

In our usage of this cop, we'd like macros ignored by default, but with a few important exceptions. We tried setting `IgnoreMacros` to `false` and adding all other macros to the `IgnoredMethods` list, but this proved brittle.

Though it expands the API surface, this change allows us to express our preferences in a more natural way. Example usage:

```yml
Style/MethodCallWithArgsParentheses:
  Enabled: true
  IgnoreMacros: true
  IncludedMacros: [
    "delete",
    "get",
    "patch",
    "post",
    "put",
  ]
  IgnoredMethods: [
    "raise",
    "require",
    "to",
  ]
```

 - [x] Wrote good commit messages.
 - [x] Commit message starts with [Fix #issue-number] (if the related issue exists).
 - [x] Feature branch is up-to-date with master (if not - rebase it).
 - [x] Squashed related commits together.
 - [x]   Added tests.
 - [x]   Added an entry to the Changelog if the new code introduces user-observable changes. See changelog entry format.
 - [x]   The PR relates to only one subject with a clear title
and description in grammatically correct, complete sentences.
 - [x]   Run bundle exec rake default. It executes all tests and RuboCop for itself, and generates the documentation.