### PR TITLE
Specify `stable` to build image on Read the Docs

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,2 +1,5 @@
+build:
+    image: stable
+
 formats:
     - htmlzip


### PR DESCRIPTION
http://www.rubocop.org seems to be redirecting to Read the Docs.
https://docs.rubocop.org

By default, Read the Docs refers to `latest` (i.e. master branch).
https://docs.readthedocs.io/en/latest/config-file/v1.html#build-image

Here is the `latest` docs.
https://docs.rubocop.org/en/latest

However I think RuboCop users expect `stable` docs.
https://docs.rubocop.org/en/stable

This idea was what @pocke taught me before. Thanks!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
