### PR TITLE
Mark Style/ModuleFunction as unsafe autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * [#6766](https://github.com/rubocop-hq/rubocop/pull/6766): Drop support for Ruby 2.2.0 and 2.2.1. ([@pocke][])
 * [#6733](https://github.com/rubocop-hq/rubocop/pull/6733): Warn duplicated keys in `.rubocop.yml`. ([@pocke][])
+* [#6613](https://github.com/rubocop-hq/rubocop/pull/6613): Mark `Style/ModuleFunction` as `SafeAutocorrect: false` and disable autocorrect by default. ([@dduugg][])
 
 ## 0.64.0 (2019-02-10)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -3490,11 +3490,13 @@ Style/ModuleFunction:
   StyleGuide: '#module-function'
   Enabled: true
   VersionAdded: '0.11'
-  VersionChanged: '0.53'
+  VersionChanged: '0.65'
   EnforcedStyle: module_function
   SupportedStyles:
     - module_function
     - extend_self
+  Autocorrect: false
+  SafeAutoCorrect: false
 
 Style/MultilineBlockChain:
   Description: 'Avoid multi-line chains of blocks.'

--- a/lib/rubocop/cop/style/module_function.rb
+++ b/lib/rubocop/cop/style/module_function.rb
@@ -46,7 +46,7 @@ module RuboCop
       #     # ...
       #   end
       #
-      # These offenses are not auto-corrected since there are different
+      # These offenses are not safe to auto-correct since there are different
       # implications to each approach.
       class ModuleFunction < Cop
         include ConfigurableEnforcedStyle

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3360,7 +3360,7 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.11 | 0.53
+Enabled | Yes | Yes (Unsafe) | 0.11 | 0.65
 
 This cop checks for use of `extend self` or `module_function` in a
 module.
@@ -3370,7 +3370,7 @@ Supported styles are: module_function, extend_self.
 In case there are private methods, the cop won't be activated.
 Otherwise, it forces to change the flow of the default code.
 
-These offenses are not auto-corrected since there are different
+These offenses are not safe to auto-correct since there are different
 implications to each approach.
 
 ### Examples
@@ -3422,6 +3422,7 @@ end
 Name | Default value | Configurable values
 --- | --- | ---
 EnforcedStyle | `module_function` | `module_function`, `extend_self`
+Autocorrect | `false` | Boolean
 
 ### References
 


### PR DESCRIPTION
This marks the Style/ModuleFunction cop as both `Autocorrect: false` and `SafeAutocorrect: false` in the default configuration. This is consistent with the documentation ("These offenses are not auto-corrected since there are different implications to each approach."), although I have slightly reworded it here.

The autocorrect was intentionally omitted when the cop was made configurable (see https://github.com/rubocop-hq/rubocop/pull/3173/files#diff-58bfe8eeff6579e001f02da76228d98fR26) because the styles are not equivalent. See the discussion at https://github.com/rubocop-hq/ruby-style-guide/issues/556 for more details.

I have not added tests b/c this is a configuration change, but happy to do so if you have any suggestions.

Thanks for your consideration.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
