### PR TITLE
Add Whitelist config to Rails/SkipsModelValidations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#4156](https://github.com/rubocop-hq/rubocop/issues/4156): Add command line option `--auto-gen-only-exclude`. ([@Ana06][], [@jonas054][])
 * [#6386](https://github.com/rubocop-hq/rubocop/pull/6386): Add `VersionAdded` meta data to config/default.yml when running `rake new_cop`. ([@koic][])
 * [#6395](https://github.com/rubocop-hq/rubocop/pull/6395): Permit to specify TargetRubyVersion 2.6. ([@koic][])
+* [#6392](https://github.com/rubocop-hq/rubocop/pull/6392): Add `Whitelist` config to `Rails/SkipsModelValidations` rule. ([@DiscoStarslayer][])
 
 ### Bug fixes
 
@@ -3624,3 +3625,4 @@
 [@albaer]: https://github.com/albaer
 [@Kevinrob]: https://github.com/Kevinrob
 [@y-yagi]: https://github.com/y-yagi
+[@DiscoStarslayer]: https://github.com/DiscoStarslayer

--- a/config/default.yml
+++ b/config/default.yml
@@ -2518,6 +2518,7 @@ Rails/SkipsModelValidations:
   Reference: 'http://guides.rubyonrails.org/active_record_validations.html#skipping-validations'
   Enabled: true
   VersionAdded: 0.47
+  VersionChanged: 0.59
   Blacklist:
     - decrement!
     - decrement_counter
@@ -2530,6 +2531,7 @@ Rails/SkipsModelValidations:
     - update_column
     - update_columns
     - update_counters
+  Whitelist: []
 
 Rails/TimeZone:
   Description: 'Checks the correct usage of time zone aware methods.'

--- a/lib/rubocop/cop/rails/skips_model_validations.rb
+++ b/lib/rubocop/cop/rails/skips_model_validations.rb
@@ -7,6 +7,8 @@ module RuboCop
       # validations which are listed in
       # http://guides.rubyonrails.org/active_record_validations.html#skipping-validations
       #
+      # Methods may be ignored from this rule by configuring a `Whitelist`.
+      #
       # @example
       #   # bad
       #   Article.first.decrement!(:view_count)
@@ -23,6 +25,16 @@ module RuboCop
       #   # good
       #   user.update(website: 'example.com')
       #   FileUtils.touch('file')
+      #
+      # @example Whitelist: ["touch"]
+      #   # bad
+      #   DiscussionBoard.decrement_counter(:post_count, 5)
+      #   DiscussionBoard.increment_counter(:post_count, 5)
+      #   person.toggle :active
+      #
+      #   # good
+      #   user.touch
+      #
       class SkipsModelValidations < Cop
         MSG = 'Avoid using `%<method>s` because it skips validations.'.freeze
 

--- a/lib/rubocop/cop/rails/skips_model_validations.rb
+++ b/lib/rubocop/cop/rails/skips_model_validations.rb
@@ -42,6 +42,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          return if whitelist.include?(node.method_name.to_s)
           return unless blacklist.include?(node.method_name.to_s)
 
           _receiver, method_name, *args = *node
@@ -63,6 +64,10 @@ module RuboCop
 
         def blacklist
           cop_config['Blacklist'] || []
+        end
+
+        def whitelist
+          cop_config['Whitelist'] || []
         end
       end
     end

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1870,11 +1870,13 @@ Include | `app/models/**/*.rb` | Array
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.47 | 
+Enabled | Yes | No | 0.47 | 0.59
 
 This cop checks for the use of methods which skip
 validations which are listed in
 http://guides.rubyonrails.org/active_record_validations.html#skipping-validations
+
+Methods may be ignored from this rule by configuring a `Whitelist`.
 
 ### Examples
 
@@ -1895,12 +1897,24 @@ Post.update_counters 5, comment_count: -1, action_count: 1
 user.update(website: 'example.com')
 FileUtils.touch('file')
 ```
+#### Whitelist: ["touch"]
+
+```ruby
+# bad
+DiscussionBoard.decrement_counter(:post_count, 5)
+DiscussionBoard.increment_counter(:post_count, 5)
+person.toggle :active
+
+# good
+user.touch
+```
 
 ### Configurable attributes
 
 Name | Default value | Configurable values
 --- | --- | ---
 Blacklist | `decrement!`, `decrement_counter`, `increment!`, `increment_counter`, `toggle!`, `touch`, `update_all`, `update_attribute`, `update_column`, `update_columns`, `update_counters` | Array
+Whitelist | `[]` | Array
 
 ### References
 

--- a/spec/rubocop/cop/rails/skips_model_validations_spec.rb
+++ b/spec/rubocop/cop/rails/skips_model_validations_spec.rb
@@ -88,10 +88,10 @@ RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
     end
 
     it 'registers an offense for method not in whitelist' do
-      inspect_source('User.toggle!(:attr)')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq([format(msg, 'toggle!')])
+      expect_offense(<<-RUBY.strip_indent)
+        user.toggle!(:active)
+             ^^^^^^^ Avoid using `toggle!` because it skips validations.
+      RUBY
     end
 
     it 'accepts method in whitelist, superseding the blacklist' do

--- a/spec/rubocop/cop/rails/skips_model_validations_spec.rb
+++ b/spec/rubocop/cop/rails/skips_model_validations_spec.rb
@@ -87,14 +87,14 @@ RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
       }
     end
 
-    it 'registers an offense for method not on Whitelist' do
+    it 'registers an offense for method not in whitelist' do
       inspect_source('User.toggle!(:attr)')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq([format(msg, 'toggle!')])
     end
 
-    it 'accepts method on whitelist, superseding the blacklist' do
+    it 'accepts method in whitelist, superseding the blacklist' do
       expect_no_offenses('User.touch(:attr)')
     end
   end

--- a/spec/rubocop/cop/rails/skips_model_validations_spec.rb
+++ b/spec/rubocop/cop/rails/skips_model_validations_spec.rb
@@ -78,4 +78,24 @@ RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
       RUBY
     end
   end
+
+  context 'with whitelist' do
+    let(:cop_config) do
+      {
+        'Blacklist' => %w[toggle! touch],
+        'Whitelist' => %w[touch]
+      }
+    end
+
+    it 'registers an offense for method not on Whitelist' do
+      inspect_source('User.toggle!(:attr)')
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.messages)
+        .to eq([format(msg, 'toggle!')])
+    end
+
+    it 'accepts method on whitelist, superseding the blacklist' do
+      expect_no_offenses('User.touch(:attr)')
+    end
+  end
 end


### PR DESCRIPTION
# Rails/SkipsModelValidations

Rails/SkipsModelValidations is a very useful rule as it can help catch some easy to miss gotchas regarding Validation in ActiveRecord. 

Sometimes you need exceptions though, for instance in one of our projects we have this rule enabled, but would still like to allow the `touch` method as we feel it is relatively safe to call even without validation.

Currently to make this happen we have a rubocop config that looks like the following:
```yml
Rails/SkipsModelValidations:
  Blacklist:
    - decrement!
    - decrement_counter
    - increment!
    - increment_counter
    - toggle!
    - update_all
    - update_attribute
    - update_column
    - update_columns
    - update_counters
```
It is hard to tell just glancing at the config what this is doing, but if you look closely you can see we are missing the `touch` method in the `Blacklist`. While this works, it exposes us to two issues:

- Config is less self-documenting, hard to notice `touch` is missing without looking up the full list
- If new methods are added that skip validation, they will not be part of our `Blacklist` since we are overriding the blacklist from our upstream config.

I propose adding a new `Whitelist` config option that lets you explicitly declare that you are ok with certain methods from being ignored by the rule. The equivalent config from above would then be:
```yml
Rails/SkipsModelValidations:
  Whitelist:
    - touch
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
