### PR TITLE
Start converting tests to use expect_correction

### DIFF
--- a/spec/rubocop/cop/bundler/insecure_protocol_source_spec.rb
+++ b/spec/rubocop/cop/bundler/insecure_protocol_source_spec.rb
@@ -10,12 +10,20 @@ RSpec.describe RuboCop::Cop::Bundler::InsecureProtocolSource do
       source :gemcutter
              ^^^^^^^^^^ The source `:gemcutter` is deprecated because HTTP requests are insecure. Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
     RUBY
+
+    expect_correction(<<-RUBY.strip_indent)
+      source 'https://rubygems.org'
+    RUBY
   end
 
   it 'registers an offense when using `source :rubygems`' do
     expect_offense(<<-RUBY.strip_indent)
       source :rubygems
              ^^^^^^^^^ The source `:rubygems` is deprecated because HTTP requests are insecure. Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
+    RUBY
+
+    expect_correction(<<-RUBY.strip_indent)
+      source 'https://rubygems.org'
     RUBY
   end
 
@@ -24,23 +32,9 @@ RSpec.describe RuboCop::Cop::Bundler::InsecureProtocolSource do
       source :rubyforge
              ^^^^^^^^^^ The source `:rubyforge` is deprecated because HTTP requests are insecure. Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
     RUBY
-  end
 
-  it 'autocorrects `source :gemcutter`' do
-    new_source = autocorrect_source('source :gemcutter')
-
-    expect(new_source).to eq("source 'https://rubygems.org'")
-  end
-
-  it 'autocorrects `source :rubygems`' do
-    new_source = autocorrect_source('source :rubygems')
-
-    expect(new_source).to eq("source 'https://rubygems.org'")
-  end
-
-  it 'autocorrects `source :rubyforge`' do
-    new_source = autocorrect_source('source :rubyforge')
-
-    expect(new_source).to eq("source 'https://rubygems.org'")
+    expect_correction(<<-RUBY.strip_indent)
+      source 'https://rubygems.org'
+    RUBY
   end
 end

--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -50,11 +50,8 @@ RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
         gem 'rspec'
         ^^^^^^^^^^^ Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem `rspec` should appear before `rubocop`.
       RUBY
-    end
 
-    it 'autocorrects' do
-      new_source = autocorrect_source_with_loop(source)
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect_correction(<<-RUBY.strip_indent)
         gem 'rspec'
         gem 'rubocop'
       RUBY
@@ -87,11 +84,8 @@ RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
         gem 'rspec'
         ^^^^^^^^^^^ Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem `rspec` should appear before `rubocop`.
       RUBY
-    end
 
-    it 'autocorrects' do
-      new_source = autocorrect_source_with_loop(source)
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect_correction(<<-RUBY.strip_indent)
         gem 'rspec'
         gem 'rubocop',
             '0.1.1'
@@ -191,11 +185,8 @@ RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
           gem 'rspec'
           ^^^^^^^^^^^ Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem `rspec` should appear before `rubocop`.
         RUBY
-      end
 
-      it 'autocorrects' do
-        new_source = autocorrect_source_with_loop(source)
-        expect(new_source).to eq(<<-RUBY.strip_indent)
+        expect_correction(<<-RUBY.strip_indent)
           # For
           # test
           gem 'rspec'
@@ -262,11 +253,8 @@ RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
         gem 'a'
         ^^^^^^^ Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem `a` should appear before `Z`.
       RUBY
-    end
 
-    it 'autocorrects' do
-      new_source = autocorrect_source_with_loop(source)
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect_correction(<<-RUBY.strip_indent)
         gem 'a'
         gem 'Z'
       RUBY
@@ -295,11 +283,8 @@ RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
           ^^^^^^^ Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem `b` should appear before `c`.
         end
       RUBY
-    end
 
-    it 'autocorrects' do
-      new_source = autocorrect_source_with_loop(source)
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect_correction(<<-RUBY.strip_indent)
         gem 'a'
 
         group :development do

--- a/spec/rubocop/cop/internal_affairs/offense_location_keyword_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/offense_location_keyword_spec.rb
@@ -5,19 +5,31 @@ RSpec.describe RuboCop::Cop::InternalAffairs::OffenseLocationKeyword do
 
   context 'when `node.loc.selector` is passed' do
     it 'registers an offense' do
-      expect_offense(<<-RUBY.strip_indent, 'example_cop.rb')
+      expect_offense(<<-RUBY.strip_indent)
         add_offense(node, location: node.loc.selector)
                                     ^^^^^^^^^^^^^^^^^ Use `:selector` as the location argument to `#add_offense`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        add_offense(node, location: :selector)
       RUBY
     end
 
     it 'registers an offense if message argument is passed' do
-      expect_offense(<<-RUBY.strip_indent, 'example_cop.rb')
+      expect_offense(<<-RUBY.strip_indent)
         add_offense(
           node,
           message: 'message',
           location: node.loc.selector
                     ^^^^^^^^^^^^^^^^^ Use `:selector` as the location argument to `#add_offense`.
+        )
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        add_offense(
+          node,
+          message: 'message',
+          location: :selector
         )
       RUBY
     end
@@ -32,32 +44,6 @@ RSpec.describe RuboCop::Cop::InternalAffairs::OffenseLocationKeyword do
   it 'does not register an offense when the `loc` is on a different node' do
     expect_no_offenses(<<-RUBY.strip_indent, 'example_cop.rb')
       add_offense(node, location: other_node.loc.selector)
-    RUBY
-  end
-
-  it 'auto-corrects `location` when it is the only keyword' do
-    corrected =
-      autocorrect_source('add_offense(node, location: node.loc.selector)')
-
-    expect(corrected).to eq('add_offense(node, location: :selector)')
-  end
-
-  it 'auto-corrects `location` when there are other keywords' do
-    corrected = autocorrect_source(<<-RUBY.strip_indent)
-      add_offense(
-        node,
-        message: 'foo',
-        location: node.loc.selector,
-        severity: :warning
-      )
-    RUBY
-    expect(corrected).to eq(<<-RUBY.strip_indent)
-      add_offense(
-        node,
-        message: 'foo',
-        location: :selector,
-        severity: :warning
-      )
     RUBY
   end
 end

--- a/spec/rubocop/cop/internal_affairs/redundant_location_argument_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/redundant_location_argument_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantLocationArgument do
           add_offense(node, location: :expression)
                             ^^^^^^^^^^^^^^^^^^^^^ Redundant location argument to `#add_offense`.
         RUBY
+
+        expect_correction(<<-RUBY.strip_indent)
+          add_offense(node)
+        RUBY
       end
 
       context 'when there is a message argument' do
@@ -18,50 +22,36 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantLocationArgument do
             add_offense(node, location: :expression, message: 'message')
                               ^^^^^^^^^^^^^^^^^^^^^ Redundant location argument to `#add_offense`.
           RUBY
+
+          expect_correction(<<-RUBY.strip_indent)
+            add_offense(node, message: 'message')
+          RUBY
         end
       end
 
-      it 'removes default `location` when there are no other keywords' do
-        corrected = autocorrect_source(<<-RUBY.strip_indent)
-          add_offense(node, location: :expression)
-        RUBY
-
-        expect(corrected).to eq(<<-RUBY.strip_indent)
-          add_offense(node)
-        RUBY
-      end
-
       it 'removes default `location` when preceded by another keyword' do
-        corrected = autocorrect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           add_offense(node, message: 'foo', location: :expression)
+                                            ^^^^^^^^^^^^^^^^^^^^^ Redundant location argument to `#add_offense`.
         RUBY
 
-        expect(corrected).to eq(<<-RUBY.strip_indent)
-          add_offense(node, message: 'foo')
-        RUBY
-      end
-
-      it 'removes default `location` when followed by another keyword' do
-        corrected = autocorrect_source(<<-RUBY.strip_indent)
-          add_offense(node, location: :expression, message: 'foo')
-        RUBY
-
-        expect(corrected).to eq(<<-RUBY.strip_indent)
+        expect_correction(<<-RUBY.strip_indent)
           add_offense(node, message: 'foo')
         RUBY
       end
 
       it 'removes default `location` surrounded by other keywords' do
