### PR TITLE
[FIX #5949] Improve Lint/EnsureReturn cop documentation

### DIFF
--- a/lib/rubocop/cop/lint/ensure_return.rb
+++ b/lib/rubocop/cop/lint/ensure_return.rb
@@ -3,6 +3,9 @@
 module RuboCop
   module Cop
     module Lint
+      # Explicit return from an ensure block alters the control flow
+      # as the return will take precedence over any exception being raised,
+      # and the exception will be silently thrown away.
       # This cop checks for *return* from an *ensure* block.
       #
       # @example

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -604,6 +604,9 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 --- | --- | --- | --- | ---
 Enabled | Yes | No | 0.9 | 
 
+Explicit return from an ensure block alters the control flow
+as the return will take precedence over any exception being raised,
+and the exception will be silently thrown away.
 This cop checks for *return* from an *ensure* block.
 
 ### Examples


### PR DESCRIPTION
Related to #5949, I improved the `Lint/EnsureReturn` cop documentation.

I think someone already added an entry in the style guide for this? 

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
