### PR TITLE
Refactor and add missing test case for TrailingComma mixin

### DIFF
--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -98,7 +98,7 @@ module RuboCop
         items = elements(node).map(&:source_range)
         return false if items.empty?
 
-        return false if single_argument_not_multiline?(items, node)
+        return false if allowed_multiline_argument?(items, node)
 
         items << node.loc.begin << node.loc.end
         (items.map(&:first_line) + items.map(&:last_line)).uniq.size > 1
@@ -107,8 +107,8 @@ module RuboCop
       # A single argument with the closing bracket on the same line as the end
       # of the argument is not considered multiline, even if the argument
       # itself might span multiple lines.
-      def single_argument_not_multiline?(items, node)
-        items.size == 1 && !Util.begins_its_line?(node.loc.end)
+      def allowed_multiline_argument?(items, node)
+        items.one? && !Util.begins_its_line?(node.loc.end)
       end
 
       def elements(node)

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -89,40 +89,27 @@ module RuboCop
       # on different lines, each item within is on its own line, and the
       # closing bracket is on its own line.
       def multiline?(node)
-        # No need to process anything if the whole node is not multiline
-        # Without the 2nd check, Foo.new({}) is considered multiline, which
-        # it should not be. Essentially, if there are no elements, the
-        # expression can not be multiline.
-        return false unless node.multiline?
-
-        items = elements(node).map(&:source_range)
-        return false if items.empty?
-
-        return false if allowed_multiline_argument?(items, node)
-
-        items << node.loc.begin << node.loc.end
-        (items.map(&:first_line) + items.map(&:last_line)).uniq.size > 1
+        node.multiline? && !allowed_multiline_argument?(node)
       end
 
       # A single argument with the closing bracket on the same line as the end
       # of the argument is not considered multiline, even if the argument
       # itself might span multiple lines.
-      def allowed_multiline_argument?(items, node)
-        items.one? && !Util.begins_its_line?(node.loc.end)
+      def allowed_multiline_argument?(node)
+        elements(node).one? && !Util.begins_its_line?(node.loc.end)
       end
 
       def elements(node)
         return node.children unless node.send_type?
 
-        _receiver, _method_name, *args = *node
-        args.flat_map do |a|
+        node.arguments.flat_map do |argument|
           # For each argument, if it is a multi-line hash without braces,
           # then promote the hash elements to method arguments
           # for the purpose of determining multi-line-ness.
-          if a.hash_type? && a.multiline? && !a.braces?
-            a.children
+          if argument.hash_type? && argument.multiline? && !argument.braces?
+            argument.children
           else
-            a
+            argument
           end
         end
       end

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -212,8 +212,8 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'accepts an empty hash being passed as a method argument' do
         expect_no_offenses(<<-RUBY.strip_indent)
-          Foo.new([
-                   ])
+          Foo.new({
+                   })
         RUBY
       end
 
@@ -373,6 +373,13 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
           method(
             1, 2,
           )
+        RUBY
+      end
+
+      it 'accepts a multiline call with single argument on multiple lines' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          method(a:
+                    "foo")
         RUBY
       end
     end


### PR DESCRIPTION
I was working on something else, and came across [this line of code](https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/mixin/trailing_comma.rb#L101) in `Mixin/TrailingComma`.

It didn't seem to be doing anything, and removing it still passed all the tests. However, the comment allowed me to reverse engineer the edge cases that this line covers, so I added a unit test for it.

After doing that, I poked around a bit in the method, and it started to untangle, resulting in a much simpler implementation that still passes all the tests.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