-        corrected = autocorrect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           add_offense(
             node,
             severity: :error,
             location: :expression,
+            ^^^^^^^^^^^^^^^^^^^^^ Redundant location argument to `#add_offense`.
             message: 'message'
           )
         RUBY
 
-        expect(corrected).to eq(<<-RUBY.strip_indent)
+        expect_correction(<<-RUBY.strip_indent)
           add_offense(
             node,
             severity: :error,

--- a/spec/rubocop/cop/internal_affairs/redundant_message_argument_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/redundant_message_argument_spec.rb
@@ -6,15 +6,13 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantMessageArgument do
   context 'when `MSG` is passed' do
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent, 'example_cop.rb')
-      add_offense(node, message: MSG)
-                        ^^^^^^^^^^^^ Redundant message argument to `#add_offense`.
+        add_offense(node, message: MSG)
+                          ^^^^^^^^^^^^ Redundant message argument to `#add_offense`.
       RUBY
-    end
 
-    it 'auto-corrects' do
-      new_source = autocorrect_source('add_offense(node, message: MSG)')
-
-      expect(new_source).to eq('add_offense(node)')
+      expect_correction(<<-RUBY.strip_indent)
+        add_offense(node)
+      RUBY
     end
   end
 
@@ -26,23 +24,17 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantMessageArgument do
 
   context 'when `#message` is passed' do
     it 'registers an offense' do
-      expect_offense(<<-RUBY.strip_indent, 'example_cop.rb')
-      add_offense(node, location: :expression, message: message)
-                                               ^^^^^^^^^^^^^^^^ Redundant message argument to `#add_offense`.
-      RUBY
-    end
-
-    it 'auto-corrects' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         add_offense(
           node,
           location: :expression,
           message: message,
+          ^^^^^^^^^^^^^^^^ Redundant message argument to `#add_offense`.
           severity: :error
         )
       RUBY
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect_correction(<<-RUBY.strip_indent)
         add_offense(
           node,
           location: :expression,
@@ -59,13 +51,10 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantMessageArgument do
           add_offense(node, message: message(node))
                             ^^^^^^^^^^^^^^^^^^^^^^ Redundant message argument to `#add_offense`.
         RUBY
-      end
 
-      it 'auto-corrects' do
-        new_source =
-          autocorrect_source('add_offense(node, message: message(node))')
-
-        expect(new_source).to eq('add_offense(node)')
+        expect_correction(<<-RUBY.strip_indent)
+          add_offense(node)
+        RUBY
       end
     end
 
@@ -78,18 +67,8 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantMessageArgument do
                       ^^^^^^^^^^^^^^^^^^^^^^ Redundant message argument to `#add_offense`.
                       severity: :fatal)
         RUBY
-      end
 
-      it 'auto-corrects' do
-        new_source =
-          autocorrect_source(<<-RUBY.strip_indent)
-            add_offense(node,
-                        location: :selector,
-                        message: message(node),
-                        severity: :fatal)
-          RUBY
-
-        expect(new_source).to eq(<<-RUBY.strip_indent)
+        expect_correction(<<-RUBY.strip_indent)
           add_offense(node,
                       location: :selector,
                       severity: :fatal)

--- a/spec/rubocop/cop/rails/active_record_aliases_spec.rb
+++ b/spec/rubocop/cop/rails/active_record_aliases_spec.rb
@@ -4,34 +4,28 @@ RSpec.describe RuboCop::Cop::Rails::ActiveRecordAliases do
   subject(:cop) { described_class.new }
 
   describe '#update_attributes' do
-    it 'registers an offense' do
+    it 'registers an offense and corrects' do
       expect_offense(<<-RUBY.strip_indent)
         book.update_attributes(author: "Alice")
              ^^^^^^^^^^^^^^^^^ Use `update` instead of `update_attributes`.
       RUBY
-    end
 
-    it 'is autocorrected' do
-      new_source = autocorrect_source(
-        'book.update_attributes(author: "Alice")'
-      )
-      expect(new_source).to eq 'book.update(author: "Alice")'
+      expect_correction(<<-RUBY.strip_indent)
+        book.update(author: "Alice")
+      RUBY
     end
   end
 
   describe '#update_attributes!' do
-    it 'registers an offense' do
+    it 'registers an offense and corrects' do
       expect_offense(<<-RUBY.strip_indent)
         book.update_attributes!(author: "Bob")
              ^^^^^^^^^^^^^^^^^^ Use `update!` instead of `update_attributes!`.
       RUBY
-    end
 
-    it 'is autocorrected' do
-      new_source = autocorrect_source(
-        'book.update_attributes!(author: "Bob")'
-      )
-      expect(new_source).to eq 'book.update!(author: "Bob")'
+      expect_correction(<<-RUBY.strip_indent)
+        book.update!(author: "Bob")
+      RUBY
     end
   end
 
@@ -39,32 +33,24 @@ RSpec.describe RuboCop::Cop::Rails::ActiveRecordAliases do
     it 'does not register an offense' do
       expect_no_offenses('book.update(author: "Alice")')
     end
-
-    it 'is not autocorrected' do
-      source = 'book.update(author: "Alice")'
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq source
-    end
   end
 
   describe '#update!' do
     it 'does not register an offense' do
       expect_no_offenses('book.update!(author: "Bob")')
     end
-
-    it 'is not autocorrected' do
-      source = 'book.update!(author: "Bob")'
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq source
-    end
   end
 
   describe 'other use of the `update_attributes` string' do
     it 'does not autocorrect the other usage' do
-      new_source = autocorrect_source(
-        'update_attributes_book.update_attributes(author: "Alice")'
-      )
-      expect(new_source).to eq 'update_attributes_book.update(author: "Alice")'
+      expect_offense(<<-RUBY.strip_indent)
+        update_attributes_book.update_attributes(author: "Alice")
+                               ^^^^^^^^^^^^^^^^^ Use `update` instead of `update_attributes`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        update_attributes_book.update(author: "Alice")
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/rails/active_support_aliases_spec.rb
+++ b/spec/rubocop/cop/rails/active_support_aliases_spec.rb
@@ -5,18 +5,15 @@ RSpec.describe RuboCop::Cop::Rails::ActiveSupportAliases do
 
   describe 'String' do
     describe '#starts_with?' do
-      it 'is registered as an offense' do
+      it 'registers as an offense and corrects' do
         expect_offense(<<-RUBY.strip_indent)
           'some_string'.starts_with?('prefix')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `start_with?` instead of `starts_with?`.
         RUBY
-      end
 
-      it 'is autocorrected' do
-        new_source = autocorrect_source(
-          "'some_string'.starts_with?('prefix')"
-        )
-        expect(new_source).to eq "'some_string'.start_with?('prefix')"
+        expect_correction(<<-RUBY.strip_indent)
+          'some_string'.start_with?('prefix')
+        RUBY
       end
     end
 
@@ -27,18 +24,15 @@ RSpec.describe RuboCop::Cop::Rails::ActiveSupportAliases do
     end
 
     describe '#ends_with?' do
-      it 'is registered as an offense' do
+      it 'registers as an offense and corrects' do
         expect_offense(<<-RUBY.strip_indent)
           'some_string'.ends_with?('prefix')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `end_with?` instead of `ends_with?`.
         RUBY
-      end
 
-      it 'is autocorrected' do
-        new_source = autocorrect_source(
-          "'some_string'.ends_with?('prefix')"
-        )
-        expect(new_source).to eq "'some_string'.end_with?('prefix')"
+        expect_correction(<<-RUBY.strip_indent)
+          'some_string'.end_with?('prefix')
+        RUBY
       end
     end
 
@@ -51,17 +45,15 @@ RSpec.describe RuboCop::Cop::Rails::ActiveSupportAliases do
 
   describe 'Array' do
     describe '#append' do
