### PR TITLE
Fix the cache directory path in the doc

### DIFF
--- a/manual/caching.md
+++ b/manual/caching.md
@@ -31,7 +31,7 @@ overrides the setting.
 ### Cache Path
 
 By default, the cache is stored in either
-`$XDG_CACHE_HOME/rubocop_cache` if `$XDG_CACHE_HOME` is set, or in
+`$XDG_CACHE_HOME/$UID/rubocop_cache` if `$XDG_CACHE_HOME` is set, or in
 `$HOME/.cache/rubocop_cache/` if it's not. The configuration parameter
 `AllCops: CacheRootDirectory` can be used to set the root to a
 different path. One reason to use this option could be that there's a


### PR DESCRIPTION
Hello. According to [`lib/rubocop/result_cache.rb`](https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/result_cache.rb), the path contains the user ID of the process.