### PR TITLE
[Fix #6575] Fix `Naming/PredicateName` cop suggesting invalid rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#6651](https://github.com/rubocop-hq/rubocop/issues/6651): Fix auto-correct issue in `Style/RegexpLiteral` cop when there is string interpolation. ([@roooodcastro][])
 * [#6670](https://github.com/rubocop-hq/rubocop/issues/6670): Fix a false positive for `Style/SafeNavigation` when a method call safeguarded with a negative check for the object. ([@koic][])
 * [#6633](https://github.com/rubocop-hq/rubocop/issues/6633): Fix `Lint/SafeNavigation` complaining about use of `to_d`. ([@tejasbubane][])
+* [#6575](https://github.com/rubocop-hq/rubocop/issues/6575): Fix `Naming/PredicateName` suggesting invalid rename. ([@tejasbubane][])
 
 ### Changes
 

--- a/lib/rubocop/cop/naming/predicate_name.rb
+++ b/lib/rubocop/cop/naming/predicate_name.rb
@@ -61,7 +61,7 @@ module RuboCop
         private
 
         def allowed_method_name?(method_name, prefix)
-          !method_name.start_with?(prefix) ||
+          !method_name.match(/^#{prefix}[^0-9]/) ||
             method_name == expected_name(method_name, prefix) ||
             method_name.end_with?('=') ||
             predicate_whitelist.include?(method_name)

--- a/spec/rubocop/cop/naming/predicate_name_spec.rb
+++ b/spec/rubocop/cop/naming/predicate_name_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe RuboCop::Cop::Naming::PredicateName, :config do
         def is_hello=; end
       RUBY
     end
+
+    it 'accepts method name when corrected name is invalid identifier' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def is_2d?; end
+      RUBY
+    end
   end
 
   context 'without blacklisted prefixes' do
@@ -58,6 +64,12 @@ RSpec.describe RuboCop::Cop::Naming::PredicateName, :config do
     it 'accepts method name that starts with unknown prefix' do
       expect_no_offenses(<<-RUBY.strip_indent)
         def have_attr; end
+      RUBY
+    end
+
+    it 'accepts method name when corrected name is invalid identifier' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def is_2d?; end
       RUBY
     end
   end
@@ -100,6 +112,14 @@ RSpec.describe RuboCop::Cop::Naming::PredicateName, :config do
         PATTERN
       RUBY
     end
+
+    it 'accepts method name when corrected name is invalid identifier' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        define_method(:is_2d?) do |method_name|
+          method_name == 'hello'
+        end
+      RUBY
+    end
   end
 
   context 'without method definition macros' do
@@ -124,6 +144,14 @@ RSpec.describe RuboCop::Cop::Naming::PredicateName, :config do
             (send nil? :method_name) :==
             (str 'hello'))
         PATTERN
+      RUBY
+    end
+
+    it 'accepts method name when corrected name is invalid identifier' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        define_method(:is_2d?) do |method_name|
+          method_name == 'hello'
+        end
       RUBY
     end
   end


### PR DESCRIPTION
Fixes #6575 

Do not suggest change if the suggested identifier is invalid.

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.