### PR TITLE
Tweak document and message for `Style/FlipFlop` cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -3129,7 +3129,7 @@ Style/ExpandPathArguments:
   VersionAdded: '0.53'
 
 Style/FlipFlop:
-  Description: 'Checks for flip flops'
+  Description: 'Checks for flip-flops'
   StyleGuide: '#no-flip-flops'
   Enabled: true
   VersionAdded: '0.16'

--- a/lib/rubocop/cop/style/flip_flop.rb
+++ b/lib/rubocop/cop/style/flip_flop.rb
@@ -3,7 +3,8 @@
 module RuboCop
   module Cop
     module Style
-      # This cop looks for uses of flip flop operator
+      # This cop looks for uses of flip-flop operator.
+      # flip-flop operator is deprecated since Ruby 2.6.0.
       #
       # @example
       #   # bad
@@ -16,7 +17,7 @@ module RuboCop
       #     puts x if (x >= 5) && (x <= 10)
       #   end
       class FlipFlop < Cop
-        MSG = 'Avoid the use of flip flop operators.'.freeze
+        MSG = 'Avoid the use of flip-flop operators.'.freeze
 
         def on_iflipflop(node)
           add_offense(node)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1895,7 +1895,8 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 --- | --- | --- | --- | ---
 Enabled | Yes | No | 0.16 | -
 
-This cop looks for uses of flip flop operator
+This cop looks for uses of flip-flop operator.
+flip-flop operator is deprecated since Ruby 2.6.0.
 
 ### Examples
 

--- a/spec/rubocop/cop/style/flip_flop_spec.rb
+++ b/spec/rubocop/cop/style/flip_flop_spec.rb
@@ -3,20 +3,20 @@
 RSpec.describe RuboCop::Cop::Style::FlipFlop do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for inclusive flip flops' do
+  it 'registers an offense for inclusive flip-flops' do
     expect_offense(<<-RUBY.strip_indent)
       DATA.each_line do |line|
       print line if (line =~ /begin/)..(line =~ /end/)
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid the use of flip flop operators.
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid the use of flip-flop operators.
       end
     RUBY
   end
 
-  it 'registers an offense for exclusive flip flops' do
+  it 'registers an offense for exclusive flip-flops' do
     expect_offense(<<-RUBY.strip_indent)
       DATA.each_line do |line|
       print line if (line =~ /begin/)...(line =~ /end/)
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid the use of flip flop operators.
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid the use of flip-flop operators.
       end
     RUBY
   end


### PR DESCRIPTION
flip-flop operator is deprecated since Ruby 2.6.0.

> The flip-flop syntax is deprecated. [Feature #5400]

- https://github.com/ruby/ruby/blob/v2_6_0/NEWS#language-changes
- https://bugs.ruby-lang.org/issues/5400

```console
% cat example.rb
(1..20).each do |x|
  puts x if (x == 5) .. (x == 10)
end

% ruby -v
ruby 2.6.0p0 (2018-12-25 revision 66547) [x86_64-darwin17]

% ruby example.rb
example.rb:2: warning: flip-flop is deprecated
5
6
7
8
9
10
```

This PR tweaks document and offense message for `Style/FlipFlop` cop.
It will more clarify the reason for checking flip-flop operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
