### PR TITLE
Move #6321 changelog entry and remove duplicate header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,12 @@
 ### Changes
 
 * [#3727](https://github.com/rubocop-hq/rubocop/issues/3727): Enforce single spaces for `key` option in `Layout/AlignHash` cop. ([@albaer][])
+* [#6321](https://github.com/rubocop-hq/rubocop/pull/6321): Fix run of RuboCop when cache directory is not writable. ([@Kevinrob][])
 
 ## 0.59.2 (2018-09-24)
 ### New features
 
 * Update `Style/MethodCallWithoutArgsParentheses` to highlight the closing parentheses in additition to the opening parentheses. ([@rrosenblum][])
-
-## 0.59.2 (2018-09-24)
 
 ### Bug fixes
 
@@ -44,7 +43,6 @@
 ### Changes
 
 * [#6286](https://github.com/rubocop-hq/rubocop/pull/6286): Allow exclusion of certain methods for `Metrics/MethodLength`. ([@akanoi][])
-* [#6321](https://github.com/rubocop-hq/rubocop/pull/6321): Fix run of RuboCop when cache directory is not writable. ([@Kevinrob][])
 
 ## 0.59.1 (2018-09-15)
 


### PR DESCRIPTION
When I make the PR #6321, the version `0.59.2` wasn't out yet and the changelog entry was added to it when we recently merge the PR.  
This PR move the changelog entry to the `master (unreleased)` section.

Beside this, the duplicate `0.59.2 (2018-09-24)` header was removed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] ~Commit message starts with `[Fix #issue-number]`~ (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] ~Added tests.~
* [ ] ~Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).~
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] ~Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.~

[1]: http://chris.beams.io/posts/git-commit/
