### PR TITLE
Reduce the size of our utility drawer

### DIFF
--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -42,7 +42,8 @@ module RuboCop
       SHORTHAND_ASSIGNMENTS = %i[op_asgn or_asgn and_asgn].freeze
       ASSIGNMENTS = (EQUALS_ASSIGNMENTS + SHORTHAND_ASSIGNMENTS).freeze
 
-      CONDITIONALS = %i[if while until case].freeze
+      BASIC_CONDITIONALS = %i[if while until].freeze
+      CONDITIONALS = [*BASIC_CONDITIONALS, :case].freeze
       VARIABLES = %i[ivar gvar cvar lvar].freeze
       REFERENCES = %i[nth_ref back_ref].freeze
       KEYWORDS = %i[alias and break case class def defs defined?
@@ -429,6 +430,10 @@ module RuboCop
 
       def assignment?
         ASSIGNMENTS.include?(type)
+      end
+
+      def basic_conditional?
+        BASIC_CONDITIONALS.include?(type)
       end
 
       def conditional?

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -37,6 +37,11 @@ module RuboCop
                             regexp irange erange].freeze
       IMMUTABLE_LITERALS = (LITERALS - MUTABLE_LITERALS).freeze
 
+      EQUALS_ASSIGNMENTS = %i[lvasgn ivasgn cvasgn gvasgn
+                              casgn masgn].freeze
+      SHORTHAND_ASSIGNMENTS = %i[op_asgn or_asgn and_asgn].freeze
+      ASSIGNMENTS = (EQUALS_ASSIGNMENTS + SHORTHAND_ASSIGNMENTS).freeze
+
       CONDITIONALS = %i[if while until case].freeze
       VARIABLES = %i[ivar gvar cvar lvar].freeze
       REFERENCES = %i[nth_ref back_ref].freeze
@@ -360,16 +365,6 @@ module RuboCop
         source_length.zero?
       end
 
-      def_node_matcher :equals_asgn?, <<-PATTERN
-        {lvasgn ivasgn cvasgn gvasgn casgn masgn}
-      PATTERN
-
-      def_node_matcher :shorthand_asgn?, '{op_asgn or_asgn and_asgn}'
-
-      def_node_matcher :assignment?, <<-PATTERN
-        {equals_asgn? shorthand_asgn?}
-      PATTERN
-
       # Some cops treat the shovel operator as a kind of assignment.
       def_node_matcher :assignment_or_similar?, <<-PATTERN
         {assignment? (send _recv :<< ...)}
@@ -422,6 +417,18 @@ module RuboCop
 
       def reference?
         REFERENCES.include?(type)
+      end
+
+      def equals_asgn?
+        EQUALS_ASSIGNMENTS.include?(type)
+      end
+
+      def shorthand_asgn?
+        SHORTHAND_ASSIGNMENTS.include?(type)
+      end
+
+      def assignment?
+        ASSIGNMENTS.include?(type)
       end
 
       def conditional?

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -438,20 +438,6 @@ module RuboCop
         OPERATOR_KEYWORDS.include?(type)
       end
 
-      def unary_operation?
-        return false unless loc.respond_to?(:selector) && loc.selector
-
-        Cop::Util.operator?(loc.selector.source.to_sym) &&
-          source_range.begin_pos == loc.selector.begin_pos
-      end
-
-      def binary_operation?
-        return false unless loc.respond_to?(:selector) && loc.selector
-
-        Cop::Util.operator?(method_name) &&
-          source_range.begin_pos != loc.selector.begin_pos
-      end
-
       def parenthesized_call?
         loc.respond_to?(:begin) && loc.begin && loc.begin.is?('(')
       end

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -37,6 +37,7 @@ module RuboCop
                             regexp irange erange].freeze
       IMMUTABLE_LITERALS = (LITERALS - MUTABLE_LITERALS).freeze
 
