### PR TITLE
relax bundler dev dependency to allow bundler v2.0.0.pre2

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '~> 1.4.0')
 
-  s.add_development_dependency('bundler', '~> 1.3')
+  s.add_development_dependency('bundler', '>= 1.3.0', '< 3.0')
   s.add_development_dependency('rack', '>= 2.0')
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
ruby 2.6.0-rc1 was released.
https://www.ruby-lang.org/en/news/2018/12/06/ruby-2-6-0-rc1-released/
n
it seems to bundles bundler v2.0.0.pre2 https://github.com/bundler/bundler/releases/tag/v2.0.0.pre.2

I'd like to test rubocop with v2.6.0-rc1. But without this changes, it got following errors.

```
$ bunlde install
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 1.3)

  Current Bundler version:
    bundler (2.0.0)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?

Could not find gem 'bundler (~> 1.3)' in any of the relevant sources:
  the local ruby installation
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
