### PR TITLE
Fix heredoc detection in trailing comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#6623](https://github.com/rubocop-hq/rubocop/pull/6623): Fix heredoc detection in trailing comma. ([@palkan][])
+
 ## 0.62.0 (2019-01-01)
 
 ### New features

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -17,9 +17,9 @@ module RuboCop
       end
 
       def check(node, items, kind, begin_pos, end_pos)
-        after_last_item = range_between(begin_pos, end_pos)
+        return if heredoc?(items.last)
 
-        return if heredoc?(after_last_item.source)
+        after_last_item = range_between(begin_pos, end_pos)
 
         comma_offset = after_last_item.source =~ /,/
 
@@ -74,10 +74,6 @@ module RuboCop
           comment_offset = comment.loc.expression.begin_pos - range.begin_pos
           comment_offset >= 0 && comment_offset < comma_offset
         end
-      end
-
-      def heredoc?(source_after_last_item)
-        source_after_last_item !~ /^\s*#/ && source_after_last_item =~ /\w/
       end
 
       # Returns true if the node has round/square/curly brackets.
@@ -168,6 +164,43 @@ module RuboCop
 
       # By default, there's no reason to avoid auto-correct.
       def avoid_autocorrect?(_nodes)
+        false
+      end
+
+      def heredoc?(node)
+        return false unless node.is_a?(RuboCop::AST::Node)
+        return true if node.loc.respond_to?(:heredoc_body)
+
+        return heredoc_send?(node) if node.send_type?
+
+        # handle hash values
+        #
+        #   some_method({
+        #     'auth' => <<-SOURCE
+        #       ...
+        #     SOURCE
+        #   })
+        return heredoc?(node.children.last) if node.pair_type?
+
+        false
+      end
+
+      def heredoc_send?(node)
+        # handle heredocs with methods
+        #
+        #   some_method(<<-CODE.strip.chomp)
+        #     ...
+        #   CODE
+        return heredoc?(node.children.first) if node.children.size == 2
+        # handle nested methods
+        #
+        #   some_method(
+        #     another_method(<<-CODE.strip.chomp)
+        #       ...
+        #     CODE
+        #   )
+        return heredoc?(node.children.last) if node.children.size > 2
+
         false
       end
     end

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -133,6 +133,40 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
         RUBY
       end
 
+      it 'accepts comma inside a heredoc with comments inside' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          route(
+            <<-HELP
+            ,
+            # some comment
+            HELP
+          )
+        RUBY
+      end
+
+      it 'accepts comma inside a heredoc with method and comments inside' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          route(
+            <<-HELP.chomp
+            ,
+            # some comment
+            HELP
+          )
+        RUBY
+      end
+
+      it 'accepts comma inside a heredoc in brackets' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          new_source = autocorrect_source(
+            autocorrect_source(<<-SOURCE.strip_indent)
+              run(
+                    :foo, defaults.merge(
+                                          bar: 3))
+            SOURCE
+          )
+        RUBY
+      end
+
       it 'auto-corrects unwanted comma in a method call with hash parameters' \
          ' at the end' do
         new_source = autocorrect_source(<<-RUBY.strip_indent)
@@ -194,6 +228,17 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
                         c: 0,
                         d: 1,
                      )
+        RUBY
+      end
+
+      it 'accepts missing comma after heredoc with comments' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          route(
+            <<-HELP.chomp
+            ,
+            # some comment
+            HELP
+          )
         RUBY
       end
 


### PR DESCRIPTION
Fixes the regression (false negatives) introduced in https://github.com/rubocop-hq/rubocop/commit/27341536e6cbea0105a6e3ee887a2f292517538c.

When `#` appeared inside a heredoc, we assume it's not a heredoc.

Example failing code:

```ruby
test(
  <<-CODE.squiggly
    ,
    # and a "comment"
  CODE
)
```

(See failed run https://travis-ci.org/rubocop-hq/rubocop-md/jobs/474056101#L469)

This PR changes the way we detect heredocs: from regexeps to AST "analysis".

**NOTE:** I'm not very happy with the implementation (it's not easy to cover all the cases), but, IMO, it is much better than regexp-based checks.
