### PR TITLE
Fix exit status when rubocop is interrupted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#5934](https://github.com/rubocop-hq/rubocop/issues/5934): Handle the combination of `--auto-gen-config` and `--config FILE` correctly. ([@jonas054][])
 * [#5970](https://github.com/rubocop-hq/rubocop/issues/5970): Make running `--auto-gen-config` in a subdirectory work. ([@jonas054][])
 * [#6412](https://github.com/rubocop-hq/rubocop/issues/6412): Fix an `unknown keywords` error when using `Psych.safe_load` with Ruby 2.6.0-preview2. ([@koic][])
+* [#6436](https://github.com/rubocop-hq/rubocop/pull/6436): Fix exit status code to be 130 when rubocop is interrupted. ([@deivid-rodriguez][])
 
 ## 0.60.0 (2018-10-26)
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -10,9 +10,10 @@ module RuboCop
     SKIPPED_PHASE_1 = 'Phase 1 of 2: run Metrics/LineLength cop (skipped ' \
                       'because the default Metrics/LineLength:Max is ' \
                       'overridden)'.freeze
-    STATUS_SUCCESS  = 0
-    STATUS_OFFENSES = 1
-    STATUS_ERROR    = 2
+    STATUS_SUCCESS     = 0
+    STATUS_OFFENSES    = 1
+    STATUS_ERROR       = 2
+    STATUS_INTERRUPTED = 128 + Signal.list['INT']
 
     class Finished < RuntimeError; end
 
@@ -163,7 +164,9 @@ module RuboCop
 
       all_pass_or_excluded = all_passed || @options[:auto_gen_config]
 
-      if all_pass_or_excluded && !runner.aborting? && runner.errors.empty?
+      if runner.aborting?
+        STATUS_INTERRUPTED
+      elsif all_pass_or_excluded && runner.errors.empty?
         STATUS_SUCCESS
       else
         STATUS_OFFENSES

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
   subject(:cli) { described_class.new }
 
   context 'when interrupted' do
-    it 'returns 1' do
+    it 'returns 130' do
       allow_any_instance_of(RuboCop::Runner)
         .to receive(:aborting?).and_return(true)
       create_empty_file('example.rb')
-      expect(cli.run(['example.rb'])).to eq(1)
+      expect(cli.run(['example.rb'])).to eq(130)
     end
   end
 


### PR DESCRIPTION
I wanted to resume the work I started on https://github.com/rubocop-hq/rubocop/pull/5808, but I noticed a small issue with the status code rubocop has when interrupted. If you type Ctrl-C while rubocop is running, it will have an exit status of "1", which in rubocop's domain means "offenses were detected". However, this is not accurate since one may interrupt rubocop without any offenses having yet been detected (for example, because it will take too long to run).

So I changed the status code in this situation to be 130, which is a common practice for scripts. See for example https://stackoverflow.com/a/40484670/143243.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
