### PR TITLE
Minor code enhancements to numeric predicate cop

### DIFF
--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -109,8 +109,7 @@ module RuboCop
         end
 
         def require_parentheses?(node)
-          node.send_type? &&
-            node.binary_operation? && node.source !~ /^\(.*\)$/
+          node.send_type? && node.binary_operation? && !node.parenthesized?
         end
 
         def replacement_supported?(operator)

--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -78,6 +78,12 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
                         expected: 'def m(foo); foo.zero?; end',
                         use: 'foo.zero?',
                         instead_of: 'foo == 0'
+
+        it_behaves_like 'code with offense',
+                        'def m(foo); foo - 1 == 0; end',
+                        expected: 'def m(foo); (foo - 1).zero?; end',
+                        use: '(foo - 1).zero?',
+                        instead_of: 'foo - 1 == 0'
       end
     end
 


### PR DESCRIPTION
When reviewing [this bug fix](https://github.com/rubocop-hq/rubocop/pull/6355) from @koic, I saw some 
opportunities for minor improvements to the code and test coverage. This change doesn't alter the behaviour of the cop, but:

1. Adds a test case for auto-correct when the offending code is binary operation with `lvar` left hand side, to ensure parens are properly added.

2. Replaces the use of regular expressions to check whether the expression is parenthesized or not.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
