### PR TITLE
Fix link URL in Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,4 +15,4 @@ Before submitting the PR make sure the following are checked:
   and description in grammatically correct, complete sentences.
 * [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
 
-[1]: http://chris.beams.io/posts/git-commit/
+[1]: https://chris.beams.io/posts/git-commit/


### PR DESCRIPTION
When I created https://github.com/rubocop-hq/rubocop/pull/6457, I found http://chris.beams.io/posts/git-commit/ is redirected to https://chris.beams.io/posts/git-commit/.

```
$ curl -i http://chris.beams.io/posts/git-commit/
HTTP/1.1 301 Moved Permanently
Cache-Control: public, max-age=0, must-revalidate
Content-Length: 56
Content-Type: text/plain; charset=utf-8
Date: Wed, 31 Oct 2018 02:17:19 GMT
Location: https://chris.beams.io/posts/git-commit/
Age: 635647
Connection: keep-alive
Server: Netlify
X-NF-Request-ID: 17b05a5a-c928-4aeb-abb1-f1848dec7445-7471466

Redirecting to https://chris.beams.io/posts/git-commit/
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
