### PR TITLE
Make Layout/AccessModifierIndentation work with arbitrary blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * [#6577](https://github.com/rubocop-hq/rubocop/pull/6577): Prevent Rails/Blank cop from adding offense when define the blank method. ([@jonatas][])
 * [#6554](https://github.com/rubocop-hq/rubocop/issues/6554): Prevent Layout/RescueEnsureAlignment cop from breaking on block assignment when assignment is on a separate line. ([@timmcanty][])
 * [#6343](https://github.com/rubocop-hq/rubocop/pull/6343): Optimise `--auto-gen-config` when `Metrics/LineLength` cop is disabled. ([@tom-lord][])
-* [#6389](https://github.com/rubocop-hq/rubocop/pull/6389): Fix false negative for `Style/TrailingCommaInHashLitera`/`Style/TrailingCommaInArrayLiteral` when there is a comment in the last line. ([@bayandin][])
+* [#6389](https://github.com/rubocop-hq/rubocop/pull/6389): Fix false negative for `Style/TrailingCommaInHashLiteral`/`Style/TrailingCommaInArrayLiteral` when there is a comment in the last line. ([@bayandin][])
 * [#6566](https://github.com/rubocop-hq/rubocop/issues/6566): Fix false positive for `Layout/EmptyLinesAroundAccessModifier` when at the end of specifying a superclass is missing blank line. ([@koic][])
 * [#6571](https://github.com/rubocop-hq/rubocop/issues/6571): Fix a false positive for `Layout/TrailingCommaInArguments` when a line break before a method call and `EnforcedStyleForMultiline` is set to `consistent_comma`. ([@koic][])
 * [#6573](https://github.com/rubocop-hq/rubocop/pull/6573): Make `Layout/AccessModifierIndentation` work for dynamic module or class definitions. ([@deivid-rodriguez][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#6598](https://github.com/rubocop-hq/rubocop/pull/6598): Fix a false positive for `Style/MethodCallWithArgsParentheses` `omit_parentheses` enforced style for default argument value calls. ([@gsamokovarov][])
 * [#6598](https://github.com/rubocop-hq/rubocop/pull/6598): Fix a false positive for `Style/MethodCallWithArgsParentheses` `omit_parentheses` enforced style for argument calls with braced blocks. ([@gsamokovarov][])
 * [#6594](https://github.com/rubocop-hq/rubocop/pull/6594): Fix a false positive for `Rails/OutputSafety` when the receiver is a non-interpolated string literal. ([@amatsuda][])
+* [#6574](https://github.com/rubocop-hq/rubocop/pull/6574): Fix `Style/AccessModifierIndentation` not handling arbitrary blocks. ([@deivid-rodriguez][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/access_modifier_indentation.rb
+++ b/lib/rubocop/cop/layout/access_modifier_indentation.rb
@@ -54,8 +54,6 @@ module RuboCop
         end
 
         def on_block(node)
-          return unless node.class_constructor?
-
           check_body(node.body, node)
         end
 

--- a/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
@@ -103,12 +103,12 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
       RUBY
     end
 
-    it 'accepts misaligned private in blocks that are not recognized as ' \
-       'class/module definitions' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+    it 'registers an offense for access modifiers in arbitrary blocks' do
+      expect_offense(<<-RUBY.strip_indent)
         Test = func do
 
         private
+        ^^^^^^^ Indent access modifiers like `private`.
 
           def test; end
         end


### PR DESCRIPTION
This PR makes the `Layout/AccessModifierIndentation` cop work for arbitrary blocks, and not only for dynamic class or module definitions. It is built on top of #6573, so any revieweres please have a look at that one first.

This PR changes the expectation of an existing spec, which explicitly stated that this case should not be detected. I don't see why, though. The spec was introduced in https://github.com/rubocop-hq/rubocop/commit/d2c042346c624ed15572e6a74bf512fb544002fb as part of a refactor. Neither the commit message nor the [associated PR](https://github.com/rubocop-hq/rubocop/pull/1164) explain the reason for the spec, so I would appreciate some input here.

Also, I'm unsure whether to tag this a "bug fix", "feature", or "change" if this is accepted :smiley:.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] ~Added~ Changed tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
