### PR TITLE
Remove invalid config in default.yml

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -3393,7 +3393,6 @@ Style/MethodCallWithArgsParentheses:
   IgnoredMethods: []
   AllowParenthesesInMultilineCall: false
   AllowParenthesesInChaining: false
-  AllowParenthesesInCamelCaseMethod: false
   EnforcedStyle: require_parentheses
   SupportedStyles:
     - require_parentheses

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2902,7 +2902,6 @@ IgnoreMacros | `true` | Boolean
 IgnoredMethods | `[]` | Array
 AllowParenthesesInMultilineCall | `false` | Boolean
 AllowParenthesesInChaining | `false` | Boolean
-AllowParenthesesInCamelCaseMethod | `false` | Boolean
 EnforcedStyle | `require_parentheses` | `require_parentheses`, `omit_parentheses`
 
 ### References


### PR DESCRIPTION
I got this warning for the current config file.

```
Warning: Style/MethodCallWithArgsParentheses does not support AllowParenthesesInCamelCaseMethod parameter.

Supported parameters are:

  - Enabled
  - IgnoreMacros
  - IgnoredMethods
  - AllowParenthesesInMultilineCall
  - AllowParenthesesInChaining
  - EnforcedStyle
  - SupportedStyles
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
