### PR TITLE
Add expect_no_corrections helper

### DIFF
--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -17,18 +17,8 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
             error
         end
       RUBY
-    end
 
-    it 'corrects the alignment' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
-        begin
-          something
-            rescue
-            error
-        end
-      RUBY
-
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect_correction(<<-RUBY.strip_indent)
         begin
           something
         rescue
@@ -48,18 +38,8 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
             error
         end
       RUBY
-    end
 
-    it 'corrects the alignment' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
-        def test
-          something
-            rescue
-            error
-        end
-      RUBY
-
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect_correction(<<-RUBY.strip_indent)
         def test
           something
         rescue
@@ -79,18 +59,8 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
             error
         end
       RUBY
-    end
 
-    it 'corrects the alignment' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
-        def Test.test
-          something
-            rescue
-            error
-        end
-      RUBY
-
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect_correction(<<-RUBY.strip_indent)
         def Test.test
           something
         rescue
@@ -110,18 +80,8 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
             error
         end
       RUBY
-    end
 
-    it 'corrects the alignment' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
-        class C
-          something
-            rescue
-            error
-        end
-      RUBY
-
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect_correction(<<-RUBY.strip_indent)
         class C
           something
         rescue
@@ -141,18 +101,8 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
             error
         end
       RUBY
-    end
 
-    it 'corrects the alignment' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
-        module M
-          something
-            rescue
-            error
-        end
-      RUBY
-
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect_correction(<<-RUBY.strip_indent)
         module M
           something
         rescue
@@ -172,18 +122,8 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
             error
         end
       RUBY
-    end
 
-    it 'corrects the alignment' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
-        begin
-          something
-            ensure
-            error
-        end
-      RUBY
-
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect_correction(<<-RUBY.strip_indent)
         begin
           something
         ensure
@@ -203,18 +143,8 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
             error
         end
       RUBY
-    end
 
-    it 'corrects the alignment' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
-        def test
-          something
-            ensure
-            error
-        end
-      RUBY
-
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect_correction(<<-RUBY.strip_indent)
         def test
           something
         ensure
@@ -234,18 +164,8 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
             error
         end
       RUBY
-    end
 
-    it 'corrects the alignment' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
-        def Test.test
-          something
-            ensure
-            error
-        end
-      RUBY
-
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect_correction(<<-RUBY.strip_indent)
         def Test.test
           something
         ensure
@@ -265,18 +185,8 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
             error
         end
       RUBY
-    end
 
-    it 'corrects the alignment' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
-        class C
-          something
-            ensure
-            error
-        end
-      RUBY
-
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect_correction(<<-RUBY.strip_indent)
         class C
           something
         ensure
@@ -296,18 +206,8 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
             error
         end
       RUBY
-    end
 
-    it 'corrects the alignment' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
-        module M
-          something
-            ensure
-            error
-        end
-      RUBY
-
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect_correction(<<-RUBY.strip_indent)
         module M
           something
         ensure
@@ -484,20 +384,8 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
             end
           end
         RUBY
-      end
 
-      it 'corrects the alignment' do
-        new_source = autocorrect_source(<<-RUBY.strip_indent)
-          def foo
-            [1, 2, 3].each do |el|
-              el.to_s
-          rescue StandardError => _exception
-              next
-            end
-          end
-        RUBY
-
-        expect(new_source).to eq(<<-RUBY.strip_indent)
+        expect_correction(<<-RUBY.strip_indent)
           def foo
             [1, 2, 3].each do |el|
               el.to_s
@@ -548,10 +436,8 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
             'baz'
           end
         RUBY
-      end
 
-      it 'correct alignment' do
-        expect_no_offenses(<<-RUBY.strip_indent)
+        expect_correction(<<-RUBY.strip_indent)
           private def test
             'foo'
           rescue
@@ -560,16 +446,8 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
         RUBY
       end
 
-      it 'corrects the alignment' do
-        new_source = autocorrect_source(<<-RUBY.strip_indent)
-          private def test
-            'foo'
-            rescue
-            'baz'
-          end
-        RUBY
-
-        expect(new_source).to eq(<<-RUBY.strip_indent)
+      it 'correct alignment' do
+        expect_no_offenses(<<-RUBY.strip_indent)
           private def test
             'foo'
           rescue
@@ -589,10 +467,8 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
             'baz'
           end
         RUBY
-      end
 
-      it 'correct alignment' do
-        expect_no_offenses(<<-RUBY.strip_indent)
+        expect_correction(<<-RUBY.strip_indent)
           private def Test.test
             'foo'
           rescue
