### PR TITLE
Add internal investigation to contributing doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3636,3 +3636,4 @@
 [@andrew-aladev]: https://github.com/andrew-aladev
 [@y-yagi]: https://github.com/y-yagi
 [@DiscoStarslayer]: https://github.com/DiscoStarslayer
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,10 @@ $ rubocop -V
   you want to have your own version, or is otherwise necessary, that
   is fine, but please isolate to its own commit so I can cherry-pick
   around it.
-* Make sure the test suite is passing and the code you wrote doesn't produce
-  RuboCop offenses (usually this is as simple as running `bundle exec rake`).
+* Make sure the test suite is passing
+  (usually this is as simple as running `bundle exec rake`).
+* Make sure the code you wrote doesn't produce RuboCop offenses,
+  by running `bundle exec rake internal_investigation`.
 * [Squash related commits together][5].
 * Open a [pull request][4] that relates to *only* one subject with a clear title
   and description in grammatically correct, complete sentences.


### PR DESCRIPTION
This PR adds a note to CONTRIBUTING.md saying to run the `internal investigation` rake task in order to check whether the code produces Rubocop offenses.  Previously it said this was part of what was usually done by `bundle exec rake` but that never seemed to do it for me.  Not sure why, as I see it in the `default` task list, and I've verified that the `RakeTask.new(:internal_investigation)` is getting called, but my rake-fu is not terribly strong, but at least this way everybody will (well, should anyway) run the task to check explicitly.