### PR TITLE
Fix --auto-gen-config when cops have regexp literal exclude paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 ### Changes
 
 * [#6492](https://github.com/rubocop-hq/rubocop/issues/6492): Auto-correct chunks of comment lines in `Layout/CommentIndentation` to avoid unnecessary iterations for `rubocop -a`. ([@jonas054][])
+* Fix `--auto-gen-config` when individual cops have regexp literal exclude paths. ([@maxh][])
 
 ## 0.60.0 (2018-10-26)
 

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -184,8 +184,8 @@ module RuboCop
         parent = Pathname.new(Dir.pwd)
 
         output_buffer.puts '  Exclude:'
-        excludes(offending_files, cop_name, parent).each do |file|
-          output_exclude_path(output_buffer, file, parent)
+        excludes(offending_files, cop_name, parent).each do |exclude_path|
+          output_exclude_path(output_buffer, exclude_path, parent)
         end
       end
 
@@ -201,12 +201,17 @@ module RuboCop
         ((cfg['Exclude'] || []) + offending_files).uniq
       end
 
-      def output_exclude_path(output_buffer, file, parent)
-        file_path = Pathname.new(file)
+      def output_exclude_path(output_buffer, exclude_path, parent)
+        # exclude_path is either relative path, an absolute path, or a regexp.
+        file_path = Pathname.new(exclude_path)
         relative = file_path.relative_path_from(parent)
         output_buffer.puts "    - '#{relative}'"
       rescue ArgumentError
+        file = exclude_path
         output_buffer.puts "    - '#{file}'"
+      rescue TypeError
+        regexp = exclude_path
+        output_buffer.puts "    - !ruby/regexp /#{regexp.source}/"
       end
     end
   end

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
         Cop2:
           Exclude:
             - "**/*.blah"
+            - !ruby/regexp /.*/bar/*/foo\.rb$/
       YAML
 
       formatter.started(['test_a.rb', 'test_b.rb'])
@@ -121,6 +122,7 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
        'Cop2:',
        '  Exclude:',
        "    - '**/*.blah'",
+       "    - !ruby/regexp /.*/bar/*/foo\.rb$/",
        "    - 'test_a.rb'",
        ''].join("\n")
     end


### PR DESCRIPTION
Previously, `rubocop --auto-gen-config` would fail with the error:

![image](https://user-images.githubusercontent.com/1289501/48357346-391ef300-e64d-11e8-8ed7-a06e71779248.png)

Because our main config contains excludes regexps on individual cops like:

```yml
Lint/AmbiguousBlockAssociation:
  Enabled: true
  Exclude:
    - !ruby/regexp /_spec\.rb$/
```

Now, these exclude path are outputted in the `.rubocop_todo.yml` file correctly.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
