### PR TITLE
Fix rubydoc.info links

### DIFF
--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -24,7 +24,7 @@ module RuboCop
       # @return [Parser::Source::Range]
       #   the location where the violation is detected.
       #
-      # @see https://www.rubydoc.info/github/whitequark/parser/Parser/Source/Range
+      # @see https://www.rubydoc.info/gems/parser/Parser/Source/Range
       #   Parser::Source::Range
       attr_reader :location
 

--- a/manual/extensions.md
+++ b/manual/extensions.md
@@ -55,7 +55,7 @@ Please see the documents below for more formatter API details.
 
 * [RuboCop::Formatter::BaseFormatter](https://www.rubydoc.info/gems/rubocop/RuboCop/Formatter/BaseFormatter)
 * [RuboCop::Cop::Offense](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Offense)
-* [Parser::Source::Range](https://www.rubydoc.info/github/whitequark/parser/Parser/Source/Range)
+* [Parser::Source::Range](https://www.rubydoc.info/gems/parser/Parser/Source/Range)
 
 #### Using a Custom Formatter from the Command Line
 

--- a/manual/node_pattern.md
+++ b/manual/node_pattern.md
@@ -191,8 +191,8 @@ We can use the `#prime?` method directly in the expression:
 
 The RuboCop base includes two useful methods to use the node pattern with Ruby in a
 simple way. You can use the macros to define methods. The basics are
-[def_node_matcher](http://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/NodePattern/Macros#def_node_matcher-instance_method)
-and [def_node_search](http://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/NodePattern/Macros#def_node_search-instance_method).
+[def_node_matcher](https://www.rubydoc.info/gems/rubocop/RuboCop/NodePattern/Macros#def_node_matcher-instance_method)
+and [def_node_search](https://www.rubydoc.info/gems/rubocop/RuboCop/NodePattern/Macros#def_node_search-instance_method).
 
 When you define a pattern, it creates a method that accepts a node and tries to match.
 
@@ -286,7 +286,7 @@ matched with an expression like:
 Curious about how it works?
 
 Check more details in the
-[documentation](http://www.rubydoc.info/gems/rubocop/RuboCop/NodePattern)
+[documentation](https://www.rubydoc.info/gems/rubocop/RuboCop/NodePattern)
 or browse the [source code](https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/node_pattern.rb)
 directly. It's easy to read and hack on.
 


### PR DESCRIPTION
* Instead of linking to a "github/bbatsov/RuboCop" path, use "gems/rubocop".
* Instead of linking to a "github/whitequark/parser" path, use "gems/parser".
* Use https instead of http.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
