### PR TITLE
Remove progressbar from OffenseCountFormatter

### DIFF
--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -615,6 +615,8 @@ require_relative 'rubocop/cop/security/yaml_load'
 require_relative 'rubocop/cop/team'
 
 require_relative 'rubocop/formatter/base_formatter'
+# relies on base_formatter
+require_relative 'rubocop/formatter/progressbar_formatter'
 require_relative 'rubocop/formatter/simple_text_formatter'
 # relies on simple text
 require_relative 'rubocop/formatter/clang_style_formatter'

--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -22,7 +22,8 @@ module RuboCop
         'worst' => WorstOffendersFormatter,
         'tap' => TapFormatter,
         'quiet' => QuietFormatter,
-        'autogenconf' => AutoGenConfigFormatter
+        'autogenconf' => AutoGenConfigFormatter,
+        'bar' => ProgressbarFormatter
       }.freeze
 
       FORMATTER_APIS = %i[started finished].freeze

--- a/lib/rubocop/formatter/offense_count_formatter.rb
+++ b/lib/rubocop/formatter/offense_count_formatter.rb
@@ -17,27 +17,10 @@ module RuboCop
       def started(target_files)
         super
         @offense_counts = Hash.new(0)
-
-        return unless output.tty?
-
-        file_phrase = target_files.count == 1 ? 'file' : 'files'
-
-        # 185/407 files |====== 45 ======>                    |  ETA: 00:00:04
-        # %c / %C       |       %w       >         %i         |       %e
-        bar_format = " %c/%C #{file_phrase} |%w>%i| %e "
-
-        @progressbar = ProgressBar.create(
-          output: output,
-          total: target_files.count,
-          format: bar_format,
-          autostart: false
-        )
-        @progressbar.start
       end
 
       def file_finished(_file, offenses)
         offenses.each { |o| @offense_counts[o.cop_name] += 1 }
-        @progressbar.increment if instance_variable_defined?(:@progressbar)
       end
 
       def finished(_inspected_files)

--- a/lib/rubocop/formatter/progressbar_formatter.rb
+++ b/lib/rubocop/formatter/progressbar_formatter.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'ruby-progressbar'
+
+module RuboCop
+  module Formatter
+    # This formatter displays only a progressbar and no additional output.
+    #
+    class ProgressbarFormatter < BaseFormatter
+      def started(target_files)
+        super
+
+        file_phrase = target_files.count == 1 ? 'file' : 'files'
+
+        # 185/407 files |====== 45 ======>                    |  ETA: 00:00:04
+        # %c / %C       |       %w       >         %i         |       %e
+        bar_format = " %c/%C #{file_phrase} |%w>%i| %e "
+
+        @progressbar = ProgressBar.create(
+          output: output,
+          total: target_files.count,
+          format: bar_format,
+          autostart: false
+        )
+
+        @progressbar.start
+      end
+
+      def file_finished(_file, offenses)
+        @progressbar.clear unless offenses.empty?
+
+        @progressbar.increment
+      end
+    end
+  end
+end

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -399,6 +399,7 @@ module RuboCop
                '  [t]ap',
                '  [q]uiet',
                '  [a]utogenconf',
