### PR TITLE
Fix delete unnecessary code in cli.rb

### DIFF
--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -79,7 +79,6 @@ module RuboCop
             run_line_length_cop_auto_gen_config(paths)
           else
             puts Rainbow(SKIPPED_PHASE_1).yellow
-            ''
           end
         run_all_cops_auto_gen_config(line_length_contents, paths)
       else
@@ -233,7 +232,6 @@ module RuboCop
         puts '# Supports --auto-correct' if cop.new.support_autocorrect?
         puts "#{cop.cop_name}:"
         puts config_lines(cop)
-        puts
       end
     end
 


### PR DESCRIPTION
This Pull Request is refactoring of lib/rubocop/cli.rb

* Delete unnecessary return value ''
* Delete unnecessary puts

Only refactoring, so it should be safe to change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
