### PR TITLE
Use https whenever possible

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,8 +61,8 @@ Here are a few examples:
 * If this is your first contribution to RuboCop project, add a link definition for the implicit link to the bottom of the changelog as `[@username]: https://github.com/username`.
 
 [1]: https://github.com/rubocop-hq/rubocop/issues
-[2]: http://gun.io/blog/how-to-github-fork-branch-and-pull-request
-[3]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[2]: https://www.gun.io/blog/how-to-github-fork-branch-and-pull-request
+[3]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [4]: https://help.github.com/articles/about-pull-requests
 [5]: http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html
-[6]: http://daringfireball.net/projects/markdown/syntax
+[6]: https://daringfireball.net/projects/markdown/syntax

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-[![Gem Version](https://badge.fury.io/rb/rubocop.svg)](http://badge.fury.io/rb/rubocop)
+[![Gem Version](https://badge.fury.io/rb/rubocop.svg)](https://badge.fury.io/rb/rubocop)
 [![CircleCI Status](https://circleci.com/gh/rubocop-hq/rubocop/tree/master.svg?style=svg)](https://circleci.com/gh/rubocop-hq/rubocop/tree/master)
 [![AppVeyor Status](https://ci.appveyor.com/api/projects/status/sj3ye7n5690d0nvg?svg=true)](https://ci.appveyor.com/project/bbatsov/rubocop)
 [![Coverage Status](https://img.shields.io/codeclimate/coverage/github/bbatsov/rubocop.svg)](https://codeclimate.com/github/bbatsov/rubocop)
 [![Code Climate](https://codeclimate.com/github/bbatsov/rubocop/badges/gpa.svg)](https://codeclimate.com/github/bbatsov/rubocop)
-[![Inline docs](http://inch-ci.org/github/bbatsov/rubocop.svg)](http://inch-ci.org/github/bbatsov/rubocop)
+[![Inline docs](https://inch-ci.org/github/bbatsov/rubocop.svg)](https://inch-ci.org/github/bbatsov/rubocop)
 [![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=rubocop&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=rubocop&package-manager=bundler&version-scheme=semver)
 
 [![Patreon](https://img.shields.io/badge/patreon-donate-orange.svg)](https://www.patreon.com/bbatsov)
@@ -99,7 +99,7 @@ RuboCop's logo was created by [Dimiter Petrov](https://www.chadomoto.com/). You 
 formats [here](https://github.com/rubocop-hq/rubocop/tree/master/logo).
 
 The logo is licensed under a
-[Creative Commons Attribution-NonCommercial 4.0 International License](http://creativecommons.org/licenses/by-nc/4.0/deed.en_GB).
+[Creative Commons Attribution-NonCommercial 4.0 International License](https://creativecommons.org/licenses/by-nc/4.0/deed.en_GB).
 
 ## Contributors
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -2479,7 +2479,7 @@ Rails/RequestReferer:
 Rails/ReversibleMigration:
   Description: 'Checks whether the change method of the migration file is reversible.'
   StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#reversible-migration'
-  Reference: 'http://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html'
+  Reference: 'https://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html'
   Enabled: true
   VersionAdded: '0.47'
   Include:
@@ -2515,7 +2515,7 @@ Rails/SkipsModelValidations:
   Description: >-
                  Use methods that skips model validations with caution.
                  See reference for more information.
-  Reference: 'http://guides.rubyonrails.org/active_record_validations.html#skipping-validations'
+  Reference: 'https://guides.rubyonrails.org/active_record_validations.html#skipping-validations'
   Enabled: true
   VersionAdded: '0.47'
   VersionChanged: '0.60'
@@ -2586,7 +2586,7 @@ Security/JSONLoad:
   Description: >-
                  Prefer usage of `JSON.parse` over `JSON.load` due to potential
                  security issues. See reference for more information.
-  Reference: 'http://ruby-doc.org/stdlib-2.3.0/libdoc/json/rdoc/JSON.html#method-i-load'
+  Reference: 'https://ruby-doc.org/stdlib-2.3.0/libdoc/json/rdoc/JSON.html#method-i-load'
   Enabled: true
   VersionAdded: '0.43'
   VersionChanged: '0.44'
@@ -2599,7 +2599,7 @@ Security/MarshalLoad:
   Description: >-
                  Avoid using of `Marshal.load` or `Marshal.restore` due to potential
                  security issues. See reference for more information.
-  Reference: 'http://ruby-doc.org/core-2.3.3/Marshal.html#module-Marshal-label-Security+considerations'
+  Reference: 'https://ruby-doc.org/core-2.3.3/Marshal.html#module-Marshal-label-Security+considerations'
   Enabled: true
   VersionAdded: '0.47'
 
@@ -3183,7 +3183,7 @@ Style/FrozenStringLiteralComment:
 Style/GlobalVars:
   Description: 'Do not introduce global variables.'
   StyleGuide: '#instance-vars'
-  Reference: 'http://www.zenspider.com/Languages/Ruby/QuickRef.html'
+  Reference: 'https://www.zenspider.com/ruby/quickref.html'
   Enabled: true
   VersionAdded: '0.13'
   # Built-in global variables are allowed by default.

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -54,7 +54,7 @@ module RuboCop
       OPERATOR_KEYWORDS = %i[and or].freeze
       SPECIAL_KEYWORDS = %w[__FILE__ __LINE__ __ENCODING__].freeze
 
-      # @see http://rubydoc.info/gems/ast/AST/Node:initialize
+      # @see https://www.rubydoc.info/gems/ast/AST/Node:initialize
       def initialize(type, children = [], properties = {})
         @mutable_attributes = {}
 

--- a/lib/rubocop/ast/sexp.rb
+++ b/lib/rubocop/ast/sexp.rb
@@ -5,7 +5,7 @@ module RuboCop
     # This module provides a shorthand method to create a {Node} like
     # `Parser::AST::Sexp`.
     #
-    # @see http://rubydoc.info/gems/ast/AST/Sexp
+    # @see https://www.rubydoc.info/gems/ast/AST/Sexp
     module Sexp
       # Creates a {Node} with type `type` and children `children`.
       def s(type, *children)

--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -24,7 +24,7 @@ module RuboCop
       # @return [Parser::Source::Range]
       #   the location where the violation is detected.
       #
-      # @see http://rubydoc.info/github/whitequark/parser/Parser/Source/Range
+      # @see https://www.rubydoc.info/github/whitequark/parser/Parser/Source/Range
       #   Parser::Source::Range
       attr_reader :location
 

--- a/lib/rubocop/cop/rails/bulk_change_table.rb
+++ b/lib/rubocop/cop/rails/bulk_change_table.rb
@@ -63,8 +63,8 @@ module RuboCop
       #     end
       #   end
       #
-      # @see http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-change_table
-      # @see http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/Table.html
+      # @see https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-change_table
+      # @see https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/Table.html
       class BulkChangeTable < Cop
         MSG_FOR_CHANGE_TABLE = <<-MSG.strip_indent.chomp
           You can combine alter queries using `bulk: true` options.

--- a/lib/rubocop/cop/rails/inverse_of.rb
+++ b/lib/rubocop/cop/rails/inverse_of.rb
@@ -128,8 +128,8 @@ module RuboCop
       #     has_many :physicians, through: :appointments
       #   end
       #
-      # @see http://guides.rubyonrails.org/association_basics.html#bi-directional-associations
-      # @see http://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#module-ActiveRecord::Associations::ClassMethods-label-Setting+Inverses
+      # @see https://guides.rubyonrails.org/association_basics.html#bi-directional-associations
+      # @see https://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#module-ActiveRecord::Associations::ClassMethods-label-Setting+Inverses
       class InverseOf < Cop
         extend TargetRailsVersion
 

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -124,7 +124,7 @@ module RuboCop
       #     end
       #   end
       #
-      # @see http://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html
+      # @see https://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html
       class ReversibleMigration < Cop
         MSG = '%<action>s is not reversible.'.freeze
         IRREVERSIBLE_CHANGE_TABLE_CALLS = %i[

--- a/lib/rubocop/cop/rails/skips_model_validations.rb
+++ b/lib/rubocop/cop/rails/skips_model_validations.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Rails
       # This cop checks for the use of methods which skip
       # validations which are listed in
-      # http://guides.rubyonrails.org/active_record_validations.html#skipping-validations
+      # https://guides.rubyonrails.org/active_record_validations.html#skipping-validations
       #
       # Methods may be ignored from this rule by configuring a `Whitelist`.
       #

--- a/lib/rubocop/cop/style/global_vars.rb
+++ b/lib/rubocop/cop/style/global_vars.rb
@@ -23,7 +23,7 @@ module RuboCop
         MSG = 'Do not introduce global variables.'.freeze
 
         # built-in global variables and their English aliases
-        # http://www.zenspider.com/Languages/Ruby/QuickRef.html
+        # https://www.zenspider.com/ruby/quickref.html
         BUILT_IN_VARS = %w[
           $: $LOAD_PATH
           $" $LOADED_FEATURES

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -140,7 +140,7 @@ inherit_gem:
     - strict.yml
 ```
 
-**Note**: If the shared dependency is declared using a [Bundler](http://bundler.io/)
+**Note**: If the shared dependency is declared using a [Bundler](https://bundler.io/)
 Gemfile and the gem was installed using `bundle install`, it would be
 necessary to also invoke RuboCop using Bundler in order to find the
 dependency's installation path at runtime:

--- a/manual/contributing.md
+++ b/manual/contributing.md
@@ -28,7 +28,7 @@ adding or improving Cop descriptions.
 The manual is generated from the markdown files in the
 [doc](https://github.com/rubocop-hq/rubocop/tree/master/manual) folder of RuboCop's
 GitHub repo and is published to [Read the Docs](readthedocs.org). The
-[MkDocs](http://www.mkdocs.org/) tool is used to convert the markdown sources to
+[MkDocs](https://www.mkdocs.org/) tool is used to convert the markdown sources to
 HTML.
 
 To make changes to the manual you simply have to change the files under

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1673,7 +1673,7 @@ Include | `db/migrate/*.rb` | Array
 ### References
 
 * [https://github.com/rubocop-hq/rails-style-guide#reversible-migration](https://github.com/rubocop-hq/rails-style-guide#reversible-migration)
-* [http://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html](http://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html)
+* [https://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html](https://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html)
 
 ## Rails/SafeNavigation
 
@@ -1874,7 +1874,7 @@ Enabled | Yes | No | 0.47 | 0.60
 
 This cop checks for the use of methods which skip
 validations which are listed in
-http://guides.rubyonrails.org/active_record_validations.html#skipping-validations
+https://guides.rubyonrails.org/active_record_validations.html#skipping-validations
 
 Methods may be ignored from this rule by configuring a `Whitelist`.
 
@@ -1918,7 +1918,7 @@ Whitelist | `[]` | Array
 
 ### References
 
-* [http://guides.rubyonrails.org/active_record_validations.html#skipping-validations](http://guides.rubyonrails.org/active_record_validations.html#skipping-validations)
+* [https://guides.rubyonrails.org/active_record_validations.html#skipping-validations](https://guides.rubyonrails.org/active_record_validations.html#skipping-validations)
 
 ## Rails/TimeZone
 

--- a/manual/cops_security.md
+++ b/manual/cops_security.md
@@ -53,7 +53,7 @@ AutoCorrect | `false` | Boolean
 
 ### References
 
-* [http://ruby-doc.org/stdlib-2.3.0/libdoc/json/rdoc/JSON.html#method-i-load](http://ruby-doc.org/stdlib-2.3.0/libdoc/json/rdoc/JSON.html#method-i-load)
+* [https://ruby-doc.org/stdlib-2.3.0/libdoc/json/rdoc/JSON.html#method-i-load](https://ruby-doc.org/stdlib-2.3.0/libdoc/json/rdoc/JSON.html#method-i-load)
 
 ## Security/MarshalLoad
 
@@ -81,7 +81,7 @@ Marshal.load(Marshal.dump({}))
 
 ### References
 
-* [http://ruby-doc.org/core-2.3.3/Marshal.html#module-Marshal-label-Security+considerations](http://ruby-doc.org/core-2.3.3/Marshal.html#module-Marshal-label-Security+considerations)
+* [https://ruby-doc.org/core-2.3.3/Marshal.html#module-Marshal-label-Security+considerations](https://ruby-doc.org/core-2.3.3/Marshal.html#module-Marshal-label-Security+considerations)
 
 ## Security/Open
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2185,7 +2185,7 @@ AllowedVariables | `[]` | Array
 ### References
 
 * [https://github.com/rubocop-hq/ruby-style-guide#instance-vars](https://github.com/rubocop-hq/ruby-style-guide#instance-vars)
-* [http://www.zenspider.com/Languages/Ruby/QuickRef.html](http://www.zenspider.com/Languages/Ruby/QuickRef.html)
+* [https://www.zenspider.com/ruby/quickref.html](https://www.zenspider.com/ruby/quickref.html)
 
 ## Style/GuardClause
 

--- a/manual/development.md
+++ b/manual/development.md
@@ -73,7 +73,7 @@ $ bin/console
 ```
 
 First we need to declare the code that we want to match, and use the
-[ProcessedSource](http://www.rubydoc.info/gems/rubocop/RuboCop/ProcessedSource)
+[ProcessedSource](https://www.rubydoc.info/gems/rubocop/RuboCop/ProcessedSource)
 that is a simple wrap to make the parser interpret the code and build the AST:
 
 ```ruby
@@ -94,7 +94,7 @@ node.source # => "!something.empty?"
 ### Writing rules to make node pattern matches:
 
 Now that you're familiar with AST, you can learn a bit about the
-[node pattern](http://www.rubydoc.info/gems/rubocop/RuboCop/NodePattern)
+[node pattern](https://www.rubydoc.info/gems/rubocop/RuboCop/NodePattern)
 and use patterns to match with specific nodes that you want to match.
 
 You can learn more about Node Pattern [here](https://docs.rubocop.org/en/latest/node_pattern/).

--- a/manual/extensions.md
+++ b/manual/extensions.md
@@ -53,9 +53,9 @@ or implement all formatter API methods by duck typing.
 
 Please see the documents below for more formatter API details.
 
-* [RuboCop::Formatter::BaseFormatter](http://www.rubydoc.info/gems/rubocop/RuboCop/Formatter/BaseFormatter)
-* [RuboCop::Cop::Offense](http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Offense)
-* [Parser::Source::Range](http://www.rubydoc.info/github/whitequark/parser/Parser/Source/Range)
+* [RuboCop::Formatter::BaseFormatter](https://www.rubydoc.info/gems/rubocop/RuboCop/Formatter/BaseFormatter)
+* [RuboCop::Cop::Offense](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Offense)
+* [Parser::Source::Range](https://www.rubydoc.info/github/whitequark/parser/Parser/Source/Range)
 
 #### Using a Custom Formatter from the Command Line
 

--- a/manual/formatters.md
+++ b/manual/formatters.md
@@ -269,7 +269,7 @@ $ rubocop --format html -o rubocop.html
 
  **Machine-parsable**
 
-Useful for CI environments, it will format report following the [Test Anything Protocol](http://testanything.org).
+Useful for CI environments, it will format report following the [Test Anything Protocol](https://testanything.org).
 
 ```sh
 $ rubocop --format tap

--- a/manual/node_pattern.md
+++ b/manual/node_pattern.md
@@ -13,7 +13,7 @@ and solves a problem that RuboCop contributors were facing for a long time:
 
 - Ability to declaratively define rules for node search, matching, and capture.
 
-The code below belongs to [Style/ArrayJoin](http://www.rubydoc.info/github/rubocop-hq/RuboCop/RuboCop/Cop/Style/ArrayJoin)
+The code below belongs to [Style/ArrayJoin](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ArrayJoin)
 cop and it's in favor of `Array#join` over `Array#*`. Then it tries to find
 code like `%w(one two three) * ", "` and suggest to use `#join` instead.
 

--- a/manual/support.md
+++ b/manual/support.md
@@ -27,7 +27,7 @@ from other RuboCop users there.
 We're also encouraging users to ask RuboCop-related questions on StackOverflow.
 
 When doing so you should use the
-[RuboCop](http://stackoverflow.com/questions/tagged/rubocop) tag (ideally combined
+[RuboCop](https://stackoverflow.com/questions/tagged/rubocop) tag (ideally combined
 with the tag `ruby`).
 
 ## Bountysource

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -626,7 +626,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       file = abs('example1.rb')
       style_guide_link = 'https://github.com/rubocop-hq/ruby-style-guide' \
                          '#instance-vars'
-      reference_link = 'http://www.zenspider.com/Languages/Ruby/QuickRef.html'
+      reference_link = 'https://www.zenspider.com/ruby/quickref.html'
 
       expect(cli.run(['--format',
                       'emacs',


### PR DESCRIPTION
This is inspired by https://github.com/rubocop-hq/rubocop/pull/6458.

The links to zenspider were no longer going to the intended place. The link to the documentation for `Style/ArrayJoin` wasn't going to a valid url.