### PR TITLE
[Fix #6678] Allow empty constructors during Lint/DisjunctiveAssignmentInConstructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#6678](https://github.com/rubocop-hq/rubocop/issues/6678): Fix `Lint/DisjunctiveAssignmentInConstructor` when it finds an empty constructor. ([@rmm5t][])
+
 ## 0.63.0 (2019-01-16)
 
 ### New features
@@ -3758,3 +3762,4 @@
 [@Intrepidd]: https://github.com/Intrepidd
 [@Ruffeng]: https://github.com/Ruffeng
 [@roooodcastro]: https://github.com/roooodcastro
+[@rmm5t]: https://github.com/rmm5t

--- a/lib/rubocop/cop/lint/disjunctive_assignment_in_constructor.rb
+++ b/lib/rubocop/cop/lint/disjunctive_assignment_in_constructor.rb
@@ -34,12 +34,13 @@ module RuboCop
         def check(node)
           return unless node.method_name == :initialize
 
-          check_body(node)
+          check_body(node.body)
         end
 
         # @param [DefNode] node a constructor definition
-        def check_body(node)
-          body = node.body
+        def check_body(body)
+          return if body.nil?
+
           case body.type
           when :begin
             check_body_lines(body.child_nodes)

--- a/spec/rubocop/cop/lint/disjunctive_assignment_in_constructor_spec.rb
+++ b/spec/rubocop/cop/lint/disjunctive_assignment_in_constructor_spec.rb
@@ -6,6 +6,17 @@ RSpec.describe(
 ) do
   subject(:cop) { described_class.new(config) }
 
+  context 'empty constructor' do
+    it 'accepts' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class Banana
+          def initialize
+          end
+        end
+      RUBY
+    end
+  end
+
   context 'constructor does not have disjunctive assignment' do
     it 'accepts' do
       expect_no_offenses(<<-RUBY.strip_indent)


### PR DESCRIPTION
Fixes #6678 where `Lint/DisjunctiveAssignmentInConstructor`cop  would error with a `NoMethodError` when it encountered an empty constructor.

Fixes #6677 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
