### PR TITLE
Fix misleading method name for the cop generator

### DIFF
--- a/lib/rubocop/cop/generator/configuration_injector.rb
+++ b/lib/rubocop/cop/generator/configuration_injector.rb
@@ -45,15 +45,15 @@ module RuboCop
 
         def find_target_line
           configuration_entries.find.with_index do |line, index|
-            next if comment?(line)
+            next unless cop_name_line?(line)
 
             return index if badge.to_s < line
           end
           configuration_entries.size - 1
         end
 
-        def comment?(yaml)
-          yaml =~ /^[\s#]/
+        def cop_name_line?(yaml)
+          yaml !~ /^[\s#]/
         end
       end
     end


### PR DESCRIPTION
I found a misleading method name while reviewing #6645 .
I expect `comment?` method returns `true` if the argument is a comment. But it also returns `true` when the argument starts with a space.
Actually this method returns `false` if the argument is a cop name's line. Like `Layout/Tab:`. So I changed the method name to `cop_name_line?` and inverted the returned value.

This pull request only contains refactoring.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
