### PR TITLE
[Fix #6489] Fix an error for `Style/UnneededCondition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Don't show "unrecognized parameter" warning for `inherit_mode` parameter to individual cop configurations. ([@maxh][])
 * [#6449](https://github.com/rubocop-hq/rubocop/pull/6449): Fix a false negative for `Layout/IndentationWidth` when setting `EnforcedStyle: rails` of `Layout/IndentationConsistency` and method definition indented to access modifier in a singleton class. ([@koic][])
 * [#6482](https://github.com/rubocop-hq/rubocop/issues/6482): Fix a false positive for `Lint/FormatParameterMismatch` when using (digit)$ flag. ([@koic][])
+* [#6489](https://github.com/rubocop-hq/rubocop/issues/6489): Fix an error for `Style/UnneededCondition` when `if` condition and `then` branch are the same and it has no `else` branch. ([@koic][])
 
 ## 0.60.0 (2018-10-26)
 

--- a/lib/rubocop/cop/style/unneeded_condition.rb
+++ b/lib/rubocop/cop/style/unneeded_condition.rb
@@ -47,7 +47,7 @@ module RuboCop
           lambda do |corrector|
             if node.ternary?
               corrector.replace(range_of_offense(node), '||')
-            elsif node.modifier_form?
+            elsif node.modifier_form? || !node.else_branch
               corrector.replace(node.source_range, node.if_branch.source)
             else
               corrected = make_ternary_form(node)
@@ -60,7 +60,7 @@ module RuboCop
         private
 
         def message(node)
-          if node.modifier_form?
+          if node.modifier_form? || !node.else_branch
             UNNEEDED_CONDITION
           else
             MSG

--- a/spec/rubocop/cop/style/unneeded_condition_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_condition_spec.rb
@@ -73,6 +73,18 @@ RSpec.describe RuboCop::Cop::Style::UnneededCondition do
         end
       end
 
+      context 'when `if` condition and `then` branch are the same ' \
+              'and it has no `else` branch' do
+        it 'registers an offense' do
+          expect_offense(<<-RUBY.strip_indent)
+            if do_something
+            ^^^^^^^^^^^^^^^ This condition is not needed.
+              do_something
+            end
+          RUBY
+        end
+      end
+
       context 'when using ternary if in `else` branch' do
         it 'registers no offense' do
           expect_no_offenses(<<-RUBY.strip_indent)
@@ -159,6 +171,19 @@ RSpec.describe RuboCop::Cop::Style::UnneededCondition do
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           ary << (foo || bar)
+        RUBY
+      end
+
+      it 'when `if` condition and `then` branch are the same ' \
+         'and it has no `else` branch' do
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+          if do_something
+            do_something
+          end
+        RUBY
+
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          do_something
         RUBY
       end
     end


### PR DESCRIPTION
Fixes #6489.

This PR fixes an error for `Style/UnneededCondition` when `if` condition and `then` branch are the same and it has no `else` branch. The following is an error case.

```ruby
# example.rb
if 1
  1
end
```

The following is a reproduction step.

```console
% rubocop -V
0.60.0 (using Parser 2.5.3.0, running on ruby 2.5.3 x86_64-darwin17)

% rubocop example.rb --only Style/UnneededCondition -a
Inspecting 1 file

0 files inspected, no offenses detected
undefined method `basic_conditional?' for nil:NilClass
/Users/koic/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rubocop-0.60.0/lib/rubocop/cop/style/unneeded_condition.rb:94:in
`else_source'
/Users/koic/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rubocop-0.60.0/lib/rubocop/cop/style/unneeded_condition.rb:100:in
`make_ternary_form'
/Users/koic/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rubocop-0.60.0/lib/rubocop/cop/style/unneeded_condition.rb:53:in
`block in autocorrect'

(snip)
```

And this PR will change the following offense message.

## Before

```console
% rubocop example.rb --only Style/UnneededCondition
Inspecting 1 file
C

Offenses:

example.rb:1:1: C: Style/UnneededCondition: Use double pipes || instead.
if 1 ...
^^^^

1 file inspected, 1 offense detected
```

## After

```console
% rubocop example.rb --only Style/UnneededCondition
Inspecting 1 file
C

Offenses:

example.rb:1:1: C: Style/UnneededCondition: This condition is not needed.
if 1 ...
^^^^

1 file inspected, 1 offense detected
```

The auto-correct behaves as follows.

```console
% rubocop example.rb --only Style/UnneededCondition -a
Inspecting 1 file
C

Offenses:

example.rb:1:1: C: [Corrected] Style/UnneededCondition: This condition is not needed.
if 1 ...
^^^^

1 file inspected, 1 offense detected, 1 offense corrected

% cat example.rb
1
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
