### PR TITLE
[Fix #6550] Prevent Layout/RescueEnsureAlignment from breaking on assigned begin-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#6550](https://github.com/rubocop-hq/rubocop/issues/6550): Prevent Layout/RescueEnsureAlignment cop from breaking on assigned begin-end. ([@drenmi][])
+
 ## 0.61.0 (2018-12-05)
 
 ### New features

--- a/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
@@ -114,7 +114,9 @@ module RuboCop
 
         def alignment_node(node)
           ancestor_node = ancestor_node(node)
-          return nil if ancestor_node.nil?
+
+          return ancestor_node if ancestor_node.nil? ||
+                                  ancestor_node.kwbegin_type?
 
           assignment_node = assignment_node(ancestor_node)
           return assignment_node unless assignment_node.nil?

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -354,6 +354,16 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
     RUBY
   end
 
+  it 'accepts correctly aligned rescue in assigned begin-end block' do
+    expect_no_offenses(<<-RUBY)
+      foo = begin
+              bar
+            rescue BazError
+              qux
+            end
+    RUBY
+  end
+
   context '>= Ruby 2.5', :ruby25 do
     it 'accepts aligned rescue in do-end block' do
       expect_no_offenses(<<-RUBY.strip_indent)


### PR DESCRIPTION
We were missing some test cases for this cop, and accidentally introduced a regression in #6437.

The cop would break on code like:

```ruby
foo = begin
        bar
      rescue BazError
        qux
      end
```

This change adds a relevant test case and fixes the issue.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
