### PR TITLE
Support more complex argument patterns on `Rails/Validation` auto-correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#6254](https://github.com/rubocop-hq/rubocop/issues/6254): Fix `Layout/RescueEnsureAlignment` for non-local assignments. ([@marcotc][])
 * [#6648](https://github.com/rubocop-hq/rubocop/issues/6648): Fix auto-correction of `Style/EmptyLiteral` when `Hash.new` is passed as the first argument to `super`. ([@rrosenblum][])
 * [#6351](https://github.com/rubocop-hq/rubocop/pull/6351): Fix a false positive for `Layout/ClosingParenthesisIndentation` when first argument is multiline. ([@antonzaytsev][])
+* [#6689](https://github.com/rubocop-hq/rubocop/pull/6689): Support more complex argument patterns on `Rails/Validation` auto-correction. ([@r7kamura][])
 
 ## 0.63.1 (2019-01-22)
 

--- a/lib/rubocop/cop/rails/validation.rb
+++ b/lib/rubocop/cop/rails/validation.rb
@@ -57,6 +57,9 @@ module RuboCop
         end
 
         def autocorrect(node)
+          last_argument = node.arguments.last
+          return if !last_argument.literal? && !last_argument.splat_type?
+
           lambda do |corrector|
             corrector.replace(node.loc.selector, 'validates')
             correct_validate_type(corrector, node)
@@ -75,12 +78,14 @@ module RuboCop
         end
 
         def correct_validate_type(corrector, node)
-          options = node.arguments.find { |arg| !arg.sym_type? }
+          last_argument = node.arguments.last
           validate_type = node.method_name.to_s.split('_')[1]
 
-          if options
-            corrector.replace(options.loc.expression,
-                              "#{validate_type}: #{braced_options(options)}")
+          if last_argument.hash_type?
+            corrector.replace(
+              last_argument.loc.expression,
+              "#{validate_type}: #{braced_options(last_argument)}"
+            )
           else
             corrector.insert_after(node.loc.expression,
                                    ", #{validate_type}: true")

--- a/spec/rubocop/cop/rails/validation_spec.rb
+++ b/spec/rubocop/cop/rails/validation_spec.rb
@@ -20,34 +20,130 @@ RSpec.describe RuboCop::Cop::Rails::Validation do
     end
   end
 
-  describe 'autocorrect' do
-    described_class::TYPES.each do |parameter|
-      it "corrects validates_#{parameter}_of" do
-        new_source = autocorrect_source(
-          "validates_#{parameter}_of :full_name, :birth_date"
-        )
-        expect(new_source).to eq(
-          "validates :full_name, :birth_date, #{parameter}: true"
-        )
+  describe '#autocorrect' do
+    shared_examples 'auto-corrects' do
+      it 'auto-corrects' do
+        expect(autocorrect_source(source)).to eq(auto_corrected_source)
       end
     end
 
-    it 'corrects validates_numericality_of with options' do
-      new_source = autocorrect_source(
-        'validates_numericality_of :age, minimum: 0, maximum: 122'
-      )
-      expect(new_source).to eq(
-        'validates :age, numericality: { minimum: 0, maximum: 122 }'
-      )
+    shared_examples 'does not auto-correct' do
+      it 'does not auto-correct' do
+        expect(autocorrect_source(source)).to eq(source)
+      end
     end
 
-    it 'autocorrect validates_numericality_of with options in braces' do
-      new_source = autocorrect_source(
-        'validates_numericality_of :age, { minimum: 0, maximum: 122 }'
-      )
-      expect(new_source).to eq(
-        'validates :age, numericality: { minimum: 0, maximum: 122 }'
-      )
+    described_class::TYPES.each do |type|
+      context "with validates_#{type}_of" do
+        let(:auto_corrected_source) do
+          "validates :full_name, :birth_date, #{type}: true"
+        end
+
+        let(:source) do
+          "validates_#{type}_of :full_name, :birth_date"
+        end
+
+        include_examples 'auto-corrects'
+      end
+    end
+
+    context 'with single attribute name' do
+      let(:auto_corrected_source) do
+        'validates :a, numericality: true'
+      end
+
+      let(:source) do
+        'validates_numericality_of :a'
+      end
+
+      include_examples 'auto-corrects'
+    end
+
+    context 'with multi attribute names' do
+      let(:auto_corrected_source) do
+        'validates :a, :b, numericality: true'
+      end
+
+      let(:source) do
+        'validates_numericality_of :a, :b'
+      end
+
+      include_examples 'auto-corrects'
+    end
+
+    context 'with non-braced hash literal' do
+      let(:auto_corrected_source) do
+        'validates :a, :b, numericality: { minimum: 1 }'
+      end
+
+      let(:source) do
+        'validates_numericality_of :a, :b, minimum: 1'
+      end
+
+      include_examples 'auto-corrects'
+    end
+
+    context 'with braced hash literal' do
+      let(:auto_corrected_source) do
+        'validates :a, :b, numericality: { minimum: 1 }'
+      end
+
+      let(:source) do
+        'validates_numericality_of :a, :b, { minimum: 1 }'
+      end
+
+      include_examples 'auto-corrects'
+    end
+
+    context 'with splat' do
+      let(:auto_corrected_source) do
+        'validates :a, *b, numericality: true'
+      end
+
+      let(:source) do
+        'validates_numericality_of :a, *b'
+      end
+
+      include_examples 'auto-corrects'
+    end
+
+    context 'with splat and options' do
+      let(:auto_corrected_source) do
+        'validates :a, *b, :c, numericality: { minimum: 1 }'
+      end
+
+      let(:source) do
+        'validates_numericality_of :a, *b, :c, minimum: 1'
+      end
+
+      include_examples 'auto-corrects'
+    end
+
+    context 'with trailing send node' do
+      let(:source) do
+        'validates_numericality_of :a, b'
+      end
+
+      include_examples 'does not auto-correct'
+    end
+
+    context 'with trailing constant' do
+      let(:source) do
+        'validates_numericality_of :a, B'
+      end
+
+      include_examples 'does not auto-correct'
+    end
+
+    context 'with trailing local variable' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          b = { minimum: 1 }
+          validates_numericality_of :a, b
+        RUBY
+      end
+
+      include_examples 'does not auto-correct'
     end
   end
 end


### PR DESCRIPTION
## About

I changed `#autocorrect` implementation to support more different arguments pattern by checking `node.arguments.last` type.

## Background

I tried to auto-correct the following code with Rails/Validation cop with rubocop 0.63.0.

```rb
# app/models/example_model.rb
class ExampleModel < ActiveRecord::Base
  ATTRIBUTES = %i(b c)

  validates_numericality_of :a, *ATTRIBUTES, only_integer: true
end
```

### Expected behavior

I expected that it would be auto-corrected like this:

```
$ rubocop --auto-correct --only Rails/Validation app/models/example_model.rb
Inspecting 1 file
C

Offenses:

app/models/example_model.rb:4:3: C: [Corrected] Rails/Validation: Prefer the new style validations validates :column, numericality: value over validates_numericality_of.
  validates_numericality_of :a, *ATTRIBUTES, only_integer: true
  ^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
```

```rb
class ExampleModel < ActiveRecord::Base
  ATTRIBUTES = %i(b c)

  validates :a, *ATTRIBUTES, numericality: { only_integer: true }
end
```

### Actual behavior

Unfortunately it failed because Rails/Validation's `#autocorrect` doesn't support splat node in arguments.

```
$ rubocop --auto-correct --only Rails/Validation app/models/example_model.rb
Inspecting 1 file


0 files inspected, no offenses detected
undefined method `braces?' for "s(:splat,\n  s(:const, nil, :ATTRIBUTES))":RuboCop::AST::Node
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/cop/rails/validation.rb:91:in `braced_options'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/cop/rails/validation.rb:83:in `correct_validate_type'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/cop/rails/validation.rb:62:in `block in autocorrect'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/cop/corrector.rb:64:in `block (2 levels) in rewrite'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/parser-2.5.3.0/lib/parser/source/tree_rewriter.rb:220:in `transaction'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/cop/corrector.rb:63:in `block in rewrite'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/cop/corrector.rb:61:in `each'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/cop/corrector.rb:61:in `rewrite'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/cop/team.rb:128:in `autocorrect_all_cops'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/cop/team.rb:72:in `autocorrect'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/cop/team.rb:100:in `block in offenses'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/cop/team.rb:117:in `investigate'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/cop/team.rb:96:in `offenses'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/cop/team.rb:44:in `inspect_file'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/runner.rb:280:in `inspect_file'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/runner.rb:227:in `block in do_inspection_loop'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/runner.rb:259:in `block in iterate_until_no_changes'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/runner.rb:252:in `loop'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/runner.rb:252:in `iterate_until_no_changes'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/runner.rb:223:in `do_inspection_loop'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/runner.rb:126:in `block in file_offenses'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/runner.rb:144:in `file_offense_cache'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/runner.rb:124:in `file_offenses'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/runner.rb:112:in `process_file'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/runner.rb:89:in `block in each_inspected_file'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/runner.rb:86:in `each'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/runner.rb:86:in `reduce'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/runner.rb:86:in `each_inspected_file'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/runner.rb:76:in `inspect_files'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/runner.rb:48:in `run'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/cli.rb:174:in `execute_runner'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/cli.rb:75:in `execute_runners'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/lib/rubocop/cli.rb:47:in `run'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/exe/rubocop:13:in `block in <top (required)>'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/2.4.0/benchmark.rb:308:in `realtime'
/Users/r7kamura/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-0.63.0/exe/rubocop:12:in `<top (required)>'
/Users/r7kamura/.rbenv/versions/2.4.1/bin/rubocop:22:in `load'
/Users/r7kamura/.rbenv/versions/2.4.1/bin/rubocop:22:in `<main>'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
