### PR TITLE
Do not show warning for inherit_mode cop parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#6436](https://github.com/rubocop-hq/rubocop/pull/6436): Fix exit status code to be 130 when rubocop is interrupted. ([@deivid-rodriguez][])
 * [#6443](https://github.com/rubocop-hq/rubocop/pull/6443): Fix an incorrect autocorrect for `Style/BracesAroundHashParameters` when the opening brace is bofore the first hash element at same line. ([@koic][])
 * [#6445](https://github.com/rubocop-hq/rubocop/pull/6445): Treat `yield` and `super` like regular method calls in `Style/AlignHash`. ([@mvz][])
+* Don't show "unrecognized parameter" warning for `inherit_mode` parameter to individual cop configurations. ([@maxh][])
 
 ## 0.60.0 (2018-10-26)
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -14,7 +14,7 @@ module RuboCop
     include PathUtil
     include FileFinder
 
-    COMMON_PARAMS = %w[Exclude Include Severity
+    COMMON_PARAMS = %w[Exclude Include Severity inherit_mode
                        AutoCorrect StyleGuide Details].freeze
     # 2.2 is the oldest officially supported Ruby version.
     DEFAULT_RUBY_VERSION = 2.2

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -108,6 +108,9 @@ RSpec.describe RuboCop::Config do
             Include:
               - lib/file.xyz
             Severity: warning
+            inherit_mode:
+              merge:
+                - Exclude
             StyleGuide: https://example.com/some-style.html
         YAML
       end


### PR DESCRIPTION
This disables (what I believe to be) an untrue warning. Currently, when running:

`rubocop --auto-gen-config`

I see the following warning:

Warning: unrecognized parameter Lint/AmbiguousBlockAssociation:inherit_mode found in .rubocop.yml

The parameter is working as intended according to the documentation [here](https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md#merging-arrays-using-inherit_mode), however. We believe the warning is spurious. With this change applied, the warning does not appear. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
