### PR TITLE
[Fix #3301] Consider the scope of local variables in Style/InfiniteLoop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#6436](https://github.com/rubocop-hq/rubocop/pull/6436): Fix exit status code to be 130 when rubocop is interrupted. ([@deivid-rodriguez][])
 * [#6443](https://github.com/rubocop-hq/rubocop/pull/6443): Fix an incorrect autocorrect for `Style/BracesAroundHashParameters` when the opening brace is bofore the first hash element at same line. ([@koic][])
 * [#6445](https://github.com/rubocop-hq/rubocop/pull/6445): Treat `yield` and `super` like regular method calls in `Style/AlignHash`. ([@mvz][])
+* [#3301](https://github.com/rubocop-hq/rubocop/issues/3301): Don't suggest or make semantic changes to the code in `Style/InfiniteLoop`. ([@jonas054][])
 
 ## 0.60.0 (2018-10-26)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -3268,7 +3268,8 @@ Style/InfiniteLoop:
   StyleGuide: '#infinite-loop'
   Enabled: true
   VersionAdded: '0.26'
-  SafeAutoCorrect: false
+  VersionChanged: '0.61'
+  SafeAutoCorrect: true
 
 Style/InlineComment:
   Description: 'Avoid trailing inline comments.'

--- a/lib/rubocop/cop/style/infinite_loop.rb
+++ b/lib/rubocop/cop/style/infinite_loop.rb
@@ -20,16 +20,21 @@ module RuboCop
 
         MSG = 'Use `Kernel#loop` for infinite loops.'.freeze
 
-        def on_while(node)
-          return unless node.condition.truthy_literal?
+        def join_force?(force_class)
+          force_class == VariableForce
+        end
 
-          add_offense(node, location: :keyword)
+        def after_leaving_scope(scope, _variable_table)
+          @variables ||= []
+          @variables.concat(scope.variables.values)
+        end
+
+        def on_while(node)
+          while_or_until(node) if node.condition.truthy_literal?
         end
 
         def on_until(node)
-          return unless node.condition.falsey_literal?
-
-          add_offense(node, location: :keyword)
+          while_or_until(node) if node.condition.falsey_literal?
         end
 
         alias on_while_post on_while
@@ -46,6 +51,37 @@ module RuboCop
         end
 
         private
+
+        def while_or_until(node)
+          range = node.source_range
+          # Not every `while true` and `until false` can be turned into a
+          # `loop do` without further modification. The reason is that a
+          # variable that's introduced inside a while/until loop is in scope
+          # outside of that loop too, but a variable that's assigned for the
+          # first time inside a block can not be accessed after the block. In
+          # those more complicated cases we don't report an offense.
+          return if @variables.any? do |var|
+            assigned_inside_loop?(var, range) &&
+            !assigned_before_loop?(var, range) &&
+            referenced_after_loop?(var, range)
+          end
+
+          add_offense(node, location: :keyword)
+        end
+
+        def assigned_inside_loop?(var, range)
+          var.assignments.any? { |a| range.contains?(a.node.source_range) }
+        end
+
+        def assigned_before_loop?(var, range)
+          b = range.begin_pos
+          var.assignments.any? { |a| a.node.source_range.end_pos < b }
+        end
+
+        def referenced_after_loop?(var, range)
+          e = range.end_pos
+          var.references.any? { |r| r.node.source_range.begin_pos > e }
+        end
 
         def replace_begin_end_with_modifier(node)
           lambda do |corrector|

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2530,7 +2530,7 @@ raise ArgumentError, 'Error message here'
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes (Unsafe) | 0.26 | -
+Enabled | Yes | Yes  | 0.26 | 0.61
 
 Use `Kernel#loop` for infinite loops.
 

--- a/spec/rubocop/cop/style/infinite_loop_spec.rb
+++ b/spec/rubocop/cop/style/infinite_loop_spec.rb
@@ -33,6 +33,102 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop do
     expect_no_offenses('loop { break if something }')
   end
 
+  it 'accepts while true if loop {} would change semantics' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def f1
+        a = nil # This `a` is local to `f1` and should not affect `f2`.
+        puts a
+      end
+
+      def f2
+        b = 17
+        while true
+          # `a` springs into existence here, while `b` already existed. Because
+          # of `a` we can't introduce a block.
+          a, b = 42, 42
+          break
+        end
+        puts a, b
+      end
+    RUBY
+  end
+
+  it 'accepts modifier while true if loop {} would change semantics' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      a = next_value or break while true
+      p a
+    RUBY
+  end
+
+  it 'registers an offense for modifier until false if loop {} would not ' \
+     'change semantics' do
+    expect_offense(<<-RUBY.strip_indent)
+      a = nil
+      a = next_value or break until false
+                              ^^^^^ Use `Kernel#loop` for infinite loops.
+      p a
+    RUBY
+  end
+
+  it 'registers an offense for until false if loop {} would work because of ' \
+     'previous assignment in a while loop' do
+    expect_offense(<<-RUBY.strip_indent)
+      while true
+        a = 42
+        break
+      end
+      until false
+      ^^^^^ Use `Kernel#loop` for infinite loops.
+        # The variable `a` already exits here, having been introduced in the
+        # above `while` loop. We can therefore safely change it too `Kernel#loop`.
+        a = 43
+        break
+      end
+      puts a
+    RUBY
+  end
+
+  it 'registers an offense for until false if loop {} would work because the ' \
+     'assigned variable is not used afterwards' do
+    expect_offense(<<-RUBY.strip_indent)
+      until false
+      ^^^^^ Use `Kernel#loop` for infinite loops.
+        a = 43
+        break
+      end
+    RUBY
+  end
+
+  it 'registers an offense for while true or until false if loop {} would ' \
+     'work because of an earlier assignment' do
+    expect_offense(<<-RUBY.strip_indent)
+      a = 0
+      while true
+      ^^^^^ Use `Kernel#loop` for infinite loops.
+        a = 42 # `a` is in scope outside of the `while`
+        break
+      end
+      until false
+      ^^^^^ Use `Kernel#loop` for infinite loops.
+        a = 43 # `a` is in scope outside of the `while`
+        break
+      end
+      puts a
+    RUBY
+  end
+
+  it 'registers an offense for while true if loop {} would work because it ' \
+     'is an instance variable being assigned' do
+    expect_offense(<<-RUBY.strip_indent)
+      while true
+      ^^^^^ Use `Kernel#loop` for infinite loops.
+        @a = 42
+        break
+      end
+      puts @a
+    RUBY
+  end
+
   shared_examples_for 'auto-corrector' do |keyword, lit|
     it "auto-corrects single line modifier #{keyword}" do
       new_source =


### PR DESCRIPTION
If there is a local variable that springs into existence inside a `while` or `until` loop, and then is referenced after that loop, then it won't work to change the loop into `Kernel#loop`. The reason is that a block has a local scope that `while` and `until` constructs don't, so the variable will be unknown outside of that block.

This changes `Style/InfiniteLoop` into a safe cop for auto-correct.

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.