### PR TITLE
[Fix #6722] Fix an error for `Style/OneLineConditional`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#6668](https://github.com/rubocop-hq/rubocop/issues/6668): Fix autocorrection for `Style/UnneededCondition` when conditional has the `unless` form. ([@mvz][])
 * [#6382](https://github.com/rubocop-hq/rubocop/issues/6382): Fix `Layout/IndentationWidth` with `Layout/EndAlignment` set to start_of_line. ([@dischorde][], [@siegfault][], [@mhelmetag][])
 * [#6710](https://github.com/rubocop-hq/rubocop/issues/6710): Fix `Naming/MemoizedInstanceVariableName` on method starts with underscore. ([@pocke][])
+* [#6722](https://github.com/rubocop-hq/rubocop/issues/6722): Fix an error for `Style/OneLineConditional` when `then` branch has no body. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/one_line_conditional.rb
+++ b/lib/rubocop/cop/style/one_line_conditional.rb
@@ -67,6 +67,8 @@ module RuboCop
         end
 
         def expr_replacement(node)
+          return 'nil' if node.nil?
+
           requires_parentheses?(node) ? "(#{node.source})" : node.source
         end
 

--- a/spec/rubocop/cop/style/one_line_conditional_spec.rb
+++ b/spec/rubocop/cop/style/one_line_conditional_spec.rb
@@ -38,6 +38,13 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional do
     end
   end
 
+  context 'one line if/then/else/end when `then` branch has no body' do
+    let(:source) { 'if cond then else dont end' }
+
+    include_examples 'offense', 'if'
+    include_examples 'autocorrect', 'cond ? nil : dont'
+  end
+
   context 'one line if/then/end' do
     let(:source) { 'if cond then run end' }
 


### PR DESCRIPTION
Fixes #6722.

This PR fixes an error for `Style/OneLineConditional` when `then` branch has no body. The following is an error case.

```ruby
# example.rb
if cond then else dont end
```

The following is a reproduction step.

```console
% rubocop -v
0.63.1

% rubocop -a example.rb --only Style/OneLineConditional
Inspecting 1 file

0 files inspected, no offenses detected
undefined method `type' for nil:NilClass
/Users/koic/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rubocop-.63.1/lib/rubocop/cop/style/one_line_conditional.rb:74:in `requires_parentheses?'
/Users/koic/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rubocop-.63.1/lib/rubocop/cop/style/one_line_conditional.rb:70:in `expr_replacement'
/Users/koic/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rubocop-.63.1/lib/rubocop/cop/style/one_line_conditional.rb:65:in `to_ternary'

(snip)
```

This PR auto-corrected to the following code.

```ruby
cond ? nil : dont
```

Actually the above code is the same behavior as `unless` modifier. But this PR aims auto-corrected to an equivalent code without causing an error.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
