### PR TITLE
[Fix #6382] Fix `Layout/IndentationWidth` with `Layout/EndAlignment` …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#6351](https://github.com/rubocop-hq/rubocop/pull/6351): Fix a false positive for `Layout/ClosingParenthesisIndentation` when first argument is multiline. ([@antonzaytsev][])
 * [#6689](https://github.com/rubocop-hq/rubocop/pull/6689): Support more complex argument patterns on `Rails/Validation` auto-correction. ([@r7kamura][])
 * [#6668](https://github.com/rubocop-hq/rubocop/issues/6668): Fix autocorrection for `Style/UnneededCondition` when conditional has the `unless` form. ([@mvz][])
+* [#6382](https://github.com/rubocop-hq/rubocop/issues/6382): Fix `Layout/IndentationWidth` with `Layout/EndAlignment` set to start_of_line. ([@dischorde][], [@siegfault][], [@mhelmetag][])
 
 ## 0.63.1 (2019-01-22)
 
@@ -345,7 +346,7 @@
 * [#5881](https://github.com/rubocop-hq/rubocop/pull/5881): Add new `Rails/BulkChangeTable` cop. ([@wata727][])
 * [#5444](https://github.com/rubocop-hq/rubocop/pull/5444): Add new `Style/AccessModifierDeclarations` cop. ([@brandonweiss][])
 * [#5803](https://github.com/rubocop-hq/rubocop/issues/5803): Add new `Style/UnneededCondition` cop. ([@balbesina][])
-* [#5406](https://github.com/rubocop-hq/rubocop/issues/5406): Add new `Layout/ClosingHeredocIndentation` cop. ([@siggymcfried][])
+* [#5406](https://github.com/rubocop-hq/rubocop/issues/5406): Add new `Layout/ClosingHeredocIndentation` cop. ([@siegfault][])
 * [#5823](https://github.com/rubocop-hq/rubocop/issues/5823): Add new `slashes` style to `Rails/FilePath` since Ruby accepts forward slashes even on Windows. ([@sunny][])
 * New cop `Layout/LeadingBlankLines` checks for empty lines at the beginning of a file. ([@rrosenblum][])
 
@@ -642,7 +643,7 @@
 * [#5177](https://github.com/rubocop-hq/rubocop/pull/5177): Add new `Rails/LexicallyScopedActionFilter` cop. ([@wata727][])
 * [#5173](https://github.com/rubocop-hq/rubocop/pull/5173): Add new `Style/EvalWithLocation` cop. ([@pocke][])
 * [#5208](https://github.com/rubocop-hq/rubocop/pull/5208): Add new `Rails/Presence` cop. ([@wata727][])
-* Allow auto-correction of ClassAndModuleChildren. ([@siggymcfried][], [@melch][])
+* Allow auto-correction of ClassAndModuleChildren. ([@siegfault][], [@melch][])
 
 ### Bug fixes
 
@@ -3689,7 +3690,7 @@
 [@walf443]: https://github.com/walf443
 [@reitermarkus]: https://github.com/reitermarkus
 [@chrishulton]: https://github.com/chrishulton
-[@siggymcfried]: https://github.com/siggymcfried
+[@siegfault]: https://github.com/siegfault
 [@melch]: https://github.com/melch
 [@nattfodd]: https://github.com/nattfodd
 [@flyerhzm]: https://github.com/flyerhzm
@@ -3784,3 +3785,5 @@
 [@rmm5t]: https://github.com/rmm5t
 [@marcotc]: https://github.com/marcotc
 [@dazuma]: https://github.com/dazuma
+[@dischorde]: https://github.com/dischorde
+[@mhelmetag]: https://github.com/mhelmetag

--- a/lib/rubocop/cop/mixin/end_keyword_alignment.rb
+++ b/lib/rubocop/cop/mixin/end_keyword_alignment.rb
@@ -54,12 +54,9 @@ module RuboCop
       end
 
       def variable_alignment?(whole_expression, rhs, end_alignment_style)
-        case end_alignment_style
-        when :variable
-          !line_break_before_keyword?(whole_expression, rhs)
-        when :start_of_line
-          true
-        end
+        return if end_alignment_style == :keyword
+
+        !line_break_before_keyword?(whole_expression, rhs)
       end
 
       def line_break_before_keyword?(whole_expression, rhs)

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -514,6 +514,17 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
               RUBY
             end
 
+            it 'accepts an if/else in assignment on next line' do
+              expect_no_offenses(<<-RUBY.strip_indent)
+                var =
+                  if a
+                    0
+                  else
+                    1
+                  end
+              RUBY
+            end
+
             it 'registers an offense for a while' do
               expect_offense(<<-RUBY.strip_indent)
                 var = while a


### PR DESCRIPTION
Fixes #6382 to allow:
```
variable =
  if true
    :foo
  else
    :bar
  end
```
which currently violates `Layout/IndentationWidth` & `Layout/ElseAlignment` when `Layout/EndAlignment` is set to `start_of_line`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
