### PR TITLE
[Fix #6627] Fix handling of hashes (with heredoc) in Style/TrailingCommaInArguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* [#6627](https://github.com/rubocop-hq/rubocop/pull/6627): Fix handling of hashes in trailing comma. ([@abrom][])
 * [#6623](https://github.com/rubocop-hq/rubocop/pull/6623): Fix heredoc detection in trailing comma. ([@palkan][])
 * [#6100](https://github.com/rubocop-hq/rubocop/issues/6100): Fix a false positive in `Naming/ConstantName` cop when rhs is a conditional expression. ([@tatsuyafw][])
 

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -180,7 +180,9 @@ module RuboCop
         #       ...
         #     SOURCE
         #   })
-        return heredoc?(node.children.last) if node.pair_type?
+        if node.pair_type? || node.hash_type?
+          return heredoc?(node.children.last)
+        end
 
         false
       end

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -167,6 +167,52 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
         RUBY
       end
 
+      context 'when there is string interpolation inside heredoc parameter' do
+        it 'accepts comma inside a heredoc parameter' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            some_method(
+              <<-SQL
+                \#{variable}.a ASC,
+                \#{variable}.b ASC
+              SQL
+            )
+          RUBY
+        end
+
+        it 'accepts comma inside a heredoc parameter when on a single line' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            some_method(
+              bar: <<-BAR
+                \#{variable} foo, bar
+              BAR
+            )
+          RUBY
+        end
+
+        it 'auto-corrects unwanted comma inside string interpolation' do
+          new_source = autocorrect_source(<<-RUBY.strip_indent)
+            some_method(
+              bar: <<-BAR,
+                \#{other_method(a, b,)} foo, bar
+              BAR
+              baz: <<-BAZ
+                \#{third_method(c, d,)} foo, bar
+              BAZ
+            )
+          RUBY
+          expect(new_source).to eq(<<-RUBY.strip_indent)
+            some_method(
+              bar: <<-BAR,
+                \#{other_method(a, b)} foo, bar
+              BAR
+              baz: <<-BAZ
+                \#{third_method(c, d)} foo, bar
+              BAZ
+            )
+          RUBY
+        end
+      end
+
       it 'auto-corrects unwanted comma in a method call with hash parameters' \
          ' at the end' do
         new_source = autocorrect_source(<<-RUBY.strip_indent)


### PR DESCRIPTION
Extends #6623 fix for regression added in #6389 where string interpolation within heredoc would cause following commas (within the string) to be treated as code. This change addresses use case where heredoc is a parameter of a hash which contains string interpolation

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