-      it 'is registered as an offense' do
+      it 'registers as an offense and does not correct' do
         expect_offense(<<-RUBY.strip_indent)
           [1, 'a', 3].append('element')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `<<` instead of `append`.
         RUBY
-      end
 
-      it 'is not autocorrected' do
-        source = "[1, 'a', 3].append('element')"
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq source
+        expect_correction(<<-RUBY.strip_indent)
+          [1, 'a', 3].append('element')
+        RUBY
       end
     end
 
@@ -72,18 +64,15 @@ RSpec.describe RuboCop::Cop::Rails::ActiveSupportAliases do
     end
 
     describe '#prepend' do
-      it 'is registered as an offense' do
+      it 'registers as an offense and corrects' do
         expect_offense(<<-RUBY.strip_indent)
           [1, 'a', 3].prepend('element')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `unshift` instead of `prepend`.
         RUBY
-      end
 
-      it 'is autocorrected' do
-        new_source = autocorrect_source(
-          "[1, 'a', 3].prepend('element')"
-        )
-        expect(new_source).to eq "[1, 'a', 3].unshift('element')"
+        expect_correction(<<-RUBY.strip_indent)
+          [1, 'a', 3].unshift('element')
+        RUBY
       end
     end
 

--- a/spec/rubocop/cop/rails/application_job_spec.rb
+++ b/spec/rubocop/cop/rails/application_job_spec.rb
@@ -70,11 +70,10 @@ RSpec.describe RuboCop::Cop::Rails::ApplicationJob do
           class MyJob < ActiveJob::Base; end
                         ^^^^^^^^^^^^^^^ Jobs should subclass `ApplicationJob`.
         RUBY
-      end
 
-      it 'auto-corrects' do
-        expect(autocorrect_source('class MyJob < ActiveJob::Base; end'))
-          .to eq('class MyJob < ApplicationJob; end')
+        expect_correction(<<-RUBY.strip_indent)
+          class MyJob < ApplicationJob; end
+        RUBY
       end
     end
 
@@ -99,30 +98,36 @@ RSpec.describe RuboCop::Cop::Rails::ApplicationJob do
     end
 
     it 'corrects jobs defined using Class.new' do
-      source = 'MyJob = Class.new(ActiveJob::Base)'
-      inspect_source(source)
-      expect(cop.messages).to eq(['Jobs should subclass `ApplicationJob`.'])
-      expect(cop.highlights).to eq(['ActiveJob::Base'])
-      expect(autocorrect_source(source))
-        .to eq('MyJob = Class.new(ApplicationJob)')
+      expect_offense(<<-RUBY.strip_indent)
+        MyJob = Class.new(ActiveJob::Base)
+                          ^^^^^^^^^^^^^^^ Jobs should subclass `ApplicationJob`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        MyJob = Class.new(ApplicationJob)
+      RUBY
     end
 
     it 'corrects nested jobs defined using Class.new' do
-      source = 'Nested::MyJob = Class.new(ActiveJob::Base)'
-      inspect_source(source)
-      expect(cop.messages).to eq(['Jobs should subclass `ApplicationJob`.'])
-      expect(cop.highlights).to eq(['ActiveJob::Base'])
-      expect(autocorrect_source(source))
-        .to eq('Nested::MyJob = Class.new(ApplicationJob)')
+      expect_offense(<<-RUBY.strip_indent)
+        Nested::MyJob = Class.new(ActiveJob::Base)
+                                  ^^^^^^^^^^^^^^^ Jobs should subclass `ApplicationJob`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        Nested::MyJob = Class.new(ApplicationJob)
+      RUBY
     end
 
     it 'corrects anonymous jobs' do
-      source = 'Class.new(ActiveJob::Base) {}'
-      inspect_source(source)
-      expect(cop.messages).to eq(['Jobs should subclass `ApplicationJob`.'])
-      expect(cop.highlights).to eq(['ActiveJob::Base'])
-      expect(autocorrect_source(source))
-        .to eq('Class.new(ApplicationJob) {}')
+      expect_offense(<<-RUBY.strip_indent)
+        Class.new(ActiveJob::Base) {}
+                  ^^^^^^^^^^^^^^^ Jobs should subclass `ApplicationJob`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        Class.new(ApplicationJob) {}
+      RUBY
     end
 
     it 'allows ApplicationJob defined using Class.new' do

--- a/spec/rubocop/cop/rails/application_record_spec.rb
+++ b/spec/rubocop/cop/rails/application_record_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::ApplicationRecord do
-  let(:msgs) { ['Models should subclass `ApplicationRecord`.'] }
-
   context 'rails 4', :rails4, :config do
     subject(:cop) { described_class.new(config) }
 
@@ -64,66 +62,90 @@ RSpec.describe RuboCop::Cop::Rails::ApplicationRecord do
     end
 
     it 'corrects models that subclass ActiveRecord::Base' do
-      source = "class MyModel < ActiveRecord::Base\nend"
-      inspect_source(source)
-      expect(cop.messages).to eq(msgs)
-      expect(cop.highlights).to eq(['ActiveRecord::Base'])
-      expect(autocorrect_source(source))
-        .to eq("class MyModel < ApplicationRecord\nend")
+      expect_offense(<<-RUBY.strip_indent)
+        class MyModel < ActiveRecord::Base
+                        ^^^^^^^^^^^^^^^^^^ Models should subclass `ApplicationRecord`.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        class MyModel < ApplicationRecord
+        end
+      RUBY
     end
 
     it 'corrects single-line class definitions' do
-      source = 'class MyModel < ActiveRecord::Base; end'
-      inspect_source(source)
-      expect(cop.messages).to eq(msgs)
-      expect(cop.highlights).to eq(['ActiveRecord::Base'])
-      expect(autocorrect_source(source))
-        .to eq('class MyModel < ApplicationRecord; end')
+      expect_offense(<<-RUBY.strip_indent)
+        class MyModel < ActiveRecord::Base; end
+                        ^^^^^^^^^^^^^^^^^^ Models should subclass `ApplicationRecord`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        class MyModel < ApplicationRecord; end
+      RUBY
     end
 
     it 'corrects namespaced models that subclass ActiveRecord::Base' do
-      source = "module Nested\n  class MyModel < ActiveRecord::Base\n  end\nend"
-      inspect_source(source)
-      expect(cop.messages).to eq(msgs)
-      expect(cop.highlights).to eq(['ActiveRecord::Base'])
-      expect(autocorrect_source(source))
-        .to eq("module Nested\n  class MyModel < ApplicationRecord\n  end\nend")
+      expect_offense(<<-RUBY.strip_indent)
+        module Nested
+          class MyModel < ActiveRecord::Base
+                          ^^^^^^^^^^^^^^^^^^ Models should subclass `ApplicationRecord`.
+          end
+        end
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        module Nested
+          class MyModel < ApplicationRecord
+          end
+        end
+      RUBY
     end
 
     it 'corrects models defined using nested constants' do
-      source = "class Nested::MyModel < ActiveRecord::Base\nend"
-      inspect_source(source)
-      expect(cop.messages).to eq(msgs)
-      expect(cop.highlights).to eq(['ActiveRecord::Base'])
-      expect(autocorrect_source(source))
-        .to eq("class Nested::MyModel < ApplicationRecord\nend")
+      expect_offense(<<-RUBY.strip_indent)
+        class Nested::MyModel < ActiveRecord::Base
+                                ^^^^^^^^^^^^^^^^^^ Models should subclass `ApplicationRecord`.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        class Nested::MyModel < ApplicationRecord
+        end
+      RUBY
     end
 
     it 'corrects models defined using Class.new' do
