### PR TITLE
Fix AlignHash behaviour for super and yield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#6412](https://github.com/rubocop-hq/rubocop/issues/6412): Fix an `unknown keywords` error when using `Psych.safe_load` with Ruby 2.6.0-preview2. ([@koic][])
 * [#6436](https://github.com/rubocop-hq/rubocop/pull/6436): Fix exit status code to be 130 when rubocop is interrupted. ([@deivid-rodriguez][])
 * [#6443](https://github.com/rubocop-hq/rubocop/pull/6443): Fix an incorrect autocorrect for `Style/BracesAroundHashParameters` when the opening brace is bofore the first hash element at same line. ([@koic][])
+* [#6445](https://github.com/rubocop-hq/rubocop/pull/6445): Treat `yield` and `super` like regular method calls in `Style/AlignHash`. ([@mvz][])
 
 ## 0.60.0 (2018-10-26)
 

--- a/lib/rubocop/cop/layout/align_hash.rb
+++ b/lib/rubocop/cop/layout/align_hash.rb
@@ -182,6 +182,7 @@ module RuboCop
 
         def on_send(node)
           return if double_splat?(node)
+          return unless node.arguments?
 
           last_argument = node.last_argument
 
@@ -190,6 +191,8 @@ module RuboCop
 
           ignore_node(last_argument)
         end
+        alias on_super on_send
+        alias on_yield on_send
 
         def on_hash(node)
           return if ignored_node?(node)

--- a/spec/rubocop/cop/layout/align_hash_spec.rb
+++ b/spec/rubocop/cop/layout/align_hash_spec.rb
@@ -61,6 +61,38 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
           ^^^^ Align the elements of a hash literal if they span more than one line.
       RUBY
     end
+
+    it 'registers offense for misaligned keys in implicit hash for super' do
+      expect_offense(<<-RUBY.strip_indent)
+        super(a: 0,
+          b: 1)
+          ^^^^ Align the elements of a hash literal if they span more than one line.
+      RUBY
+    end
+
+    it 'registers offense for misaligned keys in explicit hash for super' do
+      expect_offense(<<-RUBY.strip_indent)
+        super({a: 0,
+          b: 1})
+          ^^^^ Align the elements of a hash literal if they span more than one line.
+      RUBY
+    end
+
+    it 'registers offense for misaligned keys in implicit hash for yield' do
+      expect_offense(<<-RUBY.strip_indent)
+        yield(a: 0,
+          b: 1)
+          ^^^^ Align the elements of a hash literal if they span more than one line.
+      RUBY
+    end
+
+    it 'registers offense for misaligned keys in explicit hash for yield' do
+      expect_offense(<<-RUBY.strip_indent)
+        yield({a: 0,
+          b: 1})
+          ^^^^ Align the elements of a hash literal if they span more than one line.
+      RUBY
+    end
   end
 
   context 'always ignore last argument hash' do
@@ -80,6 +112,34 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
     it 'accepts misaligned keys in explicit hash' do
       expect_no_offenses(<<-RUBY.strip_indent)
         func({a: 0,
+          b: 1})
+      RUBY
+    end
+
+    it 'accepts misaligned keys in implicit hash for super' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        super(a: 0,
+          b: 1)
+      RUBY
+    end
+
+    it 'accepts misaligned keys in explicit hash for super' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        super({a: 0,
+          b: 1})
+      RUBY
+    end
+
+    it 'accepts misaligned keys in implicit hash for yield' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        yield(a: 0,
+          b: 1)
+      RUBY
+    end
+
+    it 'accepts misaligned keys in explicit hash for yield' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        yield({a: 0,
           b: 1})
       RUBY
     end
@@ -106,6 +166,36 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
           ^^^^ Align the elements of a hash literal if they span more than one line.
       RUBY
     end
+
+    it 'accepts misaligned keys in implicit hash for super' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        super(a: 0,
+          b: 1)
+      RUBY
+    end
+
+    it 'registers offense for misaligned keys in explicit hash for super' do
+      expect_offense(<<-RUBY.strip_indent)
+        super({a: 0,
+          b: 1})
+          ^^^^ Align the elements of a hash literal if they span more than one line.
+      RUBY
+    end
+
+    it 'accepts misaligned keys in implicit hash for yield' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        yield(a: 0,
+          b: 1)
+      RUBY
+    end
+
+    it 'registers offense for misaligned keys in explicit hash for yield' do
+      expect_offense(<<-RUBY.strip_indent)
+        yield({a: 0,
+          b: 1})
+          ^^^^ Align the elements of a hash literal if they span more than one line.
+      RUBY
+    end
   end
 
   context 'ignore explicit last argument hash' do
@@ -126,6 +216,36 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
     it 'accepts misaligned keys in explicit hash' do
       expect_no_offenses(<<-RUBY.strip_indent)
         func({a: 0,
+          b: 1})
+      RUBY
+    end
+
+    it 'registers offense for misaligned keys in implicit hash for super' do
+      expect_offense(<<-RUBY.strip_indent)
+        super(a: 0,
+          b: 1)
+          ^^^^ Align the elements of a hash literal if they span more than one line.
+      RUBY
+    end
+
+    it 'accepts misaligned keys in explicit hash for super' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        super({a: 0,
+          b: 1})
+      RUBY
+    end
+
+    it 'registers offense for misaligned keys in implicit hash for yield' do
+      expect_offense(<<-RUBY.strip_indent)
+        yield(a: 0,
+          b: 1)
+          ^^^^ Align the elements of a hash literal if they span more than one line.
+      RUBY
+    end
+
+    it 'accepts misaligned keys in explicit hash for yield' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        yield({a: 0,
           b: 1})
       RUBY
     end
@@ -624,5 +744,13 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
         }
       RUBY
     end
+  end
+
+  it 'register no offense for superclass call without args' do
+    expect_no_offenses('super')
+  end
+
+  it 'register no offense for yield without args' do
+    expect_no_offenses('yield')
   end
 end


### PR DESCRIPTION
This makes the AlignHash cop handle `super` and `yield` in the same way as regular method calls. Previously, the `EnforcedLastArgumentHashStyle` configuration was ignored for these special calls. This PR fixes this by aliasing `on_super` and `on_yield` to `on_send`, similarly to how MethodCallWithArgsParentheses handles this. 

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
