### PR TITLE
Changes to MkDocs / ReadTheDocs navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ repo_url: https://github.com/rubocop-hq/rubocop
 edit_uri: edit/master/manual/
 copyright: "Copyright &copy; 2012-2018 Bozhidar Batsov and RuboCop contributors"
 docs_dir: manual
-nav:
+pages:
 - Home: index.md
 - Installation: installation.md
 - Basic Usage: basic_usage.md


### PR DESCRIPTION
It seems that `pages` may once be deprecated but for the moment (at ReadTheDocs) the `nav` identifier won't work. If replaced with `pages` the intended navigation will be shown. On using `nav` the raw build process on RTD will show:

> WARNING -  Config value: 'nav'. Warning: Unrecognised configuration name: nav

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
