### PR TITLE
[Fix #6533] Improve warning message for unrecognized parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 * [#595](https://github.com/rubocop-hq/rubocop/issues/595): Exclude files ignored by `git`. ([@AlexWayfer][])
 * [#6429](https://github.com/rubocop-hq/rubocop/issues/6429): Fix autocorrect in Rails/Validation to not wrap hash options with braces in an extra set of braces. ([@bquorning][])
+* [#6533](https://github.com/rubocop-hq/rubocop/issues/6533): Improved warning message for unrecognized cop parameters to include Supported parameters. ([@MagedMilad][])
 
 ## 0.61.1 (2018-12-06)
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -16,6 +16,9 @@ module RuboCop
 
     COMMON_PARAMS = %w[Exclude Include Severity inherit_mode
                        AutoCorrect StyleGuide Details].freeze
+    INTERNAL_PARAMS = %w[Description StyleGuide VersionAdded
+                         VersionChanged Reference Safe SafeAutoCorrect].freeze
+
     # 2.2 is the oldest officially supported Ruby version.
     DEFAULT_RUBY_VERSION = 2.2
     KNOWN_RUBIES = [2.2, 2.3, 2.4, 2.5, 2.6].freeze
@@ -509,12 +512,17 @@ module RuboCop
     def validate_parameter_names(valid_cop_names)
       valid_cop_names.each do |name|
         validate_section_presence(name)
-        self[name].each_key do |param|
-          next if COMMON_PARAMS.include?(param) ||
-                  ConfigLoader.default_configuration[name].key?(param)
+        default_config = ConfigLoader.default_configuration[name]
 
-          warn Rainbow("Warning: unrecognized parameter #{name}:#{param} " \
-                       "found in #{smart_loaded_path}").yellow
+        self[name].each_key do |param|
+          next if COMMON_PARAMS.include?(param) || default_config.key?(param)
+
+          message =
+            "Warning: #{name} does not support #{param} parameter.\n\n" \
+            "Supported parameters are:\n\n" \
+            "  - #{(default_config.keys - INTERNAL_PARAMS).join("\n  - ")}\n"
+
+          warn Rainbow(message).yellow.to_s
         end
       end
     end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1443,10 +1443,20 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       YAML
 
       expect(cli.run(%w[--format simple example])).to eq(1)
-      expect($stderr.string)
-        .to eq(['Warning: unrecognized parameter Metrics/LineLength:Min ' \
-                'found in example/.rubocop.yml',
-                ''].join("\n"))
+
+      expect($stderr.string).to eq(<<-RESULT.strip_margin('|'))
+        |Warning: Metrics/LineLength does not support Min parameter.
+        |
+        |Supported parameters are:
+        |
+        |  - Enabled
+        |  - Max
+        |  - AllowHeredoc
+        |  - AllowURI
+        |  - URISchemes
+        |  - IgnoreCopDirectives
+        |  - IgnoredPatterns
+      RESULT
     end
 
     it 'prints an error message for an unrecognized EnforcedStyle' do

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe RuboCop::Config do
       it 'prints a warning message' do
         configuration # ConfigLoader.load_file will validate config
         expect($stderr.string).to match(
-          %r{unrecognized parameter Metrics/LineLength:Min}
+          %r{Metrics/LineLength does not support Min parameter.}
         )
       end
     end


### PR DESCRIPTION
Fixes: #6533 

#### Commit Summary
- Improve the warning message of unrecognized cop parameters to be: `Warning: <cop> does not support <offending parameter> parameter. Supported parameters are: <list of supported parameters>`
-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
