### PR TITLE
adds bundle exec to `rake default` PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,6 @@ Before submitting the PR make sure the following are checked:
 * [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
 * [ ] The PR relates to *only* one subject with a clear title
   and description in grammatically correct, complete sentences.
-* [ ] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
+* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
 
 [1]: http://chris.beams.io/posts/git-commit/


### PR DESCRIPTION
Adds a `bundle exec` prefix to the `rake default` command in the PR template. 

This is a small quality of life improvement, that can be helpful to developers starting to work on this project, I know I was bit by forgetting to run with this option 😬 

more info on bundle exec here: https://bundler.io/man/bundle-exec.1.html

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
