### PR TITLE
[Fix #6597] - LineEndConcatenation is unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 * [#6382](https://github.com/rubocop-hq/rubocop/issues/6382): Fix `Layout/IndentationWidth` with `Layout/EndAlignment` set to start_of_line. ([@dischorde][], [@siegfault][], [@mhelmetag][])
 * [#6710](https://github.com/rubocop-hq/rubocop/issues/6710): Fix `Naming/MemoizedInstanceVariableName` on method starts with underscore. ([@pocke][])
 
+### Changes
+
+* [#6597](https://github.com/rubocop-hq/rubocop/issues/6597): `Style/LineEndConcatenation` is now known to be unsafe for auto-correct. ([@jaredbeck][])
+
 ## 0.63.1 (2019-01-22)
 
 ### Bug fixes

--- a/config/default.yml
+++ b/config/default.yml
@@ -3374,7 +3374,9 @@ Style/LineEndConcatenation:
                  Use \ instead of + or << to concatenate two string literals at
                  line end.
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.18'
+  VersionChanged: '0.64'
 
 Style/MethodCallWithArgsParentheses:
   Description: 'Use parentheses for method calls with arguments.'

--- a/manual/auto_correct.md
+++ b/manual/auto_correct.md
@@ -16,13 +16,38 @@ Some automatic corrections that _are_ possible have not been implemented yet.
 $ rubocop --safe-auto-correct
 ```
 
-In RuboCop 0.60, we began to annotate cops as `Safe` or not safe.
+In RuboCop 0.60, we began to annotate cops as `Safe` or not safe. Eventually,
+the safety of each cop will be determined.
 
-> - Safe (true/false) - indicates whether the cop can yield false positives (by 
+> - Safe (true/false) - indicates whether the cop can yield false positives (by
 >   design) or not.
-> - SafeAutoCorrect (true/false) - indicates whether the auto-correct the cop 
+> - SafeAutoCorrect (true/false) - indicates whether the auto-correct the cop
 >   does is safe (equivalent) by design.
 > https://github.com/rubocop-hq/rubocop/issues/5978#issuecomment-395958738
 
-If a cop is annotated as "not safe", it will be omitted. As of December, not
-all cops have a `Safe` annotation.
+If a cop is annotated as "not safe", it will be omitted.
+
+#### Example of Unsafe Cop
+
+```ruby
+array = []
+array << 'Foo' <<
+         'Bar' <<
+         'Baz'
+puts array.join('-')
+```
+
+`Style/LineEndConcatenation` will correct the above to:
+
+```ruby
+array = []
+array << 'Foo' \
+  'Bar' \
+  'Baz'
+puts array.join('-')
+```
+
+Therefore, in this (unusual) scenario, `Style/LineEndConcatenation` is unsafe.
+
+(This is a contrived example. Real code would use `%w` for an array of string
+literals.)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2738,7 +2738,7 @@ EnforcedStyle | `call` | `call`, `braces`
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.18 | -
+Enabled | Yes | Yes (Unsafe) | 0.18 | 0.64
 
 This cop checks for string literal concatenation at
 the end of a line.


### PR DESCRIPTION
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
