### PR TITLE
Fix a false negative for `Layout/IndentationWidth`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#3301](https://github.com/rubocop-hq/rubocop/issues/3301): Don't suggest or make semantic changes to the code in `Style/InfiniteLoop`. ([@jonas054][])
 * [#3586](https://github.com/rubocop-hq/rubocop/issues/3586): Handle single argument spanning multiple lines in `Style/TrailingCommaInArguments`. ([@jonas054][])
 * [#6478](https://github.com/rubocop-hq/rubocop/pull/6478): Fix EmacsComment#encoding to match the `coding` variable. ([@akihiro17][])
+* [#6449](https://github.com/rubocop-hq/rubocop/pull/6449): Fix a false negative for `Layout/IndentationWidth` when setting `EnforcedStyle: rails` of `Layout/IndentationConsistency` and method definition indented to access modifier in a singleton class. ([@koic][])
 
 ## 0.60.0 (2018-10-26)
 

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -96,6 +96,12 @@ module RuboCop
           check_members(node.loc.keyword, members)
         end
 
+        def on_sclass(node)
+          _class_name, *members = *node
+
+          check_members(node.loc.keyword, members)
+        end
+
         def on_send(node)
           super
           return unless node.adjacent_def_modifier?

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -1107,6 +1107,32 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
             .to eq(['Use 2 (not 0) spaces for rails indentation.'] * 2)
           expect(cop.offenses.map(&:line)).to eq([9, 14])
         end
+
+        it 'registers an offense for normal non-rails indentation ' \
+           'when defined in a singleton class' do
+          inspect_source(<<-RUBY.strip_indent)
+            class << self
+              public
+
+              def e
+              end
+
+              protected
+
+              def f
+              end
+
+              private
+
+              def g
+              end
+            end
+          RUBY
+
+          expect(cop.messages)
+            .to eq(['Use 2 (not 0) spaces for rails indentation.'] * 2)
+          expect(cop.offenses.map(&:line)).to eq([9, 14])
+        end
       end
     end
 


### PR DESCRIPTION
Reopen #6449.

This PR fixes a false negative for `Layout/IndentationWidth` when setting `EnforcedStyle: rails` of `Layout/IndentationConsistency` and method definition indented to access modifier in a singleton class.

The following is an example.

```console
% rubocop -V
0.60.0 (using Parser 2.5.3.0, running on ruby 2.6.0 x86_64-darwin17)

% cat .rubocop.yml
Layout/IndentationConsistency:
  EnforcedStyle: rails

% cat example.rb
class << self
  private

  def do_something
    puts 'hi'
  end
end
```

## Before

```console
% rubocop --only Layout/IndentationWidth
Inspecting 1 file
.

1 file inspected, no offenses detected
```

## After

```console
% rubocop --only Layout/IndentationWidth
Inspecting 1 file
C

Offenses:

example.rb:4:3: C: Layout/IndentationWidth: Use 2 (not 0) spaces for rails indentation.
  def do_something

1 file inspected, 1 offense detected

% rubocop --only Layout/IndentationWidth -a
Inspecting 1 file
C

Offenses:

example.rb:4:3: C: [Corrected] Layout/IndentationWidth: Use 2 (not 0) spaces for rails indentation.
  def do_something

1 file inspected, 1 offense detected, 1 offense corrected

% cat example.rb
class << self
  private

    def do_something
      puts 'hi'
    end
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
