### PR TITLE
Fix an incorrect autocorrect for `Style/BracesAroundHashParameters`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#5970](https://github.com/rubocop-hq/rubocop/issues/5970): Make running `--auto-gen-config` in a subdirectory work. ([@jonas054][])
 * [#6412](https://github.com/rubocop-hq/rubocop/issues/6412): Fix an `unknown keywords` error when using `Psych.safe_load` with Ruby 2.6.0-preview2. ([@koic][])
 * [#6436](https://github.com/rubocop-hq/rubocop/pull/6436): Fix exit status code to be 130 when rubocop is interrupted. ([@deivid-rodriguez][])
+* [#6443](https://github.com/rubocop-hq/rubocop/pull/6443): Fix an incorrect autocorrect for `Style/BracesAroundHashParameters` when the opening brace is bofore the first hash element at same line. ([@koic][])
 
 ## 0.60.0 (2018-10-26)
 

--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -154,7 +154,7 @@ module RuboCop
         end
 
         def right_whole_line_range(loc_end)
-          if range_by_whole_lines(loc_end).source.strip =~ /}\s*,?\z/
+          if range_by_whole_lines(loc_end).source.strip =~ /\A}\s*,?\z/
             range_by_whole_lines(loc_end, include_final_newline: true)
           else
             loc_end

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -351,6 +351,25 @@ RSpec.describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
         )
         RUBY
       end
+
+      it 'corrects when the opening brace is before the first hash element' \
+         'at same line' do
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
+          foo = Foo.new(
+            { foo: 'foo',
+              bar: 'bar',
+              baz: 'this is the last element'}
+          )
+        RUBY
+
+        expect(corrected).to eq(<<-RUBY.strip_indent)
+          foo = Foo.new(
+             foo: 'foo',
+              bar: 'bar',
+              baz: 'this is the last element'
+          )
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
Fixes rubocop-hq/rubocop-jp#45. (This link is Japanese issue)

This PR fixes an incorrect autocorrect for `Style/BracesAroundHashParameters` when the opening brace is before the first hash element.

```console
% rubocop -V
0.60.0 (using Parser 2.5.1.2, running on ruby 2.5.1 x86_64-darwin17)

% cat example.rb
# frozen_string_literal: true

foo = Foo.new(
  { foo: 'foo',
    bar: 'bar',
    baz: 'this is the last element'}
)
```

The following difference is the execution result of `rubocop -a` command.

## Before

The last element is lost.

```diff
diff --git a/example.rb b/example.rb
index ecf9711..c9a02b8 100644
--- a/example.rb
+++ b/example.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true

 foo = Foo.new(
-  { foo: 'foo',
-    bar: 'bar',
-    baz: 'this is the last element'}
+  foo: 'foo',
+  bar: 'bar'
 )
```

## After

Remove only the braces.

```diff
diff --git a/example.rb b/example.rb
index ecf9711..57790da 100644
--- a/example.rb
+++ b/example.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true

 foo = Foo.new(
-  { foo: 'foo',
-    bar: 'bar',
-    baz: 'this is the last element'}
+  foo: 'foo',
+  bar: 'bar',
+  baz: 'this is the last element'
 )
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
