### PR TITLE
[Fix #6262] Optimise --auto-gen-config when Metrics/LineLength cop is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#6554](https://github.com/rubocop-hq/rubocop/issues/6554): Prevent Layout/RescueEnsureAlignment cop from breaking on block assignment when assignment is on a separate line. ([@timmcanty][])
+* [#6343](https://github.com/rubocop-hq/rubocop/pull/6343): Optimise `--auto-gen-config` when `Metrics/LineLength` cop is disabled. ([@tom-lord][])
 
 ## 0.61.1 (2018-12-06)
 
@@ -3686,3 +3687,4 @@
 [@dduugg]: https://github.com/dduugg
 [@mmedal]: https://github.com/mmedal
 [@timmcanty]: https://github.com/timmcanty
+[@tom-lord]: https://github.com/tom-lord

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -65,8 +65,7 @@ module RuboCop
       if @options[:auto_gen_config]
         reset_config_and_auto_gen_file
         line_length_contents =
-          if max_line_length(@config_store.for(Dir.pwd)) ==
-             max_line_length(ConfigLoader.default_configuration)
+          if perform_line_length_initial_run?
             run_line_length_cop_auto_gen_config(paths)
           else
             puts Rainbow(SKIPPED_PHASE_1).yellow
@@ -78,8 +77,27 @@ module RuboCop
       end
     end
 
+    def perform_line_length_initial_run?
+      line_length_enabled?(@config_store.for(Dir.pwd)) &&
+        same_max_line_length?(
+          @config_store.for(Dir.pwd), ConfigLoader.default_configuration
+        )
+    end
+
+    def line_length_enabled?(config)
+      line_length_cop(config)['Enabled']
+    end
+
+    def same_max_line_length?(config1, config2)
+      max_line_length(config1) == max_line_length(config2)
+    end
+
     def max_line_length(config)
-      config.for_cop('Metrics/LineLength')['Max']
+      line_length_cop(config)['Max']
+    end
+
+    def line_length_cop(config)
+      config.for_cop('Metrics/LineLength')
     end
 
     # Do an initial run with only Metrics/LineLength so that cops that depend

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -7,9 +7,14 @@ module RuboCop
   class CLI
     include Formatter::TextUtil
 
-    SKIPPED_PHASE_1 = 'Phase 1 of 2: run Metrics/LineLength cop (skipped ' \
-                      'because the default Metrics/LineLength:Max is ' \
-                      'overridden)'.freeze
+    PHASE_1 = 'Phase 1 of 2: run Metrics/LineLength cop'.freeze
+    PHASE_2 = 'Phase 2 of 2: run all cops'.freeze
+
+    PHASE_1_OVERRIDDEN = '(skipped because the default Metrics/LineLength:Max' \
+                         ' is overridden)'.freeze
+    PHASE_1_DISABLED   = '(skipped because Metrics/LineLength is ' \
+                         'disabled)'.freeze
+
     STATUS_SUCCESS     = 0
     STATUS_OFFENSES    = 1
     STATUS_ERROR       = 2
@@ -64,24 +69,25 @@ module RuboCop
     def execute_runners(paths)
       if @options[:auto_gen_config]
         reset_config_and_auto_gen_file
-        line_length_contents =
-          if perform_line_length_initial_run?
-            run_line_length_cop_auto_gen_config(paths)
-          else
-            puts Rainbow(SKIPPED_PHASE_1).yellow
-            ''
-          end
+        line_length_contents = maybe_run_line_length_cop(paths)
         run_all_cops_auto_gen_config(line_length_contents, paths)
       else
         execute_runner(paths)
       end
     end
 
-    def perform_line_length_initial_run?
-      line_length_enabled?(@config_store.for(Dir.pwd)) &&
-        same_max_line_length?(
-          @config_store.for(Dir.pwd), ConfigLoader.default_configuration
-        )
+    def maybe_run_line_length_cop(paths)
+      if !line_length_enabled?(@config_store.for(Dir.pwd))
+        puts Rainbow("#{PHASE_1} #{PHASE_1_DISABLED}").yellow
+        ''
+      elsif !same_max_line_length?(
+        @config_store.for(Dir.pwd), ConfigLoader.default_configuration
+      )
+        puts Rainbow("#{PHASE_1} #{PHASE_1_OVERRIDDEN}").yellow
+        ''
+      else
+        run_line_length_cop_auto_gen_config(paths)
+      end
     end
 
     def line_length_enabled?(config)
@@ -103,7 +109,7 @@ module RuboCop
     # Do an initial run with only Metrics/LineLength so that cops that depend
     # on Metrics/LineLength:Max get the correct value for that parameter.
     def run_line_length_cop_auto_gen_config(paths)
-      puts Rainbow('Phase 1 of 2: run Metrics/LineLength cop').yellow
+      puts Rainbow(PHASE_1).yellow
       @options[:only] = ['Metrics/LineLength']
       execute_runner(paths)
       @options.delete(:only)
@@ -116,7 +122,7 @@ module RuboCop
     end
 
     def run_all_cops_auto_gen_config(line_length_contents, paths)
-      puts Rainbow('Phase 2 of 2: run all cops').yellow
+      puts Rainbow(PHASE_2).yellow
       result = execute_runner(paths)
       # This run was made with the current maximum length allowed, so append
       # the saved setting for LineLength.

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -129,7 +129,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     context 'with Metrics/LineLength:Max overridden' do
       before do
         create_file('.rubocop.yml', ['Metrics/LineLength:',
-                                     "  Max: #{line_length_max}"])
+                                     "  Max: #{line_length_max}",
+                                     "  Enabled: #{line_length_enabled}"])
         create_file('.rubocop_todo.yml', [''])
         create_file('example.rb', <<-RUBY.strip_indent)
           def f
