### PR TITLE
Update RuboCop version of issue template when releasing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,5 +35,5 @@ Include the output of `rubocop -V` or `bundle exec rubocop -V` if using Bundler.
 
 ```
 $ [bundle exec] rubocop -V
-0.50.0 (using Parser 2.4.0.0, running on ruby 2.4.2 x86_64-linux)
+0.59.2 (using Parser 2.5.1.2, running on ruby 2.5.1 x86_64-linux)
 ```

--- a/tasks/cut_release.rake
+++ b/tasks/cut_release.rake
@@ -33,6 +33,17 @@ namespace :cut_release do
     end
   end
 
+  def update_issue_template(old_version, new_version)
+    issue_template = File.read('.github/ISSUE_TEMPLATE/bug_report.md')
+
+    File.open('.github/ISSUE_TEMPLATE/bug_report.md', 'w') do |f|
+      f << issue_template.sub(
+        "#{old_version} (using Parser ",
+        "#{new_version} (using Parser "
+      )
+    end
+  end
+
   def add_header_to_changelog(version)
     changelog = File.read('CHANGELOG.md')
     head, tail = changelog.split("## master (unreleased)\n\n", 2)
@@ -76,6 +87,7 @@ namespace :cut_release do
 
     update_readme(old_version, new_version)
     update_manual(old_version, new_version)
+    update_issue_template(old_version, new_version)
     add_header_to_changelog(new_version)
     create_release_notes(new_version)
 


### PR DESCRIPTION
This PR updates RuboCop version of issue template when releasing.

The following is an example.

```console
% rake cut_release:minor
Changed version from 0.59.2 to 0.60.0.
```

The difference added is as follows.

```diff
% git diff .github/ISSUE_TEMPLATE/bug_report.md
diff --git a/.github/ISSUE_TEMPLATE/bug_report.md
b/.github/ISSUE_TEMPLATE/bug_report.md
index 1bd42396c..de3f7e5f7 100644
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,5 +35,5 @@ Include the output of `rubocop -V` or `bundle exec
rubocop -V` if using Bundler.

 $ [bundle exec] rubocop -V
-0.59.2 (using Parser 2.5.1.2, running on ruby 2.5.1 x86_64-linux)
+0.60.0 (using Parser 2.5.1.2, running on ruby 2.5.1 x86_64-linux)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