@@ -601,16 +477,8 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
         RUBY
       end
 
-      it 'corrects the alignment' do
-        new_source = autocorrect_source(<<-RUBY.strip_indent)
-          private def Test.test
-            'foo'
-            rescue
-            'baz'
-          end
-        RUBY
-
-        expect(new_source).to eq(<<-RUBY.strip_indent)
+      it 'correct alignment' do
+        expect_no_offenses(<<-RUBY.strip_indent)
           private def Test.test
             'foo'
           rescue
@@ -630,10 +498,8 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
             'baz'
           end
         RUBY
-      end
 
-      it 'correct alignment' do
-        expect_no_offenses(<<-RUBY.strip_indent)
+        expect_correction(<<-RUBY.strip_indent)
           private def test
             'foo'
           ensure
@@ -642,16 +508,8 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
         RUBY
       end
 
-      it 'corrects the alignment' do
-        new_source = autocorrect_source(<<-RUBY.strip_indent)
-          private def test
-            'foo'
-            ensure
-            'baz'
-          end
-        RUBY
-
-        expect(new_source).to eq(<<-RUBY.strip_indent)
+      it 'correct alignment' do
+        expect_no_offenses(<<-RUBY.strip_indent)
           private def test
             'foo'
           ensure
@@ -671,10 +529,8 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
             'baz'
           end
         RUBY
-      end
 
-      it 'correct alignment' do
-        expect_no_offenses(<<-RUBY.strip_indent)
+        expect_correction(<<-RUBY.strip_indent)
           private def Test.test
             'foo'
           ensure
@@ -683,16 +539,8 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
         RUBY
       end
 
-      it 'corrects the alignment' do
-        new_source = autocorrect_source(<<-RUBY.strip_indent)
-          private def Test.test
-            'foo'
-            ensure
-            'baz'
-          end
-        RUBY
-
-        expect(new_source).to eq(<<-RUBY.strip_indent)
+      it 'correct alignment' do
+        expect_no_offenses(<<-RUBY.strip_indent)
           private def Test.test
             'foo'
           ensure
@@ -719,23 +567,8 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
             end
           end
         RUBY
-      end
 
-      it 'does not correct alignment' do
-        source = <<-RUBY.strip_indent
-          def test
-          'foo'; rescue; 'baz'
-          end
-
-          def test
-            begin
-            'foo'; rescue; 'baz'
-            end
-          end
-        RUBY
-
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(source)
+        expect_no_corrections
       end
     end
 
@@ -754,23 +587,8 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
             end
           end
         RUBY
-      end
 
-      it 'does not correct alignment' do
-        source = <<-RUBY.strip_indent
-          def test
-          'foo'; ensure; 'baz'
-          end
-
-          def test
-            begin
-            'foo'; ensure; 'baz'
-            end
-          end
-        RUBY
-
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(source)
+        expect_no_corrections
       end
     end
   end

--- a/spec/rubocop/cop/style/preferred_hash_methods_spec.rb
+++ b/spec/rubocop/cop/style/preferred_hash_methods_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe RuboCop::Cop::Style::PreferredHashMethods, :config do
         o.has_key?(o)
           ^^^^^^^^ Use `Hash#key?` instead of `Hash#has_key?`.
       RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        o.key?(o)
+      RUBY
     end
 
     it 'accepts has_key? with no args' do
@@ -22,29 +26,27 @@ RSpec.describe RuboCop::Cop::Style::PreferredHashMethods, :config do
         o.has_value?(o)
           ^^^^^^^^^^ Use `Hash#value?` instead of `Hash#has_value?`.
       RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        o.value?(o)
+      RUBY
     end
 
     context 'when using safe navigation operator', :ruby23 do
       it 'registers an offense for has_value? with one arg' do
         expect_offense(<<-RUBY.strip_indent)
-        o&.has_value?(o)
-           ^^^^^^^^^^ Use `Hash#value?` instead of `Hash#has_value?`.
+          o&.has_value?(o)
+             ^^^^^^^^^^ Use `Hash#value?` instead of `Hash#has_value?`.
+        RUBY
+
+        expect_correction(<<-RUBY.strip_indent)
+          o&.value?(o)
         RUBY
       end
     end
 
     it 'accepts has_value? with no args' do
       expect_no_offenses('o.has_value?')
