### PR TITLE
Modify example code to not contain offenses

### DIFF
--- a/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
@@ -33,10 +33,11 @@ module RuboCop
       #
       #   # bad
       #   h = { a: { b: 2 } }
+      #   foo = { { a: 1 } => { b: { c: 2 } } }
       #
       #   # good
       #   h = { a: { b: 2 }}
-      #
+      #   foo = {{ a: 1 } => { b: { c: 2 }}}
       #
       # @example EnforcedStyleForEmptyBraces: no_space (default)
       #   # The `no_space` EnforcedStyleForEmptyBraces style enforces that

--- a/lib/rubocop/cop/rails/inverse_of.rb
+++ b/lib/rubocop/cop/rails/inverse_of.rb
@@ -38,9 +38,8 @@ module RuboCop
       #   # good
       #   class Blog < ApplicationRecord
       #     has_many(:posts,
-      #       -> { order(published_at: :desc) },
-      #       inverse_of: :blog
-      #     )
+      #              -> { order(published_at: :desc) },
+      #              inverse_of: :blog)
       #   end
       #
       #   class Post < ApplicationRecord
@@ -62,9 +61,8 @@ module RuboCop
       #   # When you don't want to use the inverse association.
       #   class Blog < ApplicationRecord
       #     has_many(:posts,
-      #       -> { order(published_at: :desc) },
-      #       inverse_of: false
-      #     )
+      #              -> { order(published_at: :desc) },
+      #              inverse_of: false)
       #   end
       #
       # @example

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -4028,9 +4028,11 @@ h = {a: 1, b: 2}
 
 # bad
 h = { a: { b: 2 } }
+foo = { { a: 1 } => { b: { c: 2 } } }
 
 # good
 h = { a: { b: 2 }}
+foo = {{ a: 1 } => { b: { c: 2 }}}
 ```
 #### EnforcedStyleForEmptyBraces: no_space (default)
 

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -923,9 +923,8 @@ end
 # good
 class Blog < ApplicationRecord
   has_many(:posts,
-    -> { order(published_at: :desc) },
-    inverse_of: :blog
-  )
+           -> { order(published_at: :desc) },
+           inverse_of: :blog)
 end
 
 class Post < ApplicationRecord
@@ -947,9 +946,8 @@ end
 # When you don't want to use the inverse association.
 class Blog < ApplicationRecord
   has_many(:posts,
-    -> { order(published_at: :desc) },
-    inverse_of: false
-  )
+           -> { order(published_at: :desc) },
+           inverse_of: false)
 end
 ```
 ```ruby


### PR DESCRIPTION
The examples in `Rails/InverseOf` contain offense for `Layout/AlignParameters` and `Layout/MultilineMethodCallBraceLayout`. Ideally, I think the examples should be free of offenses unless they are needed to show off behavior.