### PR TITLE
Various omit parentheses fixes volume n+1

### DIFF
--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -245,7 +245,8 @@ module RuboCop
         def call_in_logical_operators?(node)
           node.parent &&
             (logical_operator?(node.parent) ||
-             node.parent.descendants.any?(&method(:logical_operator?)))
+             node.parent.send_type? &&
+             node.parent.arguments.any?(&method(:logical_operator?)))
         end
 
         def call_in_optional_arguments?(node)

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -268,7 +268,9 @@ module RuboCop
         end
 
         def call_as_argument_or_chain?(node)
-          node.parent && (node.parent.send_type? || node.parent.csend_type?)
+          node.parent &&
+            (node.parent.send_type? && !assigned_before?(node.parent, node) ||
+             node.parent.csend_type?)
         end
 
         def hash_literal_in_arguments?(node)
@@ -314,6 +316,11 @@ module RuboCop
 
         def regexp_slash_literal?(node)
           node.regexp_type? && node.loc.begin.source == '/'
+        end
+
+        def assigned_before?(node, target)
+          node.assignment? &&
+            node.loc.operator.begin < target.loc.begin
         end
       end
     end

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -340,6 +340,23 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
+    it 'register an offense in complex conditionals' do
+      expect_offense(<<-RUBY.strip_indent)
+        def foo
+          if cond.present? && verify?(:something)
+            h.do_with(kw: value)
+                     ^^^^^^^^^^^ Omit parentheses for method calls with arguments.
+          elsif cond.present? || verify?(:something_else)
+            h.do_with(kw: value)
+                     ^^^^^^^^^^^ Omit parentheses for method calls with arguments.
+          elsif whatevs?
+            h.do_with(kw: value)
+                     ^^^^^^^^^^^ Omit parentheses for method calls with arguments.
+          end
+        end
+      RUBY
+    end
+
     it 'accepts no parens in method call without args' do
       expect_no_offenses('top.test')
     end

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -357,6 +357,23 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
+    it 'register an offense in assignments' do
+      expect_offense(<<-RUBY.strip_indent)
+        foo = A::B.new(c)
+                      ^^^ Omit parentheses for method calls with arguments.
+        bar.foo = A::B.new(c)
+                          ^^^ Omit parentheses for method calls with arguments.
+        bar.foo(42).quux = A::B.new(c)
+                                   ^^^ Omit parentheses for method calls with arguments.
+
+        bar.foo(42).quux &&= A::B.new(c)
+                                     ^^^ Omit parentheses for method calls with arguments.
+
+        bar.foo(42).quux += A::B.new(c)
+                                    ^^^ Omit parentheses for method calls with arguments.
+      RUBY
+    end
+
     it 'accepts no parens in method call without args' do
       expect_no_offenses('top.test')
     end


### PR DESCRIPTION
🎶 He's making a bug-list
🎶 And checking it twice
🎶 Gonna find out if the bugs are naughty or nice
🎶 `omit_parentheses` fixes are coming to Rubocop 🎄 

---

Before:

```ruby
def foo
  if cond.present? && verify?(:something)
    h.do_with(kw: value)
  elsif cond.present? || verify?(:something_else)
    h.do_with(kw: value)
  elsif whatevs?
    h.do_with(kw: value)
             ^^^^^^^^^^^ Omit parentheses for method calls with arguments.
  end
end
```

Now:

```ruby
def foo
  if cond.present? && verify?(:something)
    h.do_with(kw: value)
             ^^^^^^^^^^^ Omit parentheses for method calls with arguments.
  elsif cond.present? || verify?(:something_else)
    h.do_with(kw: value)
             ^^^^^^^^^^^ Omit parentheses for method calls with arguments.
  elsif whatevs?
    h.do_with(kw: value)
             ^^^^^^^^^^^ Omit parentheses for method calls with arguments.
  end
end
```

---

Before:

```ruby
bar.foo.quux = A::B.new(c) # No offense here!
bar.foo(42).quux = A::B.new(c)
       ^^^^ Omit parentheses for method calls with arguments.
```

Now:

```ruby
bar.foo.quux = A::B.new(c)
                       ^^^ Omit parentheses for method calls with arguments.
bar.foo(42).quux = A::B.new(c)
                           ^^^ Omit parentheses for method calls with arguments.
```


