### PR TITLE
[Fix #6519] Allow Style/BlockComments with apiDoc documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 ### Changes
 
 * [#6492](https://github.com/rubocop-hq/rubocop/issues/6492): Auto-correct chunks of comment lines in `Layout/CommentIndentation` to avoid unnecessary iterations for `rubocop -a`. ([@jonas054][])
+* [#6519](https://github.com/rubocop-hq/rubocop/issues/6519): Allow `Style/BlockComments` with apiDoc documentation. ([@anthony-robin][])
 
 ## 0.60.0 (2018-10-26)
 

--- a/lib/rubocop/cop/style/block_comments.rb
+++ b/lib/rubocop/cop/style/block_comments.rb
@@ -16,16 +16,20 @@ module RuboCop
       #   # Multiple lines
       #   # of comments...
       #
+      #   =begin
+      #   @api {get} / my endpoint description
+      #   =end
       class BlockComments < Cop
         include RangeHelp
 
         MSG = 'Do not use block comments.'.freeze
         BEGIN_LENGTH = "=begin\n".length
         END_LENGTH = "\n=end".length
+        APIDOC_PATTERN = '@api'.freeze
 
         def investigate(processed_source)
           processed_source.each_comment do |comment|
-            next unless comment.document?
+            next if !comment.document? || apidoc?(comment)
 
             add_offense(comment)
           end
@@ -55,6 +59,10 @@ module RuboCop
           eq_end = range_between(expr.end_pos - END_LENGTH, expr.end_pos)
           contents = range_between(eq_begin.end_pos, eq_end.begin_pos)
           [eq_begin, eq_end, contents]
+        end
+
+        def apidoc?(comment)
+          comment.text.include? APIDOC_PATTERN
         end
       end
     end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -341,6 +341,10 @@ of comments...
 # good
 # Multiple lines
 # of comments...
+
+=begin
+@api {get} / my endpoint description
+=end
 ```
 
 ### References

--- a/spec/rubocop/cop/style/block_comments_spec.rb
+++ b/spec/rubocop/cop/style/block_comments_spec.rb
@@ -16,6 +16,20 @@ RSpec.describe RuboCop::Cop::Style::BlockComments do
     expect_no_offenses('# comment')
   end
 
+  it 'accepts apiDoc related comments' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      =begin
+      @api {get} / my endpoint description
+      ...
+      =end
+
+      =begin
+      @apiDefine UserNotFound
+      ...
+      =end
+    RUBY
+  end
+
   it 'auto-corrects a block comment into a regular comment' do
     new_source = autocorrect_source(<<-RUBY.strip_indent)
       =begin


### PR DESCRIPTION
[apiDoc][1] is a nice and very popular library to write documentation and it handles ruby project
in a clean way.

However, the library [force us][2] to use the block comments to define the documentation until
they handle regular comments.

Removing offense for this particular case will avoid disabling completely the cop which would
prevent the code to another unwanted `=begin / =end` comments.

```ruby
=begin
@api {get} / my endpoint description
=end

=begin
@apiDefine MySharedDocumentation
=end
```

[1]: http://apidocjs.com/
[2]: https://github.com/apidoc/apidoc/issues/620