### PR TITLE
Cut 0.63.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,5 +35,5 @@ Include the output of `rubocop -V` or `bundle exec rubocop -V` if using Bundler.
 
 ```
 $ [bundle exec] rubocop -V
-0.63.0 (using Parser 2.5.1.2, running on ruby 2.5.1 x86_64-linux)
+0.63.1 (using Parser 2.5.1.2, running on ruby 2.5.1 x86_64-linux)
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+## 0.63.1 (2019-01-22)
+
 ### Bug fixes
 
 * [#6678](https://github.com/rubocop-hq/rubocop/issues/6678): Fix `Lint/DisjunctiveAssignmentInConstructor` when it finds an empty constructor. ([@rmm5t][])

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ haven't reached version 1.0 yet). To prevent an unwanted RuboCop update you
 might want to use a conservative version locking in your `Gemfile`:
 
 ```rb
-gem 'rubocop', '~> 0.63.0', require: false
+gem 'rubocop', '~> 0.63.1', require: false
 ```
 
 ## Quickstart

--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -3,7 +3,7 @@
 module RuboCop
   # This module holds the RuboCop version information.
   module Version
-    STRING = '0.63.0'.freeze
+    STRING = '0.63.1'.freeze
 
     MSG = '%<version>s (using Parser %<parser_version>s, running on ' \
           '%<ruby_engine>s %<ruby_version>s %<ruby_platform>s)'.freeze

--- a/manual/installation.md
+++ b/manual/installation.md
@@ -16,7 +16,7 @@ haven't reached version 1.0 yet). To prevent an unwanted RuboCop update you
 might want to use a conservative version locking in your `Gemfile`:
 
 ```rb
-gem 'rubocop', '~> 0.63.0', require: false
+gem 'rubocop', '~> 0.63.1', require: false
 ```
 
 !!! Note

--- a/relnotes/v0.63.1.md
+++ b/relnotes/v0.63.1.md
@@ -1,0 +1,9 @@
+### Bug fixes
+
+* [#6678](https://github.com/rubocop-hq/rubocop/issues/6678): Fix `Lint/DisjunctiveAssignmentInConstructor` when it finds an empty constructor. ([@rmm5t][])
+* Do not attempt to auto-correct mass assignment or optional assignment in `Rails/RelativeDateConstant`. ([@rrosenblum][])
+* Fix auto-correction of `Style/WordArray` and `Style/SymbolArray` when all elements are on separate lines and there is a trailing comment after the closing bracket. ([@rrosenblum][])
+* Fix an exception that occurs when auto-correcting `Layout/ClosingParenthesesIndentation` when there are no arguments. ([@rrosenblum][])
+
+[@rmm5t]: https://github.com/rmm5t
+[@rrosenblum]: https://github.com/rrosenblum


### PR DESCRIPTION
Cutting a bug fix release, since `Lint/DisjunctiveAssignmentInConstructor` breaks on common code.

### Bug fixes

* [#6678](https://github.com/rubocop-hq/rubocop/issues/6678): Fix `Lint/DisjunctiveAssignmentInConstructor` when it finds an empty constructor. ([@rmm5t][])
* Do not attempt to auto-correct mass assignment or optional assignment in `Rails/RelativeDateConstant`. ([@rrosenblum][])
* Fix auto-correction of `Style/WordArray` and `Style/SymbolArray` when all elements are on separate lines and there is a trailing comment after the closing bracket. ([@rrosenblum][])
* Fix an exception that occurs when auto-correcting `Layout/ClosingParenthesesIndentation` when there are no arguments. ([@rrosenblum][])

[@rmm5t]: https://github.com/rmm5t
[@rrosenblum]: https://github.com/rrosenblum
