### PR TITLE
[Fix #6651] Make Style/RegexpLiteral correctly auto-correct inner slashes when there's interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#6617](https://github.com/rubocop-hq/rubocop/issues/6617): Prevent traversal error on infinite ranges. ([@drenmi][])
 * [#6625](https://github.com/rubocop-hq/rubocop/issues/6625): Revert the "auto-exclusion of files ignored by git" feature. ([@bbatsov][])
 * [#4460](https://github.com/rubocop-hq/rubocop/issues/4460): Fix the determination of unsafe auto-correct in `Style/TernaryParentheses`. ([@jonas054][])
+* [#6651](https://github.com/rubocop-hq/rubocop/issues/6651): Fix auto-correct issue in `Style/RegexpLiteral` cop when there is string interpolation. ([@roooodcastro][])
 
 ### Changes
 
@@ -3746,3 +3747,4 @@
 [@amatsuda]: https://github.com/amatsuda
 [@Intrepidd]: https://github.com/Intrepidd
 [@Ruffeng]: https://github.com/Ruffeng
+[@roooodcastro]: https://github.com/roooodcastro

--- a/lib/rubocop/cop/style/regexp_literal.rb
+++ b/lib/rubocop/cop/style/regexp_literal.rb
@@ -150,8 +150,9 @@ module RuboCop
           cop_config['AllowInnerSlashes']
         end
 
-        def node_body(node)
-          node.each_child_node(:str).map(&:source).join
+        def node_body(node, include_begin_nodes: false)
+          types = include_begin_nodes ? %i[str begin] : %i[str]
+          node.each_child_node(*types).map(&:source).join
         end
 
         def slash_literal?(node)
@@ -186,7 +187,7 @@ module RuboCop
         end
 
         def inner_slash_indices(node)
-          text    = node_body(node)
+          text    = node_body(node, include_begin_nodes: true)
           pattern = inner_slash_before_correction(node)
           index   = -1
           indices = []

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -92,6 +92,30 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
       end
     end
 
+    describe 'a single-line `//` regex with slashes and interpolation' do
+      let(:source) { 'foo = /users\/#{user.id}\/forms/' }
+
+      it 'registers an offense' do
+        expect_offense(<<-'RUBY'.strip_indent)
+          foo = /users\/#{user.id}\/forms/
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `%r` around regular expression.
+        RUBY
+      end
+
+      it 'auto-corrects' do
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq('foo = %r{users/#{user.id}/forms}')
+      end
+
+      describe 'when configured to allow inner slashes' do
+        before { cop_config['AllowInnerSlashes'] = true }
+
+        it 'is accepted' do
+          expect_no_offenses('foo = /users\/#{user.id}\/forms/')
+        end
+      end
+    end
+
     describe 'a single-line `%r//` regex with slashes' do
       let(:source) { 'foo = %r/\//' }
 


### PR DESCRIPTION
Let me start this by saying that I don't know much about ASTs and never messed with them in Ruby, so this fix might be all wrong.

The issue this PR intends to fix is one where the `Style/RegexpLiteral` cop fails to correctly replace and fix inner slashes after changing a regex from `/users\/#{user.id}\/forms/` to `%r{users/#{user.id}/forms}`.

Analysing the execution flow of this cop, I noticed that when there's no interpolation, the resulting AST's regexp node has only a single child, of type `srt`. The cop correctly corrects this case. When there is an interpolation in the mix, however, the AST node now has 4 children, of types: `[:str, :begin, :str, :regopt]`.

Example output of `node.child_nodes`:

* when regex is `/users\/user.id\/forms/`: (no interpolation)

```ruby
> node.child_nodes
=> [s(:str, "users/user.id/forms"), s(:regopt)]
```

* when regex is `/users\/#{user.id}\/forms/`: (interpolation):

```ruby
> node.children
=> [s(:str, "users/"), s(:begin,
  s(:send,
    s(:send, nil, :user), :id)), s(:str, "/forms"), s(:regopt)]
```

Specifically, the cop method `node_body` filters these children and only considers the `str` children. This is useful to avoid trying to detect and fix stuff inside the interpolation which isn't part of the regex, but at the same time, in this specific case, the resulting body will be `users\/\/forms`. Rubocop can correctly identify both offenses there, but for some reason it cannot correct them. The fix for this was to have `node_body` ignore the `begin` node for the detection, but include it for the auto-correction. This way the cop works as intended for all (tested) cases.

I just don't know if including the `begin` node type in there is enough, or if there's some other type that should be included as well. Please advise if this fix is not adequate or safe.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.