### PR TITLE
Fix EmacsComment#encoding to match the 'coding' variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 * [#6443](https://github.com/rubocop-hq/rubocop/pull/6443): Fix an incorrect autocorrect for `Style/BracesAroundHashParameters` when the opening brace is bofore the first hash element at same line. ([@koic][])
 * [#6445](https://github.com/rubocop-hq/rubocop/pull/6445): Treat `yield` and `super` like regular method calls in `Style/AlignHash`. ([@mvz][])
 * [#3301](https://github.com/rubocop-hq/rubocop/issues/3301): Don't suggest or make semantic changes to the code in `Style/InfiniteLoop`. ([@jonas054][])
+* [#6478](https://github.com/rubocop-hq/rubocop/pull/6478): Fix EmacsComment#encoding to match the `coding` variable. ([@akihiro17][])
+
 
 ## 0.60.0 (2018-10-26)
 

--- a/lib/rubocop/magic_comment.rb
+++ b/lib/rubocop/magic_comment.rb
@@ -134,7 +134,7 @@ module RuboCop
       OPERATOR  = ':'.freeze
 
       def encoding
-        match('encoding')
+        match('(?:en)?coding')
       end
 
       private

--- a/spec/rubocop/magic_comment_spec.rb
+++ b/spec/rubocop/magic_comment_spec.rb
@@ -115,6 +115,13 @@ RSpec.describe RuboCop::MagicComment do
     frozen_string_literal: true
   )
 
+  include_examples(
+    'magic comment',
+    '# -*- coding: ASCII-8BIT; frozen_string_literal: true -*-',
+    encoding: 'ascii-8bit',
+    frozen_string_literal: true
+  )
+
   include_examples 'magic comment',
                    '# vim: filetype=ruby, fileencoding=ascii-8bit',
                    encoding: 'ascii-8bit'


### PR DESCRIPTION
the `coding` variable(`-*- coding: xxx -*-`) is also used to specify the encoding of a file in Emacs.

https://github.com/jwiegley/ruby-mode/blob/master/ruby-mode.el#L360
https://www.gnu.org/software/emacs/manual/html_node/emacs/Specify-Coding.html
```
You can specify the coding system for a particular file in the file itself, ~~
You do this by defining a value for the “variable” named coding
```

In this PR, Rubocop can detect the `coding` variable correctly.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
