### PR TITLE
fix Lint/AmbiguousBlockAssociation cites unambiguous lambda

### DIFF
--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
   it_behaves_like 'accepts', 'Hash[some_method(a) { |el| el }]'
   it_behaves_like 'accepts', 'foo = lambda do |diagnostic|;end'
   it_behaves_like 'accepts', 'Proc.new { puts "proc" }'
-  it_behaves_like 'accepts', 'expect { order.save }.to(change { orders.size })'
+  it_behaves_like 'accepts', 'expect { order.save }.to change { orders.size }'
   it_behaves_like 'accepts', 'scope :active, -> { where(status: "active") }'
   it_behaves_like(
     'accepts',


### PR DESCRIPTION
fix AmbiguousBlockAssociation accepts  to rspec `to change lambda`

With this fix the following code is ok for AmbiguousBlockAssociation cop:

This method is also used in the [official document](https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/change-matcher)