### PR TITLE
Adds parser gem as a development dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#6658](https://github.com/rubocop-hq/rubocop/pull/6658): Adds `parser` gem as a development dependency. ([@jbernardo95][])
+
 ### Bug fixes
 
 * [#6623](https://github.com/rubocop-hq/rubocop/pull/6623): Fix heredoc detection in trailing comma. ([@palkan][])
@@ -3737,3 +3741,4 @@
 [@amatsuda]: https://github.com/amatsuda
 [@Intrepidd]: https://github.com/Intrepidd
 [@Ruffeng]: https://github.com/Ruffeng
+[@jbernardo95]: https://github.com/jbernardo95

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,10 @@ gem 'simplecov', '~> 0.10'
 gem 'test-queue'
 gem 'yard', '~> 0.9'
 
+group :development do
+  gem 'parser'
+end
+
 group :test do
   gem 'safe_yaml', require: false
   gem 'webmock', require: false


### PR DESCRIPTION
The first recommended in the [development guide](https://rubocop.readthedocs.io/en/latest/development/) is to install de `parser` gem. So, why not have it as a development dependency ?