### PR TITLE
Add `VersionAdded` to config/default.yml when running `rake new_cop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#5980](https://github.com/rubocop-hq/rubocop/issues/5980): Add --safe and --safe-auto-correct options. ([@Darhazer][])
 * [#4156](https://github.com/rubocop-hq/rubocop/issues/4156): Add command line option `--auto-gen-only-exclude`. ([@Ana06][], [@jonas054][])
+* [#6386](https://github.com/rubocop-hq/rubocop/pull/6386): Add `VersionAdded` meta data to config/default.yml when running `rake new_cop`. ([@koic][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -128,6 +128,7 @@ module RuboCop
           #{badge}:
             Description: 'TODO: Write a description of the cop.'
             Enabled: true
+            VersionAdded: #{bump_minor_version}
 
         YAML
         target_line = config.find.with_index(1) do |line, index|
@@ -208,6 +209,12 @@ module RuboCop
           .gsub(/([^A-Z])([A-Z]+)/, '\1_\2')
           .gsub(/([A-Z])([A-Z][^A-Z\d]+)/, '\1_\2')
           .downcase
+      end
+
+      def bump_minor_version
+        versions = RuboCop::Version::STRING.split('.')
+
+        "#{versions[0]}.#{versions[1].succ}"
       end
     end
   end

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -193,6 +193,8 @@ RSpec.describe RuboCop::Cop::Generator do
     end
 
     it 'inserts the cop in alphabetical' do
+      stub_const('RuboCop::Version::STRING', '0.58.2')
+
       expect(File).to receive(:write).with(path, <<-YAML.strip_indent)
         Style/Alias:
           Enabled: true
@@ -200,6 +202,7 @@ RSpec.describe RuboCop::Cop::Generator do
         Style/FakeCop:
           Description: 'TODO: Write a description of the cop.'
           Enabled: true
+          VersionAdded: 0.59
 
         Style/Lambda:
           Enabled: true


### PR DESCRIPTION
#6293 extended cop metadata.

This PR adds `VersionAdded` to config/default.yml when running `rake new_cop`.

The following is an example.

```console
% rubocop -V
0.59.2 (using Parser 2.5.1.2, running on ruby 2.5.1 x86_64-darwin17)
% bunle exec rake new_cop[Lint/TheNewCop]
```

In the current RuboCop, a new cop is added with a minor version.

```diff
diff --git a/config/default.yml b/config/default.yml
index e784ea6b7..522f6aa4e 100644
--- a/config/default.yml
+++ b/config/default.yml
@@ -1507,6 +1507,11 @@ Lint/Syntax:
   VersionAdded: 0.9

+Lint/TheNewCop:
+  Description: 'TODO: Write a description of the cop.'
+  Enabled: true
+  VersionAdded: 0.60
+
 Lint/UnderscorePrefixedVariableName:
   Description: 'Do not use prefix `_` for a variable that is used.'
   Enabled: true
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
