### PR TITLE
[Fix #6710] Fix `Naming/MemoizedInstanceVariableName` on method starts with underscore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#6689](https://github.com/rubocop-hq/rubocop/pull/6689): Support more complex argument patterns on `Rails/Validation` auto-correction. ([@r7kamura][])
 * [#6668](https://github.com/rubocop-hq/rubocop/issues/6668): Fix autocorrection for `Style/UnneededCondition` when conditional has the `unless` form. ([@mvz][])
 * [#6382](https://github.com/rubocop-hq/rubocop/issues/6382): Fix `Layout/IndentationWidth` with `Layout/EndAlignment` set to start_of_line. ([@dischorde][], [@siegfault][], [@mhelmetag][])
+* [#6710](https://github.com/rubocop-hq/rubocop/issues/6710): Fix `Naming/MemoizedInstanceVariableName` on method starts with underscore. ([@pocke][])
 
 ## 0.63.1 (2019-01-22)
 

--- a/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
+++ b/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
@@ -132,9 +132,7 @@ module RuboCop
           variable = ivar_assign.children.first
           variable_name = variable.to_s.sub('@', '')
 
-          return false unless valid_leading_underscore?(variable_name)
-
-          variable_name.sub(/\A_/, '') == method_name.sub(/\A_/, '')
+          variable_name_candidates(method_name).include?(variable_name)
         end
 
         def message(variable)
@@ -152,14 +150,19 @@ module RuboCop
           style == :required ? "_#{suggestion}" : suggestion
         end
 
-        def valid_leading_underscore?(variable_name)
+        def variable_name_candidates(method_name)
+          no_underscore = method_name.sub(/\A_/, '')
+          with_underscore = "_#{method_name}"
           case style
           when :required
-            variable_name.start_with?('_')
+            [with_underscore,
+             method_name.start_with?('_') ? method_name : nil].compact
           when :disallowed
-            !variable_name.start_with?('_')
+            [method_name, no_underscore]
+          when :optional
+            [method_name, with_underscore, no_underscore]
           else
-            true
+            raise 'Unreachable'
           end
         end
       end

--- a/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
@@ -104,7 +104,6 @@ RSpec.describe RuboCop::Cop::Naming::MemoizedInstanceVariableName, :config do
       end
 
       it 'does not register an offense with a leading `_` for both names' do
-        pending
         expect_no_offenses(<<-RUBY.strip_indent)
           def _foo
             @_foo ||= :foo


### PR DESCRIPTION
Fix #6710 


Note: This pull request does not add test cases because the test case has been added in #6125. This pull request just removes `pending`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
