### PR TITLE
Add coverage for subprocess specs

### DIFF
--- a/lib/rubocop/rspec/host_environment_simulation_helper.rb
+++ b/lib/rubocop/rspec/host_environment_simulation_helper.rb
@@ -10,7 +10,7 @@ module HostEnvironmentSimulatorHelper
       pid = ::Process.fork do
         # Need to write coverage result under different name
         if defined?(SimpleCov)
-          SimpleCov.coverage_dir "coverage/ignored_results_#{Process.pid}"
+          SimpleCov.command_name "rspec-fork-#{Process.pid}"
           SimpleCov.pid = Process.pid
         end
 


### PR DESCRIPTION
Per discussion in https://github.com/rubocop-hq/rubocop/pull/3705#issuecomment-460966422

Since PR https://github.com/rubocop-hq/rubocop/pull/6255 the coverage results from the different suites (one per tested Ruby version) are merged together, and the result is sent to Code Climate.

That means we no longer need to ignore coverage results from the specs that are run in a separate process. We just need to give these coverage results their own name (e.g. a namespace) and set a new PID (I think to stop SimpleCov's `at_exit` hook when the fork ends) and these subprocess results will be merged with the coverage results of the rest of the suite.

I tried running `rm -fv coverage/.*  ; COVERAGE=true bundle exec rake spec` before and after this change, and the “after” run gives me extra coverage for the lib/rubocop/rspec/host_environment_simulation_helper.rb file. The merging of each suite’s coverage results is handled elsewhere, and shouldn’t need to change: https://github.com/rubocop-hq/rubocop/blob/2269afce304dc349972a9d7f3062d353140e03b5/.circleci/config.yml#L261

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
