### PR TITLE
Add `range_type?` which means `irange_type?` and `erange_type?`

### DIFF
--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -471,6 +471,10 @@ module RuboCop
         int_type? || float_type?
       end
 
+      def range_type?
+        irange_type? || erange_type?
+      end
+
       def_node_matcher :guard_clause?, <<-PATTERN
         [{(send nil? {:raise :fail} ...) return break next} single_line?]
       PATTERN

--- a/lib/rubocop/cop/correctors/for_to_each_corrector.rb
+++ b/lib/rubocop/cop/correctors/for_to_each_corrector.rb
@@ -36,7 +36,7 @@ module RuboCop
       end
 
       def requires_parentheses?
-        collection_node.irange_type? || collection_node.erange_type?
+        collection_node.range_type?
       end
 
       def end_position

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -278,7 +278,7 @@ module RuboCop
         end
 
         def array_or_range?(node)
-          node.array_type? || node.irange_type? || node.erange_type?
+          node.array_type? || node.range_type?
         end
       end
     end

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -259,16 +259,14 @@ module RuboCop
             allowed_chained_call_with_parentheses?(node)
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity
         def call_in_literals?(node)
           node.parent &&
             (node.parent.pair_type? ||
              node.parent.array_type? ||
-             node.parent.irange_type? || node.parent.erange_type? ||
+             node.parent.range_type? ||
              splat?(node.parent) ||
              ternary_if?(node.parent))
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
         def call_in_logical_operators?(node)
           node.parent &&

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -131,8 +131,7 @@ module RuboCop
         end
 
         def requires_parentheses?(node)
-          node.irange_type? ||
-            node.erange_type? ||
+          node.range_type? ||
             (node.send_type? && node.loc.dot.nil?)
         end
 

--- a/spec/rubocop/ast/range_node_spec.rb
+++ b/spec/rubocop/ast/range_node_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe RuboCop::AST::RangeNode do
       end
 
       it { expect(range_node.is_a?(described_class)).to be(true) }
+      it { expect(range_node.range_type?).to be(true) }
     end
 
     context 'with an exclusive range' do
@@ -18,6 +19,7 @@ RSpec.describe RuboCop::AST::RangeNode do
       end
 
       it { expect(range_node.is_a?(described_class)).to be(true) }
+      it { expect(range_node.range_type?).to be(true) }
     end
 
     context 'with an infinite range' do
@@ -27,6 +29,7 @@ RSpec.describe RuboCop::AST::RangeNode do
       end
 
       it { expect(range_node.is_a?(described_class)).to be(true) }
+      it { expect(range_node.range_type?).to be(true) }
     end
   end
 end


### PR DESCRIPTION
Follow up of https://github.com/rubocop-hq/rubocop/pull/6126#discussion_r255288410.

This PR adds `range_type?` method which means both `irange_type?` method and `erange_type?` method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
