### PR TITLE
Add AllowParenthesesInCamelCaseMethod option to default config

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -3386,6 +3386,7 @@ Style/MethodCallWithArgsParentheses:
   IgnoredMethods: []
   AllowParenthesesInMultilineCall: false
   AllowParenthesesInChaining: false
+  AllowParenthesesInCamelCaseMethod: false
   EnforcedStyle: require_parentheses
   SupportedStyles:
     - require_parentheses

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2902,6 +2902,7 @@ IgnoreMacros | `true` | Boolean
 IgnoredMethods | `[]` | Array
 AllowParenthesesInMultilineCall | `false` | Boolean
 AllowParenthesesInChaining | `false` | Boolean
+AllowParenthesesInCamelCaseMethod | `false` | Boolean
 EnforcedStyle | `require_parentheses` | `require_parentheses`, `omit_parentheses`
 
 ### References


### PR DESCRIPTION
This is necessary to prevent a warning when the new `AllowParenthesesInCamelCaseMethod` option introduced in #6643 is used.

/cc @Drenmi 