-      source = 'MyModel = Class.new(ActiveRecord::Base)'
-      inspect_source(source)
-      expect(cop.messages).to eq(msgs)
-      expect(cop.highlights).to eq(['ActiveRecord::Base'])
-      expect(autocorrect_source(source))
-        .to eq('MyModel = Class.new(ApplicationRecord)')
+      expect_offense(<<-RUBY.strip_indent)
+        MyModel = Class.new(ActiveRecord::Base)
+                            ^^^^^^^^^^^^^^^^^^ Models should subclass `ApplicationRecord`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        MyModel = Class.new(ApplicationRecord)
+      RUBY
     end
 
     it 'corrects nested models defined using Class.new' do
-      source = 'Nested::MyModel = Class.new(ActiveRecord::Base)'
-      inspect_source(source)
-      expect(cop.messages).to eq(msgs)
-      expect(cop.highlights).to eq(['ActiveRecord::Base'])
-      expect(autocorrect_source(source))
-        .to eq('Nested::MyModel = Class.new(ApplicationRecord)')
+      expect_offense(<<-RUBY.strip_indent)
+        Nested::MyModel = Class.new(ActiveRecord::Base)
+                                    ^^^^^^^^^^^^^^^^^^ Models should subclass `ApplicationRecord`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        Nested::MyModel = Class.new(ApplicationRecord)
+      RUBY
     end
 
     it 'corrects anonymous models' do
-      source = 'Class.new(ActiveRecord::Base) {}'
-      inspect_source(source)
-      expect(cop.messages).to eq(msgs)
-      expect(cop.highlights).to eq(['ActiveRecord::Base'])
-      expect(autocorrect_source(source))
-        .to eq('Class.new(ApplicationRecord) {}')
+      expect_offense(<<-RUBY.strip_indent)
+        Class.new(ActiveRecord::Base) {}
+                  ^^^^^^^^^^^^^^^^^^ Models should subclass `ApplicationRecord`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        Class.new(ApplicationRecord) {}
+      RUBY
     end
 
     it 'allows ApplicationRecord defined using Class.new' do

--- a/spec/rubocop/cop/rails/assert_not_spec.rb
+++ b/spec/rubocop/cop/rails/assert_not_spec.rb
@@ -3,63 +3,59 @@
 RSpec.describe RuboCop::Cop::Rails::AssertNot do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense when using `assert !`' do
+  it 'registers an offense and corrects using `assert !`' do
     expect_offense(<<-RUBY.strip_indent)
       assert !foo
       ^^^^^^^^^^^ Prefer `assert_not` over `assert !`.
     RUBY
-  end
 
-  it 'registers an offense when using `assert !` with a failure message' do
-    expect_offense(<<-RUBY.strip_indent)
-      assert !foo, 'a failure message'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `assert_not` over `assert !`.
-    RUBY
-  end
-
-  it 'registers an offense when using `assert !` with a more complex value' do
-    expect_offense(<<-RUBY.strip_indent)
-      assert !foo.bar(baz)
-      ^^^^^^^^^^^^^^^^^^^^ Prefer `assert_not` over `assert !`.
-    RUBY
-  end
-
-  it 'autocorrects `assert !`' do
-    new_source = autocorrect_source(<<-RUBY.strip_indent)
-      assert !foo
-    RUBY
-
-    expect(new_source).to eq(<<-RUBY.strip_indent)
+    expect_correction(<<-RUBY.strip_indent)
       assert_not foo
     RUBY
   end
 
-  it 'autocorrects `assert !` with a failure message' do
-    new_source = autocorrect_source(<<-RUBY.strip_indent)
+  it 'registers an offense and corrects using `assert !` ' \
+    'with a failure message' do
+    expect_offense(<<-RUBY.strip_indent)
       assert !foo, 'a failure message'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `assert_not` over `assert !`.
     RUBY
 
-    expect(new_source).to eq(<<-RUBY.strip_indent)
+    expect_correction(<<-RUBY.strip_indent)
       assert_not foo, 'a failure message'
     RUBY
   end
 
-  it 'autocorrects `assert !` with extra spaces' do
-    new_source = autocorrect_source(<<-RUBY.strip_indent)
-      assert   !  foo
+  it 'registers an offense and corrects using `assert !` ' \
+    'with a more complex value' do
+    expect_offense(<<-RUBY.strip_indent)
+      assert !foo.bar(baz)
+      ^^^^^^^^^^^^^^^^^^^^ Prefer `assert_not` over `assert !`.
     RUBY
 
-    expect(new_source).to eq(<<-RUBY.strip_indent)
+    expect_correction(<<-RUBY.strip_indent)
+      assert_not foo.bar(baz)
+    RUBY
+  end
+
+  it 'autocorrects `assert !` with extra spaces' do
+    expect_offense(<<-RUBY.strip_indent)
+      assert   !  foo
+      ^^^^^^^^^^^^^^^ Prefer `assert_not` over `assert !`.
+    RUBY
+
+    expect_correction(<<-RUBY.strip_indent)
       assert_not foo
     RUBY
   end
 
   it 'autocorrects `assert !` with parentheses' do
-    new_source = autocorrect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       assert(!foo)
+      ^^^^^^^^^^^^ Prefer `assert_not` over `assert !`.
     RUBY
 
-    expect(new_source).to eq(<<-RUBY.strip_indent)
+    expect_correction(<<-RUBY.strip_indent)
       assert_not(foo)
     RUBY
   end

--- a/spec/rubocop/cop/rails/belongs_to_spec.rb
+++ b/spec/rubocop/cop/rails/belongs_to_spec.rb
@@ -5,31 +5,26 @@ RSpec.describe RuboCop::Cop::Rails::BelongsTo do
 
   let(:config) { RuboCop::Config.new }
 
-  it 'registers an offense when specifying `required: false`' do
+  it 'registers an offense and corrects when specifying `required: false`' do
     expect_offense(<<-RUBY.strip_indent)
       belongs_to :foo, required: false
       ^^^^^^^^^^ You specified `required: false`, in Rails > 5.0 the required option is deprecated and you want to use `optional: true`.
     RUBY
+
+    expect_correction(<<-RUBY.strip_indent)
+      belongs_to :foo, optional: true
+    RUBY
   end
 
-  it 'registers an offense when specifying `required: true`' do
+  it 'registers an offense and corrects when specifying `required: true`' do
     expect_offense(<<-RUBY.strip_indent)
       belongs_to :foo, required: true
       ^^^^^^^^^^ You specified `required: true`, in Rails > 5.0 the required option is deprecated and you want to use `optional: false`. In most configurations, this is the default and you can omit this option altogether
     RUBY
-  end
 
-  it 'auto-corrects `required: false` to `optional: true`' do
-    expect(autocorrect_source('belongs_to :foo, required: false'))
-      .to eq('belongs_to :foo, optional: true')
-    expect(cop.offenses.last.status).to eq(:corrected)
-  end
-
-  it 'auto-corrects `required: true` to `optional: false`' do
-    code = 'belongs_to :foo, required: true'
-    expect(autocorrect_source(code))
-      .to eq('belongs_to :foo, optional: false')
-    expect(cop.offenses.last.status).to eq(:corrected)
+    expect_correction(<<-RUBY.strip_indent)
+      belongs_to :foo, optional: false
+    RUBY
   end
 
   it 'registers no offense when setting `optional: true`' do

--- a/spec/rubocop/cop/rails/blank_spec.rb
+++ b/spec/rubocop/cop/rails/blank_spec.rb
@@ -176,58 +176,42 @@ RSpec.describe RuboCop::Cop::Rails::Blank, :config do
 
     context 'modifier unless' do
       context 'with a receiver' do
-        it 'registers an offense' do
+        it 'registers an offense and corrects' do
           expect_offense(<<-RUBY.strip_indent)
-          something unless foo.present?
-                    ^^^^^^^^^^^^^^^^^^^ Use `if foo.blank?` instead of `unless foo.present?`.
+            something unless foo.present?
+                      ^^^^^^^^^^^^^^^^^^^ Use `if foo.blank?` instead of `unless foo.present?`.
           RUBY
-        end
 
-        it 'auto-corrects' do
-          new_source = autocorrect_source('something unless foo.present?')
-
-          expect(new_source).to eq('something if foo.blank?')
+          expect_correction(<<-RUBY.strip_indent)
+            something if foo.blank?
+          RUBY
         end
       end
 
       context 'without a receiver' do
