### PR TITLE
[Fix #6701] Trailing comma detection regression with HEREDOC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#6382](https://github.com/rubocop-hq/rubocop/issues/6382): Fix `Layout/IndentationWidth` with `Layout/EndAlignment` set to start_of_line. ([@dischorde][], [@siegfault][], [@mhelmetag][])
 * [#6710](https://github.com/rubocop-hq/rubocop/issues/6710): Fix `Naming/MemoizedInstanceVariableName` on method starts with underscore. ([@pocke][])
 * [#6722](https://github.com/rubocop-hq/rubocop/issues/6722): Fix an error for `Style/OneLineConditional` when `then` branch has no body. ([@koic][])
+* [#6702](https://github.com/rubocop-hq/rubocop/pull/6702): Fix `TrailingComma` regression where heredoc with commas caused false positives. ([@abrom][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/trailing_comma_in_array_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_array_literal_spec.rb
@@ -100,6 +100,33 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArrayLiteral, :config do
                    ]
         RUBY
       end
+
+      it 'accepts HEREDOC with commas' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          [
+            <<-TEXT, 123
+              Something with a , in it
+            TEXT
+          ]
+        RUBY
+      end
+
+      it 'auto-corrects unwanted comma where HEREDOC has commas' do
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+          [
+            <<-TEXT, 123,
+              Something with a , in it
+            TEXT
+          ]
+        RUBY
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          [
+            <<-TEXT, 123
+              Something with a , in it
+            TEXT
+          ]
+        RUBY
+      end
     end
 
     context 'when EnforcedStyleForMultiline is comma' do

--- a/spec/rubocop/cop/style/trailing_comma_in_hash_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_hash_literal_spec.rb
@@ -154,12 +154,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInHashLiteral, :config do
         RUBY
       end
 
-      it 'accepts missing comma after a heredoc' do
-        # A heredoc that's the last item in a literal or parameter list can not
-        # have a trailing comma. It's a syntax error.
+      it 'accepts trailing comma after a heredoc' do
         expect_no_offenses(<<-RUBY.strip_indent)
           route(help: {
-            'auth' => <<-HELP.chomp
+            'auth' => <<-HELP.chomp,
           ...
           HELP
           })
@@ -238,12 +236,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInHashLiteral, :config do
         RUBY
       end
 
-      it 'accepts missing comma after a heredoc' do
-        # A heredoc that's the last item in a literal or parameter list can not
-        # have a trailing comma. It's a syntax error.
+      it 'accepts trailing comma after a heredoc' do
         expect_no_offenses(<<-RUBY.strip_indent)
           route(help: {
-            'auth' => <<-HELP.chomp
+            'auth' => <<-HELP.chomp,
           ...
           HELP
           })


### PR DESCRIPTION
The TrailingCommaInArguments and TrailingCommaInArrayLiteral cops have a false positive when the parent node contains HEREDOC with commas in them. The issue appears to be due to lax comma detection.

Instead of only matching the last item for heredoc, match all items and search for optional whitespace followed by trailing commas, excluding newlines in the match when heredoc is present. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
