### PR TITLE
A bit more edge cases for Style/MethodCallWithArgsParentheses

### DIFF
--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -153,7 +153,9 @@ module RuboCop
 
         def add_offense_for_omit_parentheses(node)
           return unless node.parenthesized?
+          return if node.implicit_call?
           return if super_call_without_arguments?(node)
+          return if camel_case_method_call_without_arguments?(node)
           return if eligible_for_parentheses_presence?(node)
 
           add_offense(node, location: node.loc.begin.join(node.loc.end))
@@ -212,9 +214,12 @@ module RuboCop
           node.super_type? && node.arguments.none?
         end
 
+        def camel_case_method_call_without_arguments?(node)
+          node.camel_case_method? && node.arguments.none?
+        end
+
         def eligible_for_parentheses_presence?(node)
-          node.implicit_call? ||
-            call_in_literals?(node) ||
+          call_in_literals?(node) ||
             call_with_ambiguous_arguments?(node) ||
             call_in_logical_operators?(node) ||
             allowed_multiline_call_with_parentheses?(node) ||

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -227,8 +227,7 @@ module RuboCop
 
         def call_in_arguments_or_literals?(node)
           node.parent &&
-            (node.parent.send_type? ||
-             node.parent.pair_type? ||
+            (node.parent.pair_type? ||
              node.parent.array_type?)
         end
 
@@ -250,8 +249,9 @@ module RuboCop
         end
 
         def allowed_chained_call_with_parentheses?(node)
-          cop_config['AllowParenthesesInChaining'] &&
-            node.descendants.first && node.descendants.first.send_type?
+          (node.parent && node.parent.send_type?) ||
+            cop_config['AllowParenthesesInChaining'] &&
+              node.descendants.first && node.descendants.first.send_type?
         end
 
         def parentheses_at_the_end_of_multiline_call?(node)

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -388,8 +388,20 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       expect_no_offenses('foo &block')
     end
 
-    it 'accepts super with parentheses' do
+    it 'accepts parens in super without args' do
       expect_no_offenses('super()')
+    end
+
+    it 'accepts parens in ternary condition calls' do
+      expect_no_offenses(<<-RUBY)
+        foo.include?(bar) ? bar : quux
+      RUBY
+    end
+
+    it 'accepts parens in args with ternary conditions' do
+      expect_no_offenses(<<-RUBY)
+        foo.include?(bar ? baz : quux)
+      RUBY
     end
 
     it 'auto-corrects single-line calls' do

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -283,13 +283,6 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
-    it 'register an offense for methods starting with capital letter' do
-      expect_offense(<<-RUBY.strip_indent)
-        Test()
-            ^^ Omit parentheses for method calls with arguments.
-      RUBY
-    end
-
     it 'register an offense for multi-line method calls' do
       expect_offense(<<-RUBY.strip_indent)
         test(
@@ -390,6 +383,10 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
 
     it 'accepts parens in super without args' do
       expect_no_offenses('super()')
+    end
+
+    it 'accepts parens in camel case method without args' do
+      expect_no_offenses('Array()')
     end
 
     it 'accepts parens in ternary condition calls' do

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -317,12 +317,19 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
-    it 'register an offense accepts parens in do-end blocks' do
+    it 'register an offense for parens in do-end blocks' do
       expect_offense(<<-RUBY.strip_indent)
         foo(:arg) do
            ^^^^^^ Omit parentheses for method calls with arguments.
           bar
         end
+      RUBY
+    end
+
+    it 'register an offense for hashes in keyword values' do
+      expect_offense(<<-RUBY.strip_indent)
+        method_call(hash: {foo: :bar})
+                   ^^^^^^^^^^^^^^^^^^^ Omit parentheses for method calls with arguments.
       RUBY
     end
 
@@ -340,6 +347,12 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
 
     it 'accepts parens in nested method args' do
       expect_no_offenses('top.test 1, 2, foo: [bar(3)]')
+    end
+
+    it 'accepts parens in calls with hash as arg' do
+      expect_no_offenses('top.test({foo: :bar})')
+      expect_no_offenses('top.test({foo: :bar}.merge(baz: :maz))')
+      expect_no_offenses('top.test(:first, {foo: :bar}.merge(baz: :maz))')
     end
 
     it 'accepts special lambda call syntax' do


### PR DESCRIPTION
During the testing of the cop in my company's big code-base I have found the following edge cases:

1. Allow parens in `foo.include?(bar) ? bar : quux`
    This is needed, because of the precedence of the ternary if. You may want to be explicit what argument you are calling the condition method with. This naturally leads to:
2. Allow parens in `foo.include?(bar ? baz : quux)`
3. Allow parens in `ConstantLikeMethod()`. If you have parens around a constant-companion-like method call, the parens may be needed to signal the method call and not a constant access.
4. Allow parens in`foo({hash: literal_anywhere_as_argument})` and
    `foo({hash: literal}.merge(quite: common))`.

I have thrown a few refactorings and re-organizations as well.