### PR TITLE
Fix typo in ReflectionClassName Cop

### DIFF
--- a/lib/rubocop/cop/rails/reflection_class_name.rb
+++ b/lib/rubocop/cop/rails/reflection_class_name.rb
@@ -14,7 +14,7 @@ module RuboCop
       #   # good
       #   has_many :accounts, class_name: 'Account'
       class ReflectionClassName < Cop
-        MSG = 'Use a string has value for a class_name.'.freeze
+        MSG = 'Use a string value for `class_name`.'.freeze
 
         def_node_matcher :association_with_options?, <<-PATTERN
           (send nil? {:has_many :has_one :belongs_to} _ (hash $...))

--- a/spec/rubocop/cop/rails/reflection_class_name_spec.rb
+++ b/spec/rubocop/cop/rails/reflection_class_name_spec.rb
@@ -9,28 +9,28 @@ RSpec.describe RuboCop::Cop::Rails::ReflectionClassName do
     it 'has_many' do
       expect_offense(<<-RUBY.strip_indent)
       has_many :accounts, class_name: Account, foreign_key: :account_id
-                          ^^^^^^^^^^^^^^^^^^^ Use a string has value for a class_name.
+                          ^^^^^^^^^^^^^^^^^^^ Use a string value for `class_name`.
       RUBY
     end
 
     it '.name' do
       expect_offense(<<-RUBY.strip_indent)
       has_many :accounts, class_name: Account.name
-                          ^^^^^^^^^^^^^^^^^^^^^^^^ Use a string has value for a class_name.
+                          ^^^^^^^^^^^^^^^^^^^^^^^^ Use a string value for `class_name`.
       RUBY
     end
 
     it 'has_one' do
       expect_offense(<<-RUBY.strip_indent)
       has_one :account, class_name: Account
-                        ^^^^^^^^^^^^^^^^^^^ Use a string has value for a class_name.
+                        ^^^^^^^^^^^^^^^^^^^ Use a string value for `class_name`.
       RUBY
     end
 
     it 'belongs_to' do
       expect_offense(<<-RUBY.strip_indent)
       belongs_to :account, class_name: Account
-                           ^^^^^^^^^^^^^^^^^^^ Use a string has value for a class_name.
+                           ^^^^^^^^^^^^^^^^^^^ Use a string value for `class_name`.
       RUBY
     end
   end


### PR DESCRIPTION
Hi,

I'm not an English native speaker but the `has` in `Use a string has value for a class_name.` looks like a typo to me

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