+      CONDITIONALS = %i[if while until case].freeze
       VARIABLES = %i[ivar gvar cvar lvar].freeze
       REFERENCES = %i[nth_ref back_ref].freeze
       KEYWORDS = %i[alias and break case class def defs defined?
@@ -421,6 +422,10 @@ module RuboCop
 
       def reference?
         REFERENCES.include?(type)
+      end
+
+      def conditional?
+        CONDITIONALS.include?(type)
       end
 
       def keyword?

--- a/lib/rubocop/ast/node/mixin/binary_operator_node.rb
+++ b/lib/rubocop/ast/node/mixin/binary_operator_node.rb
@@ -31,7 +31,7 @@ module RuboCop
         rhs = rhs.children.first if rhs.begin_type?
 
         [lhs, rhs].each_with_object([]) do |side, collection|
-          if AST::Node::OPERATOR_KEYWORDS.include?(side.type)
+          if side.operator_keyword?
             collection.concat(side.conditions)
           else
             collection << side

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -182,6 +182,13 @@ module RuboCop
         block_literal? && loc.expression && loc.expression.source == '->'
       end
 
+      # Checks whether this is a unary operation.
+      #
+      # @example
+      #
+      #   -foo
+      #
+      # @return [Boolean] whether this method is a unary operation
       def unary_operation?
         return false unless loc.selector
 
@@ -189,6 +196,13 @@ module RuboCop
           loc.expression.begin_pos == loc.selector.begin_pos
       end
 
+      # Checks whether this is a binary operation.
+      #
+      # @example
+      #
+      #   foo + bar
+      #
+      # @return [Bookean] whether this method is a binary operation
       def binary_operation?
         return false unless loc.selector
 

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -192,8 +192,7 @@ module RuboCop
       def unary_operation?
         return false unless loc.selector
 
-        Cop::Util.operator?(loc.selector.source.to_sym) &&
-          loc.expression.begin_pos == loc.selector.begin_pos
+        operator_method? && loc.expression.begin_pos == loc.selector.begin_pos
       end
 
       # Checks whether this is a binary operation.
@@ -206,8 +205,7 @@ module RuboCop
       def binary_operation?
         return false unless loc.selector
 
-        Cop::Util.operator?(method_name) &&
-          loc.expression.begin_pos != loc.selector.begin_pos
+        operator_method? && loc.expression.begin_pos != loc.selector.begin_pos
       end
 
       private

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -182,6 +182,20 @@ module RuboCop
         block_literal? && loc.expression && loc.expression.source == '->'
       end
 
+      def unary_operation?
+        return false unless loc.selector
+
+        Cop::Util.operator?(loc.selector.source.to_sym) &&
+          loc.expression.begin_pos == loc.selector.begin_pos
+      end
+
+      def binary_operation?
+        return false unless loc.selector
+
+        Cop::Util.operator?(method_name) &&
+          loc.expression.begin_pos != loc.selector.begin_pos
+      end
+
       private
 
       def_node_matcher :macro_scope?, <<-PATTERN

--- a/lib/rubocop/ast/node/mixin/method_identifier_predicates.rb
+++ b/lib/rubocop/ast/node/mixin/method_identifier_predicates.rb
@@ -13,8 +13,8 @@ module RuboCop
                               select! times upto].freeze
 
       # http://phrogz.net/programmingruby/language.html#table_18.4
-      OPERATOR_METHODS = %i(| ^ & <=> == === =~ > >= < <= << >> + - * /
-                            % ** ~ +@ -@ !@ ~@ [] []= ! != !~ `).freeze
+      OPERATOR_METHODS = %i[| ^ & <=> == === =~ > >= < <= << >> + - * /
+                            % ** ~ +@ -@ !@ ~@ [] []= ! != !~ `].freeze
 
       # Checks whether the method name matches the argument.
       #

