### PR TITLE
Add option to enforce frozen_string_literal: true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [#6363](https://github.com/rubocop-hq/rubocop/issues/6363): Allow `Style/YodaCondition` cop to be configured to enforce yoda conditions. ([@tejasbubane][])
 * [#6150](https://github.com/rubocop-hq/rubocop/issues/6150): Add support to enforce disabled cops to be executed. ([@roooodcastro][])
 * [#6596](https://github.com/rubocop-hq/rubocop/pull/6596): Add new `Rails/BelongsTo` cop with auto-correct for Rails >= 5. ([@petehamilton][])
+* Add `always_enabled` option to `Style/FrozenStringLiteralComment` to enforce frozen_string_literal is always set to true. ([@martingordon][])
 
 ### Bug fixes
 
@@ -165,7 +166,7 @@
 
 ### New features
 
-* Update `Style/MethodCallWithoutArgsParentheses` to highlight the closing parentheses in additition to the opening parentheses. ([@rrosenblum][])
+* Update `Style/MethodCallWithoutArgsParentheses` to highlight the closing parentheses in addition to the opening parentheses. ([@rrosenblum][])
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#6643](https://github.com/rubocop-hq/rubocop/pull/6643): Support `AllowParenthesesInCamelCaseMethod` option on `Style/MethodCallWithArgsParentheses` `omit_parentheses`. ([@dazuma][])
+* [#6422](https://github.com/rubocop-hq/rubocop/pull/6422): Add `always_enabled` option to `Style/FrozenStringLiteralComment` to enforce frozen_string_literal is always set to true. ([@martingordon][])
 
 ### Bug fixes
 
@@ -33,7 +34,6 @@
 * [#6363](https://github.com/rubocop-hq/rubocop/issues/6363): Allow `Style/YodaCondition` cop to be configured to enforce yoda conditions. ([@tejasbubane][])
 * [#6150](https://github.com/rubocop-hq/rubocop/issues/6150): Add support to enforce disabled cops to be executed. ([@roooodcastro][])
 * [#6596](https://github.com/rubocop-hq/rubocop/pull/6596): Add new `Rails/BelongsTo` cop with auto-correct for Rails >= 5. ([@petehamilton][])
-* Add `always_enabled` option to `Style/FrozenStringLiteralComment` to enforce frozen_string_literal is always set to true. ([@martingordon][])
 
 ### Bug fixes
 
@@ -3788,3 +3788,4 @@
 [@dazuma]: https://github.com/dazuma
 [@dischorde]: https://github.com/dischorde
 [@mhelmetag]: https://github.com/mhelmetag
+[@martingordon]: https://github.com/martingordon

--- a/config/default.yml
+++ b/config/default.yml
@@ -3205,6 +3205,9 @@ Style/FrozenStringLiteralComment:
     # `when_needed` will add the frozen string literal comment to files
     # only when the `TargetRubyVersion` is set to 2.3+.
     - when_needed
+    # `always_enabled` will enforce that the frozen string literal comment exists
+    # and is set to true
+    - always_enabled
     # `always` will always add the frozen string literal comment to a file
     # regardless of the Ruby version or if `freeze` or `<<` are called on a
     # string literal. If you run code against multiple versions of Ruby, it is

--- a/lib/rubocop/cop/mixin/frozen_string_literal.rb
+++ b/lib/rubocop/cop/mixin/frozen_string_literal.rb
@@ -16,6 +16,12 @@ module RuboCop
         end
       end
 
+      def frozen_string_literal_comment_set_to_true?
+        leading_comment_lines.any? do |line|
+          MagicComment.parse(line).frozen_string_literal?
+        end
+      end
+
       private
 
       def frozen_string_literals_enabled?

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2089,6 +2089,30 @@ module Foo
   # ...
 end
 ```
+#### EnforcedStyle: always_enabled
+
+```ruby
+# The `always_enabled` style will enforce that the frozen string
+# literal comment appears in the file and that it is set to true.
+# bad
+module Bar
+  # ...
+end
+
+# bad
+# frozen_string_literal: false
+
+module Bar
+  # ...
+end
+
+# good
+# frozen_string_literal: true
+
+module Bar
+  # ...
+end
+```
 #### EnforcedStyle: always
 
 ```ruby
@@ -2129,7 +2153,7 @@ end
 
 Name | Default value | Configurable values
 --- | --- | ---
-EnforcedStyle | `when_needed` | `when_needed`, `always`, `never`
+EnforcedStyle | `when_needed` | `when_needed`, `always_enabled`, `always`, `never`
 
 ## Style/GlobalVars
 


### PR DESCRIPTION
This commit adds `always_enabled` to the `Style/FrozenStringLiteralComment` cop’s enforced styles to enforce that the `frozen_string_literal` comment is present and set to true. This is useful for ensuring that all code is valid for upcoming Ruby versions that enforce frozen string literals by default.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
