### PR TITLE
Detect OS more consistently

### DIFF
--- a/lib/rubocop/platform.rb
+++ b/lib/rubocop/platform.rb
@@ -5,7 +5,7 @@ module RuboCop
   # on.
   module Platform
     def self.windows?
-      RUBY_PLATFORM =~ /cygwin|mswin|mingw|bccwin|wince|emx/
+      RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/
     end
   end
 end


### PR DESCRIPTION
This should fix #6720 and implements the suggested solution.

I did not add new tests, as testing this issue would require adding additional matrix combinations to the AppVeyor build (there is no JRuby/Windows combo being tested in CI) and I have no desire at this time to debug any failures on an entirely new build combination. I did run the default rake task locally and the results are no worse after than before the changes in this PR.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
