### PR TITLE
Revert "Fix Lint/AmbiguousBlockAssociation cites unambiguous lambda (…

### DIFF
--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
   it_behaves_like 'accepts', 'Hash[some_method(a) { |el| el }]'
   it_behaves_like 'accepts', 'foo = lambda do |diagnostic|;end'
   it_behaves_like 'accepts', 'Proc.new { puts "proc" }'
-  it_behaves_like 'accepts', 'expect { order.save }.to change { orders.size }'
+  it_behaves_like 'accepts', 'expect { order.save }.to(change { orders.size })'
   it_behaves_like 'accepts', 'scope :active, -> { where(status: "active") }'
   it_behaves_like(
     'accepts',


### PR DESCRIPTION
…#6650)"

This reverts commit 3a32310b97619a22930745a7e1f66dba1ea409c0.


**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
