### PR TITLE
Fix Emacs style frozen string literal comment check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#5538](https://github.com/rubocop-hq/rubocop/issues/5538): Fix false negatives in modifier cops when line length cop is disabled. ([@drenmi][])
 * [#6340](https://github.com/rubocop-hq/rubocop/pull/6340): Fix an error for `Rails/ReversibleMigration` when block argument is empty. ([@koic][])
 * [#6274](https://github.com/rubocop-hq/rubocop/issues/6274): Fix "[Corrected]" message being displayed even when nothing has been corrected. ([@jekuta][])
+* [#6380](https://github.com/rubocop-hq/rubocop/pull/6380): Allow use of a hyphen-separated frozen string literal in Emacs style magic comment. ([@y-yagi][])
 
 ### Changes
 
@@ -3620,3 +3621,4 @@
 [@lukasz-wojcik]: https://github.com/lukasz-wojcik
 [@albaer]: https://github.com/albaer
 [@Kevinrob]: https://github.com/Kevinrob
+[@y-yagi]: https://github.com/y-yagi

--- a/lib/rubocop/magic_comment.rb
+++ b/lib/rubocop/magic_comment.rb
@@ -140,7 +140,7 @@ module RuboCop
       private
 
       def extract_frozen_string_literal
-        match('frozen_string_literal')
+        match('frozen[_-]string[_-]literal')
       end
     end
 

--- a/spec/rubocop/magic_comment_spec.rb
+++ b/spec/rubocop/magic_comment_spec.rb
@@ -74,6 +74,10 @@ RSpec.describe RuboCop::MagicComment do
                    frozen_string_literal: true
 
   include_examples 'magic comment',
+                   '# -*- frozen-string-literal: true -*-',
+                   frozen_string_literal: true
+
+  include_examples 'magic comment',
                    '# frozen_string_literal: invalid',
                    frozen_string_literal: 'invalid'
 


### PR DESCRIPTION
Emacs style + hyphen delimited frozen literal comment(`-*- frozen-string-literal: true -*-`) is a valid comment.
Ref: https://github.com/ruby/ruby/blob/0cb0835581de93f97861e38acf6ae338ad49f8b5/test/ruby/test_literal.rb#L149-L152

But RuboCop does not recognize this comment currently. This fix allows using that format comment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
