### PR TITLE
Use verifying doubles where possible

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -92,8 +92,3 @@ RSpec/SubjectStub:
     - 'spec/rubocop/formatter/base_formatter_spec.rb'
     - 'spec/rubocop/formatter/json_formatter_spec.rb'
     - 'spec/rubocop/formatter/progress_formatter_spec.rb'
-
-# Offense count: 39
-# Configuration parameters: IgnoreSymbolicNames.
-RSpec/VerifiedDoubles:
-  Enabled: false

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -453,7 +453,10 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
   end
 
   describe 'caching' do
-    let(:cache) { double('cache', 'valid?' => true, 'load' => cached_offenses) }
+    let(:cache) do
+      instance_double(RuboCop::ResultCache, 'valid?' => true,
+                                            'load' => cached_offenses)
+    end
     let(:source) { %(puts "Hi"\n) }
 
     before do

--- a/spec/rubocop/cop/commissioner_spec.rb
+++ b/spec/rubocop/cop/commissioner_spec.rb
@@ -3,9 +3,12 @@
 RSpec.describe RuboCop::Cop::Commissioner do
   describe '#investigate' do
     let(:cop) do
-      double(RuboCop::Cop, offenses: [], excluded_file?: false).as_null_object
+      # rubocop:disable RSpec/VerifiedDoubles
+      double(RuboCop::Cop::Cop, offenses: [],
+                                excluded_file?: false).as_null_object
+      # rubocop:enable RSpec/VerifiedDoubles
     end
-    let(:force) { double(RuboCop::Cop::Force).as_null_object }
+    let(:force) { instance_double(RuboCop::Cop::Force).as_null_object }
 
     it 'returns all offenses found by the cops' do
       allow(cop).to receive(:offenses).and_return([1])
@@ -20,9 +23,11 @@ RSpec.describe RuboCop::Cop::Commissioner do
     context 'when a cop has no interest in the file' do
       it 'returns all offenses except the ones of the cop' do
         cops = []
-        cops << double('cop A', offenses: %w[foo], excluded_file?: false)
-        cops << double('cop B', excluded_file?: true)
-        cops << double('cop C', offenses: %w[baz], excluded_file?: false)
+        cops << instance_double(RuboCop::Cop::Cop, offenses: %w[foo],
+                                                   excluded_file?: false)
+        cops << instance_double(RuboCop::Cop::Cop, excluded_file?: true)
+        cops << instance_double(RuboCop::Cop::Cop, offenses: %w[baz],
+                                                   excluded_file?: false)
         cops.each(&:as_null_object)
 
         commissioner = described_class.new(cops, [])

--- a/spec/rubocop/cop/force_spec.rb
+++ b/spec/rubocop/cop/force_spec.rb
@@ -3,7 +3,12 @@
 RSpec.describe RuboCop::Cop::Force do
   subject(:force) { described_class.new(cops) }
 
-  let(:cops) { [double('cop1'), double('cop2')] }
+  let(:cops) do
+    [
+      instance_double(RuboCop::Cop::Cop),
+      instance_double(RuboCop::Cop::Cop)
+    ]
+  end
 
   describe '.force_name' do
     it 'returns the class name without namespace' do
@@ -13,14 +18,9 @@ RSpec.describe RuboCop::Cop::Force do
 
   describe '#run_hook' do
     it 'invokes a hook in all cops' do
-      expect(cops).to all(receive(:some_hook).with(:foo, :bar))
+      expect(cops).to all(receive(:message).with(:foo))
 
-      force.run_hook(:some_hook, :foo, :bar)
-    end
-
-    it 'does not invoke a hook if the cop does not respond to the hook' do
-      expect(cops.last).to receive(:some_hook).with(:foo, :bar)
-      force.run_hook(:some_hook, :foo, :bar)
+      force.run_hook(:message, :foo)
     end
   end
 end

--- a/spec/rubocop/cop/variable_force/assignment_spec.rb
+++ b/spec/rubocop/cop/variable_force/assignment_spec.rb
@@ -33,7 +33,9 @@ RSpec.describe RuboCop::Cop::VariableForce::Assignment do
   let(:assignment) { described_class.new(lvasgn_node, variable) }
 
   describe '.new' do
-    let(:variable) { double('variable') }
+    let(:variable) do
+      instance_double(RuboCop::Cop::VariableForce::Variable)
+    end
 
     context 'when an assignment node is passed' do
       it 'does not raise error' do

