### PR TITLE
Allow Rails html_safe for non-interpolated String literal receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#6571](https://github.com/rubocop-hq/rubocop/issues/6571): Fix a false positive for `Layout/TrailingCommaInArguments` when a line break before a method call and `EnforcedStyleForMultiline` is set to `consistent_comma`. ([@koic][])
 * [#6562](https://github.com/rubocop-hq/rubocop/pull/6562): Fix a false positive for `Style/MethodCallWithArgsParentheses`  `omit_parentheses` enforced style after safe navigation call. ([@gsamokovarov][])
 * [#6570](https://github.com/rubocop-hq/rubocop/pull/6570): Fix a false positive for `Style/MethodCallWithArgsParentheses` `omit_parentheses` enforced style while splatting the result of a method invocation. ([@gsamokovarov][])
+* [#6594](https://github.com/rubocop-hq/rubocop/pull/6594): Fix a false positive for `Rails/OutputSafety` when the receiver is a non-interpolated string literal. ([@amatsuda][])
 
 ## 0.61.1 (2018-12-06)
 
@@ -3698,3 +3699,4 @@
 [@tom-lord]: https://github.com/tom-lord
 [@bayandin]: https://github.com/bayandin
 [@nadiyaka]: https://github.com/nadiyaka
+[@amatsuda]: https://github.com/amatsuda

--- a/lib/rubocop/cop/rails/output_safety.rb
+++ b/lib/rubocop/cop/rails/output_safety.rb
@@ -66,6 +66,8 @@ module RuboCop
         MSG = 'Tagging a string as html safe may be a security risk.'.freeze
 
         def on_send(node)
+          return if non_interpolated_string?(node)
+
           return unless looks_like_rails_html_safe?(node) ||
                         looks_like_rails_raw?(node) ||
                         looks_like_rails_safe_concat?(node)
@@ -75,6 +77,10 @@ module RuboCop
         alias on_csend on_send
 
         private
+
+        def non_interpolated_string?(node)
+          node.receiver && node.receiver.str_type? && !node.receiver.dstr_type?
+        end
 
         def looks_like_rails_html_safe?(node)
           node.receiver && node.method?(:html_safe) && !node.arguments?

--- a/spec/rubocop/cop/rails/output_safety_spec.rb
+++ b/spec/rubocop/cop/rails/output_safety_spec.rb
@@ -29,14 +29,20 @@ RSpec.describe RuboCop::Cop::Rails::OutputSafety do
   end
 
   context 'when using `#html_safe`' do
-    it 'registers an offense for literal receiver and no argument' do
-      expect_offense(<<-RUBY.strip_indent)
+    it 'does not register an offense for static string literal receiver' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         "foo".html_safe
-              ^^^^^^^^^ Tagging a string as html safe may be a security risk.
       RUBY
     end
 
-    it 'registers an offense for variable receiver and no argument' do
+    it 'registers an offense for dynamic string literal receiver' do
+      expect_offense(<<-'RUBY'.strip_indent)
+        "foo#{1}".html_safe
+                  ^^^^^^^^^ Tagging a string as html safe may be a security risk.
+      RUBY
+    end
+
+    it 'registers an offense for variable receiver' do
       expect_offense(<<-RUBY.strip_indent)
         foo.html_safe
             ^^^^^^^^^ Tagging a string as html safe may be a security risk.


### PR DESCRIPTION
Current Rails/OutputSafety cop seems to be always warning any kinds of `html_safe` method call as possibly insecure code.

But in fact, `html_safe` is not such a dangerous thing. It's a part of Rails core API, and it's not something that is discouraged to use that way. It can just be a security risk only when the string could contain random user input values.

Actually, the document of this cop indicates the following code as a "good" code, so I guess this is just an implementation bug. https://github.com/rubocop-hq/rubocop/blob/a5abbde/manual/cops_rails.md#examples-27

```
out = "<h1>trusted content</h1>".html_safe
```

And so attached is a patch that allows `html_safe` call on non-interpolated string literals, just as documented.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.