### PR TITLE
Drop Ruby 2.2.0 and 2.2.1 to use Psych 3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#6748](https://github.com/rubocop-hq/rubocop/issues/6748): Fix `Style/RaiseArgs` auto-correction breaking in contexts that require parentheses. ([@drenmi][])
 
+### Changes
+
+* [#6766](https://github.com/rubocop-hq/rubocop/pull/6766): Drop support for Ruby 2.2.0 and 2.2.1. ([@pocke][])
+
 ## 0.64.0 (2019-02-10)
 
 ### New features

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -183,8 +183,7 @@ module RuboCop
         if defined?(SafeYAML) && SafeYAML.respond_to?(:load)
           SafeYAML.load(yaml_code, filename,
                         whitelisted_tags: %w[!ruby/regexp])
-        # Ruby 2.6+
-        elsif Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1')
+        else
           YAML.safe_load(
             yaml_code,
             permitted_classes: [Regexp, Symbol],
@@ -192,8 +191,6 @@ module RuboCop
             aliases: false,
             filename: filename
           )
-        else
-          YAML.safe_load(yaml_code, [Regexp, Symbol], [], false, filename)
         end
       end
     end

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.name = 'rubocop'
   s.version = RuboCop::Version::STRING
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.2.0'
+  s.required_ruby_version = '>= 2.2.2'
   s.authors = ['Bozhidar Batsov', 'Jonas Arvidsson', 'Yuji Nakayama']
   s.description = <<-DESCRIPTION
     Automatic Ruby code style checking tool.
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('parallel', '~> 1.10')
   s.add_runtime_dependency('parser', '>= 2.5', '!= 2.5.1.1')
   s.add_runtime_dependency('powerpack', '~> 0.1')
+  s.add_runtime_dependency('psych', '>= 3.1.0')
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '~> 1.4.0')


### PR DESCRIPTION
see https://github.com/rubocop-hq/rubocop/pull/6733#discussion_r254700697


This pull request drops supporting Ruby 2.2.0 and 2.2.1 to use Psych 3.1.

Parameter style of `YAML.load` has been changed since Psych 3.1. Psych 3.1 still supports the old parameter style, but it displays a warning. So we need to change the behaviour between Psych 3.1 and others to avoid the warning. We can delete the branch by dropping old versions of Psych.

And Psych 3.1 also has a location feature. I'd like to use the feature in #6733.



Note: I'd like to drop Ruby 2.2 also. Personally, I think we can drop it after Ruby 2.3 EOL, it is March 2019.
I'm looking forward to using Safe Navigation Operator in RuboCop! :wink:  


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
