### PR TITLE
Update terminology in rails/validation.rb

### DIFF
--- a/lib/rubocop/cop/rails/validation.rb
+++ b/lib/rubocop/cop/rails/validation.rb
@@ -47,11 +47,11 @@ module RuboCop
           uniqueness
         ].freeze
 
-        BLACKLIST = TYPES.map { |p| "validates_#{p}_of".to_sym }.freeze
-        WHITELIST = TYPES.map { |p| "validates :column, #{p}: value" }.freeze
+        DENYLIST = TYPES.map { |p| "validates_#{p}_of".to_sym }.freeze
+        ALLOWLIST = TYPES.map { |p| "validates :column, #{p}: value" }.freeze
 
         def on_send(node)
-          return unless !node.receiver && BLACKLIST.include?(node.method_name)
+          return unless !node.receiver && DENYLIST.include?(node.method_name)
 
           add_offense(node, location: :selector)
         end
@@ -71,7 +71,7 @@ module RuboCop
         end
 
         def preferred_method(method)
-          WHITELIST[BLACKLIST.index(method.to_sym)]
+          ALLOWLIST[DENYLIST.index(method.to_sym)]
         end
 
         def correct_validate_type(corrector, node)

--- a/spec/rubocop/cop/rails/validation_spec.rb
+++ b/spec/rubocop/cop/rails/validation_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::Rails::Validation do
   subject(:cop) { described_class.new }
 
-  described_class::BLACKLIST.each_with_index do |validation, number|
+  described_class::DENYLIST.each_with_index do |validation, number|
     it "registers an offense for #{validation}" do
       inspect_source("#{validation} :name")
       expect(cop.offenses.size).to eq(1)
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::Rails::Validation do
     it "outputs the correct message for #{validation}" do
       inspect_source("#{validation} :name")
       expect(cop.offenses.first.message)
-        .to include(described_class::WHITELIST[number])
+        .to include(described_class::ALLOWLIST[number])
     end
   end
 


### PR DESCRIPTION
This Pull Request updates `lib/rubocop/cop/rails/validation.rb`.

Allowlist & Denylist is easier to understand and better terminology. 

[Original motivation](https://github.com/rails/rails/issues/33677), other community efforts examples:

- https://github.com/rails/rails/pull/33681
- https://github.com/graphiti-api/graphiti/pull/10
- https://github.com/rails/rails/pull/33718
- https://github.com/ruby/psych/pull/378
- https://github.com/ruby/ruby/pull/2008
- https://github.com/ruby/ruby/pull/2009
- https://github.com/rubocop-hq/rubocop/pull/6464
- https://github.com/rubygems/rubygems/pull/2463
- https://github.com/dtao/safe_yaml/pull/93
- https://github.com/rack/rack/pull/1314
- https://github.com/rubocop-hq/rubocop/pull/6466
- https://github.com/rspec/rspec-core/pull/2576
- https://github.com/rspec/rspec-expectations/pull/1083
- https://github.com/rspec/rspec-mocks/pull/1246
- https://github.com/rspec/rspec-support/pull/356
- https://github.com/flavorjones/loofah/pull/158
- https://github.com/pry/pry/pull/1874
- https://github.com/pry/pry/pull/1875

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
