### PR TITLE
[Fix #6725][Fix #6540] Mark Style/SymbolProc as unsafe for auto-correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Changes
 
 * [#6597](https://github.com/rubocop-hq/rubocop/issues/6597): `Style/LineEndConcatenation` is now known to be unsafe for auto-correct. ([@jaredbeck][])
+* [#6725](https://github.com/rubocop-hq/rubocop/issues/6725): Mark `Style/SymbolProc` as unsafe for auto-correct. ([@drenmi][])
 
 ## 0.63.1 (2019-01-22)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -4096,8 +4096,9 @@ Style/SymbolLiteral:
 Style/SymbolProc:
   Description: 'Use symbols as procs instead of blocks when possible.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.26'
-  VersionChanged: '0.40'
+  VersionChanged: '0.64'
   # A list of method names to be ignored by the check.
   # The names should be fairly unique, otherwise you'll end up ignoring lots of code.
   IgnoredMethods:

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -5912,7 +5912,7 @@ This cop checks symbol literal syntax.
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.26 | 0.40
+Enabled | Yes | Yes (Unsafe) | 0.26 | 0.64
 
 Use symbols as procs when possible.
 


### PR DESCRIPTION
Marking `Style/SymbolProc` as unsafe for auto-correct, since there are many cases where this is unsafe.

Some examples: #6725, #6540, #6448, #6052, #5098, #5009, #3071, #2135, #2588

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
