### PR TITLE
Remove forceful exit

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -29,6 +29,7 @@ Metrics/ModuleLength:
 RSpec/AnyInstance:
   Exclude:
     - 'spec/rubocop/cli_spec.rb'
+    - 'spec/rubocop/runner_spec.rb'
     - 'spec/rubocop/cop/lint/duplicate_methods_spec.rb'
     - 'spec/rubocop/target_finder_spec.rb'
 
@@ -65,6 +66,7 @@ RSpec/ExpectOutput:
 RSpec/MessageSpies:
   Exclude:
     - 'spec/rubocop/cli_spec.rb'
+    - 'spec/rubocop/runner_spec.rb'
     - 'spec/rubocop/config_loader_spec.rb'
     - 'spec/rubocop/config_store_spec.rb'
     - 'spec/rubocop/cop/commissioner_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -29,7 +29,6 @@ Metrics/ModuleLength:
 RSpec/AnyInstance:
   Exclude:
     - 'spec/rubocop/cli_spec.rb'
-    - 'spec/rubocop/runner_spec.rb'
     - 'spec/rubocop/cop/lint/duplicate_methods_spec.rb'
     - 'spec/rubocop/target_finder_spec.rb'
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -62,7 +62,7 @@ module RuboCop
     def trap_interrupt(runner)
       Signal.trap('INT') do
         exit!(1) if runner.aborting?
-        runner.abort
+        runner.aborting = true
         warn
         warn 'Exiting... Interrupt again to exit immediately.'
       end

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -59,15 +59,6 @@ module RuboCop
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
-    def trap_interrupt(runner)
-      Signal.trap('INT') do
-        exit!(1) if runner.aborting?
-        runner.aborting = true
-        warn
-        warn 'Exiting... Interrupt again to exit immediately.'
-      end
-    end
-
     private
 
     def execute_runners(paths)
@@ -156,7 +147,6 @@ module RuboCop
     def execute_runner(paths)
       runner = Runner.new(@options, @config_store)
 
-      trap_interrupt(runner)
       all_passed = runner.run(paths)
       display_warning_summary(runner.warnings)
       display_error_summary(runner.errors)

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -34,7 +34,7 @@ module RuboCop
       Signal.trap('INT') do
         exit!(1) if aborting?
         self.aborting = true
-        warn
+        warn ''
         warn 'Exiting... Interrupt again to exit immediately.'
       end
     end

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -32,10 +32,9 @@ module RuboCop
 
     def trap_interrupt
       Signal.trap('INT') do
-        exit!(1) if aborting?
         self.aborting = true
         warn ''
-        warn 'Exiting... Interrupt again to exit immediately.'
+        warn 'Exiting...'
       end
     end
 

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -20,6 +20,7 @@ module RuboCop
     MAX_ITERATIONS = 200
 
     attr_reader :errors, :warnings
+    attr_writer :aborting
 
     def initialize(options, config_store)
       @options = options
@@ -41,10 +42,6 @@ module RuboCop
 
     def aborting?
       @aborting
-    end
-
-    def abort
-      @aborting = true
     end
 
     private

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -30,6 +30,15 @@ module RuboCop
       @aborting = false
     end
 
+    def trap_interrupt
+      Signal.trap('INT') do
+        exit!(1) if aborting?
+        self.aborting = true
+        warn
+        warn 'Exiting... Interrupt again to exit immediately.'
+      end
+    end
+
     def run(paths)
       target_files = find_target_files(paths)
       if @options[:list_target_files]
@@ -72,6 +81,8 @@ module RuboCop
     end
 
     def each_inspected_file(files)
+      trap_interrupt
+
       files.reduce(true) do |all_passed, file|
         break false if aborting?
 

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -19,8 +19,7 @@ module RuboCop
 
     MAX_ITERATIONS = 200
 
-    attr_reader :errors, :warnings, :aborting
-    alias aborting? aborting
+    attr_reader :errors, :warnings
 
     def initialize(options, config_store)
       @options = options
@@ -38,6 +37,10 @@ module RuboCop
         warm_cache(target_files) if @options[:parallel]
         inspect_files(target_files)
       end
+    end
+
+    def aborting?
+      @aborting
     end
 
     def abort

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     context 'with SIGINT once' do
       it 'aborts processing' do
         cli.trap_interrupt(runner)
-        expect(runner).to receive(:abort)
+        expect(runner).to receive(:aborting=).with(true)
         interrupt
       end
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -16,51 +16,6 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     end
   end
 
