### PR TITLE
Update redirected and deprecated resources

### DIFF
--- a/manual/extensions.md
+++ b/manual/extensions.md
@@ -32,10 +32,8 @@ See [development](development.md).
 
 #### Known Custom Cops
 
-* [rubocop-rspec](https://github.com/nevir/rubocop-rspec) -
+* [rubocop-rspec](https://github.com/rubocop-hq/rubocop-rspec) -
   RSpec-specific analysis
-* [rubocop-cask](https://github.com/caskroom/rubocop-cask) - Analysis
-  for Homebrew-Cask files.
 * [rubocop-thread_safety](https://github.com/covermymeds/rubocop-thread_safety) -
   Thread-safety analysis
 * [rubocop-require_tools](https://github.com/milch/rubocop-require_tools) -


### PR DESCRIPTION
Cops under `rubocop-rspec` moved to the main project.

`rubocop-cask` has been deprecated and merged into Homebrew.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
