### PR TITLE
Test with JIT compiler on latest Ruby

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,24 @@ jobs:
     steps:
       *rubocop_steps
 
+  # With JIT compiler enabled!
+  ruby-head-spec-with-jit:
+    docker:
+      - image: rubocophq/circleci-ruby-snapshot:latest
+    environment:
+      RUBYOPT: '--jit'
+      <<: *common_env
+    steps:
+      *spec_steps
+  ruby-head-rubocop-with-jit:
+    docker:
+      - image: rubocophq/circleci-ruby-snapshot:latest
+    environment:
+      RUBYOPT: '--jit'
+      <<: *common_env
+    steps:
+      *rubocop_steps
+
   # JRuby 9.2
   jruby-9.2-spec:
     docker:
@@ -265,8 +283,12 @@ workflows:
       - ruby-head-spec:
           requires:
             - cc-setup
+      - ruby-head-spec-with-jit:
+          requires:
+            - cc-setup
       - ruby-head-ascii_spec
       - ruby-head-rubocop
+      - ruby-head-rubocop-with-jit
       - jruby-9.2-spec:
           requires:
             - cc-setup


### PR DESCRIPTION
Since we *are* testing against the nightly version of Ruby, we might as well also test with what is probably its most important feature, JIT, enabled.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
