### PR TITLE
Fix an error for `Style/NumericPredicate`

### DIFF
--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -109,7 +109,8 @@ module RuboCop
         end
 
         def require_parentheses?(node)
-          node.binary_operation? && node.source !~ /^\(.*\)$/
+          node.send_type? &&
+            node.binary_operation? && node.source !~ /^\(.*\)$/
         end
 
         def replacement_supported?(operator)

--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -71,6 +71,14 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
         it_behaves_like 'code without offense',
                         '0 == $CHILD_STATUS'
       end
+
+      context 'when comparing against a method argument variable' do
+        it_behaves_like 'code with offense',
+                        'def m(foo); foo == 0; end',
+                        expected: 'def m(foo); foo.zero?; end',
+                        use: 'foo.zero?',
+                        instead_of: 'foo == 0'
+      end
     end
 
     context 'with checking if a number is not zero' do


### PR DESCRIPTION
Follow upf of #6347.

This PR fixes an error for `Style/NumericPredicate` when comparing against a method argument variable.

The following is a reproduction step.

This occurs only in master (It does not occur in RuboCop 0.59.2).

```console
% rubocop -V
0.59.2 (using Parser 2.5.1.2, running on ruby 2.5.1 x86_64-darwin17)

% cat example.rb
def m(foo)
  foo == 0
end

% rubocop example.rb --only Style/NumericPredicate -d
For /private/tmp: configuration from
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.59.2/config/default.yml
Inspecting 1 file
Scanning /private/tmp/example.rb
An error occurred while Style/NumericPredicate cop was inspecting
/private/tmp/example.rb:2:2.
undefined method `binary_operation?' for s(:lvar, :foo):RuboCop::AST::Node
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.59.2/lib/rubocop/cop/style/numeric_predicate.rb:112:in
`require_parentheses?'
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.59.2/lib/rubocop/cop/style/numeric_predicate.rb:104:in
`parenthesized_source'
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.59.2/lib/rubocop/cop/style/numeric_predicate.rb:96:in
`replacement'
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.59.2/lib/rubocop/cop/style/numeric_predicate.rb:91:in
`check'
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.59.2/lib/rubocop/cop/style/numeric_predicate.rb:61:in
`on_send'
/Users/koic/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rubocop-0.59.2/lib/rubocop/cop/commissioner.rb:58:in
`block (2 levels) in trigger_responding_cops'

(snip)
```

This error is caused by the difference between `send` node type and
`lvar` node type below.

The following result is an S expression with `send` node type.

```console
% ruby-parse -e 'def m(foo); bar == 0; end'
(def :m
  (args
    (arg :foo))
  (send
    (send nil :bar) :==
    (int 0)))
```

The following result is an S expression with `lvar` node type.
Because it uses the value of argument.

```console
% ruby-parse -e 'def m(foo); foo == 0; end'
(def :m
  (args
    (arg :foo))
  (send
    (lvar :foo) :==
    (int 0)))
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
