### PR TITLE
Fix NoMethodError for `Style/FrozenStringLiteralComment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#6449](https://github.com/rubocop-hq/rubocop/pull/6449): Fix a false negative for `Layout/IndentationWidth` when setting `EnforcedStyle: rails` of `Layout/IndentationConsistency` and method definition indented to access modifier in a singleton class. ([@koic][])
 * [#6482](https://github.com/rubocop-hq/rubocop/issues/6482): Fix a false positive for `Lint/FormatParameterMismatch` when using (digit)$ flag. ([@koic][])
 * [#6489](https://github.com/rubocop-hq/rubocop/issues/6489): Fix an error for `Style/UnneededCondition` when `if` condition and `then` branch are the same and it has no `else` branch. ([@koic][])
+* Fix NoMethodError for `Style/FrozenStringLiteral` when a file contains only a shebang. ([@takaram][])
 
 ### Changes
 
@@ -3660,3 +3661,4 @@
 [@DiscoStarslayer]: https://github.com/DiscoStarslayer
 [@itsWill]: https://github.com/itsWill
 [@xlts]: https://github.com/xlts
+[@takaram]: https://github.com/takaram

--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -101,9 +101,9 @@ module RuboCop
             token_number += 1
           end
 
-          if processed_source.tokens[token_number].text =~
-             Encoding::ENCODING_PATTERN
-            token = processed_source.tokens[token_number]
+          next_token = processed_source.tokens[token_number]
+          if next_token && next_token.text =~ Encoding::ENCODING_PATTERN
+            token = next_token
           end
 
           token
@@ -155,7 +155,9 @@ module RuboCop
 
         def proceeding_comment
           last_special_comment = last_special_comment(processed_source)
-          if processed_source.following_line(last_special_comment).empty?
+          following_line = processed_source.following_line(last_special_comment)
+
+          if following_line && following_line.empty?
             "\n#{FROZEN_STRING_LITERAL_ENABLED}"
           else
             "\n#{FROZEN_STRING_LITERAL_ENABLED}\n"

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -148,6 +148,14 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
       RUBY
     end
 
+    it 'registers an offence for not having a frozen string literal comment ' \
+       'when there is only a shebang' do
+      expect_offense(<<-RUBY.strip_indent)
+        #!/usr/bin/env ruby
+        ^ Missing magic comment `# frozen_string_literal: true`.
+      RUBY
+    end
+
     context 'auto-correct' do
       it 'adds a frozen string literal comment to the first line if one is ' \
          'missing' do
@@ -252,6 +260,18 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
           # frozen_string_literal: true
 
           puts 1
+        RUBY
+      end
+
+      it 'adds a frozen string literal comment after a shebang when there is ' \
+         'only a shebang' do
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+          #!/usr/bin/env ruby
+        RUBY
+
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          #!/usr/bin/env ruby
+          # frozen_string_literal: true
         RUBY
       end
     end


### PR DESCRIPTION
This PR fixes an error for `Style/FrozenStringLiteralComment` when a file
contains only a shebang.

This is the reproduction step.

```ShellSession
$ cat shebang.rb
#!/usr/bin/env ruby

$ rubocop shebang.rb
Inspecting 1 file
An error occurred while Style/FrozenStringLiteralComment cop was inspecting /home/takuya/scripts/shebang.rb.
To see the complete backtrace run rubocop -d.
.

1 file inspected, no offenses detected

1 error occurred:
An error occurred while Style/FrozenStringLiteralComment cop was inspecting /home/takuya/scripts/shebang.rb.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop-hq/rubocop/issues

Mention the following information in the issue report:
0.60.0 (using Parser 2.5.1.2, running on ruby 2.5.0 x86_64-linux)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
