### PR TITLE
[Fix #6641] Specify `Performance/RangeInclude` as unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * [#6526](https://github.com/rubocop-hq/rubocop/issues/6526): Fix a wrong line highlight in `Lint/ShadowedException` cop. ([@tatsuyafw][])
 * [#6617](https://github.com/rubocop-hq/rubocop/issues/6617): Prevent traversal error on infinite ranges. ([@drenmi][])
 
+### Changes
+
+* [#6641](https://github.com/rubocop-hq/rubocop/issues/6641): Specify `Performance/RangeInclude` as unsafe because `Range#include?` and `Range#cover?` are not equivalent. ([@koic][])
+
 ## 0.62.0 (2019-01-01)
 
 ### New features

--- a/config/default.yml
+++ b/config/default.yml
@@ -2074,6 +2074,7 @@ Performance/RangeInclude:
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#cover-vs-include-code'
   Enabled: true
   VersionAdded: '0.36'
+  Safe: false
 
 Performance/RedundantBlockCall:
   Description: 'Use `yield` instead of `block.call`.'

--- a/lib/rubocop/cop/performance/range_include.rb
+++ b/lib/rubocop/cop/performance/range_include.rb
@@ -9,6 +9,9 @@ module RuboCop
       # end points of the `Range`. In a great majority of cases, this is what
       # is wanted.
       #
+      # This cop is `Safe: false` by default because `Range#include?` and
+      # `Range#cover?` are not equivalent behaviour.
+      #
       # @example
       #   # bad
       #   ('a'..'z').include?('b') # => true

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -515,13 +515,16 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.36 | -
+Enabled | No | Yes  | 0.36 | -
 
 This cop identifies uses of `Range#include?`, which iterates over each
 item in a `Range` to see if a specified item is there. In contrast,
 `Range#cover?` simply compares the target item with the beginning and
 end points of the `Range`. In a great majority of cases, this is what
 is wanted.
+
+This cop is `Safe: false` by default because `Range#include?` and
+`Range#cover?` are not equivalent behaviour.
 
 ### Examples
 


### PR DESCRIPTION
Fixes #6641.

This PR specifies `Performance/RangeInclude` as unsafe because `Range#include?` and `Range#cover?` are not equivalent behaviour.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
