### PR TITLE
[Fix #6360] Detect bad indentation in `if` nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [#6511](https://github.com/rubocop-hq/rubocop/issues/6511): Fix an incorrect auto-correct for `Style/EmptyCaseCondition` when used as an argument of a method. ([@koic][])
 * [#6509](https://github.com/rubocop-hq/rubocop/issues/6509): Fix an incorrect auto-correct for `Style/RaiseArgs` when an exception object is assigned to a local variable. ([@koic][])
 * [#6534](https://github.com/rubocop-hq/rubocop/issues/6534): Fix a false positive for `Lint/UselessAccessModifier` when using `private_class_method`. ([@dduugg][])
+* [#6360](https://github.com/rubocop-hq/rubocop/issues/6360): Detect bad indentation in `if` nodes even if the first branch is empty. ([@bquorning][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -147,7 +147,7 @@ module RuboCop
         end
 
         def on_if(node, base = node)
-          return if ignored_node?(node) || !node.body
+          return if ignored_node?(node)
           return if node.ternary? || node.modifier_form?
 
           check_if(node, node.body, node.else_branch, base.loc)

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -122,6 +122,32 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
         RUBY
       end
 
+      it 'registers an offense for bad indentation of an else body when if ' \
+         'body contains no code' do
+        expect_offense(<<-RUBY.strip_indent)
+          if cond
+            # nothing here
+          else
+           func2
+          ^ Use 2 (not 1) spaces for indentation.
+          end
+        RUBY
+      end
+
+      it 'registers an offense for bad indentation of an else body when if ' \
+         'and elsif body contains no code' do
+        expect_offense(<<-RUBY.strip_indent)
+          if cond
+            # nothing here
+          elsif cond2
+            # nothing here either
+          else
+           func2
+          ^ Use 2 (not 1) spaces for indentation.
+          end
+        RUBY
+      end
+
       it 'registers an offense for bad indentation of an elsif body' do
         expect_offense(<<-RUBY.strip_indent)
           if a1


### PR DESCRIPTION
Don't ignore `if` nodes with an empty body. There may still be invalid indentation in other parts of the node.

I am not sure why `|| !node.body` was added in 219dfe1935232d6bc8e0c8f74f6ec566414e1297, but it looks like a mistake.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
