### PR TITLE
[Fix #6254] Fix RescueEnsureAlignment for non-local assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bug fixes
 
+* [#6254](https://github.com/rubocop-hq/rubocop/issues/6254): Fix `Layout/RescueEnsureAlignment` for non-local assignments. ([@marcotc][])
 * [#6627](https://github.com/rubocop-hq/rubocop/pull/6627): Fix handling of hashes in trailing comma. ([@abrom][])
 * [#6623](https://github.com/rubocop-hq/rubocop/pull/6623): Fix heredoc detection in trailing comma. ([@palkan][])
 * [#6100](https://github.com/rubocop-hq/rubocop/issues/6100): Fix a false positive in `Naming/ConstantName` cop when rhs is a conditional expression. ([@tatsuyafw][])
@@ -3758,3 +3759,4 @@
 [@Intrepidd]: https://github.com/Intrepidd
 [@Ruffeng]: https://github.com/Ruffeng
 [@roooodcastro]: https://github.com/roooodcastro
+[@marcotc]: https://github.com/marcotc

--- a/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
@@ -30,7 +30,17 @@ module RuboCop
         ANCESTOR_TYPES = %i[kwbegin def defs class module].freeze
         RUBY_2_5_ANCESTOR_TYPES = (ANCESTOR_TYPES + %i[block]).freeze
         ANCESTOR_TYPES_WITH_ACCESS_MODIFIERS = %i[def defs].freeze
-        ASSIGNMENT_TYPES = %i[lvasgn].freeze
+        ASSIGNMENT_TYPES = %i[
+          lvasgn
+          ivasgn
+          cvasgn
+          gvasgn
+          casgn
+          masgn
+          op_asgn
+          and_asgn
+          or_asgn
+        ].freeze
 
         def on_resbody(node)
           check(node) unless modifier?(node)

--- a/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
@@ -30,17 +30,6 @@ module RuboCop
         ANCESTOR_TYPES = %i[kwbegin def defs class module].freeze
         RUBY_2_5_ANCESTOR_TYPES = (ANCESTOR_TYPES + %i[block]).freeze
         ANCESTOR_TYPES_WITH_ACCESS_MODIFIERS = %i[def defs].freeze
-        ASSIGNMENT_TYPES = %i[
-          lvasgn
-          ivasgn
-          cvasgn
-          gvasgn
-          casgn
-          masgn
-          op_asgn
-          and_asgn
-          or_asgn
-        ].freeze
 
         def on_resbody(node)
           check(node) unless modifier?(node)
@@ -151,8 +140,7 @@ module RuboCop
         def assignment_node(node)
           assignment_node = node.ancestors.first
           return nil unless
-            assignment_node &&
-            ASSIGNMENT_TYPES.include?(assignment_node.type)
+            assignment_node && assignment_node.assignment?
 
           assignment_node
         end

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -375,12 +375,76 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
       RUBY
     end
 
-    it 'accepts aligned rescue in assigned do-end block' do
+    it 'accepts aligned rescue do-end block assigned to local variable' do
       expect_no_offenses(<<-RUBY.strip_indent)
         result = [1, 2, 3].map do |el|
           el.to_s
         rescue StandardError => _exception
           next
+        end
+      RUBY
+    end
+
+    it 'accepts aligned rescue in do-end block assigned to instance variable' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        @instance = [].map do |_|
+        rescue StandardError => _
+        end
+      RUBY
+    end
+
+    it 'accepts aligned rescue in do-end block assigned to class variable' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        @@class = [].map do |_|
+        rescue StandardError => _
+        end
+      RUBY
+    end
+
+    it 'accepts aligned rescue in do-end block assigned to global variable' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        $global = [].map do |_|
+        rescue StandardError => _
+        end
+      RUBY
+    end
+
+    it 'accepts aligned rescue in do-end block assigned to class' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        CLASS = [].map do |_|
+        rescue StandardError => _
+        end
+      RUBY
+    end
+
+    it 'accepts aligned rescue in do-end block on multi-assignment' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        a, b = [].map do |_|
+        rescue StandardError => _
+        end
+      RUBY
+    end
+
+    it 'accepts aligned rescue in do-end block on operation assignment' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        a += [].map do |_|
+        rescue StandardError => _
+        end
+      RUBY
+    end
+
+    it 'accepts aligned rescue in do-end block on and-assignment' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        a &&= [].map do |_|
+        rescue StandardError => _
+        end
+      RUBY
+    end
+
+    it 'accepts aligned rescue in do-end block on or-assignment' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        a ||= [].map do |_|
+        rescue StandardError => _
         end
       RUBY
     end


### PR DESCRIPTION
This PR fixes the alignment of `rescue` and `ensure` keywords when those are part of an assignment do-end block.

The behaviour is currently correct when assigning into local variable, but not for instance variables, class variables, global variables or class constants. 

One thing to notice in this PR is that I used all applicable assignment nodes available on [`whitequark/parser`](
https://github.com/whitequark/parser/blob/fbe0e8cbec557c96b0e0f4a8c5201155ee478284/lib/parser/tree_rewriter.rb#L80). Let me know if we only want a subset of that list.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
