### PR TITLE
Fix super edge cases for omit_parentheses style of Style/MethodCallWithArgsParentheses

### DIFF
--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -264,13 +264,14 @@ module RuboCop
         end
 
         def call_with_braced_block?(node)
-          node.send_type? && node.block_node && node.block_node.braces?
+          (node.send_type? || node.super_type?) &&
+            node.block_node && node.block_node.braces?
         end
 
         def call_as_argument_or_chain?(node)
           node.parent &&
             (node.parent.send_type? && !assigned_before?(node.parent, node) ||
-             node.parent.csend_type?)
+             node.parent.csend_type? || node.parent.super_type?)
         end
 
         def hash_literal_in_arguments?(node)

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -459,6 +459,14 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       expect_no_offenses('super()')
     end
 
+    it 'accepts parens in super method calls as arguments' do
+      expect_no_offenses('super foo(bar)')
+    end
+
+    it 'accepts parens in super calls with braced blocks' do
+      expect_no_offenses('super(foo(bar)) { yield }')
+    end
+
     it 'accepts parens in camel case method without args' do
       expect_no_offenses('Array()')
     end


### PR DESCRIPTION
1. Calls with arguments as `super` arguments.
```ruby
super foo(bar)
         ^^^^^ Omit parentheses for method calls with arguments.
```

2. Braced `super` calls.
```ruby
super(foo(bar)) { yield }
     ^^^^^^^^^^ Omit parentheses for method calls with arguments.
```