### PR TITLE
[Fix #6482] Fix a false positive for `Lint/FormatParameterMismatch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#6478](https://github.com/rubocop-hq/rubocop/pull/6478): Fix EmacsComment#encoding to match the `coding` variable. ([@akihiro17][])
 * Don't show "unrecognized parameter" warning for `inherit_mode` parameter to individual cop configurations. ([@maxh][])
 * [#6449](https://github.com/rubocop-hq/rubocop/pull/6449): Fix a false negative for `Layout/IndentationWidth` when setting `EnforcedStyle: rails` of `Layout/IndentationConsistency` and method definition indented to access modifier in a singleton class. ([@koic][])
+* [#6482](https://github.com/rubocop-hq/rubocop/issues/6482): Fix a false positive for `Lint/FormatParameterMismatch` when using (digit)$ flag. ([@koic][])
 
 ## 0.60.0 (2018-10-26)
 

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -29,6 +29,7 @@ module RuboCop
         SHOVEL = '<<'.freeze
         PERCENT = '%'.freeze
         PERCENT_PERCENT = '%%'.freeze
+        DIGIT_DOLLAR_FLAG = /%(\d+)\$/.freeze
         STRING_TYPES = %i[str dstr].freeze
         NAMED_INTERPOLATION = /%(?:<\w+>|\{\w+\})/.freeze
 
@@ -132,11 +133,21 @@ module RuboCop
           return :unknown unless node.str_type?
           return 1 if node.source =~ NAMED_INTERPOLATION
 
+          max_digit_dollar_num = max_digit_dollar_num(node)
+          return max_digit_dollar_num if max_digit_dollar_num &&
+                                         max_digit_dollar_num.nonzero?
+
           node
             .source
             .scan(FIELD_REGEX)
             .reject { |x| x.first == PERCENT_PERCENT }
             .reduce(0) { |acc, elem| acc + arguments_count(elem[2]) }
+        end
+
+        def max_digit_dollar_num(node)
+          node.source.scan(DIGIT_DOLLAR_FLAG).map do |digit_dollar_num|
+            digit_dollar_num.first.to_i
+          end.max
         end
 
         # number of arguments required for the format sequence

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -146,6 +146,25 @@ RSpec.describe RuboCop::Cop::Lint::FormatParameterMismatch do
     end
   end
 
+  context 'when using (digit)$ flag' do
+    it 'does not register an offense' do
+      expect_no_offenses("format('%1$s %2$s', 'foo', 'bar')")
+    end
+
+    it 'does not register an offense when match between the maximum value ' \
+       'specified by (digit)$ flag and the number of arguments' do
+      expect_no_offenses("format('%1$s %1$s', 'foo')")
+    end
+
+    it 'registers an offense when mismatch between the maximum value ' \
+       'specified by (digit)$ flag and the number of arguments' do
+      expect_offense(<<-RUBY.strip_indent)
+        format('%1$s %2$s', 'foo', 'bar', 'baz')
+        ^^^^^^ Number of arguments (3) to `format` doesn't match the number of fields (2).
+      RUBY
+    end
+  end
+
   context 'when format is not a string literal' do
     it 'does not register an offense' do
       expect_no_offenses('puts str % [1, 2]')


### PR DESCRIPTION
Fixes #6482.

This PR fixes a false positive for `Lint/FormatParameterMismatch` when using (digit)$ flag.

```ruby
format('%1$s %1$s', 'foo')
```

The following an explanation about (digit)$ flag written in the document.

> Specifies the absolute argument number for this field.
> Absolute and relative argument numbers cannot be mixed in a
> sprintf string.

https://ruby-doc.org/core-2.5.3/Kernel.html#method-i-sprintf

This PR adds a check on the maximum value specified by (digit)$ and the number of arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
