### PR TITLE
Optionally, allow parentheses in control flow conditions

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -3356,6 +3356,7 @@ Style/MethodCallWithArgsParentheses:
   VersionChanged: '0.61'
   IgnoreMacros: true
   IgnoredMethods: []
+  AllowParenthesesInControlFlow: false
   AllowParenthesesInMultilineCall: false
   AllowParenthesesInChaining: false
   EnforcedStyle: require_parentheses

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2896,6 +2896,25 @@ foo().bar(1)
 
 # good
 foo().bar 1
+
+# AllowParenthesesInControlFlow: false (default)
+
+# bad
+process(:work) if condition(true)
+
+# good
+process :work if condition true
+
+# AllowParenthesesInControlFlow: true (default)
+
+# good
+process(:work) if condition(true)
+
+# good
+process :work if condition(true)
+
+# good
+process :work if condition true
 ```
 
 ### Configurable attributes
@@ -2904,6 +2923,7 @@ Name | Default value | Configurable values
 --- | --- | ---
 IgnoreMacros | `true` | Boolean
 IgnoredMethods | `[]` | Array
+AllowParenthesesInControlFlow | `false` | Boolean
 AllowParenthesesInMultilineCall | `false` | Boolean
 AllowParenthesesInChaining | `false` | Boolean
 EnforcedStyle | `require_parentheses` | `require_parentheses`, `omit_parentheses`


### PR DESCRIPTION
This is yet-another-option for the `omit_parentheses` style for the
`Style/MethodCallWithArgsParentheses` cop. When set to true, it allows
the presence of parentheses in control flow conditions and the body of
their expression modifier forms.