### PR TITLE
[Fix #6509] Fix an incorrect auto-correct for `Style/RaiseArgs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#6482](https://github.com/rubocop-hq/rubocop/issues/6482): Fix a false positive for `Lint/FormatParameterMismatch` when using (digit)$ flag. ([@koic][])
 * [#6489](https://github.com/rubocop-hq/rubocop/issues/6489): Fix an error for `Style/UnneededCondition` when `if` condition and `then` branch are the same and it has no `else` branch. ([@koic][])
 * Fix NoMethodError for `Style/FrozenStringLiteral` when a file contains only a shebang. ([@takaram][])
+* [#6509](https://github.com/rubocop-hq/rubocop/issues/6509): Fix an incorrect auto-correct for `Style/RaiseArgs` when an exception object is assigned to a local variable. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/raise_args.rb
+++ b/lib/rubocop/cop/style/raise_args.rb
@@ -68,7 +68,7 @@ module RuboCop
 
           message = message_node && message_node.source
 
-          correction = exception_node.const_name.to_s
+          correction = exception_node.source
           correction = "#{correction}, #{message}" if message
 
           "#{node.method_name} #{correction}"

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -143,6 +143,24 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
       end
     end
 
+    context 'when an exception object is assigned to a local variable' do
+      it 'auto-corrects to exploded style' do
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+          def do_something
+            klass = RuntimeError
+            raise klass.new('hi')
+          end
+        RUBY
+
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          def do_something
+            klass = RuntimeError
+            raise klass, 'hi'
+          end
+        RUBY
+      end
+    end
+
     it 'accepts exception constructor with more than 1 argument' do
       expect_no_offenses('raise MyCustomError.new(a1, a2, a3)')
     end


### PR DESCRIPTION
Fixes #6509.

This PR fixes an incorrect auto-correct for `Style/RaiseArgs` when an exception object is assigned to a local variable.

The following is an issue example.

```console
% rubocop -V
0.60.0 (using Parser 2.5.3.0, running on ruby 2.5.3 x86_64-darwin17)
% cat example.rb
def do_something
  klass = RuntimeError
  raise klass.new('hi')
end
```

## Before

```console
% rubocop -a example.rb --only Style/RaiseArgs
(snip)
% cat example.rb
def do_something
  klass = RuntimeError
  raise , 'hi'
end
```

## After

```console
% rubocop -a example.rb --only Style/RaiseArgs
(snip)
% cat example.rb
def do_something
  klass = RuntimeError
  raise klass, 'hi'
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
