### PR TITLE
[Fix #6493] `Layout/FirstMethodArgumentLineBreak` for multi-line single argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changes
 
 * [#5977](https://github.com/rubocop-hq/rubocop/issues/5977): Warn for Performance Cops. ([@koic][])
+* [#6493](https://github.com/rubocop-hq/rubocop/issues/6493): Fix `Layout/FirstMethodArgumentLineBreak` for multi-line single argument. ([@marcotc][])
+* [#6699](https://github.com/rubocop-hq/rubocop/issues/6699): Fix infinite loop for `Layout/IndentationWidth` and `Layout/IndentationConsistency` when bad modifier indentation before good method definition. ([@koic][])
 
 ## 0.66.0 (2019-03-18)
 

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -464,7 +464,10 @@ module RuboCop
       end
 
       def argument?
-        parent && parent.send_type? && parent.arguments.include?(self)
+        # TODO: Adds support safe navigator calls.
+        # TODO: Discuss with maintainers if this should be applied 'everywhere'
+        parent && (parent.send_type? || parent.csend_type?) &&
+          parent.arguments.include?(self)
       end
 
       def numeric_type?

--- a/lib/rubocop/cop/layout/first_method_argument_line_break.rb
+++ b/lib/rubocop/cop/layout/first_method_argument_line_break.rb
@@ -46,7 +46,19 @@ module RuboCop
         alias on_csend on_send
 
         def autocorrect(node)
-          EmptyLineCorrector.insert_before(node)
+          lambda do |corrector|
+            first_arg = if node.argument?
+                          node
+                        else
+                          # In case of keyword arguments
+                          node.parent
+                        end
+
+            block_start_col = first_arg.parent.source_range.column
+
+            corrector.insert_before(first_arg.source_range,
+                                    "\n#{' ' * block_start_col}")
+          end
         end
       end
     end

--- a/lib/rubocop/cop/mixin/first_element_line_break.rb
+++ b/lib/rubocop/cop/mixin/first_element_line_break.rb
@@ -21,6 +21,14 @@ module RuboCop
       end
 
       def check_children_line_break(node, children, start = node)
+        return if children.empty?
+
+        return add_offense(children.first) if children.first.multiline?
+
+        check_multiple_children_line_break(children, start)
+      end
+
+      def check_multiple_children_line_break(children, start)
         return if children.size < 2
 
         line = start.first_line

--- a/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
@@ -95,6 +95,33 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak do
     end
   end
 
+  context 'single arg spanning multiple lines' do
+    it 'detects the offense' do
+      expect_offense(<<-RUBY.strip_indent)
+        foo([
+            ^ Add a line break before the first argument of a multi-line method argument list.
+        ])
+      RUBY
+    end
+
+    it 'autocorrects the offense' do
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        begin
+          foo([
+          ])
+        end
+      RUBY
+
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        begin
+          foo(
+          [
+          ])
+        end
+      RUBY
+    end
+  end
+
   it 'ignores arguments listed on a single line' do
     expect_no_offenses('foo(bar, baz, bing)')
   end


### PR DESCRIPTION
As per #6493, `Layout/FirstMethodArgumentLineBreak` did not consider a single multi-line argument as a valid trigger for a "multi-line method call" (a condition necessary for the cop to activate).

It works correctly with many arguments spanning many lines, but not with a single argument spanning many lines.

This PR addresses this issue. This affects methods with a single multi-line literal, array, hash, or proc-like parameter.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
