### PR TITLE
Use h2 for ISSUE_TEMPLATE header

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,18 +3,18 @@ name: Feature Request
 about: Suggest new RuboCop features or improvements to existing features.
 ---
 
-**Is your feature request related to a problem? Please describe.**
+## Is your feature request related to a problem? Please describe.
 
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+## Describe the solution you'd like
 
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+## Describe alternatives you've considered
 
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+## Additional context
 
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
The ISSUE_TEMPLATE for a feature request uses `**` to highlight the section header.
I think `##` is more clearly than `**`. `**` only makes it bolder, so I think it is a bit of hard to find the section headers from an issue.

The ISSUE_TEMPLATE for a bug report uses `##` as a header.

I put an example below.

------


# before

---
name: Feature Request
about: Suggest new RuboCop features or improvements to existing features.
---

**Is your feature request related to a problem? Please describe.**

A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

**Describe the solution you'd like**

A clear and concise description of what you want to happen.

**Describe alternatives you've considered**

A clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context or screenshots about the feature request here.



# after





## Is your feature request related to a problem? Please describe.

A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

## Describe the solution you'd like

A clear and concise description of what you want to happen.

## Describe alternatives you've considered

A clear and concise description of any alternative solutions or features you've considered.

## Additional context

Add any other context or screenshots about the feature request here.
