### PR TITLE
Fix incorrect changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 * [#6598](https://github.com/rubocop-hq/rubocop/pull/6598): Fix a false positive for `Style/MethodCallWithArgsParentheses` `omit_parentheses` enforced style for argument calls with braced blocks. ([@gsamokovarov][])
 * [#6594](https://github.com/rubocop-hq/rubocop/pull/6594): Fix a false positive for `Rails/OutputSafety` when the receiver is a non-interpolated string literal. ([@amatsuda][])
 * [#6574](https://github.com/rubocop-hq/rubocop/pull/6574): Fix `Style/AccessModifierIndentation` not handling arbitrary blocks. ([@deivid-rodriguez][])
-[#6370](https://github.com/rubocop-hq/rubocop/issues/6370): Fix the enforcing style from `extend self` into `module_function` when there are private methods
+* [#6370](https://github.com/rubocop-hq/rubocop/issues/6370): Fix the enforcing style from `extend self` into `module_function` when there are private methods. ([@Ruffeng][])
 
 ### Changes
 
@@ -3721,4 +3721,4 @@
 [@nadiyaka]: https://github.com/nadiyaka
 [@amatsuda]: https://github.com/amatsuda
 [@Intrepidd]: https://github.com/Intrepidd
-[@ruffeng]: https://github.com/Ruffeng
+[@Ruffeng]: https://github.com/Ruffeng

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -77,8 +77,18 @@ RSpec.describe 'RuboCop Project', type: :feature do
       File.read(path)
     end
 
+    let(:lines) { changelog.each_line }
+
+    let(:non_reference_lines) do
+      lines.take_while { |line| !line.start_with?('[@') }
+    end
+
     it 'has newline at end of file' do
       expect(changelog.end_with?("\n")).to be true
+    end
+
+    it 'has either entries, headers, or empty lines' do
+      expect(non_reference_lines).to all(match(/^(\*|#|$)/))
     end
 
     it 'has link definitions for all implicit links' do
@@ -92,8 +102,6 @@ RSpec.describe 'RuboCop Project', type: :feature do
 
     describe 'entry' do
       subject(:entries) { lines.grep(/^\*/).map(&:chomp) }
-
-      let(:lines) { changelog.each_line }
 
       it 'has a whitespace between the * and the body' do
         expect(entries).to all(match(/^\* \S/))


### PR DESCRIPTION
It went undetected in https://github.com/rubocop-hq/rubocop/pull/6590.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
