### PR TITLE
Allow parens for optional keyword value calls in Style/MethodCallWithArgsParentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug fixes
 
+* [#6765](https://github.com/rubocop-hq/rubocop/pull/6765): Fix false positives in keyword arguments for `Style/MethodCallWithArgsParentheses` `omit_parentheses`. ([@gsamokovarov]][])
 * [#6763](https://github.com/rubocop-hq/rubocop/pull/6763): Fix false positives in range literals for `Style/MethodCallWithArgsParentheses` `omit_parentheses`. ([@gsamokovarov]][])
 * [#6748](https://github.com/rubocop-hq/rubocop/issues/6748): Fix `Style/RaiseArgs` auto-correction breaking in contexts that require parentheses. ([@drenmi][])
 

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -278,7 +278,8 @@ module RuboCop
         end
 
         def call_in_optional_arguments?(node)
-          node.parent && node.parent.optarg_type?
+          node.parent &&
+            (node.parent.optarg_type? || node.parent.kwoptarg_type?)
         end
 
         def call_with_ambiguous_arguments?(node)

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -410,6 +410,18 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
+    it 'accepts parens in default keyword argument value calls' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def regular(arg: default(42))
+          nil
+        end
+
+        def seatle_style arg: default(42)
+          nil
+        end
+      RUBY
+    end
+
     it 'accepts parens in method args' do
       expect_no_offenses('top.test 1, 2, foo: bar(3)')
     end


### PR DESCRIPTION
Yet-another-edge-case for the `omit_parentheses` style.

---

Before:

```ruby
def foo(bar: baz(42))
                ^^^^ Omit parentheses for method calls with arguments.
end
```

After:

```ruby
def foo(bar: baz(42))
end
```