### PR TITLE
[Fix #6412] Fix an error when using Ruby 2.6.0-preview2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#5934](https://github.com/rubocop-hq/rubocop/issues/5934): Handle the combination of `--auto-gen-config` and `--config FILE` correctly. ([@jonas054][])
 * [#5970](https://github.com/rubocop-hq/rubocop/issues/5970): Make running `--auto-gen-config` in a subdirectory work. ([@jonas054][])
+* [#6412](https://github.com/rubocop-hq/rubocop/issues/6412): Fix an `unknown keywords` error when using `Psych.safe_load` with Ruby 2.6.0-preview2. ([@koic][])
 
 ## 0.60.0 (2018-10-26)
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -184,7 +184,8 @@ module RuboCop
         if defined?(SafeYAML) && SafeYAML.respond_to?(:load)
           SafeYAML.load(yaml_code, filename,
                         whitelisted_tags: %w[!ruby/regexp])
-        elsif RUBY_VERSION >= '2.6'
+        # Ruby 2.6+
+        elsif Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1')
           YAML.safe_load(
             yaml_code,
             whitelist_classes: [Regexp, Symbol],


### PR DESCRIPTION
Fixes #6412.

This PR fixes an `unknown keywords` error when using `Psych.safe_load` with Ruby 2.6.0-preview2.

```console
% ruby -v
ruby 2.6.0preview2 (2018-05-31 trunk 63539) [x86_64-darwin17]
% rubocop -V
0.60.0 (using Parser 2.5.1.2, running on ruby 2.6.0 x86_64-darwin17)
% rubocop
unknown keywords: whitelist_classes, whitelist_symbols, aliases, filename
/Users/koic/.rbenv/versions/2.6.0-preview2/lib/ruby/2.6.0/psych.rb:313:in `safe_load'
/Users/koic/.rbenv/versions/2.6.0-preview2/lib/ruby/gems/2.6.0/gems/rubocop-0.60.0/lib/rubocop/config_loader.rb:185:in `yaml_safe_load'
/Users/koic/.rbenv/versions/2.6.0-preview2/lib/ruby/gems/2.6.0/gems/rubocop-0.60.0/lib/rubocop/config_loader.rb:159:in `load_yaml_configuration'
/Users/koic/.rbenv/versions/2.6.0-preview2/lib/ruby/gems/2.6.0/gems/rubocop-0.60.0/lib/rubocop/config_loader.rb:40:in `load_file'
/Users/koic/.rbenv/versions/2.6.0-preview2/lib/ruby/gems/2.6.0/gems/rubocop-0.60.0/lib/rubocop/config_loader.rb:82:in `configuration_from_file'
/Users/koic/.rbenv/versions/2.6.0-preview2/lib/ruby/gems/2.6.0/gems/rubocop-0.60.0/lib/rubocop/config_store.rb:44:in `for'
/Users/koic/.rbenv/versions/2.6.0-preview2/lib/ruby/gems/2.6.0/gems/rubocop-0.60.0/lib/rubocop/cli.rb:187:in `apply_default_formatter'
/Users/koic/.rbenv/versions/2.6.0-preview2/lib/ruby/gems/2.6.0/gems/rubocop-0.60.0/lib/rubocop/cli.rb:40:in `run'
/Users/koic/.rbenv/versions/2.6.0-preview2/lib/ruby/gems/2.6.0/gems/rubocop-0.60.0/exe/rubocop:13:in `block in <top (required)>'
/Users/koic/.rbenv/versions/2.6.0-preview2/lib/ruby/2.6.0/benchmark.rb:308:in `realtime'
/Users/koic/.rbenv/versions/2.6.0-preview2/lib/ruby/gems/2.6.0/gems/rubocop-0.60.0/exe/rubocop:12:in `<top (required)>'
/Users/koic/.rbenv/versions/2.6.0-preview2/bin/rubocop:23:in `load'
/Users/koic/.rbenv/versions/2.6.0-preview2/bin/rubocop:23:in `<main>'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