--- a/spec/rubocop/cop/variable_force/variable_spec.rb
+++ b/spec/rubocop/cop/variable_force/variable_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe RuboCop::Cop::VariableForce::Variable do
 
     let(:name) { :foo }
     let(:declaration_node) { s(:arg, name) }
-    let(:scope) { double('scope').as_null_object }
+    let(:scope) do
+      instance_double(RuboCop::Cop::VariableForce::Scope).as_null_object
+    end
     let(:variable) { described_class.new(name, declaration_node, scope) }
 
     context 'when the variable is not assigned' do

--- a/spec/rubocop/formatter/base_formatter_spec.rb
+++ b/spec/rubocop/formatter/base_formatter_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Formatter::BaseFormatter do
   include FileHelper
 
   describe 'how the API methods are invoked', :isolated_environment do
-    subject(:formatter) { double('formatter').as_null_object }
+    subject(:formatter) { instance_double(described_class).as_null_object }
 
     let(:runner) { RuboCop::Runner.new({}, RuboCop::ConfigStore.new) }
     let(:output) { $stdout.string }
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Formatter::BaseFormatter do
 
     describe 'invocation order' do
       subject(:formatter) do
-        formatter = double('formatter')
+        formatter = instance_double(described_class)
         %i[started file_started file_finished finished output]
           .each do |message|
           allow(formatter).to receive(message) do

--- a/spec/rubocop/formatter/colorizable_spec.rb
+++ b/spec/rubocop/formatter/colorizable_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RuboCop::Formatter::Colorizable do
     formatter_class.new(output, options)
   end
 
-  let(:output) { double('output') }
+  let(:output) { instance_double(IO) }
 
   around do |example|
     original_state = Rainbow.enabled

--- a/spec/rubocop/formatter/fuubar_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/fuubar_style_formatter_spec.rb
@@ -51,7 +51,17 @@ RSpec.describe RuboCop::Formatter::FuubarStyleFormatter do
     end
 
     def offense(severity, status = :uncorrected)
