### PR TITLE
[Fix #6526] Fix a wrong line highlight in `Lint/ShadowedException` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#6623](https://github.com/rubocop-hq/rubocop/pull/6623): Fix heredoc detection in trailing comma. ([@palkan][])
 * [#6100](https://github.com/rubocop-hq/rubocop/issues/6100): Fix a false positive in `Naming/ConstantName` cop when rhs is a conditional expression. ([@tatsuyafw][])
+* [#6526](https://github.com/rubocop-hq/rubocop/issues/6526): Fix a wrong line highlight in `Lint/ShadowedException` cop. ([@tatsuyafw][])
 
 ## 0.62.0 (2019-01-01)
 

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -198,6 +198,8 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedException do
       expect_offense(<<-RUBY.strip_indent)
         begin
           something
+        rescue NoMethodError
+          handle_no_method_error
         rescue Exception
         ^^^^^^^^^^^^^^^^ Do not shadow rescued Exceptions.
           handle_exception
@@ -217,6 +219,20 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedException do
         ^^^^^^^^^^^^^^^^ Do not shadow rescued Exceptions.
           handle_exception
         rescue NoMethodError, ZeroDivisionError
+          handle_standard_error
+        end
+      RUBY
+    end
+
+    it 'registers an offense for two exceptions when there are ' \
+       'multiple levels of exceptions in the same rescue' do
+      expect_offense(<<-RUBY.strip_indent)
+        begin
+          something
+        rescue ZeroDivisionError
+          handle_exception
+        rescue NoMethodError, StandardError
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not shadow rescued Exceptions.
           handle_standard_error
         end
       RUBY


### PR DESCRIPTION
Fixes #6526.

As reported in #6526, `Lint/ShadowedException` cop highlighted a wrong line as below.

```
begin
  something
rescue ZeroDivisionError
^^^^^^^^^^^^^^^^^^^^^^^^
  handle_exception
rescue NoMethodError, StandardError
  handle_standard_error
end
```

or

```
begin
  something
rescue ZeroDivisionError
^^^^^^^^^^^^^^^^^^^^^^^^
  handle_exception
rescue StandardError
  handle_standard_error
rescue NoMethodError
  handle_standard_error
end
```

This change fixes the above incorrect behavior.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
