### PR TITLE
Explicitly use RSpec namespace in external top level shared_*

### DIFF
--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -3,7 +3,7 @@
 require 'tmpdir'
 require 'fileutils'
 
-shared_context 'isolated environment', :isolated_environment do
+RSpec.shared_context 'isolated environment', :isolated_environment do
   around do |example|
     Dir.mktmpdir do |tmpdir|
       original_home = ENV['HOME']
@@ -36,7 +36,7 @@ shared_context 'isolated environment', :isolated_environment do
 end
 
 # `cop_config` must be declared with #let.
-shared_context 'config', :config do
+RSpec.shared_context 'config', :config do
   let(:config) do
     # Module#<
     unless described_class < RuboCop::Cop::Cop
@@ -59,38 +59,38 @@ shared_context 'config', :config do
   end
 end
 
-shared_context 'ruby 2.2', :ruby22 do
+RSpec.shared_context 'ruby 2.2', :ruby22 do
   let(:ruby_version) { 2.2 }
 end
 
-shared_context 'ruby 2.3', :ruby23 do
+RSpec.shared_context 'ruby 2.3', :ruby23 do
   let(:ruby_version) { 2.3 }
 end
 
-shared_context 'ruby 2.4', :ruby24 do
+RSpec.shared_context 'ruby 2.4', :ruby24 do
   let(:ruby_version) { 2.4 }
 end
 
-shared_context 'ruby 2.5', :ruby25 do
+RSpec.shared_context 'ruby 2.5', :ruby25 do
   let(:ruby_version) { 2.5 }
 end
 
-shared_context 'ruby 2.6', :ruby26 do
+RSpec.shared_context 'ruby 2.6', :ruby26 do
   let(:ruby_version) { 2.6 }
 end
 
-shared_context 'with Rails', :enabled_rails do
+RSpec.shared_context 'with Rails', :enabled_rails do
   let(:enabled_rails) { true }
 end
 
-shared_context 'with Rails 3', :rails3 do
+RSpec.shared_context 'with Rails 3', :rails3 do
   let(:rails_version) { 3.0 }
 end
 
-shared_context 'with Rails 4', :rails4 do
+RSpec.shared_context 'with Rails 4', :rails4 do
   let(:rails_version) { 4.0 }
 end
 
-shared_context 'with Rails 5', :rails5 do
+RSpec.shared_context 'with Rails 5', :rails5 do
   let(:rails_version) { 5.0 }
 end

--- a/lib/rubocop/rspec/shared_examples.rb
+++ b/lib/rubocop/rspec/shared_examples.rb
@@ -2,7 +2,7 @@
 
 # `cop` and `source` must be declared with #let.
 
-shared_examples_for 'misaligned' do |annotated_source, used_style|
+RSpec.shared_examples_for 'misaligned' do |annotated_source, used_style|
   config_to_allow_offenses = if used_style
                                { 'EnforcedStyleAlignWith' => used_style.to_s }
                              else
@@ -31,7 +31,7 @@ shared_examples_for 'misaligned' do |annotated_source, used_style|
   end
 end
 
-shared_examples_for 'aligned' do |alignment_base, arg, end_kw, name|
+RSpec.shared_examples_for 'aligned' do |alignment_base, arg, end_kw, name|
   name ||= alignment_base
   name = name.gsub(/\n/, ' <newline>')
   it "accepts matching #{name} ... end" do
@@ -40,7 +40,7 @@ shared_examples_for 'aligned' do |alignment_base, arg, end_kw, name|
   end
 end
 
-shared_examples_for 'debugger' do |name, src|
+RSpec.shared_examples_for 'debugger' do |name, src|
   it "reports an offense for a #{name} call" do
     inspect_source(src)
     src = [src] if src.is_a? String
@@ -51,7 +51,7 @@ shared_examples_for 'debugger' do |name, src|
   end
 end
 
-shared_examples_for 'non-debugger' do |name, src|
+RSpec.shared_examples_for 'non-debugger' do |name, src|
   it "does not report an offense for #{name}" do
     inspect_source(src)
     expect(cop.offenses).to be_empty


### PR DESCRIPTION
If lib/rubocop/rspec/shared_contexts.rb and lib/rubocop/rspec/shared_examples.rb
are required after RSpec has been set to not expose the DSL globally,
then you will get the following error:

```
NoMethodError:
  undefined method `shared_context' for main:Object
# ./lib/rubocop/rspec/shared_contexts.rb:6:in `<top (required)>'
# ./lib/rubocop/rspec/support.rb:7:in `require_relative'
# ./lib/rubocop/rspec/support.rb:7:in `<top (required)>'
```

This change does not negatively affect users who still expose the DSL
globally.

I discovered this in rather large (and unfortunately) private application when I attempted to disable the global RSpec DSL via `config.expose_dsl_globally = false`. In this app we have a ton of specs and a handful of custom cops. Those custom cops have specs to verify we've written the custom cops correctly. For just those custom cops we `require 'rubocop/rspec/support'`. If that require is called after the main `spec_helper` is required the above error happens.

With a bit of temporarily mangling rubocop's main `spec_helper.rb` you can repro this issue. Currently rubocop's `spec_helper.rb` is structured where it loads `'rubocop/rspec/support'` before disabling the global monkey patch. Briefly:

```ruby
# Require supporting files exposed for testing.
require 'rubocop/rspec/support'

RSpec.configure do |config|
  config.disable_monkey_patching!

  config.include RuboCop::RSpec::ExpectOffense
end
```

If you change the file so that those files are loaded after the monkey patch is disabled i.e.:

```ruby
RSpec.configure do |config|
  config.disable_monkey_patching!

  # Require supporting files exposed for testing.
  require 'rubocop/rspec/support'

  config.include RuboCop::RSpec::ExpectOffense
end
```

and then run the rubocop specs you will get the above error. I realize the example is abnormal ruby and rspec it was just a very easy and simple way to demonstrate the issue.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