-        it 'registers an offense' do
+        it 'registers an offense and corrects' do
           expect_offense(<<-RUBY.strip_indent)
-          something unless present?
-                    ^^^^^^^^^^^^^^^ Use `if blank?` instead of `unless present?`.
+            something unless present?
+                      ^^^^^^^^^^^^^^^ Use `if blank?` instead of `unless present?`.
           RUBY
-        end
 
-        it 'auto-corrects' do
-          new_source = autocorrect_source('something unless present?')
-
-          expect(new_source).to eq('something if blank?')
+          expect_correction(<<-RUBY.strip_indent)
+            something if blank?
+          RUBY
         end
       end
     end
 
     context 'normal unless present?' do
-      let(:source) do
-        <<-RUBY.strip_indent
-          unless foo.present?
-            something
-          end
-        RUBY
-      end
-
-      it 'registers an offense' do
+      it 'registers an offense and corrects' do
         expect_offense(<<-RUBY.strip_indent)
           unless foo.present?
           ^^^^^^^^^^^^^^^^^^^ Use `if foo.blank?` instead of `unless foo.present?`.
             something
           end
         RUBY
-      end
 
-      it 'auto-corrects' do
-        new_source = autocorrect_source(source)
-
-        expect(new_source).to eq(<<-RUBY.strip_indent)
+        expect_correction(<<-RUBY.strip_indent)
           if foo.blank?
             something
           end
@@ -236,17 +220,7 @@ RSpec.describe RuboCop::Cop::Rails::Blank, :config do
     end
 
     context 'unless present? with an else' do
-      let(:source) do
-        <<-RUBY.strip_indent
-          unless foo.present?
-            something
-          else
-            something_else
-          end
-        RUBY
-      end
-
-      it 'registers an offense' do
+      it 'registers an offense and corrects' do
         expect_offense(<<-RUBY.strip_indent)
           unless foo.present?
           ^^^^^^^^^^^^^^^^^^^ Use `if foo.blank?` instead of `unless foo.present?`.
@@ -255,12 +229,8 @@ RSpec.describe RuboCop::Cop::Rails::Blank, :config do
             something_else
           end
         RUBY
-      end
 
-      it 'auto-corrects' do
-        new_source = autocorrect_source(source)
-
-        expect(new_source).to eq(<<-RUBY.strip_indent)
+        expect_correction(<<-RUBY.strip_indent)
           if foo.blank?
             something
           else

--- a/spec/rubocop/cop/rails/delegate_allow_blank_spec.rb
+++ b/spec/rubocop/cop/rails/delegate_allow_blank_spec.rb
@@ -3,10 +3,14 @@
 RSpec.describe RuboCop::Cop::Rails::DelegateAllowBlank do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense when using allow_blank' do
+  it 'registers an offense and corrects when using allow_blank' do
     expect_offense(<<-RUBY.strip_indent)
       delegate :foo, to: :bar, allow_blank: true
                                ^^^^^^^^^^^^^^^^^ `allow_blank` is not a valid option, use `allow_nil`.
+    RUBY
+
+    expect_correction(<<-RUBY.strip_indent)
+      delegate :foo, to: :bar, allow_nil: true
     RUBY
   end
 
@@ -16,12 +20,5 @@ RSpec.describe RuboCop::Cop::Rails::DelegateAllowBlank do
 
   it 'does not register an offense when no extra options given' do
     expect_no_offenses('delegate :foo, to: :bar')
-  end
-
-  it 'autocorrects allow_blank to allow_nil' do
-    source = 'delegate :foo, to: :bar, allow_blank: true'
-    new_source = autocorrect_source(source)
-
-    expect(new_source).to eq('delegate :foo, to: :bar, allow_nil: true')
   end
 end

--- a/spec/rubocop/cop/rails/environment_comparison_spec.rb
+++ b/spec/rubocop/cop/rails/environment_comparison_spec.rb
@@ -5,32 +5,25 @@ RSpec.describe RuboCop::Cop::Rails::EnvironmentComparison do
 
   let(:config) { RuboCop::Config.new }
 
-  it 'registers an offense when using `Rails.env == production`' do
+  it 'registers an offense and corrects comparing Rails.env to a string' do
     expect_offense(<<-RUBY.strip_indent)
       Rails.env == 'production'
       ^^^^^^^^^^^^^^^^^^^^^^^^^ Favor `Rails.env.production?` over `Rails.env == 'production'`.
-      Rails.env == :development
-      ^^^^^^^^^^^^^^^^^^^^^^^^^ Do not compare `Rails.env` with a symbol, it will always evaluate to `false`.
+    RUBY
+
+    expect_correction(<<-RUBY.strip_indent)
+      Rails.env.production?
     RUBY
   end
 
-  it 'autocorrects a string' do
-    new_source = autocorrect_source(<<-RUBY.strip_indent)
-      Rails.env == 'development'
+  it 'registers an offense and corrects comparing Rails.env to a symbol' do
+    expect_offense(<<-RUBY.strip_indent)
+      Rails.env == :production
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Do not compare `Rails.env` with a symbol, it will always evaluate to `false`.
     RUBY
 
-    expect(new_source).to eq(<<-RUBY.strip_indent)
-      Rails.env.development?
-    RUBY
-  end
-
-  it 'autocorrects a symbol' do
-    new_source = autocorrect_source(<<-RUBY.strip_indent)
-      Rails.env == :test
-    RUBY
-
-    expect(new_source).to eq(<<-RUBY.strip_indent)
-      Rails.env.test?
+    expect_correction(<<-RUBY.strip_indent)
+      Rails.env.production?
     RUBY
   end
 

--- a/spec/rubocop/cop/rails/find_by_spec.rb
+++ b/spec/rubocop/cop/rails/find_by_spec.rb
@@ -3,10 +3,14 @@
 RSpec.describe RuboCop::Cop::Rails::FindBy do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense when using `#first`' do
+  it 'registers an offense when using `#first` and does not auto-correct' do
     expect_offense(<<-RUBY.strip_indent)
       User.where(id: x).first
            ^^^^^^^^^^^^^^^^^^ Use `find_by` instead of `where.first`.
+    RUBY
+
+    expect_correction(<<-RUBY.strip_indent)
+      User.where(id: x).first
     RUBY
   end
 
@@ -15,21 +19,13 @@ RSpec.describe RuboCop::Cop::Rails::FindBy do
       User.where(id: x).take
            ^^^^^^^^^^^^^^^^^ Use `find_by` instead of `where.take`.
     RUBY
+
+    expect_correction(<<-RUBY.strip_indent)
+      User.find_by(id: x)
+    RUBY
   end
 
   it 'does not register an offense when using find_by' do
     expect_no_offenses('User.find_by(id: x)')
-  end
-
-  it 'autocorrects where.take to find_by' do
-    new_source = autocorrect_source('User.where(id: x).take')
-
-    expect(new_source).to eq('User.find_by(id: x)')
-  end
-
-  it 'does not autocorrect where.first' do
-    new_source = autocorrect_source('User.where(id: x).first')
-
-    expect(new_source).to eq('User.where(id: x).first')
   end
 end

--- a/spec/rubocop/cop/rails/find_each_spec.rb
+++ b/spec/rubocop/cop/rails/find_each_spec.rb
@@ -45,15 +45,25 @@ RSpec.describe RuboCop::Cop::Rails::FindEach do
   end
 
   it 'auto-corrects each to find_each' do
-    new_source = autocorrect_source('User.all.each { |u| u.x }')
+    expect_offense(<<-RUBY.strip_indent)
+      User.all.each { |u| u.x }
+               ^^^^ Use `find_each` instead of `each`.
+    RUBY
 
-    expect(new_source).to eq('User.all.find_each { |u| u.x }')
+    expect_correction(<<-RUBY.strip_indent)
+      User.all.find_each { |u| u.x }
+    RUBY
   end
 
   it 'registers an offense with non-send ancestors' do
