### PR TITLE
Fix the algorithm for determining ABCSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#6804](https://github.com/rubocop-hq/rubocop/pull/6804): Fix auto-correction of `Style/NumericLiterals` on numeric literal with exponent. ([@pocke][])
 * [#6800](https://github.com/rubocop-hq/rubocop/issues/6800): Fix an incorrect auto-correct for `Rails/Validation` when method arguments are enclosed in parentheses. ([@koic][])
 * [#6808](https://github.com/rubocop-hq/rubocop/issues/6808): Prevent false positive in `Naming/ConstantName` when assigning a frozen range. ([@drenmi][])
+* Fix the calculation of `Metrics/AbcSize`. Comparison methods and `else` branches add to the comparison count. ([@rrosenblum][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1632,9 +1632,12 @@ Metrics/AbcSize:
   Description: >-
                  A calculated magnitude based on number of assignments,
                  branches, and conditions.
-  Reference: 'http://c2.com/cgi/wiki?AbcMetric'
+  Reference:
+    - http://c2.com/cgi/wiki?AbcMetric
+    - https://en.wikipedia.org/wiki/ABC_Software_Metric'
   Enabled: true
   VersionAdded: '0.27'
+  VersionChanged: '0.66'
   # The ABC size is a calculated magnitude, so this number can be an Integer or
   # a Float.
   Max: 15

--- a/lib/rubocop/cop/message_annotator.rb
+++ b/lib/rubocop/cop/message_annotator.rb
@@ -64,7 +64,7 @@ module RuboCop
       end
 
       def urls
-        [style_guide_url, reference_url].compact
+        [style_guide_url, *reference_urls].compact
       end
 
       private
@@ -89,9 +89,9 @@ module RuboCop
           !urls.empty?
       end
 
-      def reference_url
-        url = cop_config['Reference']
-        url.nil? || url.empty? ? nil : url
+      def reference_urls
+        urls = Array(cop_config['Reference'])
+        urls.nil? || urls.empty? ? nil : urls.reject(&:empty?)
       end
 
       def extra_details?

--- a/lib/rubocop/cop/metrics/abc_size.rb
+++ b/lib/rubocop/cop/metrics/abc_size.rb
@@ -6,6 +6,7 @@ module RuboCop
       # This cop checks that the ABC size of methods is not higher than the
       # configured maximum. The ABC size is based on assignments, branches
       # (method calls), and conditions. See http://c2.com/cgi/wiki?AbcMetric
+      # and https://en.wikipedia.org/wiki/ABC_Software_Metric.
       class AbcSize < Cop
         include MethodComplexity
 

--- a/manual/cops_metrics.md
+++ b/manual/cops_metrics.md
@@ -4,11 +4,12 @@
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.27 | -
+Enabled | Yes | No | 0.27 | 0.66
 
 This cop checks that the ABC size of methods is not higher than the
 configured maximum. The ABC size is based on assignments, branches
 (method calls), and conditions. See http://c2.com/cgi/wiki?AbcMetric
+and https://en.wikipedia.org/wiki/ABC_Software_Metric.
 
 ### Configurable attributes
 
@@ -19,6 +20,7 @@ Max | `15` | Integer
 ### References
 
 * [http://c2.com/cgi/wiki?AbcMetric](http://c2.com/cgi/wiki?AbcMetric)
+* [https://en.wikipedia.org/wiki/ABC_Software_Metric'](https://en.wikipedia.org/wiki/ABC_Software_Metric')
 
 ## Metrics/BlockLength
 

--- a/spec/rubocop/cop/message_annotator_spec.rb
+++ b/spec/rubocop/cop/message_annotator_spec.rb
@@ -139,6 +139,25 @@ RSpec.describe RuboCop::Cop::MessageAnnotator do
       expect(urls).to eq(%w[https://example.com/some_style_guide])
     end
 
+    it 'returns an empty array if the reference url is blank' do
+      config['Cop/Cop'] = {
+        'Reference' => ''
+      }
+
+      expect(urls.empty?).to be(true)
+    end
+
+    it 'returns multiple reference urls' do
+      config['Cop/Cop'] = {
+        'Reference' => ['https://example.com/some_style_guide',
+                        'https://example.com/some_other_guide',
+                        '']
+      }
+
+      expect(urls).to eq(['https://example.com/some_style_guide',
+                          'https://example.com/some_other_guide'])
+    end
+
     it 'returns style guide and reference url when they are specified' do
       config['Cop/Cop'] = {
         'StyleGuide' => '#target_based_url',

--- a/spec/rubocop/cop/metrics/abc_size_spec.rb
+++ b/spec/rubocop/cop/metrics/abc_size_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
        'scores' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [6.4/0]
-          my_options = Hash.new if 1 == 1 || 2 == 2 # 1, 3, 2
+        ^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [5.74/0]
+          my_options = Hash.new if 1 == 1 || 2 == 2 # 1, 1, 4
           my_options.each do |key, value|           # 0, 1, 0
             p key                                   # 0, 1, 0
             p value                                 # 0, 1, 0
@@ -95,10 +95,10 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
     end
   end
 
-  context 'when Max is 1.8' do
-    let(:cop_config) { { 'Max' => 1.8 } }
+  context 'when Max is 2.3' do
+    let(:cop_config) { { 'Max' => 2.3 } }
 
-    it 'accepts a total score of 1.7' do
+    it 'accepts a total score of 2.24' do
       expect_no_offenses(<<-RUBY.strip_indent)
         def method_name
           y = 1 if y == 1
@@ -108,10 +108,10 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
   end
 
   {
-    1.3 => '3.74/1.3', # no more than 2 decimals reported
-    10.3 => '37.42/10.3',
-    100.321 => '374.2/100.3', # 4 significant digits, so only 1 decimal here
-    1000.3 => '3742/1000'
+    1.3 => '4.24/1.3', # no more than 2 decimals reported
+    10.3 => '42.43/10.3',
+    100.321 => '424.3/100.3', # 4 significant digits, so only 1 decimal here
+    1000.3 => '4243/1000'
   }.each do |max, presentation|
     context "when Max is #{max}" do
       let(:cop_config) { { 'Max' => max } }

--- a/spec/rubocop/cop/metrics/utils/abc_size_calculator_spec.rb
+++ b/spec/rubocop/cop/metrics/utils/abc_size_calculator_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe RuboCop::Cop::Metrics::Utils::AbcSizeCalculator do
       end
     end
 
-    context '2 assignments, 8 branches, 3 conditions' do
+    context '2 assignments, 8 branches, 4 conditions' do
       it 'returns 8.77' do
         node = parse_source(<<-RUBY.strip_indent).ast
           def method_name
@@ -42,7 +42,64 @@ RSpec.describe RuboCop::Cop::Metrics::Utils::AbcSizeCalculator do
             end
           end
         RUBY
-        expect(described_class.calculate(node)).to be_within(0.001).of(8.77)
+        expect(described_class.calculate(node)).to be_within(0.001).of(9.17)
+      end
+    end
+
+    context '2 assignments, 9 branches, 5 conditions' do
+      it 'returns 10.49' do
+        node = parse_source(<<-RUBY.strip_indent).ast
+          def method_name
+            a = b ? c : d
+            if a < b
+              a
+            else
+              e = f ? g : h
+
+              # The * and - are counted as branches because they are parsed as
+              # `send` nodes. YARV might optimize them, but to `parser` they
+              # are methods.
+              e * 2.4 - 781.0
+            end
+          end
+        RUBY
+        expect(described_class.calculate(node)).to be_within(0.001).of(10.49)
+      end
+    end
+
+    context 'elsif vs else if' do
+      it 'counts elsif as 1 condition' do
+        node = parse_source(<<-RUBY.strip_indent).ast
+          def method_name
+            if foo        # 0, 1, 1
+              bar         # 0, 2, 1
+            elsif baz     # 0, 3, 2
+              qux         # 0, 4, 2
+            else          # 0, 4, 3
+              foobar      # 0, 5, 3
+            end
+          end
+        RUBY
+
+        expect(described_class.calculate(node)).to be_within(0.001).of(5.83)
+      end
+
+      it 'counts else if as 2 conditions' do
+        node = parse_source(<<-RUBY.strip_indent).ast
+          def method_name
+            if foo        # 0, 1, 1
+              bar         # 0, 2, 1
+            else          # 0, 2, 2
+              if baz      # 0, 3, 3
+                qux       # 0, 4, 3
+              else        # 0, 4, 4
+                foobar    # 0, 5, 4
+              end
+            end
+          end
+        RUBY
+
+        expect(described_class.calculate(node)).to be_within(0.001).of(6.4)
       end
     end
   end


### PR DESCRIPTION
I was doing some research on the ABC size metric, and I think our implementation may be incorrect.

The wikipedia theory section, https://en.wikipedia.org/wiki/ABC_Software_Metric#Theory, a few implementations from other languages. In each case, `else` and conditional operators increase the count for condition. In our implementation, `else` never increases a count, and conditional operators increase the branch count.