### PR TITLE
Edge cases in Style/MethodCallWithArgsParentheses

### DIFF
--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -215,6 +215,7 @@ module RuboCop
           node.implicit_call? ||
             call_in_arguments_or_literals?(node) ||
             call_with_braced_block?(node) ||
+            call_with_splats?(node) ||
             call_in_logical_operators?(node) ||
             allowed_multiline_call_with_parentheses?(node) ||
             allowed_chained_call_with_parentheses?(node)
@@ -222,6 +223,10 @@ module RuboCop
 
         def call_with_braced_block?(node)
           node.block_node && node.block_node.braces?
+        end
+
+        def call_with_splats?(node)
+          node.descendants.any? { |n| n.splat_type? || n.kwsplat_type? }
         end
 
         def call_in_logical_operators?(node)

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -157,6 +157,7 @@ module RuboCop
 
         def add_offense_for_omit_parentheses(node)
           return unless node.parenthesized?
+          return if super_call_without_arguments?(node)
           return if eligible_for_parentheses_presence?(node)
 
           add_offense(node, location: node.loc.begin.join(node.loc.end))
@@ -209,6 +210,10 @@ module RuboCop
 
           first_node = node.arguments.first
           first_node.begin_type? && first_node.parenthesized_call?
+        end
+
+        def super_call_without_arguments?(node)
+          node.super_type? && node.arguments.none?
         end
 
         def eligible_for_parentheses_presence?(node)

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -111,6 +111,10 @@ module RuboCop
         include IgnoredMethods
 
         TRAILING_WHITESPACE_REGEX = /\s+\Z/.freeze
+        LOGICAL_OPERATOR_CHECK = lambda do |node|
+          node.parent.respond_to?(:logical_operator?) &&
+            node.parent.logical_operator?
+        end
 
         def on_send(node)
           case style
@@ -170,7 +174,7 @@ module RuboCop
 
         def autocorrect_for_omit_parentheses(node)
           lambda do |corrector|
-            if parentheses_at_end_of_multiline?(node)
+            if parentheses_at_the_end_of_multiline_call?(node)
               corrector.replace(args_begin(node), ' \\')
             else
               corrector.replace(args_begin(node), ' ')
@@ -211,12 +215,19 @@ module RuboCop
           node.implicit_call? ||
             call_in_arguments_or_literals?(node) ||
             call_with_braced_block?(node) ||
+            call_in_logical_operators?(node) ||
             allowed_multiline_call_with_parentheses?(node) ||
             allowed_chained_call_with_parentheses?(node)
         end
 
         def call_with_braced_block?(node)
           node.block_node && node.block_node.braces?
+        end
+
+        def call_in_logical_operators?(node)
+          node.descendants.any?(&LOGICAL_OPERATOR_CHECK) || (node.parent &&
+            (LOGICAL_OPERATOR_CHECK.call(node.parent) ||
+             node.parent.descendants.any?(&LOGICAL_OPERATOR_CHECK)))
         end
 
         def allowed_multiline_call_with_parentheses?(node)
@@ -235,7 +246,7 @@ module RuboCop
              node.parent.array_type?)
         end
 
-        def parentheses_at_end_of_multiline?(node)
+        def parentheses_at_the_end_of_multiline_call?(node)
           node.multiline? &&
             node.loc.begin.source_line
                 .gsub(TRAILING_WHITESPACE_REGEX, '')

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -388,6 +388,10 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       expect_no_offenses('foo &block')
     end
 
+    it 'accepts super with parentheses' do
+      expect_no_offenses('super()')
+    end
+
     it 'auto-corrects single-line calls' do
       original = <<-RUBY.strip_indent
         top.test(1, 2, foo: bar(3))

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -370,10 +370,17 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       expect_no_offenses('foo(a) || bar(b)')
     end
 
-    it 'accepts parens in calls with arguments with logical operators' do
+    it 'accepts parens in calls with args with logical operators' do
       expect_no_offenses('foo(a, b || c)')
       expect_no_offenses('foo a, b || c')
       expect_no_offenses('foo a, b(1) || c(2, d(3))')
+    end
+
+    it 'accepts parens in args splat' do
+      expect_no_offenses('foo(*args)')
+      expect_no_offenses('foo *args')
+      expect_no_offenses('foo(**kwargs)')
+      expect_no_offenses('foo **kwargs')
     end
 
     it 'auto-corrects single-line calls' do

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -271,7 +271,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
     end
   end
 
-  context 'when EnforcedStyle is omit' do
+  context 'when EnforcedStyle is omit_parentheses' do
     let(:cop_config) do
       { 'EnforcedStyle' => 'omit_parentheses' }
     end
@@ -363,6 +363,17 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
 
     it 'accepts parens in blocks with braces' do
       expect_no_offenses('foo(1) { 2 }')
+    end
+
+    it 'accepts parens in calls with logical operators' do
+      expect_no_offenses('foo(a) && bar(b)')
+      expect_no_offenses('foo(a) || bar(b)')
+    end
+
+    it 'accepts parens in calls with arguments with logical operators' do
+      expect_no_offenses('foo(a, b || c)')
+      expect_no_offenses('foo a, b || c')
+      expect_no_offenses('foo a, b(1) || c(2, d(3))')
     end
 
     it 'auto-corrects single-line calls' do

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -383,6 +383,11 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       expect_no_offenses('foo **kwargs')
     end
 
+    it 'accepts parens in implicit #to_proc' do
+      expect_no_offenses('foo(&block)')
+      expect_no_offenses('foo &block')
+    end
+
     it 'auto-corrects single-line calls' do
       original = <<-RUBY.strip_indent
         top.test(1, 2, foo: bar(3))


### PR DESCRIPTION
This change covers a few edge case for the newly introduced alternative style of `omit_parentheses` for the `Style/MethodCallWithArgsParentheses` cop that enforces the parentheses omission method calls style.

1. Allow parentheses in method calls with logical operators.
2. Allow parentheses in `method_call(*args)`.
3. Allow parentheses in `method_call(&block)`.
4. Allow parentheses in `super()`.