-    end
-
-    it 'auto-corrects has_key? with key?' do
-      new_source = autocorrect_source('hash.has_key?(:test)')
-      expect(new_source).to eq('hash.key?(:test)')
-    end
-
-    it 'auto-corrects has_value? with value?' do
-      new_source = autocorrect_source('hash.has_value?(value)')
-      expect(new_source).to eq('hash.value?(value)')
     end
   end
 
@@ -55,6 +57,10 @@ RSpec.describe RuboCop::Cop::Style::PreferredHashMethods, :config do
       expect_offense(<<-RUBY.strip_indent)
         o.key?(o)
           ^^^^ Use `Hash#has_key?` instead of `Hash#key?`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        o.has_key?(o)
       RUBY
     end
 
@@ -67,20 +73,14 @@ RSpec.describe RuboCop::Cop::Style::PreferredHashMethods, :config do
         o.value?(o)
           ^^^^^^ Use `Hash#has_value?` instead of `Hash#value?`.
       RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        o.has_value?(o)
+      RUBY
     end
 
     it 'accepts value? with no args' do
       expect_no_offenses('o.value?')
-    end
-
-    it 'auto-corrects key? with has_key?' do
-      new_source = autocorrect_source('hash.key?(:test)')
-      expect(new_source).to eq('hash.has_key?(:test)')
-    end
-
-    it 'auto-corrects value? with has_value?' do
-      new_source = autocorrect_source('hash.value?(value)')
-      expect(new_source).to eq('hash.has_value?(value)')
     end
   end
 end

--- a/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
+++ b/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
         a, b, _ = foo()
               ^^ Do not use trailing `_`s in parallel assignment. Prefer `a, b, = foo()`.
       RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        a, b, = foo()
+      RUBY
     end
 
     it 'registers an offense when multiple underscores are used '\
@@ -18,12 +22,20 @@ RSpec.describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
         a, _, _ = foo()
            ^^^^^ Do not use trailing `_`s in parallel assignment. Prefer `a, = foo()`.
       RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        a, = foo()
+      RUBY
     end
 
     it 'registers an offense for splat underscore as the last variable' do
       expect_offense(<<-RUBY.strip_indent)
         a, *_ = foo()
            ^^^ Do not use trailing `_`s in parallel assignment. Prefer `a, = foo()`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        a, = foo()
       RUBY
     end
 
@@ -33,6 +45,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
         a, _, = foo()
            ^^^ Do not use trailing `_`s in parallel assignment. Prefer `a, = foo()`.
       RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        a, = foo()
+      RUBY
     end
 
     it 'registers an offense when underscore is the only variable ' \
@@ -41,6 +57,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
         _, = foo()
         ^^^^^ Do not use trailing `_`s in parallel assignment. Prefer `foo()`.
       RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        foo()
+      RUBY
     end
 
     it 'registers an offense for an underscore as the last param ' \
@@ -48,6 +68,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
       expect_offense(<<-RUBY.strip_indent)
         _, b, _ = foo()
               ^^ Do not use trailing `_`s in parallel assignment. Prefer `_, b, = foo()`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        _, b, = foo()
       RUBY
     end
 
@@ -90,6 +114,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
         a, *_, _, _ = foo()
            ^^^^^^^^^ Do not use trailing `_`s in parallel assignment. Prefer `a, = foo()`.
       RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        a, = foo()
+      RUBY
     end
 
     it 'registers an offense for nested assignments with trailing ' \
@@ -97,6 +125,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
       expect_offense(<<-RUBY.strip_indent)
         a, (b, _) = foo()
               ^^ Do not use trailing `_`s in parallel assignment. Prefer `a, (b,) = foo()`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        a, (b,) = foo()
       RUBY
     end
 
@@ -106,6 +138,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
         a, (_, (b, _), *_) = foo()
                   ^^ Do not use trailing `_`s in parallel assignment. Prefer `a, (_, (b,), *_) = foo()`.
                       ^^^ Do not use trailing `_`s in parallel assignment. Prefer `a, (_, (b, _),) = foo()`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        a, (_, (b,),) = foo()
       RUBY
     end
 
@@ -130,60 +166,6 @@ RSpec.describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
     end
 
     describe 'autocorrect' do
