### PR TITLE
[Fix #6274] Don't cache corrected status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#6334](https://github.com/rubocop-hq/rubocop/pull/6334): Fix a false negative for `Style/RedundantFreeze` when assigning a range object to a constant. ([@koic][])
 * [#5538](https://github.com/rubocop-hq/rubocop/issues/5538): Fix false negatives in modifier cops when line length cop is disabled. ([@drenmi][])
 * [#6340](https://github.com/rubocop-hq/rubocop/pull/6340): Fix an error for `Rails/ReversibleMigration` when block argument is empty. ([@koic][])
+* [#6274](https://github.com/rubocop-hq/rubocop/issues/6274): Fix "[Corrected]" message being displayed even when nothing has been corrected. ([@jekuta][])
 
 ### Changes
 

--- a/lib/rubocop/cached_data.rb
+++ b/lib/rubocop/cached_data.rb
@@ -31,7 +31,7 @@ module RuboCop
         },
         message: message(offense),
         cop_name: offense.cop_name,
-        status: offense.status
+        status: :uncorrected
       }
     end
 

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -45,6 +45,29 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
       end
     end
 
+    # Fixes https://github.com/rubocop-hq/rubocop/issues/6274
+    context 'when offenses are saved by autocorrect run' do
+      let(:corrected_offense) do
+        RuboCop::Cop::Offense.new(
+          :warning, location, 'unused var', 'Lint/UselessAssignment', :corrected
+        )
+      end
+      let(:uncorrected_offense) do
+        RuboCop::Cop::Offense.new(
+          corrected_offense.severity.name,
+          corrected_offense.location,
+          corrected_offense.message,
+          corrected_offense.cop_name,
+          :uncorrected
+        )
+      end
+
+      it 'serializes them with :uncorrected status' do
+        cache.save([corrected_offense])
+        expect(cache.load).to match_array([uncorrected_offense])
+      end
+    end
+
     context 'when no option is given' do
       let(:options2) { {} }
 


### PR DESCRIPTION
It seems to me that this issue was introduced with the addition of caching for auto-correct (#5857). When we auto-correct a file we also cache all the offenses that were found. However we cache these issues with the status `:corrected`. 
If someone now reverts the those changes and inspects the file again, the offenses will get pulled from the cache, but since the status is `:corrected` on those offenses, the user will also receive an output saying the offenses were corrected, as if they ran rubocop with auto-correct.

Since the cache is about saving the offenses of the original file, and when we run the auto-correct we are not using the cache for files that have offenses, it seems to me that the most obvious solution is to cache the offenses always with the flag `:uncorrected`.

Closes #6274 