### PR TITLE
Add rubocop-i18n to extensions page

### DIFF
--- a/manual/extensions.md
+++ b/manual/extensions.md
@@ -40,6 +40,7 @@ See [development](development.md).
   Thread-safety analysis
 * [rubocop-require_tools](https://github.com/milch/rubocop-require_tools) -
   Dynamic analysis for missing require statements
+* [rubocop-i18n](https://github.com/puppetlabs/rubocop-i18n) - i18n wrapper function analysis (gettext and rails-i18n)
 
 ### Custom Formatters
 


### PR DESCRIPTION
I'm one of the maintainers on the rubocop-i18n project, and I'd like to add it to the "Known Custom Cops" list.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
