### PR TITLE
Suppress deprecation warnings of `Psych.safe_load` args in Ruby 2.6

### DIFF
--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -181,6 +181,14 @@ module RuboCop
         if defined?(SafeYAML) && SafeYAML.respond_to?(:load)
           SafeYAML.load(yaml_code, filename,
                         whitelisted_tags: %w[!ruby/regexp])
+        elsif RUBY_VERSION >= '2.6'
+          YAML.safe_load(
+            yaml_code,
+            whitelist_classes: [Regexp, Symbol],
+            whitelist_symbols: [],
+            aliases: false,
+            filename: filename
+          )
         else
           YAML.safe_load(yaml_code, [Regexp, Symbol], [], false, filename)
         end


### PR DESCRIPTION
Follow up of https://github.com/rubocop-hq/rubocop/pull/6395#issuecomment-431591167.

The interface of `Psych.safe_load` will change from Ruby 2.6.
https://github.com/ruby/ruby/commit/1c92766bf0b7394057c00f576fce5464a3037fd9

This PR suppresses the following wargnins.

```console
cd /path/to/rubocop/repo
% ruby -v
ruby 2.6.0dev (2018-10-21 trunk 65252) [x86_64-darwin17]
bundle exec rspec

(snip)

warning: Passing whitelist_classes with the 2nd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, whitelist_classes: ...) instead.
warning: Passing whitelist_symbols with the 3rd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, whitelist_symbols: ...) instead.
warning: Passing aliases with the 4th argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, aliases: ...) instead.
warning: Passing filename with the 5th argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, filename: ...) instead.
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
