### PR TITLE
Add AllowParenthesesInCamelCaseMethod option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#6643](https://github.com/rubocop-hq/rubocop/pull/6643): Support `AllowParenthesesInCamelCaseMethod` option on `Style/MethodCallWithArgsParentheses` `omit_parentheses`. ([@dazuma][])
+
 ## 0.63.1 (2019-01-22)
 
 ### Bug fixes
@@ -3771,3 +3775,4 @@
 [@roooodcastro]: https://github.com/roooodcastro
 [@rmm5t]: https://github.com/rmm5t
 [@marcotc]: https://github.com/marcotc
+[@dazuma]: https://github.com/dazuma

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2771,7 +2771,7 @@ In the default style (require_parentheses), macro methods are ignored.
 Additional methods can be added to the `IgnoredMethods` list. This
 option is valid only in the default style.
 
-In the alternative style (omit_parentheses), there are two additional
+In the alternative style (omit_parentheses), there are three additional
 options.
 
 1. `AllowParenthesesInChaining` is `false` by default. Setting it to
@@ -2781,6 +2781,12 @@ options.
 2. `AllowParenthesesInMultilineCall` is `false` by default. Setting it
     to `true` allows the presence of parentheses in multi-line method
     calls.
+
+3. `AllowParenthesesInCamelCaseMethod` is `false` by default. This
+    allows the presence of parentheses when calling a method whose name
+    begins with a capital letter and which has no arguments. Setting it
+    to `true` allows the presence of parentheses in such a method call
+    even with arguments.
 
 ### Examples
 
@@ -2870,6 +2876,22 @@ foo().bar(1)
 
 # good
 foo().bar 1
+
+# AllowParenthesesInCamelCaseMethod: false (default)
+
+# bad
+Array(1)
+
+# good
+Array 1
+
+# AllowParenthesesInCamelCaseMethod: true
+
+# good
+Array(1)
+
+# good
+Array 1
 ```
 
 ### Configurable attributes

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -374,6 +374,13 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
+    it 'register an offense for camel-case methods with arguments' do
+      expect_offense(<<-RUBY.strip_indent)
+        Array(:arg)
+             ^^^^^^ Omit parentheses for method calls with arguments.
+      RUBY
+    end
+
     it 'accepts no parens in method call without args' do
       expect_no_offenses('top.test')
     end
@@ -558,6 +565,16 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
+    it 'auto-corrects camel-case methods with arguments' do
+      original = <<-RUBY.strip_indent
+        Array(:arg)
+      RUBY
+
+      expect(autocorrect_source(original)).to eq(<<-RUBY.strip_indent)
+        Array :arg
+      RUBY
+    end
+
     context 'TargetRubyVersion >= 2.3', :ruby23 do
       it 'accepts parens in chaining with safe operators' do
         expect_no_offenses('Something.find(criteria: given)&.field')
@@ -637,6 +654,19 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
         RUBY
 
         expect(autocorrect_source(original)).to eq(original)
+      end
+    end
+
+    context 'allowing parens in camel-case methods' do
+      let(:cop_config) do
+        {
+          'EnforcedStyle' => 'omit_parentheses',
+          'AllowParenthesesInCamelCaseMethod' => true
+        }
+      end
+
+      it 'accepts parens for camel-case method names' do
+        expect_no_offenses('Array(nil)')
       end
     end
   end


### PR DESCRIPTION
This adds the option `AllowParenthesesInCamelCaseMethod` to the `Style/MethodCallWithArgsParentheses` cop, which takes effect when `EnforcedStyle: omit_parentheses`. When this option is set to `true`, methods whose name begins with a capital letter (i.e. which look like constants/modules) may be called using parentheses even when taking arguments. When this option is set to `false` (the default, and identical to previous behavior), such methods may be called using parentheses when taking no arguments but must omit the parentheses when taking arguments.

This style (always using parens when calling such methods) is useful in the `omit_parentheses` case because even though it is not actually syntactically ambiguous when arguments are present, it still it makes it syntactically more obvious that a method is being called rather than a constant being invoked.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
