### PR TITLE
[Fix #3904] Build config & sync cop descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@
 ### Changes
 
 * [#595](https://github.com/rubocop-hq/rubocop/issues/595): Exclude files ignored by `git`. ([@AlexWayfer][])
+* [#3904](https://github.com/rubocop-hq/rubocop/issues/3904): Deduplicate descriptions by copying cop descriptions into config. ([@garettarrowood][])
 * [#6429](https://github.com/rubocop-hq/rubocop/issues/6429): Fix autocorrect in Rails/Validation to not wrap hash options with braces in an extra set of braces. ([@bquorning][])
 * [#6533](https://github.com/rubocop-hq/rubocop/issues/6533): Improved warning message for unrecognized cop parameters to include Supported parameters. ([@MagedMilad][])
 

--- a/bin/build_config
+++ b/bin/build_config
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.join(__dir__, '..', 'lib'))
+
+require 'yard'
+
+require 'rubocop'
+require 'rubocop/description_extractor'
+require 'rubocop/config_formatter'
+
+departments =
+  "{,#{RuboCop::Cop::Cop.registry.departments.map(&:downcase).join(',')}}"
+
+glob = File.join(__dir__, '..', 'lib', 'rubocop', 'cop', departments, '*.rb')
+YARD.parse(Dir[glob], [])
+
+descriptions = RuboCop::DescriptionExtractor.new(YARD::Registry.all).to_h
+current_config = YAML.load_file('config/default.yml')
+
+File.write(
+  'config/default.yml',
+  RuboCop::ConfigFormatter.new(current_config, descriptions).dump
+)

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,1034 +1,1193 @@
----
+# Common configuration.
+
 AllCops:
   RubyInterpreters:
-  - ruby
-  - macruby
-  - rake
-  - jruby
-  - rbx
+    - ruby
+    - macruby
+    - rake
+    - jruby
+    - rbx
+  # Include common Ruby source files.
   Include:
-  - "**/*.rb"
-  - "**/*.arb"
-  - "**/*.axlsx"
-  - "**/*.builder"
-  - "**/*.fcgi"
-  - "**/*.gemfile"
-  - "**/*.gemspec"
-  - "**/*.god"
-  - "**/*.jb"
-  - "**/*.jbuilder"
-  - "**/*.mspec"
-  - "**/*.opal"
-  - "**/*.pluginspec"
-  - "**/*.podspec"
-  - "**/*.rabl"
-  - "**/*.rake"
-  - "**/*.rbuild"
-  - "**/*.rbw"
-  - "**/*.rbx"
-  - "**/*.ru"
-  - "**/*.ruby"
-  - "**/*.spec"
-  - "**/*.thor"
-  - "**/*.watchr"
-  - "**/.irbrc"
-  - "**/.pryrc"
-  - "**/buildfile"
-  - "**/Appraisals"
-  - "**/Berksfile"
-  - "**/Brewfile"
-  - "**/Buildfile"
-  - "**/Capfile"
-  - "**/Cheffile"
-  - "**/Dangerfile"
-  - "**/Deliverfile"
-  - "**/Fastfile"
-  - "**/*Fastfile"
-  - "**/Gemfile"
-  - "**/Guardfile"
-  - "**/Jarfile"
-  - "**/Mavenfile"
-  - "**/Podfile"
-  - "**/Puppetfile"
-  - "**/Rakefile"
-  - "**/Snapfile"
-  - "**/Thorfile"
-  - "**/Vagabondfile"
-  - "**/Vagrantfile"
+    - '**/*.rb'
+    - '**/*.arb'
+    - '**/*.axlsx'
+    - '**/*.builder'
+    - '**/*.fcgi'
+    - '**/*.gemfile'
+    - '**/*.gemspec'
+    - '**/*.god'
+    - '**/*.jb'
+    - '**/*.jbuilder'
+    - '**/*.mspec'
+    - '**/*.opal'
+    - '**/*.pluginspec'
+    - '**/*.podspec'
+    - '**/*.rabl'
+    - '**/*.rake'
+    - '**/*.rbuild'
+    - '**/*.rbw'
+    - '**/*.rbx'
+    - '**/*.ru'
+    - '**/*.ruby'
+    - '**/*.spec'
+    - '**/*.thor'
+    - '**/*.watchr'
+    - '**/.irbrc'
+    - '**/.pryrc'
+    - '**/buildfile'
+    - '**/Appraisals'
+    - '**/Berksfile'
+    - '**/Brewfile'
+    - '**/Buildfile'
+    - '**/Capfile'
+    - '**/Cheffile'
+    - '**/Dangerfile'
+    - '**/Deliverfile'
+    - '**/Fastfile'
+    - '**/*Fastfile'
+    - '**/Gemfile'
+    - '**/Guardfile'
+    - '**/Jarfile'
+    - '**/Mavenfile'
+    - '**/Podfile'
+    - '**/Puppetfile'
+    - '**/Rakefile'
+    - '**/Snapfile'
+    - '**/Thorfile'
+    - '**/Vagabondfile'
+    - '**/Vagrantfile'
   Exclude:
-  - node_modules/**/*
-  - vendor/**/*
-  - ".git/**/*"
+    - 'node_modules/**/*'
+    - 'vendor/**/*'
+    - '.git/**/*'
+  # Default formatter will be used if no `-f/--format` option is given.
   DefaultFormatter: progress
+  # Cop names are displayed in offense messages by default. Change behavior
+  # by overriding DisplayCopNames, or by giving the `--no-display-cop-names`
+  # option.
   DisplayCopNames: true
+  # Style guide URLs are not displayed in offense messages by default. Change
+  # behavior by overriding `DisplayStyleGuide`, or by giving the
+  # `-S/--display-style-guide` option.
   DisplayStyleGuide: false
+  # When specifying style guide URLs, any paths and/or fragments will be
+  # evaluated relative to the base URL.
   StyleGuideBaseURL: https://github.com/rubocop-hq/ruby-style-guide
+  # Extra details are not displayed in offense messages by default. Change
+  # behavior by overriding ExtraDetails, or by giving the
+  # `-E/--extra-details` option.
   ExtraDetails: false
+  # Additional cops that do not reference a style guide rule may be enabled by
+  # default. Change behavior by overriding `StyleGuideCopsOnly`, or by giving
+  # the `--only-guide-cops` option.
   StyleGuideCopsOnly: false
+  # All cops except the ones configured `Enabled: false` in this file are enabled by default.
+  # Change this behavior by overriding either `DisabledByDefault` or `EnabledByDefault`.
+  # When `DisabledByDefault` is `true`, all cops in the default configuration
+  # are disabled, and only cops in user configuration are enabled. This makes
+  # cops opt-in instead of opt-out. Note that when `DisabledByDefault` is `true`,
+  # cops in user configuration will be enabled even if they don't set the
+  # Enabled parameter.
+  # When `EnabledByDefault` is `true`, all cops, even those configured `Enabled: false`
+  # in this file are enabled by default. Cops can still be disabled in user configuration.
+  # Note that it is invalid to set both EnabledByDefault and DisabledByDefault
+  # to true in the same configuration.
   EnabledByDefault: false
   DisabledByDefault: false
+  # Enables the result cache if `true`. Can be overridden by the `--cache` command
+  # line option.
   UseCache: true
+  # Threshold for how many files can be stored in the result cache before some
+  # of the files are automatically removed.
   MaxFilesInCache: 20000
-  CacheRootDirectory:
+  # The cache will be stored in "rubocop_cache" under this directory. If
+  # CacheRootDirectory is ~ (nil), which it is by default, the root will be
+  # taken from the environment variable `$XDG_CACHE_HOME` if it is set, or if
+  # `$XDG_CACHE_HOME` is not set, it will be `$HOME/.cache/`.
+  CacheRootDirectory: ~
+  # It is possible for a malicious user to know the location of RuboCop's cache
+  # directory by looking at CacheRootDirectory, and create a symlink in its
+  # place that could cause RuboCop to overwrite unintended files, or read
+  # malicious input. If you are certain that your cache location is secure from
+  # this kind of attack, and wish to use a symlinked cache location, set this
+  # value to "true".
   AllowSymlinksInCacheRootDirectory: false
-  TargetRubyVersion:
-  TargetRailsVersion:
+  # What MRI version of the Ruby interpreter is the inspected code intended to
+  # run on? (If there is more than one, set this to the lowest version.)
+  # If a value is specified for TargetRubyVersion then it is used. Acceptable
+  # values are specificed as a float (i.e. 2.5); the teeny version of Ruby
+  # should not be included. If the project specifies a Ruby version in the
+  # .ruby-version file, Gemfile or gems.rb file, RuboCop will try to determine
+  # the desired version of Ruby by inspecting the .ruby-version file first,
+  # followed by the Gemfile.lock or gems.locked file. (Although the Ruby version
+  # is specified in the Gemfile or gems.rb file, RuboCop reads the final value
+  # from the lock file.) If the Ruby version is still unresolved, RuboCop will
+  # use the oldest officially supported Ruby version (currently Ruby 2.2).
+  TargetRubyVersion: ~
+  # What version of Rails is the inspected code using?  If a value is specified
+  # for TargetRailsVersion then it is used. Acceptable values are specificed
+  # as a float (i.e. 5.1); the patch version of Rails should not be included.
+  # If TargetRailsVersion is not set, RuboCop will parse the Gemfile.lock or
+  # gems.locked file to find the version of Rails that has been bound to the
+  # application. If neither of those files exist, RuboCop will use Rails 5.0
+  # as the default.
+  TargetRailsVersion: ~
+
+#################### Bundler ###############################
 
 Bundler/DuplicatedGem:
-  Description: A Gem's requirements should be listed only once in a Gemfile.
+  Description: 'Checks for duplicate gem entries in Gemfile.'
   Enabled: true
   VersionAdded: '0.46'
   Include:
-  - "**/*.gemfile"
-  - "**/Gemfile"
-  - "**/gems.rb"
+    - '**/*.gemfile'
+    - '**/Gemfile'
+    - '**/gems.rb'
 
 Bundler/GemComment:
-  Description: Add a comment describing each gem in your Gemfile.
+  Description: 'Add a comment describing each gem.'
   Enabled: false
   VersionAdded: '0.59'
   Include:
-  - "**/*.gemfile"
-  - "**/Gemfile"
-  - "**/gems.rb"
+    - '**/*.gemfile'
+    - '**/Gemfile'
+    - '**/gems.rb'
   Whitelist: []
 
 Bundler/InsecureProtocolSource:
-  Description: |-
-    The symbol argument `:gemcutter`, `:rubygems`, and `:rubyforge`
-    are deprecated. So please change your source to URL string that
-    'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
+  Description: >-
+                 The source `:gemcutter`, `:rubygems` and `:rubyforge` are deprecated
+                 because HTTP requests are insecure. Please change your source to
+                 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
   Enabled: true
   VersionAdded: '0.50'
   Include:
-  - "**/*.gemfile"
-  - "**/Gemfile"
-  - "**/gems.rb"
+    - '**/*.gemfile'
+    - '**/Gemfile'
+    - '**/gems.rb'
 
 Bundler/OrderedGems:
-  Description: Gems should be alphabetically sorted within groups.
+  Description: >-
+                 Gems within groups in the Gemfile should be alphabetically sorted.
   Enabled: true
   VersionAdded: '0.46'
   VersionChanged: '0.47'
   TreatCommentsAsGroupSeparators: true
   Include:
-  - "**/*.gemfile"
-  - "**/Gemfile"
-  - "**/gems.rb"
+    - '**/*.gemfile'
+    - '**/Gemfile'
+    - '**/gems.rb'
+
+#################### Gemspec ###############################
 
 Gemspec/DuplicatedAssignment:
-  Description: |-
-    An attribute assignment method calls should be listed only once
-    in a gemspec.
+  Description: 'An attribute assignment method calls should be listed only once in a gemspec.'
   Enabled: true
   VersionAdded: '0.52'
   Include:
-  - "**/*.gemspec"
+    - '**/*.gemspec'
 
 Gemspec/OrderedDependencies:
-  Description: Dependencies in the gemspec should be alphabetically sorted.
+  Description: >-
+                 Dependencies in the gemspec should be alphabetically sorted.
   Enabled: true
   VersionAdded: '0.51'
   TreatCommentsAsGroupSeparators: true
   Include:
-  - "**/*.gemspec"
+    - '**/*.gemspec'
 
 Gemspec/RequiredRubyVersion:
-  Description: |-
-    Checks that `required_ruby_version` of gemspec and `TargetRubyVersion`
-    of .rubocop.yml are equal.
-    Thereby, RuboCop to perform static analysis working on the version
-    required by gemspec.
+  Description: 'Checks that `required_ruby_version` of gemspec and `TargetRubyVersion` of .rubocop.yml are equal.'
   Enabled: true
   VersionAdded: '0.52'
   Include:
-  - "**/*.gemspec"
+    - '**/*.gemspec'
+
+#################### Layout ###########################
 
 Layout/AccessModifierIndentation:
-  Description: |-
-    Modifiers should be indented as deep as method definitions, or as deep
-    as the class/module keyword, depending on configuration.
-  StyleGuide: "#indent-public-private-protected"
+  Description: Check indentation of private/protected visibility modifiers.
+  StyleGuide: '#indent-public-private-protected'
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: indent
   SupportedStyles:
-  - outdent
-  - indent
-  IndentationWidth:
+    - outdent
+    - indent
+  # By default, the indentation width from Layout/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
 
 Layout/AlignArray:
-  Description: |-
-    Here we check if the elements of a multi-line array literal are
-    aligned.
-  StyleGuide: "#align-multiline-arrays"
+  Description: >-
+                 Align the elements of an array literal if they span more than
+                 one line.
+  StyleGuide: '#align-multiline-arrays'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/AlignHash:
-  Description: |-
-    Check that the keys, separators, and values of a multi-line hash
-    literal are aligned according to configuration. The configuration
-    options are:
+  Description: >-
+                 Align the elements of a hash literal if they span more than
+                 one line.
   Enabled: true
   VersionAdded: '0.49'
+  # Alignment of entries using hash rocket as separator. Valid values are:
+  #
+  # key - left alignment of keys
+  #   'a' => 2
+  #   'bb' => 3
+  # separator - alignment of hash rockets, keys are right aligned
+  #    'a' => 2
+  #   'bb' => 3
+  # table - left alignment of keys, hash rockets, and values
+  #   'a'  => 2
+  #   'bb' => 3
   EnforcedHashRocketStyle: key
   SupportedHashRocketStyles:
-  - key
-  - separator
-  - table
+    - key
+    - separator
+    - table
+  # Alignment of entries using colon as separator. Valid values are:
+  #
+  # key - left alignment of keys
+  #   a: 0
+  #   bb: 1
+  # separator - alignment of colons, keys are right aligned
+  #    a: 0
+  #   bb: 1
+  # table - left alignment of keys and values
+  #   a:  0
+  #   bb: 1
   EnforcedColonStyle: key
   SupportedColonStyles:
-  - key
-  - separator
-  - table
+    - key
+    - separator
+    - table
+  # Select whether hashes that are the last argument in a method call should be
+  # inspected? Valid values are:
+  #
+  # always_inspect - Inspect both implicit and explicit hashes.
+  #   Registers an offense for:
+  #     function(a: 1,
+  #       b: 2)
+  #   Registers an offense for:
+  #     function({a: 1,
+  #       b: 2})
+  # always_ignore - Ignore both implicit and explicit hashes.
+  #   Accepts:
+  #     function(a: 1,
+  #       b: 2)
+  #   Accepts:
+  #     function({a: 1,
+  #       b: 2})
+  # ignore_implicit - Ignore only implicit hashes.
+  #   Accepts:
+  #     function(a: 1,
+  #       b: 2)
+  #   Registers an offense for:
+  #     function({a: 1,
+  #       b: 2})
+  # ignore_explicit - Ignore only explicit hashes.
+  #   Accepts:
+  #     function({a: 1,
+  #       b: 2})
+  #   Registers an offense for:
+  #     function(a: 1,
+  #       b: 2)
   EnforcedLastArgumentHashStyle: always_inspect
   SupportedLastArgumentHashStyles:
-  - always_inspect
-  - always_ignore
-  - ignore_implicit
-  - ignore_explicit
+    - always_inspect
+    - always_ignore
+    - ignore_implicit
+    - ignore_explicit
 
 Layout/AlignParameters:
-  Description: |-
-    Here we check if the parameters on a multi-line method call or
-    definition are aligned.
-  StyleGuide: "#no-double-indent"
+  Description: >-
+                 Align the parameters of a method call if they span more
+                 than one line.
+  StyleGuide: '#no-double-indent'
   Enabled: true
   VersionAdded: '0.49'
+  # Alignment of parameters in multi-line method calls.
+  #
+  # The `with_first_parameter` style aligns the following lines along the same
+  # column as the first parameter.
+  #
+  #     method_call(a,
+  #                 b)
+  #
+  # The `with_fixed_indentation` style aligns the following lines with one
+  # level of indentation relative to the start of the line with the method call.
+  #
+  #     method_call(a,
+  #       b)
   EnforcedStyle: with_first_parameter
   SupportedStyles:
-  - with_first_parameter
-  - with_fixed_indentation
-  IndentationWidth:
+    - with_first_parameter
+    - with_fixed_indentation
+  # By default, the indentation width from Layout/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
 
 Layout/BlockAlignment:
-  Description: |-
-    This cop checks whether the end keywords are aligned properly for do
-    end blocks.
+  Description: 'Align block ends correctly.'
   Enabled: true
   VersionAdded: '0.53'
+  # The value `start_of_block` means that the `end` should be aligned with line
+  # where the `do` keyword appears.
+  # The value `start_of_line` means it should be aligned with the whole
+  # expression's starting line.
+  # The value `either` means both are allowed.
   EnforcedStyleAlignWith: either
   SupportedStylesAlignWith:
-  - either
-  - start_of_block
-  - start_of_line
+    - either
+    - start_of_block
+    - start_of_line
 
 Layout/BlockEndNewline:
-  Description: |-
-    This cop checks whether the end statement of a do..end block
-    is on its own line.
+  Description: 'Put end statement of multiline block on its own line.'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/CaseIndentation:
-  Description: |-
-    This cop checks how the *when*s of a *case* expression
-    are indented in relation to its *case* or *end* keyword.
-  StyleGuide: "#indent-when-to-case"
+  Description: 'Indentation of when in a case/when/[else/]end.'
+  StyleGuide: '#indent-when-to-case'
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: case
   SupportedStyles:
-  - case
-  - end
+    - case
+    - end
   IndentOneStep: false
-  IndentationWidth:
+  # By default, the indentation width from `Layout/IndentationWidth` is used.
+  # But it can be overridden by setting this parameter.
+  # This only matters if `IndentOneStep` is `true`
+  IndentationWidth: ~
 
 Layout/ClassStructure:
-  Description: 'Checks if the code style follows the ExpectedOrder configuration:'
-  StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#consistent-classes
+  Description: 'Enforces a configured order of definitions within a class body.'
+  StyleGuide: 'https://github.com/rubocop-hq/ruby-style-guide#consistent-classes'
   Enabled: false
   VersionAdded: '0.52'
   Categories:
     module_inclusion:
-    - include
-    - prepend
-    - extend
+      - include
+      - prepend
+      - extend
   ExpectedOrder:
-  - module_inclusion
-  - constants
-  - public_class_methods
-  - initializer
-  - public_methods
-  - protected_methods
-  - private_methods
+      - module_inclusion
+      - constants
+      - public_class_methods
+      - initializer
+      - public_methods
+      - protected_methods
+      - private_methods
 
 Layout/ClosingHeredocIndentation:
-  Description: Checks the indentation of here document closings.
+  Description: 'Checks the indentation of here document closings.'
   Enabled: true
   VersionAdded: '0.57'
 
 Layout/ClosingParenthesisIndentation:
-  Description: |-
-    This cop checks the indentation of hanging closing parentheses in
-    method calls, method definitions, and grouped expressions. A hanging
-    closing parenthesis means `)` preceded by a line break.
+  Description: 'Checks the indentation of hanging closing parentheses.'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/CommentIndentation:
-  Description: This cop checks the indentation of comments.
+  Description: 'Indentation of comments.'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/ConditionPosition:
-  Description: |-
-    This cop checks for conditions that are not on the same line as
-    if/while/until.
-  StyleGuide: "#same-line-condition"
+  Description: >-
+                 Checks for condition placed in a confusing position relative to
+                 the keyword.
+  StyleGuide: '#same-line-condition'
   Enabled: true
   VersionAdded: '0.53'
 
 Layout/DefEndAlignment:
-  Description: |-
-    This cop checks whether the end keywords of method definitions are
-    aligned properly.
+  Description: 'Align ends corresponding to defs correctly.'
   Enabled: true
   VersionAdded: '0.53'
+  # The value `def` means that `end` should be aligned with the def keyword.
+  # The value `start_of_line` means that `end` should be aligned with method
+  # calls like `private`, `public`, etc, if present in front of the `def`
+  # keyword on the same line.
   EnforcedStyleAlignWith: start_of_line
   SupportedStylesAlignWith:
-  - start_of_line
-  - def
+    - start_of_line
+    - def
   AutoCorrect: false
   Severity: warning
 
 Layout/DotPosition:
-  Description: This cop checks the . position in multi-line method calls.
-  StyleGuide: "#consistent-multi-line-chains"
+  Description: 'Checks the position of the dot in multi-line method calls.'
+  StyleGuide: '#consistent-multi-line-chains'
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: leading
   SupportedStyles:
-  - leading
-  - trailing
+    - leading
+    - trailing
 
 Layout/ElseAlignment:
-  Description: |-
-    This cop checks the alignment of else keywords. Normally they should
-    be aligned with an if/unless/while/until/begin/def keyword, but there
-    are special cases when they should follow the same rules as the
-    alignment of end.
+  Description: 'Align elses and elsifs correctly.'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/EmptyComment:
-  Description: This cop checks empty comment.
+  Description: 'Checks empty comment.'
   Enabled: true
   VersionAdded: '0.53'
   AllowBorderComment: true
   AllowMarginComment: true
 
 Layout/EmptyLineAfterGuardClause:
-  Description: This cop enforces empty line after guard clause
+  Description: 'Add empty line after guard clause.'
   Enabled: true
   VersionAdded: '0.56'
   VersionChanged: '0.59'
 
 Layout/EmptyLineAfterMagicComment:
-  Description: Checks for a newline after the final magic comment.
-  StyleGuide: "#separate-magic-comments-from-code"
+  Description: 'Add an empty line after magic comments to separate them from code.'
+  StyleGuide: '#separate-magic-comments-from-code'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/EmptyLineBetweenDefs:
-  Description: |-
-    This cop checks whether method definitions are
-    separated by one empty line.
-  StyleGuide: "#empty-lines-between-methods"
+  Description: 'Use empty lines between defs.'
+  StyleGuide: '#empty-lines-between-methods'
   Enabled: true
   VersionAdded: '0.49'
+  # If `true`, this parameter means that single line method definitions don't
+  # need an empty line between them.
   AllowAdjacentOneLineDefs: false
+  # Can be array to specify minimum and maximum number of empty lines, e.g. [1, 2]
   NumberOfEmptyLines: 1
 
 Layout/EmptyLines:
-  Description: This cop checks for two or more consecutive blank lines.
-  StyleGuide: "#two-or-more-empty-lines"
+  Description: "Don't use several empty lines in a row."
+  StyleGuide: '#two-or-more-empty-lines'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/EmptyLinesAroundAccessModifier:
-  Description: Access modifiers should be surrounded by blank lines.
-  StyleGuide: "#empty-lines-around-access-modifier"
+  Description: "Keep blank lines around access modifiers."
+  StyleGuide: '#empty-lines-around-access-modifier'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/EmptyLinesAroundArguments:
-  Description: |-
-    This cop checks if empty lines exist around the arguments
-    of a method invocation.
+  Description: "Keeps track of empty lines around method arguments."
   Enabled: true
   VersionAdded: '0.52'
 
 Layout/EmptyLinesAroundBeginBody:
-  Description: |-
-    This cop checks if empty lines exist around the bodies of begin-end
-    blocks.
-  StyleGuide: "#empty-lines-around-bodies"
+  Description: "Keeps track of empty lines around begin-end bodies."
+  StyleGuide: '#empty-lines-around-bodies'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/EmptyLinesAroundBlockBody:
-  Description: |-
-    This cop checks if empty lines around the bodies of blocks match
-    the configuration.
-  StyleGuide: "#empty-lines-around-bodies"
+  Description: "Keeps track of empty lines around block bodies."
+  StyleGuide: '#empty-lines-around-bodies'
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: no_empty_lines
   SupportedStyles:
-  - empty_lines
-  - no_empty_lines
+    - empty_lines
+    - no_empty_lines
 
 Layout/EmptyLinesAroundClassBody:
-  Description: |-
-    This cop checks if empty lines around the bodies of classes match
-    the configuration.
-  StyleGuide: "#empty-lines-around-bodies"
+  Description: "Keeps track of empty lines around class bodies."
+  StyleGuide: '#empty-lines-around-bodies'
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.53'
   EnforcedStyle: no_empty_lines
   SupportedStyles:
-  - empty_lines
-  - empty_lines_except_namespace
-  - empty_lines_special
-  - no_empty_lines
-  - beginning_only
-  - ending_only
+    - empty_lines
+    - empty_lines_except_namespace
+    - empty_lines_special
+    - no_empty_lines
+    - beginning_only
+    - ending_only
 
 Layout/EmptyLinesAroundExceptionHandlingKeywords:
-  Description: |-
-    This cop checks if empty lines exist around the bodies of `begin`
-    sections. This cop doesn't check empty lines at `begin` body
-    beginning/end and around method definition body.
-    `Style/EmptyLinesAroundBeginBody` or `Style/EmptyLinesAroundMethodBody`
-    can be used for this purpose.
-  StyleGuide: "#empty-lines-around-bodies"
+  Description: "Keeps track of empty lines around exception handling keywords."
+  StyleGuide: '#empty-lines-around-bodies'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/EmptyLinesAroundMethodBody:
-  Description: This cop checks if empty lines exist around the bodies of methods.
-  StyleGuide: "#empty-lines-around-bodies"
+  Description: "Keeps track of empty lines around method bodies."
+  StyleGuide: '#empty-lines-around-bodies'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/EmptyLinesAroundModuleBody:
-  Description: |-
-    This cop checks if empty lines around the bodies of modules match
-    the configuration.
-  StyleGuide: "#empty-lines-around-bodies"
+  Description: "Keeps track of empty lines around module bodies."
+  StyleGuide: '#empty-lines-around-bodies'
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: no_empty_lines
   SupportedStyles:
-  - empty_lines
-  - empty_lines_except_namespace
-  - empty_lines_special
-  - no_empty_lines
+    - empty_lines
+    - empty_lines_except_namespace
+    - empty_lines_special
+    - no_empty_lines
 
 Layout/EndAlignment:
-  Description: This cop checks whether the end keywords are aligned properly.
+  Description: 'Align ends correctly.'
   Enabled: true
   VersionAdded: '0.53'
+  # The value `keyword` means that `end` should be aligned with the matching
+  # keyword (`if`, `while`, etc.).
+  # The value `variable` means that in assignments, `end` should be aligned
+  # with the start of the variable on the left hand side of `=`. In all other
+  # situations, `end` should still be aligned with the keyword.
+  # The value `start_of_line` means that `end` should be aligned with the start
+  # of the line which the matching keyword appears on.
   EnforcedStyleAlignWith: keyword
   SupportedStylesAlignWith:
-  - keyword
-  - variable
-  - start_of_line
+    - keyword
+    - variable
+    - start_of_line
   AutoCorrect: false
   Severity: warning
 
 Layout/EndOfLine:
-  Description: This cop checks for Windows-style line endings in the source code.
-  StyleGuide: "#crlf"
+  Description: 'Use Unix-style line endings.'
+  StyleGuide: '#crlf'
   Enabled: true
   VersionAdded: '0.49'
+  # The `native` style means that CR+LF (Carriage Return + Line Feed) is
+  # enforced on Windows, and LF is enforced on other platforms. The other styles
+  # mean LF and CR+LF, respectively.
   EnforcedStyle: native
   SupportedStyles:
-  - native
-  - lf
-  - crlf
+    - native
+    - lf
+    - crlf
 
 Layout/ExtraSpacing:
-  Description: This cop checks for extra/unnecessary whitespace.
+  Description: 'Do not use unnecessary spacing.'
   Enabled: true
   VersionAdded: '0.49'
+  # When true, allows most uses of extra spacing if the intent is to align
+  # things with the previous or next line, not counting empty lines or comment
+  # lines.
   AllowForAlignment: true
+  # When true, forces the alignment of `=` in assignments on consecutive lines.
   ForceEqualSignAlignment: false
 
 Layout/FirstArrayElementLineBreak:
-  Description: |-
-    This cop checks for a line break before the first element in a
-    multi-line array.
+  Description: >-
+                 Checks for a line break before the first element in a
+                 multi-line array.
   Enabled: false
   VersionAdded: '0.49'
 
 Layout/FirstHashElementLineBreak:
-  Description: |-
-    This cop checks for a line break before the first element in a
-    multi-line hash.
+  Description: >-
+                 Checks for a line break before the first element in a
+                 multi-line hash.
   Enabled: false
   VersionAdded: '0.49'
 
 Layout/FirstMethodArgumentLineBreak:
-  Description: |-
-    This cop checks for a line break before the first argument in a
-    multi-line method call.
+  Description: >-
+                 Checks for a line break before the first argument in a
+                 multi-line method call.
   Enabled: false
   VersionAdded: '0.49'
 
 Layout/FirstMethodParameterLineBreak:
-  Description: |-
-    This cop checks for a line break before the first parameter in a
-    multi-line method parameter definition.
+  Description: >-
+                 Checks for a line break before the first parameter in a
+                 multi-line method parameter definition.
   Enabled: false
   VersionAdded: '0.49'
 
 Layout/FirstParameterIndentation:
-  Description: |-
-    This cop checks the indentation of the first parameter in a method call.
-    Parameters after the first one are checked by Layout/AlignParameters,
-    not by this cop.
+  Description: 'Checks the indentation of the first parameter in a method call.'
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.56'
   EnforcedStyle: special_for_inner_method_call_in_parentheses
   SupportedStyles:
-  - consistent
-  - consistent_relative_to_receiver
-  - special_for_inner_method_call
-  - special_for_inner_method_call_in_parentheses
-  IndentationWidth:
+    # The first parameter should always be indented one step more than the
+    # preceding line.
+    - consistent
+    # The first parameter should always be indented one level relative to the
+    # parent that is receiving the parameter
+    - consistent_relative_to_receiver
+    # The first parameter should normally be indented one step more than the
+    # preceding line, but if it's a parameter for a method call that is itself
+    # a parameter in a method call, then the inner parameter should be indented
+    # relative to the inner method.
+    - special_for_inner_method_call
+    # Same as `special_for_inner_method_call` except that the special rule only
+    # applies if the outer method call encloses its arguments in parentheses.
+    - special_for_inner_method_call_in_parentheses
+  # By default, the indentation width from `Layout/IndentationWidth` is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
 
 Layout/IndentArray:
-  Description: |-
-    This cop checks the indentation of the first element in an array literal
-    where the opening bracket and the first element are on separate lines.
-    The other elements' indentations are handled by the AlignArray cop.
+  Description: >-
+                 Checks the indentation of the first element in an array
+                 literal.
   Enabled: true
   VersionAdded: '0.49'
+  # The value `special_inside_parentheses` means that array literals with
+  # brackets that have their opening bracket on the same line as a surrounding
+  # opening round parenthesis, shall have their first element indented relative
+  # to the first position inside the parenthesis.
+  #
+  # The value `consistent` means that the indentation of the first element shall
+  # always be relative to the first position of the line where the opening
+  # bracket is.
+  #
+  # The value `align_brackets` means that the indentation of the first element
+  # shall always be relative to the position of the opening bracket.
   EnforcedStyle: special_inside_parentheses
   SupportedStyles:
-  - special_inside_parentheses
-  - consistent
-  - align_brackets
-  IndentationWidth:
+    - special_inside_parentheses
+    - consistent
+    - align_brackets
+  # By default, the indentation width from `Layout/IndentationWidth` is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
 
 Layout/IndentAssignment:
-  Description: |-
-    This cop checks the indentation of the first line of the
-    right-hand-side of a multi-line assignment.
+  Description: >-
+                 Checks the indentation of the first line of the
+                 right-hand-side of a multi-line assignment.
   Enabled: true
   VersionAdded: '0.49'
-  IndentationWidth:
+  # By default, the indentation width from `Layout/IndentationWidth` is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
 
 Layout/IndentHash:
-  Description: |-
-    This cop checks the indentation of the first key in a hash literal
-    where the opening brace and the first key are on separate lines. The
-    other keys' indentations are handled by the AlignHash cop.
+  Description: 'Checks the indentation of the first key in a hash literal.'
   Enabled: true
   VersionAdded: '0.49'
+  # The value `special_inside_parentheses` means that hash literals with braces
+  # that have their opening brace on the same line as a surrounding opening
+  # round parenthesis, shall have their first key indented relative to the
+  # first position inside the parenthesis.
+  #
+  # The value `consistent` means that the indentation of the first key shall
+  # always be relative to the first position of the line where the opening
+  # brace is.
+  #
+  # The value `align_braces` means that the indentation of the first key shall
+  # always be relative to the position of the opening brace.
   EnforcedStyle: special_inside_parentheses
   SupportedStyles:
-  - special_inside_parentheses
-  - consistent
-  - align_braces
-  IndentationWidth:
+    - special_inside_parentheses
+    - consistent
+    - align_braces
+  # By default, the indentation width from `Layout/IndentationWidth` is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
 
 Layout/IndentHeredoc:
-  Description: |-
-    This cop checks the indentation of the here document bodies. The bodies
-    are indented one step.
-    In Ruby 2.3 or newer, squiggly heredocs (`<<~`) should be used. If you
-    use the older rubies, you should introduce some library to your project
-    (e.g. ActiveSupport, Powerpack or Unindent).
-    Note: When `Metrics/LineLength`'s `AllowHeredoc` is false (not default),
-          this cop does not add any offenses for long here documents to
-          avoid `Metrics/LineLength`'s offenses.
-  StyleGuide: "#squiggly-heredocs"
+  Description: 'This cop checks the indentation of the here document bodies.'
+  StyleGuide: '#squiggly-heredocs'
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: auto_detection
   SupportedStyles:
-  - auto_detection
-  - squiggly
-  - active_support
-  - powerpack
-  - unindent
+    - auto_detection
+    - squiggly
+    - active_support
+    - powerpack
+    - unindent
 
 Layout/IndentationConsistency:
-  Description: This cop checks for inconsistent indentation.
-  StyleGuide: "#spaces-indentation"
+  Description: 'Keep indentation straight.'
+  StyleGuide: '#spaces-indentation'
   Enabled: true
   VersionAdded: '0.49'
+  # The difference between `rails` and `normal` is that the `rails` style
+  # prescribes that in classes and modules the `protected` and `private`
+  # modifier keywords shall be indented the same as public methods and that
+  # protected and private members shall be indented one step more than the
+  # modifiers. Other than that, both styles mean that entities on the same
+  # logical depth shall have the same indentation.
   EnforcedStyle: normal
   SupportedStyles:
-  - normal
-  - rails
+    - normal
+    - rails
 
 Layout/IndentationWidth:
-  Description: |-
-    This cop checks for indentation that doesn't use the specified number
-    of spaces.
-  StyleGuide: "#spaces-indentation"
+  Description: 'Use 2 spaces for indentation.'
+  StyleGuide: '#spaces-indentation'
   Enabled: true
   VersionAdded: '0.49'
+  # Number of spaces for each indentation level.
   Width: 2
   IgnoredPatterns: []
 
 Layout/InitialIndentation:
-  Description: |-
-    This cop checks for indentation of the first non-blank non-comment
-    line in a file.
+  Description: >-
+    Checks the indentation of the first non-blank non-comment line in a file.
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/LeadingBlankLines:
-  Description: |-
-    This cop checks for unnecessary leading blank lines at the beginning
-    of a file.
+  Description: Check for unnecessary blank lines at the beginning of a file.
   Enabled: true
   VersionAdded: '0.57'
 
 Layout/LeadingCommentSpace:
-  Description: |-
-    This cop checks whether comments have a leading space after the
-    `#` denoting the start of the comment. The leading space is not
-    required for some RDoc special syntax, like `#++`, `#--`,
-    `#:nodoc`, `=begin`- and `=end` comments, "shebang" directives,
-    or rackup options.
-  StyleGuide: "#hash-space"
+  Description: 'Comments should start with a space.'
+  StyleGuide: '#hash-space'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/MultilineArrayBraceLayout:
-  Description: |-
-    This cop checks that the closing brace in an array literal is either
-    on the same line as the last array element or on a new line.
+  Description: >-
+                 Checks that the closing brace in an array literal is
+                 either on the same line as the last array element, or
+                 a new line.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
   SupportedStyles:
-  - symmetrical
-  - new_line
-  - same_line
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last element
+    - symmetrical
+    - new_line
+    - same_line
 
 Layout/MultilineAssignmentLayout:
-  Description: |-
-    This cop checks whether the multiline assignments have a newline
-    after the assignment operator.
-  StyleGuide: "#indent-conditional-assignment"
+  Description: 'Check for a newline after the assignment operator in multi-line assignments.'
+  StyleGuide: '#indent-conditional-assignment'
   Enabled: false
   VersionAdded: '0.49'
+  # The types of assignments which are subject to this rule.
   SupportedTypes:
-  - block
-  - case
-  - class
-  - if
-  - kwbegin
-  - module
+    - block
+    - case
+    - class
+    - if
+    - kwbegin
+    - module
   EnforcedStyle: new_line
   SupportedStyles:
-  - same_line
-  - new_line
+    # Ensures that the assignment operator and the rhs are on the same line for
+    # the set of supported types.
+    - same_line
+    # Ensures that the assignment operator and the rhs are on separate lines
+    # for the set of supported types.
+    - new_line
 
 Layout/MultilineBlockLayout:
-  Description: |-
-    This cop checks whether the multiline do end blocks have a newline
-    after the start of the block. Additionally, it checks whether the block
-    arguments, if any, are on the same line as the start of the block.
+  Description: 'Ensures newlines after multiline block do statements.'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/MultilineHashBraceLayout:
-  Description: |-
-    This cop checks that the closing brace in a hash literal is either
-    on the same line as the last hash element, or a new line.
+  Description: >-
+                 Checks that the closing brace in a hash literal is
+                 either on the same line as the last hash element, or
+                 a new line.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
   SupportedStyles:
-  - symmetrical
-  - new_line
-  - same_line
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on same line as last element
+    - symmetrical
+    - new_line
+    - same_line
 
 Layout/MultilineMethodCallBraceLayout:
-  Description: |-
-    This cop checks that the closing brace in a method call is either
-    on the same line as the last method argument, or a new line.
+  Description: >-
+                 Checks that the closing brace in a method call is
+                 either on the same line as the last method argument, or
+                 a new line.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
   SupportedStyles:
-  - symmetrical
-  - new_line
-  - same_line
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last argument
+    - symmetrical
+    - new_line
+    - same_line
 
 Layout/MultilineMethodCallIndentation:
-  Description: |-
-    This cop checks the indentation of the method name part in method calls
-    that span more than one line.
+  Description: >-
+                 Checks indentation of method calls with the dot operator
+                 that span more than one line.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: aligned
   SupportedStyles:
-  - aligned
-  - indented
-  - indented_relative_to_receiver
-  IndentationWidth:
+    - aligned
+    - indented
+    - indented_relative_to_receiver
+  # By default, the indentation width from Layout/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
 
 Layout/MultilineMethodDefinitionBraceLayout:
-  Description: |-
-    This cop checks that the closing brace in a method definition is either
-    on the same line as the last method parameter, or a new line.
+  Description: >-
+                 Checks that the closing brace in a method definition is
+                 either on the same line as the last method parameter, or
+                 a new line.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
   SupportedStyles:
-  - symmetrical
-  - new_line
-  - same_line
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last parameter
+    - symmetrical
+    - new_line
+    - same_line
 
 Layout/MultilineOperationIndentation:
-  Description: |-
-    This cop checks the indentation of the right hand side operand in
-    binary operations that span more than one line.
+  Description: >-
+                 Checks indentation of binary operations that span more than
+                 one line.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: aligned
   SupportedStyles:
-  - aligned
-  - indented
-  IndentationWidth:
+    - aligned
+    - indented
+  # By default, the indentation width from `Layout/IndentationWidth` is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
 
 Layout/RescueEnsureAlignment:
-  Description: |-
-    This cop checks whether the rescue and ensure keywords are aligned
-    properly.
+  Description: 'Align rescues and ensures correctly.'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceAfterColon:
-  Description: |-
-    Checks for colon (:) not followed by some kind of space.
-    N.B. this cop does not handle spaces after a ternary operator, which are
-    instead handled by Layout/SpaceAroundOperators.
-  StyleGuide: "#spaces-operators"
+  Description: 'Use spaces after colons.'
+  StyleGuide: '#spaces-operators'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceAfterComma:
-  Description: Checks for comma (,) not followed by some kind of space.
-  StyleGuide: "#spaces-operators"
+  Description: 'Use spaces after commas.'
+  StyleGuide: '#spaces-operators'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceAfterMethodName:
-  Description: Checks for space between a method name and a left parenthesis in defs.
-  StyleGuide: "#parens-no-spaces"
+  Description: >-
+                 Do not put a space between a method name and the opening
+                 parenthesis in a method definition.
+  StyleGuide: '#parens-no-spaces'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceAfterNot:
-  Description: This cop checks for space after `!`.
-  StyleGuide: "#no-space-bang"
+  Description: Tracks redundant space after the ! operator.
+  StyleGuide: '#no-space-bang'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceAfterSemicolon:
-  Description: Checks for semicolon (;) not followed by some kind of space.
-  StyleGuide: "#spaces-operators"
+  Description: 'Use spaces after semicolons.'
+  StyleGuide: '#spaces-operators'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceAroundBlockParameters:
-  Description: Checks the spacing inside and after block parameters pipes.
+  Description: 'Checks the spacing inside and after block parameters pipes.'
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyleInsidePipes: no_space
   SupportedStylesInsidePipes:
-  - space
-  - no_space
+    - space
+    - no_space
 
 Layout/SpaceAroundEqualsInParameterDefault:
-  Description: |-
-    Checks that the equals signs in parameter default assignments
-    have or don't have surrounding space depending on configuration.
-  StyleGuide: "#spaces-around-equals"
+  Description: >-
+                 Checks that the equals signs in parameter default assignments
+                 have or don't have surrounding space depending on
+                 configuration.
+  StyleGuide: '#spaces-around-equals'
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: space
   SupportedStyles:
-  - space
-  - no_space
+    - space
+    - no_space
 
 Layout/SpaceAroundKeyword:
-  Description: Checks the spacing around the keywords.
+  Description: 'Use a space around keywords if appropriate.'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceAroundOperators:
-  Description: |-
-    Checks that operators have space around them, except for **
-    which should not have surrounding space.
-  StyleGuide: "#spaces-operators"
+  Description: 'Use a single space around operators.'
+  StyleGuide: '#spaces-operators'
   Enabled: true
   VersionAdded: '0.49'
+  # When `true`, allows most uses of extra spacing if the intent is to align
+  # with an operator on the previous or next line, not counting empty lines
+  # or comment lines.
   AllowForAlignment: true
 
 Layout/SpaceBeforeBlockBraces:
-  Description: |-
-    Checks that block braces have or don't have a space before the opening
-    brace depending on configuration.
+  Description: >-
+                 Checks that the left block brace has or doesn't have space
+                 before it.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: space
   SupportedStyles:
-  - space
-  - no_space
+    - space
+    - no_space
   EnforcedStyleForEmptyBraces: space
   SupportedStylesForEmptyBraces:
-  - space
-  - no_space
-  VersionChanged: 0.52.1
+    - space
+    - no_space
+  VersionChanged: '0.52.1'
 
 Layout/SpaceBeforeComma:
-  Description: Checks for comma (,) preceded by space.
+  Description: 'No spaces before commas.'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceBeforeComment:
-  Description: |-
-    This cop checks for missing space between a token and a comment on the
-    same line.
+  Description: >-
+                 Checks for missing space between code and a comment on the
+                 same line.
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceBeforeFirstArg:
-  Description: |-
-    Checks that exactly one space is used between a method name and the
-    first argument for method calls without parentheses.
+  Description: >-
+                 Checks that exactly one space is used between a method name
+                 and the first argument for method calls without parentheses.
   Enabled: true
   VersionAdded: '0.49'
+  # When `true`, allows most uses of extra spacing if the intent is to align
+  # things with the previous or next line, not counting empty lines or comment
+  # lines.
   AllowForAlignment: true
 
 Layout/SpaceBeforeSemicolon:
-  Description: Checks for semicolon (;) preceded by space.
+  Description: 'No spaces before semicolons.'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceInLambdaLiteral:
-  Description: |-
-    This cop checks for spaces between `->` and opening parameter
-    parenthesis (`(`) in lambda literals.
+  Description: 'Checks for spaces in lambda literals.'
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: require_no_space
   SupportedStyles:
-  - require_no_space
-  - require_space
+    - require_no_space
+    - require_space
 
 Layout/SpaceInsideArrayLiteralBrackets:
-  Description: |-
-    Checks that brackets used for array literals have or don't have
-    surrounding space depending on configuration.
+  Description: 'Checks the spacing inside array literal brackets.'
   Enabled: true
   VersionAdded: '0.52'
   EnforcedStyle: no_space
   SupportedStyles:
-  - space
-  - no_space
-  - compact
+    - space
+    - no_space
+    # 'compact' normally requires a space inside the brackets, with the exception
+    # that successive left brackets or right brackets are collapsed together
+    - compact
   EnforcedStyleForEmptyBrackets: no_space
   SupportedStylesForEmptyBrackets:
-  - space
-  - no_space
+    - space
+    - no_space
 
 Layout/SpaceInsideArrayPercentLiteral:
-  Description: |-
-    Checks for unnecessary additional spaces inside array percent literals
-    (i.e. %i/%w).
+  Description: 'No unnecessary additional spaces between elements in %i/%w literals.'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceInsideBlockBraces:
-  Description: |-
-    Checks that block braces have or don't have surrounding space inside
-    them on configuration. For blocks taking parameters, it checks that the
-    left brace has or doesn't have trailing space depending on
-    configuration.
+  Description: >-
+                 Checks that block braces have or don't have surrounding space.
+                 For blocks taking parameters, checks that the left brace has
+                 or doesn't have trailing space.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: space
   SupportedStyles:
-  - space
-  - no_space
+    - space
+    - no_space
   EnforcedStyleForEmptyBraces: no_space
   SupportedStylesForEmptyBraces:
-  - space
-  - no_space
+    - space
+    - no_space
+  # Space between `{` and `|`. Overrides `EnforcedStyle` if there is a conflict.
   SpaceBeforeBlockParameters: true
 
 Layout/SpaceInsideHashLiteralBraces:
-  Description: |-
-    Checks that braces used for hash literals have or don't have
-    surrounding space depending on configuration.
-  StyleGuide: "#spaces-operators"
+  Description: "Use spaces inside hash literal braces - or don't."
+  StyleGuide: '#spaces-operators'
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: space
   SupportedStyles:
-  - space
-  - no_space
-  - compact
+    - space
+    - no_space
+    # 'compact' normally requires a space inside hash braces, with the exception
+    # that successive left braces or right braces are collapsed together
+    - compact
   EnforcedStyleForEmptyBraces: no_space
   SupportedStylesForEmptyBraces:
-  - space
-  - no_space
+    - space
+    - no_space
+
 
 Layout/SpaceInsideParens:
-  Description: Checks for spaces inside ordinary round parentheses.
-  StyleGuide: "#spaces-braces"
+  Description: 'No spaces after ( or before ).'
+  StyleGuide: '#spaces-braces'
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.55'
   EnforcedStyle: no_space
   SupportedStyles:
-  - space
-  - no_space
+    - space
+    - no_space
 
 Layout/SpaceInsidePercentLiteralDelimiters:
-  Description: |-
-    Checks for unnecessary additional spaces inside the delimiters of
-    %i/%w/%x literals.
+  Description: 'No unnecessary spaces inside delimiters of %i/%w/%x literals.'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceInsideRangeLiteral:
-  Description: Checks for spaces inside range literals.
-  StyleGuide: "#no-space-inside-range-literals"
+  Description: 'No spaces inside range literals.'
+  StyleGuide: '#no-space-inside-range-literals'
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceInsideReferenceBrackets:
-  Description: |-
-    Checks that reference brackets have or don't have
-    surrounding space depending on configuration.
+  Description: 'Checks the spacing inside referential brackets.'
   Enabled: true
   VersionAdded: '0.52'
   VersionChanged: '0.53'
   EnforcedStyle: no_space
   SupportedStyles:
-  - space
-  - no_space
+    - space
+    - no_space
   EnforcedStyleForEmptyBrackets: no_space
   SupportedStylesForEmptyBrackets:
-  - space
-  - no_space
+    - space
+    - no_space
 
 Layout/SpaceInsideStringInterpolation:
-  Description: This cop checks for whitespace within string interpolations.
-  StyleGuide: "#string-interpolation"
+  Description: 'Checks for padding/surrounding spaces inside string interpolation.'
+  StyleGuide: '#string-interpolation'
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: no_space
   SupportedStyles:
-  - space
-  - no_space
+    - space
+    - no_space
 
 Layout/Tab:
-  Description: This cop checks for tabs inside the source code.
-  StyleGuide: "#spaces-indentation"
+  Description: 'No hard tabs.'
+  StyleGuide: '#spaces-indentation'
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.51'
-  IndentationWidth:
+  # By default, the indentation width from Layout/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  # It is used during auto-correction to determine how many spaces should
+  # replace each tab.
+  IndentationWidth: ~
 
 Layout/TrailingBlankLines:
-  Description: |-
-    This cop looks for trailing blank lines and a final newline in the
-    source code.
-  StyleGuide: "#newline-eof"
+  Description: 'Checks trailing blank lines and final newline.'
+  StyleGuide: '#newline-eof'
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: final_newline
   SupportedStyles:
-  - final_newline
-  - final_blank_line
+    - final_newline
+    - final_blank_line
 
 Layout/TrailingWhitespace:
-  Description: This cop looks for trailing whitespace in the source code.
-  StyleGuide: "#no-trailing-whitespace"
+  Description: 'Avoid trailing whitespace.'
+  StyleGuide: '#no-trailing-whitespace'
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.55'
   AllowInHeredoc: false
 
+#################### Lint ##################################
+### Warnings
+
 Lint/AmbiguousBlockAssociation:
-  Description: |-
-    This cop checks for ambiguous block association with method
-    when param passed without parentheses.
-  StyleGuide: "#syntax"
+  Description: >-
+                 Checks for ambiguous block association with method when param passed without
+                 parentheses.
+  StyleGuide: '#syntax'
   Enabled: true
   VersionAdded: '0.48'
 
 Lint/AmbiguousOperator:
-  Description: |-
-    This cop checks for ambiguous operators in the first argument of a
-    method invocation without parentheses.
-  StyleGuide: "#method-invocation-parens"
+  Description: >-
+                 Checks for ambiguous operators in the first argument of a
+                 method invocation without parentheses.
+  StyleGuide: '#method-invocation-parens'
   Enabled: true
   VersionAdded: '0.17'
 
 Lint/AmbiguousRegexpLiteral:
-  Description: |-
-    This cop checks for ambiguous regexp literals in the first argument of
-    a method invocation without parentheses.
+  Description: >-
+                 Checks for ambiguous regexp literals in the first argument of
+                 a method invocation without parentheses.
   Enabled: true
   VersionAdded: '0.17'
 
 Lint/AssignmentInCondition:
-  Description: |-
-    This cop checks for assignments in the conditions of
-    if/while/until.
-  StyleGuide: "#safe-assignment-in-condition"
+  Description: "Don't use assignment in conditions."
+  StyleGuide: '#safe-assignment-in-condition'
   Enabled: true
   VersionAdded: '0.9'
   AllowSafeAssignment: true
 
 Lint/BigDecimalNew:
-  Description: |-
-    `BigDecimal.new()` is deprecated since BigDecimal 1.3.3.
-    This cop identifies places where `BigDecimal.new()`
-    can be replaced by `BigDecimal()`.
+  Description: '`BigDecimal.new()` is deprecated. Use `BigDecimal()` instead.'
   Enabled: true
   VersionAdded: '0.53'
 
 Lint/BooleanSymbol:
-  Description: |-
-    This cop checks for `:true` and `:false` symbols.
-    In most cases it would be a typo.
+  Description: 'Check for `:true` and `:false` symbols.'
   Enabled: true
   VersionAdded: '0.50'
 
 Lint/CircularArgumentReference:
-  Description: |-
-    This cop checks for circular argument references in optional keyword
-    arguments and optional ordinal arguments.
+  Description: "Default values in optional keyword arguments and optional ordinal arguments should not refer back to the name of the argument."
   Enabled: true
   VersionAdded: '0.33'
 
 Lint/Debugger:
-  Description: This cop checks for calls to debugger or pry.
+  Description: 'Check for debugger calls.'
   Enabled: true
   VersionAdded: '0.14'
   VersionChanged: '0.49'
 
 Lint/DeprecatedClassMethods:
-  Description: This cop checks for uses of the deprecated class method usages.
+  Description: 'Check for deprecated class method calls.'
   Enabled: true
   VersionAdded: '0.19'
 
@@ -1039,82 +1198,66 @@ Lint/DisjunctiveAssignmentInConstructor:
   VersionAdded: '0.62'
 
 Lint/DuplicateCaseCondition:
-  Description: |-
-    This cop checks that there are no repeated conditions
-    used in case 'when' expressions.
+  Description: 'Do not repeat values in case conditionals.'
   Enabled: true
   VersionAdded: '0.45'
 
 Lint/DuplicateMethods:
-  Description: |-
-    This cop checks for duplicated instance (or singleton) method
-    definitions.
+  Description: 'Check for duplicate method definitions.'
   Enabled: true
   VersionAdded: '0.29'
 
 Lint/DuplicatedKey:
-  Description: This cop checks for duplicated keys in hash literals.
+  Description: 'Check for duplicate keys in hash literals.'
   Enabled: true
   VersionAdded: '0.34'
 
 Lint/EachWithObjectArgument:
-  Description: |-
-    This cop checks if each_with_object is called with an immutable
-    argument. Since the argument is the object that the given block shall
-    make calls on to build something based on the enumerable that
-    each_with_object iterates over, an immutable argument makes no sense.
-    It's definitely a bug.
+  Description: 'Check for immutable argument given to each_with_object.'
   Enabled: true
   VersionAdded: '0.31'
 
 Lint/ElseLayout:
-  Description: |-
-    This cop checks for odd else block layout - like
-    having an expression on the same line as the else keyword,
-    which is usually a mistake.
+  Description: 'Check for odd code arrangement in an else block.'
   Enabled: true
   VersionAdded: '0.17'
 
 Lint/EmptyEnsure:
-  Description: This cop checks for empty `ensure` blocks
+  Description: 'Checks for empty ensure block.'
   Enabled: true
   VersionAdded: '0.10'
   VersionChanged: '0.48'
   AutoCorrect: false
 
 Lint/EmptyExpression:
-  Description: This cop checks for the presence of empty expressions.
+  Description: 'Checks for empty expressions.'
   Enabled: true
   VersionAdded: '0.45'
 
 Lint/EmptyInterpolation:
-  Description: This cop checks for empty interpolation.
+  Description: 'Checks for empty string interpolation.'
   Enabled: true
   VersionAdded: '0.20'
   VersionChanged: '0.45'
 
 Lint/EmptyWhen:
-  Description: This cop checks for the presence of `when` branches without a body.
+  Description: 'Checks for `when` branches with empty bodies.'
   Enabled: true
   VersionAdded: '0.45'
 
 Lint/EndInMethod:
-  Description: This cop checks for END blocks in method definitions.
+  Description: 'END blocks should not be placed inside method definitions.'
   Enabled: true
   VersionAdded: '0.9'
 
 Lint/EnsureReturn:
-  Description: |-
-    This cop checks for *return* from an *ensure* block.
-    Explicit return from an ensure block alters the control flow
-    as the return will take precedence over any exception being raised,
-    and the exception will be silently thrown away as if it were rescued.
-  StyleGuide: "#no-return-ensure"
+  Description: 'Do not use return in an ensure block.'
+  StyleGuide: '#no-return-ensure'
   Enabled: true
   VersionAdded: '0.9'
 
 Lint/ErbNewArguments:
-  Description: This cop emulates the following Ruby warnings in Ruby 2.6.
+  Description: 'Use `:trim_mode` and `:eoutvar` keyword arguments to `ERB.new`.'
   Enabled: true
   VersionAdded: '0.56'
 
@@ -1125,343 +1268,298 @@ Lint/FlipFlop:
   VersionAdded: '0.16'
 
 Lint/FloatOutOfRange:
-  Description: |-
-    This cop identifies Float literals which are, like, really really really
-    really really really really really big. Too big. No-one needs Floats
-    that big. If you need a float that big, something is wrong with you.
+  Description: >-
+                 Catches floating-point literals too large or small for Ruby to
+                 represent.
   Enabled: true
   VersionAdded: '0.36'
 
 Lint/FormatParameterMismatch:
-  Description: |-
-    This lint sees if there is a mismatch between the number of
-    expected fields for format/sprintf/#% and what is actually
-    passed as arguments.
+  Description: 'The number of parameters to format/sprint must match the fields.'
   Enabled: true
   VersionAdded: '0.33'
 
 Lint/HandleExceptions:
-  Description: This cop checks for *rescue* blocks with no body.
-  StyleGuide: "#dont-hide-exceptions"
+  Description: "Don't suppress exception."
+  StyleGuide: '#dont-hide-exceptions'
   Enabled: true
   VersionAdded: '0.9'
 
 Lint/ImplicitStringConcatenation:
-  Description: |-
-    This cop checks for implicit string concatenation of string literals
-    which are on the same line.
+  Description: >-
+                 Checks for adjacent string literals on the same line, which
+                 could better be represented as a single string literal.
   Enabled: true
   VersionAdded: '0.36'
 
 Lint/IneffectiveAccessModifier:
-  Description: |-
-    This cop checks for `private` or `protected` access modifiers which are
-    applied to a singleton method. These access modifiers do not make
-    singleton methods private/protected. `private_class_method` can be
-    used for that.
+  Description: >-
+                 Checks for attempts to use `private` or `protected` to set
+                 the visibility of a class method, which does not work.
   Enabled: true
   VersionAdded: '0.36'
 
 Lint/InheritException:
-  Description: |-
-    This cop looks for error classes inheriting from `Exception`
-    and its standard library subclasses, excluding subclasses of
-    `StandardError`. It is configurable to suggest using either
-    `RuntimeError` (default) or `StandardError` instead.
+  Description: 'Avoid inheriting from the `Exception` class.'
   Enabled: true
   VersionAdded: '0.41'
+  # The default base class in favour of `Exception`.
   EnforcedStyle: runtime_error
   SupportedStyles:
-  - runtime_error
-  - standard_error
+    - runtime_error
+    - standard_error
 
 Lint/InterpolationCheck:
-  Description: This cop checks for interpolation in a single quoted string.
+  Description: 'Raise warning for interpolation in single q strs'
   Enabled: true
   VersionAdded: '0.50'
 
 Lint/LiteralAsCondition:
-  Description: |-
-    This cop checks for literals used as the conditions or as
-    operands in and/or expressions serving as the conditions of
-    if/while/until.
+  Description: 'Checks of literals used in conditions.'
   Enabled: true
   VersionAdded: '0.51'
 
 Lint/LiteralInInterpolation:
-  Description: This cop checks for interpolated literals.
+  Description: 'Checks for literals used in interpolation.'
   Enabled: true
   VersionAdded: '0.19'
   VersionChanged: '0.32'
 
 Lint/Loop:
-  Description: This cop checks for uses of *begin...end while/until something*.
-  StyleGuide: "#loop-with-break"
+  Description: >-
+                 Use Kernel#loop with break rather than begin/end/until or
+                 begin/end/while for post-loop tests.
+  StyleGuide: '#loop-with-break'
   Enabled: true
   VersionAdded: '0.9'
 
 Lint/MissingCopEnableDirective:
-  Description: |-
-    This cop checks that there is an `# rubocop:enable ...` statement
-    after a `# rubocop:disable ...` statement. This will prevent leaving
-    cop disables on wide ranges of code, that latter contributors to
-    a file wouldn't be aware of.
+  Description: 'Checks for a `# rubocop:enable` after `# rubocop:disable`'
   Enabled: true
   VersionAdded: '0.52'
+  # Maximum number of consecutive lines the cop can be disabled for.
+  # 0 allows only single-line disables
+  # 1 would mean the maximum allowed is the following:
+  #   # rubocop:disable SomeCop
+  #   a = 1
+  #   # rubocop:enable SomeCop
+  # .inf for any size
   MaximumRangeSize: .inf
 
 Lint/MultipleCompare:
-  Description: |-
-    In math and Python, we can use `x < y < z` style comparison to compare
-    multiple value. However, we can't use the comparison in Ruby. However,
-    the comparison is not syntax error. This cop checks the bad usage of
-    comparison operators.
+  Description: "Use `&&` operator to compare multiple value."
   Enabled: true
   VersionAdded: '0.47'
 
 Lint/NestedMethodDefinition:
-  Description: This cop checks for nested method definitions.
-  StyleGuide: "#no-nested-methods"
+  Description: 'Do not use nested method definitions.'
+  StyleGuide: '#no-nested-methods'
   Enabled: true
   VersionAdded: '0.32'
 
 Lint/NestedPercentLiteral:
-  Description: This cop checks for nested percent literals.
+  Description: 'Checks for nested percent literals.'
   Enabled: true
   VersionAdded: '0.52'
 
 Lint/NextWithoutAccumulator:
-  Description: Don't omit the accumulator when calling `next` in a `reduce` block.
+  Description:  >-
+                  Do not omit the accumulator when calling `next`
+                  in a `reduce`/`inject` block.
   Enabled: true
   VersionAdded: '0.36'
 
 Lint/NonLocalExitFromIterator:
-  Description: |-
-    This cop checks for non-local exits from iterators without a return
-    value. It registers an offense under these conditions:
+  Description: 'Do not use return in iterator to cause non-local exit.'
   Enabled: true
   VersionAdded: '0.30'
 
 Lint/NumberConversion:
-  Description: |-
-    This cop warns the usage of unsafe number conversions. Unsafe
-    number conversion can cause unexpected error if auto type conversion
-    fails. Cop prefer parsing with number class instead.
+  Description: 'Checks unsafe usage of number conversion methods.'
   Enabled: false
   VersionAdded: '0.53'
 
 Lint/OrderedMagicComments:
-  Description: |-
-    Checks the proper ordering of magic comments and whether
-    a magic comment is not placed before a shebang.
+  Description: 'Checks the proper ordering of magic comments and whether a magic comment is not placed before a shebang.'
   Enabled: true
   VersionAdded: '0.53'
 
 Lint/ParenthesesAsGroupedExpression:
-  Description: |-
-    Checks for space between the name of a called method and a left
-    parenthesis.
-  StyleGuide: "#parens-no-spaces"
+  Description: >-
+                 Checks for method calls with a space before the opening
+                 parenthesis.
+  StyleGuide: '#parens-no-spaces'
   Enabled: true
   VersionAdded: '0.12'
 
 Lint/PercentStringArray:
-  Description: This cop checks for quotes and commas in %w, e.g. `%w('foo', "bar")`
+  Description: >-
+                 Checks for unwanted commas and quotes in %w/%W literals.
   Enabled: true
   VersionAdded: '0.41'
 
 Lint/PercentSymbolArray:
-  Description: This cop checks for colons and commas in %i, e.g. `%i(:foo, :bar)`
+  Description: >-
+                 Checks for unwanted commas and colons in %i/%I literals.
   Enabled: true
   VersionAdded: '0.41'
 
 Lint/RandOne:
-  Description: |-
-    This cop checks for `rand(1)` calls.
-    Such calls always return `0`.
+  Description: >-
+                 Checks for `rand(1)` calls. Such calls always return `0`
+                 and most likely a mistake.
   Enabled: true
   VersionAdded: '0.36'
 
 Lint/RedundantWithIndex:
-  Description: This cop checks for redundant `with_index`.
+  Description: 'Checks for redundant `with_index`.'
   Enabled: true
   VersionAdded: '0.50'
 
 Lint/RedundantWithObject:
-  Description: This cop checks for redundant `with_object`.
+  Description: 'Checks for redundant `with_object`.'
   Enabled: true
   VersionAdded: '0.51'
 
 Lint/RegexpAsCondition:
-  Description: |-
-    This cop checks for regexp literals used as `match-current-line`.
-    If a regexp literal is in condition, the regexp matches `$_` implicitly.
+  Description: >-
+                 Do not use regexp literal as a condition.
+                 The regexp literal matches `$_` implicitly.
   Enabled: true
   VersionAdded: '0.51'
 
 Lint/RequireParentheses:
-  Description: |-
-    This cop checks for expressions where there is a call to a predicate
-    method with at least one argument, where no parentheses are used around
-    the parameter list, and a boolean operator, && or ||, is used in the
-    last argument.
+  Description: >-
+                 Use parentheses in the method call to avoid confusion
+                 about precedence.
   Enabled: true
   VersionAdded: '0.18'
 
 Lint/RescueException:
-  Description: This cop checks for *rescue* blocks targeting the Exception class.
-  StyleGuide: "#no-blind-rescues"
+  Description: 'Avoid rescuing the Exception class.'
+  StyleGuide: '#no-blind-rescues'
   Enabled: true
   VersionAdded: '0.9'
-  VersionChanged: 0.27.1
+  VersionChanged: '0.27.1'
 
 Lint/RescueType:
-  Description: |-
-    Check for arguments to `rescue` that will result in a `TypeError`
-    if an exception is raised.
+  Description: 'Avoid rescuing from non constants that could result in a `TypeError`.'
   Enabled: true
   VersionAdded: '0.49'
 
 Lint/ReturnInVoidContext:
-  Description: |-
-    This cop checks for the use of a return with a value in a context
-    where the value will be ignored. (initialize and setter methods)
+  Description: 'Checks for return in void context.'
   Enabled: true
   VersionAdded: '0.50'
 
 Lint/SafeNavigationChain:
-  Description: |-
-    The safe navigation operator returns nil if the receiver is
-    nil. If you chain an ordinary method call after a safe
-    navigation operator, it raises NoMethodError. We should use a
-    safe navigation operator after a safe navigation operator.
-    This cop checks for the problem outlined above.
+  Description: 'Do not chain ordinary method call after safe navigation operator.'
   Enabled: true
   VersionAdded: '0.47'
   VersionChanged: '0.56'
   Whitelist:
-  - present?
-  - blank?
-  - presence
-  - try
-  - try!
+    - present?
+    - blank?
+    - presence
+    - try
+    - try!
 
 Lint/SafeNavigationConsistency:
-  Description: |-
-    This cop check to make sure that if safe navigation is used for a method
-    call in an `&&` or `||` condition that safe navigation is used for all
-    method calls on that same object.
+  Description: >-
+                 Check to make sure that if safe navigation is used for a method
+                 call in an `&&` or `||` condition that safe navigation is used
+                 for all method calls on that same object.
   Enabled: true
   VersionAdded: '0.55'
   Whitelist:
-  - present?
-  - blank?
-  - presence
-  - try
-  - try!
+    - present?
+    - blank?
+    - presence
+    - try
+    - try!
+
 
 Lint/ScriptPermission:
-  Description: |-
-    This cop checks if a file which has a shebang line as
-    its first line is granted execute permission.
+  Description: 'Grant script file execute permission.'
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.50'
 
 Lint/ShadowedArgument:
-  Description: This cop checks for shadowed arguments.
+  Description: 'Avoid reassigning arguments before they were used.'
   Enabled: true
   VersionAdded: '0.52'
   IgnoreImplicitReferences: false
 
+
 Lint/ShadowedException:
-  Description: |-
-    This cop checks for a rescued exception that get shadowed by a
-    less specific exception being rescued before a more specific
-    exception is rescued.
+  Description: >-
+                  Avoid rescuing a higher level exception
+                  before a lower level exception.
   Enabled: true
   VersionAdded: '0.41'
 
 Lint/ShadowingOuterLocalVariable:
-  Description: |-
-    This cop looks for use of the same name as outer local variables
-    for block arguments or block local variables.
-    This is a mimic of the warning
-    "shadowing outer local variable - foo" from `ruby -cw`.
+  Description: >-
+                 Do not use the same name as outer local variable
+                 for block arguments or block local variables.
   Enabled: true
   VersionAdded: '0.9'
 
 Lint/StringConversionInInterpolation:
-  Description: |-
-    This cop checks for string conversion in string interpolation,
-    which is redundant.
-  StyleGuide: "#no-to-s"
+  Description: 'Checks for Object#to_s usage in string interpolation.'
+  StyleGuide: '#no-to-s'
   Enabled: true
   VersionAdded: '0.19'
   VersionChanged: '0.20'
 
 Lint/Syntax:
-  Description: |-
-    This is not actually a cop. It does not inspect anything. It just
-    provides methods to repack Parser's diagnostics/errors
-    into RuboCop's offenses.
+  Description: 'Checks syntax error'
   Enabled: true
   VersionAdded: '0.9'
 
+
 Lint/UnderscorePrefixedVariableName:
-  Description: |-
-    This cop checks for underscore-prefixed variables that are actually
-    used.
+  Description: 'Do not use prefix `_` for a variable that is used.'
   Enabled: true
   VersionAdded: '0.21'
 
 Lint/UnifiedInteger:
-  Description: This cop checks for using Fixnum or Bignum constant.
+  Description: 'Use Integer instead of Fixnum or Bignum'
   Enabled: true
   VersionAdded: '0.43'
 
 Lint/UnneededCopDisableDirective:
-  Description: |-
-    This cop detects instances of rubocop:disable comments that can be
-    removed without causing any offenses to be reported. It's implemented
-    as a cop in that it inherits from the Cop base class and calls
-    add_offense. The unusual part of its implementation is that it doesn't
-    have any on_* methods or an investigate method. This means that it
-    doesn't take part in the investigation phase when the other cops do
-    their work. Instead, it waits until it's called in a later stage of the
-    execution. The reason it can't be implemented as a normal cop is that
-    it depends on the results of all other cops to do its work.
+  Description: >-
+                 Checks for rubocop:disable comments that can be removed.
+                 Note: this cop is not disabled when disabling all cops.
+                 It must be explicitly disabled.
   Enabled: true
   VersionAdded: '0.53'
 
 Lint/UnneededCopEnableDirective:
-  Description: |-
-    This cop detects instances of rubocop:enable comments that can be
-    removed.
+  Description: Checks for rubocop:enable comments that can be removed.
   Enabled: true
   VersionAdded: '0.53'
 
 Lint/UnneededRequireStatement:
-  Description: Checks for unnecessary `require` statement.
+  Description: 'Checks for unnecessary `require` statement.'
   Enabled: true
   VersionAdded: '0.51'
 
 Lint/UnneededSplatExpansion:
-  Description: This cop checks for unneeded usages of splat expansion
+  Description: 'Checks for splat unnecessarily being called on literals'
   Enabled: true
   VersionAdded: '0.43'
 
 Lint/UnreachableCode:
-  Description: |-
-    This cop checks for unreachable code.
-    The check are based on the presence of flow of control
-    statement in non-final position in *begin*(implicit) blocks.
+  Description: 'Unreachable code.'
   Enabled: true
   VersionAdded: '0.9'
 
 Lint/UnusedBlockArgument:
-  Description: This cop checks for unused block arguments.
-  StyleGuide: "#underscore-unused-vars"
+  Description: 'Checks for unused block arguments.'
+  StyleGuide: '#underscore-unused-vars'
   Enabled: true
   VersionAdded: '0.21'
   VersionChanged: '0.22'
@@ -1469,8 +1567,8 @@ Lint/UnusedBlockArgument:
   AllowUnusedKeywordArguments: false
 
 Lint/UnusedMethodArgument:
-  Description: This cop checks for unused method arguments.
-  StyleGuide: "#underscore-unused-vars"
+  Description: 'Checks for unused method arguments.'
+  StyleGuide: '#underscore-unused-vars'
   Enabled: true
   VersionAdded: '0.21'
   VersionChanged: '0.35'
@@ -1478,30 +1576,23 @@ Lint/UnusedMethodArgument:
   IgnoreEmptyMethods: true
 
 Lint/UriEscapeUnescape:
-  Description: |-
-    This cop identifies places where `URI.escape` can be replaced by
-    `CGI.escape`, `URI.encode_www_form`, or `URI.encode_www_form_component`
-    depending on your specific use case.
-    Also this cop identifies places where `URI.unescape` can be replaced by
-    `CGI.unescape`, `URI.decode_www_form`,
-    or `URI.decode_www_form_component` depending on your specific use case.
+  Description: >-
+                 `URI.escape` method is obsolete and should not be used. Instead, use
+                 `CGI.escape`, `URI.encode_www_form` or `URI.encode_www_form_component`
+                 depending on your specific use case.
+                 Also `URI.unescape` method is obsolete and should not be used. Instead, use
+                 `CGI.unescape`, `URI.decode_www_form` or `URI.decode_www_form_component`
+                 depending on your specific use case.
   Enabled: true
   VersionAdded: '0.50'
 
 Lint/UriRegexp:
-  Description: |-
-    This cop identifies places where `URI.regexp` is obsolete and should
-    not be used. Instead, use `URI::DEFAULT_PARSER.make_regexp`.
+  Description: 'Use `URI::DEFAULT_PARSER.make_regexp` instead of `URI.regexp`.'
   Enabled: true
   VersionAdded: '0.50'
 
 Lint/UselessAccessModifier:
-  Description: |-
-    This cop checks for redundant access modifiers, including those with no
-    code, those which are repeated, and leading `public` modifiers in a
-    class or module body. Conditionally-defined methods are considered as
-    always being defined, and thus access modifiers guarding such methods
-    are not redundant.
+  Description: 'Checks for useless access modifiers.'
   Enabled: true
   VersionAdded: '0.20'
   VersionChanged: '0.47'
@@ -1509,68 +1600,60 @@ Lint/UselessAccessModifier:
   MethodCreatingMethods: []
 
 Lint/UselessAssignment:
-  Description: |-
-    This cop checks for every useless assignment to local variable in every
-    scope.
-    The basic idea for this cop was from the warning of `ruby -cw`:
-  StyleGuide: "#underscore-unused-vars"
+  Description: 'Checks for useless assignment to a local variable.'
+  StyleGuide: '#underscore-unused-vars'
   Enabled: true
   VersionAdded: '0.11'
 
 Lint/UselessComparison:
-  Description: This cop checks for comparison of something with itself.
+  Description: 'Checks for comparison of something with itself.'
   Enabled: true
   VersionAdded: '0.11'
 
 Lint/UselessElseWithoutRescue:
-  Description: This cop checks for useless `else` in `begin..end` without `rescue`.
+  Description: 'Checks for useless `else` in `begin..end` without `rescue`.'
   Enabled: true
   VersionAdded: '0.17'
 
 Lint/UselessSetterCall:
-  Description: |-
-    This cop checks for setter call to local variable as the final
-    expression of a function definition.
+  Description: 'Checks for useless setter call to a local variable.'
   Enabled: true
   VersionAdded: '0.13'
 
 Lint/Void:
-  Description: |-
-    This cop checks for operators, variables, literals, and nonmutating
-    methods used in void context.
+  Description: 'Possible use of operator/literal/variable in void context.'
   Enabled: true
   VersionAdded: '0.9'
   CheckForMethodsWithNoSideEffects: false
 
+#################### Metrics ###############################
+
 Metrics/AbcSize:
-  Description: |-
-    This cop checks that the ABC size of methods is not higher than the
-    configured maximum. The ABC size is based on assignments, branches
-    (method calls), and conditions. See http://c2.com/cgi/wiki?AbcMetric
-  Reference: http://c2.com/cgi/wiki?AbcMetric
+  Description: >-
+                 A calculated magnitude based on number of assignments,
+                 branches, and conditions.
+  Reference: 'http://c2.com/cgi/wiki?AbcMetric'
   Enabled: true
   VersionAdded: '0.27'
+  # The ABC size is a calculated magnitude, so this number can be an Integer or
+  # a Float.
   Max: 15
 
 Metrics/BlockLength:
-  Description: |-
-    This cop checks if the length of a block exceeds some maximum value.
-    Comment lines can optionally be ignored.
-    The maximum allowed length is configurable.
-    The cop can be configured to ignore blocks passed to certain methods.
+  Description: 'Avoid long blocks with many lines.'
   Enabled: true
   VersionAdded: '0.44'
   VersionChanged: '0.58'
-  CountComments: false
+  CountComments: false  # count full line comments?
   Max: 25
   ExcludedMethods:
-  - refine
+    # By default, exclude the `#refine` method, as it tends to have larger
+    # associated blocks.
+    - refine
 
 Metrics/BlockNesting:
-  Description: |-
-    This cop checks for excessive nesting of conditional and looping
-    constructs.
-  StyleGuide: "#three-is-the-number-thou-shalt-count"
+  Description: 'Avoid excessive block nesting'
+  StyleGuide: '#three-is-the-number-thou-shalt-count'
   Enabled: true
   VersionAdded: '0.25'
   VersionChanged: '0.47'
@@ -1578,320 +1661,312 @@ Metrics/BlockNesting:
   Max: 3
 
 Metrics/ClassLength:
-  Description: |-
-    This cop checks if the length a class exceeds some maximum value.
-    Comment lines can optionally be ignored.
-    The maximum allowed length is configurable.
+  Description: 'Avoid classes longer than 100 lines of code.'
   Enabled: true
   VersionAdded: '0.25'
-  CountComments: false
+  CountComments: false  # count full line comments?
   Max: 100
 
+# Avoid complex methods.
 Metrics/CyclomaticComplexity:
-  Description: |-
-    This cop checks that the cyclomatic complexity of methods is not higher
-    than the configured maximum. The cyclomatic complexity is the number of
-    linearly independent paths through a method. The algorithm counts
-    decision points and adds one.
+  Description: >-
+                 A complexity metric that is strongly correlated to the number
+                 of test cases needed to validate a method.
   Enabled: true
   VersionAdded: '0.25'
   Max: 6
 
 Metrics/LineLength:
-  Description: |-
-    This cop checks the length of lines in the source code.
-    The maximum length is configurable.
-    The tab size is configured in the `IndentationWidth`
-    of the `Layout/Tab` cop.
-  StyleGuide: "#80-character-limits"
+  Description: 'Limit lines to 80 characters.'
+  StyleGuide: '#80-character-limits'
   Enabled: true
   VersionAdded: '0.25'
   VersionChanged: '0.46'
   Max: 80
+  # To make it possible to copy or click on URIs in the code, we allow lines
+  # containing a URI to be longer than Max.
   AllowHeredoc: true
   AllowURI: true
   URISchemes:
-  - http
-  - https
+    - http
+    - https
+  # The IgnoreCopDirectives option causes the LineLength rule to ignore cop
+  # directives like '# rubocop: enable ...' when calculating a line's length.
   IgnoreCopDirectives: false
+  # The IgnoredPatterns option is a list of !ruby/regexp and/or string
+  # elements. Strings will be converted to Regexp objects. A line that matches
+  # any regular expression listed in this option will be ignored by LineLength.
   IgnoredPatterns: []
 
 Metrics/MethodLength:
-  Description: |-
-    This cop checks if the length of a method exceeds some maximum value.
-    Comment lines can optionally be ignored.
-    The maximum allowed length is configurable.
-  StyleGuide: "#short-methods"
+  Description: 'Avoid methods longer than 10 lines of code.'
+  StyleGuide: '#short-methods'
   Enabled: true
   VersionAdded: '0.25'
-  VersionChanged: 0.59.2
-  CountComments: false
+  VersionChanged: '0.59.2'
+  CountComments: false  # count full line comments?
   Max: 10
   ExcludedMethods: []
 
 Metrics/ModuleLength:
-  Description: |-
-    This cop checks if the length a module exceeds some maximum value.
-    Comment lines can optionally be ignored.
-    The maximum allowed length is configurable.
+  Description: 'Avoid modules longer than 100 lines of code.'
   Enabled: true
   VersionAdded: '0.31'
-  CountComments: false
+  CountComments: false  # count full line comments?
   Max: 100
 
 Metrics/ParameterLists:
-  Description: |-
-    This cop checks for methods with too many parameters.
-    The maximum number of parameters is configurable.
-    Keyword arguments can optionally be excluded from the total count.
-  StyleGuide: "#too-many-params"
+  Description: 'Avoid parameter lists longer than three or four parameters.'
+  StyleGuide: '#too-many-params'
   Enabled: true
   VersionAdded: '0.25'
   Max: 5
   CountKeywordArgs: true
 
 Metrics/PerceivedComplexity:
-  Description: |-
-    This cop tries to produce a complexity score that's a measure of the
-    complexity the reader experiences when looking at a method. For that
-    reason it considers `when` nodes as something that doesn't add as much
-    complexity as an `if` or a `&&`. Except if it's one of those special
-    `case`/`when` constructs where there's no expression after `case`. Then
-    the cop treats it as an `if`/`elsif`/`elsif`... and lets all the `when`
-    nodes count. In contrast to the CyclomaticComplexity cop, this cop
-    considers `else` nodes as adding complexity.
+  Description: >-
+                 A complexity metric geared towards measuring complexity for a
+                 human reader.
   Enabled: true
   VersionAdded: '0.25'
   Max: 7
 
+#################### Naming ##############################
+
 Naming/AccessorMethodName:
-  Description: This cop makes sure that accessor methods are named properly.
-  StyleGuide: "#accessor_mutator_method_names"
+  Description: Check the naming of accessor methods for get_/set_.
+  StyleGuide: '#accessor_mutator_method_names'
   Enabled: true
   VersionAdded: '0.50'
 
 Naming/AsciiIdentifiers:
-  Description: This cop checks for non-ascii characters in identifier names.
-  StyleGuide: "#english-identifiers"
+  Description: 'Use only ascii symbols in identifiers.'
+  StyleGuide: '#english-identifiers'
   Enabled: true
   VersionAdded: '0.50'
 
 Naming/BinaryOperatorParameterName:
-  Description: |-
-    This cop makes sure that certain binary operator methods have their
-    sole  parameter named `other`.
-  StyleGuide: "#other-arg"
+  Description: 'When defining binary operators, name the argument other.'
+  StyleGuide: '#other-arg'
   Enabled: true
   VersionAdded: '0.50'
 
 Naming/ClassAndModuleCamelCase:
-  Description: |-
-    This cop checks for class and module names with
-    an underscore in them.
-  StyleGuide: "#camelcase-classes"
+  Description: 'Use CamelCase for classes and modules.'
+  StyleGuide: '#camelcase-classes'
   Enabled: true
   VersionAdded: '0.50'
 
 Naming/ConstantName:
-  Description: |-
-    This cop checks whether constant names are written using
-    SCREAMING_SNAKE_CASE.
-  StyleGuide: "#screaming-snake-case"
+  Description: 'Constants should use SCREAMING_SNAKE_CASE.'
+  StyleGuide: '#screaming-snake-case'
   Enabled: true
   VersionAdded: '0.50'
 
 Naming/FileName:
-  Description: |-
-    This cop makes sure that Ruby source files have snake_case
-    names. Ruby scripts (i.e. source files with a shebang in the
-    first line) are ignored.
-  StyleGuide: "#snake-case-files"
+  Description: 'Use snake_case for source file names.'
+  StyleGuide: '#snake-case-files'
   Enabled: true
   VersionAdded: '0.50'
+  # Camel case file names listed in `AllCops:Include` and all file names listed
+  # in `AllCops:Exclude` are excluded by default. Add extra excludes here.
   Exclude: []
+  # When `true`, requires that each source file should define a class or module
+  # with a name which matches the file name (converted to ... case).
+  # It further expects it to be nested inside modules which match the names
+  # of subdirectories in its path.
   ExpectMatchingDefinition: false
-  Regex:
+  # If non-`nil`, expect all source file names to match the following regex.
+  # Only the file name itself is matched, not the entire file path.
+  # Use anchors as necessary if you want to match the entire name rather than
+  # just a part of it.
+  Regex: ~
+  # With `IgnoreExecutableScripts` set to `true`, this cop does not
+  # report offending filenames for executable scripts (i.e. source
+  # files with a shebang in the first line).
   IgnoreExecutableScripts: true
   AllowedAcronyms:
-  - CLI
-  - DSL
-  - ACL
-  - API
-  - ASCII
-  - CPU
-  - CSS
-  - DNS
-  - EOF
-  - GUID
-  - HTML
-  - HTTP
-  - HTTPS
-  - ID
-  - IP
-  - JSON
-  - LHS
-  - QPS
-  - RAM
-  - RHS
-  - RPC
-  - SLA
-  - SMTP
-  - SQL
-  - SSH
-  - TCP
-  - TLS
-  - TTL
-  - UDP
-  - UI
-  - UID
-  - UUID
-  - URI
-  - URL
-  - UTF8
-  - VM
-  - XML
-  - XMPP
-  - XSRF
-  - XSS
+    - CLI
+    - DSL
+    - ACL
+    - API
+    - ASCII
+    - CPU
+    - CSS
+    - DNS
+    - EOF
+    - GUID
+    - HTML
+    - HTTP
+    - HTTPS
+    - ID
+    - IP
+    - JSON
+    - LHS
+    - QPS
+    - RAM
+    - RHS
+    - RPC
+    - SLA
+    - SMTP
+    - SQL
+    - SSH
+    - TCP
+    - TLS
+    - TTL
+    - UDP
+    - UI
+    - UID
+    - UUID
+    - URI
+    - URL
+    - UTF8
+    - VM
+    - XML
+    - XMPP
+    - XSRF
+    - XSS
 
 Naming/HeredocDelimiterCase:
-  Description: |-
-    This cop checks that your heredocs are using the configured case.
-    By default it is configured to enforce uppercase heredocs.
-  StyleGuide: "#heredoc-delimiters"
+  Description: 'Use configured case for heredoc delimiters.'
+  StyleGuide: '#heredoc-delimiters'
   Enabled: true
   VersionAdded: '0.50'
   EnforcedStyle: uppercase
   SupportedStyles:
-  - lowercase
-  - uppercase
+    - lowercase
+    - uppercase
 
 Naming/HeredocDelimiterNaming:
-  Description: |-
-    This cop checks that your heredocs are using meaningful delimiters.
-    By default it disallows `END` and `EO*`, and can be configured through
-    blacklisting additional delimiters.
-  StyleGuide: "#heredoc-delimiters"
+  Description: 'Use descriptive heredoc delimiters.'
+  StyleGuide: '#heredoc-delimiters'
   Enabled: true
   VersionAdded: '0.50'
   Blacklist:
-  - !ruby/regexp /(^|\s)(EO[A-Z]{1}|END)(\s|$)/
+    - !ruby/regexp '/(^|\s)(EO[A-Z]{1}|END)(\s|$)/'
 
 Naming/MemoizedInstanceVariableName:
-  Description: |-
-    This cop checks for memoized methods whose instance variable name
-    does not match the method name.
+  Description: >-
+    Memoized method name should match memo instance variable name.
   Enabled: true
   VersionAdded: '0.53'
   VersionChanged: '0.58'
   EnforcedStyleForLeadingUnderscores: disallowed
   SupportedStylesForLeadingUnderscores:
-  - disallowed
-  - required
-  - optional
+    - disallowed
+    - required
+    - optional
 
 Naming/MethodName:
-  Description: |-
-    This cop makes sure that all methods use the configured style,
-    snake_case or camelCase, for their names.
-  StyleGuide: "#snake-case-symbols-methods-vars"
+  Description: 'Use the configured style when naming methods.'
+  StyleGuide: '#snake-case-symbols-methods-vars'
   Enabled: true
   VersionAdded: '0.50'
   EnforcedStyle: snake_case
   SupportedStyles:
-  - snake_case
-  - camelCase
+    - snake_case
+    - camelCase
 
 Naming/PredicateName:
-  Description: This cop makes sure that predicates are named properly.
-  StyleGuide: "#bool-methods-qmark"
+  Description: 'Check the names of predicate methods.'
+  StyleGuide: '#bool-methods-qmark'
   Enabled: true
   VersionAdded: '0.50'
   VersionChanged: '0.51'
+  # Predicate name prefixes.
   NamePrefix:
-  - is_
-  - has_
-  - have_
+    - is_
+    - has_
+    - have_
+  # Predicate name prefixes that should be removed.
   NamePrefixBlacklist:
-  - is_
-  - has_
-  - have_
+    - is_
+    - has_
+    - have_
+  # Predicate names which, despite having a blacklisted prefix, or no `?`,
+  # should still be accepted
   NameWhitelist:
-  - is_a?
+    - is_a?
+  # Method definition macros for dynamically generated methods.
   MethodDefinitionMacros:
-  - define_method
-  - define_singleton_method
+    - define_method
+    - define_singleton_method
+  # Exclude Rspec specs because there is a strong convention to write spec
+  # helpers in the form of `have_something` or `be_something`.
   Exclude:
-  - spec/**/*
+    - 'spec/**/*'
 
 Naming/UncommunicativeBlockParamName:
-  Description: |-
-    This cop checks block parameter names for how descriptive they
-    are. It is highly configurable.
+  Description: >-
+                Checks for block parameter names that contain capital letters,
+                end in numbers, or do not meet a minimal length.
   Enabled: true
   VersionAdded: '0.53'
+  # Parameter names may be equal to or greater than this value
   MinNameLength: 1
   AllowNamesEndingInNumbers: true
+  # Whitelisted names that will not register an offense
   AllowedNames: []
+  # Blacklisted names that will register an offense
   ForbiddenNames: []
 
 Naming/UncommunicativeMethodParamName:
-  Description: |-
-    This cop checks method parameter names for how descriptive they
-    are. It is highly configurable.
+  Description: >-
+                Checks for method parameter names that contain capital letters,
+                end in numbers, or do not meet a minimal length.
   Enabled: true
   VersionAdded: '0.53'
   VersionChanged: '0.59'
+  # Parameter names may be equal to or greater than this value
   MinNameLength: 3
   AllowNamesEndingInNumbers: true
+  # Whitelisted names that will not register an offense
   AllowedNames:
-  - io
-  - id
-  - to
-  - by
-  - 'on'
-  - in
-  - at
-  - ip
-  - db
+    - io
+    - id
+    - to
+    - by
+    - 'on'
+    - in
+    - at
+    - ip
+    - db
+  # Blacklisted names that will register an offense
   ForbiddenNames: []
 
+
 Naming/VariableName:
-  Description: |-
-    This cop makes sure that all variables use the configured style,
-    snake_case or camelCase, for their names.
-  StyleGuide: "#snake-case-symbols-methods-vars"
+  Description: 'Use the configured style when naming variables.'
+  StyleGuide: '#snake-case-symbols-methods-vars'
   Enabled: true
   VersionAdded: '0.50'
   EnforcedStyle: snake_case
   SupportedStyles:
-  - snake_case
-  - camelCase
+    - snake_case
+    - camelCase
 
 Naming/VariableNumber:
-  Description: |-
-    This cop makes sure that all numbered variables use the
-    configured style, snake_case, normalcase, or non_integer,
-    for their numbering.
+  Description: 'Use the configured style when numbering variables.'
   Enabled: true
   VersionAdded: '0.50'
   EnforcedStyle: normalcase
   SupportedStyles:
-  - snake_case
-  - normalcase
-  - non_integer
+    - snake_case
+    - normalcase
+    - non_integer
+
+#################### Performance ###########################
 
 Performance/Caller:
-  Description: |-
-    This cop identifies places where `caller[n]`
-    can be replaced by `caller(n..n).first`.
+  Description: >-
+             Use `caller(n..n)` instead of `caller`.
   Enabled: true
   VersionAdded: '0.49'
 
 Performance/CaseWhenSplat:
-  Description: |-
-    Reordering `when` conditions with a splat to the end
-    of the `when` branches can improve performance.
+  Description: >-
+                 Reordering `when` conditions with a splat to the end
+                 of the `when` branches can improve performance.
   Enabled: false
   AutoCorrect: false
   SafeAutoCorrect: false
@@ -1899,67 +1974,70 @@ Performance/CaseWhenSplat:
   VersionChanged: '0.59'
 
 Performance/Casecmp:
-  Description: |-
-    This cop identifies places where a case-insensitive string comparison
-    can better be implemented using `casecmp`.
-  Reference: https://github.com/JuanitoFatas/fast-ruby#stringcasecmp-vs-stringdowncase---code
+  Description: >-
+             Use `casecmp` rather than `downcase ==`, `upcase ==`, `== downcase`, or `== upcase`..
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringcasecmp-vs-stringdowncase---code'
   Enabled: true
   VersionAdded: '0.36'
 
 Performance/ChainArrayAllocation:
-  Description: |-
-    This cop is used to identify usages of
-    Each of these methods (`compact`, `flatten`, `map`) will generate a
-    new intermediate array that is promptly thrown away. Instead it is
-    faster to mutate when we know it's safe.
-  Reference: https://twitter.com/schneems/status/1034123879978029057
+  Description: >-
+                  Instead of chaining array methods that allocate new arrays, mutate an
+                  existing array.
+  Reference: 'https://twitter.com/schneems/status/1034123879978029057'
   Enabled: false
   VersionAdded: '0.59'
 
 Performance/CompareWithBlock:
-  Description: |-
-    This cop identifies places where `sort { |a, b| a.foo <=> b.foo }`
-    can be replaced by `sort_by(&:foo)`.
-    This cop also checks `max` and `min` methods.
+  Description: 'Use `sort_by(&:foo)` instead of `sort { |a, b| a.foo <=> b.foo }`.'
   Enabled: true
   VersionAdded: '0.46'
 
 Performance/Count:
-  Description: |-
-    This cop is used to identify usages of `count` on an `Enumerable` that
-    follow calls to `select` or `reject`. Querying logic can instead be
-    passed to the `count` call.
+  Description: >-
+                  Use `count` instead of `select...size`, `reject...size`,
+                  `select...count`, `reject...count`, `select...length`,
+                  and `reject...length`.
+  # This cop has known compatibility issues with `ActiveRecord` and other
+  # frameworks. ActiveRecord's `count` ignores the block that is passed to it.
+  # For more information, see the documentation in the cop itself.
+  # If you understand the known risk, you can disable `SafeMode`.
   SafeMode: true
   Enabled: true
   VersionAdded: '0.31'
   VersionChanged: '0.39'
 
 Performance/Detect:
-  Description: |-
-    This cop is used to identify usages of
-    `select.first`, `select.last`, `find_all.first`, and `find_all.last`
-    and change them to use `detect` instead.
-  Reference: https://github.com/JuanitoFatas/fast-ruby#enumerabledetect-vs-enumerableselectfirst-code
+  Description: >-
+                  Use `detect` instead of `select.first`, `find_all.first`,
+                  `select.last`, and `find_all.last`.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerabledetect-vs-enumerableselectfirst-code'
+  # This cop has known compatibility issues with `ActiveRecord` and other
+  # frameworks. `ActiveRecord` does not implement a `detect` method and `find`
+  # has its own meaning. Correcting `ActiveRecord` methods with this cop
+  # should be considered unsafe.
   SafeMode: true
   Enabled: true
   VersionAdded: '0.30'
   VersionChanged: '0.39'
 
 Performance/DoubleStartEndWith:
-  Description: |-
-    This cop checks for double `#start_with?` or `#end_with?` calls
-    separated by `||`. In some cases such calls can be replaced
-    with an single `#start_with?`/`#end_with?` call.
+  Description: >-
+                  Use `str.{start,end}_with?(x, ..., y, ...)`
+                  instead of `str.{start,end}_with?(x, ...) || str.{start,end}_with?(y, ...)`.
   Enabled: true
   VersionAdded: '0.36'
   VersionChanged: '0.48'
+  # Used to check for `starts_with?` and `ends_with?`.
+  # These methods are defined by `ActiveSupport`.
   IncludeActiveSupportAliases: false
 
 Performance/EndWith:
-  Description: |-
-    This cop identifies unnecessary use of a regex where `String#end_with?`
-    would suffice.
-  Reference: https://github.com/JuanitoFatas/fast-ruby#stringmatch-vs-stringstart_withstringend_with-code-start-code-end
+  Description: 'Use `end_with?` instead of a regex match anchored to the end of a string.'
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringmatch-vs-stringstart_withstringend_with-code-start-code-end'
+  # This will change to a new method call which isn't guaranteed to be on the
+  # object. Switching these methods has to be done with knowledge of the types
+  # of the variables which rubocop doesn't have.
   SafeAutoCorrect: false
   AutoCorrect: false
   Enabled: true
@@ -1967,131 +2045,111 @@ Performance/EndWith:
   VersionChanged: '0.44'
 
 Performance/FixedSize:
-  Description: Do not compute the size of statically sized objects.
+  Description: 'Do not compute the size of statically sized objects except in constants'
   Enabled: true
   VersionAdded: '0.35'
 
 Performance/FlatMap:
-  Description: This cop is used to identify usages of
-  Reference: https://github.com/JuanitoFatas/fast-ruby#enumerablemaparrayflatten-vs-enumerableflat_map-code
+  Description: >-
+                  Use `Enumerable#flat_map`
+                  instead of `Enumerable#map...Array#flatten(1)`
+                  or `Enumberable#collect..Array#flatten(1)`
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablemaparrayflatten-vs-enumerableflat_map-code'
   Enabled: true
   VersionAdded: '0.30'
   EnabledForFlattenWithoutParams: false
+  # If enabled, this cop will warn about usages of
+  # `flatten` being called without any parameters.
+  # This can be dangerous since `flat_map` will only flatten 1 level, and
+  # `flatten` without any parameters can flatten multiple levels.
 
 Performance/InefficientHashSearch:
-  Description: |-
-    This cop checks for inefficient searching of keys and values within
-    hashes.
-  Reference: https://github.com/JuanitoFatas/fast-ruby#hashkey-instead-of-hashkeysinclude-code
+  Description: 'Use `key?` or `value?` instead of `keys.include?` or `values.include?`'
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#hashkey-instead-of-hashkeysinclude-code'
   Enabled: true
   VersionAdded: '0.56'
   Safe: false
 
 Performance/LstripRstrip:
-  Description: |-
-    This cop identifies places where `lstrip.rstrip` can be replaced by
-    `strip`.
+  Description: 'Use `strip` instead of `lstrip.rstrip`.'
   Enabled: true
   VersionAdded: '0.36'
 
 Performance/OpenStruct:
-  Description: |-
-    This cop checks for `OpenStruct.new` calls.
-    Instantiation of an `OpenStruct` invalidates
-    Ruby global method cache as it causes dynamic method
-    definition during program runtime.
-    This could have an effect on performance,
-    especially in case of single-threaded
-    applications with multiple `OpenStruct` instantiations.
+  Description: 'Use `Struct` instead of `OpenStruct`.'
   Enabled: false
   VersionAdded: '0.61'
   Safe: false
 
 Performance/RangeInclude:
-  Description: |-
-    This cop identifies uses of `Range#include?`, which iterates over each
-    item in a `Range` to see if a specified item is there. In contrast,
-    `Range#cover?` simply compares the target item with the beginning and
-    end points of the `Range`. In a great majority of cases, this is what
-    is wanted.
-  Reference: https://github.com/JuanitoFatas/fast-ruby#cover-vs-include-code
+  Description: 'Use `Range#cover?` instead of `Range#include?`.'
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#cover-vs-include-code'
   Enabled: true
   VersionAdded: '0.36'
   Safe: false
 
 Performance/RedundantBlockCall:
-  Description: |-
-    This cop identifies the use of a `&block` parameter and `block.call`
-    where `yield` would do just as well.
-  Reference: https://github.com/JuanitoFatas/fast-ruby#proccall-and-block-arguments-vs-yieldcode
+  Description: 'Use `yield` instead of `block.call`.'
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#proccall-and-block-arguments-vs-yieldcode'
   Enabled: true
   VersionAdded: '0.36'
 
 Performance/RedundantMatch:
-  Description: |-
-    This cop identifies the use of `Regexp#match` or `String#match`, which
-    returns `#<MatchData>`/`nil`. The return value of `=~` is an integral
-    index/`nil` and is more performant.
+  Description: >-
+                  Use `=~` instead of `String#match` or `Regexp#match` in a context where the
+                  returned `MatchData` is not needed.
   Enabled: true
   VersionAdded: '0.36'
 
 Performance/RedundantMerge:
-  Description: |-
-    This cop identifies places where `Hash#merge!` can be replaced by
-    `Hash#[]=`.
-  Reference: https://github.com/JuanitoFatas/fast-ruby#hashmerge-vs-hash-code
+  Description: 'Use Hash#[]=, rather than Hash#merge! with a single key-value pair.'
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#hashmerge-vs-hash-code'
   Enabled: true
   VersionAdded: '0.36'
+  # Max number of key-value pairs to consider an offense
   MaxKeyValuePairs: 2
 
 Performance/RedundantSortBy:
-  Description: |-
-    This cop identifies places where `sort_by { ... }` can be replaced by
-    `sort`.
+  Description: 'Use `sort` instead of `sort_by { |x| x }`.'
   Enabled: true
   VersionAdded: '0.36'
 
 Performance/RegexpMatch:
-  Description: |-
-    In Ruby 2.4, `String#match?`, `Regexp#match?`, and `Symbol#match?`
-    have been added. The methods are faster than `match`.
-    Because the methods avoid creating a `MatchData` object or saving
-    backref.
-    So, when `MatchData` is not used, use `match?` instead of `match`.
-  Reference: https://github.com/JuanitoFatas/fast-ruby#regexp-vs-stringmatch-vs-string-vs-stringmatch-code-
+  Description: >-
+                  Use `match?` instead of `Regexp#match`, `String#match`, `Symbol#match`,
+                  `Regexp#===`, or `=~` when `MatchData` is not used.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#regexp-vs-stringmatch-vs-string-vs-stringmatch-code-'
   Enabled: true
   VersionAdded: '0.47'
 
 Performance/ReverseEach:
-  Description: |-
-    This cop is used to identify usages of `reverse.each` and
-    change them to use `reverse_each` instead.
-  Reference: https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code
+  Description: 'Use `reverse_each` instead of `reverse.each`.'
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
   Enabled: true
   VersionAdded: '0.30'
 
 Performance/Sample:
-  Description: |-
-    This cop is used to identify usages of `shuffle.first`,
-    `shuffle.last`, and `shuffle[]` and change them to use
-    `sample` instead.
-  Reference: https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code
+  Description: >-
+                  Use `sample` instead of `shuffle.first`,
+                  `shuffle.last`, and `shuffle[Integer]`.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
   Enabled: true
   VersionAdded: '0.30'
 
 Performance/Size:
-  Description: |-
-    This cop is used to identify usages of `count` on an
-    `Array` and `Hash` and change them to `size`.
-  Reference: https://github.com/JuanitoFatas/fast-ruby#arraylength-vs-arraysize-vs-arraycount-code
+  Description: >-
+                  Use `size` instead of `count` for counting
+                  the number of elements in `Array` and `Hash`.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arraylength-vs-arraysize-vs-arraycount-code'
   Enabled: true
   VersionAdded: '0.30'
 
 Performance/StartWith:
-  Description: |-
-    This cop identifies unnecessary use of a regex where
-    `String#start_with?` would suffice.
-  Reference: https://github.com/JuanitoFatas/fast-ruby#stringmatch-vs-stringstart_withstringend_with-code-start-code-end
+  Description: 'Use `start_with?` instead of a regex match anchored to the beginning of a string.'
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringmatch-vs-stringstart_withstringend_with-code-start-code-end'
+  # This will change to a new method call which isn't guaranteed to be on the
+  # object. Switching these methods has to be done with knowledge of the types
+  # of the variables which rubocop doesn't have.
   SafeAutoCorrect: false
   AutoCorrect: false
   Enabled: true
@@ -2099,96 +2157,89 @@ Performance/StartWith:
   VersionChanged: '0.44'
 
 Performance/StringReplacement:
-  Description: |-
-    This cop identifies places where `gsub` can be replaced by
-    `tr` or `delete`.
-  Reference: https://github.com/JuanitoFatas/fast-ruby#stringgsub-vs-stringtr-code
+  Description: >-
+                  Use `tr` instead of `gsub` when you are replacing the same
+                  number of characters. Use `delete` instead of `gsub` when
+                  you are deleting characters.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringgsub-vs-stringtr-code'
   Enabled: true
   VersionAdded: '0.33'
 
 Performance/TimesMap:
-  Description: |-
-    This cop checks for .times.map calls.
-    In most cases such calls can be replaced
-    with an explicit array creation.
+  Description: 'Checks for .times.map calls.'
   AutoCorrect: false
   Enabled: true
   VersionAdded: '0.36'
   VersionChanged: '0.50'
-  SafeAutoCorrect: false
+  SafeAutoCorrect: false # see https://github.com/rubocop-hq/rubocop/issues/4658
 
 Performance/UnfreezeString:
-  Description: |-
-    In Ruby 2.3 or later, use unary plus operator to unfreeze a string
-    literal instead of `String#dup` and `String.new`.
-    Unary plus operator is faster than `String#dup`.
+  Description: 'Use unary plus to get an unfrozen string literal.'
   Enabled: true
   VersionAdded: '0.50'
 
 Performance/UnneededSort:
-  Description: |-
-    This cop is used to identify instances of sorting and then
-    taking only the first or last element. The same behavior can
-    be accomplished without a relatively expensive sort by using
-    `Enumerable#min` instead of sorting and taking the first
-    element and `Enumerable#max` instead of sorting and taking the
-    last element. Similarly, `Enumerable#min_by` and
-    `Enumerable#max_by` can replace `Enumerable#sort_by` calls
-    after which only the first or last element is used.
+  Description: >-
+                  Use `min` instead of `sort.first`,
+                  `max_by` instead of `sort_by...last`, etc.
   Enabled: true
   VersionAdded: '0.55'
 
 Performance/UriDefaultParser:
-  Description: |-
-    This cop identifies places where `URI::Parser.new`
-    can be replaced by `URI::DEFAULT_PARSER`.
+  Description: 'Use `URI::DEFAULT_PARSER` instead of `URI::Parser.new`.'
   Enabled: true
   VersionAdded: '0.50'
 
+#################### Rails #################################
+
+# By default, the rails cops are not run. Override in project or home
+# directory .rubocop.yml files, or by giving the -R/--rails option.
 Rails:
   Enabled: false
 
 Rails/ActionFilter:
-  Description: This cop enforces the consistent use of action filter methods.
+  Description: 'Enforces consistent use of action filter methods.'
   Enabled: true
   VersionAdded: '0.19'
   EnforcedStyle: action
   SupportedStyles:
-  - action
-  - filter
+    - action
+    - filter
   Include:
-  - app/controllers/**/*.rb
+    - app/controllers/**/*.rb
 
 Rails/ActiveRecordAliases:
-  Description: |-
-    Checks that ActiveRecord aliases are not used. The direct method names
-    are more clear and easier to read.
+  Description: >-
+                  Avoid Active Record aliases:
+                  Use `update` instead of `update_attributes`.
+                  Use `update!` instead of `update_attributes!`.
   Enabled: true
   VersionAdded: '0.53'
 
 Rails/ActiveSupportAliases:
-  Description: |-
-    This cop checks that ActiveSupport aliases to core ruby methods
-    are not used.
+  Description: >-
+                  Avoid ActiveSupport aliases of standard ruby methods:
+                  `String#starts_with?`, `String#ends_with?`,
+                  `Array#append`, `Array#prepend`.
   Enabled: true
   VersionAdded: '0.48'
 
 Rails/ApplicationJob:
-  Description: This cop checks that jobs subclass ApplicationJob with Rails 5.0.
+  Description: 'Check that jobs subclass ApplicationJob.'
   Enabled: true
   VersionAdded: '0.49'
 
 Rails/ApplicationRecord:
-  Description: This cop checks that models subclass ApplicationRecord with Rails 5.0.
+  Description: 'Check that models subclass ApplicationRecord.'
   Enabled: true
   VersionAdded: '0.49'
 
 Rails/AssertNot:
-  Description: Use `assert_not` instead of `assert !`.
+  Description: 'Use `assert_not` instead of `assert !`.'
   Enabled: true
   VersionAdded: '0.56'
   Include:
-  - "**/test/**/*"
+    - '**/test/**/*'
 
 Rails/BelongsTo:
   Description: >-
@@ -2198,183 +2249,160 @@ Rails/BelongsTo:
   VersionAdded: '0.62'
 
 Rails/Blank:
-  Description: |-
-    This cop checks for code that can be written with simpler conditionals
-    using `Object#blank?` defined by Active Support.
+  Description: 'Enforces use of `blank?`.'
   Enabled: true
   VersionAdded: '0.48'
+  # Convert usages of `nil? || empty?` to `blank?`
   NilOrEmpty: true
+  # Convert usages of `!present?` to `blank?`
   NotPresent: true
+  # Convert usages of `unless present?` to `if blank?`
   UnlessPresent: true
 
 Rails/BulkChangeTable:
-  Description: |-
-    This Cop checks whether alter queries are combinable.
-    If combinable queries are detected, it suggests to you
-    to use `change_table` with `bulk: true` instead.
-    This option causes the migration to generate a single
-    ALTER TABLE statement combining multiple column alterations.
+  Description: 'Check whether alter queries are combinable.'
   Enabled: true
   VersionAdded: '0.57'
-  Database:
+  Database: null
   SupportedDatabases:
-  - mysql
-  - postgresql
+    - mysql
+    - postgresql
   Include:
-  - db/migrate/*.rb
+    - db/migrate/*.rb
 
 Rails/CreateTableWithTimestamps:
-  Description: |-
-    This cop checks the migration for which timestamps are not included
-    when creating a new table.
-    In many cases, timestamps are useful information and should be added.
+  Description: >-
+                  Checks the migration for which timestamps are not included
+                  when creating a new table.
   Enabled: true
   VersionAdded: '0.52'
   Include:
-  - db/migrate/*.rb
+    - db/migrate/*.rb
 
 Rails/Date:
-  Description: |-
-    This cop checks for the correct use of Date methods,
-    such as Date.today, Date.current etc.
+  Description: >-
+                  Checks the correct usage of date aware methods,
+                  such as Date.today, Date.current etc.
   Enabled: true
   VersionAdded: '0.30'
   VersionChanged: '0.33'
+  # The value `strict` disallows usage of `Date.today`, `Date.current`,
+  # `Date#to_time` etc.
+  # The value `flexible` allows usage of `Date.current`, `Date.yesterday`, etc
+  # (but not `Date.today`) which are overridden by ActiveSupport to handle current
+  # time zone.
   EnforcedStyle: flexible
   SupportedStyles:
-  - strict
-  - flexible
+    - strict
+    - flexible
 
 Rails/Delegate:
-  Description: |-
-    This cop looks for delegations that could have been created
-    automatically with the `delegate` method.
+  Description: 'Prefer delegate method for delegations.'
   Enabled: true
   VersionAdded: '0.21'
   VersionChanged: '0.50'
+  # When set to true, using the target object as a prefix of the
+  # method name without using the `delegate` method will be a
+  # violation. When set to false, this case is legal.
   EnforceForPrefixed: true
 
 Rails/DelegateAllowBlank:
-  Description: |-
-    This cop looks for delegations that pass :allow_blank as an option
-    instead of :allow_nil. :allow_blank is not a valid option to pass
-    to ActiveSupport#delegate.
+  Description: 'Do not use allow_blank as an option to delegate.'
   Enabled: true
   VersionAdded: '0.44'
 
 Rails/DynamicFindBy:
-  Description: |-
-    This cop checks dynamic `find_by_*` methods.
-    Use `find_by` instead of dynamic method.
-    See. https://github.com/rubocop-hq/rails-style-guide#find_by
-  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#find_by
+  Description: 'Use `find_by` instead of dynamic `find_by_*`.'
+  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#find_by'
   Enabled: true
   VersionAdded: '0.44'
   Whitelist:
-  - find_by_sql
+    - find_by_sql
 
 Rails/EnumUniqueness:
-  Description: This cop looks for duplicate values in enum declarations.
+  Description: 'Avoid duplicate integers in hash-syntax `enum` declaration.'
   Enabled: true
   VersionAdded: '0.46'
   Include:
-  - app/models/**/*.rb
+    - app/models/**/*.rb
 
 Rails/EnvironmentComparison:
-  Description: |-
-    This cop checks that Rails.env is compared using `.production?`-like
-    methods instead of equality against a string or symbol.
+  Description: "Favor `Rails.env.production?` over `Rails.env == 'production'`"
   Enabled: true
   VersionAdded: '0.52'
 
 Rails/Exit:
-  Description: |-
-    This cop enforces that `exit` calls are not used within a rails app.
-    Valid options are instead to raise an error, break, return, or some
-    other form of stopping execution of current request.
+  Description: >-
+                  Favor `fail`, `break`, `return`, etc. over `exit` in
+                  application or library code outside of Rake files to avoid
+                  exits during unit testing or running in production.
   Enabled: true
   VersionAdded: '0.41'
   Include:
-  - app/**/*.rb
-  - config/**/*.rb
-  - lib/**/*.rb
+    - app/**/*.rb
+    - config/**/*.rb
+    - lib/**/*.rb
   Exclude:
-  - lib/**/*.rake
+    - lib/**/*.rake
 
 Rails/FilePath:
-  Description: |-
-    This cop is used to identify usages of file path joining process
-    to use `Rails.root.join` clause. It is used to add uniformity when
-    joining paths.
+  Description: 'Use `Rails.root.join` for file path joining.'
   Enabled: true
   VersionAdded: '0.47'
   VersionChanged: '0.57'
   EnforcedStyle: arguments
   SupportedStyles:
-  - slashes
-  - arguments
+    - slashes
+    - arguments
 
 Rails/FindBy:
-  Description: |-
-    This cop is used to identify usages of `where.first` and
-    change them to use `find_by` instead.
-  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#find_by
+  Description: 'Prefer find_by over where.first.'
+  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#find_by'
   Enabled: true
   VersionAdded: '0.30'
   Include:
-  - app/models/**/*.rb
+    - app/models/**/*.rb
 
 Rails/FindEach:
-  Description: |-
-    This cop is used to identify usages of `all.each` and
-    change them to use `all.find_each` instead.
-  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#find-each
+  Description: 'Prefer all.find_each over all.find.'
+  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#find-each'
   Enabled: true
   VersionAdded: '0.30'
   Include:
-  - app/models/**/*.rb
+    - app/models/**/*.rb
 
 Rails/HasAndBelongsToMany:
-  Description: This cop checks for the use of the has_and_belongs_to_many macro.
-  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#has-many-through
+  Description: 'Prefer has_many :through to has_and_belongs_to_many.'
+  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#has-many-through'
   Enabled: true
   VersionAdded: '0.12'
   Include:
-  - app/models/**/*.rb
+    - app/models/**/*.rb
 
 Rails/HasManyOrHasOneDependent:
-  Description: |-
-    This cop looks for `has_many` or `has_one` associations that don't
-    specify a `:dependent` option.
-    It doesn't register an offense if `:through` option was specified.
-  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#has_many-has_one-dependent-option
+  Description: 'Define the dependent option to the has_many and has_one associations.'
+  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#has_many-has_one-dependent-option'
   Enabled: true
   VersionAdded: '0.50'
   Include:
-  - app/models/**/*.rb
+    - app/models/**/*.rb
 
 Rails/HttpPositionalArguments:
-  Description: |-
-    This cop is used to identify usages of http methods like `get`, `post`,
-    `put`, `patch` without the usage of keyword arguments in your tests and
-    change them to use keyword args. This cop only applies to Rails >= 5.
-    If you are running Rails < 5 you should disable the
-    Rails/HttpPositionalArguments cop or set your TargetRailsVersion in your
-    .rubocop.yml file to 4.0, etc.
+  Description: 'Use keyword arguments instead of positional arguments in http method calls.'
   Enabled: true
   VersionAdded: '0.44'
   Include:
-  - spec/**/*
-  - test/**/*
+    - 'spec/**/*'
+    - 'test/**/*'
 
 Rails/HttpStatus:
-  Description: Enforces use of symbolic or numeric value to define HTTP status.
+  Description: 'Enforces use of symbolic or numeric value to define HTTP status.'
   Enabled: true
   VersionAdded: '0.54'
   EnforcedStyle: symbolic
   SupportedStyles:
-  - numeric
-  - symbolic
+    - numeric
+    - symbolic
 
 Rails/IgnoredSkipActionFilterOption:
   Description: 'Checks that `if` and `only` (or `except`) are not used together as options of `skip_*` action filter.'
@@ -2385,107 +2413,83 @@ Rails/IgnoredSkipActionFilterOption:
     - app/controllers/**/*.rb
 
 Rails/InverseOf:
-  Description: |-
-    This cop looks for has_(one|many) and belongs_to associations where
-    Active Record can't automatically determine the inverse association
-    because of a scope or the options used. Using the blog with order scope
-    example below, traversing the a Blog's association in both directions
-    with `blog.posts.first.blog` would cause the `blog` to be loaded from
-    the database twice.
+  Description: 'Checks for associations where the inverse cannot be determined automatically.'
   Enabled: true
   VersionAdded: '0.52'
   Include:
-  - app/models/**/*.rb
+    - app/models/**/*.rb
 
 Rails/LexicallyScopedActionFilter:
-  Description: |-
-    This cop checks that methods specified in the filter's `only` or
-    `except` options are defined within the same class or module.
-  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#lexically-scoped-action-filter
+  Description: "Checks that methods specified in the filter's `only` or `except` options are explicitly defined in the controller."
+  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#lexically-scoped-action-filter'
   Enabled: true
   VersionAdded: '0.52'
   Include:
-  - app/controllers/**/*.rb
+    - app/controllers/**/*.rb
 
 Rails/LinkToBlank:
-  Description: |-
-    This cop checks for calls to `link_to` that contain a
-    `target: '_blank'` but no `rel: 'noopener'`. This can be a security
-    risk as the loaded page will have control over the previous page
-    and could change its location for phishing purposes.
+  Description: 'Checks that `link_to` with a `target: "_blank"` have a `rel: "noopener"` option passed to them.'
   Reference: https://mathiasbynens.github.io/rel-noopener/
   Enabled: true
   VersionAdded: '0.62'
 
 Rails/NotNullColumn:
-  Description: |-
-    This cop checks for add_column call with NOT NULL constraint
-    in migration file.
+  Description: 'Do not add a NOT NULL column without a default value'
   Enabled: true
   VersionAdded: '0.43'
   Include:
-  - db/migrate/*.rb
+    - db/migrate/*.rb
 
 Rails/Output:
-  Description: This cop checks for the use of output calls like puts and print
+  Description: 'Checks for calls to puts, print, etc.'
   Enabled: true
   VersionAdded: '0.15'
   VersionChanged: '0.19'
   Include:
-  - app/**/*.rb
-  - config/**/*.rb
-  - db/**/*.rb
-  - lib/**/*.rb
+    - app/**/*.rb
+    - config/**/*.rb
+    - db/**/*.rb
+    - lib/**/*.rb
 
 Rails/OutputSafety:
-  Description: |-
-    This cop checks for the use of output safety calls like `html_safe`,
-    `raw`, and `safe_concat`. These methods do not escape content. They
-    simply return a SafeBuffer containing the content as is. Instead,
-    use `safe_join` to join content and escape it and concat to
-    concatenate content and escape it, ensuring its safety.
+  Description: 'The use of `html_safe` or `raw` may be a security risk.'
   Enabled: true
   VersionAdded: '0.41'
 
 Rails/PluralizationGrammar:
-  Description: |-
-    This cop checks for correct grammar when using ActiveSupport's
-    core extensions to the numeric classes.
+  Description: 'Checks for incorrect grammar when using methods like `3.day.ago`.'
   Enabled: true
   VersionAdded: '0.35'
 
 Rails/Presence:
-  Description: |-
-    This cop checks code that can be written more easily using
-    `Object#presence` defined by Active Support.
+  Description: 'Checks code that can be written more easily using `Object#presence` defined by Active Support.'
   Enabled: true
   VersionAdded: '0.52'
 
 Rails/Present:
-  Description: |-
-    This cop checks for code that can be written with simpler conditionals
-    using `Object#present?` defined by Active Support.
+  Description: 'Enforces use of `present?`.'
   Enabled: true
   VersionAdded: '0.48'
+  # Convert usages of `!nil? && !empty?` to `present?`
   NotNilAndNotEmpty: true
+  # Convert usages of `!blank?` to `present?`
   NotBlank: true
+  # Convert usages of `unless blank?` to `if present?`
   UnlessBlank: true
 
 Rails/ReadWriteAttribute:
-  Description: |-
-    This cop checks for the use of the `read_attribute` or `write_attribute`
-    methods and recommends square brackets instead.
-  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#read-attribute
+  Description: >-
+                 Checks for read_attribute(:attr) and
+                 write_attribute(:attr, val).
+  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#read-attribute'
   Enabled: true
   VersionAdded: '0.20'
   VersionChanged: '0.29'
   Include:
-  - app/models/**/*.rb
+    - app/models/**/*.rb
 
 Rails/RedundantReceiverInWithOptions:
-  Description: |-
-    This cop checks for redundant receiver in `with_options`.
-    Receiver is implicit from Rails 4.2 or higher.
+  Description: 'Checks for redundant receiver in `with_options`.'
   Enabled: true
   VersionAdded: '0.52'
 
@@ -2495,58 +2499,50 @@ Rails/ReflectionClassName:
   VersionAdded: '0.64'
 
 Rails/RefuteMethods:
-  Description: Use `assert_not` methods instead of `refute` methods.
+  Description: 'Use `assert_not` methods instead of `refute` methods.'
   Enabled: true
   VersionAdded: '0.56'
   Include:
-  - "**/test/**/*"
+    - '**/test/**/*'
 
 Rails/RelativeDateConstant:
-  Description: |-
-    This cop checks whether constant value isn't relative date.
-    Because the relative date will be evaluated only once.
+  Description: 'Do not assign relative date to constants.'
   Enabled: true
   VersionAdded: '0.48'
   VersionChanged: '0.59'
   AutoCorrect: false
 
 Rails/RequestReferer:
-  Description: |-
-    This cop checks for consistent uses of `request.referer` or
-    `request.referrer`, depending on the cop's configuration.
+  Description: 'Use consistent syntax for request.referer.'
   Enabled: true
   VersionAdded: '0.41'
   EnforcedStyle: referer
   SupportedStyles:
-  - referer
-  - referrer
+    - referer
+    - referrer
 
 Rails/ReversibleMigration:
-  Description: |-
-    This cop checks whether the change method of the migration file is
-    reversible.
-  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#reversible-migration
-  Reference: https://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html
+  Description: 'Checks whether the change method of the migration file is reversible.'
+  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#reversible-migration'
+  Reference: 'https://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html'
   Enabled: true
   VersionAdded: '0.47'
   Include:
-  - db/migrate/*.rb
+    - db/migrate/*.rb
 
 Rails/SafeNavigation:
-  Description: |-
-    This cop converts usages of `try!` to `&.`. It can also be configured
-    to convert `try`. It will convert code to use safe navigation if the
-    target Ruby version is set to 2.3+
+  Description: "Use Ruby's safe navigation operator (`&.`) instead of `try!`"
   Enabled: true
   VersionAdded: '0.43'
+  # This will convert usages of `try` to use safe navigation as well as `try!`.
+  # `try` and `try!` work slightly differently. `try!` and safe navigation will
+  # both raise a `NoMethodError` if the receiver of the method call does not
+  # implement the intended method. `try` will not raise an exception for this.
   ConvertTry: false
 
 Rails/SaveBang:
-  Description: |-
-    This cop identifies possible cases where Active Record save! or related
-    should be used instead of save because the model might have failed to
-    save and an exception is better than unhandled failure.
-  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#save-bang
+  Description: 'Identifies possible cases where Active Record save! or related should be used.'
+  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#save-bang'
   Enabled: false
   VersionAdded: '0.42'
   VersionChanged: '0.59'
@@ -2554,615 +2550,651 @@ Rails/SaveBang:
   AllowedReceivers: []
 
 Rails/ScopeArgs:
-  Description: |-
-    This cop checks for scope calls where it was passed
-    a method (usually a scope) instead of a lambda/proc.
+  Description: 'Checks the arguments of ActiveRecord scopes.'
   Enabled: true
   VersionAdded: '0.19'
   Include:
-  - app/models/**/*.rb
+    - app/models/**/*.rb
 
 Rails/SkipsModelValidations:
-  Description: |-
-    This cop checks for the use of methods which skip
-    validations which are listed in
-    https://guides.rubyonrails.org/active_record_validations.html#skipping-validations
-  Reference: https://guides.rubyonrails.org/active_record_validations.html#skipping-validations
+  Description: >-
+                 Use methods that skips model validations with caution.
+                 See reference for more information.
+  Reference: 'https://guides.rubyonrails.org/active_record_validations.html#skipping-validations'
   Enabled: true
   VersionAdded: '0.47'
   VersionChanged: '0.60'
   Blacklist:
-  - decrement!
-  - decrement_counter
-  - increment!
-  - increment_counter
-  - toggle!
-  - touch
-  - update_all
-  - update_attribute
-  - update_column
-  - update_columns
-  - update_counters
+    - decrement!
+    - decrement_counter
+    - increment!
+    - increment_counter
+    - toggle!
+    - touch
+    - update_all
+    - update_attribute
+    - update_column
+    - update_columns
+    - update_counters
   Whitelist: []
 
 Rails/TimeZone:
-  Description: This cop checks for the use of Time methods without zone.
-  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#time
-  Reference: http://danilenko.org/2012/7/6/rails_timezones
+  Description: 'Checks the correct usage of time zone aware methods.'
+  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#time'
+  Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
   Enabled: true
   VersionAdded: '0.30'
   VersionChanged: '0.33'
+  # The value `strict` means that `Time` should be used with `zone`.
+  # The value `flexible` allows usage of `in_time_zone` instead of `zone`.
   EnforcedStyle: flexible
   SupportedStyles:
-  - strict
-  - flexible
+    - strict
+    - flexible
 
 Rails/UniqBeforePluck:
-  Description: Prefer the use of uniq (or distinct), before pluck instead of after.
+  Description: 'Prefer the use of uniq or distinct before pluck.'
   Enabled: true
   VersionAdded: '0.40'
   VersionChanged: '0.47'
   EnforcedStyle: conservative
   SupportedStyles:
-  - conservative
-  - aggressive
+    - conservative
+    - aggressive
   AutoCorrect: false
 
 Rails/UnknownEnv:
-  Description: |-
-    This cop checks that environments called with `Rails.env` predicates
-    exist.
+  Description: 'Use correct environment name.'
   Enabled: true
   VersionAdded: '0.51'
   Environments:
-  - development
-  - test
-  - production
+    - development
+    - test
+    - production
 
 Rails/Validation:
-  Description: This cop checks for the use of old-style attribute validation macros.
+  Description: 'Use validates :attribute, hash of validations.'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.41'
   Include:
-  - app/models/**/*.rb
+    - app/models/**/*.rb
+
+#################### Security ##############################
 
 Security/Eval:
-  Description: This cop checks for the use of `Kernel#eval` and `Binding#eval`.
+  Description: 'The use of eval represents a serious security risk.'
   Enabled: true
   VersionAdded: '0.47'
 
 Security/JSONLoad:
-  Description: |-
-    This cop checks for the use of JSON class methods which have potential
-    security issues.
-  Reference: https://ruby-doc.org/stdlib-2.3.0/libdoc/json/rdoc/JSON.html#method-i-load
+  Description: >-
+                 Prefer usage of `JSON.parse` over `JSON.load` due to potential
+                 security issues. See reference for more information.
+  Reference: 'https://ruby-doc.org/stdlib-2.3.0/libdoc/json/rdoc/JSON.html#method-i-load'
   Enabled: true
   VersionAdded: '0.43'
   VersionChanged: '0.44'
+  # Autocorrect here will change to a method that may cause crashes depending
+  # on the value of the argument.
   AutoCorrect: false
   SafeAutoCorrect: false
 
 Security/MarshalLoad:
-  Description: |-
-    This cop checks for the use of Marshal class methods which have
-    potential security issues leading to remote code execution when
-    loading from an untrusted source.
-  Reference: https://ruby-doc.org/core-2.3.3/Marshal.html#module-Marshal-label-Security+considerations
+  Description: >-
+                 Avoid using of `Marshal.load` or `Marshal.restore` due to potential
+                 security issues. See reference for more information.
+  Reference: 'https://ruby-doc.org/core-2.3.3/Marshal.html#module-Marshal-label-Security+considerations'
   Enabled: true
   VersionAdded: '0.47'
 
 Security/Open:
-  Description: This cop checks for the use of `Kernel#open`.
+  Description: 'The use of Kernel#open represents a serious security risk.'
   Enabled: true
   VersionAdded: '0.53'
   Safe: false
 
 Security/YAMLLoad:
-  Description: |-
-    This cop checks for the use of YAML class methods which have
-    potential security issues leading to remote code execution when
-    loading from an untrusted source.
-  Reference: https://ruby-doc.org/stdlib-2.3.3/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security
+  Description: >-
+                 Prefer usage of `YAML.safe_load` over `YAML.load` due to potential
+                 security issues. See reference for more information.
+  Reference: 'https://ruby-doc.org/stdlib-2.3.3/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security'
   Enabled: true
   VersionAdded: '0.47'
   SafeAutoCorrect: false
 
+#################### Style ###############################
+
 Style/AccessModifierDeclarations:
-  Description: |-
-    Access modifiers should be declared to apply to a group of methods
-    or inline before each method, depending on configuration.
+  Description: 'Checks style of how access modifiers are used.'
   Enabled: true
   VersionAdded: '0.57'
   EnforcedStyle: group
   SupportedStyles:
-  - inline
-  - group
+    - inline
+    - group
 
 Style/Alias:
-  Description: |-
-    This cop enforces the use of either `#alias` or `#alias_method`
-    depending on configuration.
-    It also flags uses of `alias :symbol` rather than `alias bareword`.
-  StyleGuide: "#alias-method"
+  Description: 'Use alias instead of alias_method.'
+  StyleGuide: '#alias-method'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.36'
   EnforcedStyle: prefer_alias
   SupportedStyles:
-  - prefer_alias
-  - prefer_alias_method
+    - prefer_alias
+    - prefer_alias_method
 
 Style/AndOr:
-  Description: |-
-    This cop checks for uses of `and` and `or`, and suggests using `&&` and
-    `||` instead. It can be configured to check only in conditions or in
-    all contexts.
-  StyleGuide: "#no-and-or-or"
+  Description: 'Use &&/|| instead of and/or.'
+  StyleGuide: '#no-and-or-or'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.25'
+  # Whether `and` and `or` are banned only in conditionals (conditionals)
+  # or completely (always).
   EnforcedStyle: always
   SupportedStyles:
-  - always
-  - conditionals
+    - always
+    - conditionals
 
 Style/ArrayJoin:
-  Description: This cop checks for uses of "*" as a substitute for *join*.
-  StyleGuide: "#array-join"
+  Description: 'Use Array#join instead of Array#*.'
+  StyleGuide: '#array-join'
   Enabled: true
   VersionAdded: '0.20'
   VersionChanged: '0.31'
 
 Style/AsciiComments:
-  Description: |-
-    This cop checks for non-ascii (non-English) characters
-    in comments. You could set an array of allowed non-ascii chars in
-    AllowedChars attribute (empty by default).
-  StyleGuide: "#english-comments"
+  Description: 'Use only ascii symbols in comments.'
+  StyleGuide: '#english-comments'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.52'
   AllowedChars: []
 
 Style/Attr:
-  Description: This cop checks for uses of Module#attr.
-  StyleGuide: "#attr"
+  Description: 'Checks for uses of Module#attr.'
+  StyleGuide: '#attr'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.12'
 
 Style/AutoResourceCleanup:
-  Description: |-
-    This cop checks for cases when you could use a block
-    accepting version of a method that does automatic
-    resource cleanup.
+  Description: 'Suggests the usage of an auto resource cleanup version of a method (if available).'
   Enabled: false
   VersionAdded: '0.30'
 
 Style/BarePercentLiterals:
-  Description: This cop checks if usage of %() or %Q() matches configuration.
-  StyleGuide: "#percent-q-shorthand"
+  Description: 'Checks if usage of %() or %Q() matches configuration.'
+  StyleGuide: '#percent-q-shorthand'
   Enabled: true
   VersionAdded: '0.25'
   EnforcedStyle: bare_percent
   SupportedStyles:
-  - percent_q
-  - bare_percent
+    - percent_q
+    - bare_percent
 
 Style/BeginBlock:
-  Description: This cop checks for BEGIN blocks.
-  StyleGuide: "#no-BEGIN-blocks"
+  Description: 'Avoid the use of BEGIN blocks.'
+  StyleGuide: '#no-BEGIN-blocks'
   Enabled: true
   VersionAdded: '0.9'
 
 Style/BlockComments:
-  Description: This cop looks for uses of block comments (=begin...=end).
-  StyleGuide: "#no-block-comments"
+  Description: 'Do not use block comments.'
+  StyleGuide: '#no-block-comments'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.23'
 
 Style/BlockDelimiters:
-  Description: |-
-    Check for uses of braces or do/end around single line or
-    multi-line blocks.
-  StyleGuide: "#single-line-blocks"
+  Description: >-
+                Avoid using {...} for multi-line blocks (multiline chaining is
+                always ugly).
+                Prefer {...} over do...end for single-line blocks.
+  StyleGuide: '#single-line-blocks'
   Enabled: true
   VersionAdded: '0.30'
   VersionChanged: '0.35'
   EnforcedStyle: line_count_based
   SupportedStyles:
-  - line_count_based
-  - semantic
-  - braces_for_chaining
+    # The `line_count_based` style enforces braces around single line blocks and
+    # do..end around multi-line blocks.
+    - line_count_based
+    # The `semantic` style enforces braces around functional blocks, where the
+    # primary purpose of the block is to return a value and do..end for
+    # procedural blocks, where the primary purpose of the block is its
+    # side-effects.
+    #
+    # This looks at the usage of a block's method to determine its type (e.g. is
+    # the result of a `map` assigned to a variable or passed to another
+    # method) but exceptions are permitted in the `ProceduralMethods`,
+    # `FunctionalMethods` and `IgnoredMethods` sections below.
+    - semantic
+    # The `braces_for_chaining` style enforces braces around single line blocks
+    # and do..end around multi-line blocks, except for multi-line blocks whose
+    # return value is being chained with another method (in which case braces
+    # are enforced).
+    - braces_for_chaining
   ProceduralMethods:
-  - benchmark
-  - bm
-  - bmbm
-  - create
-  - each_with_object
-  - measure
-  - new
-  - realtime
-  - tap
-  - with_object
+    # Methods that are known to be procedural in nature but look functional from
+    # their usage, e.g.
+    #
+    #   time = Benchmark.realtime do
+    #     foo.bar
+    #   end
+    #
+    # Here, the return value of the block is discarded but the return value of
+    # `Benchmark.realtime` is used.
+    - benchmark
+    - bm
+    - bmbm
+    - create
+    - each_with_object
+    - measure
+    - new
+    - realtime
+    - tap
+    - with_object
   FunctionalMethods:
-  - let
-  - let!
-  - subject
-  - watch
+    # Methods that are known to be functional in nature but look procedural from
+    # their usage, e.g.
+    #
+    #   let(:foo) { Foo.new }
+    #
+    # Here, the return value of `Foo.new` is used to define a `foo` helper but
+    # doesn't appear to be used from the return value of `let`.
+    - let
+    - let!
+    - subject
+    - watch
   IgnoredMethods:
-  - lambda
-  - proc
-  - it
+    # Methods that can be either procedural or functional and cannot be
+    # categorised from their usage alone, e.g.
+    #
+    #   foo = lambda do |x|
+    #     puts "Hello, #{x}"
+    #   end
+    #
+    #   foo = lambda do |x|
+    #     x * 100
+    #   end
+    #
+    # Here, it is impossible to tell from the return value of `lambda` whether
+    # the inner block's return value is significant.
+    - lambda
+    - proc
+    - it
 
 Style/BracesAroundHashParameters:
-  Description: |-
-    This cop checks for braces around the last parameter in a method call
-    if the last parameter is a hash.
-    It supports `braces`, `no_braces` and `context_dependent` styles.
+  Description: 'Enforce braces style around hash parameters.'
   Enabled: true
-  VersionAdded: 0.14.1
+  VersionAdded: '0.14.1'
   VersionChanged: '0.28'
   EnforcedStyle: no_braces
   SupportedStyles:
-  - braces
-  - no_braces
-  - context_dependent
+    # The `braces` style enforces braces around all method parameters that are
+    # hashes.
+    - braces
+    # The `no_braces` style checks that the last parameter doesn't have braces
+    # around it.
+    - no_braces
+    # The `context_dependent` style checks that the last parameter doesn't have
+    # braces around it, but requires braces if the second to last parameter is
+    # also a hash literal.
+    - context_dependent
 
 Style/CaseEquality:
-  Description: This cop checks for uses of the case equality operator(===).
-  StyleGuide: "#no-case-equality"
+  Description: 'Avoid explicit use of the case equality operator(===).'
+  StyleGuide: '#no-case-equality'
   Enabled: true
   VersionAdded: '0.9'
 
 Style/CharacterLiteral:
-  Description: Checks for uses of the character literal ?x.
-  StyleGuide: "#no-character-literals"
+  Description: 'Checks for uses of character literals.'
+  StyleGuide: '#no-character-literals'
   Enabled: true
   VersionAdded: '0.9'
 
 Style/ClassAndModuleChildren:
-  Description: |-
-    This cop checks the style of children definitions at classes and
-    modules. Basically there are two different styles:
-  StyleGuide: "#namespace-definition"
+  Description: 'Checks style of children classes and modules.'
+  StyleGuide: '#namespace-definition'
+  # Moving from compact to nested children requires knowledge of whether the
+  # outer parent is a module or a class. Moving from nested to compact requires
+  # verification that the outer parent is defined elsewhere. Rubocop does not
+  # have the knowledge to perform either operation safely and thus requires
+  # manual oversight.
   SafeAutoCorrect: false
   AutoCorrect: false
   Enabled: true
   VersionAdded: '0.19'
+  #
+  # Basically there are two different styles:
+  #
+  # `nested` - have each child on a separate line
+  #   class Foo
+  #     class Bar
+  #     end
+  #   end
+  #
+  # `compact` - combine definitions as much as possible
+  #   class Foo::Bar
+  #   end
+  #
+  # The compact style is only forced, for classes or modules with one child.
   EnforcedStyle: nested
   SupportedStyles:
-  - nested
-  - compact
+    - nested
+    - compact
 
 Style/ClassCheck:
-  Description: This cop enforces consistent use of `Object#is_a?` or `Object#kind_of?`.
+  Description: 'Enforces consistent use of `Object#is_a?` or `Object#kind_of?`.'
   Enabled: true
   VersionAdded: '0.24'
   EnforcedStyle: is_a?
   SupportedStyles:
-  - is_a?
-  - kind_of?
+    - is_a?
+    - kind_of?
 
 Style/ClassMethods:
-  Description: |-
-    This cop checks for uses of the class/module name instead of
-    self, when defining class/module methods.
-  StyleGuide: "#def-self-class-methods"
+  Description: 'Use self when defining module/class methods.'
+  StyleGuide: '#def-self-class-methods'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.20'
 
 Style/ClassVars:
-  Description: |-
-    This cop checks for uses of class variables. Offenses
-    are signaled only on assignment to class variables to
-    reduce the number of offenses that would be reported.
-  StyleGuide: "#no-class-vars"
+  Description: 'Avoid the use of class variables.'
+  StyleGuide: '#no-class-vars'
   Enabled: true
   VersionAdded: '0.13'
 
+# Align with the style guide.
 Style/CollectionMethods:
-  Description: |-
-    This cop enforces the use of consistent method names
-    from the Enumerable module.
-  StyleGuide: "#map-find-select-reduce-size"
+  Description: 'Preferred collection methods.'
+  StyleGuide: '#map-find-select-reduce-size'
   Enabled: false
   VersionAdded: '0.9'
   VersionChanged: '0.27'
   Safe: false
+  # Mapping from undesired method to desired method
+  # e.g. to use `detect` over `find`:
+  #
+  # Style/CollectionMethods:
+  #   PreferredMethods:
+  #     find: detect
   PreferredMethods:
-    collect: map
-    collect!: map!
-    inject: reduce
-    detect: find
-    find_all: select
+    collect: 'map'
+    collect!: 'map!'
+    inject: 'reduce'
+    detect: 'find'
+    find_all: 'select'
 
 Style/ColonMethodCall:
-  Description: |-
-    This cop checks for methods invoked via the :: operator instead
-    of the . operator (like FileUtils::rmdir instead of FileUtils.rmdir).
-  StyleGuide: "#double-colons"
+  Description: 'Do not use :: for method call.'
+  StyleGuide: '#double-colons'
   Enabled: true
   VersionAdded: '0.9'
 
 Style/ColonMethodDefinition:
-  Description: |-
-    This cop checks for class methods that are defined using the `::`
-    operator instead of the `.` operator.
-  StyleGuide: "#colon-method-definition"
+  Description: 'Do not use :: for defining class methods.'
+  StyleGuide: '#colon-method-definition'
   Enabled: true
   VersionAdded: '0.52'
 
 Style/CommandLiteral:
-  Description: This cop enforces using `` or %x around command literals.
-  StyleGuide: "#percent-x"
+  Description: 'Use `` or %x around command literals.'
+  StyleGuide: '#percent-x'
   Enabled: true
   VersionAdded: '0.30'
   EnforcedStyle: backticks
+  # backticks: Always use backticks.
+  # percent_x: Always use `%x`.
+  # mixed: Use backticks on single-line commands, and `%x` on multi-line commands.
   SupportedStyles:
-  - backticks
-  - percent_x
-  - mixed
+    - backticks
+    - percent_x
+    - mixed
+  # If `false`, the cop will always recommend using `%x` if one or more backticks
+  # are found in the command string.
   AllowInnerBackticks: false
 
+# Checks formatting of special comments
 Style/CommentAnnotation:
-  Description: |-
-    This cop checks that comment annotation keywords are written according
-    to guidelines.
-  StyleGuide: "#annotate-keywords"
+  Description: >-
+                 Checks formatting of special comments
+                 (TODO, FIXME, OPTIMIZE, HACK, REVIEW).
+  StyleGuide: '#annotate-keywords'
   Enabled: true
   VersionAdded: '0.10'
   VersionChanged: '0.31'
   Keywords:
-  - TODO
-  - FIXME
-  - OPTIMIZE
-  - HACK
-  - REVIEW
+    - TODO
+    - FIXME
+    - OPTIMIZE
+    - HACK
+    - REVIEW
 
 Style/CommentedKeyword:
-  Description: |-
-    This cop checks for comments put on the same line as some keywords.
-    These keywords are: `begin`, `class`, `def`, `end`, `module`.
+  Description: 'Do not place comments on the same line as certain keywords.'
   Enabled: true
   VersionAdded: '0.51'
 
 Style/ConditionalAssignment:
-  Description: |-
-    Check for `if` and `case` statements where each branch is used for
-    assignment to the same variable when using the return of the
-    condition can be used instead.
+  Description: >-
+                 Use the return value of `if` and `case` statements for
+                 assignment to a variable and variable comparison instead
+                 of assigning that variable inside of each branch.
   Enabled: true
   VersionAdded: '0.36'
   VersionChanged: '0.47'
   EnforcedStyle: assign_to_condition
   SupportedStyles:
-  - assign_to_condition
-  - assign_inside_condition
+    - assign_to_condition
+    - assign_inside_condition
+  # When configured to `assign_to_condition`, `SingleLineConditionsOnly`
+  # will only register an offense when all branches of a condition are
+  # a single line.
+  # When configured to `assign_inside_condition`, `SingleLineConditionsOnly`
+  # will only register an offense for assignment to a condition that has
+  # at least one multiline branch.
   SingleLineConditionsOnly: true
   IncludeTernaryExpressions: true
 
+# Checks that you have put a copyright in a comment before any code.
+#
+# You can override the default Notice in your .rubocop.yml file.
+#
+# In order to use autocorrect, you must supply a value for the
+# `AutocorrectNotice` key that matches the regexp Notice. A blank
+# `AutocorrectNotice` will cause an error during autocorrect.
+#
+# Autocorrect will add a copyright notice in a comment at the top
+# of the file immediately after any shebang or encoding comments.
+#
+# Example rubocop.yml:
+#
+# Style/Copyright:
+#   Enabled: true
+#   Notice: 'Copyright (\(c\) )?2015 Yahoo! Inc'
+#   AutocorrectNotice: '# Copyright (c) 2015 Yahoo! Inc.'
+#
 Style/Copyright:
-  Description: Check that a copyright notice was given in each source file.
+  Description: 'Include a copyright notice in each file before any code.'
   Enabled: false
   VersionAdded: '0.30'
-  Notice: "^Copyright (\\(c\\) )?2[0-9]{3} .+"
+  Notice: '^Copyright (\(c\) )?2[0-9]{3} .+'
   AutocorrectNotice: ''
 
 Style/DateTime:
-  Description: |-
-    This cop checks for consistent usage of the `DateTime` class over the
-    `Time` class. This cop is disabled by default since these classes,
-    although highly overlapping, have particularities that make them not
-    replaceable in certain situations when dealing with multiple timezones
-    and/or DST.
-  StyleGuide: "#date--time"
+  Description: 'Use Time over DateTime.'
+  StyleGuide: '#date--time'
   Enabled: false
   VersionAdded: '0.51'
   VersionChanged: '0.59'
   AllowCoercion: false
 
 Style/DefWithParentheses:
-  Description: |-
-    This cop checks for parentheses in the definition of a method,
-    that does not take any arguments. Both instance and
-    class/singleton methods are checked.
-  StyleGuide: "#method-parens"
+  Description: 'Use def with parentheses when there are arguments.'
+  StyleGuide: '#method-parens'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.12'
 
 Style/Dir:
-  Description: |-
-    This cop checks for places where the `#__dir__` method can replace more
-    complex constructs to retrieve a canonicalized absolute path to the
-    current file.
+  Description: >-
+                 Use the `__dir__` method to retrieve the canonicalized
+                 absolute path to the current file.
   Enabled: true
   VersionAdded: '0.50'
 
 Style/Documentation:
-  Description: |-
-    This cop checks for missing top-level documentation of
-    classes and modules. Classes with no body are exempt from the
-    check and so are namespace modules - modules that have nothing in
-    their bodies except classes, other modules, or constant definitions.
+  Description: 'Document classes and non-namespace modules.'
   Enabled: true
   VersionAdded: '0.9'
   Exclude:
-  - spec/**/*
-  - test/**/*
+    - 'spec/**/*'
+    - 'test/**/*'
 
 Style/DocumentationMethod:
-  Description: |-
-    This cop checks for missing documentation comment for public methods.
-    It can optionally be configured to also require documentation for
-    non-public methods.
+  Description: 'Checks for missing documentation comment for public methods.'
   Enabled: false
   VersionAdded: '0.43'
   Exclude:
-  - spec/**/*
-  - test/**/*
+    - 'spec/**/*'
+    - 'test/**/*'
   RequireForNonPublicMethods: false
 
 Style/DoubleNegation:
-  Description: |-
-    This cop checks for uses of double negation (!!) to convert something
-    to a boolean value. As this is both cryptic and usually redundant, it
-    should be avoided.
-  StyleGuide: "#no-bang-bang"
+  Description: 'Checks for uses of double negation (!!).'
+  StyleGuide: '#no-bang-bang'
   Enabled: true
   VersionAdded: '0.19'
 
 Style/EachForSimpleLoop:
-  Description: |-
-    This cop checks for loops which iterate a constant number of times,
-    using a Range literal and `#each`. This can be done more readably using
-    `Integer#times`.
+  Description: >-
+                 Use `Integer#times` for a simple loop which iterates a fixed
+                 number of times.
   Enabled: true
   VersionAdded: '0.41'
 
 Style/EachWithObject:
-  Description: |-
-    This cop looks for inject / reduce calls where the passed in object is
-    returned at the end and so could be replaced by each_with_object without
-    the need to return the object at the end.
+  Description: 'Prefer `each_with_object` over `inject` or `reduce`.'
   Enabled: true
   VersionAdded: '0.22'
   VersionChanged: '0.42'
 
 Style/EmptyBlockParameter:
-  Description: |-
-    This cop checks for pipes for empty block parameters. Pipes for empty
-    block parameters do not cause syntax errors, but they are redundant.
+  Description: 'Omit pipes for empty block parameters.'
   Enabled: true
   VersionAdded: '0.52'
 
 Style/EmptyCaseCondition:
-  Description: This cop checks for case statements with an empty condition.
+  Description: 'Avoid empty condition in case statements.'
   Enabled: true
   VersionAdded: '0.40'
 
 Style/EmptyElse:
-  Description: |-
-    Checks for empty else-clauses, possibly including comments and/or an
-    explicit `nil` depending on the EnforcedStyle.
+  Description: 'Avoid empty else-clauses.'
   Enabled: true
   VersionAdded: '0.28'
   VersionChanged: '0.32'
   EnforcedStyle: both
+  # empty - warn only on empty `else`
+  # nil - warn on `else` with nil in it
+  # both - warn on empty `else` and `else` with `nil` in it
   SupportedStyles:
-  - empty
-  - nil
-  - both
+    - empty
+    - nil
+    - both
 
 Style/EmptyLambdaParameter:
-  Description: |-
-    This cop checks for parentheses for empty lambda parameters. Parentheses
-    for empty lambda parameters do not cause syntax errors, but they are
-    redundant.
+  Description: 'Omit parens for empty lambda parameters.'
   Enabled: true
   VersionAdded: '0.52'
 
 Style/EmptyLiteral:
-  Description: |-
-    This cop checks for the use of a method, the result of which
-    would be a literal, like an empty array, hash, or string.
-  StyleGuide: "#literal-array-hash"
+  Description: 'Prefer literals to Array.new/Hash.new/String.new.'
+  StyleGuide: '#literal-array-hash'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.12'
 
 Style/EmptyMethod:
-  Description: |-
-    This cop checks for the formatting of empty method definitions.
-    By default it enforces empty method definitions to go on a single
-    line (compact style), but it can be configured to enforce the `end`
-    to go on its own line (expanded style).
-  StyleGuide: "#no-single-line-methods"
+  Description: 'Checks the formatting of empty method definitions.'
+  StyleGuide: '#no-single-line-methods'
   Enabled: true
   VersionAdded: '0.46'
   EnforcedStyle: compact
   SupportedStyles:
-  - compact
-  - expanded
+    - compact
+    - expanded
 
 Style/Encoding:
-  Description: This cop checks ensures source files have no utf-8 encoding comments.
-  StyleGuide: "#utf-8"
+  Description: 'Use UTF-8 as the source file encoding.'
+  StyleGuide: '#utf-8'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.50'
 
 Style/EndBlock:
-  Description: This cop checks for END blocks.
-  StyleGuide: "#no-END-blocks"
+  Description: 'Avoid the use of END blocks.'
+  StyleGuide: '#no-END-blocks'
   Enabled: true
   VersionAdded: '0.9'
 
 Style/EvalWithLocation:
-  Description: |-
-    This cop checks `eval` method usage. `eval` can receive source location
-    metadata, that are filename and line number. The metadata is used by
-    backtraces. This cop recommends to pass the metadata to `eval` method.
+  Description: 'Pass `__FILE__` and `__LINE__` to `eval` method, as they are used by backtraces.'
   Enabled: true
   VersionAdded: '0.52'
 
 Style/EvenOdd:
-  Description: |-
-    This cop checks for places where `Integer#even?` or `Integer#odd?`
-    can be used.
-  StyleGuide: "#predicate-methods"
+  Description: 'Favor the use of Integer#even? && Integer#odd?'
+  StyleGuide: '#predicate-methods'
   Enabled: true
   VersionAdded: '0.12'
   VersionChanged: '0.29'
 
 Style/ExpandPathArguments:
-  Description: |-
-    This cop checks for use of the `File.expand_path` arguments.
-    Likewise, it also checks for the `Pathname.new` argument.
+  Description: "Use `expand_path(__dir__)` instead of `expand_path('..', __FILE__)`."
   Enabled: true
   VersionAdded: '0.53'
 
 Style/For:
-  Description: |-
-    This cop looks for uses of the `for` keyword or `each` method. The
-    preferred alternative is set in the EnforcedStyle configuration
-    parameter. An `each` call with a block on a single line is always
-    allowed.
-  StyleGuide: "#no-for-loops"
+  Description: 'Checks use of for or each in multiline loops.'
+  StyleGuide: '#no-for-loops'
   Enabled: true
   VersionAdded: '0.13'
   VersionChanged: '0.59'
   EnforcedStyle: each
   SupportedStyles:
-  - each
-  - for
+    - each
+    - for
 
 Style/FormatString:
-  Description: |-
-    This cop enforces the use of a single string formatting utility.
-    Valid options include Kernel#format, Kernel#sprintf and String#%.
-  StyleGuide: "#sprintf"
+  Description: 'Enforce the use of Kernel#sprintf, Kernel#format or String#%.'
+  StyleGuide: '#sprintf'
   Enabled: true
   VersionAdded: '0.19'
   VersionChanged: '0.49'
   EnforcedStyle: format
   SupportedStyles:
-  - format
-  - sprintf
-  - percent
+    - format
+    - sprintf
+    - percent
 
 Style/FormatStringToken:
-  Description: Use a consistent style for named format string tokens.
+  Description: 'Use a consistent style for format string tokens.'
   Enabled: true
   EnforcedStyle: annotated
   SupportedStyles:
-  - annotated
-  - template
-  - unannotated
+    # Prefer tokens which contain a sprintf like type annotation like
+    # `%<name>s`, `%<age>d`, `%<score>f`
+    - annotated
+    # Prefer simple looking "template" style tokens like `%{name}`, `%{age}`
+    - template
+    - unannotated
   VersionAdded: '0.49'
   VersionChanged: '0.52'
 
@@ -3170,126 +3202,129 @@ Style/FrozenStringLiteralComment:
   Description: >-
                  Add the frozen_string_literal comment to the top of files
                  to help transition to frozen string literals by default.
-
   Enabled: true
   VersionAdded: '0.36'
   VersionChanged: '0.47'
   EnforcedStyle: when_needed
   SupportedStyles:
-  - when_needed
-  - always
-  - never
+    # `when_needed` will add the frozen string literal comment to files
+    # only when the `TargetRubyVersion` is set to 2.3+.
+    - when_needed
+    # `always` will always add the frozen string literal comment to a file
+    # regardless of the Ruby version or if `freeze` or `<<` are called on a
+    # string literal. If you run code against multiple versions of Ruby, it is
+    # possible that this will create errors in Ruby 2.3.0+.
+    - always
+    # `never` will enforce that the frozen string literal comment does not
+    # exist in a file.
+    - never
 
 Style/GlobalVars:
-  Description: |-
-    This cop looks for uses of global variables.
-    It does not report offenses for built-in global variables.
-    Built-in global variables are allowed by default. Additionally
-    users can allow additional variables via the AllowedVariables option.
-  StyleGuide: "#instance-vars"
-  Reference: https://www.zenspider.com/ruby/quickref.html
+  Description: 'Do not introduce global variables.'
+  StyleGuide: '#instance-vars'
+  Reference: 'https://www.zenspider.com/ruby/quickref.html'
   Enabled: true
   VersionAdded: '0.13'
+  # Built-in global variables are allowed by default.
   AllowedVariables: []
 
 Style/GuardClause:
-  Description: |-
-    Use a guard clause instead of wrapping the code inside a conditional
-    expression
-  StyleGuide: "#no-nested-conditionals"
+  Description: 'Check for conditionals that can be replaced with guard clauses'
+  StyleGuide: '#no-nested-conditionals'
   Enabled: true
   VersionAdded: '0.20'
   VersionChanged: '0.22'
+  # `MinBodyLength` defines the number of lines of the a body of an `if` or `unless`
+  # needs to have to trigger this cop
   MinBodyLength: 1
 
 Style/HashSyntax:
-  Description: This cop checks hash literal syntax.
-  StyleGuide: "#hash-literals"
+  Description: >-
+                 Prefer Ruby 1.9 hash syntax { a: 1, b: 2 } over 1.8 syntax
+                 { :a => 1, :b => 2 }.
+  StyleGuide: '#hash-literals'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.43'
   EnforcedStyle: ruby19
   SupportedStyles:
-  - ruby19
-  - hash_rockets
-  - no_mixed_keys
-  - ruby19_no_mixed_keys
+    # checks for 1.9 syntax (e.g. {a: 1}) for all symbol keys
+    - ruby19
+    # checks for hash rocket syntax for all hashes
+    - hash_rockets
+    # forbids mixed key syntaxes (e.g. {a: 1, :b => 2})
+    - no_mixed_keys
+    # enforces both ruby19 and no_mixed_keys styles
+    - ruby19_no_mixed_keys
+  # Force hashes that have a symbol value to use hash rockets
   UseHashRocketsWithSymbolValues: false
+  # Do not suggest { a?: 1 } over { :a? => 1 } in ruby19 style
   PreferHashRocketsForNonAlnumEndingSymbols: false
 
 Style/IdenticalConditionalBranches:
-  Description: |-
-    This cop checks for identical lines at the beginning or end of
-    each branch of a conditional statement.
+  Description: >-
+                 Checks that conditional statements do not have an identical
+                 line at the end of each branch, which can validly be moved
+                 out of the conditional.
   Enabled: true
   VersionAdded: '0.36'
 
 Style/IfInsideElse:
-  Description: |-
-    If the `else` branch of a conditional consists solely of an `if` node,
-    it can be combined with the `else` to become an `elsif`.
-    This helps to keep the nesting level from getting too deep.
+  Description: 'Finds if nodes inside else, which can be converted to elsif.'
   Enabled: true
   VersionAdded: '0.36'
 
 Style/IfUnlessModifier:
-  Description: |-
-    Checks for if and unless statements that would fit on one line
-    if written as a modifier if/unless. The maximum line length is
-    configured in the `Metrics/LineLength` cop. The tab size is configured
-    in the `IndentationWidth` of the `Layout/Tab` cop.
-  StyleGuide: "#if-as-a-modifier"
+  Description: >-
+                 Favor modifier if/unless usage when you have a
+                 single-line body.
+  StyleGuide: '#if-as-a-modifier'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.30'
 
 Style/IfUnlessModifierOfIfUnless:
-  Description: |-
-    Checks for if and unless statements used as modifiers of other if or
-    unless statements.
+  Description: >-
+                 Avoid modifier if/unless usage on conditionals.
   Enabled: true
   VersionAdded: '0.39'
 
 Style/IfWithSemicolon:
-  Description: Checks for uses of semicolon in if statements.
-  StyleGuide: "#no-semicolon-ifs"
+  Description: 'Do not use if x; .... Use the ternary operator instead.'
+  StyleGuide: '#no-semicolon-ifs'
   Enabled: true
   VersionAdded: '0.9'
 
 Style/ImplicitRuntimeError:
-  Description: |-
-    This cop checks for `raise` or `fail` statements which do not specify an
-    explicit exception class. (This raises a `RuntimeError`. Some projects
-    might prefer to use exception classes which more precisely identify the
-    nature of the error.)
+  Description: >-
+                 Use `raise` or `fail` with an explicit exception class and
+                 message, rather than just a message.
   Enabled: false
   VersionAdded: '0.41'
 
 Style/InfiniteLoop:
-  Description: Use `Kernel#loop` for infinite loops.
-  StyleGuide: "#infinite-loop"
+  Description: 'Use Kernel#loop for infinite loops.'
+  StyleGuide: '#infinite-loop'
   Enabled: true
   VersionAdded: '0.26'
   VersionChanged: '0.61'
   SafeAutoCorrect: true
 
 Style/InlineComment:
-  Description: This cop checks for trailing inline comments.
+  Description: 'Avoid trailing inline comments.'
   Enabled: false
   VersionAdded: '0.23'
 
 Style/InverseMethods:
-  Description: |-
-    This cop check for usages of not (`not` or `!`) called on a method
-    when an inverse of that method can be used instead.
-    Methods that can be inverted by a not (`not` or `!`) should be defined
-    in `InverseMethods`
-    Methods that are inverted by inverting the return
-    of the block that is passed to the method should be defined in
-    `InverseBlocks`
+  Description: >-
+                 Use the inverse method instead of `!.method`
+                 if an inverse method is defined.
   Enabled: true
   Safe: false
   VersionAdded: '0.48'
+  # `InverseMethods` are methods that can be inverted by a not (`not` or `!`)
+  # The relationship of inverse methods only needs to be defined in one direction.
+  # Keys and values both need to be defined as symbols.
   InverseMethods:
     :any?: :none?
     :even?: :odd?
@@ -3297,63 +3332,60 @@ Style/InverseMethods:
     :=~: :!~
     :<: :>=
     :>: :<=
+    # `ActiveSupport` defines some common inverse methods. They are listed below,
+    # and not enabled by default.
+    #:present?: :blank?,
+    #:include?: :exclude?
+  # `InverseBlocks` are methods that are inverted by inverting the return
+  # of the block that is passed to the method
   InverseBlocks:
     :select: :reject
     :select!: :reject!
 
 Style/IpAddresses:
-  Description: |-
-    This cop checks for hardcoded IP addresses, which can make code
-    brittle. IP addresses are likely to need to be changed when code
-    is deployed to a different server or environment, which may break
-    a deployment if forgotten. Prefer setting IP addresses in ENV or
-    other configuration.
+  Description: "Don't include literal IP addresses in code."
   Enabled: false
   VersionAdded: '0.58'
+  # Allow strings to be whitelisted
   Whitelist:
-  - "::"
+    - "::"
+    # :: is a valid IPv6 address, but could potentially be legitimately in code
 
 Style/Lambda:
-  Description: |-
-    This cop (by default) checks for uses of the lambda literal syntax for
-    single line lambdas, and the method call syntax for multiline lambdas.
-    It is configurable to enforce one of the styles for both single line
-    and multiline lambdas as well.
-  StyleGuide: "#lambda-multi-line"
+  Description: 'Use the new lambda literal syntax for single-line blocks.'
+  StyleGuide: '#lambda-multi-line'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.40'
   EnforcedStyle: line_count_dependent
   SupportedStyles:
-  - line_count_dependent
-  - lambda
-  - literal
+    - line_count_dependent
+    - lambda
+    - literal
 
 Style/LambdaCall:
-  Description: This cop checks for use of the lambda.(args) syntax.
-  StyleGuide: "#proc-call"
+  Description: 'Use lambda.call(...) instead of lambda.(...).'
+  StyleGuide: '#proc-call'
   Enabled: true
-  VersionAdded: 0.13.1
+  VersionAdded: '0.13.1'
   VersionChanged: '0.14'
   EnforcedStyle: call
   SupportedStyles:
-  - call
-  - braces
+    - call
+    - braces
 
 Style/LineEndConcatenation:
-  Description: |-
-    This cop checks for string literal concatenation at
-    the end of a line.
+  Description: >-
+                 Use \ instead of + or << to concatenate two string literals at
+                 line end.
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '0.18'
   VersionChanged: '0.64'
 
 Style/MethodCallWithArgsParentheses:
-  Description: |-
-    This cop enforces the presence (default) or absence of parentheses in
-    method calls containing parameters.
-  StyleGuide: "#method-invocation-parens"
+  Description: 'Use parentheses for method calls with arguments.'
+  StyleGuide: '#method-invocation-parens'
   Enabled: false
   VersionAdded: '0.47'
   VersionChanged: '0.61'
@@ -3364,99 +3396,98 @@ Style/MethodCallWithArgsParentheses:
   AllowParenthesesInCamelCaseMethod: false
   EnforcedStyle: require_parentheses
   SupportedStyles:
-  - require_parentheses
-  - omit_parentheses
+    - require_parentheses
+    - omit_parentheses
 
 Style/MethodCallWithoutArgsParentheses:
-  Description: This cop checks for unwanted parentheses in parameterless method calls.
-  StyleGuide: "#method-invocation-parens"
+  Description: 'Do not use parentheses for method calls with no arguments.'
+  StyleGuide: '#method-invocation-parens'
   Enabled: true
   IgnoredMethods: []
   VersionAdded: '0.47'
   VersionChanged: '0.55'
 
 Style/MethodCalledOnDoEndBlock:
-  Description: |-
-    This cop checks for methods called on a do...end block. The point of
-    this check is that it's easy to miss the call tacked on to the block
-    when reading code.
-  StyleGuide: "#single-line-blocks"
+  Description: 'Avoid chaining a method call on a do...end block.'
+  StyleGuide: '#single-line-blocks'
   Enabled: false
   VersionAdded: '0.14'
 
 Style/MethodDefParentheses:
-  Description: |-
-    This cop checks for parentheses around the arguments in method
-    definitions. Both instance and class/singleton methods are checked.
-  StyleGuide: "#method-parens"
+  Description: >-
+                 Checks if the method definitions have or don't have
+                 parentheses.
+  StyleGuide: '#method-parens'
   Enabled: true
   VersionAdded: '0.16'
   VersionChanged: '0.35'
   EnforcedStyle: require_parentheses
   SupportedStyles:
-  - require_parentheses
-  - require_no_parentheses
-  - require_no_parentheses_except_multiline
+    - require_parentheses
+    - require_no_parentheses
+    - require_no_parentheses_except_multiline
 
 Style/MethodMissingSuper:
-  Description: |-
-    This cop checks for the presence of `method_missing` without
-    falling back on `super`.
-  StyleGuide: "#no-method-missing"
+  Description: Checks for `method_missing` to call `super`.
+  StyleGuide: '#no-method-missing'
   Enabled: true
   VersionAdded: '0.56'
 
 Style/MinMax:
-  Description: This cop checks for potential uses of `Enumerable#minmax`.
+  Description: >-
+                 Use `Enumerable#minmax` instead of `Enumerable#min`
+                 and `Enumerable#max` in conjunction.'
   Enabled: true
   VersionAdded: '0.50'
 
 Style/MissingElse:
-  Description: Checks for `if` expressions that do not have an `else` branch.
+  Description: >-
+                Require if/case expressions to have an else branches.
+                If enabled, it is recommended that
+                Style/UnlessElse and Style/EmptyElse be enabled.
+                This will conflict with Style/EmptyElse if
+                Style/EmptyElse is configured to style "both"
   Enabled: false
   VersionAdded: '0.30'
   VersionChanged: '0.38'
   EnforcedStyle: both
   SupportedStyles:
-  - if
-  - case
-  - both
+    # if - warn when an if expression is missing an else branch
+    # case - warn when a case expression is missing an else branch
+    # both - warn when an if or case expression is missing an else branch
+    - if
+    - case
+    - both
 
 Style/MissingRespondToMissing:
-  Description: |-
-    This cop checks for the presence of `method_missing` without also
-    defining `respond_to_missing?`.
-  StyleGuide: "#no-method-missing"
+  Description: >-
+                  Checks if `method_missing` is implemented
+                  without implementing `respond_to_missing`.
+  StyleGuide: '#no-method-missing'
   Enabled: true
   VersionAdded: '0.56'
 
 Style/MixinGrouping:
-  Description: |-
-    This cop checks for grouping of mixins in `class` and `module` bodies.
-    By default it enforces mixins to be placed in separate declarations,
-    but it can be configured to enforce grouping them in one declaration.
-  StyleGuide: "#mixin-grouping"
+  Description: 'Checks for grouping of mixins in `class` and `module` bodies.'
+  StyleGuide: '#mixin-grouping'
   Enabled: true
   VersionAdded: '0.48'
   VersionChanged: '0.49'
   EnforcedStyle: separated
   SupportedStyles:
-  - separated
-  - grouped
+    # separated: each mixed in module goes in a separate statement.
+    # grouped: mixed in modules are grouped into a single statement.
+    - separated
+    - grouped
 
 Style/MixinUsage:
-  Description: |-
-    This cop checks that `include`, `extend` and `prepend` statements appear
-    inside classes and modules, not at the top level, so as to not affect
-    the behavior of `Object`.
+  Description: 'Checks that `include`, `extend` and `prepend` exists at the top level.'
   Enabled: true
   VersionAdded: '0.51'
 
 Style/ModuleFunction:
-  Description: |-
-    This cop checks for use of `extend self` or `module_function` in a
-    module.
-  StyleGuide: "#module-function"
+  Description: 'Checks for usage of `extend self` in modules.'
+  StyleGuide: '#module-function'
   Enabled: true
   VersionAdded: '0.11'
   VersionChanged: '0.65'
@@ -3468,58 +3499,56 @@ Style/ModuleFunction:
   SafeAutoCorrect: false
 
 Style/MultilineBlockChain:
-  Description: |-
-    This cop checks for chaining of a block after another block that spans
-    multiple lines.
-  StyleGuide: "#single-line-blocks"
+  Description: 'Avoid multi-line chains of blocks.'
+  StyleGuide: '#single-line-blocks'
   Enabled: true
   VersionAdded: '0.13'
 
 Style/MultilineIfModifier:
-  Description: Checks for uses of if/unless modifiers with multiple-lines bodies.
-  StyleGuide: "#no-multiline-if-modifiers"
+  Description: 'Only use if/unless modifiers on single line statements.'
+  StyleGuide: '#no-multiline-if-modifiers'
   Enabled: true
   VersionAdded: '0.45'
 
 Style/MultilineIfThen:
-  Description: Checks for uses of the `then` keyword in multi-line if statements.
-  StyleGuide: "#no-then"
+  Description: 'Do not use then for multi-line if/unless.'
+  StyleGuide: '#no-then'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.26'
 
 Style/MultilineMemoization:
-  Description: This cop checks expressions wrapping styles for multiline memoization.
+  Description: 'Wrap multiline memoizations in a `begin` and `end` block.'
   Enabled: true
   VersionAdded: '0.44'
   VersionChanged: '0.48'
   EnforcedStyle: keyword
   SupportedStyles:
-  - keyword
-  - braces
+    - keyword
+    - braces
 
 Style/MultilineMethodSignature:
-  Description: This cop checks for method signatures that span multiple lines.
+  Description: 'Avoid multi-line method signatures.'
   Enabled: false
   VersionAdded: '0.59'
 
 Style/MultilineTernaryOperator:
-  Description: This cop checks for multi-line ternary op expressions.
-  StyleGuide: "#no-multiline-ternary"
+  Description: >-
+                 Avoid multi-line ?: (the ternary operator);
+                 use if/unless instead.
+  StyleGuide: '#no-multiline-ternary'
   Enabled: true
   VersionAdded: '0.9'
 
 Style/MultipleComparison:
-  Description: |-
-    This cop checks against comparing a variable with multiple items, where
-    `Array#include?` could be used instead to avoid code repetition.
+  Description: >-
+                 Avoid comparing a variable with multiple items in a conditional,
+                 use Array#include? instead.
   Enabled: true
   VersionAdded: '0.49'
 
 Style/MutableConstant:
-  Description: |-
-    This cop checks whether some constant value isn't a
-    mutable literal (e.g. array or hash).
+  Description: 'Do not assign mutable objects to constants.'
   Enabled: true
   VersionAdded: '0.34'
   VersionChanged: '0.65'
@@ -3535,123 +3564,131 @@ Style/MutableConstant:
     - strict
 
 Style/NegatedIf:
-  Description: |-
-    Checks for uses of if with a negated condition. Only ifs
-    without else are considered. There are three different styles:
-  StyleGuide: "#unless-for-negatives"
+  Description: >-
+                 Favor unless over if for negative conditions
+                 (or control flow or).
+  StyleGuide: '#unless-for-negatives'
   Enabled: true
   VersionAdded: '0.20'
   VersionChanged: '0.48'
   EnforcedStyle: both
   SupportedStyles:
-  - both
-  - prefix
-  - postfix
+    # both: prefix and postfix negated `if` should both use `unless`
+    # prefix: only use `unless` for negated `if` statements positioned before the body of the statement
+    # postfix: only use `unless` for negated `if` statements positioned after the body of the statement
+    - both
+    - prefix
+    - postfix
 
 Style/NegatedWhile:
-  Description: Checks for uses of while with a negated condition.
-  StyleGuide: "#until-for-negatives"
+  Description: 'Favor until over while for negative conditions.'
+  StyleGuide: '#until-for-negatives'
   Enabled: true
   VersionAdded: '0.20'
 
 Style/NestedModifier:
-  Description: |-
-    This cop checks for nested use of if, unless, while and until in their
-    modifier form.
-  StyleGuide: "#no-nested-modifiers"
+  Description: 'Avoid using nested modifiers.'
+  StyleGuide: '#no-nested-modifiers'
   Enabled: true
   VersionAdded: '0.35'
 
 Style/NestedParenthesizedCalls:
-  Description: |-
-    This cop checks for unparenthesized method calls in the argument list
-    of a parenthesized method call.
+  Description: >-
+                 Parenthesize method calls which are nested inside the
+                 argument list of another parenthesized method call.
   Enabled: true
   VersionAdded: '0.36'
   VersionChanged: '0.50'
   Whitelist:
-  - be
-  - be_a
-  - be_an
-  - be_between
-  - be_falsey
-  - be_kind_of
-  - be_instance_of
-  - be_truthy
-  - be_within
-  - eq
-  - eql
-  - end_with
-  - include
-  - match
-  - raise_error
-  - respond_to
-  - start_with
+    - be
+    - be_a
+    - be_an
+    - be_between
+    - be_falsey
+    - be_kind_of
+    - be_instance_of
+    - be_truthy
+    - be_within
+    - eq
+    - eql
+    - end_with
+    - include
+    - match
+    - raise_error
+    - respond_to
+    - start_with
 
 Style/NestedTernaryOperator:
-  Description: This cop checks for nested ternary op expressions.
-  StyleGuide: "#no-nested-ternary"
+  Description: 'Use one expression per branch in a ternary operator.'
+  StyleGuide: '#no-nested-ternary'
   Enabled: true
   VersionAdded: '0.9'
 
 Style/Next:
-  Description: Use `next` to skip iteration instead of a condition at the end.
-  StyleGuide: "#no-nested-conditionals"
+  Description: 'Use `next` to skip iteration instead of a condition at the end.'
+  StyleGuide: '#no-nested-conditionals'
   Enabled: true
   VersionAdded: '0.22'
   VersionChanged: '0.35'
+  # With `always` all conditions at the end of an iteration needs to be
+  # replaced by next - with `skip_modifier_ifs` the modifier if like this one
+  # are ignored: [1, 2].each { |a| return 'yes' if a == 1 }
   EnforcedStyle: skip_modifier_ifs
+  # `MinBodyLength` defines the number of lines of the a body of an `if` or `unless`
+  # needs to have to trigger this cop
   MinBodyLength: 3
   SupportedStyles:
-  - skip_modifier_ifs
-  - always
+    - skip_modifier_ifs
+    - always
 
 Style/NilComparison:
-  Description: |-
-    This cop checks for comparison of something with nil using `==` and
-    `nil?`.
-  StyleGuide: "#predicate-methods"
+  Description: 'Prefer x.nil? to x == nil.'
+  StyleGuide: '#predicate-methods'
   Enabled: true
   VersionAdded: '0.12'
   VersionChanged: '0.59'
   EnforcedStyle: predicate
   SupportedStyles:
-  - predicate
-  - comparison
+    - predicate
+    - comparison
 
 Style/NonNilCheck:
-  Description: This cop checks for non-nil checks, which are usually redundant.
-  StyleGuide: "#no-non-nil-checks"
+  Description: 'Checks for redundant nil checks.'
+  StyleGuide: '#no-non-nil-checks'
   Enabled: true
   VersionAdded: '0.20'
   VersionChanged: '0.22'
+  # With `IncludeSemanticChanges` set to `true`, this cop reports offenses for
+  # `!x.nil?` and autocorrects that and `x != nil` to solely `x`, which is
+  # **usually** OK, but might change behavior.
+  #
+  # With `IncludeSemanticChanges` set to `false`, this cop does not report
+  # offenses for `!x.nil?` and does no changes that might change behavior.
   IncludeSemanticChanges: false
 
 Style/Not:
-  Description: This cop checks for uses of the keyword `not` instead of `!`.
-  StyleGuide: "#bang-not-not"
+  Description: 'Use ! instead of not.'
+  StyleGuide: '#bang-not-not'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.20'
 
 Style/NumericLiteralPrefix:
-  Description: |-
-    This cop checks for octal, hex, binary, and decimal literals using
-    uppercase prefixes and corrects them to lowercase prefix
-    or no prefix (in case of decimals).
-  StyleGuide: "#numeric-literal-prefixes"
+  Description: 'Use smallcase prefixes for numeric literals.'
+  StyleGuide: '#numeric-literal-prefixes'
   Enabled: true
   VersionAdded: '0.41'
   EnforcedOctalStyle: zero_with_o
   SupportedOctalStyles:
-  - zero_with_o
-  - zero_only
+    - zero_with_o
+    - zero_only
+
 
 Style/NumericLiterals:
-  Description: |-
-    This cop checks for big numeric literals without _ between groups
-    of digits in them.
-  StyleGuide: "#underscores-in-numerics"
+  Description: >-
+                 Add underscores to large numeric literals to improve their
+                 readability.
+  StyleGuide: '#underscores-in-numerics'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.48'
@@ -3659,13 +3696,14 @@ Style/NumericLiterals:
   Strict: false
 
 Style/NumericPredicate:
-  Description: |-
-    This cop checks for usage of comparison operators (`==`,
-    `>`, `<`) to test numbers as zero, positive, or negative.
-    These can be replaced by their respective predicate methods.
-    The cop can also be configured to do the reverse.
-  StyleGuide: "#predicate-methods"
+  Description: >-
+                 Checks for the use of predicate- or comparison methods for
+                 numeric comparisons.
+  StyleGuide: '#predicate-methods'
   Safe: false
+  # This will change to a new method call which isn't guaranteed to be on the
+  # object. Switching these methods has to be done with knowledge of the types
+  # of the variables which rubocop doesn't have.
   SafeAutoCorrect: false
   AutoCorrect: false
   Enabled: true
@@ -3673,63 +3711,64 @@ Style/NumericPredicate:
   VersionChanged: '0.59'
   EnforcedStyle: predicate
   SupportedStyles:
-  - predicate
-  - comparison
+    - predicate
+    - comparison
   IgnoredMethods: []
+  # Exclude RSpec specs because assertions like `expect(1).to be > 0` cause
+  # false positives.
   Exclude:
-  - spec/**/*
+    - 'spec/**/*'
 
 Style/OneLineConditional:
-  Description: |-
-    TODO: Make configurable.
-    Checks for uses of if/then/else/end on a single line.
-  StyleGuide: "#ternary-operator"
+  Description: >-
+                 Favor the ternary operator(?:) over
+                 if/then/else/end constructs.
+  StyleGuide: '#ternary-operator'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.38'
 
 Style/OptionHash:
-  Description: |-
-    This cop checks for options hashes and discourages them if the
-    current Ruby version supports keyword arguments.
+  Description: "Don't use option hashes when you can use keyword arguments."
   Enabled: false
   VersionAdded: '0.33'
   VersionChanged: '0.34'
+  # A list of parameter names that will be flagged by this cop.
   SuspiciousParamNames:
-  - options
-  - opts
-  - args
-  - params
-  - parameters
+    - options
+    - opts
+    - args
+    - params
+    - parameters
 
 Style/OptionalArguments:
-  Description: |-
-    This cop checks for optional arguments to methods
-    that do not come at the end of the argument list
-  StyleGuide: "#optional-arguments"
+  Description: >-
+                 Checks for optional arguments that do not appear at the end
+                 of the argument list
+  StyleGuide: '#optional-arguments'
   Enabled: true
   VersionAdded: '0.33'
 
 Style/OrAssignment:
-  Description: This cop checks for potential usage of the `||=` operator.
-  StyleGuide: "#double-pipe-for-uninit"
+  Description: 'Recommend usage of double pipe equals (||=) where applicable.'
+  StyleGuide: '#double-pipe-for-uninit'
   Enabled: true
   VersionAdded: '0.50'
 
 Style/ParallelAssignment:
-  Description: |-
-    Checks for simple usages of parallel assignment.
-    This will only complain when the number of variables
-    being assigned matched the number of assigning variables.
-  StyleGuide: "#parallel-assignment"
+  Description: >-
+                  Check for simple usages of parallel assignment.
+                  It will only warn when the number of variables
+                  matches on both sides of the assignment.
+  StyleGuide: '#parallel-assignment'
   Enabled: true
   VersionAdded: '0.32'
 
 Style/ParenthesesAroundCondition:
-  Description: |-
-    This cop checks for the presence of superfluous parentheses around the
-    condition of if/unless/while/until.
-  StyleGuide: "#no-parens-around-condition"
+  Description: >-
+                 Don't use parentheses around the condition of an
+                 if/unless/while.
+  StyleGuide: '#no-parens-around-condition'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.56'
@@ -3737,182 +3776,174 @@ Style/ParenthesesAroundCondition:
   AllowInMultilineConditions: false
 
 Style/PercentLiteralDelimiters:
-  Description: This cop enforces the consistent usage of `%`-literal delimiters.
-  StyleGuide: "#percent-literal-braces"
+  Description: 'Use `%`-literal delimiters consistently'
+  StyleGuide: '#percent-literal-braces'
   Enabled: true
   VersionAdded: '0.19'
+  # Specify the default preferred delimiter for all types with the 'default' key
+  # Override individual delimiters (even with default specified) by specifying
+  # an individual key
   PreferredDelimiters:
-    default: "()"
-    "%i": "[]"
-    "%I": "[]"
-    "%r": "{}"
-    "%w": "[]"
-    "%W": "[]"
-  VersionChanged: 0.48.1
+    default: ()
+    '%i': '[]'
+    '%I': '[]'
+    '%r': '{}'
+    '%w': '[]'
+    '%W': '[]'
+  VersionChanged: '0.48.1'
 
 Style/PercentQLiterals:
-  Description: This cop checks for usage of the %Q() syntax when %q() would do.
+  Description: 'Checks if uses of %Q/%q match the configured preference.'
   Enabled: true
   VersionAdded: '0.25'
   EnforcedStyle: lower_case_q
   SupportedStyles:
-  - lower_case_q
-  - upper_case_q
+    - lower_case_q # Use `%q` when possible, `%Q` when necessary
+    - upper_case_q # Always use `%Q`
 
 Style/PerlBackrefs:
-  Description: |-
-    This cop looks for uses of Perl-style regexp match
-    backreferences like $1, $2, etc.
-  StyleGuide: "#no-perl-regexp-last-matchers"
+  Description: 'Avoid Perl-style regex back references.'
+  StyleGuide: '#no-perl-regexp-last-matchers'
   Enabled: true
   VersionAdded: '0.13'
 
 Style/PreferredHashMethods:
-  Description: |-
-    This cop (by default) checks for uses of methods Hash#has_key? and
-    Hash#has_value? where it enforces Hash#key? and Hash#value?
-    It is configurable to enforce the inverse, using `verbose` method
-    names also.
-  StyleGuide: "#hash-key"
+  Description: 'Checks use of `has_key?` and `has_value?` Hash methods.'
+  StyleGuide: '#hash-key'
   Enabled: true
   VersionAdded: '0.41'
   VersionChanged: '0.44'
   EnforcedStyle: short
   SupportedStyles:
-  - short
-  - verbose
+    - short
+    - verbose
 
 Style/Proc:
-  Description: |-
-    This cop checks for uses of Proc.new where Kernel#proc
-    would be more appropriate.
-  StyleGuide: "#proc"
+  Description: 'Use proc instead of Proc.new.'
+  StyleGuide: '#proc'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.18'
 
 Style/RaiseArgs:
-  Description: |-
-    This cop checks the args passed to `fail` and `raise`. For exploded
-    style (default), it recommends passing the exception class and message
-    to `raise`, rather than construct an instance of the error. It will
-    still allow passing just a message, or the construction of an error
-    with more than one argument.
-  StyleGuide: "#exception-class-messages"
+  Description: 'Checks the arguments passed to raise/fail.'
+  StyleGuide: '#exception-class-messages'
   Enabled: true
   VersionAdded: '0.14'
   VersionChanged: '0.40'
   EnforcedStyle: exploded
   SupportedStyles:
-  - compact
-  - exploded
+    - compact # raise Exception.new(msg)
+    - exploded # raise Exception, msg
 
 Style/RandomWithOffset:
-  Description: |-
-    This cop checks for the use of randomly generated numbers,
-    added/subtracted with integer literals, as well as those with
-    Integer#succ and Integer#pred methods. Prefer using ranges instead,
-    as it clearly states the intentions.
-  StyleGuide: "#random-numbers"
+  Description: >-
+                 Prefer to use ranges when generating random numbers instead of
+                 integers with offsets.
+  StyleGuide: '#random-numbers'
   Enabled: true
   VersionAdded: '0.52'
 
 Style/RedundantBegin:
-  Description: This cop checks for redundant `begin` blocks.
-  StyleGuide: "#begin-implicit"
+  Description: "Don't use begin blocks when they are not needed."
+  StyleGuide: '#begin-implicit'
   Enabled: true
   VersionAdded: '0.10'
   VersionChanged: '0.21'
 
 Style/RedundantConditional:
-  Description: This cop checks for redundant returning of true/false in conditionals.
+  Description: "Don't return true/false from a conditional."
   Enabled: true
   VersionAdded: '0.50'
 
 Style/RedundantException:
-  Description: This cop checks for RuntimeError as the argument of raise/fail.
-  StyleGuide: "#no-explicit-runtimeerror"
+  Description: "Checks for an obsolete RuntimeException argument in raise/fail."
+  StyleGuide: '#no-explicit-runtimeerror'
   Enabled: true
   VersionAdded: '0.14'
   VersionChanged: '0.29'
 
 Style/RedundantFreeze:
-  Description: This cop check for uses of Object#freeze on immutable objects.
+  Description: "Checks usages of Object#freeze on immutable objects."
   Enabled: true
   VersionAdded: '0.34'
 
 Style/RedundantParentheses:
-  Description: This cop checks for redundant parentheses.
+  Description: "Checks for parentheses that seem not to serve any purpose."
   Enabled: true
   VersionAdded: '0.36'
 
 Style/RedundantReturn:
-  Description: This cop checks for redundant `return` expressions.
-  StyleGuide: "#no-explicit-return"
+  Description: "Don't use return where it's not required."
+  StyleGuide: '#no-explicit-return'
   Enabled: true
   VersionAdded: '0.10'
   VersionChanged: '0.14'
+  # When `true` allows code like `return x, y`.
   AllowMultipleReturnValues: false
 
 Style/RedundantSelf:
-  Description: This cop checks for redundant uses of `self`.
-  StyleGuide: "#no-self-unless-required"
+  Description: "Don't use self where it's not needed."
+  StyleGuide: '#no-self-unless-required'
   Enabled: true
   VersionAdded: '0.10'
   VersionChanged: '0.13'
 
 Style/RegexpLiteral:
-  Description: This cop enforces using // or %r around regular expressions.
-  StyleGuide: "#percent-r"
+  Description: 'Use / or %r around regular expressions.'
+  StyleGuide: '#percent-r'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.30'
   EnforcedStyle: slashes
+  # slashes: Always use slashes.
+  # percent_r: Always use `%r`.
+  # mixed: Use slashes on single-line regexes, and `%r` on multi-line regexes.
   SupportedStyles:
-  - slashes
-  - percent_r
-  - mixed
+    - slashes
+    - percent_r
+    - mixed
+  # If `false`, the cop will always recommend using `%r` if one or more slashes
+  # are found in the regexp string.
   AllowInnerSlashes: false
 
 Style/RescueModifier:
-  Description: This cop checks for uses of rescue in its modifier form.
-  StyleGuide: "#no-rescue-modifiers"
+  Description: 'Avoid using rescue in its modifier form.'
+  StyleGuide: '#no-rescue-modifiers'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.34'
 
 Style/RescueStandardError:
-  Description: |-
-    This cop checks for rescuing `StandardError`. There are two supported
-    styles `implicit` and `explicit`. This cop will not register an offense
-    if any error other than `StandardError` is specified.
+  Description: 'Avoid rescuing without specifying an error class.'
   Enabled: true
   VersionAdded: '0.52'
   EnforcedStyle: explicit
+  # implicit: Do not include the error class, `rescue`
+  # explicit: Require an error class `rescue StandardError`
   SupportedStyles:
-  - implicit
-  - explicit
+    - implicit
+    - explicit
 
 Style/ReturnNil:
-  Description: This cop enforces consistency between 'return nil' and 'return'.
+  Description: 'Use return instead of return nil.'
   Enabled: false
   EnforcedStyle: return
   SupportedStyles:
-  - return
-  - return_nil
+    - return
+    - return_nil
   VersionAdded: '0.50'
 
 Style/SafeNavigation:
-  Description: |-
-    This cop transforms usages of a method call safeguarded by a non `nil`
-    check for the variable whose method is being called to
-    safe navigation (`&.`). If there is a method chain, all of the methods
-    in the chain need to be checked for safety, and all of the methods will
-    need to be changed to use safe navigation. We have limited the cop to
-    not register an offense for method chains that exceed 2 methods.
+  Description: >-
+                  This cop transforms usages of a method call safeguarded by
+                  a check for the existence of the object to
+                  safe navigation (`&.`).
   Enabled: true
   VersionAdded: '0.43'
   VersionChanged: '0.56'
+  # Safe navigation may cause a statement to start returning `nil` in addition
+  # to whatever it used to return.
   ConvertCodeThatCanStartToReturnNil: false
   Whitelist:
     - present?
@@ -3922,166 +3953,160 @@ Style/SafeNavigation:
     - try!
 
 Style/SelfAssignment:
-  Description: This cop enforces the use the shorthand for self-assignment.
-  StyleGuide: "#self-assignment"
+  Description: >-
+                 Checks for places where self-assignment shorthand should have
+                 been used.
+  StyleGuide: '#self-assignment'
   Enabled: true
   VersionAdded: '0.19'
   VersionChanged: '0.29'
 
 Style/Semicolon:
-  Description: |-
-    This cop checks for multiple expressions placed on the same line.
-    It also checks for lines terminated with a semicolon.
-  StyleGuide: "#no-semicolon"
+  Description: "Don't use semicolons to terminate expressions."
+  StyleGuide: '#no-semicolon'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.19'
+  # Allow `;` to separate several expressions on the same line.
   AllowAsExpressionSeparator: false
 
 Style/Send:
-  Description: This cop checks for the use of the send method.
-  StyleGuide: "#prefer-public-send"
+  Description: 'Prefer `Object#__send__` or `Object#public_send` to `send`, as `send` may overlap with existing methods.'
+  StyleGuide: '#prefer-public-send'
   Enabled: false
   VersionAdded: '0.33'
 
 Style/SignalException:
-  Description: This cop checks for uses of `fail` and `raise`.
-  StyleGuide: "#prefer-raise-over-fail"
+  Description: 'Checks for proper usage of fail and raise.'
+  StyleGuide: '#prefer-raise-over-fail'
   Enabled: true
   VersionAdded: '0.11'
   VersionChanged: '0.37'
   EnforcedStyle: only_raise
   SupportedStyles:
-  - only_raise
-  - only_fail
-  - semantic
+    - only_raise
+    - only_fail
+    - semantic
 
 Style/SingleLineBlockParams:
-  Description: |-
-    This cop checks whether the block parameters of a single-line
-    method accepting a block match the names specified via configuration.
+  Description: 'Enforces the names of some block params.'
   Enabled: false
   VersionAdded: '0.16'
   VersionChanged: '0.47'
   Methods:
-  - reduce:
-    - acc
-    - elem
-  - inject:
-    - acc
-    - elem
+    - reduce:
+        - acc
+        - elem
+    - inject:
+        - acc
+        - elem
 
 Style/SingleLineMethods:
-  Description: |-
-    This cop checks for single-line method definitions that contain a body.
-    It will accept single-line methods with no body.
-  StyleGuide: "#no-single-line-methods"
+  Description: 'Avoid single-line methods.'
+  StyleGuide: '#no-single-line-methods'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.19'
   AllowIfMethodIsEmpty: true
 
 Style/SpecialGlobalVars:
-  Description: This cop looks for uses of Perl-style global variables.
-  StyleGuide: "#no-cryptic-perlisms"
+  Description: 'Avoid Perl-style global variables.'
+  StyleGuide: '#no-cryptic-perlisms'
   Enabled: true
   VersionAdded: '0.13'
   VersionChanged: '0.36'
   SafeAutoCorrect: false
   EnforcedStyle: use_english_names
   SupportedStyles:
-  - use_perl_names
-  - use_english_names
+    - use_perl_names
+    - use_english_names
 
 Style/StabbyLambdaParentheses:
-  Description: |-
-    Check for parentheses around stabby lambda arguments.
-    There are two different styles. Defaults to `require_parentheses`.
-  StyleGuide: "#stabby-lambda-with-args"
+  Description: 'Check for the usage of parentheses around stabby lambda arguments.'
+  StyleGuide: '#stabby-lambda-with-args'
   Enabled: true
   VersionAdded: '0.35'
   EnforcedStyle: require_parentheses
   SupportedStyles:
-  - require_parentheses
-  - require_no_parentheses
+    - require_parentheses
+    - require_no_parentheses
 
 Style/StderrPuts:
-  Description: |-
-    This cop identifies places where `$stderr.puts` can be replaced by
-    `warn`. The latter has the advantage of easily being disabled by,
-    the `-W0` interpreter flag or setting `$VERBOSE` to `nil`.
-  StyleGuide: "#warn"
+  Description: 'Use `warn` instead of `$stderr.puts`.'
+  StyleGuide: '#warn'
   Enabled: true
   VersionAdded: '0.51'
 
 Style/StringHashKeys:
-  Description: |-
-    This cop checks for the use of strings as keys in hashes. The use of
-    symbols is preferred instead.
-  StyleGuide: "#symbols-as-keys"
+  Description: 'Prefer symbols instead of strings as hash keys.'
+  StyleGuide: '#symbols-as-keys'
   Enabled: false
   VersionAdded: '0.52'
 
 Style/StringLiterals:
-  Description: Checks if uses of quotes match the configured preference.
-  StyleGuide: "#consistent-string-literals"
+  Description: 'Checks if uses of quotes match the configured preference.'
+  StyleGuide: '#consistent-string-literals'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.36'
   EnforcedStyle: single_quotes
   SupportedStyles:
-  - single_quotes
-  - double_quotes
+    - single_quotes
+    - double_quotes
+  # If `true`, strings which span multiple lines using `\` for continuation must
+  # use the same type of quotes on each line.
   ConsistentQuotesInMultiline: false
 
 Style/StringLiteralsInInterpolation:
-  Description: |-
-    This cop checks that quotes inside the string interpolation
-    match the configured preference.
+  Description: >-
+                 Checks if uses of quotes inside expressions in interpolated
+                 strings match the configured preference.
   Enabled: true
   VersionAdded: '0.27'
   EnforcedStyle: single_quotes
   SupportedStyles:
-  - single_quotes
-  - double_quotes
+    - single_quotes
+    - double_quotes
 
 Style/StringMethods:
-  Description: |-
-    This cop enforces the use of consistent method names
-    from the String class.
+  Description: 'Checks if configured preferred methods are used over non-preferred.'
   Enabled: false
   VersionAdded: '0.34'
-  VersionChanged: 0.34.2
+  VersionChanged: '0.34.2'
+  # Mapping from undesired method to desired_method
+  # e.g. to use `to_sym` over `intern`:
+  #
+  # StringMethods:
+  #   PreferredMethods:
+  #     intern: to_sym
   PreferredMethods:
     intern: to_sym
 
 Style/StructInheritance:
-  Description: This cop checks for inheritance from Struct.new.
-  StyleGuide: "#no-extend-struct-new"
+  Description: 'Checks for inheritance from Struct.new.'
+  StyleGuide: '#no-extend-struct-new'
   Enabled: true
   VersionAdded: '0.29'
 
 Style/SymbolArray:
-  Description: |-
-    This cop can check for array literals made up of symbols that are not
-    using the %i() syntax.
-  StyleGuide: "#percent-i"
+  Description: 'Use %i or %I for arrays of symbols.'
+  StyleGuide: '#percent-i'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.49'
   EnforcedStyle: percent
   MinSize: 2
   SupportedStyles:
-  - percent
-  - brackets
+    - percent
+    - brackets
 
 Style/SymbolLiteral:
-  Description: This cop checks symbol literal syntax.
+  Description: 'Use plain symbols instead of string symbols when possible.'
   Enabled: true
   VersionAdded: '0.30'
 
 Style/SymbolProc:
-  Description: Use symbols as procs when possible.
+  Description: 'Use symbols as procs instead of blocks when possible.'
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '0.26'
@@ -4089,193 +4114,225 @@ Style/SymbolProc:
   # A list of method names to be ignored by the check.
   # The names should be fairly unique, otherwise you'll end up ignoring lots of code.
   IgnoredMethods:
-  - respond_to
-  - define_method
+    - respond_to
+    - define_method
 
 Style/TernaryParentheses:
-  Description: |-
-    This cop checks for the presence of parentheses around ternary
-    conditions. It is configurable to enforce inclusion or omission of
-    parentheses using `EnforcedStyle`. Omission is only enforced when
-    removing the parentheses won't cause a different behavior.
+  Description: 'Checks for use of parentheses around ternary conditions.'
   Enabled: true
   VersionAdded: '0.42'
   VersionChanged: '0.46'
   EnforcedStyle: require_no_parentheses
   SupportedStyles:
-  - require_parentheses
-  - require_no_parentheses
-  - require_parentheses_when_complex
+    - require_parentheses
+    - require_no_parentheses
+    - require_parentheses_when_complex
   AllowSafeAssignment: true
 
 Style/TrailingBodyOnClass:
-  Description: This cop checks for trailing code after the class definition.
+  Description: 'Class body goes below class statement.'
   Enabled: true
   VersionAdded: '0.53'
 
 Style/TrailingBodyOnMethodDefinition:
-  Description: This cop checks for trailing code after the method definition.
+  Description: 'Method body goes below definition.'
   Enabled: true
   VersionAdded: '0.52'
 
 Style/TrailingBodyOnModule:
-  Description: This cop checks for trailing code after the module definition.
+  Description: 'Module body goes below module statement.'
   Enabled: true
   VersionAdded: '0.53'
 
 Style/TrailingCommaInArguments:
-  Description: This cop checks for trailing comma in argument lists.
-  StyleGuide: "#no-trailing-params-comma"
+  Description: 'Checks for trailing comma in argument lists.'
+  StyleGuide: '#no-trailing-params-comma'
   Enabled: true
   VersionAdded: '0.36'
+  # If `comma`, the cop requires a comma after the last argument, but only for
+  # parenthesized method calls where each argument is on its own line.
+  # If `consistent_comma`, the cop requires a comma after the last argument,
+  # for all parenthesized method calls with arguments.
   EnforcedStyleForMultiline: no_comma
   SupportedStylesForMultiline:
-  - comma
-  - consistent_comma
-  - no_comma
+    - comma
+    - consistent_comma
+    - no_comma
 
 Style/TrailingCommaInArrayLiteral:
-  Description: This cop checks for trailing comma in array literals.
-  StyleGuide: "#no-trailing-array-commas"
+  Description: 'Checks for trailing comma in array literals.'
+  StyleGuide: '#no-trailing-array-commas'
   Enabled: true
   VersionAdded: '0.53'
+  # but only when each item is on its own line.
+  # If `consistent_comma`, the cop requires a comma after the last item of all
+  # non-empty array literals.
   EnforcedStyleForMultiline: no_comma
   SupportedStylesForMultiline:
-  - comma
-  - consistent_comma
-  - no_comma
+    - comma
+    - consistent_comma
+    - no_comma
 
 Style/TrailingCommaInHashLiteral:
-  Description: This cop checks for trailing comma in hash literals.
+  Description: 'Checks for trailing comma in hash literals.'
   Enabled: true
+  # If `comma`, the cop requires a comma after the last item in a hash,
+  # but only when each item is on its own line.
+  # If `consistent_comma`, the cop requires a comma after the last item of all
+  # non-empty hash literals.
   EnforcedStyleForMultiline: no_comma
   SupportedStylesForMultiline:
-  - comma
-  - consistent_comma
-  - no_comma
+    - comma
+    - consistent_comma
+    - no_comma
   VersionAdded: '0.53'
 
 Style/TrailingMethodEndStatement:
-  Description: This cop checks for trailing code after the method definition.
+  Description: 'Checks for trailing end statement on line of method body.'
   Enabled: true
   VersionAdded: '0.52'
 
 Style/TrailingUnderscoreVariable:
-  Description: This cop checks for extra underscores in variable assignment.
+  Description: >-
+                 Checks for the usage of unneeded trailing underscores at the
+                 end of parallel variable assignment.
   AllowNamedUnderscoreVariables: true
   Enabled: true
   VersionAdded: '0.31'
   VersionChanged: '0.35'
 
+# `TrivialAccessors` requires exact name matches and doesn't allow
+# predicated methods by default.
 Style/TrivialAccessors:
-  Description: |-
-    This cop looks for trivial reader/writer methods, that could
-    have been created with the attr_* family of functions automatically.
-  StyleGuide: "#attr_family"
+  Description: 'Prefer attr_* methods to trivial readers/writers.'
+  StyleGuide: '#attr_family'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.38'
+  # When set to `false` the cop will suggest the use of accessor methods
+  # in situations like:
+  #
+  # def name
+  #   @other_name
+  # end
+  #
+  # This way you can uncover "hidden" attributes in your code.
   ExactNameMatch: true
   AllowPredicates: true
+  # Allows trivial writers that don't end in an equal sign. e.g.
+  #
+  # def on_exception(action)
+  #   @on_exception=action
+  # end
+  # on_exception :restart
+  #
+  # Commonly used in DSLs
   AllowDSLWriters: false
   IgnoreClassMethods: false
   Whitelist:
-  - to_ary
-  - to_a
-  - to_c
-  - to_enum
-  - to_h
-  - to_hash
-  - to_i
-  - to_int
-  - to_io
-  - to_open
-  - to_path
-  - to_proc
-  - to_r
-  - to_regexp
-  - to_str
-  - to_s
-  - to_sym
+    - to_ary
+    - to_a
+    - to_c
+    - to_enum
+    - to_h
+    - to_hash
+    - to_i
+    - to_int
+    - to_io
+    - to_open
+    - to_path
+    - to_proc
+    - to_r
+    - to_regexp
+    - to_str
+    - to_s
+    - to_sym
 
 Style/UnlessElse:
-  Description: This cop looks for *unless* expressions with *else* clauses.
-  StyleGuide: "#no-else-with-unless"
+  Description: >-
+                 Do not use unless with else. Rewrite these with the positive
+                 case first.
+  StyleGuide: '#no-else-with-unless'
   Enabled: true
   VersionAdded: '0.9'
 
 Style/UnneededCapitalW:
-  Description: This cop checks for usage of the %W() syntax when %w() would do.
+  Description: 'Checks for %W when interpolation is not needed.'
   Enabled: true
   VersionAdded: '0.21'
   VersionChanged: '0.24'
 
 Style/UnneededCondition:
-  Description: This cop checks for unnecessary conditional expressions.
+  Description: 'Checks for unnecessary conditional expressions.'
   Enabled: true
   VersionAdded: '0.57'
 
 Style/UnneededInterpolation:
-  Description: This cop checks for strings that are just an interpolated expression.
+  Description: 'Checks for strings that are just an interpolated expression.'
   Enabled: true
   VersionAdded: '0.36'
 
 Style/UnneededPercentQ:
-  Description: This cop checks for usage of the %q/%Q syntax when '' or "" would do.
-  StyleGuide: "#percent-q"
+  Description: 'Checks for %q/%Q when single quotes or double quotes would do.'
+  StyleGuide: '#percent-q'
   Enabled: true
   VersionAdded: '0.24'
 
 Style/UnpackFirst:
-  Description: |-
-    This cop checks for accessing the first element of `String#unpack`
-    which can be replaced with the shorter method `unpack1`.
+  Description: >-
+                 Checks for accessing the first element of `String#unpack`
+                 instead of using `unpack1`
   Enabled: true
   VersionAdded: '0.54'
 
 Style/VariableInterpolation:
-  Description: This cop checks for variable interpolation (like "#@ivar").
-  StyleGuide: "#curlies-interpolate"
+  Description: >-
+                 Don't interpolate global, instance and class variables
+                 directly in strings.
+  StyleGuide: '#curlies-interpolate'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.20'
 
 Style/WhenThen:
-  Description: This cop checks for *when;* uses in *case* expressions.
-  StyleGuide: "#one-line-cases"
+  Description: 'Use when x then ... for one-line cases.'
+  StyleGuide: '#one-line-cases'
   Enabled: true
   VersionAdded: '0.9'
 
 Style/WhileUntilDo:
-  Description: Checks for uses of `do` in multi-line `while/until` statements.
-  StyleGuide: "#no-multiline-while-do"
+  Description: 'Checks for redundant do after while or until.'
+  StyleGuide: '#no-multiline-while-do'
   Enabled: true
   VersionAdded: '0.9'
 
 Style/WhileUntilModifier:
-  Description: |-
-    Checks for while and until statements that would fit on one line
-    if written as a modifier while/until. The maximum line length is
-    configured in the `Metrics/LineLength` cop.
-  StyleGuide: "#while-as-a-modifier"
+  Description: >-
+                 Favor modifier while/until usage when you have a
+                 single-line body.
+  StyleGuide: '#while-as-a-modifier'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.30'
 
 Style/WordArray:
-  Description: |-
-    This cop can check for array literals made up of word-like
-    strings, that are not using the %w() syntax.
-  StyleGuide: "#percent-w"
+  Description: 'Use %w or %W for arrays of words.'
+  StyleGuide: '#percent-w'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.36'
   EnforcedStyle: percent
   SupportedStyles:
-  - percent
-  - brackets
+    # percent style: %w(word1 word2)
+    - percent
+    # bracket style: ['word1', 'word2']
+    - brackets
+  # The `MinSize` option causes the `WordArray` rule to be ignored for arrays
+  # smaller than a certain size. The rule is only applied to arrays
+  # whose element count is greater than or equal to `MinSize`.
   MinSize: 2
-  WordRegex: !ruby/regexp /\A[\p{Word}\n\t]+\z/
+  # The regular expression `WordRegex` decides what is considered a word.
+  WordRegex: !ruby/regexp '/\A[\p{Word}\n\t]+\z/'
 
 Style/YodaCondition:
   Description: 'Forbid or enforce yoda conditions.'
@@ -4295,12 +4352,7 @@ Style/YodaCondition:
   VersionChanged: '0.63'
 
 Style/ZeroLengthPredicate:
-  Description: |-
-    This cop checks for numeric comparisons that can be replaced
-    by a predicate method, such as receiver.length == 0,
-    receiver.length > 0, receiver.length != 0,
-    receiver.length < 1 and receiver.size == 0 that can be
-    replaced by receiver.empty? and !receiver.empty.
+  Description: 'Use #empty? when testing for objects of length 0.'
   Enabled: true
   Safe: false
   VersionAdded: '0.37'

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,1193 +1,1034 @@
-# Common configuration.
-
+---
 AllCops:
   RubyInterpreters:
-    - ruby
-    - macruby
-    - rake
-    - jruby
-    - rbx
-  # Include common Ruby source files.
+  - ruby
+  - macruby
+  - rake
+  - jruby
+  - rbx
   Include:
-    - '**/*.rb'
-    - '**/*.arb'
-    - '**/*.axlsx'
-    - '**/*.builder'
-    - '**/*.fcgi'
-    - '**/*.gemfile'
-    - '**/*.gemspec'
-    - '**/*.god'
-    - '**/*.jb'
-    - '**/*.jbuilder'
-    - '**/*.mspec'
-    - '**/*.opal'
-    - '**/*.pluginspec'
-    - '**/*.podspec'
-    - '**/*.rabl'
-    - '**/*.rake'
-    - '**/*.rbuild'
-    - '**/*.rbw'
-    - '**/*.rbx'
-    - '**/*.ru'
-    - '**/*.ruby'
-    - '**/*.spec'
-    - '**/*.thor'
-    - '**/*.watchr'
-    - '**/.irbrc'
-    - '**/.pryrc'
-    - '**/buildfile'
-    - '**/Appraisals'
-    - '**/Berksfile'
-    - '**/Brewfile'
-    - '**/Buildfile'
-    - '**/Capfile'
-    - '**/Cheffile'
-    - '**/Dangerfile'
-    - '**/Deliverfile'
-    - '**/Fastfile'
-    - '**/*Fastfile'
-    - '**/Gemfile'
-    - '**/Guardfile'
-    - '**/Jarfile'
-    - '**/Mavenfile'
-    - '**/Podfile'
-    - '**/Puppetfile'
-    - '**/Rakefile'
-    - '**/Snapfile'
-    - '**/Thorfile'
-    - '**/Vagabondfile'
-    - '**/Vagrantfile'
+  - "**/*.rb"
+  - "**/*.arb"
+  - "**/*.axlsx"
+  - "**/*.builder"
+  - "**/*.fcgi"
+  - "**/*.gemfile"
+  - "**/*.gemspec"
+  - "**/*.god"
+  - "**/*.jb"
+  - "**/*.jbuilder"
+  - "**/*.mspec"
+  - "**/*.opal"
+  - "**/*.pluginspec"
+  - "**/*.podspec"
+  - "**/*.rabl"
+  - "**/*.rake"
+  - "**/*.rbuild"
+  - "**/*.rbw"
+  - "**/*.rbx"
+  - "**/*.ru"
+  - "**/*.ruby"
+  - "**/*.spec"
+  - "**/*.thor"
+  - "**/*.watchr"
+  - "**/.irbrc"
+  - "**/.pryrc"
+  - "**/buildfile"
+  - "**/Appraisals"
+  - "**/Berksfile"
+  - "**/Brewfile"
+  - "**/Buildfile"
+  - "**/Capfile"
+  - "**/Cheffile"
+  - "**/Dangerfile"
+  - "**/Deliverfile"
+  - "**/Fastfile"
+  - "**/*Fastfile"
+  - "**/Gemfile"
+  - "**/Guardfile"
+  - "**/Jarfile"
+  - "**/Mavenfile"
+  - "**/Podfile"
+  - "**/Puppetfile"
+  - "**/Rakefile"
+  - "**/Snapfile"
+  - "**/Thorfile"
+  - "**/Vagabondfile"
+  - "**/Vagrantfile"
   Exclude:
-    - 'node_modules/**/*'
-    - 'vendor/**/*'
-    - '.git/**/*'
-  # Default formatter will be used if no `-f/--format` option is given.
+  - node_modules/**/*
+  - vendor/**/*
+  - ".git/**/*"
   DefaultFormatter: progress
-  # Cop names are displayed in offense messages by default. Change behavior
-  # by overriding DisplayCopNames, or by giving the `--no-display-cop-names`
-  # option.
   DisplayCopNames: true
-  # Style guide URLs are not displayed in offense messages by default. Change
-  # behavior by overriding `DisplayStyleGuide`, or by giving the
-  # `-S/--display-style-guide` option.
   DisplayStyleGuide: false
-  # When specifying style guide URLs, any paths and/or fragments will be
-  # evaluated relative to the base URL.
   StyleGuideBaseURL: https://github.com/rubocop-hq/ruby-style-guide
-  # Extra details are not displayed in offense messages by default. Change
-  # behavior by overriding ExtraDetails, or by giving the
-  # `-E/--extra-details` option.
   ExtraDetails: false
-  # Additional cops that do not reference a style guide rule may be enabled by
-  # default. Change behavior by overriding `StyleGuideCopsOnly`, or by giving
-  # the `--only-guide-cops` option.
   StyleGuideCopsOnly: false
-  # All cops except the ones configured `Enabled: false` in this file are enabled by default.
-  # Change this behavior by overriding either `DisabledByDefault` or `EnabledByDefault`.
-  # When `DisabledByDefault` is `true`, all cops in the default configuration
-  # are disabled, and only cops in user configuration are enabled. This makes
-  # cops opt-in instead of opt-out. Note that when `DisabledByDefault` is `true`,
-  # cops in user configuration will be enabled even if they don't set the
-  # Enabled parameter.
-  # When `EnabledByDefault` is `true`, all cops, even those configured `Enabled: false`
-  # in this file are enabled by default. Cops can still be disabled in user configuration.
-  # Note that it is invalid to set both EnabledByDefault and DisabledByDefault
-  # to true in the same configuration.
   EnabledByDefault: false
   DisabledByDefault: false
-  # Enables the result cache if `true`. Can be overridden by the `--cache` command
-  # line option.
   UseCache: true
-  # Threshold for how many files can be stored in the result cache before some
-  # of the files are automatically removed.
   MaxFilesInCache: 20000
-  # The cache will be stored in "rubocop_cache" under this directory. If
-  # CacheRootDirectory is ~ (nil), which it is by default, the root will be
-  # taken from the environment variable `$XDG_CACHE_HOME` if it is set, or if
-  # `$XDG_CACHE_HOME` is not set, it will be `$HOME/.cache/`.
-  CacheRootDirectory: ~
-  # It is possible for a malicious user to know the location of RuboCop's cache
-  # directory by looking at CacheRootDirectory, and create a symlink in its
-  # place that could cause RuboCop to overwrite unintended files, or read
-  # malicious input. If you are certain that your cache location is secure from
-  # this kind of attack, and wish to use a symlinked cache location, set this
-  # value to "true".
+  CacheRootDirectory:
   AllowSymlinksInCacheRootDirectory: false
-  # What MRI version of the Ruby interpreter is the inspected code intended to
-  # run on? (If there is more than one, set this to the lowest version.)
-  # If a value is specified for TargetRubyVersion then it is used. Acceptable
-  # values are specificed as a float (i.e. 2.5); the teeny version of Ruby
-  # should not be included. If the project specifies a Ruby version in the
-  # .ruby-version file, Gemfile or gems.rb file, RuboCop will try to determine
-  # the desired version of Ruby by inspecting the .ruby-version file first,
-  # followed by the Gemfile.lock or gems.locked file. (Although the Ruby version
-  # is specified in the Gemfile or gems.rb file, RuboCop reads the final value
-  # from the lock file.) If the Ruby version is still unresolved, RuboCop will
-  # use the oldest officially supported Ruby version (currently Ruby 2.2).
-  TargetRubyVersion: ~
-  # What version of Rails is the inspected code using?  If a value is specified
-  # for TargetRailsVersion then it is used. Acceptable values are specificed
-  # as a float (i.e. 5.1); the patch version of Rails should not be included.
-  # If TargetRailsVersion is not set, RuboCop will parse the Gemfile.lock or
-  # gems.locked file to find the version of Rails that has been bound to the
-  # application. If neither of those files exist, RuboCop will use Rails 5.0
-  # as the default.
-  TargetRailsVersion: ~
-
-#################### Bundler ###############################
+  TargetRubyVersion:
+  TargetRailsVersion:
 
 Bundler/DuplicatedGem:
-  Description: 'Checks for duplicate gem entries in Gemfile.'
+  Description: A Gem's requirements should be listed only once in a Gemfile.
   Enabled: true
   VersionAdded: '0.46'
   Include:
-    - '**/*.gemfile'
-    - '**/Gemfile'
-    - '**/gems.rb'
+  - "**/*.gemfile"
+  - "**/Gemfile"
+  - "**/gems.rb"
 
 Bundler/GemComment:
-  Description: 'Add a comment describing each gem.'
+  Description: Add a comment describing each gem in your Gemfile.
   Enabled: false
   VersionAdded: '0.59'
   Include:
-    - '**/*.gemfile'
-    - '**/Gemfile'
-    - '**/gems.rb'
+  - "**/*.gemfile"
+  - "**/Gemfile"
+  - "**/gems.rb"
   Whitelist: []
 
 Bundler/InsecureProtocolSource:
-  Description: >-
-                 The source `:gemcutter`, `:rubygems` and `:rubyforge` are deprecated
-                 because HTTP requests are insecure. Please change your source to
-                 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
+  Description: |-
+    The symbol argument `:gemcutter`, `:rubygems`, and `:rubyforge`
+    are deprecated. So please change your source to URL string that
+    'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
   Enabled: true
   VersionAdded: '0.50'
   Include:
-    - '**/*.gemfile'
-    - '**/Gemfile'
-    - '**/gems.rb'
+  - "**/*.gemfile"
+  - "**/Gemfile"
+  - "**/gems.rb"
 
 Bundler/OrderedGems:
-  Description: >-
-                 Gems within groups in the Gemfile should be alphabetically sorted.
+  Description: Gems should be alphabetically sorted within groups.
   Enabled: true
   VersionAdded: '0.46'
   VersionChanged: '0.47'
   TreatCommentsAsGroupSeparators: true
   Include:
-    - '**/*.gemfile'
-    - '**/Gemfile'
-    - '**/gems.rb'
-
-#################### Gemspec ###############################
+  - "**/*.gemfile"
+  - "**/Gemfile"
+  - "**/gems.rb"
 
 Gemspec/DuplicatedAssignment:
-  Description: 'An attribute assignment method calls should be listed only once in a gemspec.'
+  Description: |-
+    An attribute assignment method calls should be listed only once
+    in a gemspec.
   Enabled: true
   VersionAdded: '0.52'
   Include:
-    - '**/*.gemspec'
+  - "**/*.gemspec"
 
 Gemspec/OrderedDependencies:
-  Description: >-
-                 Dependencies in the gemspec should be alphabetically sorted.
+  Description: Dependencies in the gemspec should be alphabetically sorted.
   Enabled: true
   VersionAdded: '0.51'
   TreatCommentsAsGroupSeparators: true
   Include:
-    - '**/*.gemspec'
+  - "**/*.gemspec"
 
 Gemspec/RequiredRubyVersion:
-  Description: 'Checks that `required_ruby_version` of gemspec and `TargetRubyVersion` of .rubocop.yml are equal.'
+  Description: |-
+    Checks that `required_ruby_version` of gemspec and `TargetRubyVersion`
+    of .rubocop.yml are equal.
+    Thereby, RuboCop to perform static analysis working on the version
+    required by gemspec.
   Enabled: true
   VersionAdded: '0.52'
   Include:
-    - '**/*.gemspec'
-
-#################### Layout ###########################
+  - "**/*.gemspec"
 
 Layout/AccessModifierIndentation:
-  Description: Check indentation of private/protected visibility modifiers.
-  StyleGuide: '#indent-public-private-protected'
+  Description: |-
+    Modifiers should be indented as deep as method definitions, or as deep
+    as the class/module keyword, depending on configuration.
+  StyleGuide: "#indent-public-private-protected"
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: indent
   SupportedStyles:
-    - outdent
-    - indent
-  # By default, the indentation width from Layout/IndentationWidth is used
-  # But it can be overridden by setting this parameter
-  IndentationWidth: ~
+  - outdent
+  - indent
+  IndentationWidth:
 
 Layout/AlignArray:
-  Description: >-
-                 Align the elements of an array literal if they span more than
-                 one line.
-  StyleGuide: '#align-multiline-arrays'
+  Description: |-
+    Here we check if the elements of a multi-line array literal are
+    aligned.
+  StyleGuide: "#align-multiline-arrays"
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/AlignHash:
-  Description: >-
-                 Align the elements of a hash literal if they span more than
-                 one line.
+  Description: |-
+    Check that the keys, separators, and values of a multi-line hash
+    literal are aligned according to configuration. The configuration
+    options are:
   Enabled: true
   VersionAdded: '0.49'
-  # Alignment of entries using hash rocket as separator. Valid values are:
-  #
-  # key - left alignment of keys
-  #   'a' => 2
-  #   'bb' => 3
-  # separator - alignment of hash rockets, keys are right aligned
-  #    'a' => 2
-  #   'bb' => 3
-  # table - left alignment of keys, hash rockets, and values
-  #   'a'  => 2
-  #   'bb' => 3
   EnforcedHashRocketStyle: key
   SupportedHashRocketStyles:
-    - key
-    - separator
-    - table
-  # Alignment of entries using colon as separator. Valid values are:
-  #
-  # key - left alignment of keys
-  #   a: 0
-  #   bb: 1
-  # separator - alignment of colons, keys are right aligned
-  #    a: 0
-  #   bb: 1
-  # table - left alignment of keys and values
-  #   a:  0
-  #   bb: 1
+  - key
+  - separator
+  - table
   EnforcedColonStyle: key
   SupportedColonStyles:
-    - key
-    - separator
-    - table
-  # Select whether hashes that are the last argument in a method call should be
-  # inspected? Valid values are:
-  #
-  # always_inspect - Inspect both implicit and explicit hashes.
-  #   Registers an offense for:
-  #     function(a: 1,
-  #       b: 2)
-  #   Registers an offense for:
-  #     function({a: 1,
-  #       b: 2})
-  # always_ignore - Ignore both implicit and explicit hashes.
-  #   Accepts:
-  #     function(a: 1,
-  #       b: 2)
-  #   Accepts:
-  #     function({a: 1,
-  #       b: 2})
-  # ignore_implicit - Ignore only implicit hashes.
-  #   Accepts:
-  #     function(a: 1,
-  #       b: 2)
-  #   Registers an offense for:
-  #     function({a: 1,
-  #       b: 2})
-  # ignore_explicit - Ignore only explicit hashes.
-  #   Accepts:
-  #     function({a: 1,
-  #       b: 2})
-  #   Registers an offense for:
-  #     function(a: 1,
-  #       b: 2)
+  - key
+  - separator
+  - table
   EnforcedLastArgumentHashStyle: always_inspect
   SupportedLastArgumentHashStyles:
-    - always_inspect
-    - always_ignore
-    - ignore_implicit
-    - ignore_explicit
+  - always_inspect
+  - always_ignore
+  - ignore_implicit
+  - ignore_explicit
 
 Layout/AlignParameters:
-  Description: >-
-                 Align the parameters of a method call if they span more
-                 than one line.
-  StyleGuide: '#no-double-indent'
+  Description: |-
+    Here we check if the parameters on a multi-line method call or
+    definition are aligned.
+  StyleGuide: "#no-double-indent"
   Enabled: true
   VersionAdded: '0.49'
-  # Alignment of parameters in multi-line method calls.
-  #
-  # The `with_first_parameter` style aligns the following lines along the same
-  # column as the first parameter.
-  #
-  #     method_call(a,
-  #                 b)
-  #
-  # The `with_fixed_indentation` style aligns the following lines with one
-  # level of indentation relative to the start of the line with the method call.
-  #
-  #     method_call(a,
-  #       b)
   EnforcedStyle: with_first_parameter
   SupportedStyles:
-    - with_first_parameter
-    - with_fixed_indentation
-  # By default, the indentation width from Layout/IndentationWidth is used
-  # But it can be overridden by setting this parameter
-  IndentationWidth: ~
+  - with_first_parameter
+  - with_fixed_indentation
+  IndentationWidth:
 
 Layout/BlockAlignment:
-  Description: 'Align block ends correctly.'
+  Description: |-
+    This cop checks whether the end keywords are aligned properly for do
+    end blocks.
   Enabled: true
   VersionAdded: '0.53'
-  # The value `start_of_block` means that the `end` should be aligned with line
-  # where the `do` keyword appears.
-  # The value `start_of_line` means it should be aligned with the whole
-  # expression's starting line.
-  # The value `either` means both are allowed.
   EnforcedStyleAlignWith: either
   SupportedStylesAlignWith:
-    - either
-    - start_of_block
-    - start_of_line
+  - either
+  - start_of_block
+  - start_of_line
 
 Layout/BlockEndNewline:
-  Description: 'Put end statement of multiline block on its own line.'
+  Description: |-
+    This cop checks whether the end statement of a do..end block
+    is on its own line.
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/CaseIndentation:
-  Description: 'Indentation of when in a case/when/[else/]end.'
-  StyleGuide: '#indent-when-to-case'
+  Description: |-
+    This cop checks how the *when*s of a *case* expression
+    are indented in relation to its *case* or *end* keyword.
+  StyleGuide: "#indent-when-to-case"
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: case
   SupportedStyles:
-    - case
-    - end
+  - case
+  - end
   IndentOneStep: false
-  # By default, the indentation width from `Layout/IndentationWidth` is used.
-  # But it can be overridden by setting this parameter.
-  # This only matters if `IndentOneStep` is `true`
-  IndentationWidth: ~
+  IndentationWidth:
 
 Layout/ClassStructure:
-  Description: 'Enforces a configured order of definitions within a class body.'
-  StyleGuide: 'https://github.com/rubocop-hq/ruby-style-guide#consistent-classes'
+  Description: 'Checks if the code style follows the ExpectedOrder configuration:'
+  StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#consistent-classes
   Enabled: false
   VersionAdded: '0.52'
   Categories:
     module_inclusion:
-      - include
-      - prepend
-      - extend
+    - include
+    - prepend
+    - extend
   ExpectedOrder:
-      - module_inclusion
-      - constants
-      - public_class_methods
-      - initializer
-      - public_methods
-      - protected_methods
-      - private_methods
+  - module_inclusion
+  - constants
+  - public_class_methods
+  - initializer
+  - public_methods
+  - protected_methods
+  - private_methods
 
 Layout/ClosingHeredocIndentation:
-  Description: 'Checks the indentation of here document closings.'
+  Description: Checks the indentation of here document closings.
   Enabled: true
   VersionAdded: '0.57'
 
 Layout/ClosingParenthesisIndentation:
-  Description: 'Checks the indentation of hanging closing parentheses.'
+  Description: |-
+    This cop checks the indentation of hanging closing parentheses in
+    method calls, method definitions, and grouped expressions. A hanging
+    closing parenthesis means `)` preceded by a line break.
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/CommentIndentation:
-  Description: 'Indentation of comments.'
+  Description: This cop checks the indentation of comments.
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/ConditionPosition:
-  Description: >-
-                 Checks for condition placed in a confusing position relative to
-                 the keyword.
-  StyleGuide: '#same-line-condition'
+  Description: |-
+    This cop checks for conditions that are not on the same line as
+    if/while/until.
+  StyleGuide: "#same-line-condition"
   Enabled: true
   VersionAdded: '0.53'
 
 Layout/DefEndAlignment:
-  Description: 'Align ends corresponding to defs correctly.'
+  Description: |-
+    This cop checks whether the end keywords of method definitions are
+    aligned properly.
   Enabled: true
   VersionAdded: '0.53'
-  # The value `def` means that `end` should be aligned with the def keyword.
-  # The value `start_of_line` means that `end` should be aligned with method
-  # calls like `private`, `public`, etc, if present in front of the `def`
-  # keyword on the same line.
   EnforcedStyleAlignWith: start_of_line
   SupportedStylesAlignWith:
-    - start_of_line
-    - def
+  - start_of_line
+  - def
   AutoCorrect: false
   Severity: warning
 
 Layout/DotPosition:
-  Description: 'Checks the position of the dot in multi-line method calls.'
-  StyleGuide: '#consistent-multi-line-chains'
+  Description: This cop checks the . position in multi-line method calls.
+  StyleGuide: "#consistent-multi-line-chains"
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: leading
   SupportedStyles:
-    - leading
-    - trailing
+  - leading
+  - trailing
 
 Layout/ElseAlignment:
-  Description: 'Align elses and elsifs correctly.'
+  Description: |-
+    This cop checks the alignment of else keywords. Normally they should
+    be aligned with an if/unless/while/until/begin/def keyword, but there
+    are special cases when they should follow the same rules as the
+    alignment of end.
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/EmptyComment:
-  Description: 'Checks empty comment.'
+  Description: This cop checks empty comment.
   Enabled: true
   VersionAdded: '0.53'
   AllowBorderComment: true
   AllowMarginComment: true
 
 Layout/EmptyLineAfterGuardClause:
-  Description: 'Add empty line after guard clause.'
+  Description: This cop enforces empty line after guard clause
   Enabled: true
   VersionAdded: '0.56'
   VersionChanged: '0.59'
 
 Layout/EmptyLineAfterMagicComment:
-  Description: 'Add an empty line after magic comments to separate them from code.'
-  StyleGuide: '#separate-magic-comments-from-code'
+  Description: Checks for a newline after the final magic comment.
+  StyleGuide: "#separate-magic-comments-from-code"
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/EmptyLineBetweenDefs:
-  Description: 'Use empty lines between defs.'
-  StyleGuide: '#empty-lines-between-methods'
+  Description: |-
+    This cop checks whether method definitions are
+    separated by one empty line.
+  StyleGuide: "#empty-lines-between-methods"
   Enabled: true
   VersionAdded: '0.49'
-  # If `true`, this parameter means that single line method definitions don't
-  # need an empty line between them.
   AllowAdjacentOneLineDefs: false
-  # Can be array to specify minimum and maximum number of empty lines, e.g. [1, 2]
   NumberOfEmptyLines: 1
 
 Layout/EmptyLines:
-  Description: "Don't use several empty lines in a row."
-  StyleGuide: '#two-or-more-empty-lines'
+  Description: This cop checks for two or more consecutive blank lines.
+  StyleGuide: "#two-or-more-empty-lines"
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/EmptyLinesAroundAccessModifier:
-  Description: "Keep blank lines around access modifiers."
-  StyleGuide: '#empty-lines-around-access-modifier'
+  Description: Access modifiers should be surrounded by blank lines.
+  StyleGuide: "#empty-lines-around-access-modifier"
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/EmptyLinesAroundArguments:
-  Description: "Keeps track of empty lines around method arguments."
+  Description: |-
+    This cop checks if empty lines exist around the arguments
+    of a method invocation.
   Enabled: true
   VersionAdded: '0.52'
 
 Layout/EmptyLinesAroundBeginBody:
-  Description: "Keeps track of empty lines around begin-end bodies."
-  StyleGuide: '#empty-lines-around-bodies'
+  Description: |-
+    This cop checks if empty lines exist around the bodies of begin-end
+    blocks.
+  StyleGuide: "#empty-lines-around-bodies"
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/EmptyLinesAroundBlockBody:
-  Description: "Keeps track of empty lines around block bodies."
-  StyleGuide: '#empty-lines-around-bodies'
+  Description: |-
+    This cop checks if empty lines around the bodies of blocks match
+    the configuration.
+  StyleGuide: "#empty-lines-around-bodies"
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: no_empty_lines
   SupportedStyles:
-    - empty_lines
-    - no_empty_lines
+  - empty_lines
+  - no_empty_lines
 
 Layout/EmptyLinesAroundClassBody:
-  Description: "Keeps track of empty lines around class bodies."
-  StyleGuide: '#empty-lines-around-bodies'
+  Description: |-
+    This cop checks if empty lines around the bodies of classes match
+    the configuration.
+  StyleGuide: "#empty-lines-around-bodies"
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.53'
   EnforcedStyle: no_empty_lines
   SupportedStyles:
-    - empty_lines
-    - empty_lines_except_namespace
-    - empty_lines_special
-    - no_empty_lines
-    - beginning_only
-    - ending_only
+  - empty_lines
+  - empty_lines_except_namespace
+  - empty_lines_special
+  - no_empty_lines
+  - beginning_only
+  - ending_only
 
 Layout/EmptyLinesAroundExceptionHandlingKeywords:
-  Description: "Keeps track of empty lines around exception handling keywords."
-  StyleGuide: '#empty-lines-around-bodies'
+  Description: |-
+    This cop checks if empty lines exist around the bodies of `begin`
+    sections. This cop doesn't check empty lines at `begin` body
+    beginning/end and around method definition body.
+    `Style/EmptyLinesAroundBeginBody` or `Style/EmptyLinesAroundMethodBody`
+    can be used for this purpose.
+  StyleGuide: "#empty-lines-around-bodies"
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/EmptyLinesAroundMethodBody:
-  Description: "Keeps track of empty lines around method bodies."
-  StyleGuide: '#empty-lines-around-bodies'
+  Description: This cop checks if empty lines exist around the bodies of methods.
+  StyleGuide: "#empty-lines-around-bodies"
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/EmptyLinesAroundModuleBody:
-  Description: "Keeps track of empty lines around module bodies."
-  StyleGuide: '#empty-lines-around-bodies'
+  Description: |-
+    This cop checks if empty lines around the bodies of modules match
+    the configuration.
+  StyleGuide: "#empty-lines-around-bodies"
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: no_empty_lines
   SupportedStyles:
-    - empty_lines
-    - empty_lines_except_namespace
-    - empty_lines_special
-    - no_empty_lines
+  - empty_lines
+  - empty_lines_except_namespace
+  - empty_lines_special
+  - no_empty_lines
 
 Layout/EndAlignment:
-  Description: 'Align ends correctly.'
+  Description: This cop checks whether the end keywords are aligned properly.
   Enabled: true
   VersionAdded: '0.53'
-  # The value `keyword` means that `end` should be aligned with the matching
-  # keyword (`if`, `while`, etc.).
-  # The value `variable` means that in assignments, `end` should be aligned
-  # with the start of the variable on the left hand side of `=`. In all other
-  # situations, `end` should still be aligned with the keyword.
-  # The value `start_of_line` means that `end` should be aligned with the start
-  # of the line which the matching keyword appears on.
   EnforcedStyleAlignWith: keyword
   SupportedStylesAlignWith:
-    - keyword
-    - variable
-    - start_of_line
+  - keyword
+  - variable
+  - start_of_line
   AutoCorrect: false
   Severity: warning
 
 Layout/EndOfLine:
-  Description: 'Use Unix-style line endings.'
-  StyleGuide: '#crlf'
+  Description: This cop checks for Windows-style line endings in the source code.
+  StyleGuide: "#crlf"
   Enabled: true
   VersionAdded: '0.49'
-  # The `native` style means that CR+LF (Carriage Return + Line Feed) is
-  # enforced on Windows, and LF is enforced on other platforms. The other styles
-  # mean LF and CR+LF, respectively.
   EnforcedStyle: native
   SupportedStyles:
-    - native
-    - lf
-    - crlf
+  - native
+  - lf
+  - crlf
 
 Layout/ExtraSpacing:
-  Description: 'Do not use unnecessary spacing.'
+  Description: This cop checks for extra/unnecessary whitespace.
   Enabled: true
   VersionAdded: '0.49'
-  # When true, allows most uses of extra spacing if the intent is to align
-  # things with the previous or next line, not counting empty lines or comment
-  # lines.
   AllowForAlignment: true
-  # When true, forces the alignment of `=` in assignments on consecutive lines.
   ForceEqualSignAlignment: false
 
 Layout/FirstArrayElementLineBreak:
-  Description: >-
-                 Checks for a line break before the first element in a
-                 multi-line array.
+  Description: |-
+    This cop checks for a line break before the first element in a
+    multi-line array.
   Enabled: false
   VersionAdded: '0.49'
 
 Layout/FirstHashElementLineBreak:
-  Description: >-
-                 Checks for a line break before the first element in a
-                 multi-line hash.
+  Description: |-
+    This cop checks for a line break before the first element in a
+    multi-line hash.
   Enabled: false
   VersionAdded: '0.49'
 
 Layout/FirstMethodArgumentLineBreak:
-  Description: >-
-                 Checks for a line break before the first argument in a
-                 multi-line method call.
+  Description: |-
+    This cop checks for a line break before the first argument in a
+    multi-line method call.
   Enabled: false
   VersionAdded: '0.49'
 
 Layout/FirstMethodParameterLineBreak:
-  Description: >-
-                 Checks for a line break before the first parameter in a
-                 multi-line method parameter definition.
+  Description: |-
+    This cop checks for a line break before the first parameter in a
+    multi-line method parameter definition.
   Enabled: false
   VersionAdded: '0.49'
 
 Layout/FirstParameterIndentation:
-  Description: 'Checks the indentation of the first parameter in a method call.'
+  Description: |-
+    This cop checks the indentation of the first parameter in a method call.
+    Parameters after the first one are checked by Layout/AlignParameters,
+    not by this cop.
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.56'
   EnforcedStyle: special_for_inner_method_call_in_parentheses
   SupportedStyles:
-    # The first parameter should always be indented one step more than the
-    # preceding line.
-    - consistent
-    # The first parameter should always be indented one level relative to the
-    # parent that is receiving the parameter
-    - consistent_relative_to_receiver
-    # The first parameter should normally be indented one step more than the
-    # preceding line, but if it's a parameter for a method call that is itself
-    # a parameter in a method call, then the inner parameter should be indented
-    # relative to the inner method.
-    - special_for_inner_method_call
-    # Same as `special_for_inner_method_call` except that the special rule only
-    # applies if the outer method call encloses its arguments in parentheses.
-    - special_for_inner_method_call_in_parentheses
-  # By default, the indentation width from `Layout/IndentationWidth` is used
-  # But it can be overridden by setting this parameter
-  IndentationWidth: ~
+  - consistent
+  - consistent_relative_to_receiver
+  - special_for_inner_method_call
+  - special_for_inner_method_call_in_parentheses
+  IndentationWidth:
 
 Layout/IndentArray:
-  Description: >-
-                 Checks the indentation of the first element in an array
-                 literal.
+  Description: |-
+    This cop checks the indentation of the first element in an array literal
+    where the opening bracket and the first element are on separate lines.
+    The other elements' indentations are handled by the AlignArray cop.
   Enabled: true
   VersionAdded: '0.49'
-  # The value `special_inside_parentheses` means that array literals with
-  # brackets that have their opening bracket on the same line as a surrounding
-  # opening round parenthesis, shall have their first element indented relative
-  # to the first position inside the parenthesis.
-  #
-  # The value `consistent` means that the indentation of the first element shall
-  # always be relative to the first position of the line where the opening
-  # bracket is.
-  #
-  # The value `align_brackets` means that the indentation of the first element
-  # shall always be relative to the position of the opening bracket.
   EnforcedStyle: special_inside_parentheses
   SupportedStyles:
-    - special_inside_parentheses
-    - consistent
-    - align_brackets
-  # By default, the indentation width from `Layout/IndentationWidth` is used
-  # But it can be overridden by setting this parameter
-  IndentationWidth: ~
+  - special_inside_parentheses
+  - consistent
+  - align_brackets
+  IndentationWidth:
 
 Layout/IndentAssignment:
-  Description: >-
-                 Checks the indentation of the first line of the
-                 right-hand-side of a multi-line assignment.
+  Description: |-
+    This cop checks the indentation of the first line of the
+    right-hand-side of a multi-line assignment.
   Enabled: true
   VersionAdded: '0.49'
-  # By default, the indentation width from `Layout/IndentationWidth` is used
-  # But it can be overridden by setting this parameter
-  IndentationWidth: ~
+  IndentationWidth:
 
 Layout/IndentHash:
-  Description: 'Checks the indentation of the first key in a hash literal.'
+  Description: |-
+    This cop checks the indentation of the first key in a hash literal
+    where the opening brace and the first key are on separate lines. The
+    other keys' indentations are handled by the AlignHash cop.
   Enabled: true
   VersionAdded: '0.49'
-  # The value `special_inside_parentheses` means that hash literals with braces
-  # that have their opening brace on the same line as a surrounding opening
-  # round parenthesis, shall have their first key indented relative to the
-  # first position inside the parenthesis.
-  #
-  # The value `consistent` means that the indentation of the first key shall
-  # always be relative to the first position of the line where the opening
-  # brace is.
-  #
-  # The value `align_braces` means that the indentation of the first key shall
-  # always be relative to the position of the opening brace.
   EnforcedStyle: special_inside_parentheses
   SupportedStyles:
-    - special_inside_parentheses
-    - consistent
-    - align_braces
-  # By default, the indentation width from `Layout/IndentationWidth` is used
-  # But it can be overridden by setting this parameter
-  IndentationWidth: ~
+  - special_inside_parentheses
+  - consistent
+  - align_braces
+  IndentationWidth:
 
 Layout/IndentHeredoc:
-  Description: 'This cop checks the indentation of the here document bodies.'
-  StyleGuide: '#squiggly-heredocs'
+  Description: |-
+    This cop checks the indentation of the here document bodies. The bodies
+    are indented one step.
+    In Ruby 2.3 or newer, squiggly heredocs (`<<~`) should be used. If you
+    use the older rubies, you should introduce some library to your project
+    (e.g. ActiveSupport, Powerpack or Unindent).
+    Note: When `Metrics/LineLength`'s `AllowHeredoc` is false (not default),
+          this cop does not add any offenses for long here documents to
+          avoid `Metrics/LineLength`'s offenses.
+  StyleGuide: "#squiggly-heredocs"
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: auto_detection
   SupportedStyles:
-    - auto_detection
-    - squiggly
-    - active_support
-    - powerpack
-    - unindent
+  - auto_detection
+  - squiggly
+  - active_support
+  - powerpack
+  - unindent
 
 Layout/IndentationConsistency:
-  Description: 'Keep indentation straight.'
-  StyleGuide: '#spaces-indentation'
+  Description: This cop checks for inconsistent indentation.
+  StyleGuide: "#spaces-indentation"
   Enabled: true
   VersionAdded: '0.49'
-  # The difference between `rails` and `normal` is that the `rails` style
-  # prescribes that in classes and modules the `protected` and `private`
-  # modifier keywords shall be indented the same as public methods and that
-  # protected and private members shall be indented one step more than the
-  # modifiers. Other than that, both styles mean that entities on the same
-  # logical depth shall have the same indentation.
   EnforcedStyle: normal
   SupportedStyles:
-    - normal
-    - rails
+  - normal
+  - rails
 
 Layout/IndentationWidth:
-  Description: 'Use 2 spaces for indentation.'
-  StyleGuide: '#spaces-indentation'
+  Description: |-
+    This cop checks for indentation that doesn't use the specified number
+    of spaces.
+  StyleGuide: "#spaces-indentation"
   Enabled: true
   VersionAdded: '0.49'
-  # Number of spaces for each indentation level.
   Width: 2
   IgnoredPatterns: []
 
 Layout/InitialIndentation:
-  Description: >-
-    Checks the indentation of the first non-blank non-comment line in a file.
+  Description: |-
+    This cop checks for indentation of the first non-blank non-comment
+    line in a file.
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/LeadingBlankLines:
-  Description: Check for unnecessary blank lines at the beginning of a file.
+  Description: |-
+    This cop checks for unnecessary leading blank lines at the beginning
+    of a file.
   Enabled: true
   VersionAdded: '0.57'
 
 Layout/LeadingCommentSpace:
-  Description: 'Comments should start with a space.'
-  StyleGuide: '#hash-space'
+  Description: |-
+    This cop checks whether comments have a leading space after the
+    `#` denoting the start of the comment. The leading space is not
+    required for some RDoc special syntax, like `#++`, `#--`,
+    `#:nodoc`, `=begin`- and `=end` comments, "shebang" directives,
+    or rackup options.
+  StyleGuide: "#hash-space"
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/MultilineArrayBraceLayout:
-  Description: >-
-                 Checks that the closing brace in an array literal is
-                 either on the same line as the last array element, or
-                 a new line.
+  Description: |-
+    This cop checks that the closing brace in an array literal is either
+    on the same line as the last array element or on a new line.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
   SupportedStyles:
-    # symmetrical: closing brace is positioned in same way as opening brace
-    # new_line: closing brace is always on a new line
-    # same_line: closing brace is always on the same line as last element
-    - symmetrical
-    - new_line
-    - same_line
+  - symmetrical
+  - new_line
+  - same_line
 
 Layout/MultilineAssignmentLayout:
-  Description: 'Check for a newline after the assignment operator in multi-line assignments.'
-  StyleGuide: '#indent-conditional-assignment'
+  Description: |-
+    This cop checks whether the multiline assignments have a newline
+    after the assignment operator.
+  StyleGuide: "#indent-conditional-assignment"
   Enabled: false
   VersionAdded: '0.49'
-  # The types of assignments which are subject to this rule.
   SupportedTypes:
-    - block
-    - case
-    - class
-    - if
-    - kwbegin
-    - module
+  - block
+  - case
+  - class
+  - if
+  - kwbegin
+  - module
   EnforcedStyle: new_line
   SupportedStyles:
-    # Ensures that the assignment operator and the rhs are on the same line for
-    # the set of supported types.
-    - same_line
-    # Ensures that the assignment operator and the rhs are on separate lines
-    # for the set of supported types.
-    - new_line
+  - same_line
+  - new_line
 
 Layout/MultilineBlockLayout:
-  Description: 'Ensures newlines after multiline block do statements.'
+  Description: |-
+    This cop checks whether the multiline do end blocks have a newline
+    after the start of the block. Additionally, it checks whether the block
+    arguments, if any, are on the same line as the start of the block.
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/MultilineHashBraceLayout:
-  Description: >-
-                 Checks that the closing brace in a hash literal is
-                 either on the same line as the last hash element, or
-                 a new line.
+  Description: |-
+    This cop checks that the closing brace in a hash literal is either
+    on the same line as the last hash element, or a new line.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
   SupportedStyles:
-    # symmetrical: closing brace is positioned in same way as opening brace
-    # new_line: closing brace is always on a new line
-    # same_line: closing brace is always on same line as last element
-    - symmetrical
-    - new_line
-    - same_line
+  - symmetrical
+  - new_line
+  - same_line
 
 Layout/MultilineMethodCallBraceLayout:
-  Description: >-
-                 Checks that the closing brace in a method call is
-                 either on the same line as the last method argument, or
-                 a new line.
+  Description: |-
+    This cop checks that the closing brace in a method call is either
+    on the same line as the last method argument, or a new line.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
   SupportedStyles:
-    # symmetrical: closing brace is positioned in same way as opening brace
-    # new_line: closing brace is always on a new line
-    # same_line: closing brace is always on the same line as last argument
-    - symmetrical
-    - new_line
-    - same_line
+  - symmetrical
+  - new_line
+  - same_line
 
 Layout/MultilineMethodCallIndentation:
-  Description: >-
-                 Checks indentation of method calls with the dot operator
-                 that span more than one line.
+  Description: |-
+    This cop checks the indentation of the method name part in method calls
+    that span more than one line.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: aligned
   SupportedStyles:
-    - aligned
-    - indented
-    - indented_relative_to_receiver
-  # By default, the indentation width from Layout/IndentationWidth is used
-  # But it can be overridden by setting this parameter
-  IndentationWidth: ~
+  - aligned
+  - indented
+  - indented_relative_to_receiver
+  IndentationWidth:
 
 Layout/MultilineMethodDefinitionBraceLayout:
-  Description: >-
-                 Checks that the closing brace in a method definition is
-                 either on the same line as the last method parameter, or
-                 a new line.
+  Description: |-
+    This cop checks that the closing brace in a method definition is either
+    on the same line as the last method parameter, or a new line.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: symmetrical
   SupportedStyles:
-    # symmetrical: closing brace is positioned in same way as opening brace
-    # new_line: closing brace is always on a new line
-    # same_line: closing brace is always on the same line as last parameter
-    - symmetrical
-    - new_line
-    - same_line
+  - symmetrical
+  - new_line
+  - same_line
 
 Layout/MultilineOperationIndentation:
-  Description: >-
-                 Checks indentation of binary operations that span more than
-                 one line.
+  Description: |-
+    This cop checks the indentation of the right hand side operand in
+    binary operations that span more than one line.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: aligned
   SupportedStyles:
-    - aligned
-    - indented
-  # By default, the indentation width from `Layout/IndentationWidth` is used
-  # But it can be overridden by setting this parameter
-  IndentationWidth: ~
+  - aligned
+  - indented
+  IndentationWidth:
 
 Layout/RescueEnsureAlignment:
-  Description: 'Align rescues and ensures correctly.'
+  Description: |-
+    This cop checks whether the rescue and ensure keywords are aligned
+    properly.
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceAfterColon:
-  Description: 'Use spaces after colons.'
-  StyleGuide: '#spaces-operators'
+  Description: |-
+    Checks for colon (:) not followed by some kind of space.
+    N.B. this cop does not handle spaces after a ternary operator, which are
+    instead handled by Layout/SpaceAroundOperators.
+  StyleGuide: "#spaces-operators"
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceAfterComma:
-  Description: 'Use spaces after commas.'
-  StyleGuide: '#spaces-operators'
+  Description: Checks for comma (,) not followed by some kind of space.
+  StyleGuide: "#spaces-operators"
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceAfterMethodName:
-  Description: >-
-                 Do not put a space between a method name and the opening
-                 parenthesis in a method definition.
-  StyleGuide: '#parens-no-spaces'
+  Description: Checks for space between a method name and a left parenthesis in defs.
+  StyleGuide: "#parens-no-spaces"
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceAfterNot:
-  Description: Tracks redundant space after the ! operator.
-  StyleGuide: '#no-space-bang'
+  Description: This cop checks for space after `!`.
+  StyleGuide: "#no-space-bang"
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceAfterSemicolon:
-  Description: 'Use spaces after semicolons.'
-  StyleGuide: '#spaces-operators'
+  Description: Checks for semicolon (;) not followed by some kind of space.
+  StyleGuide: "#spaces-operators"
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceAroundBlockParameters:
-  Description: 'Checks the spacing inside and after block parameters pipes.'
+  Description: Checks the spacing inside and after block parameters pipes.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyleInsidePipes: no_space
   SupportedStylesInsidePipes:
-    - space
-    - no_space
+  - space
+  - no_space
 
 Layout/SpaceAroundEqualsInParameterDefault:
-  Description: >-
-                 Checks that the equals signs in parameter default assignments
-                 have or don't have surrounding space depending on
-                 configuration.
-  StyleGuide: '#spaces-around-equals'
+  Description: |-
+    Checks that the equals signs in parameter default assignments
+    have or don't have surrounding space depending on configuration.
+  StyleGuide: "#spaces-around-equals"
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: space
   SupportedStyles:
-    - space
-    - no_space
+  - space
+  - no_space
 
 Layout/SpaceAroundKeyword:
-  Description: 'Use a space around keywords if appropriate.'
+  Description: Checks the spacing around the keywords.
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceAroundOperators:
-  Description: 'Use a single space around operators.'
-  StyleGuide: '#spaces-operators'
+  Description: |-
+    Checks that operators have space around them, except for **
+    which should not have surrounding space.
+  StyleGuide: "#spaces-operators"
   Enabled: true
   VersionAdded: '0.49'
-  # When `true`, allows most uses of extra spacing if the intent is to align
-  # with an operator on the previous or next line, not counting empty lines
-  # or comment lines.
   AllowForAlignment: true
 
 Layout/SpaceBeforeBlockBraces:
-  Description: >-
-                 Checks that the left block brace has or doesn't have space
-                 before it.
+  Description: |-
+    Checks that block braces have or don't have a space before the opening
+    brace depending on configuration.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: space
   SupportedStyles:
-    - space
-    - no_space
+  - space
+  - no_space
   EnforcedStyleForEmptyBraces: space
   SupportedStylesForEmptyBraces:
-    - space
-    - no_space
-  VersionChanged: '0.52.1'
+  - space
+  - no_space
+  VersionChanged: 0.52.1
 
 Layout/SpaceBeforeComma:
-  Description: 'No spaces before commas.'
+  Description: Checks for comma (,) preceded by space.
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceBeforeComment:
-  Description: >-
-                 Checks for missing space between code and a comment on the
-                 same line.
+  Description: |-
+    This cop checks for missing space between a token and a comment on the
+    same line.
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceBeforeFirstArg:
-  Description: >-
-                 Checks that exactly one space is used between a method name
-                 and the first argument for method calls without parentheses.
+  Description: |-
+    Checks that exactly one space is used between a method name and the
+    first argument for method calls without parentheses.
   Enabled: true
   VersionAdded: '0.49'
-  # When `true`, allows most uses of extra spacing if the intent is to align
-  # things with the previous or next line, not counting empty lines or comment
-  # lines.
   AllowForAlignment: true
 
 Layout/SpaceBeforeSemicolon:
-  Description: 'No spaces before semicolons.'
+  Description: Checks for semicolon (;) preceded by space.
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceInLambdaLiteral:
-  Description: 'Checks for spaces in lambda literals.'
+  Description: |-
+    This cop checks for spaces between `->` and opening parameter
+    parenthesis (`(`) in lambda literals.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: require_no_space
   SupportedStyles:
-    - require_no_space
-    - require_space
+  - require_no_space
+  - require_space
 
 Layout/SpaceInsideArrayLiteralBrackets:
-  Description: 'Checks the spacing inside array literal brackets.'
+  Description: |-
+    Checks that brackets used for array literals have or don't have
+    surrounding space depending on configuration.
   Enabled: true
   VersionAdded: '0.52'
   EnforcedStyle: no_space
   SupportedStyles:
-    - space
-    - no_space
-    # 'compact' normally requires a space inside the brackets, with the exception
-    # that successive left brackets or right brackets are collapsed together
-    - compact
+  - space
+  - no_space
+  - compact
   EnforcedStyleForEmptyBrackets: no_space
   SupportedStylesForEmptyBrackets:
-    - space
-    - no_space
+  - space
+  - no_space
 
 Layout/SpaceInsideArrayPercentLiteral:
-  Description: 'No unnecessary additional spaces between elements in %i/%w literals.'
+  Description: |-
+    Checks for unnecessary additional spaces inside array percent literals
+    (i.e. %i/%w).
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceInsideBlockBraces:
-  Description: >-
-                 Checks that block braces have or don't have surrounding space.
-                 For blocks taking parameters, checks that the left brace has
-                 or doesn't have trailing space.
+  Description: |-
+    Checks that block braces have or don't have surrounding space inside
+    them on configuration. For blocks taking parameters, it checks that the
+    left brace has or doesn't have trailing space depending on
+    configuration.
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: space
   SupportedStyles:
-    - space
-    - no_space
+  - space
+  - no_space
   EnforcedStyleForEmptyBraces: no_space
   SupportedStylesForEmptyBraces:
-    - space
-    - no_space
-  # Space between `{` and `|`. Overrides `EnforcedStyle` if there is a conflict.
+  - space
+  - no_space
   SpaceBeforeBlockParameters: true
 
 Layout/SpaceInsideHashLiteralBraces:
-  Description: "Use spaces inside hash literal braces - or don't."
-  StyleGuide: '#spaces-operators'
+  Description: |-
+    Checks that braces used for hash literals have or don't have
+    surrounding space depending on configuration.
+  StyleGuide: "#spaces-operators"
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: space
   SupportedStyles:
-    - space
-    - no_space
-    # 'compact' normally requires a space inside hash braces, with the exception
-    # that successive left braces or right braces are collapsed together
-    - compact
+  - space
+  - no_space
+  - compact
   EnforcedStyleForEmptyBraces: no_space
   SupportedStylesForEmptyBraces:
-    - space
-    - no_space
-
+  - space
+  - no_space
 
 Layout/SpaceInsideParens:
-  Description: 'No spaces after ( or before ).'
-  StyleGuide: '#spaces-braces'
+  Description: Checks for spaces inside ordinary round parentheses.
+  StyleGuide: "#spaces-braces"
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.55'
   EnforcedStyle: no_space
   SupportedStyles:
-    - space
-    - no_space
+  - space
+  - no_space
 
 Layout/SpaceInsidePercentLiteralDelimiters:
-  Description: 'No unnecessary spaces inside delimiters of %i/%w/%x literals.'
+  Description: |-
+    Checks for unnecessary additional spaces inside the delimiters of
+    %i/%w/%x literals.
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceInsideRangeLiteral:
-  Description: 'No spaces inside range literals.'
-  StyleGuide: '#no-space-inside-range-literals'
+  Description: Checks for spaces inside range literals.
+  StyleGuide: "#no-space-inside-range-literals"
   Enabled: true
   VersionAdded: '0.49'
 
 Layout/SpaceInsideReferenceBrackets:
-  Description: 'Checks the spacing inside referential brackets.'
+  Description: |-
+    Checks that reference brackets have or don't have
+    surrounding space depending on configuration.
   Enabled: true
   VersionAdded: '0.52'
   VersionChanged: '0.53'
   EnforcedStyle: no_space
   SupportedStyles:
-    - space
-    - no_space
+  - space
+  - no_space
   EnforcedStyleForEmptyBrackets: no_space
   SupportedStylesForEmptyBrackets:
-    - space
-    - no_space
+  - space
+  - no_space
 
 Layout/SpaceInsideStringInterpolation:
-  Description: 'Checks for padding/surrounding spaces inside string interpolation.'
-  StyleGuide: '#string-interpolation'
+  Description: This cop checks for whitespace within string interpolations.
+  StyleGuide: "#string-interpolation"
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: no_space
   SupportedStyles:
-    - space
-    - no_space
+  - space
+  - no_space
 
 Layout/Tab:
-  Description: 'No hard tabs.'
-  StyleGuide: '#spaces-indentation'
+  Description: This cop checks for tabs inside the source code.
+  StyleGuide: "#spaces-indentation"
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.51'
-  # By default, the indentation width from Layout/IndentationWidth is used
-  # But it can be overridden by setting this parameter
-  # It is used during auto-correction to determine how many spaces should
-  # replace each tab.
-  IndentationWidth: ~
+  IndentationWidth:
 
 Layout/TrailingBlankLines:
-  Description: 'Checks trailing blank lines and final newline.'
-  StyleGuide: '#newline-eof'
+  Description: |-
+    This cop looks for trailing blank lines and a final newline in the
+    source code.
+  StyleGuide: "#newline-eof"
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: final_newline
   SupportedStyles:
-    - final_newline
-    - final_blank_line
+  - final_newline
+  - final_blank_line
 
 Layout/TrailingWhitespace:
-  Description: 'Avoid trailing whitespace.'
-  StyleGuide: '#no-trailing-whitespace'
+  Description: This cop looks for trailing whitespace in the source code.
+  StyleGuide: "#no-trailing-whitespace"
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.55'
   AllowInHeredoc: false
 
-#################### Lint ##################################
-### Warnings
-
 Lint/AmbiguousBlockAssociation:
-  Description: >-
-                 Checks for ambiguous block association with method when param passed without
-                 parentheses.
-  StyleGuide: '#syntax'
+  Description: |-
+    This cop checks for ambiguous block association with method
+    when param passed without parentheses.
+  StyleGuide: "#syntax"
   Enabled: true
   VersionAdded: '0.48'
 
 Lint/AmbiguousOperator:
-  Description: >-
-                 Checks for ambiguous operators in the first argument of a
-                 method invocation without parentheses.
-  StyleGuide: '#method-invocation-parens'
+  Description: |-
+    This cop checks for ambiguous operators in the first argument of a
+    method invocation without parentheses.
+  StyleGuide: "#method-invocation-parens"
   Enabled: true
   VersionAdded: '0.17'
 
 Lint/AmbiguousRegexpLiteral:
-  Description: >-
-                 Checks for ambiguous regexp literals in the first argument of
-                 a method invocation without parentheses.
+  Description: |-
+    This cop checks for ambiguous regexp literals in the first argument of
+    a method invocation without parentheses.
   Enabled: true
   VersionAdded: '0.17'
 
 Lint/AssignmentInCondition:
-  Description: "Don't use assignment in conditions."
-  StyleGuide: '#safe-assignment-in-condition'
+  Description: |-
+    This cop checks for assignments in the conditions of
+    if/while/until.
+  StyleGuide: "#safe-assignment-in-condition"
   Enabled: true
   VersionAdded: '0.9'
   AllowSafeAssignment: true
 
 Lint/BigDecimalNew:
-  Description: '`BigDecimal.new()` is deprecated. Use `BigDecimal()` instead.'
+  Description: |-
+    `BigDecimal.new()` is deprecated since BigDecimal 1.3.3.
+    This cop identifies places where `BigDecimal.new()`
+    can be replaced by `BigDecimal()`.
   Enabled: true
   VersionAdded: '0.53'
 
 Lint/BooleanSymbol:
-  Description: 'Check for `:true` and `:false` symbols.'
+  Description: |-
+    This cop checks for `:true` and `:false` symbols.
+    In most cases it would be a typo.
   Enabled: true
   VersionAdded: '0.50'
 
 Lint/CircularArgumentReference:
-  Description: "Default values in optional keyword arguments and optional ordinal arguments should not refer back to the name of the argument."
+  Description: |-
+    This cop checks for circular argument references in optional keyword
+    arguments and optional ordinal arguments.
   Enabled: true
   VersionAdded: '0.33'
 
 Lint/Debugger:
-  Description: 'Check for debugger calls.'
+  Description: This cop checks for calls to debugger or pry.
   Enabled: true
   VersionAdded: '0.14'
   VersionChanged: '0.49'
 
 Lint/DeprecatedClassMethods:
-  Description: 'Check for deprecated class method calls.'
+  Description: This cop checks for uses of the deprecated class method usages.
   Enabled: true
   VersionAdded: '0.19'
 
@@ -1198,66 +1039,82 @@ Lint/DisjunctiveAssignmentInConstructor:
   VersionAdded: '0.62'
 
 Lint/DuplicateCaseCondition:
-  Description: 'Do not repeat values in case conditionals.'
+  Description: |-
+    This cop checks that there are no repeated conditions
+    used in case 'when' expressions.
   Enabled: true
   VersionAdded: '0.45'
 
 Lint/DuplicateMethods:
-  Description: 'Check for duplicate method definitions.'
+  Description: |-
+    This cop checks for duplicated instance (or singleton) method
+    definitions.
   Enabled: true
   VersionAdded: '0.29'
 
 Lint/DuplicatedKey:
-  Description: 'Check for duplicate keys in hash literals.'
+  Description: This cop checks for duplicated keys in hash literals.
   Enabled: true
   VersionAdded: '0.34'
 
 Lint/EachWithObjectArgument:
-  Description: 'Check for immutable argument given to each_with_object.'
+  Description: |-
+    This cop checks if each_with_object is called with an immutable
+    argument. Since the argument is the object that the given block shall
+    make calls on to build something based on the enumerable that
+    each_with_object iterates over, an immutable argument makes no sense.
+    It's definitely a bug.
   Enabled: true
   VersionAdded: '0.31'
 
 Lint/ElseLayout:
-  Description: 'Check for odd code arrangement in an else block.'
+  Description: |-
+    This cop checks for odd else block layout - like
+    having an expression on the same line as the else keyword,
+    which is usually a mistake.
   Enabled: true
   VersionAdded: '0.17'
 
 Lint/EmptyEnsure:
-  Description: 'Checks for empty ensure block.'
+  Description: This cop checks for empty `ensure` blocks
   Enabled: true
   VersionAdded: '0.10'
   VersionChanged: '0.48'
   AutoCorrect: false
 
 Lint/EmptyExpression:
-  Description: 'Checks for empty expressions.'
+  Description: This cop checks for the presence of empty expressions.
   Enabled: true
   VersionAdded: '0.45'
 
 Lint/EmptyInterpolation:
-  Description: 'Checks for empty string interpolation.'
+  Description: This cop checks for empty interpolation.
   Enabled: true
   VersionAdded: '0.20'
   VersionChanged: '0.45'
 
 Lint/EmptyWhen:
-  Description: 'Checks for `when` branches with empty bodies.'
+  Description: This cop checks for the presence of `when` branches without a body.
   Enabled: true
   VersionAdded: '0.45'
 
 Lint/EndInMethod:
-  Description: 'END blocks should not be placed inside method definitions.'
+  Description: This cop checks for END blocks in method definitions.
   Enabled: true
   VersionAdded: '0.9'
 
 Lint/EnsureReturn:
-  Description: 'Do not use return in an ensure block.'
-  StyleGuide: '#no-return-ensure'
+  Description: |-
+    This cop checks for *return* from an *ensure* block.
+    Explicit return from an ensure block alters the control flow
+    as the return will take precedence over any exception being raised,
+    and the exception will be silently thrown away as if it were rescued.
+  StyleGuide: "#no-return-ensure"
   Enabled: true
   VersionAdded: '0.9'
 
 Lint/ErbNewArguments:
-  Description: 'Use `:trim_mode` and `:eoutvar` keyword arguments to `ERB.new`.'
+  Description: This cop emulates the following Ruby warnings in Ruby 2.6.
   Enabled: true
   VersionAdded: '0.56'
 
@@ -1268,298 +1125,343 @@ Lint/FlipFlop:
   VersionAdded: '0.16'
 
 Lint/FloatOutOfRange:
-  Description: >-
-                 Catches floating-point literals too large or small for Ruby to
-                 represent.
+  Description: |-
+    This cop identifies Float literals which are, like, really really really
+    really really really really really big. Too big. No-one needs Floats
+    that big. If you need a float that big, something is wrong with you.
   Enabled: true
   VersionAdded: '0.36'
 
 Lint/FormatParameterMismatch:
-  Description: 'The number of parameters to format/sprint must match the fields.'
+  Description: |-
+    This lint sees if there is a mismatch between the number of
+    expected fields for format/sprintf/#% and what is actually
+    passed as arguments.
   Enabled: true
   VersionAdded: '0.33'
 
 Lint/HandleExceptions:
-  Description: "Don't suppress exception."
-  StyleGuide: '#dont-hide-exceptions'
+  Description: This cop checks for *rescue* blocks with no body.
+  StyleGuide: "#dont-hide-exceptions"
   Enabled: true
   VersionAdded: '0.9'
 
 Lint/ImplicitStringConcatenation:
-  Description: >-
-                 Checks for adjacent string literals on the same line, which
-                 could better be represented as a single string literal.
+  Description: |-
+    This cop checks for implicit string concatenation of string literals
+    which are on the same line.
   Enabled: true
   VersionAdded: '0.36'
 
 Lint/IneffectiveAccessModifier:
-  Description: >-
-                 Checks for attempts to use `private` or `protected` to set
-                 the visibility of a class method, which does not work.
+  Description: |-
+    This cop checks for `private` or `protected` access modifiers which are
+    applied to a singleton method. These access modifiers do not make
+    singleton methods private/protected. `private_class_method` can be
+    used for that.
   Enabled: true
   VersionAdded: '0.36'
 
 Lint/InheritException:
-  Description: 'Avoid inheriting from the `Exception` class.'
+  Description: |-
+    This cop looks for error classes inheriting from `Exception`
+    and its standard library subclasses, excluding subclasses of
+    `StandardError`. It is configurable to suggest using either
+    `RuntimeError` (default) or `StandardError` instead.
   Enabled: true
   VersionAdded: '0.41'
-  # The default base class in favour of `Exception`.
   EnforcedStyle: runtime_error
   SupportedStyles:
-    - runtime_error
-    - standard_error
+  - runtime_error
+  - standard_error
 
 Lint/InterpolationCheck:
-  Description: 'Raise warning for interpolation in single q strs'
+  Description: This cop checks for interpolation in a single quoted string.
   Enabled: true
   VersionAdded: '0.50'
 
 Lint/LiteralAsCondition:
-  Description: 'Checks of literals used in conditions.'
+  Description: |-
+    This cop checks for literals used as the conditions or as
+    operands in and/or expressions serving as the conditions of
+    if/while/until.
   Enabled: true
   VersionAdded: '0.51'
 
 Lint/LiteralInInterpolation:
-  Description: 'Checks for literals used in interpolation.'
+  Description: This cop checks for interpolated literals.
   Enabled: true
   VersionAdded: '0.19'
   VersionChanged: '0.32'
 
 Lint/Loop:
-  Description: >-
-                 Use Kernel#loop with break rather than begin/end/until or
-                 begin/end/while for post-loop tests.
-  StyleGuide: '#loop-with-break'
+  Description: This cop checks for uses of *begin...end while/until something*.
+  StyleGuide: "#loop-with-break"
   Enabled: true
   VersionAdded: '0.9'
 
 Lint/MissingCopEnableDirective:
-  Description: 'Checks for a `# rubocop:enable` after `# rubocop:disable`'
+  Description: |-
+    This cop checks that there is an `# rubocop:enable ...` statement
+    after a `# rubocop:disable ...` statement. This will prevent leaving
+    cop disables on wide ranges of code, that latter contributors to
+    a file wouldn't be aware of.
   Enabled: true
   VersionAdded: '0.52'
-  # Maximum number of consecutive lines the cop can be disabled for.
-  # 0 allows only single-line disables
-  # 1 would mean the maximum allowed is the following:
-  #   # rubocop:disable SomeCop
-  #   a = 1
-  #   # rubocop:enable SomeCop
-  # .inf for any size
   MaximumRangeSize: .inf
 
 Lint/MultipleCompare:
-  Description: "Use `&&` operator to compare multiple value."
+  Description: |-
+    In math and Python, we can use `x < y < z` style comparison to compare
+    multiple value. However, we can't use the comparison in Ruby. However,
+    the comparison is not syntax error. This cop checks the bad usage of
+    comparison operators.
   Enabled: true
   VersionAdded: '0.47'
 
 Lint/NestedMethodDefinition:
-  Description: 'Do not use nested method definitions.'
-  StyleGuide: '#no-nested-methods'
+  Description: This cop checks for nested method definitions.
+  StyleGuide: "#no-nested-methods"
   Enabled: true
   VersionAdded: '0.32'
 
 Lint/NestedPercentLiteral:
-  Description: 'Checks for nested percent literals.'
+  Description: This cop checks for nested percent literals.
   Enabled: true
   VersionAdded: '0.52'
 
 Lint/NextWithoutAccumulator:
-  Description:  >-
-                  Do not omit the accumulator when calling `next`
-                  in a `reduce`/`inject` block.
+  Description: Don't omit the accumulator when calling `next` in a `reduce` block.
   Enabled: true
   VersionAdded: '0.36'
 
 Lint/NonLocalExitFromIterator:
-  Description: 'Do not use return in iterator to cause non-local exit.'
+  Description: |-
+    This cop checks for non-local exits from iterators without a return
+    value. It registers an offense under these conditions:
   Enabled: true
   VersionAdded: '0.30'
 
 Lint/NumberConversion:
-  Description: 'Checks unsafe usage of number conversion methods.'
+  Description: |-
+    This cop warns the usage of unsafe number conversions. Unsafe
+    number conversion can cause unexpected error if auto type conversion
+    fails. Cop prefer parsing with number class instead.
   Enabled: false
   VersionAdded: '0.53'
 
 Lint/OrderedMagicComments:
-  Description: 'Checks the proper ordering of magic comments and whether a magic comment is not placed before a shebang.'
+  Description: |-
+    Checks the proper ordering of magic comments and whether
+    a magic comment is not placed before a shebang.
   Enabled: true
   VersionAdded: '0.53'
 
 Lint/ParenthesesAsGroupedExpression:
-  Description: >-
-                 Checks for method calls with a space before the opening
-                 parenthesis.
-  StyleGuide: '#parens-no-spaces'
+  Description: |-
+    Checks for space between the name of a called method and a left
+    parenthesis.
+  StyleGuide: "#parens-no-spaces"
   Enabled: true
   VersionAdded: '0.12'
 
 Lint/PercentStringArray:
-  Description: >-
-                 Checks for unwanted commas and quotes in %w/%W literals.
+  Description: This cop checks for quotes and commas in %w, e.g. `%w('foo', "bar")`
   Enabled: true
   VersionAdded: '0.41'
 
 Lint/PercentSymbolArray:
-  Description: >-
-                 Checks for unwanted commas and colons in %i/%I literals.
+  Description: This cop checks for colons and commas in %i, e.g. `%i(:foo, :bar)`
   Enabled: true
   VersionAdded: '0.41'
 
 Lint/RandOne:
-  Description: >-
-                 Checks for `rand(1)` calls. Such calls always return `0`
-                 and most likely a mistake.
+  Description: |-
+    This cop checks for `rand(1)` calls.
+    Such calls always return `0`.
   Enabled: true
   VersionAdded: '0.36'
 
 Lint/RedundantWithIndex:
-  Description: 'Checks for redundant `with_index`.'
+  Description: This cop checks for redundant `with_index`.
   Enabled: true
   VersionAdded: '0.50'
 
 Lint/RedundantWithObject:
-  Description: 'Checks for redundant `with_object`.'
+  Description: This cop checks for redundant `with_object`.
   Enabled: true
   VersionAdded: '0.51'
 
 Lint/RegexpAsCondition:
-  Description: >-
-                 Do not use regexp literal as a condition.
-                 The regexp literal matches `$_` implicitly.
+  Description: |-
+    This cop checks for regexp literals used as `match-current-line`.
+    If a regexp literal is in condition, the regexp matches `$_` implicitly.
   Enabled: true
   VersionAdded: '0.51'
 
 Lint/RequireParentheses:
-  Description: >-
-                 Use parentheses in the method call to avoid confusion
-                 about precedence.
+  Description: |-
+    This cop checks for expressions where there is a call to a predicate
+    method with at least one argument, where no parentheses are used around
+    the parameter list, and a boolean operator, && or ||, is used in the
+    last argument.
   Enabled: true
   VersionAdded: '0.18'
 
 Lint/RescueException:
-  Description: 'Avoid rescuing the Exception class.'
-  StyleGuide: '#no-blind-rescues'
+  Description: This cop checks for *rescue* blocks targeting the Exception class.
+  StyleGuide: "#no-blind-rescues"
   Enabled: true
   VersionAdded: '0.9'
-  VersionChanged: '0.27.1'
+  VersionChanged: 0.27.1
 
 Lint/RescueType:
-  Description: 'Avoid rescuing from non constants that could result in a `TypeError`.'
+  Description: |-
+    Check for arguments to `rescue` that will result in a `TypeError`
+    if an exception is raised.
   Enabled: true
   VersionAdded: '0.49'
 
 Lint/ReturnInVoidContext:
-  Description: 'Checks for return in void context.'
+  Description: |-
+    This cop checks for the use of a return with a value in a context
+    where the value will be ignored. (initialize and setter methods)
   Enabled: true
   VersionAdded: '0.50'
 
 Lint/SafeNavigationChain:
-  Description: 'Do not chain ordinary method call after safe navigation operator.'
+  Description: |-
+    The safe navigation operator returns nil if the receiver is
+    nil. If you chain an ordinary method call after a safe
+    navigation operator, it raises NoMethodError. We should use a
+    safe navigation operator after a safe navigation operator.
+    This cop checks for the problem outlined above.
   Enabled: true
   VersionAdded: '0.47'
   VersionChanged: '0.56'
   Whitelist:
-    - present?
-    - blank?
-    - presence
-    - try
-    - try!
+  - present?
+  - blank?
+  - presence
+  - try
+  - try!
 
 Lint/SafeNavigationConsistency:
-  Description: >-
-                 Check to make sure that if safe navigation is used for a method
-                 call in an `&&` or `||` condition that safe navigation is used
-                 for all method calls on that same object.
+  Description: |-
+    This cop check to make sure that if safe navigation is used for a method
+    call in an `&&` or `||` condition that safe navigation is used for all
+    method calls on that same object.
   Enabled: true
   VersionAdded: '0.55'
   Whitelist:
-    - present?
-    - blank?
-    - presence
-    - try
-    - try!
-
+  - present?
+  - blank?
+  - presence
+  - try
+  - try!
 
 Lint/ScriptPermission:
-  Description: 'Grant script file execute permission.'
+  Description: |-
+    This cop checks if a file which has a shebang line as
+    its first line is granted execute permission.
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.50'
 
 Lint/ShadowedArgument:
-  Description: 'Avoid reassigning arguments before they were used.'
+  Description: This cop checks for shadowed arguments.
   Enabled: true
   VersionAdded: '0.52'
   IgnoreImplicitReferences: false
 
-
 Lint/ShadowedException:
-  Description: >-
-                  Avoid rescuing a higher level exception
-                  before a lower level exception.
+  Description: |-
+    This cop checks for a rescued exception that get shadowed by a
+    less specific exception being rescued before a more specific
+    exception is rescued.
   Enabled: true
   VersionAdded: '0.41'
 
 Lint/ShadowingOuterLocalVariable:
-  Description: >-
-                 Do not use the same name as outer local variable
-                 for block arguments or block local variables.
+  Description: |-
+    This cop looks for use of the same name as outer local variables
+    for block arguments or block local variables.
+    This is a mimic of the warning
+    "shadowing outer local variable - foo" from `ruby -cw`.
   Enabled: true
   VersionAdded: '0.9'
 
 Lint/StringConversionInInterpolation:
-  Description: 'Checks for Object#to_s usage in string interpolation.'
-  StyleGuide: '#no-to-s'
+  Description: |-
+    This cop checks for string conversion in string interpolation,
+    which is redundant.
+  StyleGuide: "#no-to-s"
   Enabled: true
   VersionAdded: '0.19'
   VersionChanged: '0.20'
 
 Lint/Syntax:
-  Description: 'Checks syntax error'
+  Description: |-
+    This is not actually a cop. It does not inspect anything. It just
+    provides methods to repack Parser's diagnostics/errors
+    into RuboCop's offenses.
   Enabled: true
   VersionAdded: '0.9'
 
-
 Lint/UnderscorePrefixedVariableName:
-  Description: 'Do not use prefix `_` for a variable that is used.'
+  Description: |-
+    This cop checks for underscore-prefixed variables that are actually
+    used.
   Enabled: true
   VersionAdded: '0.21'
 
 Lint/UnifiedInteger:
-  Description: 'Use Integer instead of Fixnum or Bignum'
+  Description: This cop checks for using Fixnum or Bignum constant.
   Enabled: true
   VersionAdded: '0.43'
 
 Lint/UnneededCopDisableDirective:
-  Description: >-
-                 Checks for rubocop:disable comments that can be removed.
-                 Note: this cop is not disabled when disabling all cops.
-                 It must be explicitly disabled.
+  Description: |-
+    This cop detects instances of rubocop:disable comments that can be
+    removed without causing any offenses to be reported. It's implemented
+    as a cop in that it inherits from the Cop base class and calls
+    add_offense. The unusual part of its implementation is that it doesn't
+    have any on_* methods or an investigate method. This means that it
+    doesn't take part in the investigation phase when the other cops do
+    their work. Instead, it waits until it's called in a later stage of the
+    execution. The reason it can't be implemented as a normal cop is that
+    it depends on the results of all other cops to do its work.
   Enabled: true
   VersionAdded: '0.53'
 
 Lint/UnneededCopEnableDirective:
-  Description: Checks for rubocop:enable comments that can be removed.
+  Description: |-
+    This cop detects instances of rubocop:enable comments that can be
+    removed.
   Enabled: true
   VersionAdded: '0.53'
 
 Lint/UnneededRequireStatement:
-  Description: 'Checks for unnecessary `require` statement.'
+  Description: Checks for unnecessary `require` statement.
   Enabled: true
   VersionAdded: '0.51'
 
 Lint/UnneededSplatExpansion:
-  Description: 'Checks for splat unnecessarily being called on literals'
+  Description: This cop checks for unneeded usages of splat expansion
   Enabled: true
   VersionAdded: '0.43'
 
 Lint/UnreachableCode:
-  Description: 'Unreachable code.'
+  Description: |-
+    This cop checks for unreachable code.
+    The check are based on the presence of flow of control
+    statement in non-final position in *begin*(implicit) blocks.
   Enabled: true
   VersionAdded: '0.9'
 
 Lint/UnusedBlockArgument:
-  Description: 'Checks for unused block arguments.'
-  StyleGuide: '#underscore-unused-vars'
+  Description: This cop checks for unused block arguments.
+  StyleGuide: "#underscore-unused-vars"
   Enabled: true
   VersionAdded: '0.21'
   VersionChanged: '0.22'
@@ -1567,8 +1469,8 @@ Lint/UnusedBlockArgument:
   AllowUnusedKeywordArguments: false
 
 Lint/UnusedMethodArgument:
-  Description: 'Checks for unused method arguments.'
-  StyleGuide: '#underscore-unused-vars'
+  Description: This cop checks for unused method arguments.
+  StyleGuide: "#underscore-unused-vars"
   Enabled: true
   VersionAdded: '0.21'
   VersionChanged: '0.35'
@@ -1576,23 +1478,30 @@ Lint/UnusedMethodArgument:
   IgnoreEmptyMethods: true
 
 Lint/UriEscapeUnescape:
-  Description: >-
-                 `URI.escape` method is obsolete and should not be used. Instead, use
-                 `CGI.escape`, `URI.encode_www_form` or `URI.encode_www_form_component`
-                 depending on your specific use case.
-                 Also `URI.unescape` method is obsolete and should not be used. Instead, use
-                 `CGI.unescape`, `URI.decode_www_form` or `URI.decode_www_form_component`
-                 depending on your specific use case.
+  Description: |-
+    This cop identifies places where `URI.escape` can be replaced by
+    `CGI.escape`, `URI.encode_www_form`, or `URI.encode_www_form_component`
+    depending on your specific use case.
+    Also this cop identifies places where `URI.unescape` can be replaced by
+    `CGI.unescape`, `URI.decode_www_form`,
+    or `URI.decode_www_form_component` depending on your specific use case.
   Enabled: true
   VersionAdded: '0.50'
 
 Lint/UriRegexp:
-  Description: 'Use `URI::DEFAULT_PARSER.make_regexp` instead of `URI.regexp`.'
+  Description: |-
+    This cop identifies places where `URI.regexp` is obsolete and should
+    not be used. Instead, use `URI::DEFAULT_PARSER.make_regexp`.
   Enabled: true
   VersionAdded: '0.50'
 
 Lint/UselessAccessModifier:
-  Description: 'Checks for useless access modifiers.'
+  Description: |-
+    This cop checks for redundant access modifiers, including those with no
+    code, those which are repeated, and leading `public` modifiers in a
+    class or module body. Conditionally-defined methods are considered as
+    always being defined, and thus access modifiers guarding such methods
+    are not redundant.
   Enabled: true
   VersionAdded: '0.20'
   VersionChanged: '0.47'
@@ -1600,60 +1509,68 @@ Lint/UselessAccessModifier:
   MethodCreatingMethods: []
 
 Lint/UselessAssignment:
-  Description: 'Checks for useless assignment to a local variable.'
-  StyleGuide: '#underscore-unused-vars'
+  Description: |-
+    This cop checks for every useless assignment to local variable in every
+    scope.
+    The basic idea for this cop was from the warning of `ruby -cw`:
+  StyleGuide: "#underscore-unused-vars"
   Enabled: true
   VersionAdded: '0.11'
 
 Lint/UselessComparison:
-  Description: 'Checks for comparison of something with itself.'
+  Description: This cop checks for comparison of something with itself.
   Enabled: true
   VersionAdded: '0.11'
 
 Lint/UselessElseWithoutRescue:
-  Description: 'Checks for useless `else` in `begin..end` without `rescue`.'
+  Description: This cop checks for useless `else` in `begin..end` without `rescue`.
   Enabled: true
   VersionAdded: '0.17'
 
 Lint/UselessSetterCall:
-  Description: 'Checks for useless setter call to a local variable.'
+  Description: |-
+    This cop checks for setter call to local variable as the final
+    expression of a function definition.
   Enabled: true
   VersionAdded: '0.13'
 
 Lint/Void:
-  Description: 'Possible use of operator/literal/variable in void context.'
+  Description: |-
+    This cop checks for operators, variables, literals, and nonmutating
+    methods used in void context.
   Enabled: true
   VersionAdded: '0.9'
   CheckForMethodsWithNoSideEffects: false
 
-#################### Metrics ###############################
-
 Metrics/AbcSize:
-  Description: >-
-                 A calculated magnitude based on number of assignments,
-                 branches, and conditions.
-  Reference: 'http://c2.com/cgi/wiki?AbcMetric'
+  Description: |-
+    This cop checks that the ABC size of methods is not higher than the
+    configured maximum. The ABC size is based on assignments, branches
+    (method calls), and conditions. See http://c2.com/cgi/wiki?AbcMetric
+  Reference: http://c2.com/cgi/wiki?AbcMetric
   Enabled: true
   VersionAdded: '0.27'
-  # The ABC size is a calculated magnitude, so this number can be an Integer or
-  # a Float.
   Max: 15
 
 Metrics/BlockLength:
-  Description: 'Avoid long blocks with many lines.'
+  Description: |-
+    This cop checks if the length of a block exceeds some maximum value.
+    Comment lines can optionally be ignored.
+    The maximum allowed length is configurable.
+    The cop can be configured to ignore blocks passed to certain methods.
   Enabled: true
   VersionAdded: '0.44'
   VersionChanged: '0.58'
-  CountComments: false  # count full line comments?
+  CountComments: false
   Max: 25
   ExcludedMethods:
-    # By default, exclude the `#refine` method, as it tends to have larger
-    # associated blocks.
-    - refine
+  - refine
 
 Metrics/BlockNesting:
-  Description: 'Avoid excessive block nesting'
-  StyleGuide: '#three-is-the-number-thou-shalt-count'
+  Description: |-
+    This cop checks for excessive nesting of conditional and looping
+    constructs.
+  StyleGuide: "#three-is-the-number-thou-shalt-count"
   Enabled: true
   VersionAdded: '0.25'
   VersionChanged: '0.47'
@@ -1661,312 +1578,320 @@ Metrics/BlockNesting:
   Max: 3
 
 Metrics/ClassLength:
-  Description: 'Avoid classes longer than 100 lines of code.'
+  Description: |-
+    This cop checks if the length a class exceeds some maximum value.
+    Comment lines can optionally be ignored.
+    The maximum allowed length is configurable.
   Enabled: true
   VersionAdded: '0.25'
-  CountComments: false  # count full line comments?
+  CountComments: false
   Max: 100
 
-# Avoid complex methods.
 Metrics/CyclomaticComplexity:
-  Description: >-
-                 A complexity metric that is strongly correlated to the number
-                 of test cases needed to validate a method.
+  Description: |-
+    This cop checks that the cyclomatic complexity of methods is not higher
+    than the configured maximum. The cyclomatic complexity is the number of
+    linearly independent paths through a method. The algorithm counts
+    decision points and adds one.
   Enabled: true
   VersionAdded: '0.25'
   Max: 6
 
 Metrics/LineLength:
-  Description: 'Limit lines to 80 characters.'
-  StyleGuide: '#80-character-limits'
+  Description: |-
+    This cop checks the length of lines in the source code.
+    The maximum length is configurable.
+    The tab size is configured in the `IndentationWidth`
+    of the `Layout/Tab` cop.
+  StyleGuide: "#80-character-limits"
   Enabled: true
   VersionAdded: '0.25'
   VersionChanged: '0.46'
   Max: 80
-  # To make it possible to copy or click on URIs in the code, we allow lines
-  # containing a URI to be longer than Max.
   AllowHeredoc: true
   AllowURI: true
   URISchemes:
-    - http
-    - https
-  # The IgnoreCopDirectives option causes the LineLength rule to ignore cop
-  # directives like '# rubocop: enable ...' when calculating a line's length.
+  - http
+  - https
   IgnoreCopDirectives: false
-  # The IgnoredPatterns option is a list of !ruby/regexp and/or string
-  # elements. Strings will be converted to Regexp objects. A line that matches
-  # any regular expression listed in this option will be ignored by LineLength.
   IgnoredPatterns: []
 
 Metrics/MethodLength:
-  Description: 'Avoid methods longer than 10 lines of code.'
-  StyleGuide: '#short-methods'
+  Description: |-
+    This cop checks if the length of a method exceeds some maximum value.
+    Comment lines can optionally be ignored.
+    The maximum allowed length is configurable.
+  StyleGuide: "#short-methods"
   Enabled: true
   VersionAdded: '0.25'
-  VersionChanged: '0.59.2'
-  CountComments: false  # count full line comments?
+  VersionChanged: 0.59.2
+  CountComments: false
   Max: 10
   ExcludedMethods: []
 
 Metrics/ModuleLength:
-  Description: 'Avoid modules longer than 100 lines of code.'
+  Description: |-
+    This cop checks if the length a module exceeds some maximum value.
+    Comment lines can optionally be ignored.
+    The maximum allowed length is configurable.
   Enabled: true
   VersionAdded: '0.31'
-  CountComments: false  # count full line comments?
+  CountComments: false
   Max: 100
 
 Metrics/ParameterLists:
-  Description: 'Avoid parameter lists longer than three or four parameters.'
-  StyleGuide: '#too-many-params'
+  Description: |-
+    This cop checks for methods with too many parameters.
+    The maximum number of parameters is configurable.
+    Keyword arguments can optionally be excluded from the total count.
+  StyleGuide: "#too-many-params"
   Enabled: true
   VersionAdded: '0.25'
   Max: 5
   CountKeywordArgs: true
 
 Metrics/PerceivedComplexity:
-  Description: >-
-                 A complexity metric geared towards measuring complexity for a
-                 human reader.
+  Description: |-
+    This cop tries to produce a complexity score that's a measure of the
+    complexity the reader experiences when looking at a method. For that
+    reason it considers `when` nodes as something that doesn't add as much
+    complexity as an `if` or a `&&`. Except if it's one of those special
+    `case`/`when` constructs where there's no expression after `case`. Then
+    the cop treats it as an `if`/`elsif`/`elsif`... and lets all the `when`
+    nodes count. In contrast to the CyclomaticComplexity cop, this cop
+    considers `else` nodes as adding complexity.
   Enabled: true
   VersionAdded: '0.25'
   Max: 7
 
-#################### Naming ##############################
-
 Naming/AccessorMethodName:
-  Description: Check the naming of accessor methods for get_/set_.
-  StyleGuide: '#accessor_mutator_method_names'
+  Description: This cop makes sure that accessor methods are named properly.
+  StyleGuide: "#accessor_mutator_method_names"
   Enabled: true
   VersionAdded: '0.50'
 
 Naming/AsciiIdentifiers:
-  Description: 'Use only ascii symbols in identifiers.'
-  StyleGuide: '#english-identifiers'
+  Description: This cop checks for non-ascii characters in identifier names.
+  StyleGuide: "#english-identifiers"
   Enabled: true
   VersionAdded: '0.50'
 
 Naming/BinaryOperatorParameterName:
-  Description: 'When defining binary operators, name the argument other.'
-  StyleGuide: '#other-arg'
+  Description: |-
+    This cop makes sure that certain binary operator methods have their
+    sole  parameter named `other`.
+  StyleGuide: "#other-arg"
   Enabled: true
   VersionAdded: '0.50'
 
 Naming/ClassAndModuleCamelCase:
-  Description: 'Use CamelCase for classes and modules.'
-  StyleGuide: '#camelcase-classes'
+  Description: |-
+    This cop checks for class and module names with
+    an underscore in them.
+  StyleGuide: "#camelcase-classes"
   Enabled: true
   VersionAdded: '0.50'
 
 Naming/ConstantName:
-  Description: 'Constants should use SCREAMING_SNAKE_CASE.'
-  StyleGuide: '#screaming-snake-case'
+  Description: |-
+    This cop checks whether constant names are written using
+    SCREAMING_SNAKE_CASE.
+  StyleGuide: "#screaming-snake-case"
   Enabled: true
   VersionAdded: '0.50'
 
 Naming/FileName:
-  Description: 'Use snake_case for source file names.'
-  StyleGuide: '#snake-case-files'
+  Description: |-
+    This cop makes sure that Ruby source files have snake_case
+    names. Ruby scripts (i.e. source files with a shebang in the
+    first line) are ignored.
+  StyleGuide: "#snake-case-files"
   Enabled: true
   VersionAdded: '0.50'
-  # Camel case file names listed in `AllCops:Include` and all file names listed
-  # in `AllCops:Exclude` are excluded by default. Add extra excludes here.
   Exclude: []
-  # When `true`, requires that each source file should define a class or module
-  # with a name which matches the file name (converted to ... case).
-  # It further expects it to be nested inside modules which match the names
-  # of subdirectories in its path.
   ExpectMatchingDefinition: false
-  # If non-`nil`, expect all source file names to match the following regex.
-  # Only the file name itself is matched, not the entire file path.
-  # Use anchors as necessary if you want to match the entire name rather than
-  # just a part of it.
-  Regex: ~
-  # With `IgnoreExecutableScripts` set to `true`, this cop does not
-  # report offending filenames for executable scripts (i.e. source
-  # files with a shebang in the first line).
+  Regex:
   IgnoreExecutableScripts: true
   AllowedAcronyms:
-    - CLI
-    - DSL
-    - ACL
-    - API
-    - ASCII
-    - CPU
-    - CSS
-    - DNS
-    - EOF
-    - GUID
-    - HTML
-    - HTTP
-    - HTTPS
-    - ID
-    - IP
-    - JSON
-    - LHS
-    - QPS
-    - RAM
-    - RHS
-    - RPC
-    - SLA
-    - SMTP
-    - SQL
-    - SSH
-    - TCP
-    - TLS
-    - TTL
-    - UDP
-    - UI
-    - UID
-    - UUID
-    - URI
-    - URL
-    - UTF8
-    - VM
-    - XML
-    - XMPP
-    - XSRF
-    - XSS
+  - CLI
+  - DSL
+  - ACL
+  - API
+  - ASCII
+  - CPU
+  - CSS
+  - DNS
+  - EOF
+  - GUID
+  - HTML
+  - HTTP
+  - HTTPS
+  - ID
+  - IP
+  - JSON
+  - LHS
+  - QPS
+  - RAM
+  - RHS
+  - RPC
+  - SLA
+  - SMTP
+  - SQL
+  - SSH
+  - TCP
+  - TLS
+  - TTL
+  - UDP
+  - UI
+  - UID
+  - UUID
+  - URI
+  - URL
+  - UTF8
+  - VM
+  - XML
+  - XMPP
+  - XSRF
+  - XSS
 
 Naming/HeredocDelimiterCase:
-  Description: 'Use configured case for heredoc delimiters.'
-  StyleGuide: '#heredoc-delimiters'
+  Description: |-
+    This cop checks that your heredocs are using the configured case.
+    By default it is configured to enforce uppercase heredocs.
+  StyleGuide: "#heredoc-delimiters"
   Enabled: true
   VersionAdded: '0.50'
   EnforcedStyle: uppercase
   SupportedStyles:
-    - lowercase
-    - uppercase
+  - lowercase
+  - uppercase
 
 Naming/HeredocDelimiterNaming:
-  Description: 'Use descriptive heredoc delimiters.'
-  StyleGuide: '#heredoc-delimiters'
+  Description: |-
+    This cop checks that your heredocs are using meaningful delimiters.
+    By default it disallows `END` and `EO*`, and can be configured through
+    blacklisting additional delimiters.
+  StyleGuide: "#heredoc-delimiters"
   Enabled: true
   VersionAdded: '0.50'
   Blacklist:
-    - !ruby/regexp '/(^|\s)(EO[A-Z]{1}|END)(\s|$)/'
+  - !ruby/regexp /(^|\s)(EO[A-Z]{1}|END)(\s|$)/
 
 Naming/MemoizedInstanceVariableName:
-  Description: >-
-    Memoized method name should match memo instance variable name.
+  Description: |-
+    This cop checks for memoized methods whose instance variable name
+    does not match the method name.
   Enabled: true
   VersionAdded: '0.53'
   VersionChanged: '0.58'
   EnforcedStyleForLeadingUnderscores: disallowed
   SupportedStylesForLeadingUnderscores:
-    - disallowed
-    - required
-    - optional
+  - disallowed
+  - required
+  - optional
 
 Naming/MethodName:
-  Description: 'Use the configured style when naming methods.'
-  StyleGuide: '#snake-case-symbols-methods-vars'
+  Description: |-
+    This cop makes sure that all methods use the configured style,
+    snake_case or camelCase, for their names.
+  StyleGuide: "#snake-case-symbols-methods-vars"
   Enabled: true
   VersionAdded: '0.50'
   EnforcedStyle: snake_case
   SupportedStyles:
-    - snake_case
-    - camelCase
+  - snake_case
+  - camelCase
 
 Naming/PredicateName:
-  Description: 'Check the names of predicate methods.'
-  StyleGuide: '#bool-methods-qmark'
+  Description: This cop makes sure that predicates are named properly.
+  StyleGuide: "#bool-methods-qmark"
   Enabled: true
   VersionAdded: '0.50'
   VersionChanged: '0.51'
-  # Predicate name prefixes.
   NamePrefix:
-    - is_
-    - has_
-    - have_
-  # Predicate name prefixes that should be removed.
+  - is_
+  - has_
+  - have_
   NamePrefixBlacklist:
-    - is_
-    - has_
-    - have_
-  # Predicate names which, despite having a blacklisted prefix, or no `?`,
-  # should still be accepted
+  - is_
+  - has_
+  - have_
   NameWhitelist:
-    - is_a?
-  # Method definition macros for dynamically generated methods.
+  - is_a?
   MethodDefinitionMacros:
-    - define_method
-    - define_singleton_method
-  # Exclude Rspec specs because there is a strong convention to write spec
-  # helpers in the form of `have_something` or `be_something`.
+  - define_method
+  - define_singleton_method
   Exclude:
-    - 'spec/**/*'
+  - spec/**/*
 
 Naming/UncommunicativeBlockParamName:
-  Description: >-
-                Checks for block parameter names that contain capital letters,
-                end in numbers, or do not meet a minimal length.
+  Description: |-
+    This cop checks block parameter names for how descriptive they
+    are. It is highly configurable.
   Enabled: true
   VersionAdded: '0.53'
-  # Parameter names may be equal to or greater than this value
   MinNameLength: 1
   AllowNamesEndingInNumbers: true
-  # Whitelisted names that will not register an offense
   AllowedNames: []
-  # Blacklisted names that will register an offense
   ForbiddenNames: []
 
 Naming/UncommunicativeMethodParamName:
-  Description: >-
-                Checks for method parameter names that contain capital letters,
-                end in numbers, or do not meet a minimal length.
+  Description: |-
+    This cop checks method parameter names for how descriptive they
+    are. It is highly configurable.
   Enabled: true
   VersionAdded: '0.53'
   VersionChanged: '0.59'
-  # Parameter names may be equal to or greater than this value
   MinNameLength: 3
   AllowNamesEndingInNumbers: true
-  # Whitelisted names that will not register an offense
   AllowedNames:
-    - io
-    - id
-    - to
-    - by
-    - 'on'
-    - in
-    - at
-    - ip
-    - db
-  # Blacklisted names that will register an offense
+  - io
+  - id
+  - to
+  - by
+  - 'on'
+  - in
+  - at
+  - ip
+  - db
   ForbiddenNames: []
 
-
 Naming/VariableName:
-  Description: 'Use the configured style when naming variables.'
-  StyleGuide: '#snake-case-symbols-methods-vars'
+  Description: |-
+    This cop makes sure that all variables use the configured style,
+    snake_case or camelCase, for their names.
+  StyleGuide: "#snake-case-symbols-methods-vars"
   Enabled: true
   VersionAdded: '0.50'
   EnforcedStyle: snake_case
   SupportedStyles:
-    - snake_case
-    - camelCase
+  - snake_case
+  - camelCase
 
 Naming/VariableNumber:
-  Description: 'Use the configured style when numbering variables.'
+  Description: |-
+    This cop makes sure that all numbered variables use the
+    configured style, snake_case, normalcase, or non_integer,
+    for their numbering.
   Enabled: true
   VersionAdded: '0.50'
   EnforcedStyle: normalcase
   SupportedStyles:
-    - snake_case
-    - normalcase
-    - non_integer
-
-#################### Performance ###########################
+  - snake_case
+  - normalcase
+  - non_integer
 
 Performance/Caller:
-  Description: >-
-             Use `caller(n..n)` instead of `caller`.
+  Description: |-
+    This cop identifies places where `caller[n]`
+    can be replaced by `caller(n..n).first`.
   Enabled: true
   VersionAdded: '0.49'
 
 Performance/CaseWhenSplat:
-  Description: >-
-                 Reordering `when` conditions with a splat to the end
-                 of the `when` branches can improve performance.
+  Description: |-
+    Reordering `when` conditions with a splat to the end
+    of the `when` branches can improve performance.
   Enabled: false
   AutoCorrect: false
   SafeAutoCorrect: false
@@ -1974,70 +1899,67 @@ Performance/CaseWhenSplat:
   VersionChanged: '0.59'
 
 Performance/Casecmp:
-  Description: >-
-             Use `casecmp` rather than `downcase ==`, `upcase ==`, `== downcase`, or `== upcase`..
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringcasecmp-vs-stringdowncase---code'
+  Description: |-
+    This cop identifies places where a case-insensitive string comparison
+    can better be implemented using `casecmp`.
+  Reference: https://github.com/JuanitoFatas/fast-ruby#stringcasecmp-vs-stringdowncase---code
   Enabled: true
   VersionAdded: '0.36'
 
 Performance/ChainArrayAllocation:
-  Description: >-
-                  Instead of chaining array methods that allocate new arrays, mutate an
-                  existing array.
-  Reference: 'https://twitter.com/schneems/status/1034123879978029057'
+  Description: |-
+    This cop is used to identify usages of
+    Each of these methods (`compact`, `flatten`, `map`) will generate a
+    new intermediate array that is promptly thrown away. Instead it is
+    faster to mutate when we know it's safe.
+  Reference: https://twitter.com/schneems/status/1034123879978029057
   Enabled: false
   VersionAdded: '0.59'
 
 Performance/CompareWithBlock:
-  Description: 'Use `sort_by(&:foo)` instead of `sort { |a, b| a.foo <=> b.foo }`.'
+  Description: |-
+    This cop identifies places where `sort { |a, b| a.foo <=> b.foo }`
+    can be replaced by `sort_by(&:foo)`.
+    This cop also checks `max` and `min` methods.
   Enabled: true
   VersionAdded: '0.46'
 
 Performance/Count:
-  Description: >-
-                  Use `count` instead of `select...size`, `reject...size`,
-                  `select...count`, `reject...count`, `select...length`,
-                  and `reject...length`.
-  # This cop has known compatibility issues with `ActiveRecord` and other
-  # frameworks. ActiveRecord's `count` ignores the block that is passed to it.
-  # For more information, see the documentation in the cop itself.
-  # If you understand the known risk, you can disable `SafeMode`.
+  Description: |-
+    This cop is used to identify usages of `count` on an `Enumerable` that
+    follow calls to `select` or `reject`. Querying logic can instead be
+    passed to the `count` call.
   SafeMode: true
   Enabled: true
   VersionAdded: '0.31'
   VersionChanged: '0.39'
 
 Performance/Detect:
-  Description: >-
-                  Use `detect` instead of `select.first`, `find_all.first`,
-                  `select.last`, and `find_all.last`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerabledetect-vs-enumerableselectfirst-code'
-  # This cop has known compatibility issues with `ActiveRecord` and other
-  # frameworks. `ActiveRecord` does not implement a `detect` method and `find`
-  # has its own meaning. Correcting `ActiveRecord` methods with this cop
-  # should be considered unsafe.
+  Description: |-
+    This cop is used to identify usages of
+    `select.first`, `select.last`, `find_all.first`, and `find_all.last`
+    and change them to use `detect` instead.
+  Reference: https://github.com/JuanitoFatas/fast-ruby#enumerabledetect-vs-enumerableselectfirst-code
   SafeMode: true
   Enabled: true
   VersionAdded: '0.30'
   VersionChanged: '0.39'
 
 Performance/DoubleStartEndWith:
-  Description: >-
-                  Use `str.{start,end}_with?(x, ..., y, ...)`
-                  instead of `str.{start,end}_with?(x, ...) || str.{start,end}_with?(y, ...)`.
+  Description: |-
+    This cop checks for double `#start_with?` or `#end_with?` calls
+    separated by `||`. In some cases such calls can be replaced
+    with an single `#start_with?`/`#end_with?` call.
   Enabled: true
   VersionAdded: '0.36'
   VersionChanged: '0.48'
-  # Used to check for `starts_with?` and `ends_with?`.
-  # These methods are defined by `ActiveSupport`.
   IncludeActiveSupportAliases: false
 
 Performance/EndWith:
-  Description: 'Use `end_with?` instead of a regex match anchored to the end of a string.'
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringmatch-vs-stringstart_withstringend_with-code-start-code-end'
-  # This will change to a new method call which isn't guaranteed to be on the
-  # object. Switching these methods has to be done with knowledge of the types
-  # of the variables which rubocop doesn't have.
+  Description: |-
+    This cop identifies unnecessary use of a regex where `String#end_with?`
+    would suffice.
+  Reference: https://github.com/JuanitoFatas/fast-ruby#stringmatch-vs-stringstart_withstringend_with-code-start-code-end
   SafeAutoCorrect: false
   AutoCorrect: false
   Enabled: true
@@ -2045,111 +1967,131 @@ Performance/EndWith:
   VersionChanged: '0.44'
 
 Performance/FixedSize:
-  Description: 'Do not compute the size of statically sized objects except in constants'
+  Description: Do not compute the size of statically sized objects.
   Enabled: true
   VersionAdded: '0.35'
 
 Performance/FlatMap:
-  Description: >-
-                  Use `Enumerable#flat_map`
-                  instead of `Enumerable#map...Array#flatten(1)`
-                  or `Enumberable#collect..Array#flatten(1)`
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablemaparrayflatten-vs-enumerableflat_map-code'
+  Description: This cop is used to identify usages of
+  Reference: https://github.com/JuanitoFatas/fast-ruby#enumerablemaparrayflatten-vs-enumerableflat_map-code
   Enabled: true
   VersionAdded: '0.30'
   EnabledForFlattenWithoutParams: false
-  # If enabled, this cop will warn about usages of
-  # `flatten` being called without any parameters.
-  # This can be dangerous since `flat_map` will only flatten 1 level, and
-  # `flatten` without any parameters can flatten multiple levels.
 
 Performance/InefficientHashSearch:
-  Description: 'Use `key?` or `value?` instead of `keys.include?` or `values.include?`'
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#hashkey-instead-of-hashkeysinclude-code'
+  Description: |-
+    This cop checks for inefficient searching of keys and values within
+    hashes.
+  Reference: https://github.com/JuanitoFatas/fast-ruby#hashkey-instead-of-hashkeysinclude-code
   Enabled: true
   VersionAdded: '0.56'
   Safe: false
 
 Performance/LstripRstrip:
-  Description: 'Use `strip` instead of `lstrip.rstrip`.'
+  Description: |-
+    This cop identifies places where `lstrip.rstrip` can be replaced by
+    `strip`.
   Enabled: true
   VersionAdded: '0.36'
 
 Performance/OpenStruct:
-  Description: 'Use `Struct` instead of `OpenStruct`.'
+  Description: |-
+    This cop checks for `OpenStruct.new` calls.
+    Instantiation of an `OpenStruct` invalidates
+    Ruby global method cache as it causes dynamic method
+    definition during program runtime.
+    This could have an effect on performance,
+    especially in case of single-threaded
+    applications with multiple `OpenStruct` instantiations.
   Enabled: false
   VersionAdded: '0.61'
   Safe: false
 
 Performance/RangeInclude:
-  Description: 'Use `Range#cover?` instead of `Range#include?`.'
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#cover-vs-include-code'
+  Description: |-
+    This cop identifies uses of `Range#include?`, which iterates over each
+    item in a `Range` to see if a specified item is there. In contrast,
+    `Range#cover?` simply compares the target item with the beginning and
+    end points of the `Range`. In a great majority of cases, this is what
+    is wanted.
+  Reference: https://github.com/JuanitoFatas/fast-ruby#cover-vs-include-code
   Enabled: true
   VersionAdded: '0.36'
   Safe: false
 
 Performance/RedundantBlockCall:
-  Description: 'Use `yield` instead of `block.call`.'
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#proccall-and-block-arguments-vs-yieldcode'
+  Description: |-
+    This cop identifies the use of a `&block` parameter and `block.call`
+    where `yield` would do just as well.
+  Reference: https://github.com/JuanitoFatas/fast-ruby#proccall-and-block-arguments-vs-yieldcode
   Enabled: true
   VersionAdded: '0.36'
 
 Performance/RedundantMatch:
-  Description: >-
-                  Use `=~` instead of `String#match` or `Regexp#match` in a context where the
-                  returned `MatchData` is not needed.
+  Description: |-
+    This cop identifies the use of `Regexp#match` or `String#match`, which
+    returns `#<MatchData>`/`nil`. The return value of `=~` is an integral
+    index/`nil` and is more performant.
   Enabled: true
   VersionAdded: '0.36'
 
 Performance/RedundantMerge:
-  Description: 'Use Hash#[]=, rather than Hash#merge! with a single key-value pair.'
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#hashmerge-vs-hash-code'
+  Description: |-
+    This cop identifies places where `Hash#merge!` can be replaced by
+    `Hash#[]=`.
+  Reference: https://github.com/JuanitoFatas/fast-ruby#hashmerge-vs-hash-code
   Enabled: true
   VersionAdded: '0.36'
-  # Max number of key-value pairs to consider an offense
   MaxKeyValuePairs: 2
 
 Performance/RedundantSortBy:
-  Description: 'Use `sort` instead of `sort_by { |x| x }`.'
+  Description: |-
+    This cop identifies places where `sort_by { ... }` can be replaced by
+    `sort`.
   Enabled: true
   VersionAdded: '0.36'
 
 Performance/RegexpMatch:
-  Description: >-
-                  Use `match?` instead of `Regexp#match`, `String#match`, `Symbol#match`,
-                  `Regexp#===`, or `=~` when `MatchData` is not used.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#regexp-vs-stringmatch-vs-string-vs-stringmatch-code-'
+  Description: |-
+    In Ruby 2.4, `String#match?`, `Regexp#match?`, and `Symbol#match?`
+    have been added. The methods are faster than `match`.
+    Because the methods avoid creating a `MatchData` object or saving
+    backref.
+    So, when `MatchData` is not used, use `match?` instead of `match`.
+  Reference: https://github.com/JuanitoFatas/fast-ruby#regexp-vs-stringmatch-vs-string-vs-stringmatch-code-
   Enabled: true
   VersionAdded: '0.47'
 
 Performance/ReverseEach:
-  Description: 'Use `reverse_each` instead of `reverse.each`.'
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
+  Description: |-
+    This cop is used to identify usages of `reverse.each` and
+    change them to use `reverse_each` instead.
+  Reference: https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code
   Enabled: true
   VersionAdded: '0.30'
 
 Performance/Sample:
-  Description: >-
-                  Use `sample` instead of `shuffle.first`,
-                  `shuffle.last`, and `shuffle[Integer]`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
+  Description: |-
+    This cop is used to identify usages of `shuffle.first`,
+    `shuffle.last`, and `shuffle[]` and change them to use
+    `sample` instead.
+  Reference: https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code
   Enabled: true
   VersionAdded: '0.30'
 
 Performance/Size:
-  Description: >-
-                  Use `size` instead of `count` for counting
-                  the number of elements in `Array` and `Hash`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arraylength-vs-arraysize-vs-arraycount-code'
+  Description: |-
+    This cop is used to identify usages of `count` on an
+    `Array` and `Hash` and change them to `size`.
+  Reference: https://github.com/JuanitoFatas/fast-ruby#arraylength-vs-arraysize-vs-arraycount-code
   Enabled: true
   VersionAdded: '0.30'
 
 Performance/StartWith:
-  Description: 'Use `start_with?` instead of a regex match anchored to the beginning of a string.'
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringmatch-vs-stringstart_withstringend_with-code-start-code-end'
-  # This will change to a new method call which isn't guaranteed to be on the
-  # object. Switching these methods has to be done with knowledge of the types
-  # of the variables which rubocop doesn't have.
+  Description: |-
+    This cop identifies unnecessary use of a regex where
+    `String#start_with?` would suffice.
+  Reference: https://github.com/JuanitoFatas/fast-ruby#stringmatch-vs-stringstart_withstringend_with-code-start-code-end
   SafeAutoCorrect: false
   AutoCorrect: false
   Enabled: true
@@ -2157,89 +2099,96 @@ Performance/StartWith:
   VersionChanged: '0.44'
 
 Performance/StringReplacement:
-  Description: >-
-                  Use `tr` instead of `gsub` when you are replacing the same
-                  number of characters. Use `delete` instead of `gsub` when
-                  you are deleting characters.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringgsub-vs-stringtr-code'
+  Description: |-
+    This cop identifies places where `gsub` can be replaced by
+    `tr` or `delete`.
+  Reference: https://github.com/JuanitoFatas/fast-ruby#stringgsub-vs-stringtr-code
   Enabled: true
   VersionAdded: '0.33'
 
 Performance/TimesMap:
-  Description: 'Checks for .times.map calls.'
+  Description: |-
+    This cop checks for .times.map calls.
+    In most cases such calls can be replaced
+    with an explicit array creation.
   AutoCorrect: false
   Enabled: true
   VersionAdded: '0.36'
   VersionChanged: '0.50'
-  SafeAutoCorrect: false # see https://github.com/rubocop-hq/rubocop/issues/4658
+  SafeAutoCorrect: false
 
 Performance/UnfreezeString:
-  Description: 'Use unary plus to get an unfrozen string literal.'
+  Description: |-
+    In Ruby 2.3 or later, use unary plus operator to unfreeze a string
+    literal instead of `String#dup` and `String.new`.
+    Unary plus operator is faster than `String#dup`.
   Enabled: true
   VersionAdded: '0.50'
 
 Performance/UnneededSort:
-  Description: >-
-                  Use `min` instead of `sort.first`,
-                  `max_by` instead of `sort_by...last`, etc.
+  Description: |-
+    This cop is used to identify instances of sorting and then
+    taking only the first or last element. The same behavior can
+    be accomplished without a relatively expensive sort by using
+    `Enumerable#min` instead of sorting and taking the first
+    element and `Enumerable#max` instead of sorting and taking the
+    last element. Similarly, `Enumerable#min_by` and
+    `Enumerable#max_by` can replace `Enumerable#sort_by` calls
+    after which only the first or last element is used.
   Enabled: true
   VersionAdded: '0.55'
 
 Performance/UriDefaultParser:
-  Description: 'Use `URI::DEFAULT_PARSER` instead of `URI::Parser.new`.'
+  Description: |-
+    This cop identifies places where `URI::Parser.new`
+    can be replaced by `URI::DEFAULT_PARSER`.
   Enabled: true
   VersionAdded: '0.50'
 
-#################### Rails #################################
-
-# By default, the rails cops are not run. Override in project or home
-# directory .rubocop.yml files, or by giving the -R/--rails option.
 Rails:
   Enabled: false
 
 Rails/ActionFilter:
-  Description: 'Enforces consistent use of action filter methods.'
+  Description: This cop enforces the consistent use of action filter methods.
   Enabled: true
   VersionAdded: '0.19'
   EnforcedStyle: action
   SupportedStyles:
-    - action
-    - filter
+  - action
+  - filter
   Include:
-    - app/controllers/**/*.rb
+  - app/controllers/**/*.rb
 
 Rails/ActiveRecordAliases:
-  Description: >-
-                  Avoid Active Record aliases:
-                  Use `update` instead of `update_attributes`.
-                  Use `update!` instead of `update_attributes!`.
+  Description: |-
+    Checks that ActiveRecord aliases are not used. The direct method names
+    are more clear and easier to read.
   Enabled: true
   VersionAdded: '0.53'
 
 Rails/ActiveSupportAliases:
-  Description: >-
-                  Avoid ActiveSupport aliases of standard ruby methods:
-                  `String#starts_with?`, `String#ends_with?`,
-                  `Array#append`, `Array#prepend`.
+  Description: |-
+    This cop checks that ActiveSupport aliases to core ruby methods
+    are not used.
   Enabled: true
   VersionAdded: '0.48'
 
 Rails/ApplicationJob:
-  Description: 'Check that jobs subclass ApplicationJob.'
+  Description: This cop checks that jobs subclass ApplicationJob with Rails 5.0.
   Enabled: true
   VersionAdded: '0.49'
 
 Rails/ApplicationRecord:
-  Description: 'Check that models subclass ApplicationRecord.'
+  Description: This cop checks that models subclass ApplicationRecord with Rails 5.0.
   Enabled: true
   VersionAdded: '0.49'
 
 Rails/AssertNot:
-  Description: 'Use `assert_not` instead of `assert !`.'
+  Description: Use `assert_not` instead of `assert !`.
   Enabled: true
   VersionAdded: '0.56'
   Include:
-    - '**/test/**/*'
+  - "**/test/**/*"
 
 Rails/BelongsTo:
   Description: >-
@@ -2249,160 +2198,183 @@ Rails/BelongsTo:
   VersionAdded: '0.62'
 
 Rails/Blank:
-  Description: 'Enforces use of `blank?`.'
+  Description: |-
+    This cop checks for code that can be written with simpler conditionals
+    using `Object#blank?` defined by Active Support.
   Enabled: true
   VersionAdded: '0.48'
-  # Convert usages of `nil? || empty?` to `blank?`
   NilOrEmpty: true
-  # Convert usages of `!present?` to `blank?`
   NotPresent: true
-  # Convert usages of `unless present?` to `if blank?`
   UnlessPresent: true
 
 Rails/BulkChangeTable:
-  Description: 'Check whether alter queries are combinable.'
+  Description: |-
+    This Cop checks whether alter queries are combinable.
+    If combinable queries are detected, it suggests to you
+    to use `change_table` with `bulk: true` instead.
+    This option causes the migration to generate a single
+    ALTER TABLE statement combining multiple column alterations.
   Enabled: true
   VersionAdded: '0.57'
-  Database: null
+  Database:
   SupportedDatabases:
-    - mysql
-    - postgresql
+  - mysql
+  - postgresql
   Include:
-    - db/migrate/*.rb
+  - db/migrate/*.rb
 
 Rails/CreateTableWithTimestamps:
-  Description: >-
-                  Checks the migration for which timestamps are not included
-                  when creating a new table.
+  Description: |-
+    This cop checks the migration for which timestamps are not included
+    when creating a new table.
+    In many cases, timestamps are useful information and should be added.
   Enabled: true
   VersionAdded: '0.52'
   Include:
-    - db/migrate/*.rb
+  - db/migrate/*.rb
 
 Rails/Date:
-  Description: >-
-                  Checks the correct usage of date aware methods,
-                  such as Date.today, Date.current etc.
+  Description: |-
+    This cop checks for the correct use of Date methods,
+    such as Date.today, Date.current etc.
   Enabled: true
   VersionAdded: '0.30'
   VersionChanged: '0.33'
-  # The value `strict` disallows usage of `Date.today`, `Date.current`,
-  # `Date#to_time` etc.
-  # The value `flexible` allows usage of `Date.current`, `Date.yesterday`, etc
-  # (but not `Date.today`) which are overridden by ActiveSupport to handle current
-  # time zone.
   EnforcedStyle: flexible
   SupportedStyles:
-    - strict
-    - flexible
+  - strict
+  - flexible
 
 Rails/Delegate:
-  Description: 'Prefer delegate method for delegations.'
+  Description: |-
+    This cop looks for delegations that could have been created
+    automatically with the `delegate` method.
   Enabled: true
   VersionAdded: '0.21'
   VersionChanged: '0.50'
-  # When set to true, using the target object as a prefix of the
-  # method name without using the `delegate` method will be a
-  # violation. When set to false, this case is legal.
   EnforceForPrefixed: true
 
 Rails/DelegateAllowBlank:
-  Description: 'Do not use allow_blank as an option to delegate.'
+  Description: |-
+    This cop looks for delegations that pass :allow_blank as an option
+    instead of :allow_nil. :allow_blank is not a valid option to pass
+    to ActiveSupport#delegate.
   Enabled: true
   VersionAdded: '0.44'
 
 Rails/DynamicFindBy:
-  Description: 'Use `find_by` instead of dynamic `find_by_*`.'
-  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#find_by'
+  Description: |-
+    This cop checks dynamic `find_by_*` methods.
+    Use `find_by` instead of dynamic method.
+    See. https://github.com/rubocop-hq/rails-style-guide#find_by
+  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#find_by
   Enabled: true
   VersionAdded: '0.44'
   Whitelist:
-    - find_by_sql
+  - find_by_sql
 
 Rails/EnumUniqueness:
-  Description: 'Avoid duplicate integers in hash-syntax `enum` declaration.'
+  Description: This cop looks for duplicate values in enum declarations.
   Enabled: true
   VersionAdded: '0.46'
   Include:
-    - app/models/**/*.rb
+  - app/models/**/*.rb
 
 Rails/EnvironmentComparison:
-  Description: "Favor `Rails.env.production?` over `Rails.env == 'production'`"
+  Description: |-
+    This cop checks that Rails.env is compared using `.production?`-like
+    methods instead of equality against a string or symbol.
   Enabled: true
   VersionAdded: '0.52'
 
 Rails/Exit:
-  Description: >-
-                  Favor `fail`, `break`, `return`, etc. over `exit` in
-                  application or library code outside of Rake files to avoid
-                  exits during unit testing or running in production.
+  Description: |-
+    This cop enforces that `exit` calls are not used within a rails app.
+    Valid options are instead to raise an error, break, return, or some
+    other form of stopping execution of current request.
   Enabled: true
   VersionAdded: '0.41'
   Include:
-    - app/**/*.rb
-    - config/**/*.rb
-    - lib/**/*.rb
+  - app/**/*.rb
+  - config/**/*.rb
+  - lib/**/*.rb
   Exclude:
-    - lib/**/*.rake
+  - lib/**/*.rake
 
 Rails/FilePath:
-  Description: 'Use `Rails.root.join` for file path joining.'
+  Description: |-
+    This cop is used to identify usages of file path joining process
+    to use `Rails.root.join` clause. It is used to add uniformity when
+    joining paths.
   Enabled: true
   VersionAdded: '0.47'
   VersionChanged: '0.57'
   EnforcedStyle: arguments
   SupportedStyles:
-    - slashes
-    - arguments
+  - slashes
+  - arguments
 
 Rails/FindBy:
-  Description: 'Prefer find_by over where.first.'
-  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#find_by'
+  Description: |-
+    This cop is used to identify usages of `where.first` and
+    change them to use `find_by` instead.
+  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#find_by
   Enabled: true
   VersionAdded: '0.30'
   Include:
-    - app/models/**/*.rb
+  - app/models/**/*.rb
 
 Rails/FindEach:
-  Description: 'Prefer all.find_each over all.find.'
-  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#find-each'
+  Description: |-
+    This cop is used to identify usages of `all.each` and
+    change them to use `all.find_each` instead.
+  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#find-each
   Enabled: true
   VersionAdded: '0.30'
   Include:
-    - app/models/**/*.rb
+  - app/models/**/*.rb
 
 Rails/HasAndBelongsToMany:
-  Description: 'Prefer has_many :through to has_and_belongs_to_many.'
-  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#has-many-through'
+  Description: This cop checks for the use of the has_and_belongs_to_many macro.
+  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#has-many-through
   Enabled: true
   VersionAdded: '0.12'
   Include:
-    - app/models/**/*.rb
+  - app/models/**/*.rb
 
 Rails/HasManyOrHasOneDependent:
-  Description: 'Define the dependent option to the has_many and has_one associations.'
-  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#has_many-has_one-dependent-option'
+  Description: |-
+    This cop looks for `has_many` or `has_one` associations that don't
+    specify a `:dependent` option.
+    It doesn't register an offense if `:through` option was specified.
+  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#has_many-has_one-dependent-option
   Enabled: true
   VersionAdded: '0.50'
   Include:
-    - app/models/**/*.rb
+  - app/models/**/*.rb
 
 Rails/HttpPositionalArguments:
-  Description: 'Use keyword arguments instead of positional arguments in http method calls.'
+  Description: |-
+    This cop is used to identify usages of http methods like `get`, `post`,
+    `put`, `patch` without the usage of keyword arguments in your tests and
+    change them to use keyword args. This cop only applies to Rails >= 5.
+    If you are running Rails < 5 you should disable the
+    Rails/HttpPositionalArguments cop or set your TargetRailsVersion in your
+    .rubocop.yml file to 4.0, etc.
   Enabled: true
   VersionAdded: '0.44'
   Include:
-    - 'spec/**/*'
-    - 'test/**/*'
+  - spec/**/*
+  - test/**/*
 
 Rails/HttpStatus:
-  Description: 'Enforces use of symbolic or numeric value to define HTTP status.'
+  Description: Enforces use of symbolic or numeric value to define HTTP status.
   Enabled: true
   VersionAdded: '0.54'
   EnforcedStyle: symbolic
   SupportedStyles:
-    - numeric
-    - symbolic
+  - numeric
+  - symbolic
 
 Rails/IgnoredSkipActionFilterOption:
   Description: 'Checks that `if` and `only` (or `except`) are not used together as options of `skip_*` action filter.'
@@ -2413,83 +2385,107 @@ Rails/IgnoredSkipActionFilterOption:
     - app/controllers/**/*.rb
 
 Rails/InverseOf:
-  Description: 'Checks for associations where the inverse cannot be determined automatically.'
+  Description: |-
+    This cop looks for has_(one|many) and belongs_to associations where
+    Active Record can't automatically determine the inverse association
+    because of a scope or the options used. Using the blog with order scope
+    example below, traversing the a Blog's association in both directions
+    with `blog.posts.first.blog` would cause the `blog` to be loaded from
+    the database twice.
   Enabled: true
   VersionAdded: '0.52'
   Include:
-    - app/models/**/*.rb
+  - app/models/**/*.rb
 
 Rails/LexicallyScopedActionFilter:
-  Description: "Checks that methods specified in the filter's `only` or `except` options are explicitly defined in the controller."
-  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#lexically-scoped-action-filter'
+  Description: |-
+    This cop checks that methods specified in the filter's `only` or
+    `except` options are defined within the same class or module.
+  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#lexically-scoped-action-filter
   Enabled: true
   VersionAdded: '0.52'
   Include:
-    - app/controllers/**/*.rb
+  - app/controllers/**/*.rb
 
 Rails/LinkToBlank:
-  Description: 'Checks that `link_to` with a `target: "_blank"` have a `rel: "noopener"` option passed to them.'
+  Description: |-
+    This cop checks for calls to `link_to` that contain a
+    `target: '_blank'` but no `rel: 'noopener'`. This can be a security
+    risk as the loaded page will have control over the previous page
+    and could change its location for phishing purposes.
   Reference: https://mathiasbynens.github.io/rel-noopener/
   Enabled: true
   VersionAdded: '0.62'
 
 Rails/NotNullColumn:
-  Description: 'Do not add a NOT NULL column without a default value'
+  Description: |-
+    This cop checks for add_column call with NOT NULL constraint
+    in migration file.
   Enabled: true
   VersionAdded: '0.43'
   Include:
-    - db/migrate/*.rb
+  - db/migrate/*.rb
 
 Rails/Output:
-  Description: 'Checks for calls to puts, print, etc.'
+  Description: This cop checks for the use of output calls like puts and print
   Enabled: true
   VersionAdded: '0.15'
   VersionChanged: '0.19'
   Include:
-    - app/**/*.rb
-    - config/**/*.rb
-    - db/**/*.rb
-    - lib/**/*.rb
+  - app/**/*.rb
+  - config/**/*.rb
+  - db/**/*.rb
+  - lib/**/*.rb
 
 Rails/OutputSafety:
-  Description: 'The use of `html_safe` or `raw` may be a security risk.'
+  Description: |-
+    This cop checks for the use of output safety calls like `html_safe`,
+    `raw`, and `safe_concat`. These methods do not escape content. They
+    simply return a SafeBuffer containing the content as is. Instead,
+    use `safe_join` to join content and escape it and concat to
+    concatenate content and escape it, ensuring its safety.
   Enabled: true
   VersionAdded: '0.41'
 
 Rails/PluralizationGrammar:
-  Description: 'Checks for incorrect grammar when using methods like `3.day.ago`.'
+  Description: |-
+    This cop checks for correct grammar when using ActiveSupport's
+    core extensions to the numeric classes.
   Enabled: true
   VersionAdded: '0.35'
 
 Rails/Presence:
-  Description: 'Checks code that can be written more easily using `Object#presence` defined by Active Support.'
+  Description: |-
+    This cop checks code that can be written more easily using
+    `Object#presence` defined by Active Support.
   Enabled: true
   VersionAdded: '0.52'
 
 Rails/Present:
-  Description: 'Enforces use of `present?`.'
+  Description: |-
+    This cop checks for code that can be written with simpler conditionals
+    using `Object#present?` defined by Active Support.
   Enabled: true
   VersionAdded: '0.48'
-  # Convert usages of `!nil? && !empty?` to `present?`
   NotNilAndNotEmpty: true
-  # Convert usages of `!blank?` to `present?`
   NotBlank: true
-  # Convert usages of `unless blank?` to `if present?`
   UnlessBlank: true
 
 Rails/ReadWriteAttribute:
-  Description: >-
-                 Checks for read_attribute(:attr) and
-                 write_attribute(:attr, val).
-  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#read-attribute'
+  Description: |-
+    This cop checks for the use of the `read_attribute` or `write_attribute`
+    methods and recommends square brackets instead.
+  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#read-attribute
   Enabled: true
   VersionAdded: '0.20'
   VersionChanged: '0.29'
   Include:
-    - app/models/**/*.rb
+  - app/models/**/*.rb
 
 Rails/RedundantReceiverInWithOptions:
-  Description: 'Checks for redundant receiver in `with_options`.'
+  Description: |-
+    This cop checks for redundant receiver in `with_options`.
+    Receiver is implicit from Rails 4.2 or higher.
   Enabled: true
   VersionAdded: '0.52'
 
@@ -2499,50 +2495,58 @@ Rails/ReflectionClassName:
   VersionAdded: '0.64'
 
 Rails/RefuteMethods:
-  Description: 'Use `assert_not` methods instead of `refute` methods.'
+  Description: Use `assert_not` methods instead of `refute` methods.
   Enabled: true
   VersionAdded: '0.56'
   Include:
-    - '**/test/**/*'
+  - "**/test/**/*"
 
 Rails/RelativeDateConstant:
-  Description: 'Do not assign relative date to constants.'
+  Description: |-
+    This cop checks whether constant value isn't relative date.
+    Because the relative date will be evaluated only once.
   Enabled: true
   VersionAdded: '0.48'
   VersionChanged: '0.59'
   AutoCorrect: false
 
 Rails/RequestReferer:
-  Description: 'Use consistent syntax for request.referer.'
+  Description: |-
+    This cop checks for consistent uses of `request.referer` or
+    `request.referrer`, depending on the cop's configuration.
   Enabled: true
   VersionAdded: '0.41'
   EnforcedStyle: referer
   SupportedStyles:
-    - referer
-    - referrer
+  - referer
+  - referrer
 
 Rails/ReversibleMigration:
-  Description: 'Checks whether the change method of the migration file is reversible.'
-  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#reversible-migration'
-  Reference: 'https://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html'
+  Description: |-
+    This cop checks whether the change method of the migration file is
+    reversible.
+  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#reversible-migration
+  Reference: https://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html
   Enabled: true
   VersionAdded: '0.47'
   Include:
-    - db/migrate/*.rb
+  - db/migrate/*.rb
 
 Rails/SafeNavigation:
-  Description: "Use Ruby's safe navigation operator (`&.`) instead of `try!`"
+  Description: |-
+    This cop converts usages of `try!` to `&.`. It can also be configured
+    to convert `try`. It will convert code to use safe navigation if the
+    target Ruby version is set to 2.3+
   Enabled: true
   VersionAdded: '0.43'
-  # This will convert usages of `try` to use safe navigation as well as `try!`.
-  # `try` and `try!` work slightly differently. `try!` and safe navigation will
-  # both raise a `NoMethodError` if the receiver of the method call does not
-  # implement the intended method. `try` will not raise an exception for this.
   ConvertTry: false
 
 Rails/SaveBang:
-  Description: 'Identifies possible cases where Active Record save! or related should be used.'
-  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#save-bang'
+  Description: |-
+    This cop identifies possible cases where Active Record save! or related
+    should be used instead of save because the model might have failed to
+    save and an exception is better than unhandled failure.
+  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#save-bang
   Enabled: false
   VersionAdded: '0.42'
   VersionChanged: '0.59'
@@ -2550,651 +2554,615 @@ Rails/SaveBang:
   AllowedReceivers: []
 
 Rails/ScopeArgs:
-  Description: 'Checks the arguments of ActiveRecord scopes.'
+  Description: |-
+    This cop checks for scope calls where it was passed
+    a method (usually a scope) instead of a lambda/proc.
   Enabled: true
   VersionAdded: '0.19'
   Include:
-    - app/models/**/*.rb
+  - app/models/**/*.rb
 
 Rails/SkipsModelValidations:
-  Description: >-
-                 Use methods that skips model validations with caution.
-                 See reference for more information.
-  Reference: 'https://guides.rubyonrails.org/active_record_validations.html#skipping-validations'
+  Description: |-
+    This cop checks for the use of methods which skip
+    validations which are listed in
+    https://guides.rubyonrails.org/active_record_validations.html#skipping-validations
+  Reference: https://guides.rubyonrails.org/active_record_validations.html#skipping-validations
   Enabled: true
   VersionAdded: '0.47'
   VersionChanged: '0.60'
   Blacklist:
-    - decrement!
-    - decrement_counter
-    - increment!
-    - increment_counter
-    - toggle!
-    - touch
-    - update_all
-    - update_attribute
-    - update_column
-    - update_columns
-    - update_counters
+  - decrement!
+  - decrement_counter
+  - increment!
+  - increment_counter
+  - toggle!
+  - touch
+  - update_all
+  - update_attribute
+  - update_column
+  - update_columns
+  - update_counters
   Whitelist: []
 
 Rails/TimeZone:
-  Description: 'Checks the correct usage of time zone aware methods.'
-  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#time'
-  Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
+  Description: This cop checks for the use of Time methods without zone.
+  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#time
+  Reference: http://danilenko.org/2012/7/6/rails_timezones
   Enabled: true
   VersionAdded: '0.30'
   VersionChanged: '0.33'
-  # The value `strict` means that `Time` should be used with `zone`.
-  # The value `flexible` allows usage of `in_time_zone` instead of `zone`.
   EnforcedStyle: flexible
   SupportedStyles:
-    - strict
-    - flexible
+  - strict
+  - flexible
 
 Rails/UniqBeforePluck:
-  Description: 'Prefer the use of uniq or distinct before pluck.'
+  Description: Prefer the use of uniq (or distinct), before pluck instead of after.
   Enabled: true
   VersionAdded: '0.40'
   VersionChanged: '0.47'
   EnforcedStyle: conservative
   SupportedStyles:
-    - conservative
-    - aggressive
+  - conservative
+  - aggressive
   AutoCorrect: false
 
 Rails/UnknownEnv:
-  Description: 'Use correct environment name.'
+  Description: |-
+    This cop checks that environments called with `Rails.env` predicates
+    exist.
   Enabled: true
   VersionAdded: '0.51'
   Environments:
-    - development
-    - test
-    - production
+  - development
+  - test
+  - production
 
 Rails/Validation:
-  Description: 'Use validates :attribute, hash of validations.'
+  Description: This cop checks for the use of old-style attribute validation macros.
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.41'
   Include:
-    - app/models/**/*.rb
-
-#################### Security ##############################
+  - app/models/**/*.rb
 
 Security/Eval:
-  Description: 'The use of eval represents a serious security risk.'
+  Description: This cop checks for the use of `Kernel#eval` and `Binding#eval`.
   Enabled: true
   VersionAdded: '0.47'
 
 Security/JSONLoad:
-  Description: >-
-                 Prefer usage of `JSON.parse` over `JSON.load` due to potential
-                 security issues. See reference for more information.
-  Reference: 'https://ruby-doc.org/stdlib-2.3.0/libdoc/json/rdoc/JSON.html#method-i-load'
+  Description: |-
+    This cop checks for the use of JSON class methods which have potential
+    security issues.
+  Reference: https://ruby-doc.org/stdlib-2.3.0/libdoc/json/rdoc/JSON.html#method-i-load
   Enabled: true
   VersionAdded: '0.43'
   VersionChanged: '0.44'
-  # Autocorrect here will change to a method that may cause crashes depending
-  # on the value of the argument.
   AutoCorrect: false
   SafeAutoCorrect: false
 
 Security/MarshalLoad:
-  Description: >-
-                 Avoid using of `Marshal.load` or `Marshal.restore` due to potential
-                 security issues. See reference for more information.
-  Reference: 'https://ruby-doc.org/core-2.3.3/Marshal.html#module-Marshal-label-Security+considerations'
+  Description: |-
+    This cop checks for the use of Marshal class methods which have
+    potential security issues leading to remote code execution when
+    loading from an untrusted source.
+  Reference: https://ruby-doc.org/core-2.3.3/Marshal.html#module-Marshal-label-Security+considerations
   Enabled: true
   VersionAdded: '0.47'
 
 Security/Open:
-  Description: 'The use of Kernel#open represents a serious security risk.'
+  Description: This cop checks for the use of `Kernel#open`.
   Enabled: true
   VersionAdded: '0.53'
   Safe: false
 
 Security/YAMLLoad:
-  Description: >-
-                 Prefer usage of `YAML.safe_load` over `YAML.load` due to potential
-                 security issues. See reference for more information.
-  Reference: 'https://ruby-doc.org/stdlib-2.3.3/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security'
+  Description: |-
+    This cop checks for the use of YAML class methods which have
+    potential security issues leading to remote code execution when
+    loading from an untrusted source.
+  Reference: https://ruby-doc.org/stdlib-2.3.3/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security
   Enabled: true
   VersionAdded: '0.47'
   SafeAutoCorrect: false
 
-#################### Style ###############################
-
 Style/AccessModifierDeclarations:
-  Description: 'Checks style of how access modifiers are used.'
+  Description: |-
+    Access modifiers should be declared to apply to a group of methods
+    or inline before each method, depending on configuration.
   Enabled: true
   VersionAdded: '0.57'
   EnforcedStyle: group
   SupportedStyles:
-    - inline
-    - group
+  - inline
+  - group
 
 Style/Alias:
-  Description: 'Use alias instead of alias_method.'
-  StyleGuide: '#alias-method'
+  Description: |-
+    This cop enforces the use of either `#alias` or `#alias_method`
+    depending on configuration.
+    It also flags uses of `alias :symbol` rather than `alias bareword`.
+  StyleGuide: "#alias-method"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.36'
   EnforcedStyle: prefer_alias
   SupportedStyles:
-    - prefer_alias
-    - prefer_alias_method
+  - prefer_alias
+  - prefer_alias_method
 
 Style/AndOr:
-  Description: 'Use &&/|| instead of and/or.'
-  StyleGuide: '#no-and-or-or'
+  Description: |-
+    This cop checks for uses of `and` and `or`, and suggests using `&&` and
+    `||` instead. It can be configured to check only in conditions or in
+    all contexts.
+  StyleGuide: "#no-and-or-or"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.25'
-  # Whether `and` and `or` are banned only in conditionals (conditionals)
-  # or completely (always).
   EnforcedStyle: always
   SupportedStyles:
-    - always
-    - conditionals
+  - always
+  - conditionals
 
 Style/ArrayJoin:
-  Description: 'Use Array#join instead of Array#*.'
-  StyleGuide: '#array-join'
+  Description: This cop checks for uses of "*" as a substitute for *join*.
+  StyleGuide: "#array-join"
   Enabled: true
   VersionAdded: '0.20'
   VersionChanged: '0.31'
 
 Style/AsciiComments:
-  Description: 'Use only ascii symbols in comments.'
-  StyleGuide: '#english-comments'
+  Description: |-
+    This cop checks for non-ascii (non-English) characters
+    in comments. You could set an array of allowed non-ascii chars in
+    AllowedChars attribute (empty by default).
+  StyleGuide: "#english-comments"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.52'
   AllowedChars: []
 
 Style/Attr:
-  Description: 'Checks for uses of Module#attr.'
-  StyleGuide: '#attr'
+  Description: This cop checks for uses of Module#attr.
+  StyleGuide: "#attr"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.12'
 
 Style/AutoResourceCleanup:
-  Description: 'Suggests the usage of an auto resource cleanup version of a method (if available).'
+  Description: |-
+    This cop checks for cases when you could use a block
+    accepting version of a method that does automatic
+    resource cleanup.
   Enabled: false
   VersionAdded: '0.30'
 
 Style/BarePercentLiterals:
-  Description: 'Checks if usage of %() or %Q() matches configuration.'
-  StyleGuide: '#percent-q-shorthand'
+  Description: This cop checks if usage of %() or %Q() matches configuration.
+  StyleGuide: "#percent-q-shorthand"
   Enabled: true
   VersionAdded: '0.25'
   EnforcedStyle: bare_percent
   SupportedStyles:
-    - percent_q
-    - bare_percent
+  - percent_q
+  - bare_percent
 
 Style/BeginBlock:
-  Description: 'Avoid the use of BEGIN blocks.'
-  StyleGuide: '#no-BEGIN-blocks'
+  Description: This cop checks for BEGIN blocks.
+  StyleGuide: "#no-BEGIN-blocks"
   Enabled: true
   VersionAdded: '0.9'
 
 Style/BlockComments:
-  Description: 'Do not use block comments.'
-  StyleGuide: '#no-block-comments'
+  Description: This cop looks for uses of block comments (=begin...=end).
+  StyleGuide: "#no-block-comments"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.23'
 
 Style/BlockDelimiters:
-  Description: >-
-                Avoid using {...} for multi-line blocks (multiline chaining is
-                always ugly).
-                Prefer {...} over do...end for single-line blocks.
-  StyleGuide: '#single-line-blocks'
+  Description: |-
+    Check for uses of braces or do/end around single line or
+    multi-line blocks.
+  StyleGuide: "#single-line-blocks"
   Enabled: true
   VersionAdded: '0.30'
   VersionChanged: '0.35'
   EnforcedStyle: line_count_based
   SupportedStyles:
-    # The `line_count_based` style enforces braces around single line blocks and
-    # do..end around multi-line blocks.
-    - line_count_based
-    # The `semantic` style enforces braces around functional blocks, where the
-    # primary purpose of the block is to return a value and do..end for
-    # procedural blocks, where the primary purpose of the block is its
-    # side-effects.
-    #
-    # This looks at the usage of a block's method to determine its type (e.g. is
-    # the result of a `map` assigned to a variable or passed to another
-    # method) but exceptions are permitted in the `ProceduralMethods`,
-    # `FunctionalMethods` and `IgnoredMethods` sections below.
-    - semantic
-    # The `braces_for_chaining` style enforces braces around single line blocks
-    # and do..end around multi-line blocks, except for multi-line blocks whose
-    # return value is being chained with another method (in which case braces
-    # are enforced).
-    - braces_for_chaining
+  - line_count_based
+  - semantic
+  - braces_for_chaining
   ProceduralMethods:
-    # Methods that are known to be procedural in nature but look functional from
-    # their usage, e.g.
-    #
-    #   time = Benchmark.realtime do
-    #     foo.bar
-    #   end
-    #
-    # Here, the return value of the block is discarded but the return value of
-    # `Benchmark.realtime` is used.
-    - benchmark
-    - bm
-    - bmbm
-    - create
-    - each_with_object
-    - measure
-    - new
-    - realtime
-    - tap
-    - with_object
+  - benchmark
+  - bm
+  - bmbm
+  - create
+  - each_with_object
+  - measure
+  - new
+  - realtime
+  - tap
+  - with_object
   FunctionalMethods:
-    # Methods that are known to be functional in nature but look procedural from
-    # their usage, e.g.
-    #
-    #   let(:foo) { Foo.new }
-    #
-    # Here, the return value of `Foo.new` is used to define a `foo` helper but
-    # doesn't appear to be used from the return value of `let`.
-    - let
-    - let!
-    - subject
-    - watch
+  - let
+  - let!
+  - subject
+  - watch
   IgnoredMethods:
-    # Methods that can be either procedural or functional and cannot be
-    # categorised from their usage alone, e.g.
-    #
-    #   foo = lambda do |x|
-    #     puts "Hello, #{x}"
-    #   end
-    #
-    #   foo = lambda do |x|
-    #     x * 100
-    #   end
-    #
-    # Here, it is impossible to tell from the return value of `lambda` whether
-    # the inner block's return value is significant.
-    - lambda
-    - proc
-    - it
+  - lambda
+  - proc
+  - it
 
 Style/BracesAroundHashParameters:
-  Description: 'Enforce braces style around hash parameters.'
+  Description: |-
+    This cop checks for braces around the last parameter in a method call
+    if the last parameter is a hash.
+    It supports `braces`, `no_braces` and `context_dependent` styles.
   Enabled: true
-  VersionAdded: '0.14.1'
+  VersionAdded: 0.14.1
   VersionChanged: '0.28'
   EnforcedStyle: no_braces
   SupportedStyles:
-    # The `braces` style enforces braces around all method parameters that are
-    # hashes.
-    - braces
-    # The `no_braces` style checks that the last parameter doesn't have braces
-    # around it.
-    - no_braces
-    # The `context_dependent` style checks that the last parameter doesn't have
-    # braces around it, but requires braces if the second to last parameter is
-    # also a hash literal.
-    - context_dependent
+  - braces
+  - no_braces
+  - context_dependent
 
 Style/CaseEquality:
-  Description: 'Avoid explicit use of the case equality operator(===).'
-  StyleGuide: '#no-case-equality'
+  Description: This cop checks for uses of the case equality operator(===).
+  StyleGuide: "#no-case-equality"
   Enabled: true
   VersionAdded: '0.9'
 
 Style/CharacterLiteral:
-  Description: 'Checks for uses of character literals.'
-  StyleGuide: '#no-character-literals'
+  Description: Checks for uses of the character literal ?x.
+  StyleGuide: "#no-character-literals"
   Enabled: true
   VersionAdded: '0.9'
 
 Style/ClassAndModuleChildren:
-  Description: 'Checks style of children classes and modules.'
-  StyleGuide: '#namespace-definition'
-  # Moving from compact to nested children requires knowledge of whether the
-  # outer parent is a module or a class. Moving from nested to compact requires
-  # verification that the outer parent is defined elsewhere. Rubocop does not
-  # have the knowledge to perform either operation safely and thus requires
-  # manual oversight.
+  Description: |-
+    This cop checks the style of children definitions at classes and
+    modules. Basically there are two different styles:
+  StyleGuide: "#namespace-definition"
   SafeAutoCorrect: false
   AutoCorrect: false
   Enabled: true
   VersionAdded: '0.19'
-  #
-  # Basically there are two different styles:
-  #
-  # `nested` - have each child on a separate line
-  #   class Foo
-  #     class Bar
-  #     end
-  #   end
-  #
-  # `compact` - combine definitions as much as possible
-  #   class Foo::Bar
-  #   end
-  #
-  # The compact style is only forced, for classes or modules with one child.
   EnforcedStyle: nested
   SupportedStyles:
-    - nested
-    - compact
+  - nested
+  - compact
 
 Style/ClassCheck:
-  Description: 'Enforces consistent use of `Object#is_a?` or `Object#kind_of?`.'
+  Description: This cop enforces consistent use of `Object#is_a?` or `Object#kind_of?`.
   Enabled: true
   VersionAdded: '0.24'
   EnforcedStyle: is_a?
   SupportedStyles:
-    - is_a?
-    - kind_of?
+  - is_a?
+  - kind_of?
 
 Style/ClassMethods:
-  Description: 'Use self when defining module/class methods.'
-  StyleGuide: '#def-self-class-methods'
+  Description: |-
+    This cop checks for uses of the class/module name instead of
+    self, when defining class/module methods.
+  StyleGuide: "#def-self-class-methods"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.20'
 
 Style/ClassVars:
-  Description: 'Avoid the use of class variables.'
-  StyleGuide: '#no-class-vars'
+  Description: |-
+    This cop checks for uses of class variables. Offenses
+    are signaled only on assignment to class variables to
+    reduce the number of offenses that would be reported.
+  StyleGuide: "#no-class-vars"
   Enabled: true
   VersionAdded: '0.13'
 
-# Align with the style guide.
 Style/CollectionMethods:
-  Description: 'Preferred collection methods.'
-  StyleGuide: '#map-find-select-reduce-size'
+  Description: |-
+    This cop enforces the use of consistent method names
+    from the Enumerable module.
+  StyleGuide: "#map-find-select-reduce-size"
   Enabled: false
   VersionAdded: '0.9'
   VersionChanged: '0.27'
   Safe: false
-  # Mapping from undesired method to desired method
-  # e.g. to use `detect` over `find`:
-  #
-  # Style/CollectionMethods:
-  #   PreferredMethods:
-  #     find: detect
   PreferredMethods:
-    collect: 'map'
-    collect!: 'map!'
-    inject: 'reduce'
-    detect: 'find'
-    find_all: 'select'
+    collect: map
+    collect!: map!
+    inject: reduce
+    detect: find
+    find_all: select
 
 Style/ColonMethodCall:
-  Description: 'Do not use :: for method call.'
-  StyleGuide: '#double-colons'
+  Description: |-
+    This cop checks for methods invoked via the :: operator instead
+    of the . operator (like FileUtils::rmdir instead of FileUtils.rmdir).
+  StyleGuide: "#double-colons"
   Enabled: true
   VersionAdded: '0.9'
 
 Style/ColonMethodDefinition:
-  Description: 'Do not use :: for defining class methods.'
-  StyleGuide: '#colon-method-definition'
+  Description: |-
+    This cop checks for class methods that are defined using the `::`
+    operator instead of the `.` operator.
+  StyleGuide: "#colon-method-definition"
   Enabled: true
   VersionAdded: '0.52'
 
 Style/CommandLiteral:
-  Description: 'Use `` or %x around command literals.'
-  StyleGuide: '#percent-x'
+  Description: This cop enforces using `` or %x around command literals.
+  StyleGuide: "#percent-x"
   Enabled: true
   VersionAdded: '0.30'
   EnforcedStyle: backticks
-  # backticks: Always use backticks.
-  # percent_x: Always use `%x`.
-  # mixed: Use backticks on single-line commands, and `%x` on multi-line commands.
   SupportedStyles:
-    - backticks
-    - percent_x
-    - mixed
-  # If `false`, the cop will always recommend using `%x` if one or more backticks
-  # are found in the command string.
+  - backticks
+  - percent_x
+  - mixed
   AllowInnerBackticks: false
 
-# Checks formatting of special comments
 Style/CommentAnnotation:
-  Description: >-
-                 Checks formatting of special comments
-                 (TODO, FIXME, OPTIMIZE, HACK, REVIEW).
-  StyleGuide: '#annotate-keywords'
+  Description: |-
+    This cop checks that comment annotation keywords are written according
+    to guidelines.
+  StyleGuide: "#annotate-keywords"
   Enabled: true
   VersionAdded: '0.10'
   VersionChanged: '0.31'
   Keywords:
-    - TODO
-    - FIXME
-    - OPTIMIZE
-    - HACK
-    - REVIEW
+  - TODO
+  - FIXME
+  - OPTIMIZE
+  - HACK
+  - REVIEW
 
 Style/CommentedKeyword:
-  Description: 'Do not place comments on the same line as certain keywords.'
+  Description: |-
+    This cop checks for comments put on the same line as some keywords.
+    These keywords are: `begin`, `class`, `def`, `end`, `module`.
   Enabled: true
   VersionAdded: '0.51'
 
 Style/ConditionalAssignment:
-  Description: >-
-                 Use the return value of `if` and `case` statements for
-                 assignment to a variable and variable comparison instead
-                 of assigning that variable inside of each branch.
+  Description: |-
+    Check for `if` and `case` statements where each branch is used for
+    assignment to the same variable when using the return of the
+    condition can be used instead.
   Enabled: true
   VersionAdded: '0.36'
   VersionChanged: '0.47'
   EnforcedStyle: assign_to_condition
   SupportedStyles:
-    - assign_to_condition
-    - assign_inside_condition
-  # When configured to `assign_to_condition`, `SingleLineConditionsOnly`
-  # will only register an offense when all branches of a condition are
-  # a single line.
-  # When configured to `assign_inside_condition`, `SingleLineConditionsOnly`
-  # will only register an offense for assignment to a condition that has
-  # at least one multiline branch.
+  - assign_to_condition
+  - assign_inside_condition
   SingleLineConditionsOnly: true
   IncludeTernaryExpressions: true
 
-# Checks that you have put a copyright in a comment before any code.
-#
-# You can override the default Notice in your .rubocop.yml file.
-#
-# In order to use autocorrect, you must supply a value for the
-# `AutocorrectNotice` key that matches the regexp Notice. A blank
-# `AutocorrectNotice` will cause an error during autocorrect.
-#
-# Autocorrect will add a copyright notice in a comment at the top
-# of the file immediately after any shebang or encoding comments.
-#
-# Example rubocop.yml:
-#
-# Style/Copyright:
-#   Enabled: true
-#   Notice: 'Copyright (\(c\) )?2015 Yahoo! Inc'
-#   AutocorrectNotice: '# Copyright (c) 2015 Yahoo! Inc.'
-#
 Style/Copyright:
-  Description: 'Include a copyright notice in each file before any code.'
+  Description: Check that a copyright notice was given in each source file.
   Enabled: false
   VersionAdded: '0.30'
-  Notice: '^Copyright (\(c\) )?2[0-9]{3} .+'
+  Notice: "^Copyright (\\(c\\) )?2[0-9]{3} .+"
   AutocorrectNotice: ''
 
 Style/DateTime:
-  Description: 'Use Time over DateTime.'
-  StyleGuide: '#date--time'
+  Description: |-
+    This cop checks for consistent usage of the `DateTime` class over the
+    `Time` class. This cop is disabled by default since these classes,
+    although highly overlapping, have particularities that make them not
+    replaceable in certain situations when dealing with multiple timezones
+    and/or DST.
+  StyleGuide: "#date--time"
   Enabled: false
   VersionAdded: '0.51'
   VersionChanged: '0.59'
   AllowCoercion: false
 
 Style/DefWithParentheses:
-  Description: 'Use def with parentheses when there are arguments.'
-  StyleGuide: '#method-parens'
+  Description: |-
+    This cop checks for parentheses in the definition of a method,
+    that does not take any arguments. Both instance and
+    class/singleton methods are checked.
+  StyleGuide: "#method-parens"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.12'
 
 Style/Dir:
-  Description: >-
-                 Use the `__dir__` method to retrieve the canonicalized
-                 absolute path to the current file.
+  Description: |-
+    This cop checks for places where the `#__dir__` method can replace more
+    complex constructs to retrieve a canonicalized absolute path to the
+    current file.
   Enabled: true
   VersionAdded: '0.50'
 
 Style/Documentation:
-  Description: 'Document classes and non-namespace modules.'
+  Description: |-
+    This cop checks for missing top-level documentation of
+    classes and modules. Classes with no body are exempt from the
+    check and so are namespace modules - modules that have nothing in
+    their bodies except classes, other modules, or constant definitions.
   Enabled: true
   VersionAdded: '0.9'
   Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
+  - spec/**/*
+  - test/**/*
 
 Style/DocumentationMethod:
-  Description: 'Checks for missing documentation comment for public methods.'
+  Description: |-
+    This cop checks for missing documentation comment for public methods.
+    It can optionally be configured to also require documentation for
+    non-public methods.
   Enabled: false
   VersionAdded: '0.43'
   Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
+  - spec/**/*
+  - test/**/*
   RequireForNonPublicMethods: false
 
 Style/DoubleNegation:
-  Description: 'Checks for uses of double negation (!!).'
-  StyleGuide: '#no-bang-bang'
+  Description: |-
+    This cop checks for uses of double negation (!!) to convert something
+    to a boolean value. As this is both cryptic and usually redundant, it
+    should be avoided.
+  StyleGuide: "#no-bang-bang"
   Enabled: true
   VersionAdded: '0.19'
 
 Style/EachForSimpleLoop:
-  Description: >-
-                 Use `Integer#times` for a simple loop which iterates a fixed
-                 number of times.
+  Description: |-
+    This cop checks for loops which iterate a constant number of times,
+    using a Range literal and `#each`. This can be done more readably using
+    `Integer#times`.
   Enabled: true
   VersionAdded: '0.41'
 
 Style/EachWithObject:
-  Description: 'Prefer `each_with_object` over `inject` or `reduce`.'
+  Description: |-
+    This cop looks for inject / reduce calls where the passed in object is
+    returned at the end and so could be replaced by each_with_object without
+    the need to return the object at the end.
   Enabled: true
   VersionAdded: '0.22'
   VersionChanged: '0.42'
 
 Style/EmptyBlockParameter:
-  Description: 'Omit pipes for empty block parameters.'
+  Description: |-
+    This cop checks for pipes for empty block parameters. Pipes for empty
+    block parameters do not cause syntax errors, but they are redundant.
   Enabled: true
   VersionAdded: '0.52'
 
 Style/EmptyCaseCondition:
-  Description: 'Avoid empty condition in case statements.'
+  Description: This cop checks for case statements with an empty condition.
   Enabled: true
   VersionAdded: '0.40'
 
 Style/EmptyElse:
-  Description: 'Avoid empty else-clauses.'
+  Description: |-
+    Checks for empty else-clauses, possibly including comments and/or an
+    explicit `nil` depending on the EnforcedStyle.
   Enabled: true
   VersionAdded: '0.28'
   VersionChanged: '0.32'
   EnforcedStyle: both
-  # empty - warn only on empty `else`
-  # nil - warn on `else` with nil in it
-  # both - warn on empty `else` and `else` with `nil` in it
   SupportedStyles:
-    - empty
-    - nil
-    - both
+  - empty
+  - nil
+  - both
 
 Style/EmptyLambdaParameter:
-  Description: 'Omit parens for empty lambda parameters.'
+  Description: |-
+    This cop checks for parentheses for empty lambda parameters. Parentheses
+    for empty lambda parameters do not cause syntax errors, but they are
+    redundant.
   Enabled: true
   VersionAdded: '0.52'
 
 Style/EmptyLiteral:
-  Description: 'Prefer literals to Array.new/Hash.new/String.new.'
-  StyleGuide: '#literal-array-hash'
+  Description: |-
+    This cop checks for the use of a method, the result of which
+    would be a literal, like an empty array, hash, or string.
+  StyleGuide: "#literal-array-hash"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.12'
 
 Style/EmptyMethod:
-  Description: 'Checks the formatting of empty method definitions.'
-  StyleGuide: '#no-single-line-methods'
+  Description: |-
+    This cop checks for the formatting of empty method definitions.
+    By default it enforces empty method definitions to go on a single
+    line (compact style), but it can be configured to enforce the `end`
+    to go on its own line (expanded style).
+  StyleGuide: "#no-single-line-methods"
   Enabled: true
   VersionAdded: '0.46'
   EnforcedStyle: compact
   SupportedStyles:
-    - compact
-    - expanded
+  - compact
+  - expanded
 
 Style/Encoding:
-  Description: 'Use UTF-8 as the source file encoding.'
-  StyleGuide: '#utf-8'
+  Description: This cop checks ensures source files have no utf-8 encoding comments.
+  StyleGuide: "#utf-8"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.50'
 
 Style/EndBlock:
-  Description: 'Avoid the use of END blocks.'
-  StyleGuide: '#no-END-blocks'
+  Description: This cop checks for END blocks.
+  StyleGuide: "#no-END-blocks"
   Enabled: true
   VersionAdded: '0.9'
 
 Style/EvalWithLocation:
-  Description: 'Pass `__FILE__` and `__LINE__` to `eval` method, as they are used by backtraces.'
+  Description: |-
+    This cop checks `eval` method usage. `eval` can receive source location
+    metadata, that are filename and line number. The metadata is used by
+    backtraces. This cop recommends to pass the metadata to `eval` method.
   Enabled: true
   VersionAdded: '0.52'
 
 Style/EvenOdd:
-  Description: 'Favor the use of Integer#even? && Integer#odd?'
-  StyleGuide: '#predicate-methods'
+  Description: |-
+    This cop checks for places where `Integer#even?` or `Integer#odd?`
+    can be used.
+  StyleGuide: "#predicate-methods"
   Enabled: true
   VersionAdded: '0.12'
   VersionChanged: '0.29'
 
 Style/ExpandPathArguments:
-  Description: "Use `expand_path(__dir__)` instead of `expand_path('..', __FILE__)`."
+  Description: |-
+    This cop checks for use of the `File.expand_path` arguments.
+    Likewise, it also checks for the `Pathname.new` argument.
   Enabled: true
   VersionAdded: '0.53'
 
 Style/For:
-  Description: 'Checks use of for or each in multiline loops.'
-  StyleGuide: '#no-for-loops'
+  Description: |-
+    This cop looks for uses of the `for` keyword or `each` method. The
+    preferred alternative is set in the EnforcedStyle configuration
+    parameter. An `each` call with a block on a single line is always
+    allowed.
+  StyleGuide: "#no-for-loops"
   Enabled: true
   VersionAdded: '0.13'
   VersionChanged: '0.59'
   EnforcedStyle: each
   SupportedStyles:
-    - each
-    - for
+  - each
+  - for
 
 Style/FormatString:
-  Description: 'Enforce the use of Kernel#sprintf, Kernel#format or String#%.'
-  StyleGuide: '#sprintf'
+  Description: |-
+    This cop enforces the use of a single string formatting utility.
+    Valid options include Kernel#format, Kernel#sprintf and String#%.
+  StyleGuide: "#sprintf"
   Enabled: true
   VersionAdded: '0.19'
   VersionChanged: '0.49'
   EnforcedStyle: format
   SupportedStyles:
-    - format
-    - sprintf
-    - percent
+  - format
+  - sprintf
+  - percent
 
 Style/FormatStringToken:
-  Description: 'Use a consistent style for format string tokens.'
+  Description: Use a consistent style for named format string tokens.
   Enabled: true
   EnforcedStyle: annotated
   SupportedStyles:
-    # Prefer tokens which contain a sprintf like type annotation like
-    # `%<name>s`, `%<age>d`, `%<score>f`
-    - annotated
-    # Prefer simple looking "template" style tokens like `%{name}`, `%{age}`
-    - template
-    - unannotated
+  - annotated
+  - template
+  - unannotated
   VersionAdded: '0.49'
   VersionChanged: '0.52'
 
@@ -3202,129 +3170,126 @@ Style/FrozenStringLiteralComment:
   Description: >-
                  Add the frozen_string_literal comment to the top of files
                  to help transition to frozen string literals by default.
+
   Enabled: true
   VersionAdded: '0.36'
   VersionChanged: '0.47'
   EnforcedStyle: when_needed
   SupportedStyles:
-    # `when_needed` will add the frozen string literal comment to files
-    # only when the `TargetRubyVersion` is set to 2.3+.
-    - when_needed
-    # `always` will always add the frozen string literal comment to a file
-    # regardless of the Ruby version or if `freeze` or `<<` are called on a
-    # string literal. If you run code against multiple versions of Ruby, it is
-    # possible that this will create errors in Ruby 2.3.0+.
-    - always
-    # `never` will enforce that the frozen string literal comment does not
-    # exist in a file.
-    - never
+  - when_needed
+  - always
+  - never
 
 Style/GlobalVars:
-  Description: 'Do not introduce global variables.'
-  StyleGuide: '#instance-vars'
-  Reference: 'https://www.zenspider.com/ruby/quickref.html'
+  Description: |-
+    This cop looks for uses of global variables.
+    It does not report offenses for built-in global variables.
+    Built-in global variables are allowed by default. Additionally
+    users can allow additional variables via the AllowedVariables option.
+  StyleGuide: "#instance-vars"
+  Reference: https://www.zenspider.com/ruby/quickref.html
   Enabled: true
   VersionAdded: '0.13'
-  # Built-in global variables are allowed by default.
   AllowedVariables: []
 
 Style/GuardClause:
-  Description: 'Check for conditionals that can be replaced with guard clauses'
-  StyleGuide: '#no-nested-conditionals'
+  Description: |-
+    Use a guard clause instead of wrapping the code inside a conditional
+    expression
+  StyleGuide: "#no-nested-conditionals"
   Enabled: true
   VersionAdded: '0.20'
   VersionChanged: '0.22'
-  # `MinBodyLength` defines the number of lines of the a body of an `if` or `unless`
-  # needs to have to trigger this cop
   MinBodyLength: 1
 
 Style/HashSyntax:
-  Description: >-
-                 Prefer Ruby 1.9 hash syntax { a: 1, b: 2 } over 1.8 syntax
-                 { :a => 1, :b => 2 }.
-  StyleGuide: '#hash-literals'
+  Description: This cop checks hash literal syntax.
+  StyleGuide: "#hash-literals"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.43'
   EnforcedStyle: ruby19
   SupportedStyles:
-    # checks for 1.9 syntax (e.g. {a: 1}) for all symbol keys
-    - ruby19
-    # checks for hash rocket syntax for all hashes
-    - hash_rockets
-    # forbids mixed key syntaxes (e.g. {a: 1, :b => 2})
-    - no_mixed_keys
-    # enforces both ruby19 and no_mixed_keys styles
-    - ruby19_no_mixed_keys
-  # Force hashes that have a symbol value to use hash rockets
+  - ruby19
+  - hash_rockets
+  - no_mixed_keys
+  - ruby19_no_mixed_keys
   UseHashRocketsWithSymbolValues: false
-  # Do not suggest { a?: 1 } over { :a? => 1 } in ruby19 style
   PreferHashRocketsForNonAlnumEndingSymbols: false
 
 Style/IdenticalConditionalBranches:
-  Description: >-
-                 Checks that conditional statements do not have an identical
-                 line at the end of each branch, which can validly be moved
-                 out of the conditional.
+  Description: |-
+    This cop checks for identical lines at the beginning or end of
+    each branch of a conditional statement.
   Enabled: true
   VersionAdded: '0.36'
 
 Style/IfInsideElse:
-  Description: 'Finds if nodes inside else, which can be converted to elsif.'
+  Description: |-
+    If the `else` branch of a conditional consists solely of an `if` node,
+    it can be combined with the `else` to become an `elsif`.
+    This helps to keep the nesting level from getting too deep.
   Enabled: true
   VersionAdded: '0.36'
 
 Style/IfUnlessModifier:
-  Description: >-
-                 Favor modifier if/unless usage when you have a
-                 single-line body.
-  StyleGuide: '#if-as-a-modifier'
+  Description: |-
+    Checks for if and unless statements that would fit on one line
+    if written as a modifier if/unless. The maximum line length is
+    configured in the `Metrics/LineLength` cop. The tab size is configured
+    in the `IndentationWidth` of the `Layout/Tab` cop.
+  StyleGuide: "#if-as-a-modifier"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.30'
 
 Style/IfUnlessModifierOfIfUnless:
-  Description: >-
-                 Avoid modifier if/unless usage on conditionals.
+  Description: |-
+    Checks for if and unless statements used as modifiers of other if or
+    unless statements.
   Enabled: true
   VersionAdded: '0.39'
 
 Style/IfWithSemicolon:
-  Description: 'Do not use if x; .... Use the ternary operator instead.'
-  StyleGuide: '#no-semicolon-ifs'
+  Description: Checks for uses of semicolon in if statements.
+  StyleGuide: "#no-semicolon-ifs"
   Enabled: true
   VersionAdded: '0.9'
 
 Style/ImplicitRuntimeError:
-  Description: >-
-                 Use `raise` or `fail` with an explicit exception class and
-                 message, rather than just a message.
+  Description: |-
+    This cop checks for `raise` or `fail` statements which do not specify an
+    explicit exception class. (This raises a `RuntimeError`. Some projects
+    might prefer to use exception classes which more precisely identify the
+    nature of the error.)
   Enabled: false
   VersionAdded: '0.41'
 
 Style/InfiniteLoop:
-  Description: 'Use Kernel#loop for infinite loops.'
-  StyleGuide: '#infinite-loop'
+  Description: Use `Kernel#loop` for infinite loops.
+  StyleGuide: "#infinite-loop"
   Enabled: true
   VersionAdded: '0.26'
   VersionChanged: '0.61'
   SafeAutoCorrect: true
 
 Style/InlineComment:
-  Description: 'Avoid trailing inline comments.'
+  Description: This cop checks for trailing inline comments.
   Enabled: false
   VersionAdded: '0.23'
 
 Style/InverseMethods:
-  Description: >-
-                 Use the inverse method instead of `!.method`
-                 if an inverse method is defined.
+  Description: |-
+    This cop check for usages of not (`not` or `!`) called on a method
+    when an inverse of that method can be used instead.
+    Methods that can be inverted by a not (`not` or `!`) should be defined
+    in `InverseMethods`
+    Methods that are inverted by inverting the return
+    of the block that is passed to the method should be defined in
+    `InverseBlocks`
   Enabled: true
   Safe: false
   VersionAdded: '0.48'
-  # `InverseMethods` are methods that can be inverted by a not (`not` or `!`)
-  # The relationship of inverse methods only needs to be defined in one direction.
-  # Keys and values both need to be defined as symbols.
   InverseMethods:
     :any?: :none?
     :even?: :odd?
@@ -3332,60 +3297,63 @@ Style/InverseMethods:
     :=~: :!~
     :<: :>=
     :>: :<=
-    # `ActiveSupport` defines some common inverse methods. They are listed below,
-    # and not enabled by default.
-    #:present?: :blank?,
-    #:include?: :exclude?
-  # `InverseBlocks` are methods that are inverted by inverting the return
-  # of the block that is passed to the method
   InverseBlocks:
     :select: :reject
     :select!: :reject!
 
 Style/IpAddresses:
-  Description: "Don't include literal IP addresses in code."
+  Description: |-
+    This cop checks for hardcoded IP addresses, which can make code
+    brittle. IP addresses are likely to need to be changed when code
+    is deployed to a different server or environment, which may break
+    a deployment if forgotten. Prefer setting IP addresses in ENV or
+    other configuration.
   Enabled: false
   VersionAdded: '0.58'
-  # Allow strings to be whitelisted
   Whitelist:
-    - "::"
-    # :: is a valid IPv6 address, but could potentially be legitimately in code
+  - "::"
 
 Style/Lambda:
-  Description: 'Use the new lambda literal syntax for single-line blocks.'
-  StyleGuide: '#lambda-multi-line'
+  Description: |-
+    This cop (by default) checks for uses of the lambda literal syntax for
+    single line lambdas, and the method call syntax for multiline lambdas.
+    It is configurable to enforce one of the styles for both single line
+    and multiline lambdas as well.
+  StyleGuide: "#lambda-multi-line"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.40'
   EnforcedStyle: line_count_dependent
   SupportedStyles:
-    - line_count_dependent
-    - lambda
-    - literal
+  - line_count_dependent
+  - lambda
+  - literal
 
 Style/LambdaCall:
-  Description: 'Use lambda.call(...) instead of lambda.(...).'
-  StyleGuide: '#proc-call'
+  Description: This cop checks for use of the lambda.(args) syntax.
+  StyleGuide: "#proc-call"
   Enabled: true
-  VersionAdded: '0.13.1'
+  VersionAdded: 0.13.1
   VersionChanged: '0.14'
   EnforcedStyle: call
   SupportedStyles:
-    - call
-    - braces
+  - call
+  - braces
 
 Style/LineEndConcatenation:
-  Description: >-
-                 Use \ instead of + or << to concatenate two string literals at
-                 line end.
+  Description: |-
+    This cop checks for string literal concatenation at
+    the end of a line.
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '0.18'
   VersionChanged: '0.64'
 
 Style/MethodCallWithArgsParentheses:
-  Description: 'Use parentheses for method calls with arguments.'
-  StyleGuide: '#method-invocation-parens'
+  Description: |-
+    This cop enforces the presence (default) or absence of parentheses in
+    method calls containing parameters.
+  StyleGuide: "#method-invocation-parens"
   Enabled: false
   VersionAdded: '0.47'
   VersionChanged: '0.61'
@@ -3396,98 +3364,99 @@ Style/MethodCallWithArgsParentheses:
   AllowParenthesesInCamelCaseMethod: false
   EnforcedStyle: require_parentheses
   SupportedStyles:
-    - require_parentheses
-    - omit_parentheses
+  - require_parentheses
+  - omit_parentheses
 
 Style/MethodCallWithoutArgsParentheses:
-  Description: 'Do not use parentheses for method calls with no arguments.'
-  StyleGuide: '#method-invocation-parens'
+  Description: This cop checks for unwanted parentheses in parameterless method calls.
+  StyleGuide: "#method-invocation-parens"
   Enabled: true
   IgnoredMethods: []
   VersionAdded: '0.47'
   VersionChanged: '0.55'
 
 Style/MethodCalledOnDoEndBlock:
-  Description: 'Avoid chaining a method call on a do...end block.'
-  StyleGuide: '#single-line-blocks'
+  Description: |-
+    This cop checks for methods called on a do...end block. The point of
+    this check is that it's easy to miss the call tacked on to the block
+    when reading code.
+  StyleGuide: "#single-line-blocks"
   Enabled: false
   VersionAdded: '0.14'
 
 Style/MethodDefParentheses:
-  Description: >-
-                 Checks if the method definitions have or don't have
-                 parentheses.
-  StyleGuide: '#method-parens'
+  Description: |-
+    This cop checks for parentheses around the arguments in method
+    definitions. Both instance and class/singleton methods are checked.
+  StyleGuide: "#method-parens"
   Enabled: true
   VersionAdded: '0.16'
   VersionChanged: '0.35'
   EnforcedStyle: require_parentheses
   SupportedStyles:
-    - require_parentheses
-    - require_no_parentheses
-    - require_no_parentheses_except_multiline
+  - require_parentheses
+  - require_no_parentheses
+  - require_no_parentheses_except_multiline
 
 Style/MethodMissingSuper:
-  Description: Checks for `method_missing` to call `super`.
-  StyleGuide: '#no-method-missing'
+  Description: |-
+    This cop checks for the presence of `method_missing` without
+    falling back on `super`.
+  StyleGuide: "#no-method-missing"
   Enabled: true
   VersionAdded: '0.56'
 
 Style/MinMax:
-  Description: >-
-                 Use `Enumerable#minmax` instead of `Enumerable#min`
-                 and `Enumerable#max` in conjunction.'
+  Description: This cop checks for potential uses of `Enumerable#minmax`.
   Enabled: true
   VersionAdded: '0.50'
 
 Style/MissingElse:
-  Description: >-
-                Require if/case expressions to have an else branches.
-                If enabled, it is recommended that
-                Style/UnlessElse and Style/EmptyElse be enabled.
-                This will conflict with Style/EmptyElse if
-                Style/EmptyElse is configured to style "both"
+  Description: Checks for `if` expressions that do not have an `else` branch.
   Enabled: false
   VersionAdded: '0.30'
   VersionChanged: '0.38'
   EnforcedStyle: both
   SupportedStyles:
-    # if - warn when an if expression is missing an else branch
-    # case - warn when a case expression is missing an else branch
-    # both - warn when an if or case expression is missing an else branch
-    - if
-    - case
-    - both
+  - if
+  - case
+  - both
 
 Style/MissingRespondToMissing:
-  Description: >-
-                  Checks if `method_missing` is implemented
-                  without implementing `respond_to_missing`.
-  StyleGuide: '#no-method-missing'
+  Description: |-
+    This cop checks for the presence of `method_missing` without also
+    defining `respond_to_missing?`.
+  StyleGuide: "#no-method-missing"
   Enabled: true
   VersionAdded: '0.56'
 
 Style/MixinGrouping:
-  Description: 'Checks for grouping of mixins in `class` and `module` bodies.'
-  StyleGuide: '#mixin-grouping'
+  Description: |-
+    This cop checks for grouping of mixins in `class` and `module` bodies.
+    By default it enforces mixins to be placed in separate declarations,
+    but it can be configured to enforce grouping them in one declaration.
+  StyleGuide: "#mixin-grouping"
   Enabled: true
   VersionAdded: '0.48'
   VersionChanged: '0.49'
   EnforcedStyle: separated
   SupportedStyles:
-    # separated: each mixed in module goes in a separate statement.
-    # grouped: mixed in modules are grouped into a single statement.
-    - separated
-    - grouped
+  - separated
+  - grouped
 
 Style/MixinUsage:
-  Description: 'Checks that `include`, `extend` and `prepend` exists at the top level.'
+  Description: |-
+    This cop checks that `include`, `extend` and `prepend` statements appear
+    inside classes and modules, not at the top level, so as to not affect
+    the behavior of `Object`.
   Enabled: true
   VersionAdded: '0.51'
 
 Style/ModuleFunction:
-  Description: 'Checks for usage of `extend self` in modules.'
-  StyleGuide: '#module-function'
+  Description: |-
+    This cop checks for use of `extend self` or `module_function` in a
+    module.
+  StyleGuide: "#module-function"
   Enabled: true
   VersionAdded: '0.11'
   VersionChanged: '0.65'
@@ -3499,56 +3468,58 @@ Style/ModuleFunction:
   SafeAutoCorrect: false
 
 Style/MultilineBlockChain:
-  Description: 'Avoid multi-line chains of blocks.'
-  StyleGuide: '#single-line-blocks'
+  Description: |-
+    This cop checks for chaining of a block after another block that spans
+    multiple lines.
+  StyleGuide: "#single-line-blocks"
   Enabled: true
   VersionAdded: '0.13'
 
 Style/MultilineIfModifier:
-  Description: 'Only use if/unless modifiers on single line statements.'
-  StyleGuide: '#no-multiline-if-modifiers'
+  Description: Checks for uses of if/unless modifiers with multiple-lines bodies.
+  StyleGuide: "#no-multiline-if-modifiers"
   Enabled: true
   VersionAdded: '0.45'
 
 Style/MultilineIfThen:
-  Description: 'Do not use then for multi-line if/unless.'
-  StyleGuide: '#no-then'
+  Description: Checks for uses of the `then` keyword in multi-line if statements.
+  StyleGuide: "#no-then"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.26'
 
 Style/MultilineMemoization:
-  Description: 'Wrap multiline memoizations in a `begin` and `end` block.'
+  Description: This cop checks expressions wrapping styles for multiline memoization.
   Enabled: true
   VersionAdded: '0.44'
   VersionChanged: '0.48'
   EnforcedStyle: keyword
   SupportedStyles:
-    - keyword
-    - braces
+  - keyword
+  - braces
 
 Style/MultilineMethodSignature:
-  Description: 'Avoid multi-line method signatures.'
+  Description: This cop checks for method signatures that span multiple lines.
   Enabled: false
   VersionAdded: '0.59'
 
 Style/MultilineTernaryOperator:
-  Description: >-
-                 Avoid multi-line ?: (the ternary operator);
-                 use if/unless instead.
-  StyleGuide: '#no-multiline-ternary'
+  Description: This cop checks for multi-line ternary op expressions.
+  StyleGuide: "#no-multiline-ternary"
   Enabled: true
   VersionAdded: '0.9'
 
 Style/MultipleComparison:
-  Description: >-
-                 Avoid comparing a variable with multiple items in a conditional,
-                 use Array#include? instead.
+  Description: |-
+    This cop checks against comparing a variable with multiple items, where
+    `Array#include?` could be used instead to avoid code repetition.
   Enabled: true
   VersionAdded: '0.49'
 
 Style/MutableConstant:
-  Description: 'Do not assign mutable objects to constants.'
+  Description: |-
+    This cop checks whether some constant value isn't a
+    mutable literal (e.g. array or hash).
   Enabled: true
   VersionAdded: '0.34'
   VersionChanged: '0.65'
@@ -3564,131 +3535,123 @@ Style/MutableConstant:
     - strict
 
 Style/NegatedIf:
-  Description: >-
-                 Favor unless over if for negative conditions
-                 (or control flow or).
-  StyleGuide: '#unless-for-negatives'
+  Description: |-
+    Checks for uses of if with a negated condition. Only ifs
+    without else are considered. There are three different styles:
+  StyleGuide: "#unless-for-negatives"
   Enabled: true
   VersionAdded: '0.20'
   VersionChanged: '0.48'
   EnforcedStyle: both
   SupportedStyles:
-    # both: prefix and postfix negated `if` should both use `unless`
-    # prefix: only use `unless` for negated `if` statements positioned before the body of the statement
-    # postfix: only use `unless` for negated `if` statements positioned after the body of the statement
-    - both
-    - prefix
-    - postfix
+  - both
+  - prefix
+  - postfix
 
 Style/NegatedWhile:
-  Description: 'Favor until over while for negative conditions.'
-  StyleGuide: '#until-for-negatives'
+  Description: Checks for uses of while with a negated condition.
+  StyleGuide: "#until-for-negatives"
   Enabled: true
   VersionAdded: '0.20'
 
 Style/NestedModifier:
-  Description: 'Avoid using nested modifiers.'
-  StyleGuide: '#no-nested-modifiers'
+  Description: |-
+    This cop checks for nested use of if, unless, while and until in their
+    modifier form.
+  StyleGuide: "#no-nested-modifiers"
   Enabled: true
   VersionAdded: '0.35'
 
 Style/NestedParenthesizedCalls:
-  Description: >-
-                 Parenthesize method calls which are nested inside the
-                 argument list of another parenthesized method call.
+  Description: |-
+    This cop checks for unparenthesized method calls in the argument list
+    of a parenthesized method call.
   Enabled: true
   VersionAdded: '0.36'
   VersionChanged: '0.50'
   Whitelist:
-    - be
-    - be_a
-    - be_an
-    - be_between
-    - be_falsey
-    - be_kind_of
-    - be_instance_of
-    - be_truthy
-    - be_within
-    - eq
-    - eql
-    - end_with
-    - include
-    - match
-    - raise_error
-    - respond_to
-    - start_with
+  - be
+  - be_a
+  - be_an
+  - be_between
+  - be_falsey
+  - be_kind_of
+  - be_instance_of
+  - be_truthy
+  - be_within
+  - eq
+  - eql
+  - end_with
+  - include
+  - match
+  - raise_error
+  - respond_to
+  - start_with
 
 Style/NestedTernaryOperator:
-  Description: 'Use one expression per branch in a ternary operator.'
-  StyleGuide: '#no-nested-ternary'
+  Description: This cop checks for nested ternary op expressions.
+  StyleGuide: "#no-nested-ternary"
   Enabled: true
   VersionAdded: '0.9'
 
 Style/Next:
-  Description: 'Use `next` to skip iteration instead of a condition at the end.'
-  StyleGuide: '#no-nested-conditionals'
+  Description: Use `next` to skip iteration instead of a condition at the end.
+  StyleGuide: "#no-nested-conditionals"
   Enabled: true
   VersionAdded: '0.22'
   VersionChanged: '0.35'
-  # With `always` all conditions at the end of an iteration needs to be
-  # replaced by next - with `skip_modifier_ifs` the modifier if like this one
-  # are ignored: [1, 2].each { |a| return 'yes' if a == 1 }
   EnforcedStyle: skip_modifier_ifs
-  # `MinBodyLength` defines the number of lines of the a body of an `if` or `unless`
-  # needs to have to trigger this cop
   MinBodyLength: 3
   SupportedStyles:
-    - skip_modifier_ifs
-    - always
+  - skip_modifier_ifs
+  - always
 
 Style/NilComparison:
-  Description: 'Prefer x.nil? to x == nil.'
-  StyleGuide: '#predicate-methods'
+  Description: |-
+    This cop checks for comparison of something with nil using `==` and
+    `nil?`.
+  StyleGuide: "#predicate-methods"
   Enabled: true
   VersionAdded: '0.12'
   VersionChanged: '0.59'
   EnforcedStyle: predicate
   SupportedStyles:
-    - predicate
-    - comparison
+  - predicate
+  - comparison
 
 Style/NonNilCheck:
-  Description: 'Checks for redundant nil checks.'
-  StyleGuide: '#no-non-nil-checks'
+  Description: This cop checks for non-nil checks, which are usually redundant.
+  StyleGuide: "#no-non-nil-checks"
   Enabled: true
   VersionAdded: '0.20'
   VersionChanged: '0.22'
-  # With `IncludeSemanticChanges` set to `true`, this cop reports offenses for
-  # `!x.nil?` and autocorrects that and `x != nil` to solely `x`, which is
-  # **usually** OK, but might change behavior.
-  #
-  # With `IncludeSemanticChanges` set to `false`, this cop does not report
-  # offenses for `!x.nil?` and does no changes that might change behavior.
   IncludeSemanticChanges: false
 
 Style/Not:
-  Description: 'Use ! instead of not.'
-  StyleGuide: '#bang-not-not'
+  Description: This cop checks for uses of the keyword `not` instead of `!`.
+  StyleGuide: "#bang-not-not"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.20'
 
 Style/NumericLiteralPrefix:
-  Description: 'Use smallcase prefixes for numeric literals.'
-  StyleGuide: '#numeric-literal-prefixes'
+  Description: |-
+    This cop checks for octal, hex, binary, and decimal literals using
+    uppercase prefixes and corrects them to lowercase prefix
+    or no prefix (in case of decimals).
+  StyleGuide: "#numeric-literal-prefixes"
   Enabled: true
   VersionAdded: '0.41'
   EnforcedOctalStyle: zero_with_o
   SupportedOctalStyles:
-    - zero_with_o
-    - zero_only
-
+  - zero_with_o
+  - zero_only
 
 Style/NumericLiterals:
-  Description: >-
-                 Add underscores to large numeric literals to improve their
-                 readability.
-  StyleGuide: '#underscores-in-numerics'
+  Description: |-
+    This cop checks for big numeric literals without _ between groups
+    of digits in them.
+  StyleGuide: "#underscores-in-numerics"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.48'
@@ -3696,14 +3659,13 @@ Style/NumericLiterals:
   Strict: false
 
 Style/NumericPredicate:
-  Description: >-
-                 Checks for the use of predicate- or comparison methods for
-                 numeric comparisons.
-  StyleGuide: '#predicate-methods'
+  Description: |-
+    This cop checks for usage of comparison operators (`==`,
+    `>`, `<`) to test numbers as zero, positive, or negative.
+    These can be replaced by their respective predicate methods.
+    The cop can also be configured to do the reverse.
+  StyleGuide: "#predicate-methods"
   Safe: false
-  # This will change to a new method call which isn't guaranteed to be on the
-  # object. Switching these methods has to be done with knowledge of the types
-  # of the variables which rubocop doesn't have.
   SafeAutoCorrect: false
   AutoCorrect: false
   Enabled: true
@@ -3711,64 +3673,63 @@ Style/NumericPredicate:
   VersionChanged: '0.59'
   EnforcedStyle: predicate
   SupportedStyles:
-    - predicate
-    - comparison
+  - predicate
+  - comparison
   IgnoredMethods: []
-  # Exclude RSpec specs because assertions like `expect(1).to be > 0` cause
-  # false positives.
   Exclude:
-    - 'spec/**/*'
+  - spec/**/*
 
 Style/OneLineConditional:
-  Description: >-
-                 Favor the ternary operator(?:) over
-                 if/then/else/end constructs.
-  StyleGuide: '#ternary-operator'
+  Description: |-
+    TODO: Make configurable.
+    Checks for uses of if/then/else/end on a single line.
+  StyleGuide: "#ternary-operator"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.38'
 
 Style/OptionHash:
-  Description: "Don't use option hashes when you can use keyword arguments."
+  Description: |-
+    This cop checks for options hashes and discourages them if the
+    current Ruby version supports keyword arguments.
   Enabled: false
   VersionAdded: '0.33'
   VersionChanged: '0.34'
-  # A list of parameter names that will be flagged by this cop.
   SuspiciousParamNames:
-    - options
-    - opts
-    - args
-    - params
-    - parameters
+  - options
+  - opts
+  - args
+  - params
+  - parameters
 
 Style/OptionalArguments:
-  Description: >-
-                 Checks for optional arguments that do not appear at the end
-                 of the argument list
-  StyleGuide: '#optional-arguments'
+  Description: |-
+    This cop checks for optional arguments to methods
+    that do not come at the end of the argument list
+  StyleGuide: "#optional-arguments"
   Enabled: true
   VersionAdded: '0.33'
 
 Style/OrAssignment:
-  Description: 'Recommend usage of double pipe equals (||=) where applicable.'
-  StyleGuide: '#double-pipe-for-uninit'
+  Description: This cop checks for potential usage of the `||=` operator.
+  StyleGuide: "#double-pipe-for-uninit"
   Enabled: true
   VersionAdded: '0.50'
 
 Style/ParallelAssignment:
-  Description: >-
-                  Check for simple usages of parallel assignment.
-                  It will only warn when the number of variables
-                  matches on both sides of the assignment.
-  StyleGuide: '#parallel-assignment'
+  Description: |-
+    Checks for simple usages of parallel assignment.
+    This will only complain when the number of variables
+    being assigned matched the number of assigning variables.
+  StyleGuide: "#parallel-assignment"
   Enabled: true
   VersionAdded: '0.32'
 
 Style/ParenthesesAroundCondition:
-  Description: >-
-                 Don't use parentheses around the condition of an
-                 if/unless/while.
-  StyleGuide: '#no-parens-around-condition'
+  Description: |-
+    This cop checks for the presence of superfluous parentheses around the
+    condition of if/unless/while/until.
+  StyleGuide: "#no-parens-around-condition"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.56'
@@ -3776,174 +3737,182 @@ Style/ParenthesesAroundCondition:
   AllowInMultilineConditions: false
 
 Style/PercentLiteralDelimiters:
-  Description: 'Use `%`-literal delimiters consistently'
-  StyleGuide: '#percent-literal-braces'
+  Description: This cop enforces the consistent usage of `%`-literal delimiters.
+  StyleGuide: "#percent-literal-braces"
   Enabled: true
   VersionAdded: '0.19'
-  # Specify the default preferred delimiter for all types with the 'default' key
-  # Override individual delimiters (even with default specified) by specifying
-  # an individual key
   PreferredDelimiters:
-    default: ()
-    '%i': '[]'
-    '%I': '[]'
-    '%r': '{}'
-    '%w': '[]'
-    '%W': '[]'
-  VersionChanged: '0.48.1'
+    default: "()"
+    "%i": "[]"
+    "%I": "[]"
+    "%r": "{}"
+    "%w": "[]"
+    "%W": "[]"
+  VersionChanged: 0.48.1
 
 Style/PercentQLiterals:
-  Description: 'Checks if uses of %Q/%q match the configured preference.'
+  Description: This cop checks for usage of the %Q() syntax when %q() would do.
   Enabled: true
   VersionAdded: '0.25'
   EnforcedStyle: lower_case_q
   SupportedStyles:
-    - lower_case_q # Use `%q` when possible, `%Q` when necessary
-    - upper_case_q # Always use `%Q`
+  - lower_case_q
+  - upper_case_q
 
 Style/PerlBackrefs:
-  Description: 'Avoid Perl-style regex back references.'
-  StyleGuide: '#no-perl-regexp-last-matchers'
+  Description: |-
+    This cop looks for uses of Perl-style regexp match
+    backreferences like $1, $2, etc.
+  StyleGuide: "#no-perl-regexp-last-matchers"
   Enabled: true
   VersionAdded: '0.13'
 
 Style/PreferredHashMethods:
-  Description: 'Checks use of `has_key?` and `has_value?` Hash methods.'
-  StyleGuide: '#hash-key'
+  Description: |-
+    This cop (by default) checks for uses of methods Hash#has_key? and
+    Hash#has_value? where it enforces Hash#key? and Hash#value?
+    It is configurable to enforce the inverse, using `verbose` method
+    names also.
+  StyleGuide: "#hash-key"
   Enabled: true
   VersionAdded: '0.41'
   VersionChanged: '0.44'
   EnforcedStyle: short
   SupportedStyles:
-    - short
-    - verbose
+  - short
+  - verbose
 
 Style/Proc:
-  Description: 'Use proc instead of Proc.new.'
-  StyleGuide: '#proc'
+  Description: |-
+    This cop checks for uses of Proc.new where Kernel#proc
+    would be more appropriate.
+  StyleGuide: "#proc"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.18'
 
 Style/RaiseArgs:
-  Description: 'Checks the arguments passed to raise/fail.'
-  StyleGuide: '#exception-class-messages'
+  Description: |-
+    This cop checks the args passed to `fail` and `raise`. For exploded
+    style (default), it recommends passing the exception class and message
+    to `raise`, rather than construct an instance of the error. It will
+    still allow passing just a message, or the construction of an error
+    with more than one argument.
+  StyleGuide: "#exception-class-messages"
   Enabled: true
   VersionAdded: '0.14'
   VersionChanged: '0.40'
   EnforcedStyle: exploded
   SupportedStyles:
-    - compact # raise Exception.new(msg)
-    - exploded # raise Exception, msg
+  - compact
+  - exploded
 
 Style/RandomWithOffset:
-  Description: >-
-                 Prefer to use ranges when generating random numbers instead of
-                 integers with offsets.
-  StyleGuide: '#random-numbers'
+  Description: |-
+    This cop checks for the use of randomly generated numbers,
+    added/subtracted with integer literals, as well as those with
+    Integer#succ and Integer#pred methods. Prefer using ranges instead,
+    as it clearly states the intentions.
+  StyleGuide: "#random-numbers"
   Enabled: true
   VersionAdded: '0.52'
 
 Style/RedundantBegin:
-  Description: "Don't use begin blocks when they are not needed."
-  StyleGuide: '#begin-implicit'
+  Description: This cop checks for redundant `begin` blocks.
+  StyleGuide: "#begin-implicit"
   Enabled: true
   VersionAdded: '0.10'
   VersionChanged: '0.21'
 
 Style/RedundantConditional:
-  Description: "Don't return true/false from a conditional."
+  Description: This cop checks for redundant returning of true/false in conditionals.
   Enabled: true
   VersionAdded: '0.50'
 
 Style/RedundantException:
-  Description: "Checks for an obsolete RuntimeException argument in raise/fail."
-  StyleGuide: '#no-explicit-runtimeerror'
+  Description: This cop checks for RuntimeError as the argument of raise/fail.
+  StyleGuide: "#no-explicit-runtimeerror"
   Enabled: true
   VersionAdded: '0.14'
   VersionChanged: '0.29'
 
 Style/RedundantFreeze:
-  Description: "Checks usages of Object#freeze on immutable objects."
+  Description: This cop check for uses of Object#freeze on immutable objects.
   Enabled: true
   VersionAdded: '0.34'
 
 Style/RedundantParentheses:
-  Description: "Checks for parentheses that seem not to serve any purpose."
+  Description: This cop checks for redundant parentheses.
   Enabled: true
   VersionAdded: '0.36'
 
 Style/RedundantReturn:
-  Description: "Don't use return where it's not required."
-  StyleGuide: '#no-explicit-return'
+  Description: This cop checks for redundant `return` expressions.
+  StyleGuide: "#no-explicit-return"
   Enabled: true
   VersionAdded: '0.10'
   VersionChanged: '0.14'
-  # When `true` allows code like `return x, y`.
   AllowMultipleReturnValues: false
 
 Style/RedundantSelf:
-  Description: "Don't use self where it's not needed."
-  StyleGuide: '#no-self-unless-required'
+  Description: This cop checks for redundant uses of `self`.
+  StyleGuide: "#no-self-unless-required"
   Enabled: true
   VersionAdded: '0.10'
   VersionChanged: '0.13'
 
 Style/RegexpLiteral:
-  Description: 'Use / or %r around regular expressions.'
-  StyleGuide: '#percent-r'
+  Description: This cop enforces using // or %r around regular expressions.
+  StyleGuide: "#percent-r"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.30'
   EnforcedStyle: slashes
-  # slashes: Always use slashes.
-  # percent_r: Always use `%r`.
-  # mixed: Use slashes on single-line regexes, and `%r` on multi-line regexes.
   SupportedStyles:
-    - slashes
-    - percent_r
-    - mixed
-  # If `false`, the cop will always recommend using `%r` if one or more slashes
-  # are found in the regexp string.
+  - slashes
+  - percent_r
+  - mixed
   AllowInnerSlashes: false
 
 Style/RescueModifier:
-  Description: 'Avoid using rescue in its modifier form.'
-  StyleGuide: '#no-rescue-modifiers'
+  Description: This cop checks for uses of rescue in its modifier form.
+  StyleGuide: "#no-rescue-modifiers"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.34'
 
 Style/RescueStandardError:
-  Description: 'Avoid rescuing without specifying an error class.'
+  Description: |-
+    This cop checks for rescuing `StandardError`. There are two supported
+    styles `implicit` and `explicit`. This cop will not register an offense
+    if any error other than `StandardError` is specified.
   Enabled: true
   VersionAdded: '0.52'
   EnforcedStyle: explicit
-  # implicit: Do not include the error class, `rescue`
-  # explicit: Require an error class `rescue StandardError`
   SupportedStyles:
-    - implicit
-    - explicit
+  - implicit
+  - explicit
 
 Style/ReturnNil:
-  Description: 'Use return instead of return nil.'
+  Description: This cop enforces consistency between 'return nil' and 'return'.
   Enabled: false
   EnforcedStyle: return
   SupportedStyles:
-    - return
-    - return_nil
+  - return
+  - return_nil
   VersionAdded: '0.50'
 
 Style/SafeNavigation:
-  Description: >-
-                  This cop transforms usages of a method call safeguarded by
-                  a check for the existence of the object to
-                  safe navigation (`&.`).
+  Description: |-
+    This cop transforms usages of a method call safeguarded by a non `nil`
+    check for the variable whose method is being called to
+    safe navigation (`&.`). If there is a method chain, all of the methods
+    in the chain need to be checked for safety, and all of the methods will
+    need to be changed to use safe navigation. We have limited the cop to
+    not register an offense for method chains that exceed 2 methods.
   Enabled: true
   VersionAdded: '0.43'
   VersionChanged: '0.56'
-  # Safe navigation may cause a statement to start returning `nil` in addition
-  # to whatever it used to return.
   ConvertCodeThatCanStartToReturnNil: false
   Whitelist:
     - present?
@@ -3953,160 +3922,166 @@ Style/SafeNavigation:
     - try!
 
 Style/SelfAssignment:
-  Description: >-
-                 Checks for places where self-assignment shorthand should have
-                 been used.
-  StyleGuide: '#self-assignment'
+  Description: This cop enforces the use the shorthand for self-assignment.
+  StyleGuide: "#self-assignment"
   Enabled: true
   VersionAdded: '0.19'
   VersionChanged: '0.29'
 
 Style/Semicolon:
-  Description: "Don't use semicolons to terminate expressions."
-  StyleGuide: '#no-semicolon'
+  Description: |-
+    This cop checks for multiple expressions placed on the same line.
+    It also checks for lines terminated with a semicolon.
+  StyleGuide: "#no-semicolon"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.19'
-  # Allow `;` to separate several expressions on the same line.
   AllowAsExpressionSeparator: false
 
 Style/Send:
-  Description: 'Prefer `Object#__send__` or `Object#public_send` to `send`, as `send` may overlap with existing methods.'
-  StyleGuide: '#prefer-public-send'
+  Description: This cop checks for the use of the send method.
+  StyleGuide: "#prefer-public-send"
   Enabled: false
   VersionAdded: '0.33'
 
 Style/SignalException:
-  Description: 'Checks for proper usage of fail and raise.'
-  StyleGuide: '#prefer-raise-over-fail'
+  Description: This cop checks for uses of `fail` and `raise`.
+  StyleGuide: "#prefer-raise-over-fail"
   Enabled: true
   VersionAdded: '0.11'
   VersionChanged: '0.37'
   EnforcedStyle: only_raise
   SupportedStyles:
-    - only_raise
-    - only_fail
-    - semantic
+  - only_raise
+  - only_fail
+  - semantic
 
 Style/SingleLineBlockParams:
-  Description: 'Enforces the names of some block params.'
+  Description: |-
+    This cop checks whether the block parameters of a single-line
+    method accepting a block match the names specified via configuration.
   Enabled: false
   VersionAdded: '0.16'
   VersionChanged: '0.47'
   Methods:
-    - reduce:
-        - acc
-        - elem
-    - inject:
-        - acc
-        - elem
+  - reduce:
+    - acc
+    - elem
+  - inject:
+    - acc
+    - elem
 
 Style/SingleLineMethods:
-  Description: 'Avoid single-line methods.'
-  StyleGuide: '#no-single-line-methods'
+  Description: |-
+    This cop checks for single-line method definitions that contain a body.
+    It will accept single-line methods with no body.
+  StyleGuide: "#no-single-line-methods"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.19'
   AllowIfMethodIsEmpty: true
 
 Style/SpecialGlobalVars:
-  Description: 'Avoid Perl-style global variables.'
-  StyleGuide: '#no-cryptic-perlisms'
+  Description: This cop looks for uses of Perl-style global variables.
+  StyleGuide: "#no-cryptic-perlisms"
   Enabled: true
   VersionAdded: '0.13'
   VersionChanged: '0.36'
   SafeAutoCorrect: false
   EnforcedStyle: use_english_names
   SupportedStyles:
-    - use_perl_names
-    - use_english_names
+  - use_perl_names
+  - use_english_names
 
 Style/StabbyLambdaParentheses:
-  Description: 'Check for the usage of parentheses around stabby lambda arguments.'
-  StyleGuide: '#stabby-lambda-with-args'
+  Description: |-
+    Check for parentheses around stabby lambda arguments.
+    There are two different styles. Defaults to `require_parentheses`.
+  StyleGuide: "#stabby-lambda-with-args"
   Enabled: true
   VersionAdded: '0.35'
   EnforcedStyle: require_parentheses
   SupportedStyles:
-    - require_parentheses
-    - require_no_parentheses
+  - require_parentheses
+  - require_no_parentheses
 
 Style/StderrPuts:
-  Description: 'Use `warn` instead of `$stderr.puts`.'
-  StyleGuide: '#warn'
+  Description: |-
+    This cop identifies places where `$stderr.puts` can be replaced by
+    `warn`. The latter has the advantage of easily being disabled by,
+    the `-W0` interpreter flag or setting `$VERBOSE` to `nil`.
+  StyleGuide: "#warn"
   Enabled: true
   VersionAdded: '0.51'
 
 Style/StringHashKeys:
-  Description: 'Prefer symbols instead of strings as hash keys.'
-  StyleGuide: '#symbols-as-keys'
+  Description: |-
+    This cop checks for the use of strings as keys in hashes. The use of
+    symbols is preferred instead.
+  StyleGuide: "#symbols-as-keys"
   Enabled: false
   VersionAdded: '0.52'
 
 Style/StringLiterals:
-  Description: 'Checks if uses of quotes match the configured preference.'
-  StyleGuide: '#consistent-string-literals'
+  Description: Checks if uses of quotes match the configured preference.
+  StyleGuide: "#consistent-string-literals"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.36'
   EnforcedStyle: single_quotes
   SupportedStyles:
-    - single_quotes
-    - double_quotes
-  # If `true`, strings which span multiple lines using `\` for continuation must
-  # use the same type of quotes on each line.
+  - single_quotes
+  - double_quotes
   ConsistentQuotesInMultiline: false
 
 Style/StringLiteralsInInterpolation:
-  Description: >-
-                 Checks if uses of quotes inside expressions in interpolated
-                 strings match the configured preference.
+  Description: |-
+    This cop checks that quotes inside the string interpolation
+    match the configured preference.
   Enabled: true
   VersionAdded: '0.27'
   EnforcedStyle: single_quotes
   SupportedStyles:
-    - single_quotes
-    - double_quotes
+  - single_quotes
+  - double_quotes
 
 Style/StringMethods:
-  Description: 'Checks if configured preferred methods are used over non-preferred.'
+  Description: |-
+    This cop enforces the use of consistent method names
+    from the String class.
   Enabled: false
   VersionAdded: '0.34'
-  VersionChanged: '0.34.2'
-  # Mapping from undesired method to desired_method
-  # e.g. to use `to_sym` over `intern`:
-  #
-  # StringMethods:
-  #   PreferredMethods:
-  #     intern: to_sym
+  VersionChanged: 0.34.2
   PreferredMethods:
     intern: to_sym
 
 Style/StructInheritance:
-  Description: 'Checks for inheritance from Struct.new.'
-  StyleGuide: '#no-extend-struct-new'
+  Description: This cop checks for inheritance from Struct.new.
+  StyleGuide: "#no-extend-struct-new"
   Enabled: true
   VersionAdded: '0.29'
 
 Style/SymbolArray:
-  Description: 'Use %i or %I for arrays of symbols.'
-  StyleGuide: '#percent-i'
+  Description: |-
+    This cop can check for array literals made up of symbols that are not
+    using the %i() syntax.
+  StyleGuide: "#percent-i"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.49'
   EnforcedStyle: percent
   MinSize: 2
   SupportedStyles:
-    - percent
-    - brackets
+  - percent
+  - brackets
 
 Style/SymbolLiteral:
-  Description: 'Use plain symbols instead of string symbols when possible.'
+  Description: This cop checks symbol literal syntax.
   Enabled: true
   VersionAdded: '0.30'
 
 Style/SymbolProc:
-  Description: 'Use symbols as procs instead of blocks when possible.'
+  Description: Use symbols as procs when possible.
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '0.26'
@@ -4114,225 +4089,193 @@ Style/SymbolProc:
   # A list of method names to be ignored by the check.
   # The names should be fairly unique, otherwise you'll end up ignoring lots of code.
   IgnoredMethods:
-    - respond_to
-    - define_method
+  - respond_to
+  - define_method
 
 Style/TernaryParentheses:
-  Description: 'Checks for use of parentheses around ternary conditions.'
+  Description: |-
+    This cop checks for the presence of parentheses around ternary
+    conditions. It is configurable to enforce inclusion or omission of
+    parentheses using `EnforcedStyle`. Omission is only enforced when
+    removing the parentheses won't cause a different behavior.
   Enabled: true
   VersionAdded: '0.42'
   VersionChanged: '0.46'
   EnforcedStyle: require_no_parentheses
   SupportedStyles:
-    - require_parentheses
-    - require_no_parentheses
-    - require_parentheses_when_complex
+  - require_parentheses
+  - require_no_parentheses
+  - require_parentheses_when_complex
   AllowSafeAssignment: true
 
 Style/TrailingBodyOnClass:
-  Description: 'Class body goes below class statement.'
+  Description: This cop checks for trailing code after the class definition.
   Enabled: true
   VersionAdded: '0.53'
 
 Style/TrailingBodyOnMethodDefinition:
-  Description: 'Method body goes below definition.'
+  Description: This cop checks for trailing code after the method definition.
   Enabled: true
   VersionAdded: '0.52'
 
 Style/TrailingBodyOnModule:
-  Description: 'Module body goes below module statement.'
+  Description: This cop checks for trailing code after the module definition.
   Enabled: true
   VersionAdded: '0.53'
 
 Style/TrailingCommaInArguments:
-  Description: 'Checks for trailing comma in argument lists.'
-  StyleGuide: '#no-trailing-params-comma'
+  Description: This cop checks for trailing comma in argument lists.
+  StyleGuide: "#no-trailing-params-comma"
   Enabled: true
   VersionAdded: '0.36'
-  # If `comma`, the cop requires a comma after the last argument, but only for
-  # parenthesized method calls where each argument is on its own line.
-  # If `consistent_comma`, the cop requires a comma after the last argument,
-  # for all parenthesized method calls with arguments.
   EnforcedStyleForMultiline: no_comma
   SupportedStylesForMultiline:
-    - comma
-    - consistent_comma
-    - no_comma
+  - comma
+  - consistent_comma
+  - no_comma
 
 Style/TrailingCommaInArrayLiteral:
-  Description: 'Checks for trailing comma in array literals.'
-  StyleGuide: '#no-trailing-array-commas'
+  Description: This cop checks for trailing comma in array literals.
+  StyleGuide: "#no-trailing-array-commas"
   Enabled: true
   VersionAdded: '0.53'
-  # but only when each item is on its own line.
-  # If `consistent_comma`, the cop requires a comma after the last item of all
-  # non-empty array literals.
   EnforcedStyleForMultiline: no_comma
   SupportedStylesForMultiline:
-    - comma
-    - consistent_comma
-    - no_comma
+  - comma
+  - consistent_comma
+  - no_comma
 
 Style/TrailingCommaInHashLiteral:
-  Description: 'Checks for trailing comma in hash literals.'
+  Description: This cop checks for trailing comma in hash literals.
   Enabled: true
-  # If `comma`, the cop requires a comma after the last item in a hash,
-  # but only when each item is on its own line.
-  # If `consistent_comma`, the cop requires a comma after the last item of all
-  # non-empty hash literals.
   EnforcedStyleForMultiline: no_comma
   SupportedStylesForMultiline:
-    - comma
-    - consistent_comma
-    - no_comma
+  - comma
+  - consistent_comma
+  - no_comma
   VersionAdded: '0.53'
 
 Style/TrailingMethodEndStatement:
-  Description: 'Checks for trailing end statement on line of method body.'
+  Description: This cop checks for trailing code after the method definition.
   Enabled: true
   VersionAdded: '0.52'
 
 Style/TrailingUnderscoreVariable:
-  Description: >-
-                 Checks for the usage of unneeded trailing underscores at the
-                 end of parallel variable assignment.
+  Description: This cop checks for extra underscores in variable assignment.
   AllowNamedUnderscoreVariables: true
   Enabled: true
   VersionAdded: '0.31'
   VersionChanged: '0.35'
 
-# `TrivialAccessors` requires exact name matches and doesn't allow
-# predicated methods by default.
 Style/TrivialAccessors:
-  Description: 'Prefer attr_* methods to trivial readers/writers.'
-  StyleGuide: '#attr_family'
+  Description: |-
+    This cop looks for trivial reader/writer methods, that could
+    have been created with the attr_* family of functions automatically.
+  StyleGuide: "#attr_family"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.38'
-  # When set to `false` the cop will suggest the use of accessor methods
-  # in situations like:
-  #
-  # def name
-  #   @other_name
-  # end
-  #
-  # This way you can uncover "hidden" attributes in your code.
   ExactNameMatch: true
   AllowPredicates: true
-  # Allows trivial writers that don't end in an equal sign. e.g.
-  #
-  # def on_exception(action)
-  #   @on_exception=action
-  # end
-  # on_exception :restart
-  #
-  # Commonly used in DSLs
   AllowDSLWriters: false
   IgnoreClassMethods: false
   Whitelist:
-    - to_ary
-    - to_a
-    - to_c
-    - to_enum
-    - to_h
-    - to_hash
-    - to_i
-    - to_int
-    - to_io
-    - to_open
-    - to_path
-    - to_proc
-    - to_r
-    - to_regexp
-    - to_str
-    - to_s
-    - to_sym
+  - to_ary
+  - to_a
+  - to_c
+  - to_enum
+  - to_h
+  - to_hash
+  - to_i
+  - to_int
+  - to_io
+  - to_open
+  - to_path
+  - to_proc
+  - to_r
+  - to_regexp
+  - to_str
+  - to_s
+  - to_sym
 
 Style/UnlessElse:
-  Description: >-
-                 Do not use unless with else. Rewrite these with the positive
-                 case first.
-  StyleGuide: '#no-else-with-unless'
+  Description: This cop looks for *unless* expressions with *else* clauses.
+  StyleGuide: "#no-else-with-unless"
   Enabled: true
   VersionAdded: '0.9'
 
 Style/UnneededCapitalW:
-  Description: 'Checks for %W when interpolation is not needed.'
+  Description: This cop checks for usage of the %W() syntax when %w() would do.
   Enabled: true
   VersionAdded: '0.21'
   VersionChanged: '0.24'
 
 Style/UnneededCondition:
-  Description: 'Checks for unnecessary conditional expressions.'
+  Description: This cop checks for unnecessary conditional expressions.
   Enabled: true
   VersionAdded: '0.57'
 
 Style/UnneededInterpolation:
-  Description: 'Checks for strings that are just an interpolated expression.'
+  Description: This cop checks for strings that are just an interpolated expression.
   Enabled: true
   VersionAdded: '0.36'
 
 Style/UnneededPercentQ:
-  Description: 'Checks for %q/%Q when single quotes or double quotes would do.'
-  StyleGuide: '#percent-q'
+  Description: This cop checks for usage of the %q/%Q syntax when '' or "" would do.
+  StyleGuide: "#percent-q"
   Enabled: true
   VersionAdded: '0.24'
 
 Style/UnpackFirst:
-  Description: >-
-                 Checks for accessing the first element of `String#unpack`
-                 instead of using `unpack1`
+  Description: |-
+    This cop checks for accessing the first element of `String#unpack`
+    which can be replaced with the shorter method `unpack1`.
   Enabled: true
   VersionAdded: '0.54'
 
 Style/VariableInterpolation:
-  Description: >-
-                 Don't interpolate global, instance and class variables
-                 directly in strings.
-  StyleGuide: '#curlies-interpolate'
+  Description: This cop checks for variable interpolation (like "#@ivar").
+  StyleGuide: "#curlies-interpolate"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.20'
 
 Style/WhenThen:
-  Description: 'Use when x then ... for one-line cases.'
-  StyleGuide: '#one-line-cases'
+  Description: This cop checks for *when;* uses in *case* expressions.
+  StyleGuide: "#one-line-cases"
   Enabled: true
   VersionAdded: '0.9'
 
 Style/WhileUntilDo:
-  Description: 'Checks for redundant do after while or until.'
-  StyleGuide: '#no-multiline-while-do'
+  Description: Checks for uses of `do` in multi-line `while/until` statements.
+  StyleGuide: "#no-multiline-while-do"
   Enabled: true
   VersionAdded: '0.9'
 
 Style/WhileUntilModifier:
-  Description: >-
-                 Favor modifier while/until usage when you have a
-                 single-line body.
-  StyleGuide: '#while-as-a-modifier'
+  Description: |-
+    Checks for while and until statements that would fit on one line
+    if written as a modifier while/until. The maximum line length is
+    configured in the `Metrics/LineLength` cop.
+  StyleGuide: "#while-as-a-modifier"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.30'
 
 Style/WordArray:
-  Description: 'Use %w or %W for arrays of words.'
-  StyleGuide: '#percent-w'
+  Description: |-
+    This cop can check for array literals made up of word-like
+    strings, that are not using the %w() syntax.
+  StyleGuide: "#percent-w"
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.36'
   EnforcedStyle: percent
   SupportedStyles:
-    # percent style: %w(word1 word2)
-    - percent
-    # bracket style: ['word1', 'word2']
-    - brackets
-  # The `MinSize` option causes the `WordArray` rule to be ignored for arrays
-  # smaller than a certain size. The rule is only applied to arrays
-  # whose element count is greater than or equal to `MinSize`.
+  - percent
+  - brackets
   MinSize: 2
-  # The regular expression `WordRegex` decides what is considered a word.
-  WordRegex: !ruby/regexp '/\A[\p{Word}\n\t]+\z/'
+  WordRegex: !ruby/regexp /\A[\p{Word}\n\t]+\z/
 
 Style/YodaCondition:
   Description: 'Forbid or enforce yoda conditions.'
@@ -4352,7 +4295,12 @@ Style/YodaCondition:
   VersionChanged: '0.63'
 
 Style/ZeroLengthPredicate:
-  Description: 'Use #empty? when testing for objects of length 0.'
+  Description: |-
+    This cop checks for numeric comparisons that can be replaced
+    by a predicate method, such as receiver.length == 0,
+    receiver.length > 0, receiver.length != 0,
+    receiver.length < 1 and receiver.size == 0 that can be
+    replaced by receiver.empty? and !receiver.empty.
   Enabled: true
   Safe: false
   VersionAdded: '0.37'

--- a/lib/rubocop/config_formatter.rb
+++ b/lib/rubocop/config_formatter.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module RuboCop
+  # Builds YAML config file from two hashes
+  class ConfigFormatter
+    DEPARTMENTS = /^(#{Cop::Cop.registry.departments.join('|')})/x.freeze
+    STANDALONE_DEPARTMENT_EXCLUSIONS = ['Rails'].freeze
+
+    def initialize(config, descriptions)
+      @config = config
+      @descriptions = descriptions
+    end
+
+    def dump
+      YAML.dump(unified_config).gsub(DEPARTMENTS, "\n\\1")
+    end
+
+    private
+
+    def unified_config
+      cops.each_with_object(config.dup) do |cop, unified|
+        unified[cop] = config.fetch(cop).merge(descriptions.fetch(cop))
+      end
+    end
+
+    def cops
+      (descriptions.keys | config.keys).grep(DEPARTMENTS) -
+        STANDALONE_DEPARTMENT_EXCLUSIONS
+    end
+
+    attr_reader :config, :descriptions
+  end
+end

--- a/lib/rubocop/description_extractor.rb
+++ b/lib/rubocop/description_extractor.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module RuboCop
+  # Extracts top description lines from source code and builds hash
+  # used to update config/defauly.yml.
+  class DescriptionExtractor
+    def initialize(yardocs)
+      @code_objects = yardocs.map(&CodeObject.public_method(:new))
+    end
+
+    def to_h
+      code_objects
+        .select(&:cop?)
+        .map(&:configuration)
+        .reduce(:merge)
+    end
+
+    private
+
+    attr_reader :code_objects
+
+    # Decorator of a YARD code object for working with documented cops
+    class CodeObject
+      def initialize(yardoc)
+        @yardoc = yardoc
+      end
+
+      # Test if the YARD code object documents a concrete cop class
+      #
+      # @return [Boolean]
+      def cop?
+        class_documentation? && inherits_from_cop?
+      end
+
+      # Configuration for the documented cop that would live in default.yml
+      #
+      # @return [Hash]
+      def configuration
+        { cop_name => { 'Description' => description } }
+      end
+
+      private
+
+      attr_reader :yardoc
+
+      def cop_name
+        constant.cop_name
+      end
+
+      def description
+        yardoc.docstring.split("\n\n").first.to_s
+      end
+
+      def class_documentation?
+        yardoc.type.equal?(:class)
+      end
+
+      def inherits_from_cop?
+        constant.respond_to?(:cop_name)
+      end
+
+      def constant
+        Object.const_get(yardoc.to_s)
+      end
+    end
+  end
+end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe 'RuboCop Project', type: :feature do
       cop_names.each do |name|
         description = config[name]['Description']
         expect(description.nil?).to be(false)
-        expect(description).not_to include("\n")
       end
     end
 

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -736,7 +736,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect(stdout).to match(
           ['# Supports --auto-correct',
            'Layout/Tab:',
-           '  Description: No hard tabs.',
+           '  Description: This cop checks for tabs inside the source code.',
            /^  StyleGuide: ('|")#spaces-indentation('|")$/,
            '  Enabled: true',
            /^  VersionAdded: '[0-9\.]+'$/,
@@ -761,7 +761,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect(stdout).to match(
           ['# Supports --auto-correct',
            'Layout/Tab:',
-           '  Description: No hard tabs.',
+           '  Description: This cop checks for tabs inside the source code.',
            /^  StyleGuide: ('|")#spaces-indentation('|")$/,
            '  Enabled: true'].join("\n")
         )

--- a/spec/rubocop/config_formatter_spec.rb
+++ b/spec/rubocop/config_formatter_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rubocop/config_formatter'
+
+RSpec.describe RuboCop::ConfigFormatter do
+  let(:config) do
+    {
+      'AllCops' => {
+        'Setting' => 'fourty two'
+      },
+      'Style/Foo' => {
+        'Config' => 2,
+        'Enabled' => true
+      },
+      'Style/Bar' => {
+        'Enabled' => true
+      }
+    }
+  end
+
+  let(:descriptions) do
+    {
+      'Style/Foo' => {
+        'Description' => 'Blah'
+      },
+      'Style/Bar' => {
+        'Description' => 'Wow'
+      }
+    }
+  end
+
+  it 'builds a YAML dump with spacing between cops' do
+    formatter = described_class.new(config, descriptions)
+
+    expect(formatter.dump).to eql(<<-YAML.gsub(/^\s+\|/, ''))
+      |---
+      |AllCops:
+      |  Setting: fourty two
+      |
+      |Style/Foo:
+      |  Config: 2
+      |  Enabled: true
+      |  Description: Blah
+      |
+      |Style/Bar:
+      |  Enabled: true
+      |  Description: Wow
+    YAML
+  end
+end

--- a/spec/rubocop/description_extractor_spec.rb
+++ b/spec/rubocop/description_extractor_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'yard'
+require 'rubocop/description_extractor'
+
+RSpec.describe RuboCop::DescriptionExtractor do
+  let(:yardocs) do
+    YARD.parse_string(<<-RUBY)
+      # Summary description
+      #
+      # Some more description
+      #
+      # @example
+      #   # bad
+      #   something
+      #
+      #   # good
+      #   something
+      #
+      # @note only works with foo
+      #
+      class RuboCop::Cop::Layout::EmptyLines < RuboCop::Cop::Cop
+        # Hello
+        def bar
+        end
+      end
+      # Only line of description
+      #
+      class RuboCop::Cop::Layout::EndOfLine < RuboCop::Cop::Cop
+        # Hello
+        def bar
+        end
+      end
+    RUBY
+
+    YARD::Registry.all
+  end
+
+  it 'builds a hash of descriptions' do
+    expect(described_class.new(yardocs).to_h).to include(
+      'Layout/EmptyLines' => { 'Description' => 'Summary description' },
+      'Layout/EndOfLine' => { 'Description' => 'Only line of description' }
+    )
+  end
+end


### PR DESCRIPTION
This PR addresses #3904. It deduplicates `Cop` descriptions by loading the config and replacing its `Description`s with the ones held in `yard`. That makes the source code the single source of truth for descriptions. This was heavily inspired by @backus 's implementation in `rubocop-rspec`. (Thank you sir!)

There are a lot of consequences of loading and dumping `YAML`. Here are some of the changes you will find in `config/default.yml` that are noteworthy but (imo) seem ok.

* Lists are not indented - ref: https://stackoverflow.com/questions/17014460/yaml-indentation-for-array-in-hash
* single quotes are generally replaced with double quotes. This appears to be when the string contains special characters like `*` and `#`. They are not replaced in `VersionAdded` and `VersionChanged` settings.
* Settings such as `CacheRootDirectory: ~` are replaced with `CacheRootDirectory: `. I don't like this, but it's still valid yaml. It seems to boil down to aesthetic, though.
* [Descriptions include line feeds](https://github.com/rubocop-hq/rubocop/compare/master...garettarrowood:deduplicate_cop_documentation?expand=1#diff-db360415c82dc1c3dd5a5c2872d0cd04L31). This doesn't seem like a big deal because those line feeds are following the 80 character `Metrics/LineLength` setting enforced in the repo already. So comments will appear uniform in the file.

But. There is a deal breaking change here. All comments are stripped from the config. I looked around for a solution and only found ones involving adding comments in one line at a time. While searching for alternative yaml parsers besides `YAML`/`Pysch`,  I found [this blog post which suggests the only comment preserving YAML parser is ruamel, which is for Python](https://kev.inburke.com/kevin/more-comment-preserving-configuration-parsers/).

Possible solutions:

1. Move the comments into the config. Add keys such as `AllowSymlinksInCacheRootDirectoryDescription` and give it the associated comment as a value to save.
1. Don't mix these concerns. Put documentation in something else, designed for it, instead of a configuration file.
1. Explore trying to make all of these updates using other Ruby libraries such as `File`, instead of loading the config itself.
1. Something I haven't thought of. Have an idea?

Last note: I believe it is to our benefit to load config, make a change, and the dump it back out. After syncing descriptions, we could explore syncing any/all other values. Procedurally updating our configuration feels like a step in the right direction.

Thoughts and ideas?

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