-    inspect_source('class C; User.all.each { |u| u.x }; end')
+    expect_offense(<<-RUBY.strip_indent)
+      class C; User.all.each { |u| u.x }; end
+                        ^^^^ Use `find_each` instead of `each`.
+    RUBY
 
-    expect(cop.messages).to eq(['Use `find_each` instead of `each`.'])
+    expect_correction(<<-RUBY.strip_indent)
+      class C; User.all.find_each { |u| u.x }; end
+    RUBY
   end
 
   it 'does not register an offense when using order(...) earlier' do

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -107,12 +107,20 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
         get :create, user_id: @user.id
         ^^^ Use keyword arguments instead of positional arguments for http call: `get`.
       RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        get :create, params: { user_id: @user.id }
+      RUBY
     end
 
     it 'registers an offense for post method' do
       expect_offense(<<-RUBY.strip_indent)
         post :create, user_id: @user.id
         ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        post :create, params: { user_id: @user.id }
       RUBY
     end
 
@@ -121,12 +129,20 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
         patch :update, user_id: @user.id
         ^^^^^ Use keyword arguments instead of positional arguments for http call: `patch`.
       RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        patch :update, params: { user_id: @user.id }
+      RUBY
     end
 
     it 'registers an offense for put method' do
       expect_offense(<<-RUBY.strip_indent)
         put :create, user_id: @user.id
         ^^^ Use keyword arguments instead of positional arguments for http call: `put`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        put :create, params: { user_id: @user.id }
       RUBY
     end
 
@@ -135,12 +151,20 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
         delete :create, user_id: @user.id
         ^^^^^^ Use keyword arguments instead of positional arguments for http call: `delete`.
       RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        delete :create, params: { user_id: @user.id }
+      RUBY
     end
 
     it 'registers an offense for head method' do
       expect_offense(<<-RUBY.strip_indent)
         head :create, user_id: @user.id
         ^^^^ Use keyword arguments instead of positional arguments for http call: `head`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        head :create, params: { user_id: @user.id }
       RUBY
     end
 
@@ -181,11 +205,10 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
           get :new, user_id: @user.id
           ^^^ Use keyword arguments instead of positional arguments for http call: `get`.
         RUBY
-      end
 
-      it 'autocorrects offense' do
-        new_source = autocorrect_source('get :new, user_id: @user.id')
-        expect(new_source).to eq('get :new, params: { user_id: @user.id }')
+        expect_correction(<<-RUBY.strip_indent)
+          get :new, params: { user_id: @user.id }
+        RUBY
       end
 
       describe 'no params' do
@@ -197,8 +220,9 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
 
     describe '.patch' do
       it 'autocorrects offense' do
-        new_source = autocorrect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           patch :update,
+          ^^^^^ Use keyword arguments instead of positional arguments for http call: `patch`.
                 id: @user.id,
                 ac: {
                   article_id: @article1.id,
@@ -207,7 +231,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
                 }
         RUBY
 
