### PR TITLE
Abandon making frozen-string-literals default for Ruby 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * [#6641](https://github.com/rubocop-hq/rubocop/issues/6641): Specify `Performance/RangeInclude` as unsafe because `Range#include?` and `Range#cover?` are not equivalent. ([@koic][])
 * [#6636](https://github.com/rubocop-hq/rubocop/pull/6636): Move `FlipFlop` cop from `Style` to `Lint` department because flip-flop is deprecated since Ruby 2.6.0. ([@koic][])
+* [#6660](https://github.com/rubocop-hq/rubocop/pull/6660): Abandon making frozen string literals default for Ruby 3.0. ([@koic][])
 
 ## 0.62.0 (2019-01-01)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -3175,7 +3175,7 @@ Style/FormatStringToken:
 Style/FrozenStringLiteralComment:
   Description: >-
                  Add the frozen_string_literal comment to the top of files
-                 to help transition from Ruby 2.3.0 to Ruby 3.0.
+                 to help transition to frozen string literals by default.
   Enabled: true
   VersionAdded: '0.36'
   VersionChanged: '0.47'

--- a/lib/rubocop/cop/mixin/frozen_string_literal.rb
+++ b/lib/rubocop/cop/mixin/frozen_string_literal.rb
@@ -21,11 +21,18 @@ module RuboCop
       def frozen_string_literals_enabled?
         ruby_version = processed_source.ruby_version
         return false unless ruby_version
-        # TODO: Whether frozen string literals will be the default in Ruby 3.0
-        # or not is still unclear as of February 2018.
-        # It may be necessary to change this code in the future.
+        # TODO: Ruby officially abandon making frozen string literals default
+        # for Ruby 3.0.
+        # https://bugs.ruby-lang.org/issues/11473#note-53
+        # Whether frozen string literals will be the default after Ruby 3.0
+        # or not is still unclear as of January 2019.
+        # It may be necessary to add this code in the future.
+        #
+        #   return true if ruby_version >= 3.1
+        #
+        # And the above `ruby_version >= 3.1` is undecidedd whether it will be
+        # Ruby 3.1, 3.2, 4.0 or others.
         # See https://bugs.ruby-lang.org/issues/8976#note-41 for details.
-        return true if ruby_version >= 3.0
         return false unless ruby_version >= 2.3
 
         leading_comment_lines.any? do |line|

--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -3,10 +3,10 @@
 module RuboCop
   module Cop
     module Style
-      # This cop is designed to help upgrade to Ruby 3.0. It will add the
+      # This cop is designed to help upgrade to after Ruby 3.0. It will add the
       # comment `# frozen_string_literal: true` to the top of files to
       # enable frozen string literals. Frozen string literals may be default
-      # in Ruby 3.0. The comment will be added below a shebang and encoding
+      # after Ruby 3.0. The comment will be added below a shebang and encoding
       # comment. The frozen string literal comment is only valid in Ruby 2.3+.
       #
       # @example EnforcedStyle: when_needed (default)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2064,10 +2064,10 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 --- | --- | --- | --- | ---
 Enabled | Yes | Yes  | 0.36 | 0.47
 
-This cop is designed to help upgrade to Ruby 3.0. It will add the
+This cop is designed to help upgrade to after Ruby 3.0. It will add the
 comment `# frozen_string_literal: true` to the top of files to
 enable frozen string literals. Frozen string literals may be default
-in Ruby 3.0. The comment will be added below a shebang and encoding
+after Ruby 3.0. The comment will be added below a shebang and encoding
 comment. The frozen string literal comment is only valid in Ruby 2.3+.
 
 ### Examples


### PR DESCRIPTION
### Summary

Ruby officially abandon making frozen-string-literals default for Ruby 3.0.

The following is a quotation from Matz's comment.

> I consider this for years. I REALLY like the idea but I am sure introducing this could cause HUGE compatibility issue, even bigger than Ruby 1.9. So I officially abandon making frozen-string-literals default (for Ruby3).
>
> This does not mean we are going to remove the frozen-string-literal feature that can be specified by magic comments.

https://bugs.ruby-lang.org/issues/11473#note-53

I had the opportunity to meet Matz on this commented day and I heard that the decision on the introduction of frozen-string-literals default is undecided (Ruby 3.1, 3.2...4.0, or others).

### Other Information

There is a reference to (something like) RuboCop at DevelopersMeeting20190110Japan.

> Frozen string literal [Feature #11473]
> Matz: give up on Ruby 3.0. Maybe far future.
> Matz: Maybe we should provide our coding style to recommend style and obsolete bad style by something like rubocop.

https://docs.google.com/document/d/1W_wrFsFxxU1MepA6HBpfl-9h-nLD8EBsgMsS7yTDvHE/edit

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