--- a/lib/rubocop/ast/node/mixin/method_identifier_predicates.rb
+++ b/lib/rubocop/ast/node/mixin/method_identifier_predicates.rb
@@ -12,6 +12,10 @@ module RuboCop
                               map reduce reject reject! reverse_each select
                               select! times upto].freeze
 
+      # http://phrogz.net/programmingruby/language.html#table_18.4
+      OPERATOR_METHODS = %i(| ^ & <=> == === =~ > >= < <= << >> + - * /
+                            % ** ~ +@ -@ !@ ~@ [] []= ! != !~ `).freeze
+
       # Checks whether the method name matches the argument.
       #
       # @param [Symbol, String] name the method name to check for
@@ -24,7 +28,7 @@ module RuboCop
       #
       # @return [Boolean] whether the method is an operator
       def operator_method?
-        RuboCop::Cop::Util::OPERATOR_METHODS.include?(method_name)
+        OPERATOR_METHODS.include?(method_name)
       end
 
       # Checks whether the method is a comparison method.

--- a/lib/rubocop/cop/layout/end_alignment.rb
+++ b/lib/rubocop/cop/layout/end_alignment.rb
@@ -113,7 +113,7 @@ module RuboCop
           # assignment, we let rhs be the receiver of those method calls before
           # we check if it's an if/unless/while/until.
           return unless (rhs = first_part_of_call_chain(rhs))
-          return unless CONDITIONAL_NODES.include?(rhs.type)
+          return unless rhs.conditional?
           return if rhs.if_type? && rhs.ternary?
 
           check_asgn_alignment(node, rhs)

--- a/lib/rubocop/cop/layout/multiline_operation_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_operation_indentation.rb
@@ -61,7 +61,7 @@ module RuboCop
         private
 
         def relevant_node?(node)
-          return false if node.unary_operation?
+          return false if node.send_type? && node.unary_operation?
 
           !node.loc.dot # Don't check method calls with dot operator.
         end

--- a/lib/rubocop/cop/layout/space_around_keyword.rb
+++ b/lib/rubocop/cop/layout/space_around_keyword.rb
@@ -222,7 +222,7 @@ module RuboCop
           node.each_ancestor do |ancestor|
             return true if ancestor.and_type? || ancestor.or_type?
             return false unless ancestor.send_type?
-            return true if operator?(ancestor.method_name)
+            return true if ancestor.operator_method?
           end
           false
         end

--- a/lib/rubocop/cop/lint/assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/assignment_in_condition.rb
@@ -31,7 +31,7 @@ module RuboCop
         MSG_WITHOUT_SAFE_ASSIGNMENT_ALLOWED =
           'Use `==` if you meant to do a comparison or move the assignment ' \
           'up out of the condition.'.freeze
-        ASGN_TYPES = [:begin, *EQUALS_ASGN_NODES, :send].freeze
+        ASGN_TYPES = [:begin, *AST::Node::EQUALS_ASSIGNMENTS, :send].freeze
 
         def on_if(node)
           check(node)

--- a/lib/rubocop/cop/lint/literal_as_condition.rb
+++ b/lib/rubocop/cop/lint/literal_as_condition.rb
@@ -101,7 +101,7 @@ module RuboCop
         def check_node(node)
           if node.send_type? && node.prefix_bang?
             handle_node(node.receiver)
-          elsif LOGICAL_OPERATOR_NODES.include?(node.type)
+          elsif node.operator_keyword?
             node.each_child_node { |op| handle_node(op) }
           elsif node.begin_type? && node.children.one?
             handle_node(node.children.first)

--- a/lib/rubocop/cop/lint/safe_navigation_consistency.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_consistency.rb
@@ -34,8 +34,7 @@ module RuboCop
           'inside of `&&` and `||`.'.freeze
 
         def on_csend(node)
-          return unless node.parent &&
-                        AST::Node::OPERATOR_KEYWORDS.include?(node.parent.type)
+          return unless node.parent && node.parent.operator_keyword?
 
           check(node)
         end
@@ -72,10 +71,10 @@ module RuboCop
         def top_conditional_ancestor(node)
           parent = node.parent
           unless parent &&
-                 (AST::Node::OPERATOR_KEYWORDS.include?(parent.type) ||
+                 (parent.operator_keyword? ||
                   (parent.begin_type? &&
                    parent.parent &&
-                   AST::Node::OPERATOR_KEYWORDS.include?(parent.parent.type)))
+                   parent.parent.operator_keyword?))
             return node
           end
 

--- a/lib/rubocop/cop/lint/shadowed_argument.rb
+++ b/lib/rubocop/cop/lint/shadowed_argument.rb
@@ -154,8 +154,7 @@ module RuboCop
         def node_within_block_or_conditional?(node, stop_search_node)
           return false if node == stop_search_node
 
-          CONDITIONAL_NODES.include?(node.type) ||
-            node.block_type? ||
+          node.conditional? || node.block_type? ||
             node_within_block_or_conditional?(node.parent, stop_search_node)
         end
 

--- a/lib/rubocop/cop/mixin/check_assignment.rb
+++ b/lib/rubocop/cop/mixin/check_assignment.rb
@@ -4,11 +4,17 @@ module RuboCop
   module Cop
     # Common functionality for checking assignment nodes.
     module CheckAssignment
-      Util::ASGN_NODES.each do |type|
-        define_method("on_#{type}") do |node|
-          check_assignment(node, extract_rhs(node))
-        end
+      def on_lvasgn(node)
+        check_assignment(node, extract_rhs(node))
       end
+      alias on_ivasgn   on_lvasgn
+      alias on_cvasgn   on_lvasgn
+      alias on_gvasgn   on_lvasgn
+      alias on_casgn    on_lvasgn
+      alias on_masgn    on_lvasgn
+      alias on_op_asgn  on_lvasgn
+      alias on_or_asgn  on_lvasgn
+      alias on_and_asgn on_lvasgn
 
       def on_send(node)
         rhs = extract_rhs(node)
@@ -25,10 +31,10 @@ module RuboCop
           _scope, _lhs, rhs = *node
         elsif node.op_asgn_type?
           _lhs, _op, rhs = *node
-        elsif Util::ASGN_NODES.include?(node.type)
-          _lhs, rhs = *node
         elsif node.send_type?
           rhs = node.last_argument
+        elsif node.assignment?
+          _lhs, rhs = *node
         end
 
         rhs

--- a/lib/rubocop/cop/mixin/configurable_formatting.rb
+++ b/lib/rubocop/cop/mixin/configurable_formatting.rb
@@ -7,8 +7,6 @@ module RuboCop
       include ConfigurableEnforcedStyle
 
       def check_name(node, name, name_range)
-        return if operator?(name)
-
         if valid_name?(node, name)
           correct_style_detected
         else

--- a/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
+++ b/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
@@ -5,10 +5,9 @@ module RuboCop
     # Common functionality for checking multiline method calls and binary
     # operations.
     module MultilineExpressionIndentation # rubocop:disable Metrics/ModuleLength
-      KEYWORD_ANCESTOR_TYPES  = [:for, :return, *Util::MODIFIER_NODES].freeze
+      KEYWORD_ANCESTOR_TYPES  = %i[for if while until return].freeze
       UNALIGNED_RHS_TYPES     = %i[if while until for return
                                    array kwbegin].freeze
-      ASSIGNMENT_RHS_TYPES    = [:send, *Util::ASGN_NODES].freeze
       DEFAULT_MESSAGE_TAIL    = 'an expression'.freeze
       ASSIGNMENT_MESSAGE_TAIL = 'an expression in an assignment'.freeze
       KEYWORD_MESSAGE_TAIL    = 'a %<kind>s in %<article>s `%<keyword>s` ' \
@@ -191,7 +190,7 @@ module RuboCop
       def valid_rhs?(candidate, ancestor)
         if ancestor.send_type?
           valid_method_rhs_candidate?(candidate, ancestor)
-        elsif Util::ASGN_NODES.include?(ancestor.type)
+        elsif ancestor.assignment?
           valid_rhs_candidate?(candidate, assignment_rhs(ancestor))
         else
           false

--- a/lib/rubocop/cop/naming/method_name.rb
+++ b/lib/rubocop/cop/naming/method_name.rb
@@ -25,6 +25,8 @@ module RuboCop
         MSG = 'Use %<style>s for method names.'.freeze
 
         def on_def(node)
+          return if node.operator_method?
+
           check_name(node, node.method_name, node.loc.name)
         end
         alias on_defs on_def

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -74,7 +74,7 @@ module RuboCop
         private
 
         def on_conditionals(node)
-          node.condition.each_node(*LOGICAL_OPERATOR_NODES) do |logical_node|
+          node.condition.each_node(*AST::Node::OPERATOR_KEYWORDS) do |logical_node|
             process_logical_operator(logical_node)
           end
         end

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -74,8 +74,8 @@ module RuboCop
         private
 
         def on_conditionals(node)
-          node.condition.each_node(*AST::Node::OPERATOR_KEYWORDS) do |logical_node|
-            process_logical_operator(logical_node)
+          node.condition.each_node(*AST::Node::OPERATOR_KEYWORDS) do |operator|
+            process_logical_operator(operator)
           end
         end
 

--- a/lib/rubocop/cop/style/nested_modifier.rb
+++ b/lib/rubocop/cop/style/nested_modifier.rb
@@ -39,7 +39,7 @@ module RuboCop
         end
 
         def modifier?(node)
-          node && MODIFIER_NODES.include?(node.type) && node.modifier_form?
+          node && node.basic_conditional? && node.modifier_form?
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/style/not.rb
+++ b/lib/rubocop/cop/style/not.rb
@@ -53,7 +53,8 @@ module RuboCop
         end
 
         def requires_parens?(child)
-          child.and_type? || child.or_type? || child.binary_operation? ||
+          child.and_type? || child.or_type? ||
+            child.send_type? && child.binary_operation? ||
             child.if_type? && child.ternary?
         end
 

--- a/lib/rubocop/cop/style/one_line_conditional.rb
+++ b/lib/rubocop/cop/style/one_line_conditional.rb
@@ -53,7 +53,7 @@ module RuboCop
             return "(#{to_ternary(node)})"
           end
 
-          if node.parent.send_type? && operator?(node.parent.method_name)
+          if node.parent.send_type? && node.parent.operator_method?
             return "(#{to_ternary(node)})"
           end
 
@@ -82,7 +82,7 @@ module RuboCop
           return false unless node.send_type? && node.arguments?
           return false if node.parenthesized_call?
 
-          !operator?(node.method_name)
+          !node.operator_method?
         end
 
         def keyword_with_changed_precedence?(node)

--- a/lib/rubocop/cop/style/parentheses_around_condition.rb
+++ b/lib/rubocop/cop/style/parentheses_around_condition.rb
@@ -79,7 +79,7 @@ module RuboCop
           return false if node.if_type? && node.ternary?
           return true if node.rescue_type?
 
-          MODIFIER_NODES.include?(node.type) && node.modifier_form?
+          node.basic_conditional? && node.modifier_form?
         end
 
         def message(node)

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -108,8 +108,9 @@ module RuboCop
         def check_unary(begin_node, node)
           return if begin_node.chained?
 
-          # parens are not redundant in `(!recv.method arg)`
-          node = node.children.first while node.unary_operation?
+          node = node.children.first while
+            node.send_type? && node.unary_operation? && !node.prefix_not?
+
           if node.send_type?
             return unless method_call_with_redundant_parentheses?(node)
           end

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -108,8 +108,7 @@ module RuboCop
         def check_unary(begin_node, node)
           return if begin_node.chained?
 
-          node = node.children.first while
-            node.send_type? && node.unary_operation? && !node.prefix_not?
+          node = node.children.first while suspect_unary?(node)
 
           if node.send_type?
             return unless method_call_with_redundant_parentheses?(node)
@@ -120,6 +119,10 @@ module RuboCop
 
         def offense(node, msg)
           add_offense(node, message: "Don't use parentheses around #{msg}.")
+        end
+
+        def suspect_unary?(node)
+          node.send_type? && node.unary_operation? && !node.prefix_not?
         end
 
         def keyword_ancestor?(node)

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -121,7 +121,7 @@ module RuboCop
         end
 
         def regular_method_call?(node)
-          !(operator?(node.method_name) ||
+          !(node.operator_method? ||
             keyword?(node.method_name) ||
             node.camel_case_method? ||
             node.setter_method? ||

--- a/lib/rubocop/cop/style/unneeded_condition.rb
+++ b/lib/rubocop/cop/style/unneeded_condition.rb
@@ -90,8 +90,8 @@ module RuboCop
         end
 
         def else_source(else_branch)
-          wrap_else = MODIFIER_NODES.include?(else_branch.type) &&
-                      else_branch.modifier_form?
+          wrap_else =
+            else_branch.basic_conditional? && else_branch.modifier_form?
           wrap_else ? "(#{else_branch.source})" : else_branch.source
         end
 

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -6,8 +6,6 @@ module RuboCop
     module Util
       include PathUtil
 
-      MODIFIER_NODES = %i[if while until].freeze
-
       # Match literal regex characters, not including anchors, character
       # classes, alternatives, groups, repetitions, references, etc
       LITERAL_REGEX =

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -13,7 +13,6 @@ module RuboCop
       ASGN_NODES = (EQUALS_ASGN_NODES + SHORTHAND_ASGN_NODES).freeze
 
       MODIFIER_NODES = %i[if while until].freeze
-      CONDITIONAL_NODES = (MODIFIER_NODES + [:case]).freeze
 
       # Match literal regex characters, not including anchors, character
       # classes, alternatives, groups, repetitions, references, etc

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -14,7 +14,6 @@ module RuboCop
 
       MODIFIER_NODES = %i[if while until].freeze
       CONDITIONAL_NODES = (MODIFIER_NODES + [:case]).freeze
-      LOGICAL_OPERATOR_NODES = %i[and or].freeze
 
       # Match literal regex characters, not including anchors, character
       # classes, alternatives, groups, repetitions, references, etc

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -7,11 +7,6 @@ module RuboCop
       include PathUtil
       extend RuboCop::AST::Sexp
 
-      EQUALS_ASGN_NODES = %i[lvasgn ivasgn cvasgn gvasgn
-                             casgn masgn].freeze
-      SHORTHAND_ASGN_NODES = %i[op_asgn or_asgn and_asgn].freeze
-      ASGN_NODES = (EQUALS_ASGN_NODES + SHORTHAND_ASGN_NODES).freeze
-
       MODIFIER_NODES = %i[if while until].freeze
 
       # Match literal regex characters, not including anchors, character

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -5,7 +5,6 @@ module RuboCop
     # This module contains a collection of useful utility methods.
     module Util
       include PathUtil
-      extend RuboCop::AST::Sexp
 
       MODIFIER_NODES = %i[if while until].freeze
 

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -16,23 +16,12 @@ module RuboCop
       CONDITIONAL_NODES = (MODIFIER_NODES + [:case]).freeze
       LOGICAL_OPERATOR_NODES = %i[and or].freeze
 
-      # http://phrogz.net/programmingruby/language.html#table_18.4
-      # Backtick is added last just to help editors parse this code.
-      OPERATOR_METHODS = %w(
-        | ^ & <=> == === =~ > >= < <= << >>
-        + - * / % ** ~ +@ -@ !@ ~@ [] []= ! != !~
-      ).map(&:to_sym).push(:'`').freeze
-
       # Match literal regex characters, not including anchors, character
       # classes, alternatives, groups, repetitions, references, etc
       LITERAL_REGEX =
         /[\w\s\-,"'!#%&<>=;:`~]|\\[^AbBdDgGhHkpPRwWXsSzZ0-9]/.freeze
 
       module_function
-
-      def operator?(symbol)
-        OPERATOR_METHODS.include?(symbol)
-      end
 
       def comment_line?(line_source)
         line_source =~ /^\s*#/

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -1174,7 +1174,7 @@ RSpec.describe RuboCop::AST::SendNode do
     end
   end
 
-  describe '#stabby_lambda?' do
+  describe '#lambda_literal?' do
     context 'with a stabby lambda' do
       let(:send_node) { parse_source(source).ast.send_node }
       let(:source) { '-> (foo) { do_something(foo) }' }
@@ -1201,6 +1201,58 @@ RSpec.describe RuboCop::AST::SendNode do
       let(:source) { 'a.() {}' }
 
       it { expect(send_node.lambda?).to be_falsey }
+    end
+  end
+
+  describe '#unary_operation?' do
+    context 'with a unary operation' do
+      let(:source) { '-foo' }
+
+      it { expect(send_node.unary_operation?).to be(true) }
+    end
+
+    context 'with a binary operation' do
+      let(:source) { 'foo + bar' }
+
+      it { expect(send_node.unary_operation?).to be(false) }
+    end
+
+    context 'with a regular method call' do
+      let(:source) { 'foo(bar)' }
+
+      it { expect(send_node.unary_operation?).to be(false) }
+    end
+
+    context 'with an implicit call method' do
+      let(:source) { 'foo.(:baz)' }
+
+      it { expect(send_node.unary_operation?).to be(false) }
+    end
+  end
+
+  describe '#binary_operation??' do
+    context 'with a unary operation' do
+      let(:source) { '-foo' }
+
+      it { expect(send_node.binary_operation?).to be(false) }
+    end
+
+    context 'with a binary operation' do
+      let(:source) { 'foo + bar' }
+
+      it { expect(send_node.binary_operation?).to be(true) }
+    end
+
+    context 'with a regular method call' do
+      let(:source) { 'foo(bar)' }
+
+      it { expect(send_node.binary_operation?).to be(false) }
+    end
+
+    context 'with an implicit call method' do
+      let(:source) { 'foo.(:baz)' }
+
+      it { expect(send_node.binary_operation?).to be(false) }
     end
   end
 end

--- a/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
   let(:cop_indent) { nil } # use indentation width from Layout/IndentationWidth
 
   shared_examples 'common' do
-    # it 'accepts unary operations' do
-    #   expect_no_offenses(<<-RUBY.strip_indent)
-    #     call a,
-    #          !b
-    #   RUBY
-    # end
+    it 'accepts unary operations' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        call a,
+             !b
+      RUBY
+    end
 
     it 'accepts indented operands in ordinary statement' do
       expect_no_offenses(<<-RUBY.strip_indent)

--- a/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
   let(:cop_indent) { nil } # use indentation width from Layout/IndentationWidth
 
   shared_examples 'common' do
-    it 'accepts unary operations' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        call a,
-             !b
-      RUBY
-    end
+    # it 'accepts unary operations' do
+    #   expect_no_offenses(<<-RUBY.strip_indent)
+    #     call a,
+    #          !b
+    #   RUBY
+    # end
 
     it 'accepts indented operands in ordinary statement' do
       expect_no_offenses(<<-RUBY.strip_indent)


### PR DESCRIPTION
This pull requests moves a bunch of things from our `RuboCop::Cop::Util` module into more specialized classes, mostly node extensions. It also adds unit tests for some of them. The hope is that we can keep reducing our generic utility drawer and put things in places where they are more cohesive.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