-        expect(new_source).to eq(<<-RUBY.strip_indent)
+        expect_correction(<<-RUBY.strip_indent)
           patch :update, params: { id: @user.id, ac: {
                   article_id: @article1.id,
                   profile_id: @profile1.id,
@@ -219,8 +243,9 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
 
     describe '.post' do
       it 'autocorrects offense' do
-        new_source = autocorrect_source(<<-RUBY.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           post :create,
+          ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
                id: @user.id,
                ac: {
                  article_id: @article1.id,
@@ -229,7 +254,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
                }
         RUBY
 
-        expect(new_source).to eq(<<-RUBY.strip_indent)
+        expect_correction(<<-RUBY.strip_indent)
         post :create, params: { id: @user.id, ac: {
                article_id: @article1.id,
                profile_id: @profile1.id,
@@ -246,77 +271,113 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
     end
 
     it 'auto-corrects http action when method' do
-      new_source = autocorrect_source('post user_attrs, id: 1')
-      expect(new_source).to eq('post user_attrs, params: { id: 1 }')
+      expect_offense(<<-RUBY.strip_indent)
+        post user_attrs, id: 1
+        ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        post user_attrs, params: { id: 1 }
+      RUBY
     end
 
     it 'auto-corrects http action when symbol' do
-      new_source = autocorrect_source('post :user_attrs, id: 1')
-      expect(new_source).to eq('post :user_attrs, params: { id: 1 }')
+      expect_offense(<<-RUBY.strip_indent)
+        post :user_attrs, id: 1
+        ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        post :user_attrs, params: { id: 1 }
+      RUBY
     end
 
     it 'maintains parentheses when auto-correcting' do
-      new_source = autocorrect_source('post(:user_attrs, id: 1)')
-      expect(new_source).to eq('post(:user_attrs, params: { id: 1 })')
+      expect_offense(<<-RUBY.strip_indent)
+        post(:user_attrs, id: 1)
+        ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        post(:user_attrs, params: { id: 1 })
+      RUBY
     end
 
     it 'maintains quotes when auto-correcting' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         get '/auth/linkedin/callback', id: 1
+        ^^^ Use keyword arguments instead of positional arguments for http call: `get`.
       RUBY
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+
+      expect_correction(<<-RUBY.strip_indent)
         get '/auth/linkedin/callback', params: { id: 1 }
       RUBY
     end
 
     it 'does add session keyword when session is used' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         get some_path(profile.id), {}, 'HTTP_REFERER' => p_url(p.id).to_s
+        ^^^ Use keyword arguments instead of positional arguments for http call: `get`.
       RUBY
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect_correction(<<-RUBY.strip_indent)
         get some_path(profile.id), session: { 'HTTP_REFERER' => p_url(p.id).to_s }
       RUBY
     end
 
     it 'does not duplicate brackets when hash is already supplied' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         get some_path(profile.id), { user_id: @user.id, profile_id: p.id }, 'HTTP_REFERER' => p_url(p.id).to_s
+        ^^^ Use keyword arguments instead of positional arguments for http call: `get`.
       RUBY
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect_correction(<<-RUBY.strip_indent)
         get some_path(profile.id), params: { user_id: @user.id, profile_id: p.id }, session: { 'HTTP_REFERER' => p_url(p.id).to_s }
       RUBY
     end
 
     it 'auto-corrects http action when params is a method call' do
-      new_source = autocorrect_source('post :create, confirmation_data')
-      expect(new_source).to eq('post :create, params: confirmation_data')
+      expect_offense(<<-RUBY.strip_indent)
+        post :create, confirmation_data
+        ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        post :create, params: confirmation_data
+      RUBY
     end
 
     it 'auto-corrects http action when parameter matches ' \
       'special keyword name' do
-      new_source = autocorrect_source(<<-RUBY)
+      expect_offense(<<-RUBY.strip_indent)
         post :create, id: 7, comment: { body: "hei" }
+        ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
       RUBY
 
-      expect(new_source).to eq(<<-RUBY)
+      expect_correction(<<-RUBY.strip_indent)
         post :create, params: { id: 7, comment: { body: "hei" } }
       RUBY
     end
 
     it 'auto-corrects http action when format keyword included but not alone' do
-      new_source = autocorrect_source('post :create, id: 7, format: :rss')
-      expect(new_source).to eq('post :create, params: { id: 7, format: :rss }')
+      expect_offense(<<-RUBY.strip_indent)
+        post :create, id: 7, format: :rss
+        ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        post :create, params: { id: 7, format: :rss }
+      RUBY
     end
 
     it 'auto-corrects http action when params is a lvar' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         params = { id: 1 }
         post user_attrs, params
+        ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
       RUBY
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect_correction(<<-RUBY.strip_indent)
         params = { id: 1 }
         post user_attrs, params: params
       RUBY
@@ -324,16 +385,23 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
 
     it 'auto-corrects http action when params and action name ' \
       'are method calls' do
-      new_source = autocorrect_source('post user_attrs, params')
-      expect(new_source).to eq('post user_attrs, params: params')
+      expect_offense(<<-RUBY.strip_indent)
+        post user_attrs, params
+        ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        post user_attrs, params: params
+      RUBY
     end
 
     it 'auto-corrects http action when params is a method call with chain' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         post user_attrs, params.merge(foo: bar)
+        ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
       RUBY
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect_correction(<<-RUBY.strip_indent)
         post user_attrs, params: params.merge(foo: bar)
       RUBY
     end

--- a/spec/rubocop/cop/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rails/http_status_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
   context 'when EnforcedStyle is `symbolic`' do
     let(:cop_config) { { 'EnforcedStyle' => 'symbolic' } }
 
-    it 'registers an offense when using numeric value' do
+    it 'registers an offense and corrects using numeric value' do
       expect_offense(<<-RUBY.strip_indent)
         render :foo, status: 200
                              ^^^ Prefer `:ok` over `200` to define HTTP status code.
@@ -20,6 +20,15 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
                                       ^^^ Prefer `:moved_permanently` over `301` to define HTTP status code.
         redirect_to action: 'index', status: 301
                                              ^^^ Prefer `:moved_permanently` over `301` to define HTTP status code.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        render :foo, status: :ok
+        render json: { foo: 'bar' }, status: :not_found
+        render status: :not_found, json: { foo: 'bar' }
+        render plain: 'foo/bar', status: :not_modified
+        redirect_to root_url, status: :moved_permanently
+        redirect_to action: 'index', status: :moved_permanently
       RUBY
     end
 
@@ -44,7 +53,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
     context 'when rack is not loaded' do
       before { stub_const("#{described_class}::RACK_LOADED", false) }
 
-      it 'registers an offense when using numeric value' do
+      it 'registers an offense and does not correct using numeric value' do
         expect_offense(<<-RUBY)
           render :foo, status: 200
                                ^^^ Prefer `symbolic` over `numeric` to define HTTP status code.
@@ -55,40 +64,13 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
           redirect_to root_url, status: 301
                                         ^^^ Prefer `symbolic` over `numeric` to define HTTP status code.
         RUBY
-      end
-    end
 
-    describe 'autocorrect' do
-      context 'when render action' do
-        it 'autocorrects to symbolic style' do
-          bad = 'render :foo, status: 200'
-          good = 'render :foo, status: :ok'
-          expect(autocorrect_source(bad)).to eq(good)
-        end
-      end
-
-      context 'when render json' do
-        it 'autocorrects to symbolic style' do
-          bad = "render json: { foo: 'bar' }, status: 404"
-          good = "render json: { foo: 'bar' }, status: :not_found"
-          expect(autocorrect_source(bad)).to eq(good)
-        end
-      end
-
-      context 'when render plain' do
-        it 'autocorrects to symbolic style' do
-          bad = "render plain: 'foo/bar', status: 304"
-          good = "render plain: 'foo/bar', status: :not_modified"
-          expect(autocorrect_source(bad)).to eq(good)
-        end
-      end
-
-      context 'when redirect_to' do
-        it 'autocorrects to symbolic style' do
-          bad = 'redirect_to root_url, status: 301'
-          good = 'redirect_to root_url, status: :moved_permanently'
-          expect(autocorrect_source(bad)).to eq(good)
-        end
+        expect_correction(<<-RUBY)
+          render :foo, status: 200
+          render json: { foo: 'bar' }, status: 404
+          render plain: 'foo/bar', status: 304
+          redirect_to root_url, status: 301
+        RUBY
       end
     end
   end
@@ -110,6 +92,15 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
                                       ^^^^^^^^^^^^^^^^^^ Prefer `301` over `:moved_permanently` to define HTTP status code.
         redirect_to action: 'index', status: :moved_permanently
                                              ^^^^^^^^^^^^^^^^^^ Prefer `301` over `:moved_permanently` to define HTTP status code.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        render :foo, status: 200
+        render json: { foo: 'bar' }, status: 404
+        render status: 404, json: { foo: 'bar' }
+        render plain: 'foo/bar', status: 304
+        redirect_to root_url, status: 301
+        redirect_to action: 'index', status: 301
       RUBY
     end
 
@@ -134,7 +125,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
     context 'when rack is not loaded' do
       before { stub_const("#{described_class}::RACK_LOADED", false) }
 
-      it 'registers an offense when using symbolic value' do
+      it 'registers an offense and corrects using symbolic value' do
         expect_offense(<<-RUBY)
           render :foo, status: :ok
                                ^^^ Prefer `numeric` over `symbolic` to define HTTP status code.
@@ -145,40 +136,6 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
           redirect_to root_url, status: :moved_permanently
                                         ^^^^^^^^^^^^^^^^^^ Prefer `numeric` over `symbolic` to define HTTP status code.
         RUBY
-      end
-    end
-
-    describe 'autocorrect' do
-      context 'when render action' do
-        it 'autocorrects to symbolic style' do
-          bad = 'render :foo, status: :ok'
-          good = 'render :foo, status: 200'
-          expect(autocorrect_source(bad)).to eq(good)
-        end
-      end
-
-      context 'when render json' do
-        it 'autocorrects to symbolic style' do
-          bad = "render json: { foo: 'bar' }, status: :not_found"
-          good = "render json: { foo: 'bar' }, status: 404"
-          expect(autocorrect_source(bad)).to eq(good)
-        end
-      end
-
-      context 'when render plain' do
-        it 'autocorrects to symbolic style' do
-          bad = "render plain: 'foo/bar', status: :not_modified"
-          good = "render plain: 'foo/bar', status: 304"
-          expect(autocorrect_source(bad)).to eq(good)
-        end
-      end
-
-      context 'when redirect_to' do
-        it 'autocorrects to symbolic style' do
-          bad = 'redirect_to root_url, status: :moved_permanently'
-          good = 'redirect_to root_url, status: 301'
-          expect(autocorrect_source(bad)).to eq(good)
-        end
       end
     end
   end

--- a/spec/rubocop/cop/rails/link_to_blank_spec.rb
+++ b/spec/rubocop/cop/rails/link_to_blank_spec.rb
@@ -27,18 +27,13 @@ RSpec.describe RuboCop::Cop::Rails::LinkToBlank do
 
   context 'when using target_blank' do
     context 'when using no rel' do
-      it 'registers an offence' do
+      it 'registers and corrects an offence' do
         expect_offense(<<-RUBY.strip_indent)
           link_to 'Click here', 'https://www.example.com', target: '_blank'
                                                            ^^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
         RUBY
-      end
 
-      it 'autocorrects with a new rel' do
-        new_source = autocorrect_source(<<-RUBY.strip_indent)
-          link_to 'Click here', 'https://www.example.com', target: '_blank'
-        RUBY
-        expect(new_source).to eq(<<-RUBY.strip_indent)
+        expect_correction(<<-RUBY.strip_indent)
           link_to 'Click here', 'https://www.example.com', target: '_blank', rel: 'noopener'
         RUBY
       end
@@ -50,22 +45,15 @@ RSpec.describe RuboCop::Cop::Rails::LinkToBlank do
         RUBY
       end
 
-      it 'registers an offence when using the block syntax' do
+      it 'registers an offence and auto-corrects when using the block syntax' do
         expect_offense(<<-RUBY.strip_indent)
           link_to 'https://www.example.com', target: '_blank' do
                                              ^^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
             "Click here"
           end
         RUBY
-      end
 
-      it 'autocorrects with a new rel when using the block syntax' do
-        new_source = autocorrect_source(<<-RUBY.strip_indent)
-          link_to 'https://www.example.com', target: '_blank' do
-            "Click here"
-          end
-        RUBY
-        expect(new_source).to eq(<<-RUBY.strip_indent)
+        expect_correction(<<-RUBY.strip_indent)
           link_to 'https://www.example.com', target: '_blank', rel: 'noopener' do
             "Click here"
           end
@@ -75,19 +63,14 @@ RSpec.describe RuboCop::Cop::Rails::LinkToBlank do
 
     context 'when using rel' do
       context 'when the rel does not contain noopener' do
-        it 'registers an offence ' do
+        it 'registers an offence and corrects' do
           expect_offense(<<-RUBY.strip_indent)
             link_to 'Click here', 'https://www.example.com', "target" => '_blank', rel: 'unrelated'
                                                              ^^^^^^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
           RUBY
-        end
 
-        it 'autocorrects by appending to the existing rel' do
-          new_source = autocorrect_source(<<-RUBY.strip_indent)
-            link_to 'Click here', 'https://www.example.com', target: '_blank', rel: 'foo'
-          RUBY
-          expect(new_source).to eq(<<-RUBY.strip_indent)
-            link_to 'Click here', 'https://www.example.com', target: '_blank', rel: 'foo noopener'
+          expect_correction(<<-RUBY.strip_indent)
+            link_to 'Click here', 'https://www.example.com', "target" => '_blank', rel: 'unrelated noopener'
           RUBY
         end
       end

--- a/spec/rubocop/cop/rails/present_spec.rb
+++ b/spec/rubocop/cop/rails/present_spec.rb
@@ -154,58 +154,42 @@ RSpec.describe RuboCop::Cop::Rails::Present, :config do
     context 'unless blank?' do
       context 'modifier unless' do
         context 'with a receiver' do
-          it 'registers an offense' do
+          it 'registers an offense and corrects' do
             expect_offense(<<-RUBY.strip_indent)
               something unless foo.blank?
                         ^^^^^^^^^^^^^^^^^ Use `if foo.present?` instead of `unless foo.blank?`.
             RUBY
-          end
 
-          it 'auto-corrects' do
-            new_source = autocorrect_source('something unless foo.blank?')
-
-            expect(new_source).to eq('something if foo.present?')
+            expect_correction(<<-RUBY.strip_indent)
+              something if foo.present?
+            RUBY
           end
         end
 
         context 'without a receiver' do
-          it 'registers an offense' do
+          it 'registers an offense and corrects' do
             expect_offense(<<-RUBY.strip_indent)
               something unless blank?
                         ^^^^^^^^^^^^^ Use `if present?` instead of `unless blank?`.
             RUBY
-          end
 
-          it 'auto-corrects' do
-            new_source = autocorrect_source('something unless blank?')
-
-            expect(new_source).to eq('something if present?')
+            expect_correction(<<-RUBY.strip_indent)
+              something if present?
+            RUBY
           end
         end
       end
 
       context 'normal unless blank?' do
-        let(:source) do
-          <<-RUBY.strip_indent
-            unless foo.blank?
-              something
-            end
-          RUBY
-        end
-
-        it 'registers an offense' do
+        it 'registers an offense and corrects' do
           expect_offense(<<-RUBY.strip_indent)
             unless foo.blank?
             ^^^^^^^^^^^^^^^^^ Use `if foo.present?` instead of `unless foo.blank?`.
               something
             end
           RUBY
-        end
 
-        it 'auto-corrects' do
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq(<<-RUBY.strip_indent)
+          expect_correction(<<-RUBY.strip_indent)
             if foo.present?
               something
             end
@@ -214,16 +198,6 @@ RSpec.describe RuboCop::Cop::Rails::Present, :config do
       end
 
       context 'unless blank? with an else' do
-        let(:source) do
-          <<-RUBY.strip_indent
-            unless foo.blank?
-              something
-            else
-              something_else
-            end
-          RUBY
-        end
-
         it 'registers an offense' do
           expect_offense(<<-RUBY.strip_indent)
             unless foo.blank?
@@ -233,12 +207,8 @@ RSpec.describe RuboCop::Cop::Rails::Present, :config do
               something_else
             end
           RUBY
-        end
 
-        it 'auto-corrects' do
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq(<<-RUBY.strip_indent)
+          expect_correction(<<-RUBY.strip_indent)
             if foo.present?
               something
             else

--- a/spec/rubocop/cop/rails/refute_methods_spec.rb
+++ b/spec/rubocop/cop/rails/refute_methods_spec.rb
@@ -3,17 +3,26 @@
 RSpec.describe RuboCop::Cop::Rails::RefuteMethods do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense when using `refute` with a single argument' do
+  it 'registers an offense and correct using `refute` with a single argument' do
     expect_offense(<<-RUBY.strip_indent)
       refute foo
       ^^^^^^ Prefer `assert_not` over `refute`.
     RUBY
+
+    expect_correction(<<-RUBY.strip_indent)
+      assert_not foo
+    RUBY
   end
 
-  it 'registers an offense when using `refute` with multiple arguments' do
+  it 'registers an offense and corrects using `refute` ' \
+    'with multiple arguments' do
     expect_offense(<<-RUBY.strip_indent)
       refute foo, bar, baz
       ^^^^^^ Prefer `assert_not` over `refute`.
+    RUBY
+
+    expect_correction(<<-RUBY.strip_indent)
+      assert_not foo, bar, baz
     RUBY
   end
 
@@ -22,25 +31,9 @@ RSpec.describe RuboCop::Cop::Rails::RefuteMethods do
       refute_empty foo
       ^^^^^^^^^^^^ Prefer `assert_not_empty` over `refute_empty`.
     RUBY
-  end
 
-  it 'autocorrects `refute` with a single argument' do
-    new_source = autocorrect_source(<<-RUBY.strip_indent)
-      refute foo
-    RUBY
-
-    expect(new_source).to eq(<<-RUBY.strip_indent)
-      assert_not foo
-    RUBY
-  end
-
-  it 'autocorrects `refute` with multiple arguments' do
-    new_source = autocorrect_source(<<-RUBY.strip_indent)
-      refute foo, bar, baz
-    RUBY
-
-    expect(new_source).to eq(<<-RUBY.strip_indent)
-      assert_not foo, bar, baz
+    expect_correction(<<-RUBY.strip_indent)
+      assert_not_empty foo
     RUBY
   end
 

--- a/spec/rubocop/cop/rails/request_referer_spec.rb
+++ b/spec/rubocop/cop/rails/request_referer_spec.rb
@@ -6,32 +6,30 @@ RSpec.describe RuboCop::Cop::Rails::RequestReferer, :config do
   context 'when EnforcedStyle is referer' do
     let(:cop_config) { { 'EnforcedStyle' => 'referer' } }
 
-    it 'registers an offense for request.referrer' do
+    it 'registers an offense and corrects request.referrer' do
       expect_offense(<<-RUBY.strip_indent)
         puts request.referrer
              ^^^^^^^^^^^^^^^^ Use `request.referer` instead of `request.referrer`.
       RUBY
-    end
 
-    it 'autocorrects referrer with referer' do
-      corrected = autocorrect_source('puts request.referrer')
-      expect(corrected).to eq 'puts request.referer'
+      expect_correction(<<-RUBY.strip_indent)
+        puts request.referer
+      RUBY
     end
   end
 
   context 'when EnforcedStyle is referrer' do
     let(:cop_config) { { 'EnforcedStyle' => 'referrer' } }
 
-    it 'registers an offense for request.referer' do
+    it 'registers an offense and corrects request.referer' do
       expect_offense(<<-RUBY.strip_indent)
         puts request.referer
              ^^^^^^^^^^^^^^^ Use `request.referrer` instead of `request.referer`.
       RUBY
-    end
 
-    it 'autocorrects referer with referrer' do
-      corrected = autocorrect_source('puts request.referer')
-      expect(corrected).to eq 'puts request.referrer'
+      expect_correction(<<-RUBY.strip_indent)
+        puts request.referrer
+      RUBY
     end
   end
 end


### PR DESCRIPTION
Making use of `expect_correction` in some of the smaller groups of tests. For the most part the change went smooth. These were all manual updates. The names of some of the tests feel a bit weird now. I really enjoy having a small compact test that check for an offense, the message, and correction.

I need to open up an issue for the message in `Rails/ReadWriteAttribute`. It uses generic examples rather than actual variables names from the code. 