### PR TITLE
[Fix #4460] Improve TernaryParentheses#unparenthesized_method_call?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#6526](https://github.com/rubocop-hq/rubocop/issues/6526): Fix a wrong line highlight in `Lint/ShadowedException` cop. ([@tatsuyafw][])
 * [#6617](https://github.com/rubocop-hq/rubocop/issues/6617): Prevent traversal error on infinite ranges. ([@drenmi][])
 * [#6625](https://github.com/rubocop-hq/rubocop/issues/6625): Revert the "auto-exclusion of files ignored by git" feature. ([@bbatsov][])
+* [#4460](https://github.com/rubocop-hq/rubocop/issues/4460): Fix the determination of unsafe auto-correct in `Style/TernaryParentheses`. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -154,14 +154,12 @@ module RuboCop
         end
 
         def unparenthesized_method_call?(child)
-          argument = method_call_argument(child)
-
-          argument && !argument.parenthesized?
+          method_name(child) =~ /^[a-z]/i && !child.parenthesized?
         end
 
-        def_node_matcher :method_call_argument, <<-PATTERN
-          {(:defined? $(send nil? _) ...)
-           (send {_ nil?} _ $(send nil? _) ...)}
+        def_node_matcher :method_name, <<-PATTERN
+          {($:defined? (send nil? _) ...)
+           (send {_ nil?} $_ _ ...)}
         PATTERN
 
         def correct_parenthesized(condition)

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -155,7 +155,8 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
                       'foo = 1 + 1 == 2 ? a : b'
 
       it_behaves_like 'code with offense',
-                      'foo = (foo1 == foo2) ? a : b'
+                      'foo = (foo1 == foo2) ? a : b',
+                      'foo = foo1 == foo2 ? a : b'
 
       it_behaves_like 'code with offense',
                       'foo = (bar && baz) ? a : b',
@@ -278,6 +279,23 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
     context 'with method call condition' do
       it_behaves_like 'code with offense',
                       'foo = (defined? bar) ? a : b'
+
+      it_behaves_like 'code with offense',
+                      '(%w(a b).include? params[:t]) ? "ab" : "c"'
+
+      it_behaves_like 'code with offense',
+                      '(%w(a b).include? params[:t], 3) ? "ab" : "c"'
+
+      it_behaves_like 'code with offense',
+                      '(%w(a b).include?(params[:t], x)) ? "ab" : "c"',
+                      '%w(a b).include?(params[:t], x) ? "ab" : "c"'
+
+      it_behaves_like 'code with offense',
+                      '(%w(a b).include? "a") ? "ab" : "c"'
+
+      it_behaves_like 'code with offense',
+                      '(%w(a b).include?("a")) ? "ab" : "c"',
+                      '%w(a b).include?("a") ? "ab" : "c"'
 
       it_behaves_like 'code with offense',
                       'foo = (baz? bar) ? a : b'


### PR DESCRIPTION
We say that a method call is not safe for removing outer parentheses if the method takes an argument but doesn't enclose the argument in parentheses. E.g., `(func x) ? 1 : 0`, but the previous solution didn't get all cases right.