-      it 'removes trailing underscores automatically' do
-        new_source = autocorrect_source('a, b, _ = foo()')
-
-        expect(new_source).to eq('a, b, = foo()')
-      end
-
-      it 'removes trailing underscores and commas' do
-        new_source = autocorrect_source('a, b, _, = foo()')
-
-        expect(new_source).to eq('a, b, = foo()')
-      end
-
-      it 'removes multiple trailing underscores' do
-        new_source = autocorrect_source('a, _, _ = foo()')
-
-        expect(new_source).to eq('a, = foo()')
-      end
-
-      it 'removes trailing underscores and commas and preserves assignments' do
-        new_source = autocorrect_source('a, _, _, = foo()')
-
-        expect(new_source).to eq('a, = foo()')
-      end
-
-      it 'removes trailing comma when it is the only variable' do
-        new_source = autocorrect_source('_, = foo()')
-
-        expect(new_source).to eq('foo()')
-      end
-
-      it 'removes all assignments when every assignment is to `_`' do
-        new_source = autocorrect_source('_, _, _, = foo()')
-
-        expect(new_source).to eq('foo()')
-      end
-
-      it 'remove splat underscore' do
-        new_source = autocorrect_source('a, *_ = foo()')
-
-        expect(new_source).to eq('a, = foo()')
-      end
-
-      it 'removes underscores inside nested assignments' do
-        new_source = autocorrect_source('a, (b, _) = foo()')
-
-        expect(new_source).to eq('a, (b,) = foo()')
-      end
-
-      it 'removes trailing underscores inside complex nested assignments ' do
-        new_source = autocorrect_source('a, (_, (b, _), *_) = foo()')
-
-        expect(new_source).to eq('a, (_, (b,),) = foo()')
-      end
-
       context 'with parentheses' do
         it 'leaves parentheses but removes trailing underscores' do
           new_source = autocorrect_source('(a, b, _) = foo()')
@@ -263,6 +245,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
         a, b, _c = foo()
               ^^^ Do not use trailing `_`s in parallel assignment. Prefer `a, b, = foo()`.
       RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        a, b, = foo()
+      RUBY
     end
 
     it 'registers an offense for a named splat underscore ' \
@@ -270,6 +256,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
       expect_offense(<<-RUBY.strip_indent)
         a, *_b = foo()
            ^^^^ Do not use trailing `_`s in parallel assignment. Prefer `a, = foo()`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        a, = foo()
       RUBY
     end
 
@@ -284,6 +274,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
         a, *_b, _ = foo()
            ^^^^^^^ Do not use trailing `_`s in parallel assignment. Prefer `a, = foo()`.
       RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        a, = foo()
+      RUBY
     end
 
     it 'registers an offense for an underscore preceded by ' \
@@ -291,6 +285,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
       expect_offense(<<-RUBY.strip_indent)
         a, b, *_c, _ = foo()
               ^^^^^^^ Do not use trailing `_`s in parallel assignment. Prefer `a, b, = foo()`.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        a, b, = foo()
       RUBY
     end
 
@@ -300,32 +298,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
         a, *_b, _, _ = foo()
            ^^^^^^^^^^ Do not use trailing `_`s in parallel assignment. Prefer `a, = foo()`.
       RUBY
-    end
 
-    context 'autocorrect' do
-      it 'removes named underscore variables' do
-        new_source = autocorrect_source('a, _b = foo()')
-
-        expect(new_source).to eq('a, = foo()')
-      end
-
-      it 'removes named splat underscore variables' do
-        new_source = autocorrect_source('a, *_b = foo()')
-
-        expect(new_source).to eq('a, = foo()')
-      end
-
-      it 'removes named splat underscore and named underscore variables' do
-        new_source = autocorrect_source('a, *_b, _c = foo()')
-
-        expect(new_source).to eq('a, = foo()')
-      end
-
-      it 'works when last underscore is followed by a comma' do
-        new_source = autocorrect_source('a, _, = foo()')
-
-        expect(new_source).to eq('a, = foo()')
-      end
+      expect_correction(<<-RUBY.strip_indent)
+        a, = foo()
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/unneeded_capital_w_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_capital_w_spec.rb
@@ -16,6 +16,21 @@ RSpec.describe RuboCop::Cop::Style::UnneededCapitalW do
       %W(cat dog)
       ^^^^^^^^^^^ Do not use `%W` unless interpolation is needed. If not, use `%w`.
     RUBY
+
+    expect_correction(<<-RUBY.strip_indent)
+      %w(cat dog)
+    RUBY
+  end
+
+  it 'registers an offense for misused %W with different bracket' do
+    expect_offense(<<-RUBY.strip_indent)
+      %W[cat dog]
+      ^^^^^^^^^^^ Do not use `%W` unless interpolation is needed. If not, use `%w`.
+    RUBY
+
+    expect_correction(<<-RUBY.strip_indent)
+      %w[cat dog]
+    RUBY
   end
 
   it 'registers no offense for %W with interpolation' do
@@ -69,15 +84,5 @@ RSpec.describe RuboCop::Cop::Style::UnneededCapitalW do
 
   it 'does not register an offense for array with empty strings' do
     expect_no_offenses('["", "two", "three"]')
-  end
-
-  it 'auto-corrects an array of words' do
-    new_source = autocorrect_source('%W(one two three)')
-    expect(new_source).to eq('%w(one two three)')
-  end
-
-  it 'auto-corrects an array of words with different bracket' do
-    new_source = autocorrect_source('%W[one two three]')
-    expect(new_source).to eq('%w[one two three]')
   end
 end

--- a/spec/rubocop/cop/style/unneeded_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_interpolation_spec.rb
@@ -8,12 +8,20 @@ RSpec.describe RuboCop::Cop::Style::UnneededInterpolation do
       "#{1 + 1}"
       ^^^^^^^^^^ Prefer `to_s` over string interpolation.
     RUBY
+
+    expect_correction(<<-'RUBY'.strip_indent)
+      (1 + 1).to_s
+    RUBY
   end
 
   it 'registers an offense for "%|#{1 + 1}|"' do
     expect_offense(<<-'RUBY'.strip_indent)
       %|#{1 + 1}|
       ^^^^^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
+
+    expect_correction(<<-'RUBY'.strip_indent)
+      (1 + 1).to_s
     RUBY
   end
 
