### PR TITLE
Fix bug extend_self with private methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#6598](https://github.com/rubocop-hq/rubocop/pull/6598): Fix a false positive for `Style/MethodCallWithArgsParentheses` `omit_parentheses` enforced style for argument calls with braced blocks. ([@gsamokovarov][])
 * [#6594](https://github.com/rubocop-hq/rubocop/pull/6594): Fix a false positive for `Rails/OutputSafety` when the receiver is a non-interpolated string literal. ([@amatsuda][])
 * [#6574](https://github.com/rubocop-hq/rubocop/pull/6574): Fix `Style/AccessModifierIndentation` not handling arbitrary blocks. ([@deivid-rodriguez][])
+[#6370](https://github.com/rubocop-hq/rubocop/issues/6370): Fix the enforcing style from `extend self` into `module_function` when there are private methods
 
 ### Changes
 
@@ -3718,3 +3719,4 @@
 [@nadiyaka]: https://github.com/nadiyaka
 [@amatsuda]: https://github.com/amatsuda
 [@Intrepidd]: https://github.com/Intrepidd
+[@ruffeng]: https://github.com/Ruffeng

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3370,6 +3370,9 @@ module.
 
 Supported styles are: module_function, extend_self.
 
+In case there are private methods, the cop won't be activated.
+Otherwise, it forces to change the flow of the default code.
+
 These offenses are not auto-corrected since there are different
 implications to each approach.
 
@@ -3387,6 +3390,17 @@ end
 # good
 module Test
   module_function
+  # ...
+end
+```
+#### EnforcedStyle: module_function (default)
+
+```ruby
+# good
+module Test
+  extend self
+  # ...
+  private
   # ...
 end
 ```

--- a/spec/rubocop/cop/style/module_function_spec.rb
+++ b/spec/rubocop/cop/style/module_function_spec.rb
@@ -16,6 +16,27 @@ RSpec.describe RuboCop::Cop::Style::ModuleFunction, :config do
       RUBY
     end
 
+    it 'accepts for `extend self` in a module with private methods' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        module Test
+          extend self
+          def test; end
+          private
+          def test_private;end
+        end
+      RUBY
+    end
+
+    it 'accepts for `extend self` in a module with declarative private' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        module Test
+          extend self
+          def test; end
+          private :test
+        end
+      RUBY
+    end
+
     it 'accepts `extend self` in a class' do
       expect_no_offenses(<<-RUBY.strip_indent)
         class Test


### PR DESCRIPTION
Fix #6370. Cop extend self to turn into module_function should
not be invoked in case there are private methods. Because of that, the
flow of the code gets broken.

My idea: Since the switch from `extend self` into `module_function` forces you to change the code in the scenario you have private methods, I just added a small validation to check if there's any private declaration before. In case there are no private methods, proceed with the offense. 

It works as well for the correction ( I am not sure if I need tests there since the warning is not written at all) 

This is a very first draft PR. All refactors or wrong code is more than welcome 😄 

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
