### PR TITLE
Remove Ruby 1.9 code from `Lint/ShadowedException` cop

### DIFF
--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -86,11 +86,8 @@ module RuboCop
         end
 
         def contains_multiple_levels_of_exceptions?(group)
-          if group.size > 1 && group.include?(Exception)
-            # Treat `Exception` as the highest level exception unless `nil` was
-            # also rescued
-            return !(group.size == 2 && group.include?(NilClass))
-          end
+          # Always treat `Exception` as the highest level exception.
+          return true if group.size > 1 && group.include?(Exception)
 
           group.combination(2).any? do |a, b|
             compare_exceptions(a, b)

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -190,38 +190,6 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedException do
         end
       RUBY
     end
-
-    it 'accepts rescuing nil' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        begin
-          a
-        rescue nil
-          b
-        end
-      RUBY
-    end
-
-    it 'accepts rescuing nil and another exception' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        begin
-          a
-        rescue nil, Exception
-          b
-        end
-      RUBY
-    end
-
-    it 'registers an offense when rescuing nil multiple exceptions of ' \
-       'different levels' do
-      expect_offense(<<-RUBY.strip_indent)
-        begin
-          a
-        rescue nil, StandardError, Exception
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not shadow rescued Exceptions.
-          b
-        end
-      RUBY
-    end
   end
 
   context 'multiple rescues' do
@@ -407,30 +375,6 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedException do
           end
         RUBY
       end
-    end
-
-    it 'accepts rescuing nil before another exception' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        begin
-          a
-        rescue nil
-          b
-        rescue
-          c
-        end
-      RUBY
-    end
-
-    it 'accepts rescuing nil after another exception' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        begin
-          a
-        rescue
-          b
-        rescue nil
-          c
-        end
-      RUBY
     end
 
     it 'accepts rescuing a known exception after an unknown exceptions' do


### PR DESCRIPTION
The "non-inline" `rescue nil` was allowed in Ruby 1.9, but disallowed since 2.0: https://github.com/rubocop-hq/rubocop/issues/3249#issuecomment-229074153

A bit of the code handling `rescue nil` was removed from this cop in 7ef0cf452c83f1332d449ec0916fa (https://github.com/rubocop-hq/rubocop/pull/4846), but there was still a bit left behind, plus a few specs.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
