### PR TITLE
Fix AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,8 @@ version: "{build}"
 
 install:
   - set PATH=C:\Ruby%ruby_version%\bin;%PATH%
-  - gem update --system 2.6.14 --no-document
-  - gem install bundler --no-document
+  - gem update --no-document --system 2.7.8
+  - gem install bundler --no-document --version="<2.0.0"
   - bundle install --jobs 3 --retry 3
 
 build: off


### PR DESCRIPTION
AppVeyor builds started failing when Bundler 2 and RubyGems 3 got released recently, both dropping support for Ruby 2.2.

We *could* probably solve it by installing different RubyGems and Bundler versions for different versions of Ruby, but I don't know how to do that on Windows. On Linux something like this could be used:

```sh
if $(ruby -e 'exit (RUBY_VERSION >= "2.3.0")')
```

Using older versions of RubyGems and Bundler is probably OK for now.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
