### PR TITLE
[Fix #6708] Style/CommentedKeyword knows :yields:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 * [#6597](https://github.com/rubocop-hq/rubocop/issues/6597): `Style/LineEndConcatenation` is now known to be unsafe for auto-correct. ([@jaredbeck][])
 * [#6725](https://github.com/rubocop-hq/rubocop/issues/6725): Mark `Style/SymbolProc` as unsafe for auto-correct. ([@drenmi][])
+* [#6708](https://github.com/rubocop-hq/rubocop/issues/6708): Make `Style/CommentedKeyword` allow the `:yields:` RDoc comment. ([@bquorning][])
 
 ## 0.63.1 (2019-01-22)
 

--- a/lib/rubocop/cop/style/commented_keyword.rb
+++ b/lib/rubocop/cop/style/commented_keyword.rb
@@ -6,8 +6,8 @@ module RuboCop
       # This cop checks for comments put on the same line as some keywords.
       # These keywords are: `begin`, `class`, `def`, `end`, `module`.
       #
-      # Note that some comments (such as `:nodoc:` and `rubocop:disable`) are
-      # allowed.
+      # Note that some comments (`:nodoc:`, `:yields:, and `rubocop:disable`)
+      # are allowed.
       #
       # @example
       #   # bad
@@ -59,7 +59,7 @@ module RuboCop
         private
 
         KEYWORDS = %w[begin class def end module].freeze
-        ALLOWED_COMMENTS = %w[:nodoc: rubocop:disable].freeze
+        ALLOWED_COMMENTS = %w[:nodoc: :yields: rubocop:disable].freeze
 
         def offensive?(line)
           line = line.lstrip

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -978,8 +978,8 @@ Enabled | Yes | No | 0.51 | -
 This cop checks for comments put on the same line as some keywords.
 These keywords are: `begin`, `class`, `def`, `end`, `module`.
 
-Note that some comments (such as `:nodoc:` and `rubocop:disable`) are
-allowed.
+Note that some comments (`:nodoc:`, `:yields:, and `rubocop:disable`)
+are allowed.
 
 ### Examples
 

--- a/spec/rubocop/cop/style/commented_keyword_spec.rb
+++ b/spec/rubocop/cop/style/commented_keyword_spec.rb
@@ -123,6 +123,13 @@ RSpec.describe RuboCop::Cop::Style::CommentedKeyword do
       end
     RUBY
     expect_no_offenses(<<-RUBY.strip_indent)
+      class X
+        def y # :yields:
+          yield
+        end
+      end
+    RUBY
+    expect_no_offenses(<<-RUBY.strip_indent)
       def x # rubocop:disable Metrics/MethodLength
         y
       end


### PR DESCRIPTION
The `Style/CommentedKeyword` cop would not allow the `:yields:` RDoc directive as a trailing comment (to `def`). The documentation https://docs.ruby-lang.org/en/2.1.0/RDoc/Markup.html#class-RDoc::Markup-label-Directives lists many, many directives, but only `:nodoc:` and `:yields:` are shown as trailing comments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
