### PR TITLE
Simplify RuboCop::AST::Traversal

### DIFF
--- a/lib/rubocop/ast/traversal.rb
+++ b/lib/rubocop/ast/traversal.rb
@@ -14,170 +14,38 @@ module RuboCop
         nil
       end
 
-      NO_CHILD_NODES    = %i[true false nil int float complex
-                             rational str sym regopt self lvar
-                             ivar cvar gvar nth_ref back_ref cbase
-                             arg restarg blockarg shadowarg
-                             kwrestarg zsuper lambda redo retry].freeze
-      ONE_CHILD_NODE    = %i[splat kwsplat block_pass not break next
-                             preexe postexe match_current_line defined?
-                             arg_expr].freeze
-      MANY_CHILD_NODES  = %i[dstr dsym xstr regexp array hash pair
-                             mlhs masgn or_asgn and_asgn
-                             undef alias args super yield or and
-                             while_post until_post iflipflop eflipflop
-                             match_with_lvasgn begin kwbegin return].freeze
-      SECOND_CHILD_ONLY = %i[lvasgn ivasgn cvasgn gvasgn optarg kwarg
-                             kwoptarg].freeze
+      NO_CHILD_NODES   = %i[arg back_ref blockarg cbase complex const cvar
+                            false float gvar int ivar kwrestarg lambda lvar nil
+                            nth_ref rational redo regopt restarg retry self
+                            shadowarg str sym true zsuper].freeze
+      SOME_CHILD_NODES = %i[alias and and_asgn arg_expr args array begin block
+                            block_pass break case casgn class csend cvasgn def
+                            defined? defs dstr dsym eflipflop ensure erange for
+                            gvasgn hash if iflipflop irange ivasgn kwarg
+                            kwbegin kwoptarg kwsplat lvasgn masgn
+                            match_current_line match_with_lvasgn mlhs module
+                            next not op_asgn optarg or or_asgn pair postexe
+                            preexe regexp resbody rescue return sclass send
+                            splat super undef until until_post when while
+                            while_post xstr yield].freeze
 
       NO_CHILD_NODES.each do |type|
         module_eval("def on_#{type}(node); end", __FILE__, __LINE__)
       end
 
-      ONE_CHILD_NODE.each do |type|
+      SOME_CHILD_NODES.each do |type|
         module_eval(<<-RUBY, __FILE__, __LINE__ + 1)
           def on_#{type}(node)
-            if (child = node.children[0])
+            node.children.each do |child|
+              next if child.nil?
+              next if child.is_a?(Symbol)
+
               send(:"on_\#{child.type}", child)
             end
-          end
-        RUBY
-      end
-
-      MANY_CHILD_NODES.each do |type|
-        module_eval(<<-RUBY, __FILE__, __LINE__ + 1)
-          def on_#{type}(node)
-            node.children.each { |child| send(:"on_\#{child.type}", child) }
             nil
           end
         RUBY
       end
-
-      SECOND_CHILD_ONLY.each do |type|
-        # Guard clause is for nodes nested within mlhs
-        module_eval(<<-RUBY, __FILE__, __LINE__ + 1)
-          def on_#{type}(node)
-            if (child = node.children[1])
-              send(:"on_\#{child.type}", child)
-            end
-          end
-        RUBY
-      end
-
-      def on_const(node)
-        return unless (child = node.children[0])
-
-        send(:"on_#{child.type}", child)
-      end
-
-      def on_casgn(node)
-        children = node.children
-        if (child = children[0]) # always const???
-          send(:"on_#{child.type}", child)
-        end
-        return unless (child = children[2])
-
-        send(:"on_#{child.type}", child)
-      end
-
-      def on_class(node)
-        children = node.children
-        child = children[0] # always const???
-        send(:"on_#{child.type}", child)
-        if (child = children[1])
-          send(:"on_#{child.type}", child)
-        end
-        return unless (child = children[2])
-
-        send(:"on_#{child.type}", child)
-      end
-
-      def on_def(node)
-        children = node.children
-        on_args(children[1])
-        return unless (child = children[2])
-
-        send(:"on_#{child.type}", child)
-      end
-
-      def on_send(node)
-        node.children.each_with_index do |child, i|
-          next if i == 1
-
-          send(:"on_#{child.type}", child) if child
-        end
-        nil
-      end
-
-      alias on_csend on_send
-
-      def on_op_asgn(node)
-        children = node.children
-        child = children[0]
-        send(:"on_#{child.type}", child)
-        child = children[2]
-        send(:"on_#{child.type}", child)
-      end
-
-      def on_defs(node)
-        children = node.children
-        child = children[0]
-        send(:"on_#{child.type}", child)
-        on_args(children[2])
-        return unless (child = children[3])
-
-        send(:"on_#{child.type}", child)
-      end
-
-      def on_if(node)
-        children = node.children
-        child = children[0]
-        send(:"on_#{child.type}", child)
-        if (child = children[1])
-          send(:"on_#{child.type}", child)
-        end
-        return unless (child = children[2])
-
-        send(:"on_#{child.type}", child)
-      end
-
-      def on_while(node)
-        children = node.children
-        child = children[0]
-        send(:"on_#{child.type}", child)
-        return unless (child = children[1])
-
-        send(:"on_#{child.type}", child)
-      end
-
-      alias on_until  on_while
-      alias on_module on_while
-      alias on_sclass on_while
-
-      def on_block(node)
-        children = node.children
-        child = children[0]
-        send(:"on_#{child.type}", child) # can be send, zsuper...
-        on_args(children[1])
-        return unless (child = children[2])
-
-        send(:"on_#{child.type}", child)
-      end
-
-      def on_case(node)
-        node.children.each do |child|
-          send(:"on_#{child.type}", child) if child
-        end
-        nil
-      end
-
-      alias on_rescue  on_case
-      alias on_resbody on_case
-      alias on_ensure  on_case
-      alias on_for     on_case
-      alias on_when    on_case
-      alias on_irange  on_case
-      alias on_erange  on_case
     end
   end
 end


### PR DESCRIPTION
For all nodes with children, simply iterate over all child nodes and call the appropriate `on_#{type}` method. Some children are not `Node` instances, and must necessarily be skipped - these children appear to be either `nil` or instances of `Symbol`.

TODO: See if performance is significantly better or worse.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
