### PR TITLE
Shorten error message in case of spec failure

### DIFF
--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -84,7 +84,9 @@ RSpec.describe 'RuboCop Project', type: :feature do
     it 'has link definitions for all implicit links' do
       implicit_link_names = changelog.scan(/\[([^\]]+)\]\[\]/).flatten.uniq
       implicit_link_names.each do |name|
-        expect(changelog).to include("[#{name}]: http")
+        expect(changelog.include?("[#{name}]: http"))
+          .to be(true), "CHANGELOG.md is missing a link for #{name}. " \
+                        'Please add this link to the bottom of the file.'
       end
     end
 


### PR DESCRIPTION
Just a small tweak to one test; no functional change at all.

I suggest this improvement after recently triggering this test failure in [this commit](https://github.com/rubocop-hq/rubocop/pull/6343/commits/1f5e577a5beba23c93235fe849d2ec670c0a2022).

You can see the error message [here](https://circleci.com/gh/rubocop-hq/rubocop/19403?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)... Or more to the point, you **can't** see the error message, because it prints out the entire `CHANGELOG.md` (which is now a huge file!) and therefore the one useful thing you need to see is hidden by CircleCI; you need to "download the full error log" to actually read it.

This change, although making the test format a little unconventional, shortens the error message to _**one** line_, rather than _**3657+** lines_.

