### PR TITLE
Various fixes for the `omit_parentheses` style of `Style/MethodCallWithArgsParentheses`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@
 * [#6389](https://github.com/rubocop-hq/rubocop/pull/6389): Fix false negative for `Style/TrailingCommaInHashLitera`/`Style/TrailingCommaInArrayLiteral` when there is a comment in the last line. ([@bayandin][])
 * [#6566](https://github.com/rubocop-hq/rubocop/issues/6566): Fix false positive for `Layout/EmptyLinesAroundAccessModifier` when at the end of specifying a superclass is missing blank line. ([@koic][])
 * [#6571](https://github.com/rubocop-hq/rubocop/issues/6571): Fix a false positive for `Layout/TrailingCommaInArguments` when a line break before a method call and `EnforcedStyleForMultiline` is set to `consistent_comma`. ([@koic][])
-* [#6562](https://github.com/rubocop-hq/rubocop/pull/6562): Fix a false positive for `Style/MethodCallWithArgsParentheses`  `omit_parentheses` enforced style after safe navigation call. ([@gsamokovarov][])
+* [#6562](https://github.com/rubocop-hq/rubocop/pull/6562): Fix a false positive for `Style/MethodCallWithArgsParentheses` `omit_parentheses` enforced style after safe navigation call. ([@gsamokovarov][])
 * [#6570](https://github.com/rubocop-hq/rubocop/pull/6570): Fix a false positive for `Style/MethodCallWithArgsParentheses` `omit_parentheses` enforced style while splatting the result of a method invocation. ([@gsamokovarov][])
+* [#6595](https://github.com/rubocop-hq/rubocop/pull/6595): Fix a false positive for `Style/MethodCallWithArgsParentheses` `omit_parentheses` enforced style for calls with regexp slash literals argument. ([@gsamokovarov][])
 * [#6594](https://github.com/rubocop-hq/rubocop/pull/6594): Fix a false positive for `Rails/OutputSafety` when the receiver is a non-interpolated string literal. ([@amatsuda][])
 
 ## 0.61.1 (2018-12-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@
 * [#6571](https://github.com/rubocop-hq/rubocop/issues/6571): Fix a false positive for `Layout/TrailingCommaInArguments` when a line break before a method call and `EnforcedStyleForMultiline` is set to `consistent_comma`. ([@koic][])
 * [#6562](https://github.com/rubocop-hq/rubocop/pull/6562): Fix a false positive for `Style/MethodCallWithArgsParentheses` `omit_parentheses` enforced style after safe navigation call. ([@gsamokovarov][])
 * [#6570](https://github.com/rubocop-hq/rubocop/pull/6570): Fix a false positive for `Style/MethodCallWithArgsParentheses` `omit_parentheses` enforced style while splatting the result of a method invocation. ([@gsamokovarov][])
-* [#6595](https://github.com/rubocop-hq/rubocop/pull/6595): Fix a false positive for `Style/MethodCallWithArgsParentheses` `omit_parentheses` enforced style for calls with regexp slash literals argument. ([@gsamokovarov][])
+* [#6598](https://github.com/rubocop-hq/rubocop/pull/6598): Fix a false positive for `Style/MethodCallWithArgsParentheses` `omit_parentheses` enforced style for calls with regexp slash literals argument. ([@gsamokovarov][])
+* [#6598](https://github.com/rubocop-hq/rubocop/pull/6598): Fix a false positive for `Style/MethodCallWithArgsParentheses` `omit_parentheses` enforced style for default argument value calls. ([@gsamokovarov][])
+* [#6598](https://github.com/rubocop-hq/rubocop/pull/6598): Fix a false positive for `Style/MethodCallWithArgsParentheses` `omit_parentheses` enforced style for argument calls with braced blocks. ([@gsamokovarov][])
 * [#6594](https://github.com/rubocop-hq/rubocop/pull/6594): Fix a false positive for `Rails/OutputSafety` when the receiver is a non-interpolated string literal. ([@amatsuda][])
 
 ## 0.61.1 (2018-12-06)

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -257,12 +257,13 @@ module RuboCop
             call_as_argument_or_chain?(node) ||
             hash_literal_in_arguments?(node) ||
             node.descendants.any? do |n|
-              ambigious_literal?(n) || logical_operator?(n)
+              ambigious_literal?(n) || logical_operator?(n) ||
+                call_with_braced_block?(n)
             end
         end
 
         def call_with_braced_block?(node)
-          node.block_node && node.block_node.braces?
+          node.send_type? && node.block_node && node.block_node.braces?
         end
 
         def call_as_argument_or_chain?(node)

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -229,6 +229,7 @@ module RuboCop
           call_in_literals?(node) ||
             call_with_ambiguous_arguments?(node) ||
             call_in_logical_operators?(node) ||
+            call_in_optional_arguments?(node) ||
             allowed_multiline_call_with_parentheses?(node) ||
             allowed_chained_call_with_parentheses?(node)
         end
@@ -245,6 +246,10 @@ module RuboCop
           node.parent &&
             (logical_operator?(node.parent) ||
              node.parent.descendants.any?(&method(:logical_operator?)))
+        end
+
+        def call_in_optional_arguments?(node)
+          node.parent && node.parent.optarg_type?
         end
 
         def call_with_ambiguous_arguments?(node)

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -333,6 +333,13 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
+    it 'register an offense for %r regex literal as arguments' do
+      expect_offense(<<-RUBY.strip_indent)
+        method_call(%r{foo})
+                   ^^^^^^^^^ Omit parentheses for method calls with arguments.
+      RUBY
+    end
+
     it 'accepts no parens in method call without args' do
       expect_no_offenses('top.test')
     end
@@ -387,6 +394,10 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       expect_no_offenses('foo *args')
       expect_no_offenses('foo(**kwargs)')
       expect_no_offenses('foo **kwargs')
+    end
+
+    it 'accepts parens in slash regexp literal as argument' do
+      expect_no_offenses('foo(/regexp/)')
     end
 
     it 'accepts parens in implicit #to_proc' do

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -345,7 +345,19 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
     end
 
     it 'accepts no parens in method call with args' do
-      expect_no_offenses('top.test 1, 2, foo: bar')
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def regular(arg = default(42))
+          nil
+        end
+
+        def seatle_style arg = default(42)
+          nil
+        end
+      RUBY
+    end
+
+    it 'accepts parens in default argument value calls' do
+      expect_no_offenses('top.test 1, 2, foo: bar(3)')
     end
 
     it 'accepts parens in method args' do

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -345,6 +345,10 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
     end
 
     it 'accepts no parens in method call with args' do
+      expect_no_offenses('top.test 1, 2, foo: bar')
+    end
+
+    it 'accepts parens in default argument value calls' do
       expect_no_offenses(<<-RUBY.strip_indent)
         def regular(arg = default(42))
           nil
@@ -354,10 +358,6 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
           nil
         end
       RUBY
-    end
-
-    it 'accepts parens in default argument value calls' do
-      expect_no_offenses('top.test 1, 2, foo: bar(3)')
     end
 
     it 'accepts parens in method args' do
@@ -410,6 +410,10 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
 
     it 'accepts parens in slash regexp literal as argument' do
       expect_no_offenses('foo(/regexp/)')
+    end
+
+    it 'accepts parens in argument calls with braced blocks' do
+      expect_no_offenses('foo(bar(:arg) { 42 })')
     end
 
     it 'accepts parens in implicit #to_proc' do


### PR DESCRIPTION
Fixes:

```ruby
foo(/a*b*/)
   ^^^^^^^^ Omit parentheses for method calls with arguments.
```

```ruby
def regular(arg = default(42))
                         ^^^^ Omit parentheses for method calls with arguments.
  nil
end

def seatle_style arg = default(42)
                              ^^^^ Omit parentheses for method calls with arguments.
  nil
end
```

```ruby
foo(bar(:arg) { 42 })
       ^^^^^^ Omit parentheses for method calls with arguments.
```