### PR TITLE
Add good example for `Style/TrailingCommaInArguments`

### DIFF
--- a/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
@@ -10,6 +10,9 @@ module RuboCop
       #   method(1, 2,)
       #
       #   # good
+      #   method(1, 2)
+      #
+      #   # good
       #   method(
       #     1, 2,
       #     3,
@@ -26,6 +29,9 @@ module RuboCop
       #   method(1, 2,)
       #
       #   # good
+      #   method(1, 2)
+      #
+      #   # good
       #   method(
       #     1,
       #     2,
@@ -34,6 +40,9 @@ module RuboCop
       # @example EnforcedStyleForMultiline: no_comma (default)
       #   # bad
       #   method(1, 2,)
+      #
+      #   # good
+      #   method(1, 2)
       #
       #   # good
       #   method(

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -6070,6 +6070,9 @@ This cop checks for trailing comma in argument lists.
 method(1, 2,)
 
 # good
+method(1, 2)
+
+# good
 method(
   1, 2,
   3,
@@ -6088,6 +6091,9 @@ method(
 method(1, 2,)
 
 # good
+method(1, 2)
+
+# good
 method(
   1,
   2,
@@ -6098,6 +6104,9 @@ method(
 ```ruby
 # bad
 method(1, 2,)
+
+# good
+method(1, 2)
 
 # good
 method(


### PR DESCRIPTION
I think that it is easier to understand when good one line example `method(1, 2)` is written as contrasted to bad one line example `method(1, 2,)`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
