### PR TITLE
 Add `iterator?` to deprecated methods and prefer `block_given?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#6688](https://github.com/rubocop-hq/rubocop/pull/6688): Add `iterator?` to deprecated methods and prefer `block_given?` instead. ([@tejasbubane][])
+
 ## 0.65.0 (2019-02-19)
 
 ### New features

--- a/lib/rubocop/cop/lint/deprecated_class_methods.rb
+++ b/lib/rubocop/cop/lint/deprecated_class_methods.rb
@@ -10,12 +10,16 @@ module RuboCop
       #   # bad
       #
       #   File.exists?(some_path)
+      #   Dir.exists?(some_path)
+      #   iterator?(some_path)
       #
       # @example
       #
       #   # good
       #
       #   File.exist?(some_path)
+      #   Dir.exist?(some_path)
+      #   block_given?(some_path)
       class DeprecatedClassMethods < Cop
         # Inner class to DeprecatedClassMethods.
         # This class exists to add abstraction and clean naming to the
@@ -25,24 +29,35 @@ module RuboCop
 
           attr_reader :class_constant, :deprecated_method, :replacement_method
 
-          def initialize(class_constant, deprecated_method, replacement_method)
+          def initialize(deprecated:, replacement:, class_constant: nil)
+            @deprecated_method = deprecated
+            @replacement_method = replacement
             @class_constant = class_constant
-            @deprecated_method = deprecated_method
-            @replacement_method = replacement_method
           end
 
           def class_nodes
-            @class_nodes ||= [
-              s(:const, nil, class_constant),
-              s(:const, s(:cbase), class_constant)
-            ]
+            @class_nodes ||=
+              if class_constant
+                [
+                  s(:const, nil, class_constant),
+                  s(:const, s(:cbase), class_constant)
+                ]
+              else
+                [nil]
+              end
           end
         end
 
         MSG = '`%<current>s` is deprecated in favor of `%<prefer>s`.'.freeze
         DEPRECATED_METHODS_OBJECT = [
-          DeprecatedClassMethod.new(:File, :exists?, :exist?),
-          DeprecatedClassMethod.new(:Dir, :exists?, :exist?)
+          DeprecatedClassMethod.new(deprecated: :exists?,
+                                    replacement: :exist?,
+                                    class_constant: :File),
+          DeprecatedClassMethod.new(deprecated: :exists?,
+                                    replacement: :exist?,
+                                    class_constant: :Dir),
+          DeprecatedClassMethod.new(deprecated: :iterator?,
+                                    replacement: :block_given?)
         ].freeze
 
         def on_send(node)
@@ -83,8 +98,12 @@ module RuboCop
         end
 
         def method_call(class_constant, method)
-          format('%<constant>s.%<method>s', constant: class_constant,
-                                            method: method)
+          if class_constant
+            format('%<constant>s.%<method>s', constant: class_constant,
+                                              method: method)
+          else
+            format('%<method>s', method: method)
+          end
         end
       end
     end

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -269,11 +269,15 @@ This cop checks for uses of the deprecated class method usages.
 # bad
 
 File.exists?(some_path)
+Dir.exists?(some_path)
+iterator?(some_path)
 ```
 ```ruby
 # good
 
 File.exist?(some_path)
+Dir.exist?(some_path)
+block_given?(some_path)
 ```
 
 ## Lint/DisjunctiveAssignmentInConstructor

--- a/spec/rubocop/cop/lint/deprecated_class_methods_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_class_methods_spec.rb
@@ -3,38 +3,81 @@
 RSpec.describe RuboCop::Cop::Lint::DeprecatedClassMethods do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for File.exists?' do
-    expect_offense(<<-RUBY.strip_indent)
-      File.exists?(o)
-           ^^^^^^^ `File.exists?` is deprecated in favor of `File.exist?`.
-    RUBY
-  end
-
-  it 'registers an offense for ::File.exists?' do
-    expect_offense(<<-RUBY.strip_indent)
-      ::File.exists?(o)
+  context 'prefer `File.exist?` over `File.exists?`' do
+    it 'registers an offense for File.exists?' do
+      expect_offense(<<-RUBY.strip_indent)
+        File.exists?(o)
              ^^^^^^^ `File.exists?` is deprecated in favor of `File.exist?`.
-    RUBY
+      RUBY
+    end
+
+    it 'registers an offense for ::File.exists?' do
+      expect_offense(<<-RUBY.strip_indent)
+        ::File.exists?(o)
+               ^^^^^^^ `File.exists?` is deprecated in favor of `File.exist?`.
+      RUBY
+    end
+
+    it 'does not register an offense for File.exist?' do
+      expect_no_offenses('File.exist?(o)')
+    end
+
+    it 'auto-corrects File.exists? with File.exist?' do
+      new_source = autocorrect_source('File.exists?(something)')
+      expect(new_source).to eq('File.exist?(something)')
+    end
   end
 
-  it 'does not register an offense for File.exist?' do
-    expect_no_offenses('File.exist?(o)')
+  context 'prefer `Dir.exist?` over `Dir.exists?`' do
+    it 'registers an offense for Dir.exists?' do
+      expect_offense(<<-RUBY.strip_indent)
+        Dir.exists?(o)
+            ^^^^^^^ `Dir.exists?` is deprecated in favor of `Dir.exist?`.
+      RUBY
+    end
+
+    it 'registers an offense for ::Dir.exists?' do
+      expect_offense(<<-RUBY.strip_indent)
+        ::Dir.exists?(o)
+              ^^^^^^^ `Dir.exists?` is deprecated in favor of `Dir.exist?`.
+      RUBY
+    end
+
+    it 'does not register an offense for Dir.exist?' do
+      expect_no_offenses('Dir.exist?(o)')
+    end
+
+    it 'auto-corrects Dir.exists? with Dir.exist?' do
+      new_source = autocorrect_source('Dir.exists?(something)')
+      expect(new_source).to eq('Dir.exist?(something)')
+    end
+
+    it 'does not register an offense for offensive method `exists?`'\
+       'on other receivers' do
+      expect_no_offenses('Foo.exists?(o)')
+    end
   end
 
-  it 'registers an offense for Dir.exists?' do
-    expect_offense(<<-RUBY.strip_indent)
-      Dir.exists?(o)
-          ^^^^^^^ `Dir.exists?` is deprecated in favor of `Dir.exist?`.
-    RUBY
-  end
+  context 'prefer `block_given?` over `iterator?`' do
+    it 'registers an offense for iterator?' do
+      expect_offense(<<-RUBY.strip_indent)
+        iterator?(o)
+        ^^^^^^^^^ `iterator?` is deprecated in favor of `block_given?`.
+      RUBY
+    end
 
-  it 'auto-corrects File.exists? with File.exist?' do
-    new_source = autocorrect_source('File.exists?(something)')
-    expect(new_source).to eq('File.exist?(something)')
-  end
+    it 'does not register an offense for block_given?' do
+      expect_no_offenses('block_given?(o)')
+    end
 
-  it 'auto-corrects Dir.exists? with Dir.exist?' do
-    new_source = autocorrect_source('Dir.exists?(something)')
-    expect(new_source).to eq('Dir.exist?(something)')
+    it 'autocorrects `iterator?` to `block_given?`' do
+      new_source = autocorrect_source('iterator?')
+      expect(new_source).to eq('block_given?')
+    end
+
+    it 'does not register an offense for offensive method `iterator?`'\
+       'on other receivers' do
+      expect_no_offenses('Foo.iterator?')
+    end
   end
 end


### PR DESCRIPTION
Closes #6688 

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.