### PR TITLE
Suppress a YARD warn for `Lint/DisjunctiveAssignmentInConstructor`

### DIFF
--- a/lib/rubocop/cop/lint/disjunctive_assignment_in_constructor.rb
+++ b/lib/rubocop/cop/lint/disjunctive_assignment_in_constructor.rb
@@ -31,13 +31,13 @@ module RuboCop
 
         private
 
+        # @param [DefNode] node a constructor definition
         def check(node)
           return unless node.method_name == :initialize
 
           check_body(node.body)
         end
 
-        # @param [DefNode] node a constructor definition
         def check_body(body)
           return if body.nil?
 


### PR DESCRIPTION
This PR suppresses the following warning.

```console
% cd path/to/rubocop-repo
% bundle exec rake yard_for_generate_documentation
[warn]: @param tag has unknown parameter name: node
    in file
    `lib/rubocop/cop/lint/disjunctive_assignment_in_constructor.rb' near
    line 41
Files:         524
Modules:        80 (   11 undocumented)
Classes:       495 (    3 undocumented)
Constants:     765 (  753 undocumented)
Attributes:     26 (    0 undocumented)
Methods:      1186 ( 1052 undocumented)
 28.72% documented
```

This warning was regressed by the following changes.

```diff
         def check(node)
           return unless node.method_name == :initialize

-          check_body(node)
+          check_body(node.body)
         end

         # @param [DefNode] node a constructor definition
-        def check_body(node)
-          body = node.body
+        def check_body(body)
+          return if body.nil?
```

https://github.com/rubocop-hq/rubocop/commit/608943f62d111fe2dafbb7f122567f1a1b8ef578#diff-acaaab0e12f42621dfca06a26980cec6L34

This PR fixes by moving the YARD `@param` tag to the caller method with a high abstraction level.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
