### PR TITLE
Update unicode-display_width version to 1.4.0

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('powerpack', '~> 0.1')
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
-  s.add_runtime_dependency('unicode-display_width', '~> 1.0', '>= 1.0.1')
+  s.add_runtime_dependency('unicode-display_width', '~> 1.4.0')
 
   s.add_development_dependency('bundler', '~> 1.3')
   s.add_development_dependency('rack', '>= 2.0')


### PR DESCRIPTION
When running rubocop you will often receive the warning "NOTE: Gem.gunzip is deprecated; use Gem::Util.gunzip instead. It will be removed on or after 2018-12-01." This is due to an outdated dependency on unicode-display_width. The latest version of unicode-display_width uses zlib and generates no such warning. Rake default succeeds and there shouldn't be any user-facing effects.