### PR TITLE
[Fix #6349] MemoizedInstanceVariableName allows underscored method name

### DIFF
--- a/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
+++ b/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
@@ -132,9 +132,7 @@ module RuboCop
           variable = ivar_assign.children.first
           variable_name = variable.to_s.sub('@', '')
 
-          return false unless valid_leading_underscore?(variable_name)
-
-          variable_name.sub(/\A_/, '') == method_name.sub(/\A_/, '')
+          valid_variable_name?(method_name, variable_name)
         end
 
         def message(variable)
@@ -152,14 +150,15 @@ module RuboCop
           style == :required ? "_#{suggestion}" : suggestion
         end
 
-        def valid_leading_underscore?(variable_name)
+        def valid_variable_name?(method_name, variable_name)
+          clean_method_name = method_name.sub(/\A_/, '')
           case style
           when :required
-            variable_name.start_with?('_')
+            variable_name == '_' + clean_method_name
           when :disallowed
-            !variable_name.start_with?('_')
+            [clean_method_name, method_name].include?(variable_name)
           else
-            true
+            variable_name.sub(/\A_/, '') == clean_method_name
           end
         end
       end

--- a/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
@@ -104,7 +104,6 @@ RSpec.describe RuboCop::Cop::Naming::MemoizedInstanceVariableName, :config do
       end
 
       it 'does not register an offense with a leading `_` for both names' do
-        pending
         expect_no_offenses(<<-RUBY.strip_indent)
           def _foo
             @_foo ||= :foo


### PR DESCRIPTION
We should be allowed to write code like this:

``` ruby
def _foo
  @_foo ||= :foo
end
```
namely if the method name has a leading `_`, the memoized variable name should have it too.
Currently it gives  an error, saying the variable should be named `@foo`.

This should fix #6349