+               '  [b]ar',
                '  custom formatter class name'],
       out: ['Write output to a file instead of STDOUT.',
             'This option applies to the previously',

--- a/spec/rubocop/formatter/offense_count_formatter_spec.rb
+++ b/spec/rubocop/formatter/offense_count_formatter_spec.rb
@@ -75,24 +75,5 @@ RSpec.describe RuboCop::Formatter::OffenseCountFormatter do
         OUTPUT
       end
     end
-
-    context 'when output tty is true' do
-      let(:offenses) do
-        %w[CopB CopA CopC CopC].map do |cop|
-          instance_double(RuboCop::Cop::Offense, cop_name: cop)
-        end
-      end
-
-      before do
-        allow(output).to receive(:tty?).and_return(true)
-        formatter.started(files)
-        finish
-      end
-
-      it 'has a progresbar' do
-        formatter.finished(files)
-        expect(formatter.instance_variable_get(:@progressbar).progress).to eq 1
-      end
-    end
   end
 end

--- a/spec/rubocop/formatter/progressbar_formatter_spec.rb
+++ b/spec/rubocop/formatter/progressbar_formatter_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Formatter::ProgressbarFormatter do
+  subject(:formatter) { described_class.new(output) }
+
+  let(:output) { StringIO.new }
+
+  let(:finish) { formatter.file_finished(files.first, offenses) }
+
+  let(:files) do
+    %w[lib/rubocop.rb spec/spec_helper.rb].map do |path|
+      File.expand_path(path)
+    end
+  end
+
+  context 'when output tty is true' do
+    let(:offenses) do
+      %w[CopB CopA CopC CopC].map { |c| double('offense', cop_name: c) }
+    end
+
+    before do
+      allow(output).to receive(:tty?).and_return(true)
+      formatter.started(files)
+      finish
+    end
+
+    it 'has a progresbar' do
+      formatter.finished(files)
+      expect(formatter.instance_variable_get(:@progressbar).progress).to eq 1
+    end
+  end
+end

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                                                  [t]ap
                                                  [q]uiet
                                                  [a]utogenconf
+                                                 [b]ar
                                                  custom formatter class name
               -o, --out FILE                   Write output to a file instead of STDOUT.
                                                This option applies to the previously


### PR DESCRIPTION
Recently I started using multiple outputs to speed up my workflow especially for older projects which didn't use rubocop before. Looking through the docs and the code it felt odd, that no formatter besides the **OffenseCountFormatter** uses a progressbar.

So the PR removes the progressbar to be more consistent. If I want a progressbar I can use **FuubarStyleFormatter**

```bash
$ rake default
Files:         514
Modules:        80 (   11 undocumented)
Classes:       485 (    3 undocumented)
Constants:     751 (  738 undocumented)
Attributes:     26 (    0 undocumented)
Methods:      1163 ( 1037 undocumented)
 28.58% documented
* generated /home/holger.arndt/Projects/rubocop/manual/cops_bundler.md
* generated /home/holger.arndt/Projects/rubocop/manual/cops_gemspec.md
* generated /home/holger.arndt/Projects/rubocop/manual/cops_layout.md
* generated /home/holger.arndt/Projects/rubocop/manual/cops_lint.md
* generated /home/holger.arndt/Projects/rubocop/manual/cops_metrics.md
* generated /home/holger.arndt/Projects/rubocop/manual/cops_naming.md
* generated /home/holger.arndt/Projects/rubocop/manual/cops_performance.md
* generated /home/holger.arndt/Projects/rubocop/manual/cops_rails.md
* generated /home/holger.arndt/Projects/rubocop/manual/cops_security.md
* generated /home/holger.arndt/Projects/rubocop/manual/cops_style.md
Starting test-queue master (/tmp/test_queue_26493_47227101006560.sock)

==> Summary (8 workers in 9.4735s)

    [ 1]                                    3297 examples, 0 failures       136 suites in 8.1272s      (pid 27015 exit 0 )
    [ 2]                         6109 examples, 0 failures, 5 pending        32 suites in 9.4596s      (pid 27018 exit 0 )
    [ 3]                                    3317 examples, 0 failures        57 suites in 9.4564s      (pid 27021 exit 0 )
    [ 4]                         1716 examples, 0 failures, 1 pending        48 suites in 9.4545s      (pid 27024 exit 0 )
    [ 5]                                    3546 examples, 0 failures        96 suites in 9.4531s      (pid 27027 exit 0 )
    [ 6]                                     481 examples, 0 failures        13 suites in 9.4520s      (pid 27030 exit 0 )
    [ 7]                         3333 examples, 0 failures, 1 pending       120 suites in 9.4389s      (pid 27033 exit 0 )
    [ 8]                                     948 examples, 0 failures        21 suites in 9.4122s      (pid 27036 exit 0 )
```

WDYT?