### PR TITLE
Allow parens for calls in range literals (Style/MethodCallWithArgsParentheses)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* [#6763](https://github.com/rubocop-hq/rubocop/pull/6763): Fix false positives in range literals for `Style/MethodCallWithArgsParentheses` `omit_parentheses`. ([@gsamokovarov]][])
 * [#6748](https://github.com/rubocop-hq/rubocop/issues/6748): Fix `Style/RaiseArgs` auto-correction breaking in contexts that require parentheses. ([@drenmi][])
 
 ## 0.64.0 (2019-02-10)

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -259,13 +259,16 @@ module RuboCop
             allowed_chained_call_with_parentheses?(node)
         end
 
+        # rubocop:disable Metrics/CyclomaticComplexity
         def call_in_literals?(node)
           node.parent &&
             (node.parent.pair_type? ||
              node.parent.array_type? ||
+             node.parent.irange_type? || node.parent.erange_type? ||
              splat?(node.parent) ||
              ternary_if?(node.parent))
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         def call_in_logical_operators?(node)
           node.parent &&

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -512,6 +512,13 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
+    it 'accepts parens in range literals' do
+      expect_no_offenses(<<-RUBY)
+        1..limit(n)
+        1...limit(n)
+      RUBY
+    end
+
     it 'auto-corrects single-line calls' do
       original = <<-RUBY.strip_indent
         top.test(1, 2, foo: bar(3))


### PR DESCRIPTION
With the style of `omit_parentheses` in the `Style/MethodCallWithArgsParentheses` cop, we got:

Before:

```ruby
1..limit(n)
        ^^^ Omit parentheses for method calls with arguments.
```

After:

```ruby
1..limit(n)
```

👌