### PR TITLE
Fix false negative for Style/TrailingCommaInHashLiteral when there is a comment in the last one line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#6554](https://github.com/rubocop-hq/rubocop/issues/6554): Prevent Layout/RescueEnsureAlignment cop from breaking on block assignment when assignment is on a separate line. ([@timmcanty][])
+* [#6389](https://github.com/rubocop-hq/rubocop/pull/6389): Fix false negative for `Style/TrailingCommaInHashLitera`/`Style/TrailingCommaInArrayLiteral` when there is a comment in the last line. ([@bayandin][])
 
 ## 0.61.1 (2018-12-06)
 
@@ -3686,3 +3687,4 @@
 [@dduugg]: https://github.com/dduugg
 [@mmedal]: https://github.com/mmedal
 [@timmcanty]: https://github.com/timmcanty
+[@bayandin]: https://github.com/bayandin

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -77,7 +77,7 @@ module RuboCop
       end
 
       def heredoc?(source_after_last_item)
-        source_after_last_item =~ /\w/
+        source_after_last_item !~ /^\s*#/ && source_after_last_item =~ /\w/
       end
 
       # Returns true if the node has round/square/curly brackets.

--- a/spec/rubocop/cop/lint/unneeded_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/unneeded_cop_disable_directive_spec.rb
@@ -298,7 +298,7 @@ RSpec.describe RuboCop::Cop::Lint::UnneededCopDisableDirective do
             let(:cop_disabled_line_ranges) do
               {
                 'Metrics/MethodLength' => [1..Float::INFINITY],
-                'Metrics/ClassLength' => [1..Float::INFINITY],
+                'Metrics/ClassLength' => [1..Float::INFINITY]
                 # etc... (no need to include all cops here)
               }
             end

--- a/spec/rubocop/cop/style/trailing_comma_in_hash_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_hash_literal_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInHashLiteral, :config do
         expect_offense(<<-RUBY.strip_indent)
           MAP = { a: 1001,
                   b: 2020,
-                  c: 3333 # ,
+                  c: 3333 # a comment,
                   ^^^^^^^ Put a comma after the last item of a multiline hash.
           }
         RUBY


### PR DESCRIPTION
This PR fixes false negative for `Style/TrailingCommaInHashLitera`/`Style/TrailingCommaInArrayLiteral` when there is a comment in the last line:

```ruby
{ 
    a: 1001,
    b: 2020,
    c: 3333 # a comment,
}
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* ~[ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