-      source_range = double('source_range').as_null_object
+      source_buffer = Parser::Source::Buffer.new('test', 1)
+      source = Array.new(9) do |index|
+        "This is line #{index + 1}."
+      end
+      source_buffer.source = source.join("\n")
+      line_length = source[0].length + 1
+
+      source_range = Parser::Source::Range.new(source_buffer,
+                                               line_length + 2,
+                                               line_length + 3)
+
       RuboCop::Cop::Offense.new(
         severity, source_range,
         'message', 'Cop', status

--- a/spec/rubocop/formatter/json_formatter_spec.rb
+++ b/spec/rubocop/formatter/json_formatter_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe RuboCop::Formatter::JSONFormatter do
       formatter.file_started(files[0], {})
       expect(summary[:offense_count]).to eq(0)
       formatter.file_finished(files[0], [
-                                double('offense1'), double('offense2')
+                                instance_double(RuboCop::Cop::Offense),
+                                instance_double(RuboCop::Cop::Offense)
                               ])
       expect(summary[:offense_count]).to eq(2)
     end
@@ -82,7 +83,12 @@ RSpec.describe RuboCop::Formatter::JSONFormatter do
     subject(:hash) { formatter.hash_for_file(file, offenses) }
 
     let(:file) { File.expand_path('spec/spec_helper.rb') }
-    let(:offenses) { [double('offense1'), double('offense2')] }
+    let(:offenses) do
+      [
+        instance_double(RuboCop::Cop::Offense),
+        instance_double(RuboCop::Cop::Offense)
+      ]
+    end
 
     before do
       count = 0

--- a/spec/rubocop/formatter/offense_count_formatter_spec.rb
+++ b/spec/rubocop/formatter/offense_count_formatter_spec.rb
@@ -25,7 +25,9 @@ RSpec.describe RuboCop::Formatter::OffenseCountFormatter do
     end
 
     context 'when any offenses are detected' do
-      let(:offenses) { [double('offense', cop_name: 'OffendedCop')] }
+      let(:offenses) do
+        [instance_double(RuboCop::Cop::Offense, cop_name: 'OffendedCop')]
+      end
 
       it 'increments the count for the cop in offense_counts' do
         expect { finish }.to change(formatter, :offense_counts)
@@ -49,7 +51,9 @@ RSpec.describe RuboCop::Formatter::OffenseCountFormatter do
   describe '#finished' do
     context 'when there are many offenses' do
       let(:offenses) do
-        %w[CopB CopA CopC CopC].map { |c| double('offense', cop_name: c) }
+        %w[CopB CopA CopC CopC].map do |cop|
+          instance_double(RuboCop::Cop::Offense, cop_name: cop)
+        end
       end
 
       before do
@@ -74,7 +78,9 @@ RSpec.describe RuboCop::Formatter::OffenseCountFormatter do
 
     context 'when output tty is true' do
       let(:offenses) do
-        %w[CopB CopA CopC CopC].map { |c| double('offense', cop_name: c) }
+        %w[CopB CopA CopC CopC].map do |cop|
+          instance_double(RuboCop::Cop::Offense, cop_name: cop)
+        end
       end
 
       before do

--- a/spec/rubocop/formatter/progress_formatter_spec.rb
+++ b/spec/rubocop/formatter/progress_formatter_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe RuboCop::Formatter::ProgressFormatter do
     end
 
     context 'when any offenses are detected' do
-      let(:offenses) { [double('offense').as_null_object] }
+      let(:offenses) do
+        [instance_double(RuboCop::Cop::Offense).as_null_object]
+      end
 
       include_examples 'calls #report_file_as_mark'
     end

--- a/spec/rubocop/formatter/tap_formatter_spec.rb
+++ b/spec/rubocop/formatter/tap_formatter_spec.rb
@@ -27,7 +27,25 @@ RSpec.describe RuboCop::Formatter::TapFormatter do
     end
 
     context 'when any offenses are detected' do
-      let(:offenses) { [double('offense').as_null_object] }
+      let(:offenses) do
+        source_buffer = Parser::Source::Buffer.new('test', 1)
+        source = Array.new(9) do |index|
+          "This is line #{index + 1}."
+        end
+        source_buffer.source = source.join("\n")
+        line_length = source[0].length + 1
+
+        [
+          RuboCop::Cop::Offense.new(
+            :convention,
+            Parser::Source::Range.new(source_buffer,
+                                      line_length + 2,
+                                      line_length + 3),
+            'foo',
+            'Cop'
+          )
+        ]
+      end
 
       it 'prints "not ok"' do
         expect(output.string).to include('not ok 1')

--- a/spec/rubocop/formatter/worst_offenders_formatter_spec.rb
+++ b/spec/rubocop/formatter/worst_offenders_formatter_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RuboCop::Formatter::WorstOffendersFormatter do
 
   describe '#finished' do
     context 'when there are many offenses' do
-      let(:offense) { double('offense') }
+      let(:offense) { instance_double(RuboCop::Cop::Offense) }
 
       before do
         formatter.started(files)

--- a/spec/rubocop/rake_task_spec.rb
+++ b/spec/rubocop/rake_task_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::RakeTask do
     it 'runs with default options' do
       described_class.new
 
-      cli = double('cli', run: 0)
+      cli = instance_double(RuboCop::CLI, run: 0)
       allow(RuboCop::CLI).to receive(:new) { cli }
       expect(cli).to receive(:run).with([])
 
@@ -60,7 +60,7 @@ RSpec.describe RuboCop::RakeTask do
         task.verbose = false
       end
 
-      cli = double('cli', run: 0)
+      cli = instance_double(RuboCop::CLI, run: 0)
       allow(RuboCop::CLI).to receive(:new) { cli }
       options = ['--format', 'files', '--display-cop-names', 'lib/**/*.rb']
       expect(cli).to receive(:run).with(options)
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::RakeTask do
         task.options = [['--display-cop-names']]
       end
 
-      cli = double('cli', run: 0)
+      cli = instance_double(RuboCop::CLI, run: 0)
       allow(RuboCop::CLI).to receive(:new) { cli }
       options = ['--format', 'files', '--require', 'library',
                  '--display-cop-names']
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::RakeTask do
         task.fail_on_error = false
       end
 
-      cli = double('cli', run: 1)
+      cli = instance_double(RuboCop::CLI, run: 1)
       allow(RuboCop::CLI).to receive(:new) { cli }
 
       expect { Rake::Task['rubocop'].execute }.not_to raise_error
@@ -98,7 +98,7 @@ RSpec.describe RuboCop::RakeTask do
     it 'exits when result is not 0 and fail_on_error is true' do
       described_class.new
 
-      cli = double('cli', run: 1)
+      cli = instance_double(RuboCop::CLI, run: 1)
       allow(RuboCop::CLI).to receive(:new) { cli }
 
       expect { Rake::Task['rubocop'].execute }.to raise_error(SystemExit)
@@ -133,7 +133,7 @@ RSpec.describe RuboCop::RakeTask do
       it 'runs with --auto-correct' do
         described_class.new
 
-        cli = double('cli', run: 0)
+        cli = instance_double(RuboCop::CLI, run: 0)
         allow(RuboCop::CLI).to receive(:new) { cli }
         options = ['--auto-correct']
         expect(cli).to receive(:run).with(options)
@@ -150,7 +150,7 @@ RSpec.describe RuboCop::RakeTask do
           task.verbose = false
         end
 
-        cli = double('cli', run: 0)
+        cli = instance_double(RuboCop::CLI, run: 0)
         allow(RuboCop::CLI).to receive(:new) { cli }
         options = ['--auto-correct', '--format', 'files', '-D', 'lib/**/*.rb']
         expect(cli).to receive(:run).with(options)

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
 
   let(:file) { 'example.rb' }
   let(:options) { {} }
-  let(:config_store) { double('config_store', for: RuboCop::Config.new) }
+  let(:config_store) do
+    instance_double(RuboCop::ConfigStore, for: RuboCop::Config.new)
+  end
   let(:cache_root) { "#{Dir.pwd}/rubocop_cache" }
   let(:offenses) do
     [RuboCop::Cop::Offense.new(:warning, location, 'unused var',
@@ -265,7 +267,9 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
   end
 
   describe 'the cache path' do
-    let(:config_store) { double('config_store') }
+    let(:config_store) do
+      instance_double(RuboCop::ConfigStore)
+    end
     let(:puid) { Process.uid.to_s }
 
     before do

--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
       before do
         # The cache responds that it's not valid, which means that new results
         # should normally be collected and saved...
-        cache = double('cache', 'valid?' => false)
+        cache = instance_double(RuboCop::ResultCache, 'valid?' => false)
         # ... but there's a crash in one cop.
         runner.errors = ['An error occurred in ...']
 

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
     let(:flags) { 0 }
 
     it 'does not search excluded top level directories' do
-      config = double('config')
+      config = instance_double(RuboCop::Config)
       exclude_property = { 'Exclude' => [File.expand_path('dir1/**/*')] }
       allow(config).to receive(:for_all_cops).and_return(exclude_property)
       allow(config_store).to receive(:for).and_return(config)
@@ -332,7 +332,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
     it 'works also if a folder is named ","' do
       create_empty_file(',/ruby4.rb')
 
-      config = double('config')
+      config = instance_double(RuboCop::Config)
       exclude_property = { 'Exclude' => [File.expand_path('dir1/**/*')] }
       allow(config).to receive(:for_all_cops).and_return(exclude_property)
       allow(config_store).to receive(:for).and_return(config)
@@ -368,7 +368,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
     end
 
     it 'picks files specified to be included in config' do
-      config = double('config')
+      config = instance_double(RuboCop::Config)
       allow(config).to receive(:file_to_include?) do |file|
         File.basename(file) == 'file'
       end
@@ -384,7 +384,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
     end
 
     it 'does not pick files specified to be excluded in config' do
-      config = double('config').as_null_object
+      config = instance_double(RuboCop::Config).as_null_object
       allow(config)
         .to receive(:for_all_cops).and_return('Exclude' => [],
                                               'Include' => [],

--- a/spec/rubocop/token_spec.rb
+++ b/spec/rubocop/token_spec.rb
@@ -45,7 +45,9 @@ RSpec.describe RuboCop::Token do
     let(:parser_token) { [type, [text, range]] }
     let(:type) { :kDEF }
     let(:text) { 'def' }
-    let(:range) { double('range', line: 42, column: 30) }
+    let(:range) do
+      instance_double(Parser::Source::Range, line: 42, column: 30)
+    end
 
     it "sets parser token's type to rubocop token's type" do
       expect(token.type).to eq(type)


### PR DESCRIPTION
This changes the usage from regular doubles to verifying doubles where applicable, fixing all offenses from `RSpec/VerifiedDoubles`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