-  describe '#trap_interrupt' do
-    let(:runner) { RuboCop::Runner.new({}, RuboCop::ConfigStore.new) }
-    let(:interrupt_handlers) { [] }
-
-    before do
-      allow(Signal).to receive(:trap).with('INT') do |&block|
-        interrupt_handlers << block
-      end
-    end
-
-    def interrupt
-      interrupt_handlers.each(&:call)
-    end
-
-    it 'adds a handler for SIGINT' do
-      expect(interrupt_handlers.empty?).to be(true)
-      cli.trap_interrupt(runner)
-      expect(interrupt_handlers.size).to eq(1)
-    end
-
-    context 'with SIGINT once' do
-      it 'aborts processing' do
-        cli.trap_interrupt(runner)
-        expect(runner).to receive(:aborting=).with(true)
-        interrupt
-      end
-
-      it 'does not exit immediately' do
-        cli.trap_interrupt(runner)
-        expect_any_instance_of(Object).not_to receive(:exit)
-        expect_any_instance_of(Object).not_to receive(:exit!)
-        interrupt
-      end
-    end
-
-    context 'with SIGINT twice' do
-      it 'exits immediately' do
-        cli.trap_interrupt(runner)
-        expect_any_instance_of(Object).to receive(:exit!).with(1)
-        interrupt
-        interrupt
-      end
-    end
-  end
-
   context 'when given a file/directory that is not under the current dir' do
     shared_examples 'checks Rakefile' do
       it 'checks a Rakefile but Style/FileName does not report' do

--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -34,26 +34,10 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
       expect(interrupt_handlers.size).to eq(1)
     end
 
-    context 'with SIGINT once' do
+    context 'with SIGINT' do
       it 'aborts processing' do
         runner.trap_interrupt
         expect(runner).to receive(:aborting=).with(true)
-        interrupt
-      end
-
-      it 'does not exit immediately' do
-        runner.trap_interrupt
-        expect_any_instance_of(Object).not_to receive(:exit)
-        expect_any_instance_of(Object).not_to receive(:exit!)
-        interrupt
-      end
-    end
-
-    context 'with SIGINT twice' do
-      it 'exits immediately' do
-        runner.trap_interrupt
-        expect_any_instance_of(Object).to receive(:exit!).with(1)
-        interrupt
         interrupt
       end
     end

--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -12,12 +12,59 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
   let(:formatter_output_path) { 'formatter_output.txt' }
   let(:formatter_output) { File.read(formatter_output_path) }
 
-  before do
-    create_file('example.rb', source)
+  describe '#trap_interrupt' do
+    include_context 'cli spec behavior'
+
+    let(:runner) { described_class.new({}, RuboCop::ConfigStore.new) }
+    let(:interrupt_handlers) { [] }
+
+    before do
+      allow(Signal).to receive(:trap).with('INT') do |&block|
+        interrupt_handlers << block
+      end
+    end
+
+    def interrupt
+      interrupt_handlers.each(&:call)
+    end
+
+    it 'adds a handler for SIGINT' do
+      expect(interrupt_handlers.empty?).to be(true)
+      runner.trap_interrupt
+      expect(interrupt_handlers.size).to eq(1)
+    end
+
+    context 'with SIGINT once' do
+      it 'aborts processing' do
+        runner.trap_interrupt
+        expect(runner).to receive(:aborting=).with(true)
+        interrupt
+      end
+
+      it 'does not exit immediately' do
+        runner.trap_interrupt
+        expect_any_instance_of(Object).not_to receive(:exit)
+        expect_any_instance_of(Object).not_to receive(:exit!)
+        interrupt
+      end
+    end
+
+    context 'with SIGINT twice' do
+      it 'exits immediately' do
+        runner.trap_interrupt
+        expect_any_instance_of(Object).to receive(:exit!).with(1)
+        interrupt
+        interrupt
+      end
+    end
   end
 
   describe '#run' do
     subject(:runner) { described_class.new(options, RuboCop::ConfigStore.new) }
+
+    before do
+      create_file('example.rb', source)
+    end
 
     let(:options) { { formatters: [['progress', formatter_output_path]] } }
 
@@ -137,6 +184,10 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
         end
       end
       runner_class.new(options, RuboCop::ConfigStore.new)
+    end
+
+    before do
+      create_file('example.rb', source)
     end
 
     let(:options) do


### PR DESCRIPTION
Up to now, interrupt handling was implemented in two phases. If user would press Ctrl-C, rubocop would start exiting gracefully with the following message "Exiting... Interrupt again to exit immediately.", and if Ctrl-C was pressed again, `rubocop` would exit without any further cleanup.

However, I don't think this behavior is necessary. I tried to interrupt rubocop running without or without cache, in big or small projects, and I always get a graceful exit without even having any time to trigger the forceful exit path. So, I think we can simplify things and get rid of it.

This is actually some preparation to fix the actual end user problems I wanted to fix in #5808, but does not yet fix them. I still think this is a code simplification and an improvement in the end user experience.
  
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
