### PR TITLE
[Fix #595] Exclude files ignored by `git`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 * [#6389](https://github.com/rubocop-hq/rubocop/pull/6389): Fix false negative for `Style/TrailingCommaInHashLitera`/`Style/TrailingCommaInArrayLiteral` when there is a comment in the last line. ([@bayandin][])
 * [#6566](https://github.com/rubocop-hq/rubocop/issues/6566): Fix false positive for `Layout/EmptyLinesAroundAccessModifier` when at the end of specifying a superclass is missing blank line. ([@koic][])
 
+### Changes
+
+* [#595](https://github.com/rubocop-hq/rubocop/issues/595): Exclude files ignored by `git`. ([@AlexWayfer][])
+
 ## 0.61.1 (2018-12-06)
 
 ### Bug fixes

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'set'
+require 'open3'
 
 module RuboCop
   # This class finds target files to inspect by scanning the directory tree
@@ -59,23 +60,19 @@ module RuboCop
       end
       all_files = find_files(base_dir, File::FNM_DOTMATCH)
       hidden_files = Set.new(all_files - find_files(base_dir, 0))
+
+      git_files = ls_git_files(base_dir)
+
       base_dir_config = @config_store.for(base_dir)
 
       target_files = all_files.select do |file|
-        to_inspect?(file, hidden_files, base_dir_config)
+        to_inspect?(file, git_files, hidden_files, base_dir_config)
       end
 
       # Most recently modified file first.
       target_files.sort_by! { |path| -Integer(File.mtime(path)) } if fail_fast?
 
       target_files
-    end
-
-    def to_inspect?(file, hidden_files, base_dir_config)
-      return false if base_dir_config.file_to_exclude?(file)
-      return true if !hidden_files.include?(file) && ruby_file?(file)
-
-      base_dir_config.file_to_include?(file)
     end
 
     # Search for files recursively starting at the given base directory using
@@ -98,6 +95,31 @@ module RuboCop
                   wanted_toplevel_dirs.unshift("#{base_dir}/*")
                 end
       Dir.glob(pattern, flags).select { |path| FileTest.file?(path) }
+    end
+
+    private
+
+    def ls_git_files(base_dir)
+      return if `sh -c 'command -v git'`.empty?
+
+      output, _error, status = Open3.capture3(
+        'git', 'ls-files', '-z', base_dir,
+        '--exclude-standard', '--others', '--cached', '--modified'
+      )
+
+      return unless status.success?
+
+      output.split("\0").map { |git_file| "#{base_dir}/#{git_file}" }
+    end
+
+    def to_inspect?(file, git_files, hidden_files, base_dir_config)
+      return false if base_dir_config.file_to_exclude?(file)
+
+      if !hidden_files.include?(file) && ruby_file?(file)
+        return git_files.nil? || git_files.include?(file)
+      end
+
+      base_dir_config.file_to_include?(file)
     end
 
     def toplevel_dirs(base_dir, flags)

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -229,6 +229,7 @@ ruby interpreters listed under `AllCops`/`RubyInterpreters` are
 inspected, unless the file also matches a pattern in
 `AllCops`/`Exclude`. Hidden directories (i.e., directories whose names
 start with a dot) are not searched by default.
+Files ignored by Git are ignored by RuboCop by default.
 
 Here is an example that might be used for a Rails project:
 


### PR DESCRIPTION
Don't check files ignored by `git` by default.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
