### PR TITLE
Update terminology in http_status.rb

### DIFF
--- a/lib/rubocop/cop/rails/http_status.rb
+++ b/lib/rubocop/cop/rails/http_status.rb
@@ -143,7 +143,7 @@ module RuboCop
                 'to define HTTP status code.'.freeze
           DEFAULT_MSG = 'Prefer `numeric` over `symbolic` ' \
                         'to define HTTP status code.'.freeze
-          WHITELIST_STATUS = %i[error success missing redirect].freeze
+          PERMITTED_STATUS = %i[error success missing redirect].freeze
 
           attr_reader :node
           def initialize(node)
@@ -151,7 +151,7 @@ module RuboCop
           end
 
           def offensive?
-            !node.int_type? && !whitelisted_symbol?
+            !node.int_type? && !permitted_symbol?
           end
 
           def message
@@ -176,8 +176,8 @@ module RuboCop
             node.value
           end
 
-          def whitelisted_symbol?
-            node.sym_type? && WHITELIST_STATUS.include?(node.value)
+          def permitted_symbol?
+            node.sym_type? && PERMITTED_STATUS.include?(node.value)
           end
         end
       end


### PR DESCRIPTION
This Pull Request updates `lib/rubocop/cop/rails/http_status.rb`.

Permitted is easier to understand and better terminology. I didn't find anyone [using this constant](https://github.com/search?q=%22NumericStyleChecker%3A%3AWHITELIST_STATUS%22&type=Code), it should be safe to change.

[Original motivation](https://github.com/rails/rails/issues/33677), other community efforts examples:

- https://github.com/rails/rails/pull/33681
- https://github.com/graphiti-api/graphiti/pull/10
- https://github.com/rails/rails/pull/33718
- https://github.com/ruby/psych/pull/378
- https://github.com/ruby/ruby/pull/2008
- https://github.com/ruby/ruby/pull/2009
- https://github.com/rubocop-hq/rubocop/pull/6464
- https://github.com/rubygems/rubygems/pull/2463
- https://github.com/dtao/safe_yaml/pull/93
- https://github.com/rack/rack/pull/1314
- https://github.com/rubocop-hq/rubocop/pull/6467
- https://github.com/rspec/rspec-core/pull/2576
- https://github.com/rspec/rspec-expectations/pull/1083
- https://github.com/rspec/rspec-mocks/pull/1246
- https://github.com/rspec/rspec-support/pull/356
- https://github.com/flavorjones/loofah/pull/158
- https://github.com/pry/pry/pull/1874
- https://github.com/pry/pry/pull/1875

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
