### PR TITLE
Permit to specify TargetRubyVersion 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#5980](https://github.com/rubocop-hq/rubocop/issues/5980): Add --safe and --safe-auto-correct options. ([@Darhazer][])
 * [#4156](https://github.com/rubocop-hq/rubocop/issues/4156): Add command line option `--auto-gen-only-exclude`. ([@Ana06][], [@jonas054][])
 * [#6386](https://github.com/rubocop-hq/rubocop/pull/6386): Add `VersionAdded` meta data to config/default.yml when running `rake new_cop`. ([@koic][])
+* [#6395](https://github.com/rubocop-hq/rubocop/pull/6395): Permit to specify TargetRubyVersion 2.6. ([@koic][])
 
 ### Bug fixes
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -18,7 +18,7 @@ module RuboCop
                        AutoCorrect StyleGuide Details].freeze
     # 2.2 is the oldest officially supported Ruby version.
     DEFAULT_RUBY_VERSION = 2.2
-    KNOWN_RUBIES = [2.2, 2.3, 2.4, 2.5].freeze
+    KNOWN_RUBIES = [2.2, 2.3, 2.4, 2.5, 2.6].freeze
     OBSOLETE_RUBIES = { 1.9 => '0.50', 2.0 => '0.50', 2.1 => '0.58' }.freeze
     RUBY_VERSION_FILENAME = '.ruby-version'.freeze
     DEFAULT_RAILS_VERSION = 5.0

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1649,14 +1649,14 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       it 'fails with an error message' do
         create_file('.rubocop.yml', <<-YAML.strip_indent)
           AllCops:
-            TargetRubyVersion: 2.6
+            TargetRubyVersion: 2.7
         YAML
         expect(cli.run([])).to eq(2)
         expect($stderr.string.strip).to match(
-          /\AError: Unknown Ruby version 2.6 found in `TargetRubyVersion`/
+          /\AError: Unknown Ruby version 2.7 found in `TargetRubyVersion`/
         )
         expect($stderr.string.strip).to match(
-          /Supported versions: 2.2, 2.3, 2.4, 2.5/
+          /Supported versions: 2.2, 2.3, 2.4, 2.5, 2.6/
         )
       end
     end


### PR DESCRIPTION
Parser gem has been started development for Ruby 2.6 (edge Ruby).
https://github.com/whitequark/parser/blob/master/CHANGELOG.md#v2510-2018-04-12

AFAIK, the next Ruby version is 2.7 after Ruby 2.6.
https://bugs.ruby-lang.org/issues/14256

This PR permits Ruby 2.6, the early adapters will be able to try edge Ruby with RuboCop.

#5845 has already been finished some work to support ruby 2.6.
And this PR ends all the work related to permit to specify TargetRubyVersion 2.6.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
