### PR TITLE
UselessSetterCall gets erroneously triggered

### DIFF
--- a/spec/rubocop/cop/lint/useless_setter_call_spec.rb
+++ b/spec/rubocop/cop/lint/useless_setter_call_spec.rb
@@ -175,6 +175,30 @@ RSpec.describe RuboCop::Cop::Lint::UselessSetterCall do
     end
   end
 
+  context 'when a lvar may contain a non-local object' do
+    it 'accepts' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def test
+          some_lvar = Foo.shared_object
+          some_lvar = {} if some_lvar.nil?
+          some_lvar.attr = 1
+        end
+      RUBY
+    end
+  end
+
+  context 'when a lvar contains an object assgined to a non-local object' do
+    it 'accepts' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def test
+          some_lvar = {}
+          Foo.shared_object = some_lvar
+          some_lvar[:attr] = 1
+        end
+      RUBY
+    end
+  end
+
   it 'is not confused by operators ending with =' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def test


### PR DESCRIPTION
There are several cases that will trigger `Lint/UselessSetterCall` when mutating a non-local object.

I haven't had a crack at fixing it yet, but I've added two failing specs.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
