### PR TITLE
[Fix #6748] Fix Style/RaiseArgs auto-correction breaking in contexts that require parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#6748](https://github.com/rubocop-hq/rubocop/issues/6748): Fix `Style/RaiseArgs` auto-correction breaking in contexts that require parentheses. ([@drenmi][])
+
 ## 0.64.0 (2019-02-10)
 
 ### New features

--- a/lib/rubocop/cop/style/raise_args.rb
+++ b/lib/rubocop/cop/style/raise_args.rb
@@ -66,12 +66,14 @@ module RuboCop
         def correction_compact_to_exploded(node)
           exception_node, _new, message_node = *node.first_argument
 
-          message = message_node && message_node.source
+          arguments =
+            [exception_node, message_node].compact.map(&:source).join(', ')
 
-          correction = exception_node.source
-          correction = "#{correction}, #{message}" if message
-
-          "#{node.method_name} #{correction}"
+          if node.parent && requires_parens?(node.parent)
+            "#{node.method_name}(#{arguments})"
+          else
+            "#{node.method_name} #{arguments}"
+          end
         end
 
         def correction_exploded_to_compact(node)
@@ -79,7 +81,12 @@ module RuboCop
           return node.source if message_nodes.size > 1
 
           argument = message_nodes.first.source
-          "#{node.method_name} #{exception_node.const_name}.new(#{argument})"
+
+          if node.parent && requires_parens?(node.parent)
+            "#{node.method_name}(#{exception_node.const_name}.new(#{argument}))"
+          else
+            "#{node.method_name} #{exception_node.const_name}.new(#{argument})"
+          end
         end
 
         def check_compact(node)
@@ -118,6 +125,11 @@ module RuboCop
           # Allow code like `raise Ex.new(kw: arg)`.
           # Allow code like `raise Ex.new(*args)`.
           arg.hash_type? || arg.splat_type?
+        end
+
+        def requires_parens?(parent)
+          parent.and_type? || parent.or_type? ||
+            parent.if_type? && parent.ternary?
         end
 
         def message(node)

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -20,6 +20,45 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
       end
     end
 
+    context 'when used in a ternary expression' do
+      it 'registers an offense and auto-corrects' do
+        expect_offense(<<-RUBY.strip_indent)
+          foo ? raise(Ex, 'error') : bar
+                ^^^^^^^^^^^^^^^^^^ Provide an exception object as an argument to `raise`.
+        RUBY
+
+        expect_correction(<<-RUBY.strip_indent)
+          foo ? raise(Ex.new('error')) : bar
+        RUBY
+      end
+    end
+
+    context 'when used in a logical and expression' do
+      it 'registers an offense and auto-corrects' do
+        expect_offense(<<-RUBY.strip_indent)
+          bar && raise(Ex, 'error')
+                 ^^^^^^^^^^^^^^^^^^ Provide an exception object as an argument to `raise`.
+        RUBY
+
+        expect_correction(<<-RUBY.strip_indent)
+          bar && raise(Ex.new('error'))
+        RUBY
+      end
+    end
+
+    context 'when used in a logical or expression' do
+      it 'registers an offense and auto-corrects' do
+        expect_offense(<<-RUBY.strip_indent)
+          bar || raise(Ex, 'error')
+                 ^^^^^^^^^^^^^^^^^^ Provide an exception object as an argument to `raise`.
+        RUBY
+
+        expect_correction(<<-RUBY.strip_indent)
+          bar || raise(Ex.new('error'))
+        RUBY
+      end
+    end
+
     context 'with correct + opposite' do
       it 'reports an offense' do
         expect_offense(<<-RUBY.strip_indent)
@@ -108,6 +147,45 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
         it 'auto-corrects to exploded style' do
           new_source = autocorrect_source('raise Ex.new')
           expect(new_source).to eq('raise Ex')
+        end
+      end
+
+      context 'when used in a ternary expression' do
+        it 'registers an offense and auto-corrects' do
+          expect_offense(<<-RUBY.strip_indent)
+            foo ? raise(Ex.new('error')) : bar
+                  ^^^^^^^^^^^^^^^^^^^^^^ Provide an exception class and message as arguments to `raise`.
+          RUBY
+
+          expect_correction(<<-RUBY.strip_indent)
+            foo ? raise(Ex, 'error') : bar
+          RUBY
+        end
+      end
+
+      context 'when used in a logical and expression' do
+        it 'registers an offense and auto-corrects' do
+          expect_offense(<<-RUBY.strip_indent)
+            bar && raise(Ex.new('error'))
+                   ^^^^^^^^^^^^^^^^^^^^^^ Provide an exception class and message as arguments to `raise`.
+          RUBY
+
+          expect_correction(<<-RUBY.strip_indent)
+            bar && raise(Ex, 'error')
+          RUBY
+        end
+      end
+
+      context 'when used in a logical or expression' do
+        it 'registers an offense and auto-corrects' do
+          expect_offense(<<-RUBY.strip_indent)
+            bar || raise(Ex.new('error'))
+                   ^^^^^^^^^^^^^^^^^^^^^^ Provide an exception class and message as arguments to `raise`.
+          RUBY
+
+          expect_correction(<<-RUBY.strip_indent)
+            bar || raise(Ex, 'error')
+          RUBY
         end
       end
     end


### PR DESCRIPTION
This cop would produce invalid code, such as:

```
foo ? bar : raise FooError, 'baz'
```

in contexts where the call to `raise` requires parentheses. This change fixes that by adding parentheses, making the correction:

```
foo ? bar : raise(FooError, 'baz')
```

This treatment is applied in ternaries and when used in logical operators.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
