### PR TITLE
Fix a false negative for `Layout/IndentationWidth`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#3301](https://github.com/rubocop-hq/rubocop/issues/3301): Don't suggest or make semantic changes to the code in `Style/InfiniteLoop`. ([@jonas054][])
 * [#3586](https://github.com/rubocop-hq/rubocop/issues/3586): Handle single argument spanning multiple lines in `Style/TrailingCommaInArguments`. ([@jonas054][])
 * [#6478](https://github.com/rubocop-hq/rubocop/pull/6478): Fix EmacsComment#encoding to match the `coding` variable. ([@akihiro17][])
+* [#6449](https://github.com/rubocop-hq/rubocop/pull/6449): Fix a false negative for `Layout/IndentationWidth` when setting `EnforcedStyle: rails` of `Layout/IndentationConsistency` and method definition indented to access modifier in a singleton class. ([@koic][])
 
 ## 0.60.0 (2018-10-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#3586](https://github.com/rubocop-hq/rubocop/issues/3586): Handle single argument spanning multiple lines in `Style/TrailingCommaInArguments`. ([@jonas054][])
 * [#6478](https://github.com/rubocop-hq/rubocop/pull/6478): Fix EmacsComment#encoding to match the `coding` variable. ([@akihiro17][])
 * [#6449](https://github.com/rubocop-hq/rubocop/pull/6449): Fix a false negative for `Layout/IndentationWidth` when setting `EnforcedStyle: rails` of `Layout/IndentationConsistency` and method definition indented to access modifier in a singleton class. ([@koic][])
+* [#6482](https://github.com/rubocop-hq/rubocop/issues/6482): Fix a false positive for `Lint/FormatParameterMismatch` when using (digit)$ flag. ([@koic][])
 
 ## 0.60.0 (2018-10-26)
 

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -96,6 +96,12 @@ module RuboCop
           check_members(node.loc.keyword, members)
         end
 
+        def on_sclass(node)
+          _class_name, *members = *node
+
+          check_members(node.loc.keyword, members)
+        end
+
         def on_send(node)
           super
           return unless node.adjacent_def_modifier?

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -29,6 +29,7 @@ module RuboCop
         SHOVEL = '<<'.freeze
         PERCENT = '%'.freeze
         PERCENT_PERCENT = '%%'.freeze
+        DIGIT_DOLLAR_FLAG = /%(\d+)\$/.freeze
         STRING_TYPES = %i[str dstr].freeze
         NAMED_INTERPOLATION = /%(?:<\w+>|\{\w+\})/.freeze
 
@@ -132,11 +133,19 @@ module RuboCop
           return :unknown unless node.str_type?
           return 1 if node.source =~ NAMED_INTERPOLATION
 
+          max_digit_dollar_num = max_digit_dollar_num(node)
+          return max_digit_dollar_num if max_digit_dollar_num &&
+                                         max_digit_dollar_num.nonzero?
+
           node
             .source
             .scan(FIELD_REGEX)
             .reject { |x| x.first == PERCENT_PERCENT }
             .reduce(0) { |acc, elem| acc + arguments_count(elem[2]) }
+        end
+
+        def max_digit_dollar_num(node)
+          node.source.scan(DIGIT_DOLLAR_FLAG).map(&:first).map(&:to_i).max
         end
 
         # number of arguments required for the format sequence

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -1107,6 +1107,32 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
             .to eq(['Use 2 (not 0) spaces for rails indentation.'] * 2)
           expect(cop.offenses.map(&:line)).to eq([9, 14])
         end
+
+        it 'registers an offense for normal non-rails indentation ' \
+           'when defined in a singleton class' do
+          inspect_source(<<-RUBY.strip_indent)
+            class << self
+              public
+
+              def e
+              end
+
+              protected
+
+              def f
+              end
+
+              private
+
+              def g
+              end
+            end
+          RUBY
+
+          expect(cop.messages)
+            .to eq(['Use 2 (not 0) spaces for rails indentation.'] * 2)
+          expect(cop.offenses.map(&:line)).to eq([9, 14])
+        end
       end
     end
 

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -146,6 +146,25 @@ RSpec.describe RuboCop::Cop::Lint::FormatParameterMismatch do
     end
   end
 
+  context 'when using (digit)$ flag' do
+    it 'does not register an offense' do
+      expect_no_offenses("format('%1$s %2$s', 'foo', 'bar')")
+    end
+
+    it 'does not register an offense when match between the maximum value ' \
+       'specified by (digit)$ flag and the number of arguments' do
+      expect_no_offenses("format('%1$s %1$s', 'foo')")
+    end
+
+    it 'registers an offense when mismatch between the maximum value ' \
+       'specified by (digit)$ flag and the number of arguments' do
+      expect_offense(<<-RUBY.strip_indent)
+        format('%1$s %2$s', 'foo', 'bar', 'baz')
+        ^^^^^^ Number of arguments (3) to `format` doesn't match the number of fields (2).
+      RUBY
+    end
+  end
+
   context 'when format is not a string literal' do
     it 'does not register an offense' do
       expect_no_offenses('puts str % [1, 2]')


### PR DESCRIPTION
This PR fixes a false negative for `Layout/IndentationWidth` when setting `EnforcedStyle: rails` of `Layout/IndentationConsistency` and method definition indented to access modifier in a singleton class.

The following is an example.

```console
% rubocop -V
0.60.0 (using Parser 2.5.3.0, running on ruby 2.6.0 x86_64-darwin17)

% cat .rubocop.yml
Layout/IndentationConsistency:
  EnforcedStyle: rails

% cat example.rb
class << self
  private

  def do_something
    puts 'hi'
  end
end
```

## Before

```console
% rubocop --only Layout/IndentationWidth
Inspecting 1 file
.

1 file inspected, no offenses detected
```

## After

```console
% rubocop --only Layout/IndentationWidth
Inspecting 1 file
C

Offenses:

example.rb:4:3: C: Layout/IndentationWidth: Use 2 (not 0) spaces for rails indentation.
  def do_something

1 file inspected, 1 offense detected

% rubocop --only Layout/IndentationWidth -a
Inspecting 1 file
C

Offenses:

example.rb:4:3: C: [Corrected] Layout/IndentationWidth: Use 2 (not 0) spaces for rails indentation.
  def do_something

1 file inspected, 1 offense detected, 1 offense corrected

% cat example.rb
class << self
  private

    def do_something
      puts 'hi'
    end
end
```
I was told about this false negative by Rails committer @kamipo. Thanks!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
