### PR TITLE
[Fix #6737] Fix an incorrect auto-correct for `Rails/LinkToBlank`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#6710](https://github.com/rubocop-hq/rubocop/issues/6710): Fix `Naming/MemoizedInstanceVariableName` on method starts with underscore. ([@pocke][])
 * [#6722](https://github.com/rubocop-hq/rubocop/issues/6722): Fix an error for `Style/OneLineConditional` when `then` branch has no body. ([@koic][])
 * [#6702](https://github.com/rubocop-hq/rubocop/pull/6702): Fix `TrailingComma` regression where heredoc with commas caused false positives. ([@abrom][])
+* [#6737](https://github.com/rubocop-hq/rubocop/issues/6737): Fix an incorrect auto-correct for `Rails/LinkToBlank` when `link_to` method arguments are enclosed in parentheses. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/link_to_blank.rb
+++ b/lib/rubocop/cop/rails/link_to_blank.rb
@@ -74,7 +74,9 @@ module RuboCop
         def add_rel(send_node, offence_node, corrector)
           quote_style = offence_node.children.last.source[0]
           new_rel_exp = ", rel: #{quote_style}noopener#{quote_style}"
-          corrector.insert_after(send_node.loc.expression, new_rel_exp)
+          range = send_node.arguments.last.source_range
+
+          corrector.insert_after(range, new_rel_exp)
         end
 
         def contains_noopener?(str)

--- a/spec/rubocop/cop/rails/link_to_blank_spec.rb
+++ b/spec/rubocop/cop/rails/link_to_blank_spec.rb
@@ -59,6 +59,21 @@ RSpec.describe RuboCop::Cop::Rails::LinkToBlank do
           end
         RUBY
       end
+
+      it 'autocorrects with a new rel when using the block syntax ' \
+         'with parenthesis' do
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+          link_to('https://www.example.com', target: '_blank') do
+            "Click here"
+          end
+        RUBY
+
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          link_to('https://www.example.com', target: '_blank', rel: 'noopener') do
+            "Click here"
+          end
+        RUBY
+      end
     end
 
     context 'when using rel' do


### PR DESCRIPTION
Fixes #6737.

This PR fixes an incorrect auto-correct for `Rails/LinkToBlank` when `link_to` method arguments are enclosed in parentheses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
