### PR TITLE
Drop old Ruby version matrix from Appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,8 @@ version: "{build}"
 
 install:
   - set PATH=C:\Ruby%ruby_version%\bin;%PATH%
-  - gem update --no-document --system 2.7.8
-  - gem install bundler --no-document --version="<2.0.0"
+  - gem update --no-document --system
+  - gem install bundler --no-document
   - bundle install --jobs 3 --retry 3
 
 build: off
@@ -19,11 +19,5 @@ test_script:
 
 environment:
   matrix:
-    - ruby_version: '22'
-    - ruby_version: 22-x64
-    - ruby_version: '23'
-    - ruby_version: 23-x64
-    - ruby_version: '24'
-    - ruby_version: 24-x64
     - ruby_version: '25'
     - ruby_version: 25-x64


### PR DESCRIPTION
Appveyor is very slow in the CI matrix.

Actually, Appveyor have not recently found a problem.
This PR proposes to drop old Ruby version matrix from Appveyor CI.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
