### PR TITLE
[Fix #6633] Fix `Lint/SafeNavigation` complaining about use of `to_d`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#4460](https://github.com/rubocop-hq/rubocop/issues/4460): Fix the determination of unsafe auto-correct in `Style/TernaryParentheses`. ([@jonas054][])
 * [#6651](https://github.com/rubocop-hq/rubocop/issues/6651): Fix auto-correct issue in `Style/RegexpLiteral` cop when there is string interpolation. ([@roooodcastro][])
 * [#6670](https://github.com/rubocop-hq/rubocop/issues/6670): Fix a false positive for `Style/SafeNavigation` when a method call safeguarded with a negative check for the object. ([@koic][])
+* [#6633](https://github.com/rubocop-hq/rubocop/issues/6633): Fix `Lint/SafeNavigation` complaining about use of `to_d`. ([@tejasbubane][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/nil_methods.rb
+++ b/lib/rubocop/cop/mixin/nil_methods.rb
@@ -2,13 +2,19 @@
 
 module RuboCop
   module Cop
-    # This module provides a list of methods that are either in the NilClass,
-    # or in the cop's configuration parameter Whitelist.
+    # This module provides a list of methods that are:
+    # 1. In the NilClass by default
+    # 2. Added to NilClass by explicitly requiring any standard libraries
+    # 3. Cop's configuration parameter Whitelist.
     module NilMethods
       private
 
       def nil_methods
-        nil.methods + whitelist
+        nil.methods + other_stdlib_methods + whitelist
+      end
+
+      def other_stdlib_methods
+        [:to_d]
       end
 
       def whitelist

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
       ['safe navigation with `blank?` method', 'x&.foo.blank?'],
       ['safe navigation with `try` method', 'a&.b.try(:c)'],
       ['safe navigation with assignment method', 'x&.foo = bar'],
-      ['safe navigation with self assignment method', 'x&.foo += bar']
+      ['safe navigation with self assignment method', 'x&.foo += bar'],
+      ['safe navigation with `to_d` method', 'x&.foo.to_d']
     ].each do |name, code|
       include_examples 'accepts', name, code
     end


### PR DESCRIPTION
Fixes: https://github.com/rubocop-hq/rubocop/issues/6633

`to_d` is defined in `bigdecimal/util` in stdlib and hence should be handled like other default methods on `nil`. Refer https://github.com/rubocop-hq/rubocop/issues/6633#issuecomment-452189702

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.