### PR TITLE
Reduce regular expression usage across the board

### DIFF
--- a/lib/rubocop/cop/correctors/alignment_corrector.rb
+++ b/lib/rubocop/cop/correctors/alignment_corrector.rb
@@ -69,7 +69,8 @@ module RuboCop
         end
 
         def calculate_range(expr, line_begin_pos, column_delta)
-          starts_with_space = expr.source_buffer.source[line_begin_pos] =~ / /
+          starts_with_space =
+            expr.source_buffer.source[line_begin_pos].start_with?(' ')
           pos_to_remove = if column_delta > 0 || starts_with_space
                             line_begin_pos
                           else

--- a/lib/rubocop/cop/layout/block_end_newline.rb
+++ b/lib/rubocop/cop/layout/block_end_newline.rb
@@ -33,12 +33,10 @@ module RuboCop
         def on_block(node)
           return if node.single_line?
 
-          end_loc = node.loc.end
-
           # If the end is on its own line, there is no offense
-          return if end_loc.source_line =~ /^\s*#{end_loc.source}/
+          return if begins_its_line?(node.loc.end)
 
-          add_offense(node, location: end_loc)
+          add_offense(node, location: :end)
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/layout/empty_line_after_magic_comment.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_magic_comment.rb
@@ -24,12 +24,11 @@ module RuboCop
         include RangeHelp
 
         MSG = 'Add an empty line after magic comments.'.freeze
-        BLANK_LINE = /\A\s*\z/.freeze
 
         def investigate(source)
           return unless source.ast &&
                         (last_magic_comment = last_magic_comment(source))
-          return if source[last_magic_comment.loc.line] =~ BLANK_LINE
+          return if source[last_magic_comment.loc.line].strip.empty?
 
           offending_range =
             source_range(source.buffer, last_magic_comment.loc.line + 1, 0)

--- a/lib/rubocop/cop/layout/first_parameter_indentation.rb
+++ b/lib/rubocop/cop/layout/first_parameter_indentation.rb
@@ -168,7 +168,7 @@ module RuboCop
           text = base_range(send_node, arg_node).source.strip
           base = if text !~ /\n/ && special_inner_call_indentation?(send_node)
                    "`#{text}`"
-                 elsif text.lines.reverse_each.first =~ /^\s*#/
+                 elsif comment_line?(text.lines.reverse_each.first)
                    'the start of the previous line (not counting the comment)'
                  else
                    'the start of the previous line'

--- a/lib/rubocop/cop/layout/indent_heredoc.rb
+++ b/lib/rubocop/cop/layout/indent_heredoc.rb
@@ -88,7 +88,7 @@ module RuboCop
 
         def on_heredoc(node)
           body = heredoc_body(node)
-          return if body =~ /\A\s*\z/
+          return if body.strip.empty?
 
           body_indent_level = indent_level(body)
 

--- a/lib/rubocop/cop/layout/space_after_method_name.rb
+++ b/lib/rubocop/cop/layout/space_after_method_name.rb
@@ -27,7 +27,7 @@ module RuboCop
           expr = args.source_range
           pos_before_left_paren = range_between(expr.begin_pos - 1,
                                                 expr.begin_pos)
-          return unless pos_before_left_paren.source =~ /\s/
+          return unless pos_before_left_paren.source.start_with?(' ')
 
           add_offense(pos_before_left_paren, location: pos_before_left_paren)
         end

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -23,6 +23,7 @@ module RuboCop
         include RangeHelp
 
         IRREGULAR_METHODS = %i[[] ! []=].freeze
+        EXCESSIVE_SPACE = '  '.freeze
 
         def self.autocorrect_incompatible_with
           [Style::SelfAssignment]
@@ -139,12 +140,12 @@ module RuboCop
         end
 
         def excess_leading_space?(operator, with_space)
-          with_space.source =~ /^  / &&
+          with_space.source.start_with?(EXCESSIVE_SPACE) &&
             (!allow_for_alignment? || !aligned_with_operator?(operator))
         end
 
         def excess_trailing_space?(right_operand, with_space)
-          with_space.source =~ /  $/ &&
+          with_space.source.end_with?(EXCESSIVE_SPACE) &&
             (!allow_for_alignment? || !aligned_with_something?(right_operand))
         end
 

--- a/lib/rubocop/cop/lint/assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/assignment_in_condition.rb
@@ -34,16 +34,17 @@ module RuboCop
         ASGN_TYPES = [:begin, *AST::Node::EQUALS_ASSIGNMENTS, :send].freeze
 
         def on_if(node)
-          check(node)
-        end
+          return if node.condition.block_type?
 
