### PR TITLE
[Fix #6545] Fix Performance/RedundantMerge kwsplat regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [#6511](https://github.com/rubocop-hq/rubocop/issues/6511): Fix an incorrect auto-correct for `Style/EmptyCaseCondition` when used as an argument of a method. ([@koic][])
 * [#6509](https://github.com/rubocop-hq/rubocop/issues/6509): Fix an incorrect auto-correct for `Style/RaiseArgs` when an exception object is assigned to a local variable. ([@koic][])
 * [#6534](https://github.com/rubocop-hq/rubocop/issues/6534): Fix a false positive for `Lint/UselessAccessModifier` when using `private_class_method`. ([@dduugg][])
+* [#6545](https://github.com/rubocop-hq/rubocop/issues/6545): Fix a regression where `Performance/RedundantMerge` raises an error on a sole double splat argument passed to `merge!`. ([@mmedal][])
 
 ### Changes
 
@@ -3670,3 +3671,4 @@
 [@takaram]: https://github.com/takaram
 [@gmcgibbon]: https://github.com/gmcgibbon
 [@dduugg]: https://github.com/dduugg
+[@mmedal]: https://github.com/mmedal

--- a/lib/rubocop/cop/performance/redundant_merge.rb
+++ b/lib/rubocop/cop/performance/redundant_merge.rb
@@ -60,11 +60,16 @@ module RuboCop
 
         def non_redundant_merge?(node, receiver, pairs)
           non_redundant_pairs?(receiver, pairs) ||
+            kwsplat_used?(pairs) ||
             non_redundant_value_used?(receiver, node)
         end
 
         def non_redundant_pairs?(receiver, pairs)
           pairs.size > 1 && !receiver.pure? || pairs.size > max_key_value_pairs
+        end
+
+        def kwsplat_used?(pairs)
+          pairs.any?(&:kwsplat_type?)
         end
 
         def non_redundant_value_used?(receiver, node)

--- a/spec/rubocop/cop/performance/redundant_merge_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_merge_spec.rb
@@ -46,7 +46,15 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMerge, :config do
   end
 
   context 'when any argument is a double splat' do
-    it 'does not register an offense' do
+    it 'does not register an offense when the only argument is a' \
+       'double splat' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        foo.merge!(**bar)
+      RUBY
+    end
+
+    it 'does not register an offense when there are multiple arguments ' \
+       'and at least one is a double splat' do
       expect_no_offenses(<<-RUBY.strip_indent)
         foo.merge!(baz: qux, **bar)
       RUBY


### PR DESCRIPTION
Fix regression related to an earlier issue: #4366. When running `merge!`, passing a kwsplat as the sole argument causes rubocop to raise `undefined method 'source' for nil:NilClass`.

ex. 
```
def bar(**opts)
  opts.merge!(**foo)
  pp opts
end
```
