### PR TITLE
update helper comment url encode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#6610](https://github.com/rubocop-hq/rubocop/issues/6610): Extend `Lint/UriEscapeUnescape` to include ERB::Util.url_encode in suggested alternatives. ([@bauerjon][])
+
 ### Bug fixes
 
 * [#6678](https://github.com/rubocop-hq/rubocop/issues/6678): Fix `Lint/DisjunctiveAssignmentInConstructor` when it finds an empty constructor. ([@rmm5t][])
@@ -3763,3 +3765,4 @@
 [@Ruffeng]: https://github.com/Ruffeng
 [@roooodcastro]: https://github.com/roooodcastro
 [@rmm5t]: https://github.com/rmm5t
+[@bauerjon]: https://github.com/bauerjon

--- a/config/default.yml
+++ b/config/default.yml
@@ -1578,8 +1578,8 @@ Lint/UnusedMethodArgument:
 Lint/UriEscapeUnescape:
   Description: >-
                  `URI.escape` method is obsolete and should not be used. Instead, use
-                 `CGI.escape`, `URI.encode_www_form` or `URI.encode_www_form_component`
-                 depending on your specific use case.
+                 `CGI.escape`, `URI.encode_www_form`, `URI.encode_www_form_component`,
+                 or `ERB::Util.url_encode` depending on your specific use case.
                  Also `URI.unescape` method is obsolete and should not be used. Instead, use
                  `CGI.unescape`, `URI.decode_www_form` or `URI.decode_www_form_component`
                  depending on your specific use case.

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -2352,8 +2352,8 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 Enabled | Yes | No | 0.50 | -
 
 This cop identifies places where `URI.escape` can be replaced by
-`CGI.escape`, `URI.encode_www_form`, or `URI.encode_www_form_component`
-depending on your specific use case.
+`CGI.escape`, `URI.encode_www_form`, `URI.encode_www_form_component`
+or `ERB::Util.url_encode` depending on your specific use case.
 Also this cop identifies places where `URI.unescape` can be replaced by
 `CGI.unescape`, `URI.decode_www_form`,
 or `URI.decode_www_form_component` depending on your specific use case.
@@ -2370,6 +2370,7 @@ CGI.escape('http://example.com')
 URI.encode_www_form([['example', 'param'], ['lang', 'en']])
 URI.encode_www_form(page: 10, locale: 'en')
 URI.encode_www_form_component('http://example.com')
+ERB::Util.url_encode('http://example.com')
 
 # bad
 URI.unescape(enc_uri)

--- a/spec/rubocop/cop/lint/uri_escape_unescape_spec.rb
+++ b/spec/rubocop/cop/lint/uri_escape_unescape_spec.rb
@@ -8,35 +8,35 @@ RSpec.describe RuboCop::Cop::Lint::UriEscapeUnescape do
   it "registers an offense when using `URI.escape('http://example.com')`" do
     expect_offense(<<-RUBY.strip_indent)
       URI.escape('http://example.com')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `URI.escape` method is obsolete and should not be used. Instead, use `CGI.escape`, `URI.encode_www_form` or `URI.encode_www_form_component` depending on your specific use case.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `URI.escape` method is obsolete and should not be used. Instead, use `CGI.escape`, `URI.encode_www_form`, `URI.encode_www_form_component` or `ERB::Util.url_encode` depending on your specific use case.
     RUBY
   end
 
   it "registers an offense when using `URI.escape('@?@!', '!?')`" do
     expect_offense(<<-RUBY.strip_indent)
       URI.escape('@?@!', '!?')
-      ^^^^^^^^^^^^^^^^^^^^^^^^ `URI.escape` method is obsolete and should not be used. Instead, use `CGI.escape`, `URI.encode_www_form` or `URI.encode_www_form_component` depending on your specific use case.
+      ^^^^^^^^^^^^^^^^^^^^^^^^ `URI.escape` method is obsolete and should not be used. Instead, use `CGI.escape`, `URI.encode_www_form`, `URI.encode_www_form_component` or `ERB::Util.url_encode` depending on your specific use case.
     RUBY
   end
 
   it "registers an offense when using `::URI.escape('http://example.com')`" do
     expect_offense(<<-RUBY.strip_indent)
       ::URI.escape('http://example.com')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `::URI.escape` method is obsolete and should not be used. Instead, use `CGI.escape`, `URI.encode_www_form` or `URI.encode_www_form_component` depending on your specific use case.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `::URI.escape` method is obsolete and should not be used. Instead, use `CGI.escape`, `URI.encode_www_form`, `URI.encode_www_form_component` or `ERB::Util.url_encode` depending on your specific use case.
     RUBY
   end
 
   it "registers an offense when using `URI.encode('http://example.com')`" do
     expect_offense(<<-RUBY.strip_indent)
       URI.encode('http://example.com')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `URI.encode` method is obsolete and should not be used. Instead, use `CGI.escape`, `URI.encode_www_form` or `URI.encode_www_form_component` depending on your specific use case.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `URI.encode` method is obsolete and should not be used. Instead, use `CGI.escape`, `URI.encode_www_form`, `URI.encode_www_form_component` or `ERB::Util.url_encode` depending on your specific use case.
     RUBY
   end
 
   it "registers an offense when using `::URI.encode('http://example.com)`" do
     expect_offense(<<-RUBY.strip_indent)
       ::URI.encode('http://example.com')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `::URI.encode` method is obsolete and should not be used. Instead, use `CGI.escape`, `URI.encode_www_form` or `URI.encode_www_form_component` depending on your specific use case.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `::URI.encode` method is obsolete and should not be used. Instead, use `CGI.escape`, `URI.encode_www_form`, `URI.encode_www_form_component` or `ERB::Util.url_encode` depending on your specific use case.
     RUBY
   end
 


### PR DESCRIPTION
A change related to https://github.com/rubocop-hq/rubocop/issues/6610.

This change updates the helper output to include `ERB::Util.url_encode` as another suggestion for the deprecated `URI.encode` and `URI.escape`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/g) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
