### PR TITLE
Fix `Rails/LinkToBlank` dectection to allow `rel: 'noreferer`Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,7 @@
 ### Bug fixes
 
 * [#6627](https://github.com/rubocop-hq/rubocop/pull/6627): Fix handling of hashes in trailing comma. ([@abrom][])
+* [#6638](https://github.com/rubocop-hq/rubocop/pull/6638): Fix `Rails/LinkToBlank` dectection to allow `rel: 'noreferer`. ([@fwininger][])
 * [#6623](https://github.com/rubocop-hq/rubocop/pull/6623): Fix heredoc detection in trailing comma. ([@palkan][])
 * [#6100](https://github.com/rubocop-hq/rubocop/issues/6100): Fix a false positive in `Naming/ConstantName` cop when rhs is a conditional expression. ([@tatsuyafw][])
 * [#6526](https://github.com/rubocop-hq/rubocop/issues/6526): Fix a wrong line highlight in `Lint/ShadowedException` cop. ([@tatsuyafw][])
@@ -4018,3 +4019,4 @@
 [@att14]: https://github.com/att14
 [@houli]: https://github.com/houli
 [@lavoiesl]: https://github.com/lavoiesl
+[@fwininger]: https://github.com/fwininger

--- a/config/default.yml
+++ b/config/default.yml
@@ -2312,7 +2312,10 @@ Rails/LexicallyScopedActionFilter:
 
 Rails/LinkToBlank:
   Description: 'Checks that `link_to` with a `target: "_blank"` have a `rel: "noopener"` option passed to them.'
-  Reference: https://mathiasbynens.github.io/rel-noopener/
+  Reference:
+    - https://mathiasbynens.github.io/rel-noopener/
+    - https://html.spec.whatwg.org/multipage/links.html#link-type-noopener
+    - https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer
   Enabled: true
   VersionAdded: '0.62'
 

--- a/lib/rubocop/cop/rails/link_to_blank.rb
+++ b/lib/rubocop/cop/rails/link_to_blank.rb
@@ -8,12 +8,18 @@ module RuboCop
       # risk as the loaded page will have control over the previous page
       # and could change its location for phishing purposes.
       #
+      # The option `rel: 'noreferrer'` also blocks this behavior
+      # and removes the http-referrer header.
+      #
       # @example
       #   # bad
       #   link_to 'Click here', url, target: '_blank'
       #
       #   # good
       #   link_to 'Click here', url, target: '_blank', rel: 'noopener'
+      #
+      #   # good
+      #   link_to 'Click here', url, target: '_blank', rel: 'noreferrer'
       class LinkToBlank < Cop
         MSG = 'Specify a `:rel` option containing noopener.'
 
@@ -83,7 +89,8 @@ module RuboCop
         def contains_noopener?(value)
           return false unless value
 
-          value.to_s.split(' ').include?('noopener')
+          rel_array = value.to_s.split(' ')
+          rel_array.include?('noopener') || rel_array.include?('noreferrer')
         end
       end
     end

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1275,6 +1275,9 @@ This cop checks for calls to `link_to` that contain a
 risk as the loaded page will have control over the previous page
 and could change its location for phishing purposes.
 
+The option `rel: 'noreferrer'` also blocks this behavior
+and removes the http-referrer header.
+
 ### Examples
 
 ```ruby
@@ -1283,11 +1286,16 @@ link_to 'Click here', url, target: '_blank'
 
 # good
 link_to 'Click here', url, target: '_blank', rel: 'noopener'
+
+# good
+link_to 'Click here', url, target: '_blank', rel: 'noreferrer'
 ```
 
 ### References
 
 * [https://mathiasbynens.github.io/rel-noopener/](https://mathiasbynens.github.io/rel-noopener/)
+* [https://html.spec.whatwg.org/multipage/links.html#link-type-noopener](https://html.spec.whatwg.org/multipage/links.html#link-type-noopener)
+* [https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer](https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer)
 
 ## Rails/NotNullColumn
 

--- a/spec/rubocop/cop/rails/link_to_blank_spec.rb
+++ b/spec/rubocop/cop/rails/link_to_blank_spec.rb
@@ -111,6 +111,22 @@ RSpec.describe RuboCop::Cop::Rails::LinkToBlank do
       context 'when the rel contains noopener' do
         it 'register no offence' do
           expect_no_offenses(<<~RUBY)
+            link_to 'Click here', 'https://www.example.com', target: '_blank', rel: 'noopener unrelated'
+          RUBY
+        end
+      end
+
+      context 'when the rel contains noreferrer' do
+        it 'register no offence' do
+          expect_no_offenses(<<-RUBY)
+            link_to 'Click here', 'https://www.example.com', target: '_blank', rel: 'unrelated noreferrer'
+          RUBY
+        end
+      end
+
+      context 'when the rel contains noopener and noreferrer' do
+        it 'register no offence' do
+          expect_no_offenses(<<-RUBY)
             link_to 'Click here', 'https://www.example.com', target: '_blank', rel: 'noopener noreferrer'
           RUBY
         end


### PR DESCRIPTION
For historical reasons, the noreferrer keyword implies the behavior associated with the noopener keyword when present on a hyperlink that creates a new browsing context. That is, `<a href="..." rel="noreferrer" target="_blank">` has the same behavior as `<a href="..." rel="noreferrer noopener" target="_blank">`.

This PR allow the Cop `Rails/LinkToBlank` to have no offense with the following code : 

```ruby
link_to 'Click here', url, target: '_blank', rel: 'noreferrer'
```

Ref : https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer