### PR TITLE
Make some cops aware of safe navigation operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#6597](https://github.com/rubocop-hq/rubocop/issues/6597): `Style/LineEndConcatenation` is now known to be unsafe for auto-correct. ([@jaredbeck][])
 * [#6725](https://github.com/rubocop-hq/rubocop/issues/6725): Mark `Style/SymbolProc` as unsafe for auto-correct. ([@drenmi][])
 * [#6708](https://github.com/rubocop-hq/rubocop/issues/6708): Make `Style/CommentedKeyword` allow the `:yields:` RDoc comment. ([@bquorning][])
+* [#6749](https://github.com/rubocop-hq/rubocop/pull/6749): Make some cops aware of safe navigation operator. ([@hoshinotsuyoshi][])
 
 ## 0.63.1 (2019-01-22)
 

--- a/lib/rubocop/cop/layout/align_parameters.rb
+++ b/lib/rubocop/cop/layout/align_parameters.rb
@@ -42,6 +42,7 @@ module RuboCop
 
           check_alignment(node.arguments, base_column(node, node.arguments))
         end
+        alias on_csend on_send
         alias on_def  on_send
         alias on_defs on_send
 
@@ -52,7 +53,11 @@ module RuboCop
         private
 
         def message(node)
-          type = node && node.parent.send_type? ? 'call' : 'definition'
+          type = if node && (node.parent.send_type? || node.parent.csend_type?)
+                   'call'
+                 else
+                   'definition'
+                 end
           msg = fixed_indentation? ? FIXED_INDENT_MSG : ALIGN_PARAMS_MSG
 
           format(msg, type: type)

--- a/lib/rubocop/cop/layout/closing_parenthesis_indentation.rb
+++ b/lib/rubocop/cop/layout/closing_parenthesis_indentation.rb
@@ -78,6 +78,7 @@ module RuboCop
         def on_send(node)
           check(node, node.arguments)
         end
+        alias on_csend on_send
 
         def on_begin(node)
           check(node, node.children)

--- a/lib/rubocop/cop/layout/dot_position.rb
+++ b/lib/rubocop/cop/layout/dot_position.rb
@@ -26,7 +26,7 @@ module RuboCop
         include ConfigurableEnforcedStyle
 
         def on_send(node)
-          return unless node.dot?
+          return unless node.dot? || ampersand_dot?(node)
 
           if proper_dot_position?(node)
             correct_style_detected
@@ -34,23 +34,26 @@ module RuboCop
             add_offense(node, location: :dot) { opposite_style_detected }
           end
         end
+        alias on_csend on_send
 
         def autocorrect(node)
           lambda do |corrector|
+            dot = node.loc.dot.source
             corrector.remove(node.loc.dot)
             case style
             when :leading
-              corrector.insert_before(selector_range(node), '.')
+              corrector.insert_before(selector_range(node), dot)
             when :trailing
-              corrector.insert_after(node.receiver.source_range, '.')
+              corrector.insert_after(node.receiver.source_range, dot)
             end
           end
         end
 
         private
 
-        def message(_node)
-          'Place the . on the ' +
+        def message(node)
+          dot = node.loc.dot.source
+          "Place the #{dot} on the " +
             case style
             when :leading
               'next line, together with the method name.'
@@ -91,6 +94,10 @@ module RuboCop
         def selector_range(node)
           # l.(1) has no selector, so we use the opening parenthesis instead
           node.loc.selector || node.loc.begin
+        end
+
+        def ampersand_dot?(node)
+          node.loc.respond_to?(:dot) && node.loc.dot && node.loc.dot.is?('&.')
         end
       end
     end

--- a/lib/rubocop/cop/layout/empty_lines_around_arguments.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_arguments.rb
@@ -48,6 +48,7 @@ module RuboCop
 
           extra_lines(node) { |range| add_offense(node, location: range) }
         end
+        alias on_csend on_send
 
         def autocorrect(node)
           lambda do |corrector|

--- a/lib/rubocop/cop/layout/first_method_argument_line_break.rb
+++ b/lib/rubocop/cop/layout/first_method_argument_line_break.rb
@@ -43,6 +43,7 @@ module RuboCop
 
           check_method_line_break(node, args)
         end
+        alias on_csend on_send
 
         def autocorrect(node)
           EmptyLineCorrector.insert_before(node)

--- a/lib/rubocop/cop/layout/first_parameter_indentation.rb
+++ b/lib/rubocop/cop/layout/first_parameter_indentation.rb
@@ -154,6 +154,7 @@ module RuboCop
 
           check_alignment([node.first_argument], indent)
         end
+        alias on_csend on_send
 
         def autocorrect(node)
           AlignmentCorrector.correct(processed_source, node, column_delta)

--- a/lib/rubocop/cop/layout/indent_array.rb
+++ b/lib/rubocop/cop/layout/indent_array.rb
@@ -96,6 +96,7 @@ module RuboCop
             check(array_node, left_parenthesis)
           end
         end
+        alias on_csend on_send
 
         def autocorrect(node)
           AlignmentCorrector.correct(processed_source, node, @column_delta)

--- a/lib/rubocop/cop/layout/indent_hash.rb
+++ b/lib/rubocop/cop/layout/indent_hash.rb
@@ -94,6 +94,7 @@ module RuboCop
             check(hash_node, left_parenthesis)
           end
         end
+        alias on_csend on_send
 
         def autocorrect(node)
           AlignmentCorrector.correct(processed_source, node, @column_delta)

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -119,6 +119,7 @@ module RuboCop
           check_indentation(base.source_range, body)
           ignore_node(node.first_argument)
         end
+        alias on_csend on_send
 
         def on_def(node)
           return if ignored_node?(node)

--- a/lib/rubocop/cop/layout/space_before_first_arg.rb
+++ b/lib/rubocop/cop/layout/space_before_first_arg.rb
@@ -40,6 +40,7 @@ module RuboCop
 
           add_offense(space, location: space) if space.length != 1
         end
+        alias on_csend on_send
 
         def autocorrect(range)
           ->(corrector) { corrector.replace(range, ' ') }

--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -37,6 +37,7 @@ module RuboCop
 
           add_offense(node)
         end
+        alias on_csend on_send
 
         private
 

--- a/lib/rubocop/cop/lint/each_with_object_argument.rb
+++ b/lib/rubocop/cop/lint/each_with_object_argument.rb
@@ -24,7 +24,9 @@ module RuboCop
       class EachWithObjectArgument < Cop
         MSG = 'The argument to each_with_object can not be immutable.'.freeze
 
-        def_node_matcher :each_with_object?, '(send _ :each_with_object $_)'
+        def_node_matcher :each_with_object?, <<-PATTERN
+          ({send csend} _ :each_with_object $_)
+        PATTERN
 
         def on_send(node)
           each_with_object?(node) do |arg|
@@ -33,6 +35,7 @@ module RuboCop
             add_offense(node)
           end
         end
+        alias on_csend on_send
       end
     end
   end

--- a/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
+++ b/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
@@ -35,6 +35,7 @@ module RuboCop
 
           add_offense(nil, location: range)
         end
+        alias on_csend on_send
 
         private
 
@@ -50,7 +51,7 @@ module RuboCop
           # Escape question mark if any.
           method_regexp = Regexp.escape(node.method_name)
 
-          match = without_receiver.match(/^\s*\.?\s*#{method_regexp}(\s+)\(/)
+          match = without_receiver.match(/^\s*&?\.?\s*#{method_regexp}(\s+)\(/)
           match ? match.captures[0].length : 0
         end
 

--- a/lib/rubocop/cop/lint/require_parentheses.rb
+++ b/lib/rubocop/cop/lint/require_parentheses.rb
@@ -42,6 +42,7 @@ module RuboCop
             check_predicate(node.last_argument, node)
           end
         end
+        alias on_csend on_send
 
         private
 

--- a/lib/rubocop/cop/mixin/check_assignment.rb
+++ b/lib/rubocop/cop/mixin/check_assignment.rb
@@ -31,7 +31,7 @@ module RuboCop
           _scope, _lhs, rhs = *node
         elsif node.op_asgn_type?
           _lhs, _op, rhs = *node
-        elsif node.send_type?
+        elsif node.send_type? || node.csend_type?
           rhs = node.last_argument
         elsif node.assignment?
           _lhs, rhs = *node

--- a/lib/rubocop/cop/rails/active_record_aliases.rb
+++ b/lib/rubocop/cop/rails/active_record_aliases.rb
@@ -32,6 +32,8 @@ module RuboCop
           end
         end
 
+        alias on_csend on_send
+
         def autocorrect(node)
           lambda do |corrector|
             corrector.replace(

--- a/lib/rubocop/cop/rails/date.rb
+++ b/lib/rubocop/cop/rails/date.rb
@@ -79,6 +79,7 @@ module RuboCop
           add_offense(node, location: :selector,
                             message: format(MSG_SEND, method: node.method_name))
         end
+        alias on_csend on_send
 
         private
 

--- a/lib/rubocop/cop/rails/dynamic_find_by.rb
+++ b/lib/rubocop/cop/rails/dynamic_find_by.rb
@@ -42,6 +42,7 @@ module RuboCop
                       message: format(MSG, static_name: static_name,
                                            method: node.method_name))
         end
+        alias on_csend on_send
 
         def autocorrect(node)
           keywords = column_keywords(node.method_name)

--- a/lib/rubocop/cop/rails/find_by.rb
+++ b/lib/rubocop/cop/rails/find_by.rb
@@ -20,7 +20,7 @@ module RuboCop
         TARGET_SELECTORS = %i[first take].freeze
 
         def_node_matcher :where_first?, <<-PATTERN
-          (send (send _ :where ...) {:first :take})
+          (send ({send csend} _ :where ...) {:first :take})
         PATTERN
 
         def on_send(node)
@@ -32,6 +32,7 @@ module RuboCop
           add_offense(node, location: range,
                             message: format(MSG, method: node.method_name))
         end
+        alias on_csend on_send
 
         def autocorrect(node)
           # Don't autocorrect where(...).first, because it can return different

--- a/lib/rubocop/cop/rails/save_bang.rb
+++ b/lib/rubocop/cop/rails/save_bang.rb
@@ -146,6 +146,7 @@ module RuboCop
 
           add_offense_for_node(node)
         end
+        alias on_csend on_send
 
         def autocorrect(node)
           save_loc = node.loc.selector

--- a/lib/rubocop/cop/rails/skips_model_validations.rb
+++ b/lib/rubocop/cop/rails/skips_model_validations.rb
@@ -67,6 +67,7 @@ module RuboCop
 
           add_offense(node, location: :selector)
         end
+        alias on_csend on_send
 
         private
 

--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -53,6 +53,7 @@ module RuboCop
 
           check(node.last_argument, node.arguments)
         end
+        alias on_csend on_send
 
         # We let AutocorrectUnlessChangingAST#autocorrect work with the send
         # node, because that context is needed. When parsing the code to see if

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -142,6 +142,7 @@ module RuboCop
             add_offense_for_omit_parentheses(node)
           end
         end
+        alias on_csend on_send
         alias on_super on_send
         alias on_yield on_send
 

--- a/lib/rubocop/cop/style/method_called_on_do_end_block.rb
+++ b/lib/rubocop/cop/style/method_called_on_do_end_block.rb
@@ -39,6 +39,7 @@ module RuboCop
 
           add_offense(nil, location: range)
         end
+        alias on_csend on_send
       end
     end
   end

--- a/lib/rubocop/cop/style/nested_parenthesized_calls.rb
+++ b/lib/rubocop/cop/style/nested_parenthesized_calls.rb
@@ -20,7 +20,7 @@ module RuboCop
         def on_send(node)
           return unless node.parenthesized?
 
-          node.each_child_node(:send) do |nested|
+          node.each_child_node(:send, :csend) do |nested|
             next if allowed_omission?(nested)
 
             add_offense(nested,
@@ -28,6 +28,7 @@ module RuboCop
                         message: format(MSG, source: nested.source))
           end
         end
+        alias on_csend on_send
 
         def autocorrect(nested)
           first_arg = nested.first_argument.source_range

--- a/lib/rubocop/cop/style/preferred_hash_methods.rb
+++ b/lib/rubocop/cop/style/preferred_hash_methods.rb
@@ -41,6 +41,7 @@ module RuboCop
 
           add_offense(node, location: :selector)
         end
+        alias on_csend on_send
 
         def autocorrect(node)
           lambda do |corrector|

--- a/lib/rubocop/cop/style/send.rb
+++ b/lib/rubocop/cop/style/send.rb
@@ -17,13 +17,14 @@ module RuboCop
         MSG = 'Prefer `Object#__send__` or `Object#public_send` to ' \
               '`send`.'.freeze
 
-        def_node_matcher :sending?, '(send _ :send ...)'
+        def_node_matcher :sending?, '({send csend} _ :send ...)'
 
         def on_send(node)
           return unless sending?(node) && node.arguments?
 
           add_offense(node, location: :selector)
         end
+        alias on_csend on_send
       end
     end
   end

--- a/lib/rubocop/cop/style/string_methods.rb
+++ b/lib/rubocop/cop/style/string_methods.rb
@@ -24,6 +24,7 @@ module RuboCop
 
           add_offense(node, location: :selector)
         end
+        alias on_csend on_send
 
         def autocorrect(node)
           lambda do |corrector|

--- a/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
@@ -59,6 +59,7 @@ module RuboCop
                 node.last_argument.source_range.end_pos,
                 node.source_range.end_pos)
         end
+        alias on_csend on_send
 
         def autocorrect(range)
           PunctuationCorrector.swap_comma(range)

--- a/spec/rubocop/cop/layout/align_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/align_parameters_spec.rb
@@ -421,6 +421,16 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
           end
         RUBY
     end
+
+    context 'when using safe navigation operator', :ruby23 do
+      it 'registers an offense for parameters with single indent' do
+        expect_offense(<<-RUBY.strip_indent)
+          receiver&.function(a,
+            if b then c else d end)
+            ^^^^^^^^^^^^^^^^^^^^^^ Align the parameters of a method call if they span more than one line.
+        RUBY
+      end
+    end
   end
 
   context 'aligned with fixed indentation' do

--- a/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
@@ -387,6 +387,17 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
                  .methC
       RUBY
     end
+
+    context 'when using safe navigation operator', :ruby23 do
+      it 'registers an offense for misaligned )' do
+        expect_offense(<<-RUBY.strip_indent)
+          receiver&.some_method(
+            a
+            )
+            ^ Indent `)` to column 0 (not 2)
+        RUBY
+      end
+    end
   end
 
   context 'for method definitions' do

--- a/spec/rubocop/cop/layout/dot_position_spec.rb
+++ b/spec/rubocop/cop/layout/dot_position_spec.rb
@@ -103,6 +103,36 @@ RSpec.describe RuboCop::Cop::Layout::DotPosition, :config do
         RUBY
       end
     end
+
+    context 'when using safe navigation operator', :ruby23 do
+      it 'registers an offense for correct + opposite' do
+        expect_offense(<<-RUBY.strip_indent)
+          something
+            &.method_name
+          something&.
+                   ^^ Place the &. on the next line, together with the method name.
+            method_name
+        RUBY
+      end
+
+      it 'accepts leading do in multi-line method call' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          something
+            &.method_name
+        RUBY
+      end
+
+      it 'auto-corrects trailing dot in multi-line call' do
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+          something&.
+            method_name
+        RUBY
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          something
+            &.method_name
+        RUBY
+      end
+    end
   end
 
   context 'Trailing dots style' do
@@ -167,6 +197,34 @@ RSpec.describe RuboCop::Cop::Layout::DotPosition, :config do
         something.
           (1)
       RUBY
+    end
+
+    context 'when using safe navigation operator', :ruby23 do
+      it 'registers an offense for correct + opposite' do
+        expect_offense(<<-RUBY.strip_indent)
+        something
+          &.method_name
+          ^^ Place the &. on the previous line, together with the method call receiver.
+        RUBY
+      end
+
+      it 'accepts trailing dot in multi-line method call' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          something&.
+            method_name
+        RUBY
+      end
+
+      it 'auto-corrects leading dot in multi-line call' do
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+          something
+            &.method_name
+        RUBY
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          something&.
+            method_name
+        RUBY
+      end
     end
   end
 end

--- a/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
@@ -125,6 +125,19 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
         .to eq(['Empty line detected around arguments.'])
     end
 
+    context 'when using safe navigation operator', :ruby23 do
+      it 'registers offense for empty line before arg' do
+        inspect_source(<<-RUBY.strip_indent)
+          receiver&.foo(
+
+            bar
+          )
+        RUBY
+        expect(cop.messages)
+          .to eq(['Empty line detected around arguments.'])
+      end
+    end
+
     it 'autocorrects empty line detected at top' do
       corrected = autocorrect_source(<<-RUBY.strip_indent)
         foo(

--- a/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
@@ -24,6 +24,29 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak do
           baz)
       RUBY
     end
+
+    context 'when using safe navigation operator', :ruby23 do
+      it 'detects the offense' do
+        expect_offense(<<-RUBY.strip_indent)
+          receiver&.foo(bar,
+                        ^^^ Add a line break before the first argument of a multi-line method argument list.
+            baz)
+        RUBY
+      end
+
+      it 'autocorrects the offense' do
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+          receiver&.foo(bar,
+            baz)
+        RUBY
+
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          receiver&.foo(
+          bar,
+            baz)
+        RUBY
+      end
+    end
   end
 
   context 'hash arg spanning multiple lines' do

--- a/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
@@ -51,6 +51,18 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
         RUBY
       end
 
+      context 'when using safe navigation operator', :ruby23 do
+        it 'registers an offense for an under-indented first parameter' do
+          expect_offense(<<-RUBY.strip_indent)
+            receiver&.run(
+             :foo,
+             ^^^^ Indent the first parameter one step more than the start of the previous line.
+                bar: 3
+            )
+          RUBY
+        end
+      end
+
       it 'auto-corrects nested offenses' do
         new_source = autocorrect_source(<<-RUBY.strip_indent)
           foo(

--- a/spec/rubocop/cop/layout/indent_array_spec.rb
+++ b/spec/rubocop/cop/layout/indent_array_spec.rb
@@ -203,6 +203,18 @@ RSpec.describe RuboCop::Cop::Layout::IndentArray do
           RUBY
         end
 
+        context 'when using safe navigation operator', :ruby23 do
+          it "registers an offense for 'consistent' indentation" do
+            expect_offense(<<-RUBY.strip_indent)
+              receiver&.func([
+                1
+                ^ Use 2 spaces for indentation in an array, relative to the first position after the preceding left parenthesis.
+              ])
+              ^ Indent the right bracket the same as the first position after the preceding left parenthesis.
+            RUBY
+          end
+        end
+
         it "registers an offense for 'align_brackets' indentation" do
           expect_offense(<<-RUBY.strip_indent)
             var = [

--- a/spec/rubocop/cop/layout/indent_hash_spec.rb
+++ b/spec/rubocop/cop/layout/indent_hash_spec.rb
@@ -277,6 +277,18 @@ RSpec.describe RuboCop::Cop::Layout::IndentHash do
           RUBY
         end
 
+        context 'when using safe navigation operator', :ruby23 do
+          it "registers an offense for 'consistent' indentation" do
+            expect_offense(<<-RUBY.strip_indent)
+              receiver&.func({
+                a: 1
+                ^^^^ Use 2 spaces for indentation in a hash, relative to the first position after the preceding left parenthesis.
+              })
+              ^ Indent the right brace the same as the first position after the preceding left parenthesis.
+            RUBY
+          end
+        end
+
         it "registers an offense for 'align_braces' indentation" do
           expect_offense(<<-RUBY.strip_indent)
             var = {

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -1343,6 +1343,15 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
             }
           RUBY
         end
+
+        it 'registers an offense for an if with setter' do
+          expect_offense(<<-RUBY.strip_indent)
+            foo&.bar = if baz
+                         derp
+            ^^^^^^^^^^^^^ Use 2 (not 13) spaces for indentation.
+                       end
+          RUBY
+        end
       end
 
       # The cop uses the block end/} as the base for indentation, so if it's not

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -1334,6 +1334,17 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
         RUBY
       end
 
+      context 'when using safe navigation operator', :ruby23 do
+        it 'registers an offense for bad indentation of a {} body' do
+          expect_offense(<<-RUBY.strip_indent)
+            func {
+               receiver&.b
+            ^^^ Use 2 (not 3) spaces for indentation.
+            }
+          RUBY
+        end
+      end
+
       # The cop uses the block end/} as the base for indentation, so if it's not
       # on its own line, all bets are off.
       it 'accepts badly indented code if block end is not on separate line' do

--- a/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
@@ -27,6 +27,25 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeFirstArg, :config do
       RUBY
     end
 
+    context 'when using safe navigation operator', :ruby23 do
+      it 'registers an offense for method call with two spaces before the ' \
+         'first arg' do
+        expect_offense(<<-RUBY.strip_indent)
+          a&.something  y, z
+                      ^^ Put one space between the method name and the first argument.
+        RUBY
+      end
+
+      it 'auto-corrects extra space' do
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+          a&.something  y, z
+        RUBY
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          a&.something y, z
+        RUBY
+      end
+    end
+
     it 'registers an offense for method call with no spaces before the '\
        'first arg' do
       inspect_source(<<-RUBY.strip_indent)

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -67,6 +67,15 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Parenthesize the param `a { |el| puts el }` to make sure that the block will be associated with the `a` method call.
         RUBY
       end
+
+      context 'when using safe navigation operator', :ruby23 do
+        it 'registers an offense' do
+          expect_offense(<<-RUBY.strip_indent)
+            Foo&.some_method a { |el| puts el }
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Parenthesize the param `a { |el| puts el }` to make sure that the block will be associated with the `a` method call.
+          RUBY
+        end
+      end
     end
 
     context 'rspec expect {}.to change {}' do

--- a/spec/rubocop/cop/lint/each_with_object_argument_spec.rb
+++ b/spec/rubocop/cop/lint/each_with_object_argument_spec.rb
@@ -36,4 +36,13 @@ RSpec.describe RuboCop::Cop::Lint::EachWithObjectArgument do
   it 'accepts a string argument' do
     expect_no_offenses("collection.each_with_object('') { |e, a| a << e.to_s }")
   end
+
+  context 'when using safe navigation operator', :ruby23 do
+    it 'registers an offense for fixnum argument' do
+      expect_offense(<<-RUBY.strip_indent)
+        collection&.each_with_object(0) { |e, a| a + e }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The argument to each_with_object can not be immutable.
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -60,4 +60,14 @@ RSpec.describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression do
   it 'does not register an offense for a call with multiple arguments' do
     expect_no_offenses('assert_equal (0..1.9), acceleration.domain')
   end
+
+  context 'when using safe navigation operator', :ruby23 do
+    it 'registers an offense for method call with space before the ' \
+       'parenthesis' do
+      expect_offense(<<-RUBY.strip_indent)
+        a&.func (x)
+               ^ `(...)` interpreted as grouped expression.
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/lint/require_parentheses_spec.rb
+++ b/spec/rubocop/cop/lint/require_parentheses_spec.rb
@@ -29,6 +29,18 @@ RSpec.describe RuboCop::Cop::Lint::RequireParentheses do
     RUBY
   end
 
+  context 'when using safe navigation operator', :ruby23 do
+    it 'registers an offense for missing parentheses around expression with ' \
+       '&& operator' do
+      expect_offense(<<-RUBY.strip_indent)
+        if day&.is? 'monday' && month == :jan
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use parentheses in the method call to avoid confusion about precedence.
+          foo
+        end
+      RUBY
+    end
+  end
+
   it 'accepts missing parentheses around expression with + operator' do
     expect_no_offenses(<<-RUBY.strip_indent)
       if day_is? 'tuesday' + rest

--- a/spec/rubocop/cop/rails/active_record_aliases_spec.rb
+++ b/spec/rubocop/cop/rails/active_record_aliases_spec.rb
@@ -14,6 +14,22 @@ RSpec.describe RuboCop::Cop::Rails::ActiveRecordAliases do
         book.update(author: "Alice")
       RUBY
     end
+
+    context 'when using safe navigation operator', :ruby23 do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
+        book&.update_attributes(author: "Alice")
+              ^^^^^^^^^^^^^^^^^ Use `update` instead of `update_attributes`.
+        RUBY
+      end
+
+      it 'is autocorrected' do
+        new_source = autocorrect_source(
+          'book&.update_attributes(author: "Alice")'
+        )
+        expect(new_source).to eq 'book&.update(author: "Alice")'
+      end
+    end
   end
 
   describe '#update_attributes!' do

--- a/spec/rubocop/cop/rails/date_spec.rb
+++ b/spec/rubocop/cop/rails/date_spec.rb
@@ -28,6 +28,13 @@ RSpec.describe RuboCop::Cop::Rails::Date, :config do
         expect(cop.offenses.size).to eq(1)
       end
 
+      context 'when using safe navigation operator', :ruby23 do
+        it "registers an offense for ##{method}" do
+          inspect_source("date&.#{method}")
+          expect(cop.offenses.size).to eq(1)
+        end
+      end
+
       it "accepts variable named #{method}" do
         expect_no_offenses("#{method} = 1")
       end

--- a/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
+++ b/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
@@ -138,4 +138,16 @@ RSpec.describe RuboCop::Cop::Rails::DynamicFindBy, :config do
       User.find_by_sql(["select * from users where name = ?", name])
     RUBY
   end
+
+  context 'when using safe navigation operator', :ruby23 do
+    context 'with dynamic find_by_*' do
+      let(:source) { 'user&.find_by_name(name)' }
+
+      include_examples(
+        'register an offense and auto correct',
+        'Use `find_by` instead of dynamic `find_by_name`.',
+        'user&.find_by(name: name)'
+      )
+    end
+  end
 end

--- a/spec/rubocop/cop/rails/find_by_spec.rb
+++ b/spec/rubocop/cop/rails/find_by_spec.rb
@@ -28,4 +28,25 @@ RSpec.describe RuboCop::Cop::Rails::FindBy do
   it 'does not register an offense when using find_by' do
     expect_no_offenses('User.find_by(id: x)')
   end
+
+  it 'autocorrects where.take to find_by' do
+    new_source = autocorrect_source('User.where(id: x).take')
+
+    expect(new_source).to eq('User.find_by(id: x)')
+  end
+
+  it 'does not autocorrect where.first' do
+    new_source = autocorrect_source('User.where(id: x).first')
+
+    expect(new_source).to eq('User.where(id: x).first')
+  end
+
+  context 'when using safe navigation operator', :ruby23 do
+    it 'registers an offense when using `#first`' do
+      expect_offense(<<-RUBY.strip_indent)
+        User&.where(id: x).first
+              ^^^^^^^^^^^^^^^^^^ Use `find_by` instead of `where.first`.
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -60,6 +60,16 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
                 'if the return value is not checked.'])
     end
 
+    context 'when using safe navigation operator', :ruby23 do
+      it "when using #{method} without arguments" do
+        inspect_source("object&.#{method}")
+
+        expect(cop.messages)
+          .to eq(["Use `#{method}!` instead of `#{method}` " \
+        'if the return value is not checked.'])
+      end
+    end
+
     it "when using #{method}!" do
       expect_no_offenses("object.#{method}!")
     end
@@ -76,6 +86,14 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
       new_source = autocorrect_source("object.#{method}()")
 
       expect(new_source).to eq("object.#{method}!()")
+    end
+
+    context 'when using safe navigation operator', :ruby23 do
+      it 'autocorrects' do
+        new_source = autocorrect_source("object&.#{method}()")
+
+        expect(new_source).to eq("object&.#{method}!()")
+      end
     end
   end
 

--- a/spec/rubocop/cop/rails/skips_model_validations_spec.rb
+++ b/spec/rubocop/cop/rails/skips_model_validations_spec.rb
@@ -77,6 +77,15 @@ RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
              ^^^^^^^^^^^^^^^^ Avoid using `update_attribute` because it skips validations.
       RUBY
     end
+
+    context 'when using safe navigation operator', :ruby23 do
+      it 'registers an offense for `update_attribute`' do
+        expect_offense(<<-RUBY.strip_indent)
+        user&.update_attribute(:website, 'example.com')
+              ^^^^^^^^^^^^^^^^ Avoid using `update_attribute` because it skips validations.
+        RUBY
+      end
+    end
   end
 
   context 'with whitelist' do
@@ -92,6 +101,15 @@ RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
         user.toggle!(:active)
              ^^^^^^^ Avoid using `toggle!` because it skips validations.
       RUBY
+    end
+
+    context 'when using safe navigation operator', :ruby23 do
+      it 'registers an offense for method not in whitelist' do
+        expect_offense(<<-RUBY.strip_indent)
+        user&.toggle!(:active)
+              ^^^^^^^ Avoid using `toggle!` because it skips validations.
+        RUBY
+      end
     end
 
     it 'accepts method in whitelist, superseding the blacklist' do

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -53,6 +53,16 @@ RSpec.describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       RUBY
     end
 
+    context 'when using safe navigation operator', :ruby23 do
+      it 'registers an offense for one non-hash parameter followed by a hash ' \
+         'parameter with braces' do
+        expect_offense(<<-RUBY.strip_indent)
+          a&.where(1, { y: 2 })
+                      ^^^^^^^^ Redundant curly braces around a hash parameter.
+        RUBY
+      end
+    end
+
     it 'registers an offense for one object method hash parameter with ' \
        'braces' do
       expect_offense(<<-RUBY.strip_indent)

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -31,6 +31,15 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
+    context 'when using safe navigation operator', :ruby23 do
+      it 'register an offense for method call without parens' do
+        expect_offense(<<-RUBY.strip_indent)
+          top&.test a, b
+          ^^^^^^^^^^^^^^ Use parentheses for method calls with arguments.
+        RUBY
+      end
+    end
+
     it 'register an offense for non-receiver method call without parens' do
       expect_offense(<<-RUBY.strip_indent)
         def foo

--- a/spec/rubocop/cop/style/method_called_on_do_end_block_spec.rb
+++ b/spec/rubocop/cop/style/method_called_on_do_end_block_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe RuboCop::Cop::Style::MethodCalledOnDoEndBlock do
       RUBY
     end
 
+    context 'when using safe navigation operator', :ruby23 do
+      it 'registers an offense for a chained call' do
+        expect_offense(<<-RUBY.strip_indent)
+        a do
+          b
+        end&.c
+        ^^^^^^ Avoid chaining a method call on a do...end block.
+        RUBY
+      end
+    end
+
     it 'accepts it if there is no chained call' do
       expect_no_offenses(<<-RUBY.strip_indent)
         a do

--- a/spec/rubocop/cop/style/nested_parenthesized_calls_spec.rb
+++ b/spec/rubocop/cop/style/nested_parenthesized_calls_spec.rb
@@ -39,6 +39,22 @@ RSpec.describe RuboCop::Cop::Style::NestedParenthesizedCalls do
           puts(compute(something))
         RUBY
       end
+
+      context 'when using safe navigation operator', :ruby23 do
+        let(:source) { 'puts(receiver&.compute something)' }
+
+        it 'registers an offense' do
+          expect_offense(<<-RUBY.strip_indent)
+            puts(receiver&.compute something)
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add parentheses to nested method call `receiver&.compute something`.
+          RUBY
+        end
+
+        it 'auto-corrects by adding parentheses' do
+          new_source = autocorrect_source(source)
+          expect(new_source).to eq('puts(receiver&.compute(something))')
+        end
+      end
     end
 
     context 'with multiple arguments to the nested call' do

--- a/spec/rubocop/cop/style/preferred_hash_methods_spec.rb
+++ b/spec/rubocop/cop/style/preferred_hash_methods_spec.rb
@@ -24,6 +24,15 @@ RSpec.describe RuboCop::Cop::Style::PreferredHashMethods, :config do
       RUBY
     end
 
+    context 'when using safe navigation operator', :ruby23 do
+      it 'registers an offense for has_value? with one arg' do
+        expect_offense(<<-RUBY.strip_indent)
+        o&.has_value?(o)
+           ^^^^^^^^^^ Use `Hash#value?` instead of `Hash#has_value?`.
+        RUBY
+      end
+    end
+
     it 'accepts has_value? with no args' do
       expect_no_offenses('o.has_value?')
     end

--- a/spec/rubocop/cop/style/send_spec.rb
+++ b/spec/rubocop/cop/style/send_spec.rb
@@ -12,6 +12,15 @@ RSpec.describe RuboCop::Cop::Style::Send do
         RUBY
       end
 
+      context 'when using safe navigation operator', :ruby23 do
+        it 'registers an offense for an invocation with args' do
+          expect_offense(<<-RUBY.strip_indent)
+            Object&.send(:inspect)
+                    ^^^^ Prefer `Object#__send__` or `Object#public_send` to `send`.
+          RUBY
+        end
+      end
+
       it 'does not register an offense for an invocation without args' do
         expect_no_offenses('Object.send')
       end

--- a/spec/rubocop/cop/style/string_methods_spec.rb
+++ b/spec/rubocop/cop/style/string_methods_spec.rb
@@ -17,4 +17,19 @@ RSpec.describe RuboCop::Cop::Style::StringMethods, :config do
 
     expect(corrected).to eq("'something'.to_sym")
   end
+
+  context 'when using safe navigation operator', :ruby23 do
+    it 'registers an offense' do
+      expect_offense(<<-RUBY.strip_indent)
+      something&.intern
+                 ^^^^^^ Prefer `to_sym` over `intern`.
+      RUBY
+    end
+
+    it 'auto-corrects' do
+      corrected = autocorrect_source('something&.intern')
+
+      expect(corrected).to eq('something&.to_sym')
+    end
+  end
 end

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -73,6 +73,36 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
         HELP
       RUBY
     end
+
+    context 'when using safe navigation operator', :ruby23 do
+      it 'registers an offense for trailing comma in a method call' do
+        expect_offense(<<-RUBY.strip_indent)
+        receiver&.some_method(a, b, c, )
+                                     ^ Avoid comma after the last parameter of a method call#{extra_info}.
+        RUBY
+      end
+
+      it 'registers an offense for trailing comma in a method call with hash' \
+        ' parameters at the end' do
+        expect_offense(<<-RUBY.strip_indent)
+        receiver&.some_method(a, b, c: 0, d: 1, )
+                                              ^ Avoid comma after the last parameter of a method call#{extra_info}.
+        RUBY
+      end
+
+      it 'auto-corrects unwanted comma in a method call' do
+        new_source = autocorrect_source('receiver&.some_method(a, b, c, )')
+        expect(new_source).to eq('receiver&.some_method(a, b, c )')
+      end
+
+      it 'auto-corrects unwanted comma in a method call with hash parameters' \
+        ' at the end' do
+        new_source = autocorrect_source(
+          'receiver&.some_method(a, b, c: 0, d: 1, )'
+        )
+        expect(new_source).to eq('receiver&.some_method(a, b, c: 0, d: 1 )')
+      end
+    end
   end
 
   context 'with single line list of values' do


### PR DESCRIPTION
## Problem

Most of the cops do not detect `&.`(safe navigation operator) method offence.

For example, `Style/BracesAroundHashParameters` does not aware of code that uses `&.`.
:

```ruby
foo.test({ a: :b }) 
# => Adds an offence(Style/BracesAroundHashParameters).

foo&.test({ a: :b })
# => No offence. :(
```

(Tested by rubocop v0.62.0.)

This PR will solve some kind of this problem.

## Similar PR in past

* https://github.com/rubocop-hq/rubocop/pull/4837
    * It improved `Rails/OutputSafety`
    * https://github.com/rubocop-hq/rubocop/pull/4837/commits/1db479c23993bc4de5ce0dbf36fe427735d74c0e

## Listing target cops

I listed target cops from two perspectives:

1. Having `#on_send` but not having `#on_csend`.
2. Meaningful to implement(as far as **I thought** ).


## Target cops 👮👮👮

|                                      |           | 
|--------------------------------------|-----------| 
| Layout/AlignParameters               | c7fd520e7 | 
| Layout/ClosingParenthesisIndentation | 146e3bf90 | 
| Layout/DotPosition                   | 9d990874a | 
| Layout/EmptyLinesAroundArguments     | 826cfed92 | 
| Layout/FirstMethodArgumentLineBreak  | e8deefb72 | 
| Layout/FirstParameterIndentation     | e769ca6ab | 
| Layout/IndentArray                   | 578356550 | 
| Layout/IndentationWidth              | de1dc7f62 | 
| Layout/IndentHash                    | d7b56b83c | 
| Layout/SpaceBeforeFirstArg           | 3ae1e4ea9 | 
| Lint/AmbiguousBlockAssociation       | 9bcd5c801 | 
| Lint/EachWithObjectArgument          | 8e1945fa5 | 
| Lint/ParenthesesAsGroupedExpression  | bedcc2261 | 
| Lint/RequireParentheses              | fa699cbff | 
| Rails/ActiveRecordAliases            | b35a848c8 | 
| Rails/Date                           | 15da86271 | 
| Rails/DynamicFindBy                  | 55fc1a574 | 
| Rails/FindBy                         | dadab3d27 | 
| Rails/SaveBang                       | c1ec1d15d | 
| Rails/SkipsModelValidations          | a3ad8b65a | 
| Style/BracesAroundHashParameters     | d9599826a | 
| Style/MethodCalledOnDoEndBlock       | 995f4c1a0 | 
| Style/MethodCallWithArgsParentheses  | dcb3b34f0 | 
| Style/NestedParenthesizedCalls       | a28562217 | 
| Style/PreferredHashMethods           | 5fc114cf9 | 
| Style/Send                           | 4f6c20bb0 | 
| Style/StringMethods                  | 82402bc27 | 
| Style/TrailingCommaInArguments       | fcd785c5f | 


### TODO

- [ ] Squash commits if ok



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