@@ -22,12 +30,20 @@ RSpec.describe RuboCop::Cop::Style::UnneededInterpolation do
       %Q(#{1 + 1})
       ^^^^^^^^^^^^ Prefer `to_s` over string interpolation.
     RUBY
+
+    expect_correction(<<-'RUBY'.strip_indent)
+      (1 + 1).to_s
+    RUBY
   end
 
   it 'registers an offense for "#{1 + 1; 2 + 2}"' do
     expect_offense(<<-'RUBY'.strip_indent)
       "#{1 + 1; 2 + 2}"
       ^^^^^^^^^^^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
+
+    expect_correction(<<-'RUBY'.strip_indent)
+      (1 + 1; 2 + 2).to_s
     RUBY
   end
 
@@ -36,12 +52,20 @@ RSpec.describe RuboCop::Cop::Style::UnneededInterpolation do
       "#{@var}"
       ^^^^^^^^^ Prefer `to_s` over string interpolation.
     RUBY
+
+    expect_correction(<<-'RUBY'.strip_indent)
+      @var.to_s
+    RUBY
   end
 
   it 'registers an offense for "#@var"' do
     expect_offense(<<-'RUBY'.strip_indent)
       "#@var"
       ^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
+
+    expect_correction(<<-'RUBY'.strip_indent)
+      @var.to_s
     RUBY
   end
 
@@ -50,12 +74,20 @@ RSpec.describe RuboCop::Cop::Style::UnneededInterpolation do
       "#{@@var}"
       ^^^^^^^^^^ Prefer `to_s` over string interpolation.
     RUBY
+
+    expect_correction(<<-'RUBY'.strip_indent)
+      @@var.to_s
+    RUBY
   end
 
   it 'registers an offense for "#@@var"' do
     expect_offense(<<-'RUBY'.strip_indent)
       "#@@var"
       ^^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
+
+    expect_correction(<<-'RUBY'.strip_indent)
+      @@var.to_s
     RUBY
   end
 
@@ -64,12 +96,20 @@ RSpec.describe RuboCop::Cop::Style::UnneededInterpolation do
       "#{$var}"
       ^^^^^^^^^ Prefer `to_s` over string interpolation.
     RUBY
+
+    expect_correction(<<-'RUBY'.strip_indent)
+      $var.to_s
+    RUBY
   end
 
   it 'registers an offense for "#$var"' do
     expect_offense(<<-'RUBY'.strip_indent)
       "#$var"
       ^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
+
+    expect_correction(<<-'RUBY'.strip_indent)
+      $var.to_s
     RUBY
   end
 
@@ -78,12 +118,20 @@ RSpec.describe RuboCop::Cop::Style::UnneededInterpolation do
       "#{$1}"
       ^^^^^^^ Prefer `to_s` over string interpolation.
     RUBY
+
+    expect_correction(<<-'RUBY'.strip_indent)
+      $1.to_s
+    RUBY
   end
 
   it 'registers an offense for "#$1"' do
     expect_offense(<<-'RUBY'.strip_indent)
       "#$1"
       ^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
+
+    expect_correction(<<-'RUBY'.strip_indent)
+      $1.to_s
     RUBY
   end
 
@@ -92,12 +140,20 @@ RSpec.describe RuboCop::Cop::Style::UnneededInterpolation do
       "#{$+}"
       ^^^^^^^ Prefer `to_s` over string interpolation.
     RUBY
+
+    expect_correction(<<-'RUBY'.strip_indent)
+      $+.to_s
+    RUBY
   end
 
   it 'registers an offense for "#$+"' do
     expect_offense(<<-'RUBY'.strip_indent)
       "#$+"
       ^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
+
+    expect_correction(<<-'RUBY'.strip_indent)
+      $+.to_s
     RUBY
   end
 
@@ -106,12 +162,20 @@ RSpec.describe RuboCop::Cop::Style::UnneededInterpolation do
       var = 1; "#{var}"
                ^^^^^^^^ Prefer `to_s` over string interpolation.
     RUBY
+
+    expect_correction(<<-'RUBY'.strip_indent)
+      var = 1; var.to_s
+    RUBY
   end
 
   it 'registers an offense for ["#{@var}"]' do
     expect_offense(<<-'RUBY'.strip_indent)
       ["#{@var}", 'foo']
        ^^^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
+
+    expect_correction(<<-'RUBY'.strip_indent)
+      [@var.to_s, 'foo']
     RUBY
   end
 
@@ -133,25 +197,5 @@ RSpec.describe RuboCop::Cop::Style::UnneededInterpolation do
 
   it 'accepts strings that are part of a %W()' do
     expect_no_offenses('%W(#{@var} foo)')
-  end
-
-  it 'autocorrects "#{1 + 1; 2 + 2}"' do
-    corrected = autocorrect_source('"#{1 + 1; 2 + 2}"')
-    expect(corrected).to eq '(1 + 1; 2 + 2).to_s'
-  end
-
-  it 'autocorrects "#@var"' do
-    corrected = autocorrect_source('"#@var"')
-    expect(corrected).to eq '@var.to_s'
-  end
-
-  it 'autocorrects "#{var}"' do
-    corrected = autocorrect_source('var = 1; "#{var}"')
-    expect(corrected).to eq 'var = 1; var.to_s'
-  end
-
-  it 'autocorrects "#{@var}"' do
-    corrected = autocorrect_source('"#{@var}"')
-    expect(corrected).to eq '@var.to_s'
   end
 end

--- a/spec/rubocop/cop/style/while_until_do_spec.rb
+++ b/spec/rubocop/cop/style/while_until_do_spec.rb
@@ -9,12 +9,22 @@ RSpec.describe RuboCop::Cop::Style::WhileUntilDo do
                  ^^ Do not use `do` with multi-line `while`.
       end
     RUBY
+
+    expect_correction(<<-RUBY.strip_indent)
+      while cond
+      end
+    RUBY
   end
 
   it 'registers an offense for do in multiline until' do
     expect_offense(<<-RUBY.strip_indent)
       until cond do
                  ^^ Do not use `do` with multi-line `until`.
+      end
+    RUBY
+
+    expect_correction(<<-RUBY.strip_indent)
+      until cond
       end
     RUBY
   end
@@ -36,28 +46,6 @@ RSpec.describe RuboCop::Cop::Style::WhileUntilDo do
 
   it 'accepts multi-line until without do' do
     expect_no_offenses(<<-RUBY.strip_indent)
-      until cond
-      end
-    RUBY
-  end
-
-  it 'auto-corrects the usage of "do" in multiline while' do
-    new_source = autocorrect_source(<<-RUBY.strip_indent)
-      while cond do
-      end
-    RUBY
-    expect(new_source).to eq(<<-RUBY.strip_indent)
-      while cond
-      end
-    RUBY
-  end
-
-  it 'auto-corrects the usage of "do" in multiline until' do
-    new_source = autocorrect_source(<<-RUBY.strip_indent)
-      until cond do
-      end
-    RUBY
-    expect(new_source).to eq(<<-RUBY.strip_indent)
       until cond
       end
     RUBY


### PR DESCRIPTION
I have added `expect_no_corrections` helper, similar to the `expect_no_offenses` one. 
It can be used after an `expect_offense` to indicate a non-auto-correctable offense. Useful for cops that can correct only some of the offenses they report. 

Converted some more example to `expect_correction` / `expect_no_corrections` 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] ~Added tests.~
* [x] ~Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).~
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
