### PR TITLE
Fix a typo for `Rails/BelongsTo`

### DIFF
--- a/lib/rubocop/cop/rails/belongs_to.rb
+++ b/lib/rubocop/cop/rails/belongs_to.rb
@@ -19,7 +19,7 @@ module RuboCop
       # In the case that the developer is doing `required: false`, we
       # definitely want to autocorrect to `optional: true`.
       #
-      # However, without knowing whether they've set overriden the default
+      # However, without knowing whether they've set overridden the default
       # value of `config.active_record.belongs_to_required_by_default`, we
       # can't say whether it's safe to remove `required: true` or whether we
       # should replace it with `optional: false` (or, similarly, remove a

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -184,7 +184,7 @@ From the release notes:
 In the case that the developer is doing `required: false`, we
 definitely want to autocorrect to `optional: true`.
 
-However, without knowing whether they've set overriden the default
+However, without knowing whether they've set overridden the default
 value of `config.active_record.belongs_to_required_by_default`, we
 can't say whether it's safe to remove `required: true` or whether we
 should replace it with `optional: false` (or, similarly, remove a


### PR DESCRIPTION
This PR fixes a typo for `Rails/BelongsTo`.

```console
% misspell -i enviromnent .
lib/rubocop/cop/rails/belongs_to.rb:22:53: "overriden" is a misspelling of "overridden"
manual/cops_rails.md:187:45: "overriden" is a misspelling of "overridden"
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
