### PR TITLE
[Fix #6670] Fix a false positive for `Style/SafeNavigation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#6625](https://github.com/rubocop-hq/rubocop/issues/6625): Revert the "auto-exclusion of files ignored by git" feature. ([@bbatsov][])
 * [#4460](https://github.com/rubocop-hq/rubocop/issues/4460): Fix the determination of unsafe auto-correct in `Style/TernaryParentheses`. ([@jonas054][])
 * [#6651](https://github.com/rubocop-hq/rubocop/issues/6651): Fix auto-correct issue in `Style/RegexpLiteral` cop when there is string interpolation. ([@roooodcastro][])
+* [#6670](https://github.com/rubocop-hq/rubocop/issues/6670): Fix a false positive for `Style/SafeNavigation` when a method call safeguarded with a negative check for the object. ([@koic][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -108,6 +108,16 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
       expect_no_offenses('foo.bar.baz > 2 if foo')
     end
 
+    it 'allows a method call safeguarded with a negative check ' \
+       'for the object when using `unless`' do
+      expect_no_offenses('obj.do_something unless obj')
+    end
+
+    it 'allows a method call safeguarded with a negative check ' \
+       'for the object when using `if`' do
+      expect_no_offenses('obj.do_something if !obj')
+    end
+
     it 'allows method calls that do not get called using . safe guarded by ' \
       'an object check' do
       expect_no_offenses('foo + bar if foo')


### PR DESCRIPTION
Fixes #6670.

This PR fixes a false positive for `Style/SafeNavigation` when a method call safeguarded with a negative check for the object.

The following is a reproduction step.

```console
% rubocop -v
0.62.0

% cat example.rb
foo.bar unless foo

% rubocop --only Style/SafeNavigation
Inspecting 1 file
C

Offenses:

example.rb:1:1: C: Style/SafeNavigation: Use safe navigation (&.)
instead of checking if an object exists before calling the method.
foo.bar unless foo
^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
