### PR TITLE
[Fix #3586] Handle single argument correctly in TrailingComma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#6443](https://github.com/rubocop-hq/rubocop/pull/6443): Fix an incorrect autocorrect for `Style/BracesAroundHashParameters` when the opening brace is bofore the first hash element at same line. ([@koic][])
 * [#6445](https://github.com/rubocop-hq/rubocop/pull/6445): Treat `yield` and `super` like regular method calls in `Style/AlignHash`. ([@mvz][])
 * [#3301](https://github.com/rubocop-hq/rubocop/issues/3301): Don't suggest or make semantic changes to the code in `Style/InfiniteLoop`. ([@jonas054][])
+* [#3586](https://github.com/rubocop-hq/rubocop/issues/3586): Handle single argument spanning multiple lines in `Style/TrailingCommaInArguments`. ([@jonas054][])
 
 ## 0.60.0 (2018-10-26)
 

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -98,8 +98,17 @@ module RuboCop
         items = elements(node).map(&:source_range)
         return false if items.empty?
 
+        return false if single_argument_not_multiline?(items, node)
+
         items << node.loc.begin << node.loc.end
         (items.map(&:first_line) + items.map(&:last_line)).uniq.size > 1
+      end
+
+      # A single argument with the closing bracket on the same line as the end
+      # of the argument is not considered multiline, even if the argument
+      # itself might span multiple lines.
+      def single_argument_not_multiline?(items, node)
+        items.size == 1 && !Util.begins_its_line?(node.loc.end)
       end
 
       def elements(node)

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             func({
                    @abc => 0,
                    @xyz => 1,
-                 },)
+                 })
             func(
               {
                 abc: 0,

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -73,6 +73,21 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
     end
   end
 
+  context 'with a single argument spanning multiple lines' do
+    context 'when EnforcedStyleForMultiline is consistent_comma' do
+      let(:cop_config) { { 'EnforcedStyleForMultiline' => 'consistent_comma' } }
+
+      it 'accepts a single argument with no trailing comma' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          EmailWorker.perform_async({
+            subject: "hey there",
+            email: "foo@bar.com"
+          })
+        RUBY
+      end
+    end
+  end
+
   context 'with multi-line list of values' do
     context 'when EnforcedStyleForMultiline is no_comma' do
       let(:cop_config) { { 'EnforcedStyleForMultiline' => 'no_comma' } }


### PR DESCRIPTION
The method `TrailingComma#multiline?` should not return `true` for a single argument (possibly spanning multiple lines) followed by a closing bracket that's not on its own line.

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.