### PR TITLE
Load config from `~/rubocop/` and `$XDG_CONFIG_HOME`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+## New features
+
+* [#6662](https://github.com/rubocop-hq/rubocop/issues/6662): Support loading rubocop config from `~/rubocop/` and `$XDG_CONFIG_HOME`. ([@tejasbubane][])
+
+
 ## 0.65.0 (2019-02-19)
 
 ### New features

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -15,6 +15,7 @@ module RuboCop
   # directories are inspected.
   class ConfigLoader
     DOTFILE = '.rubocop.yml'.freeze
+    CONFIGFILE = 'rubocop/config.yml'.freeze
     RUBOCOP_HOME = File.realpath(File.join(File.dirname(__FILE__), '..', '..'))
     DEFAULT_FILE = File.join(RUBOCOP_HOME, 'config', 'default.yml')
     AUTO_GENERATED_FILE = '.rubocop_todo.yml'.freeze
@@ -75,7 +76,9 @@ module RuboCop
       # user's home directory is checked. If there's no .rubocop.yml
       # there either, the path to the default file is returned.
       def configuration_file_for(target_dir)
-        find_file_upwards(DOTFILE, target_dir, use_home: true) || DEFAULT_FILE
+        find_file_upwards(DOTFILE, target_dir, use_home: true) ||
+          find_file_upwards(CONFIGFILE, target_dir, use_home: true) ||
+          DEFAULT_FILE
       end
 
       def configuration_from_file(config_file)


### PR DESCRIPTION
if `$HOME` not set

Spec: https://specifications.freedesktop.org/basedir-spec/basedir-spec-0.8.html

Closes: #6662

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.