### PR TITLE
[Fix #5934] Handle --auto-gen-config --config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#5934](https://github.com/rubocop-hq/rubocop/issues/5934): Handle the combination of `--auto-gen-config` and `--config FILE` correctly. ([@jonas054][])
+
 ## 0.60.0 (2018-10-26)
 
 ### New features

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -118,6 +118,7 @@ module RuboCop
 
     def reset_config_and_auto_gen_file
       @config_store = ConfigStore.new
+      @config_store.options_config = @options[:config] if @options[:config]
       File.open(ConfigLoader::AUTO_GENERATED_FILE, 'w') {}
       ConfigLoader.add_inheritance_from_auto_generated_file
     end
@@ -135,6 +136,7 @@ module RuboCop
       ConfigLoader.debug = @options[:debug]
       ConfigLoader.auto_gen_config = @options[:auto_gen_config]
       ConfigLoader.ignore_parent_exclusion = @options[:ignore_parent_exclusion]
+      ConfigLoader.options_config = @options[:config]
 
       @config_store.options_config = @options[:config] if @options[:config]
       @config_store.force_default_config! if @options[:force_default_config]

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -22,7 +22,8 @@ module RuboCop
     class << self
       include FileFinder
 
-      attr_accessor :debug, :auto_gen_config, :ignore_parent_exclusion
+      attr_accessor :debug, :auto_gen_config, :ignore_parent_exclusion,
+                    :options_config
       attr_writer :default_configuration
 
       alias debug? debug
@@ -30,7 +31,7 @@ module RuboCop
       alias ignore_parent_exclusion? ignore_parent_exclusion
 
       def clear_options
-        @debug = @auto_gen_config = nil
+        @debug = @auto_gen_config = @options_config = nil
         FileFinder.root_level = nil
       end
 
@@ -127,24 +128,25 @@ module RuboCop
       def add_inheritance_from_auto_generated_file
         file_string = " #{AUTO_GENERATED_FILE}"
 
-        if File.exist?(DOTFILE)
-          files = Array(load_yaml_configuration(DOTFILE)['inherit_from'])
+        config_file = options_config || DOTFILE
+        if File.exist?(config_file)
+          files = Array(load_yaml_configuration(config_file)['inherit_from'])
           return if files.include?(AUTO_GENERATED_FILE)
 
           files.unshift(AUTO_GENERATED_FILE)
           file_string = "\n  - " + files.join("\n  - ") if files.size > 1
-          rubocop_yml_contents = IO.read(DOTFILE, encoding: Encoding::UTF_8)
+          rubocop_yml_contents = IO.read(config_file, encoding: Encoding::UTF_8)
                                    .sub(/^inherit_from: *[.\w]+/, '')
                                    .sub(/^inherit_from: *(\n *- *[.\w]+)+/, '')
         end
-        write_dotfile(file_string, rubocop_yml_contents)
+        write_config_file(config_file, file_string, rubocop_yml_contents)
         puts "Added inheritance from `#{AUTO_GENERATED_FILE}` in `#{DOTFILE}`."
       end
 
       private
 
-      def write_dotfile(file_string, rubocop_yml_contents)
-        File.open(DOTFILE, 'w') do |f|
+      def write_config_file(file_name, file_string, rubocop_yml_contents)
+        File.open(file_name, 'w') do |f|
           f.write "inherit_from:#{file_string}\n"
           f.write "\n#{rubocop_yml_contents}" if rubocop_yml_contents
         end


### PR DESCRIPTION
When a `--config` option is given with a file name that should be used instead of `.rubocop.yml`, we need to use the given file name throughout the somewhat complicated generation of the todo file.