### PR TITLE
[Fix #6755] Prevent Style/TrailingCommaInArgument from breaking when a safe method call is chained on the offending method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#6763](https://github.com/rubocop-hq/rubocop/pull/6763): Fix false positives in range literals for `Style/MethodCallWithArgsParentheses` `omit_parentheses`. ([@gsamokovarov][])
 * [#6748](https://github.com/rubocop-hq/rubocop/issues/6748): Fix `Style/RaiseArgs` auto-correction breaking in contexts that require parentheses. ([@drenmi][])
 * [#6751](https://github.com/rubocop-hq/rubocop/issues/6751): Prevent `Style/OneLineConditional` from breaking on `retry` and `break` keywords. ([@drenmi][])
+* [#6755](https://github.com/rubocop-hq/rubocop/issues/6755): Prevent `Style/TrailingCommaInArgument` from breaking when a safe method call is chained on the offending method. ([@drenmi][], [@hoshinotsuyoshi][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -91,7 +91,7 @@ module RuboCop
       end
 
       def method_name_and_arguments_on_same_line?(node)
-        node.send_type? &&
+        %i[send csend].include?(node.type) &&
           node.loc.selector.line == node.arguments.last.last_line &&
           node.last_line == node.arguments.last.last_line
       end
@@ -104,7 +104,7 @@ module RuboCop
       end
 
       def elements(node)
-        return node.children unless node.send_type?
+        return node.children unless %i[csend send].include?(node.type)
 
         node.arguments.flat_map do |argument|
           # For each argument, if it is a multi-line hash without braces,

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -416,6 +416,31 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
           )
         RUBY
       end
+
+      it 'does not break when a method call is chaned on the offending one' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo.bar(
+            baz: 1,
+          ).fetch(:qux)
+        RUBY
+      end
+
+      it 'does not break when a safe method call is chained on the ' \
+         'offending one', :ruby23 do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo
+            &.do_something(:bar, :baz)
+        RUBY
+      end
+
+      it 'does not break when a safe method call is chained on the ' \
+         'offending one', :ruby23 do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo.bar(
+            baz: 1,
+          )&.fetch(:qux)
+        RUBY
+      end
     end
 
     context 'when EnforcedStyleForMultiline is consistent_comma' do


### PR DESCRIPTION
This cop would error out on code like:

```
foo.bar(
  baz: 1,
)&.fetch(:qux)
```

This was happening because the cop wasn't taking `csend` (safe navigation) node types into consideration.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
