### PR TITLE
Add space before `in` and `your`

### DIFF
--- a/lib/rubocop/cop/style/copyright.rb
+++ b/lib/rubocop/cop/style/copyright.rb
@@ -20,7 +20,7 @@ module RuboCop
 
         MSG = 'Include a copyright notice matching /%<notice>s/ before ' \
               'any code.'.freeze
-        AUTOCORRECT_EMPTY_WARNING = 'An AutocorrectNotice must be defined in' \
+        AUTOCORRECT_EMPTY_WARNING = 'An AutocorrectNotice must be defined in ' \
                                     'your RuboCop config'.freeze
 
         def investigate(processed_source)


### PR DESCRIPTION
Minor typo-like correction.
Before the warning was:
`An AutocorrectNotice must be defined inyour RuboCop config`

Now it is
`An AutocorrectNotice must be defined in your RuboCop config`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] ~Added tests.~
* [ ] ~Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).~
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
