### PR TITLE
[Fix #6673] Fix `Style/DocumentationMethod` for inline `module_function`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#6670](https://github.com/rubocop-hq/rubocop/issues/6670): Fix a false positive for `Style/SafeNavigation` when a method call safeguarded with a negative check for the object. ([@koic][])
 * [#6633](https://github.com/rubocop-hq/rubocop/issues/6633): Fix `Lint/SafeNavigation` complaining about use of `to_d`. ([@tejasbubane][])
 * [#6575](https://github.com/rubocop-hq/rubocop/issues/6575): Fix `Naming/PredicateName` suggesting invalid rename. ([@tejasbubane][])
+* [#6673](https://github.com/rubocop-hq/rubocop/issues/6673): Fix `Style/DocumentationMethod` cop to recognize documentation comments for `def` inline with `module_function`. ([@tejasbubane][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/documentation_method.rb
+++ b/lib/rubocop/cop/style/documentation_method.rb
@@ -53,8 +53,13 @@ module RuboCop
 
         MSG = 'Missing method documentation comment.'.freeze
 
+        def_node_matcher :module_function_node?, <<-PATTERN
+          (send nil? :module_function ...)
+        PATTERN
+
         def on_def(node)
-          check(node)
+          parent = node.parent
+          module_function_node?(parent) ? check(parent) : check(node)
         end
         alias on_defs on_def
 

--- a/spec/rubocop/cop/style/documentation_method_spec.rb
+++ b/spec/rubocop/cop/style/documentation_method_spec.rb
@@ -459,7 +459,7 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
 
     context 'when declaring methods in a module' do
       context 'without documentation comment' do
-        context 'wheh method is public' do
+        context 'when method is public' do
           it 'registers an offense' do
             expect_offense(<<-CODE.strip_indent)
               module Foo
@@ -570,6 +570,30 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
             end
           end
         end
+
+        context 'when method is module_function' do
+          it 'registers an offense for inline def' do
+            expect_offense(<<-CODE.strip_indent)
+              module Foo
+                module_function def bar
+                ^^^^^^^^^^^^^^^^^^^^^^^ Missing method documentation comment.
+                end
+              end
+            CODE
+          end
+
+          it 'registers an offense for separate def' do
+            expect_offense(<<-CODE.strip_indent)
+              module Foo
+                def bar
+                ^^^^^^^ Missing method documentation comment.
+                end
+
+                module_function :bar
+              end
+            CODE
+          end
+        end
       end
 
       context 'with documentation comment' do
@@ -590,6 +614,28 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
               module Foo
                 # Documentation
                 def bar; end
+              end
+            CODE
+          end
+        end
+
+        context 'when method is module_function' do
+          it 'does not register an offense for inline def' do
+            expect_no_offenses(<<-CODE.strip_indent)
+              module Foo
+                # Documentation
+                module_function def bar; end
+              end
+            CODE
+          end
+
+          it 'does not register an offense for separate def' do
+            expect_no_offenses(<<-CODE.strip_indent)
+              module Foo
+                # Documentation
+                def bar; end
+
+                module_function :bar
               end
             CODE
           end


### PR DESCRIPTION
Fixes #6673 

Cop now recognizes documentation comments for `def` inline with `module_function`.

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.