### PR TITLE
Disable cop Rails/ActiveRecordAliases for rails < 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#6357](https://github.com/rubocop-hq/rubocop/pull/6357): Disable cop Rails/ActiveRecordAliases for rails < 4. ([@wabilin][])
 * [#4156](https://github.com/rubocop-hq/rubocop/issues/4156): Add command line option `--auto-gen-only-exclude`. ([@Ana06][], [@jonas054][])
 
 ### Bug fixes
@@ -3608,3 +3609,4 @@
 [@ryanhageman]: https://github.com/ryanhageman
 [@autopp]: https://github.com/autopp
 [@lukasz-wojcik]: https://github.com/lukasz-wojcik
+[@wabilin]: https://github.com/wabilin

--- a/lib/rubocop/cop/rails/active_record_aliases.rb
+++ b/lib/rubocop/cop/rails/active_record_aliases.rb
@@ -5,6 +5,10 @@ module RuboCop
     module Rails
       # Checks that ActiveRecord aliases are not used. The direct method names
       # are more clear and easier to read.
+      # This cop only applies to Rails >= 4.
+      # If you are running Rails < 4 you should disable the
+      # Rails/ActiveRecordAliases cop or set your TargetRailsVersion in your
+      # .rubocop.yml file to 3.2, etc.
       #
       # @example
       #   #bad
@@ -13,6 +17,10 @@ module RuboCop
       #   #good
       #   Book.update!(author: 'Alice')
       class ActiveRecordAliases < Cop
+        extend TargetRailsVersion
+
+        minimum_target_rails_version 4.0
+
         MSG = 'Use `%<prefer>s` instead of `%<current>s`.'.freeze
 
         ALIASES = {

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -58,6 +58,10 @@ Enabled | Yes | Yes  | 0.53 |
 
 Checks that ActiveRecord aliases are not used. The direct method names
 are more clear and easier to read.
+This cop only applies to Rails >= 4.
+If you are running Rails < 4 you should disable the
+Rails/ActiveRecordAliases cop or set your TargetRailsVersion in your
+.rubocop.yml file to 3.2, etc.
 
 ### Examples
 

--- a/spec/rubocop/cop/rails/active_record_aliases_spec.rb
+++ b/spec/rubocop/cop/rails/active_record_aliases_spec.rb
@@ -1,70 +1,135 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::ActiveRecordAliases do
-  subject(:cop) { described_class.new }
+  context 'rails <= 4.0', :rails3, :config do
+    subject(:cop) { described_class.new(config) }
 
-  describe '#update_attributes' do
-    it 'registers an offense' do
-      expect_offense(<<-RUBY.strip_indent)
+    describe '#update_attributes' do
+      it 'does not register an offense' do
+        expect_no_offenses(
+          'book.update_attributes(author: "Alice")'
+        )
+      end
+
+      it 'is not autocorrected' do
+        source = 'book.update_attributes(author: "Alice")'
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq source
+      end
+    end
+
+    describe '#update_attributes!' do
+      it 'does not register an offense' do
+        expect_no_offenses(
+          'book.update_attributes!(author: "Alice")'
+        )
+      end
+
+      it 'is not autocorrected' do
+        source = 'book.update_attributes!(author: "Bob")'
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq source
+      end
+    end
+
+    describe '#update' do
+      it 'does not register an offense' do
+        expect_no_offenses('book.update(author: "Alice")')
+      end
+
+      it 'is not autocorrected' do
+        source = 'book.update(author: "Alice")'
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq source
+      end
+    end
+
+    describe '#update!' do
+      it 'does not register an offense' do
+        expect_no_offenses('book.update!(author: "Bob")')
+      end
+
+      it 'is not autocorrected' do
+        source = 'book.update!(author: "Bob")'
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq source
+      end
+    end
+
+    describe 'other use of the `update_attributes` string' do
+      it 'does not autocorrect the other usage' do
+        source = 'update_attributes_book.update(author: "Alice")'
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq source
+      end
+    end
+  end
+
+  context 'rails >= 4.0', :rails4, :config do
+    subject(:cop) { described_class.new(config) }
+
+    describe '#update_attributes' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
         book.update_attributes(author: "Alice")
              ^^^^^^^^^^^^^^^^^ Use `update` instead of `update_attributes`.
-      RUBY
+        RUBY
+      end
+
+      it 'is autocorrected' do
+        new_source = autocorrect_source(
+          'book.update_attributes(author: "Alice")'
+        )
+        expect(new_source).to eq 'book.update(author: "Alice")'
+      end
     end
 
-    it 'is autocorrected' do
-      new_source = autocorrect_source(
-        'book.update_attributes(author: "Alice")'
-      )
-      expect(new_source).to eq 'book.update(author: "Alice")'
-    end
-  end
-
-  describe '#update_attributes!' do
-    it 'registers an offense' do
-      expect_offense(<<-RUBY.strip_indent)
+    describe '#update_attributes!' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
         book.update_attributes!(author: "Bob")
              ^^^^^^^^^^^^^^^^^^ Use `update!` instead of `update_attributes!`.
-      RUBY
+        RUBY
+      end
+
+      it 'is autocorrected' do
+        new_source = autocorrect_source(
+          'book.update_attributes!(author: "Bob")'
+        )
+        expect(new_source).to eq 'book.update!(author: "Bob")'
+      end
     end
 
-    it 'is autocorrected' do
-      new_source = autocorrect_source(
-        'book.update_attributes!(author: "Bob")'
-      )
-      expect(new_source).to eq 'book.update!(author: "Bob")'
-    end
-  end
+    describe '#update' do
+      it 'does not register an offense' do
+        expect_no_offenses('book.update(author: "Alice")')
+      end
 
-  describe '#update' do
-    it 'does not register an offense' do
-      expect_no_offenses('book.update(author: "Alice")')
-    end
-
-    it 'is not autocorrected' do
-      source = 'book.update(author: "Alice")'
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq source
-    end
-  end
-
-  describe '#update!' do
-    it 'does not register an offense' do
-      expect_no_offenses('book.update!(author: "Bob")')
+      it 'is not autocorrected' do
+        source = 'book.update(author: "Alice")'
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq source
+      end
     end
 
-    it 'is not autocorrected' do
-      source = 'book.update!(author: "Bob")'
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq source
-    end
-  end
+    describe '#update!' do
+      it 'does not register an offense' do
+        expect_no_offenses('book.update!(author: "Bob")')
+      end
 
-  describe 'other use of the `update_attributes` string' do
-    it 'does not autocorrect the other usage' do
-      new_source = autocorrect_source(
-        'update_attributes_book.update_attributes(author: "Alice")'
-      )
-      expect(new_source).to eq 'update_attributes_book.update(author: "Alice")'
+      it 'is not autocorrected' do
+        source = 'book.update!(author: "Bob")'
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq source
+      end
+    end
+
+    describe 'other use of the `update_attributes` string' do
+      it 'does not autocorrect the other usage' do
+        source = 'update_attributes_book.update(author: "Alice")'
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq source
+      end
     end
   end
 end


### PR DESCRIPTION
According to [Rails API Doc](https://apidock.com/rails/v3.2.13/ActiveRecord/Persistence/update),
Before Rails 4.0, `ActiveRecord::Persistence#update` is a private method.

Calling `update` to a ActiveRecord instance like example below is not allowed.
```ruby
some_record.update(my_attr: 'value')
```

Therefore, the cop `Rails/ActiveRecordAliases` should not be enabled when using rails versions before `4.0`.

**Add `minimum_target_rails_version 4.0` to cop `ActiveRecordAliases`**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
