### PR TITLE
Support brace correction on Style/Lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#6457](https://github.com/rubocop-hq/rubocop/pull/6457): Support inner slash correction on Style/RegexpLiteral. ([@r7kamura][])
+* [#6475](https://github.com/rubocop-hq/rubocop/pull/6475): Support brace correction on Style/Lambda. ([@r7kamura][])
 
 ### Bug fixes
 


### PR DESCRIPTION
## Problem

When I tried to auto-correct the following code by Style/Lambda cop:

```rb
p foo: -> do
  :bar
end
```

### Expected behavior

I expected that it would be auto-corrected to:

```rb
p foo: lambda {
  :bar
}
```

### Actual behavior

Unfortunately, this code was not auto-corrected, because changing selector from `->` to `lambda` in a unparenthesized method call would change the meaning of the code.

But I thought if its block delimiter is `{}`, it won't change the meaning of code. This is my motivation of this pull request.

### Note

`do ... end` in unparenthesized arguments must be replaced with `{ ... }` because the following code results in `ArgumentError: tried to create Proc object without a block`.

```rb
p foo: lambda do
  :bar
end

# The code above is treated as:
p(foo: lambda) do
  :bar
end
```

## Solution

I changed `RuboCop::Cop::Style::Lambda#autocorrect` so that when selector will be changed from `-> do ... end` to `lambda do ... end` in a unparenthesized method call, we'll change its block delimiter from `do ... end` to `{ ... }` too.

With this change, now we can auto-correct code 1 and code 2 to code 3 when its EnforcedStyle is `:line_count_dependent` (default) or `:lambda`.

```rb
# code 1
p foo: -> {
  :bar
}

# code 2
p foo: -> do
  :bar
end

# code 3
p foo: lambda {
  :bar
}
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
