### PR TITLE
Remove unused let statements

### DIFF
--- a/spec/rubocop/cop/lint/float_out_of_range_spec.rb
+++ b/spec/rubocop/cop/lint/float_out_of_range_spec.rb
@@ -16,8 +16,6 @@ RSpec.describe RuboCop::Cop::Lint::FloatOutOfRange do
   end
 
   context 'on whopping big floats which tip the scales' do
-    let(:source) { '9.9999e999' }
-
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)
         9.9999e999
@@ -27,8 +25,6 @@ RSpec.describe RuboCop::Cop::Lint::FloatOutOfRange do
   end
 
   context 'on floats so close to zero that nobody can tell the difference' do
-    let(:source) { '1.0e-400' }
-
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)
         1.0e-400

--- a/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
+++ b/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
@@ -149,17 +149,6 @@ RSpec.describe RuboCop::Cop::Style::IdenticalConditionalBranches do
   end
 
   context 'on case without else' do
-    let(:source) do
-      <<-RUBY.strip_indent
-        case something
-        when :a
-          do_x
-        when :b
-          do_x
-        end
-      RUBY
-    end
-
     it "doesn't register an offense" do
       expect_no_offenses(<<-RUBY.strip_indent)
         case something

--- a/spec/rubocop/cop/style/option_hash_spec.rb
+++ b/spec/rubocop/cop/style/option_hash_spec.rb
@@ -16,15 +16,6 @@ RSpec.describe RuboCop::Cop::Style::OptionHash, :config do
   end
 
   context 'when the last argument is an options hash named something else' do
-    let(:source) do
-      <<-RUBY.strip_indent
-        def steep(flavor, duration, config={})
-          mug = config.fetch(:mug)
-          prep(flavor, duration, mug)
-        end
-      RUBY
-    end
-
     it 'does not register an offense' do
       expect_no_offenses(<<-RUBY.strip_indent)
         def steep(flavor, duration, config={})

--- a/spec/rubocop/cop/style/optional_arguments_spec.rb
+++ b/spec/rubocop/cop/style/optional_arguments_spec.rb
@@ -3,10 +3,6 @@
 RSpec.describe RuboCop::Cop::Style::OptionalArguments do
   subject(:cop) { described_class.new }
 
-  let(:message) do
-    'Optional arguments should appear at the end of the argument list.'
-  end
-
   it 'registers an offense when an optional argument is followed by a ' \
      'required argument' do
     expect_offense(<<-RUBY.strip_indent)


### PR DESCRIPTION
Probably left-overs from some migration to `expect_offense`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] ~Added tests.~
* [x] ~Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).~
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
