### PR TITLE
Changed NumericLiterals error message

### DIFF
--- a/lib/rubocop/cop/style/numeric_literals.rb
+++ b/lib/rubocop/cop/style/numeric_literals.rb
@@ -30,7 +30,7 @@ module RuboCop
         include ConfigurableMax
         include IntegerNode
 
-        MSG = 'Use underscores(_) as decimal mark and ' \
+        MSG = 'Use underscores(_) as thousands separator and ' \
               'separate every 3 digits with them.'.freeze
 
         def on_int(node)

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe RuboCop::Cop::Style::NumericLiterals, :config do
   it 'registers an offense for a long undelimited integer' do
     expect_offense(<<-RUBY.strip_indent)
       a = 12345
-          ^^^^^ Use underscores(_) as decimal mark and separate every 3 digits with them.
+          ^^^^^ Use underscores(_) as thousands separator and separate every 3 digits with them.
     RUBY
   end
 
   it 'registers an offense for a float with a long undelimited integer part' do
     expect_offense(<<-RUBY.strip_indent)
       a = 123456.789
-          ^^^^^^^^^^ Use underscores(_) as decimal mark and separate every 3 digits with them.
+          ^^^^^^^^^^ Use underscores(_) as thousands separator and separate every 3 digits with them.
     RUBY
   end
 
@@ -101,7 +101,7 @@ RSpec.describe RuboCop::Cop::Style::NumericLiterals, :config do
     it 'registers an offense for an integer with misplaced underscore' do
       expect_offense(<<-RUBY.strip_indent)
         a = 123_456_78_90_00
-            ^^^^^^^^^^^^^^^^ Use underscores(_) as decimal mark and separate every 3 digits with them.
+            ^^^^^^^^^^^^^^^^ Use underscores(_) as thousands separator and separate every 3 digits with them.
       RUBY
     end
   end


### PR DESCRIPTION
Searching for `decimal mark` yields results for integer and fraction separation instead of thousands separator which is confusing.