### PR TITLE
[Fix: #6668] Fix autocorrect for UnneededCondition with unless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#6648](https://github.com/rubocop-hq/rubocop/issues/6648): Fix auto-correction of `Style/EmptyLiteral` when `Hash.new` is passed as the first argument to `super`. ([@rrosenblum][])
 * [#6351](https://github.com/rubocop-hq/rubocop/pull/6351): Fix a false positive for `Layout/ClosingParenthesisIndentation` when first argument is multiline. ([@antonzaytsev][])
 * [#6689](https://github.com/rubocop-hq/rubocop/pull/6689): Support more complex argument patterns on `Rails/Validation` auto-correction. ([@r7kamura][])
+* [#6668](https://github.com/rubocop-hq/rubocop/issues/6668): Fix autocorrection for `Style/UnneededCondition` when conditional has the `unless` form. ([@mvz][])
 
 ## 0.63.1 (2019-01-22)
 

--- a/lib/rubocop/cop/style/unneeded_condition.rb
+++ b/lib/rubocop/cop/style/unneeded_condition.rb
@@ -96,8 +96,9 @@ module RuboCop
         end
 
         def make_ternary_form(node)
-          ternary_form = [node.if_branch.source,
-                          else_source(node.else_branch)].join(' || ')
+          _condition, if_branch, else_branch = *node
+          ternary_form = [if_branch.source,
+                          else_source(else_branch)].join(' || ')
 
           if node.parent && node.parent.send_type?
             "(#{ternary_form})"

--- a/spec/rubocop/cop/style/unneeded_condition_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_condition_spec.rb
@@ -225,4 +225,57 @@ RSpec.describe RuboCop::Cop::Style::UnneededCondition do
       end
     end
   end
+
+  context 'when inverted condition (unless)' do
+    it 'registers no offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        unless a
+          b
+        else
+          c
+        end
+      RUBY
+    end
+
+    context 'when condition and else branch are same' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
+          unless b
+          ^^^^^^^^ Use double pipes `||` instead.
+            y(x, z)
+          else
+            b
+          end
+        RUBY
+      end
+
+      context 'when unless branch is complex' do
+        it 'registers no offense' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            unless b
+              c
+              d
+            else
+              b
+            end
+          RUBY
+        end
+      end
+    end
+
+    describe '#autocorrection' do
+      it 'auto-corrects offense' do
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+          unless b
+            c
+          else
+            b
+          end
+        RUBY
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          b || c
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
Autocorrection of Style/UnneededCondition was broken for the `unless` case. This change adds tests for it and ensures the condition is put first in the resulting expression. See #6668 for more details.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
