### PR TITLE
Specify default EnforcedStyle in `Style/MethodCallWithArgsParentheses` doc

### DIFF
--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -21,7 +21,7 @@ module RuboCop
       #     to `true` allows the presence of parentheses in multi-line method
       #     calls.
       #
-      # @example EnforcedStyle: require_parentheses
+      # @example EnforcedStyle: require_parentheses (default)
       #
       #
       #   # bad

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2810,7 +2810,7 @@ options.
 
 ### Examples
 
-#### EnforcedStyle: require_parentheses
+#### EnforcedStyle: require_parentheses (default)
 
 ```ruby
 # bad


### PR DESCRIPTION
Follow up of #6469.

This PR specifies the default EnforcedStyle in `Style/MethodCallWithArgsParentheses` doc.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
