### PR TITLE
Fix a false positive parentheses omission in safe navigation calls

### DIFF
--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -248,7 +248,7 @@ module RuboCop
 
         def call_with_ambiguous_arguments?(node)
           call_with_braced_block?(node) ||
-            call_as_argument?(node) ||
+            call_as_argument_or_chain?(node) ||
             hash_literal_in_arguments?(node) ||
             node.descendants.any? do |n|
               splat?(n) || ternary_if?(n) || logical_operator?(n)
@@ -259,8 +259,8 @@ module RuboCop
           node.block_node && node.block_node.braces?
         end
 
-        def call_as_argument?(node)
-          node.parent && node.parent.send_type?
+        def call_as_argument_or_chain?(node)
+          node.parent && (node.parent.send_type? || node.parent.csend_type?)
         end
 
         def hash_literal_in_arguments?(node)
@@ -275,7 +275,7 @@ module RuboCop
         end
 
         def allowed_chained_call_with_parentheses?(node)
-          return unless cop_config['AllowParenthesesInChaining']
+          return false unless cop_config['AllowParenthesesInChaining']
 
           previous = node.descendants.first
           return false unless previous && previous.send_type?

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -476,6 +476,12 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
+    context 'TargetRubyVersion >= 2.3', :ruby23 do
+      it 'accepts parens in chaining with safe operators' do
+        expect_no_offenses('Something.find(criteria: given)&.field')
+      end
+    end
+
     context 'allowing parenthesis in chaining' do
       let(:cop_config) do
         {


### PR DESCRIPTION
The safe navigation produces false positives for the `omit_parentheses`
style of the `Style/MethodCallWithArgsParentheses` cop.

Here is an example:

```
› bundle exec rubocop app/services/request_accountant_change.rb
Inspecting 1 file
C

Offenses:

app/services/request_accountant_change.rb:7:34: C: Style/MethodCallWithArgsParentheses: Omit parentheses for method calls with arguments.
    @accountant_id = User.find_by(email: email)&.id || SecondaryEmail.find_by(address: email)&.user_id
                                 ^^^^^^^^^^^^^^
app/services/request_accountant_change.rb:7:78: C: Style/MethodCallWithArgsParentheses: Omit parentheses for method calls with arguments.
    @accountant_id = User.find_by(email: email)&.id || SecondaryEmail.find_by(address: email)&.user_id
                                                                             ^^^^^^^^^^^^^^^^
```

Handling the safe navigation operator fixes those bad reports.
