### PR TITLE
[#6492] Auto-correct chunks of comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 * [#6449](https://github.com/rubocop-hq/rubocop/pull/6449): Fix a false negative for `Layout/IndentationWidth` when setting `EnforcedStyle: rails` of `Layout/IndentationConsistency` and method definition indented to access modifier in a singleton class. ([@koic][])
 * [#6482](https://github.com/rubocop-hq/rubocop/issues/6482): Fix a false positive for `Lint/FormatParameterMismatch` when using (digit)$ flag. ([@koic][])
 
+### Changes
+
+* [#6492](https://github.com/rubocop-hq/rubocop/issues/6492): Auto-correct chunks of comment lines in `Layout/CommentIndentation` to avoid unnecessary iterations for `rubocop -a`. ([@jonas054][])
+
 ## 0.60.0 (2018-10-26)
 
 ### New features

--- a/spec/rubocop/cop/layout/comment_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/comment_indentation_spec.rb
@@ -143,6 +143,8 @@ RSpec.describe RuboCop::Cop::Layout::CommentIndentation do
   it 'auto-corrects' do
     new_source = autocorrect_source(<<-RUBY.strip_indent)
        # comment
+       # comment
+       # comment
       hash1 = { a: 0,
            # comment
                 bb: 1,
@@ -168,6 +170,8 @@ RSpec.describe RuboCop::Cop::Layout::CommentIndentation do
         end
     RUBY
     expect(new_source).to eq(<<-RUBY.strip_indent)
+      # comment
+      # comment
       # comment
       hash1 = { a: 0,
                 # comment


### PR DESCRIPTION
One common reason for `rubocop -a` to be slow is that individual corrections create new offenses for the next iteration of the inspect/autocorrect loop. Perhaps the worst problem is posed by `Layout/CommentIndentation` when it fixes only the last comment line in a large multi-line inline comment. Then we must go through the loop as many times as there are lines in that multi-line comment.

This change improves the situation a lot, but I think it's too early to close the issue. More improvements can probably be made before we're satisfied.