### PR TITLE
Rails/Blank skips offense when defining the `blank?` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#4229](https://github.com/rubocop-hq/rubocop/issues/4229): Fix unexpected Style/HashSyntax consistency offence. ([@timon][])
 * [#6500](https://github.com/rubocop-hq/rubocop/issues/6500): Add offense to use `in_time_zone` instead of deprecated `to_time_in_current_zone`. ([@nadiyaka][])
+* [#6577](https://github.com/rubocop-hq/rubocop/pull/6577): Prevent Rails/Blank cop from adding offense when define the blank method. ([@jonatas][])
 * [#6554](https://github.com/rubocop-hq/rubocop/issues/6554): Prevent Layout/RescueEnsureAlignment cop from breaking on block assignment when assignment is on a separate line. ([@timmcanty][])
 * [#6343](https://github.com/rubocop-hq/rubocop/pull/6343): Optimise `--auto-gen-config` when `Metrics/LineLength` cop is disabled. ([@tom-lord][])
 * [#6389](https://github.com/rubocop-hq/rubocop/pull/6389): Fix false negative for `Style/TrailingCommaInHashLitera`/`Style/TrailingCommaInArrayLiteral` when there is a comment in the last line. ([@bayandin][])

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -216,6 +216,11 @@ end
 if foo.blank?
   something
 end
+
+# good
+def blank?
+  !present?
+end
 ```
 
 ### Configurable attributes

--- a/spec/rubocop/cop/rails/blank_spec.rb
+++ b/spec/rubocop/cop/rails/blank_spec.rb
@@ -129,6 +129,10 @@ RSpec.describe RuboCop::Cop::Rails::Blank, :config do
     it_behaves_like 'offense', '!present?',
                     'blank?',
                     'Use `blank?` instead of `!present?`.'
+
+    it 'accepts !present? if its in the body of a `blank?` method' do
+      expect_no_offenses('def blank?; !present? end')
+    end
   end
 
   context 'UnlessPresent set to true' do


### PR DESCRIPTION
We found a case that we need to disable the `Rails/Blank` cop when we're creating the `blank?` method.

So, it adds an offense when we have:

```ruby
def blank?
  !present?
end
```

But it should accept because it's the method definition.

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
