### PR TITLE
[Fix #5970] Handle paths in inherit_from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#5934](https://github.com/rubocop-hq/rubocop/issues/5934): Handle the combination of `--auto-gen-config` and `--config FILE` correctly. ([@jonas054][])
+* [#5970](https://github.com/rubocop-hq/rubocop/issues/5970): Make running `--auto-gen-config` in a subdirectory work. ([@jonas054][])
 
 ## 0.60.0 (2018-10-26)
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -136,8 +136,9 @@ module RuboCop
           files.unshift(AUTO_GENERATED_FILE)
           file_string = "\n  - " + files.join("\n  - ") if files.size > 1
           rubocop_yml_contents = IO.read(config_file, encoding: Encoding::UTF_8)
-                                   .sub(/^inherit_from: *[.\w]+/, '')
-                                   .sub(/^inherit_from: *(\n *- *[.\w]+)+/, '')
+                                   .sub(%r{^inherit_from: *[.\/\w]+}, '')
+                                   .sub(%r{^inherit_from: *(\n *- *[.\/\w]+)+},
+                                        '')
         end
         write_config_file(config_file, file_string, rubocop_yml_contents)
         puts "Added inheritance from `#{AUTO_GENERATED_FILE}` in `#{DOTFILE}`."
@@ -148,7 +149,7 @@ module RuboCop
       def write_config_file(file_name, file_string, rubocop_yml_contents)
         File.open(file_name, 'w') do |f|
           f.write "inherit_from:#{file_string}\n"
-          f.write "\n#{rubocop_yml_contents}" if rubocop_yml_contents
+          f.write "\n#{rubocop_yml_contents}" if rubocop_yml_contents =~ /\S/
         end
       end
 


### PR DESCRIPTION
We couldn't deal with slashes in `inherit_from` file paths.

There was also a weird checking of falsiness of the parameter `rubocop_yml_contents`, even though it's always truthy. Checking if it contains any non-whitespace achieves the desired result.