### PR TITLE
Have rubocop fail nicely when unable to load requirements

### DIFF
--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -14,8 +14,8 @@ module RuboCop
         else
           begin
             require(r)
-          rescue LoadError => exception
-            puts "Unable to load requirement '#{r}', are you missing a gem or a file?"
+          rescue LoadError
+            puts "Unable to load '#{r}', are you missing a gem or a file?"
             exit
           end
         end

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -12,7 +12,12 @@ module RuboCop
         if r.start_with?('.')
           require(File.join(config_dir, r))
         else
-          require(r)
+          begin
+            require(r)
+          rescue LoadError => exception
+            puts "Unable to load requirement '#{r}', are you missing a gem or a file?"
+            exit
+          end
         end
       end
     end


### PR DESCRIPTION
I was wondering if this type of code change would be something you would be interested in. Some requirements if missing when rubocop is executed raises an error with the normal text blob that comes with it. Something like this would make the error more user friendly when requirements can't be found by Rubocop.

I can add the additional items if this is given a 👍 
-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