@@ -146,6 +147,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       context 'when .rubocop.yml has Metrics/LineLength:Max less than code ' \
               'base max' do
         let(:line_length_max) { 90 }
+        let(:line_length_enabled) { true }
 
         it "bases other cops' configuration on the overridden LineLength:Max" do
           expect(cli.run(['--auto-gen-config'])).to eq(0)
@@ -174,6 +176,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
             Metrics/LineLength:
               Max: 90
+              Enabled: true
           YAML
           $stdout = StringIO.new
           expect(described_class.new.run(%w[--format simple --debug])).to eq(1)
@@ -189,9 +192,52 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         end
       end
 
+      context 'when .rubocop.yml has Metrics/LineLength disabled ' do
+        let(:line_length_max) { 90 }
+        let(:line_length_enabled) { false }
+
+        it 'skips the cop from both phases of the run' do
+          expect(cli.run(['--auto-gen-config'])).to eq(0)
+          expect($stdout.string).to include(<<-YAML.strip_indent)
+            Added inheritance from `.rubocop_todo.yml` in `.rubocop.yml`.
+            Phase 1 of 2: run Metrics/LineLength cop (skipped because the default Metrics/LineLength:Max is overridden)
+            Phase 2 of 2: run all cops
+          YAML
+
+          # The code base max line length is 99, but the setting Enabled: false
+          # overrides that so no Metrics/LineLength:Max setting is generated in
+          # .rubocop_todo.yml.
+          expect(IO.readlines('.rubocop_todo.yml')
+                  .drop_while { |line| line.start_with?('#') }.join)
+            .to eq(<<-YAML.strip_indent)
+
+              # Offense count: 1
+              # Cop supports --auto-correct.
+              Style/IfUnlessModifier:
+                Exclude:
+                  - 'example.rb'
+            YAML
+          expect(IO.read('.rubocop.yml')).to eq(<<-YAML.strip_indent)
+            inherit_from: .rubocop_todo.yml
+
+            Metrics/LineLength:
+              Max: 90
+              Enabled: false
+          YAML
+          $stdout = StringIO.new
+          expect(described_class.new.run(%w[--format simple])).to eq(0)
+          expect($stderr.string).to eq('')
+          expect($stdout.string).to eq(<<-OUTPUT.strip_indent)
+
+            1 file inspected, no offenses detected
+          OUTPUT
+        end
+      end
+
       context 'when .rubocop.yml has Metrics/LineLength:Max more than code ' \
               'base max' do
         let(:line_length_max) { 150 }
+        let(:line_length_enabled) { true }
 
         it "bases other cops' configuration on the overridden LineLength:Max" do
           expect(cli.run(['--auto-gen-config'])).to eq(0)
@@ -218,6 +264,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
             Metrics/LineLength:
               Max: 150
+              Enabled: true
           YAML
           $stdout = StringIO.new
           expect(described_class.new.run(%w[--format simple])).to eq(0)

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           expect(cli.run(['--auto-gen-config'])).to eq(0)
           expect($stdout.string).to include(<<-YAML.strip_indent)
             Added inheritance from `.rubocop_todo.yml` in `.rubocop.yml`.
-            Phase 1 of 2: run Metrics/LineLength cop (skipped because the default Metrics/LineLength:Max is overridden)
+            Phase 1 of 2: run Metrics/LineLength cop (skipped because Metrics/LineLength is disabled)
             Phase 2 of 2: run all cops
           YAML
 


### PR DESCRIPTION
Resolves https://github.com/rubocop-hq/rubocop/issues/6262

With this change, running `rubocop --auto-gen-config` will now **skip** "Phase 1 of 2: run Metrics/LineLength cop", if the `Metrics/LineLength` cop is disabled.

This makes the todo file generation faster, when line length checks are disabled.