### PR TITLE
[Fix #6571] Fix a false positive for `Layout/TrailingCommaInArguments`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#6343](https://github.com/rubocop-hq/rubocop/pull/6343): Optimise `--auto-gen-config` when `Metrics/LineLength` cop is disabled. ([@tom-lord][])
 * [#6389](https://github.com/rubocop-hq/rubocop/pull/6389): Fix false negative for `Style/TrailingCommaInHashLitera`/`Style/TrailingCommaInArrayLiteral` when there is a comment in the last line. ([@bayandin][])
 * [#6566](https://github.com/rubocop-hq/rubocop/issues/6566): Fix false positive for `Layout/EmptyLinesAroundAccessModifier` when at the end of specifying a superclass is missing blank line. ([@koic][])
+* [#6571](https://github.com/rubocop-hq/rubocop/issues/6571): Fix a false positive for `Layout/TrailingCommaInArguments` when a line break before a method call and `EnforcedStyleForMultiline` is set to `consistent_comma`. ([@koic][])
 
 ## 0.61.1 (2018-12-06)
 

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -63,7 +63,7 @@ module RuboCop
         when :comma
           multiline?(node) && no_elements_on_same_line?(node)
         when :consistent_comma
-          multiline?(node)
+          multiline?(node) && !method_name_and_arguments_on_same_line?(node)
         else
           false
         end
@@ -90,6 +90,12 @@ module RuboCop
       # closing bracket is on its own line.
       def multiline?(node)
         node.multiline? && !allowed_multiline_argument?(node)
+      end
+
+      def method_name_and_arguments_on_same_line?(node)
+        node.send_type? &&
+          node.loc.selector.line == node.arguments.last.last_line &&
+          node.last_line == node.arguments.last.last_line
       end
 
       # A single argument with the closing bracket on the same line as the end

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       expect_no_offenses('some_method(a, b, c)')
     end
 
+    it 'accepts method call without trailing comma ' \
+       'when a line break before a method call' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        obj
+          .do_something(:foo, :bar)
+      RUBY
+    end
+
     it 'accepts method call without trailing comma with single element hash' \
         ' parameters at the end' do
       expect_no_offenses('some_method(a: 1)')
@@ -301,6 +309,16 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
                         a: 0,
                         b: 1,
                      )
+        RUBY
+      end
+
+      it 'accepts a trailing comma in a method call with ' \
+         'a single hash parameter to a receiver object' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          obj.some_method(
+                            a: 0,
+                            b: 1,
+                         )
         RUBY
       end
 


### PR DESCRIPTION
Fixes #6571.

This PR fixes a false positive for `Layout/TrailingCommaInArguments` when a line break before a method call and `EnforcedStyleForMultiline` is set to `consistent_comma`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
