### PR TITLE
Increase code coverage

### DIFF
--- a/lib/rubocop/cop/layout/closing_heredoc_indentation.rb
+++ b/lib/rubocop/cop/layout/closing_heredoc_indentation.rb
@@ -74,24 +74,12 @@ module RuboCop
           indent_level(heredoc_opening(node))
         end
 
-        def empty_heredoc?(node)
-          node.loc.heredoc_body.source.empty? || !contents_indentation(node)
-        end
-
         def argument_indentation_correct?(node)
           return unless node.argument? || node.chained?
 
           opening_indentation(
             find_node_used_heredoc_argument(node.parent)
           ) == closing_indentation(node)
-        end
-
-        def contents_indentation(node)
-          source_lines = node.loc.heredoc_body.source.split("\n")
-
-          source_lines.reject(&:empty?).map do |line|
-            indent_level(line)
-          end.min
         end
 
         def closing_indentation(node)

--- a/lib/rubocop/cop/style/yoda_condition.rb
+++ b/lib/rubocop/cop/style/yoda_condition.rb
@@ -97,11 +97,6 @@ module RuboCop
             !noncommutative_operator?(node)
         end
 
-        def both_literals?(node)
-          lhs, _operator, rhs = *node
-          lhs.literal? && rhs.literal?
-        end
-
         def valid_yoda?(node)
           lhs, _operator, rhs = *node
 

--- a/spec/rubocop/cop/lint/implicit_string_concatenation_spec.rb
+++ b/spec/rubocop/cop/lint/implicit_string_concatenation_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe RuboCop::Cop::Lint::ImplicitStringConcatenation do
       expect_offense(<<-RUBY.strip_indent)
         class A; "abc" "def"; end
                  ^^^^^^^^^^^ Combine "abc" and "def" into a single string literal, rather than using implicit string concatenation.
+        class B; 'ghi' 'jkl'; end
+                 ^^^^^^^^^^^ Combine 'ghi' and 'jkl' into a single string literal, rather than using implicit string concatenation.
       RUBY
     end
   end
@@ -32,7 +34,7 @@ RSpec.describe RuboCop::Cop::Lint::ImplicitStringConcatenation do
   context 'when the string literals contain newlines' do
     it 'registers an offense' do
       inspect_source(<<-RUBY.strip_indent)
-        def method; "ab\\nc" "de\\nf"; end
+        def method; "ab\nc" "de\nf"; end
       RUBY
 
       expect(cop.offenses.size).to eq(1)


### PR DESCRIPTION
I was looking a bit at our code coverage results, and in these two files I found three unused methods:

- https://codeclimate.com/github/bbatsov/rubocop/lib/rubocop/cop/layout/closing_heredoc_indentation.rb/source
- https://codeclimate.com/github/bbatsov/rubocop/lib/rubocop/cop/style/yoda_condition.rb/source

In ImplicitStringConcatenation I found a couple of lines that could easily be covered by tests, but weren’t:

- https://codeclimate.com/github/bbatsov/rubocop/lib/rubocop/cop/lint/implicit_string_concatenation.rb/source

I am thinking it might be a good idea to have coverage reports in our pull requests. WDYT?

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
