### PR TITLE
Update configuration.md

### DIFF
--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -425,6 +425,8 @@ Metrics/LineLength:
     compromise.
 ```
 
+These details will only be seen when rubocop is run with the `--extra-details` flag or if `ExtraDetails` is set to true in your global rubocop configuration. 
+
 #### AutoCorrect
 
 Cops that support the `--auto-correct` option can have that support


### PR DESCRIPTION
Adding some additional details to make it more clear when and how the extra details will show up in messages.

We were attempting to make this change in our configuration and were puzzled for a while as to why the change wasn't showing up in messages. Almost by accident, I noticed the `--extra-details` flag that the rubocop CLI command takes and then another colleague found that this change could be made globally. Thought it could be helpful to have this information right there in the configuration documentation to avoid future users from being confused by this. 