-        def on_while(node)
-          check(node)
-        end
+          traverse_node(node.condition, ASGN_TYPES) do |asgn_node|
+            next :skip_children if skip_children?(asgn_node)
+            next if allowed_construct?(asgn_node)
 
-        def on_until(node)
-          check(node)
+            add_offense(asgn_node, location: :operator)
+          end
         end
+        alias on_while on_if
+        alias on_until on_if
 
         private
 
@@ -52,17 +53,6 @@ module RuboCop
             MSG_WITH_SAFE_ASSIGNMENT_ALLOWED
           else
             MSG_WITHOUT_SAFE_ASSIGNMENT_ALLOWED
-          end
-        end
-
-        def check(node)
-          return if node.condition.block_type?
-
-          traverse_node(node.condition, ASGN_TYPES) do |asgn_node|
-            next :skip_children if skip_children?(asgn_node)
-            next if allowed_construct?(asgn_node)
-
-            add_offense(asgn_node, location: :operator)
           end
         end
 

--- a/lib/rubocop/cop/lint/assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/assignment_in_condition.rb
@@ -75,7 +75,7 @@ module RuboCop
         end
 
         def skip_children?(asgn_node)
-          (asgn_node.send_type? && asgn_node.method_name !~ /=\z/) ||
+          (asgn_node.send_type? && !asgn_node.assignment_method?) ||
             empty_condition?(asgn_node) ||
             (safe_assignment_allowed? && safe_assignment?(asgn_node))
         end

--- a/lib/rubocop/cop/lint/useless_setter_call.rb
+++ b/lib/rubocop/cop/lint/useless_setter_call.rb
@@ -49,17 +49,14 @@ module RuboCop
 
         private
 
+        def_node_matcher :setter_call_to_local_variable?, <<-PATTERN
+          [(send (lvar _) ...) setter_method?]
+        PATTERN
+
         def last_expression(body)
           expression = body.begin_type? ? body.children : body
 
           expression.is_a?(Array) ? expression.last : expression
-        end
-
-        def setter_call_to_local_variable?(node)
-          return unless node && node.send_type?
-          return unless node.receiver && node.receiver.lvar_type?
-
-          node.method_name =~ /(?:\w|\[\])=$/
         end
 
         # This class tracks variable assignments in a method body

--- a/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
+++ b/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
@@ -120,7 +120,7 @@ module RuboCop
       def keyword_message_tail(node)
         keyword = node.loc.keyword.source
         kind    = keyword == 'for' ? 'collection' : 'condition'
-        article = keyword =~ /^[iu]/ ? 'an' : 'a'
+        article = keyword.start_with?('i', 'u') ? 'an' : 'a'
 
         format(KEYWORD_MESSAGE_TAIL, kind: kind,
                                      article: article,

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -69,17 +69,7 @@ module RuboCop
           return false if node.parent.nil?
           return true if ASSIGNMENT_TYPES.include?(node.parent.type)
 
-          if node.parent.send_type?
-            _receiver, _name, *args = *node.parent
-            return !method_uses_parens?(node.parent, args.first)
-          end
-
-          false
-        end
-
-        def method_uses_parens?(node, limit)
-          source = node.source_range.source_line[0...limit.loc.column]
-          source =~ /\s*\(\s*$/
+          node.parent.send_type? && !node.parent.parenthesized?
         end
 
         def to_modifier_form(node)

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -31,8 +31,6 @@ module RuboCop
         ASSIGNMENT_TYPES = %i[lvasgn casgn cvasgn
                               gvasgn ivasgn masgn].freeze
 
-        NAMED_CAPTURE = /\?<.+>/.freeze
-
         def on_if(node)
           return unless eligible_node?(node)
           return if named_capture_in_condition?(node)

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -155,12 +155,13 @@ module RuboCop
 
         def unparenthesized_method_call?(child)
           argument = method_call_argument(child)
-          argument && argument !~ /^\(/
+
+          argument && !argument.parenthesized?
         end
 
         def_node_matcher :method_call_argument, <<-PATTERN
-          {(:defined? $...)
-           (send {_ nil?} _ $(send nil? _)...)}
+          {(:defined? $(send nil? _) ...)
+           (send {_ nil?} _ $(send nil? _) ...)}
         PATTERN
 
         def correct_parenthesized(condition)


### PR DESCRIPTION
This PR addresses code locations where regular expressions can be replaced with node extension methods, named helpers, `#start_with?`, etc. There is still much more in there, but this is a start.

Looking through the usages, I noticed many more opportunities for improvement once we can find the right abstractions.

I'm not sure if it's possible to implement an effective internal investigation for the use of regular expressions, but I might give it a try later.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
