### PR TITLE
Fix some tasks not running on default rake task

### DIFF
--- a/tasks/spec_runner.rake
+++ b/tasks/spec_runner.rake
@@ -21,13 +21,16 @@ module RuboCop
 
     def run_specs
       rspec_args = %w[spec]
-      with_encoding do
+
+      n_failures = with_encoding do
         if Process.respond_to?(:fork)
           parallel_runner_klass.new(rspec_args).execute
         else
           ::RSpec::Core::Runner.run(rspec_args)
         end
       end
+
+      exit!(n_failures) unless n_failures.zero?
     end
 
     private
@@ -55,6 +58,8 @@ module RuboCop
     class ParallelRunner < ::TestQueue::Runner
       def initialize(rspec_args)
         super(Framework.new(rspec_args))
+
+        @exit_when_done = true
       end
 
       def run_worker(iterator)


### PR DESCRIPTION
This PR fixes the underlying problem described in #6423, and thus supersedes that PR. The problem was that the spec runner was exiting after itself, so it wouldn't allow further tasks to be run.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
