### PR TITLE
add specs for Layout/RescueEnsureAlignment fix c8ab8d9 from #6254

### DIFF
--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -364,6 +364,28 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
     RUBY
   end
 
+  context 'rescue with assigned begin' do
+    it 'accepts variable-aligned rescue in or-assigned begin-end block' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        @bar ||= begin
+          expensive_method
+        rescue StandardError
+          fall_back
+        end
+      RUBY
+    end
+
+    it 'accepts variable-aligned rescue in assigned begin-end block' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        @bar = begin
+          expensive_method
+        rescue StandardError
+          fall_back
+        end
+      RUBY
+    end
+  end
+
   context '>= Ruby 2.5', :ruby25 do
     it 'accepts aligned rescue in do-end block' do
       expect_no_offenses(<<-RUBY.strip_indent)


### PR DESCRIPTION
This PR demonstrates that there are still unexpected issues with `Layout/RescueEnsureAlignment` even after issue #6254 was resolved. I'm not familiar enough with Rubocop internals to resolve the issue, but the specs still failing include the original test case from @ashmaroli.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
