### PR TITLE
Improve Ctrl-C handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
 * [#6594](https://github.com/rubocop-hq/rubocop/pull/6594): Fix a false positive for `Rails/OutputSafety` when the receiver is a non-interpolated string literal. ([@amatsuda][])
 * [#6574](https://github.com/rubocop-hq/rubocop/pull/6574): Fix `Style/AccessModifierIndentation` not handling arbitrary blocks. ([@deivid-rodriguez][])
 * [#6370](https://github.com/rubocop-hq/rubocop/issues/6370): Fix the enforcing style from `extend self` into `module_function` when there are private methods. ([@Ruffeng][])
+* [#6461](https://github.com/rubocop-hq/rubocop/pull/6461): Restrict Ctrl-C handling to RuboCop's loop and simplify it to a single phase. ([@deivid-rodriguez][])
 
 ### Changes
 

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -30,15 +30,6 @@ module RuboCop
       @aborting = false
     end
 
-    def trap_interrupt
-      Signal.trap('INT') do
-        exit!(1) if aborting?
-        self.aborting = true
-        warn ''
-        warn 'Exiting... Interrupt again to exit immediately.'
-      end
-    end
-
     def run(paths)
       target_files = find_target_files(paths)
       if @options[:list_target_files]
@@ -47,6 +38,12 @@ module RuboCop
         warm_cache(target_files) if @options[:parallel]
         inspect_files(target_files)
       end
+    rescue Interrupt
+      self.aborting = true
+      warn ''
+      warn 'Exiting...'
+
+      false
     end
 
     def aborting?
@@ -81,11 +78,7 @@ module RuboCop
     end
 
     def each_inspected_file(files)
-      trap_interrupt
-
       files.reduce(true) do |all_passed, file|
-        break false if aborting?
-
         offenses = process_file(file)
         yield file
 

--- a/spec/rubocop/formatter/base_formatter_spec.rb
+++ b/spec/rubocop/formatter/base_formatter_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Formatter::BaseFormatter do
-  include FileHelper
+  include_context 'cli spec behavior'
 
   describe 'how the API methods are invoked', :isolated_environment do
     subject(:formatter) { instance_double(described_class).as_null_object }
@@ -18,14 +18,9 @@ RSpec.describe RuboCop::Formatter::BaseFormatter do
 
       allow(RuboCop::Formatter::SimpleTextFormatter)
         .to receive(:new).and_return(formatter)
-      $stdout = StringIO.new
       # avoid intermittent failure caused when another test set global
       # options on ConfigLoader
       RuboCop::ConfigLoader.clear_options
-    end
-
-    after do
-      $stdout = STDOUT
     end
 
     def run

--- a/spec/rubocop/formatter/base_formatter_spec.rb
+++ b/spec/rubocop/formatter/base_formatter_spec.rb
@@ -100,9 +100,12 @@ RSpec.describe RuboCop::Formatter::BaseFormatter do
             end
           end
 
-          allow(runner).to receive(:aborting?) do
-            formatter.processed_file_count == 2
-          end
+          allow(runner).to receive(:process_file)
+            .and_wrap_original do |m, *args|
+              raise Interrupt if formatter.processed_file_count == 2
+
+              m.call(*args)
+            end
 
           run
 


### PR DESCRIPTION
This PR builds on top of #6452 and improves the user experience when clicking Ctrl-C by not installing any global trap handlers, and thus:

* Not leaking the handler to the rest of the process after rubocop is done.
* Keeping the previous global handlers in use when rubocop starts. For example, when clicking Ctrl-C during the execution of rubocop CLI specs, one gets the expected handling of Ctrl-C. You can see the comparison of the before and after on this [screen recording](https://asciinema.org/a/6MWQZVLrPrW1DfAlFH3CxmvjQ).

I felt it was better to propose these changes as two separate PRs, so technically this PR depends on #6452. But all changes in both PRs are included here, so if it's handier or considered better, this PR could be reviewed and merged direcly as a single set of changes, and thus superseding #6452.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
