### PR TITLE
Braced options in Rails/Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### Changes
 
 * [#595](https://github.com/rubocop-hq/rubocop/issues/595): Exclude files ignored by `git`. ([@AlexWayfer][])
+* [#6429](https://github.com/rubocop-hq/rubocop/issues/6429): Fix autocorrect in Rails/Validation to not wrap hash options with braces in an extra set of braces. ([@bquorning][])
 
 ## 0.61.1 (2018-12-06)
 

--- a/lib/rubocop/cop/rails/validation.rb
+++ b/lib/rubocop/cop/rails/validation.rb
@@ -80,10 +80,18 @@ module RuboCop
 
           if options
             corrector.replace(options.loc.expression,
-                              "#{validate_type}: { #{options.source} }")
+                              "#{validate_type}: #{braced_options(options)}")
           else
             corrector.insert_after(node.loc.expression,
                                    ", #{validate_type}: true")
+          end
+        end
+
+        def braced_options(options)
+          if options.braces?
+            options.source
+          else
+            "{ #{options.source} }"
           end
         end
       end

--- a/spec/rubocop/cop/rails/validation_spec.rb
+++ b/spec/rubocop/cop/rails/validation_spec.rb
@@ -39,4 +39,13 @@ RSpec.describe RuboCop::Cop::Rails::Validation do
       'validates :age, numericality: { minimum: 0, maximum: 122 }'
     )
   end
+
+  it 'autocorrect validates_numericality_of with options in braces' do
+    new_source = autocorrect_source(
+      'validates_numericality_of :age, { minimum: 0, maximum: 122 }'
+    )
+    expect(new_source).to eq(
+      'validates :age, numericality: { minimum: 0, maximum: 122 }'
+    )
+  end
 end

--- a/spec/rubocop/cop/rails/validation_spec.rb
+++ b/spec/rubocop/cop/rails/validation_spec.rb
@@ -3,6 +3,10 @@
 RSpec.describe RuboCop::Cop::Rails::Validation do
   subject(:cop) { described_class.new }
 
+  it 'accepts new style validations' do
+    expect_no_offenses('validates :name')
+  end
+
   described_class::DENYLIST.each_with_index do |validation, number|
     it "registers an offense for #{validation}" do
       inspect_source("#{validation} :name")
@@ -16,36 +20,34 @@ RSpec.describe RuboCop::Cop::Rails::Validation do
     end
   end
 
-  described_class::TYPES.each do |parameter|
-    it "autocorrect validates_#{parameter}_of" do
+  describe 'autocorrect' do
+    described_class::TYPES.each do |parameter|
+      it "corrects validates_#{parameter}_of" do
+        new_source = autocorrect_source(
+          "validates_#{parameter}_of :full_name, :birth_date"
+        )
+        expect(new_source).to eq(
+          "validates :full_name, :birth_date, #{parameter}: true"
+        )
+      end
+    end
+
+    it 'corrects validates_numericality_of with options' do
       new_source = autocorrect_source(
-        "validates_#{parameter}_of :full_name, :birth_date"
+        'validates_numericality_of :age, minimum: 0, maximum: 122'
       )
       expect(new_source).to eq(
-        "validates :full_name, :birth_date, #{parameter}: true"
+        'validates :age, numericality: { minimum: 0, maximum: 122 }'
       )
     end
-  end
 
-  it 'accepts new style validations' do
-    expect_no_offenses('validates :name')
-  end
-
-  it 'autocorrect validates_length_of' do
-    new_source = autocorrect_source(
-      'validates_numericality_of :age, minimum: 0, maximum: 122'
-    )
-    expect(new_source).to eq(
-      'validates :age, numericality: { minimum: 0, maximum: 122 }'
-    )
-  end
-
-  it 'autocorrect validates_numericality_of with options in braces' do
-    new_source = autocorrect_source(
-      'validates_numericality_of :age, { minimum: 0, maximum: 122 }'
-    )
-    expect(new_source).to eq(
-      'validates :age, numericality: { minimum: 0, maximum: 122 }'
-    )
+    it 'autocorrect validates_numericality_of with options in braces' do
+      new_source = autocorrect_source(
+        'validates_numericality_of :age, { minimum: 0, maximum: 122 }'
+      )
+      expect(new_source).to eq(
+        'validates :age, numericality: { minimum: 0, maximum: 122 }'
+      )
+    end
   end
 end


### PR DESCRIPTION
Fixes #6429

Rails/Validation autocorrect was failing to recognize options hashes that already was wrapped in braces, always adding an extra set of braces around them.

Not that this PR *does* contain two commits – the last commit changing the order of specs a little bit, to make the spec file more readable. There should be no changes to the actual specs.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
