### PR TITLE
Fix an error for `Rails/ReversibleMigration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#6331](https://github.com/rubocop-hq/rubocop/issues/6331): Fix a false positive for `Style/RedundantFreeze` and a false negative for `Style/MutableConstant` when assigning a regexp object to a constant. ([@koic][])
 * [#6334](https://github.com/rubocop-hq/rubocop/pull/6334): Fix a false negative for `Style/RedundantFreeze` when assigning a range object to a constant. ([@koic][])
 * [#5538](https://github.com/rubocop-hq/rubocop/pull/5538): Fix false negatives in modifier cops when line length cop is disabled. ([@drenmi][])
+* [#6340](https://github.com/rubocop-hq/rubocop/pull/6340): Fix an error for `Rails/ReversibleMigration` when block argument is empty. ([@koic][])
 
 ## 0.59.2 (2018-09-24)
 

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -169,6 +169,7 @@ module RuboCop
         def on_block(node)
           return unless within_change_method?(node)
           return if within_reversible_or_up_only_block?(node)
+          return if node.body.nil?
 
           check_change_table_node(node.send_node, node.body)
         end

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -73,6 +73,15 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
     RUBY
   end
 
+  context 'when block argument is empty' do
+    it_behaves_like 'accepts', 'create_table', <<-RUBY
+      def change
+        change_table :invoices do |t|
+        end
+      end
+    RUBY
+  end
+
   context 'within #reversible' do
     it_behaves_like 'accepts', 'execute', <<-RUBY
       reversible do |dir|


### PR DESCRIPTION
This PR fixes an error for `Rails/ReversibleMigration` when block argument is empty.

The following is a reproduction step.

```console
% rubocop -V
0.59.2 (using Parser 2.5.1.2, running on ruby 2.5.1 x86_64-darwin17)

% cat db/migrate/20180926221900_change_invoices.rb
class ChangeInvoices < ActiveRecord::Migration[5.2]
  def change
    change_table :invoices do |t|
    end
  end
end

% rubocop db/migrate/20180926221900_change_invoices.rb --only
  Rails/ReversibleMigration -d
For /private/tmp: configuration from
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.59.2/config/default.yml
Inheriting configuration from
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.59.2/config/enabled.yml
Inheriting configuration from
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.59.2/config/disabled.yml
Inspecting 1 file
Scanning /private/tmp/db/migrate/20180926221900_change_invoices.rb
An error occurred while Rails/ReversibleMigration cop was inspecting
/private/tmp/db/migrate/20180926221900_change_invoices.rb:3:4.
undefined method `send_type?' for nil:NilClass
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.59.2/lib/rubocop/cop/rails/reversible_migration.rb:238:in
`block in check_change_table_node'
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.59.2/lib/rubocop/cop/rails/reversible_migration.rb:156:in
`change_table_call'

(snip)

Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop-hq/rubocop/issues

Mention the following information in the issue report:
0.59.2 (using Parser 2.5.1.2, running on ruby 2.5.1 x86_64-darwin17)
Finished in 0.3659559999941848 seconds
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
