### PR TITLE
Improve specs thanks to rspectre

### DIFF
--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -10,15 +10,10 @@ RSpec.describe 'RuboCop Project', type: :feature do
       .map(&:cop_name)
   end
 
-  shared_context 'configuration file' do |config_path|
-    subject(:config) { RuboCop::ConfigLoader.load_file(config_path) }
+  describe 'default configuration file' do
+    subject(:config) { RuboCop::ConfigLoader.load_file('config/default.yml') }
 
     let(:configuration_keys) { config.keys }
-    let(:raw_configuration) { config.to_h.values }
-  end
-
-  describe 'default configuration file' do
-    include_context 'configuration file', 'config/default.yml'
 
     it 'has configuration for all cops' do
       expect(configuration_keys).to match_array(%w[AllCops Rails] + cop_names)

--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -39,11 +39,6 @@ RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
   end
 
   context 'When gems are not alphabetically sorted' do
-    let(:source) { <<-RUBY.strip_indent }
-      gem 'rubocop'
-      gem 'rspec'
-    RUBY
-
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)
         gem 'rubocop'
@@ -71,12 +66,6 @@ RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
   end
 
   context 'When a gem declaration takes several lines' do
-    let(:source) { <<-RUBY.strip_indent }
-      gem 'rubocop',
-          '0.1.1'
-      gem 'rspec'
-    RUBY
-
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)
         gem 'rubocop',
@@ -153,14 +142,6 @@ RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
   end
 
   context 'When gem groups is separated by multiline comment' do
-    let(:source) { <<-RUBY.strip_indent }
-      # For code quality
-      gem 'rubocop'
-      # For
-      # test
-      gem 'rspec'
-    RUBY
-
     context 'with TreatCommentsAsGroupSeparators: true' do
       let(:treat_comments_as_group_separators) { true }
 
@@ -242,11 +223,6 @@ RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
   end
 
   context 'When a gem that starts with a capital letter is not sorted' do
-    let(:source) { <<-RUBY.strip_indent }
-      gem 'Z'
-      gem 'a'
-    RUBY
-
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)
         gem 'Z'
@@ -262,16 +238,6 @@ RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
   end
 
   context 'When there are duplicated gems in group' do
-    let(:source) { <<-RUBY.strip_indent }
-      gem 'a'
-
-      group :development do
-        gem 'b'
-        gem 'c'
-        gem 'b'
-      end
-    RUBY
-
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)
         gem 'a'

--- a/spec/rubocop/cop/gemspec/ordered_dependencies_spec.rb
+++ b/spec/rubocop/cop/gemspec/ordered_dependencies_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::Gemspec::OrderedDependencies, :config do
     end
   end
 
-  include_examples 'ordered dependency', 'add_dependency' do
+  it_behaves_like 'ordered dependency', 'add_dependency' do
     let(:offense_message) { <<-RUBY.strip_indent }
       Gem::Specification.new do |spec|
         spec.add_dependency 'rubocop'
@@ -135,7 +135,7 @@ RSpec.describe RuboCop::Cop::Gemspec::OrderedDependencies, :config do
     RUBY
   end
 
-  include_examples 'ordered dependency', 'add_runtime_dependency' do
+  it_behaves_like 'ordered dependency', 'add_runtime_dependency' do
     let(:offense_message) { <<-RUBY.strip_indent }
       Gem::Specification.new do |spec|
         spec.add_runtime_dependency 'rubocop'
@@ -156,7 +156,7 @@ RSpec.describe RuboCop::Cop::Gemspec::OrderedDependencies, :config do
     RUBY
   end
 
-  include_examples 'ordered dependency', 'add_development_dependency' do
+  it_behaves_like 'ordered dependency', 'add_development_dependency' do
     let(:offense_message) { <<-RUBY.strip_indent }
       Gem::Specification.new do |spec|
         spec.add_development_dependency 'rubocop'

--- a/spec/rubocop/cop/layout/multiline_array_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_array_brace_layout_spec.rb
@@ -20,17 +20,17 @@ RSpec.describe RuboCop::Cop::Layout::MultilineArrayBraceLayout, :config do
     expect_no_offenses('[]')
   end
 
-  include_examples 'multiline literal brace layout' do
+  it_behaves_like 'multiline literal brace layout' do
     let(:open) { '[' }
     let(:close) { ']' }
   end
 
-  include_examples 'multiline literal brace layout method argument' do
+  it_behaves_like 'multiline literal brace layout method argument' do
     let(:open) { '[' }
     let(:close) { ']' }
   end
 
-  include_examples 'multiline literal brace layout trailing comma' do
+  it_behaves_like 'multiline literal brace layout trailing comma' do
     let(:open) { '[' }
     let(:close) { ']' }
   end

--- a/spec/rubocop/cop/layout/multiline_array_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_array_brace_layout_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe RuboCop::Cop::Layout::MultilineArrayBraceLayout, :config do
   it_behaves_like 'multiline literal brace layout method argument' do
     let(:open) { '[' }
     let(:close) { ']' }
+    let(:a) { 'a: 1' }
+    let(:b) { 'b: 2' }
   end
 
   it_behaves_like 'multiline literal brace layout trailing comma' do

--- a/spec/rubocop/cop/layout/multiline_hash_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_hash_brace_layout_spec.rb
@@ -40,8 +40,6 @@ RSpec.describe RuboCop::Cop::Layout::MultilineHashBraceLayout, :config do
     let(:close) { '}' }
     let(:a) { 'a: 1' }
     let(:b) { 'b: 2' }
-    let(:multi_prefix) { 'b: ' }
-    let(:multi) { ['[', '1', ']'] }
   end
 
   it_behaves_like 'multiline literal brace layout trailing comma' do

--- a/spec/rubocop/cop/layout/multiline_hash_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_hash_brace_layout_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineHashBraceLayout, :config do
     expect_no_offenses('{}')
   end
 
-  include_examples 'multiline literal brace layout' do
+  it_behaves_like 'multiline literal brace layout' do
     let(:open) { '{' }
     let(:close) { '}' }
     let(:a) { 'a: 1' }
@@ -35,7 +35,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineHashBraceLayout, :config do
     end
   end
 
-  include_examples 'multiline literal brace layout method argument' do
+  it_behaves_like 'multiline literal brace layout method argument' do
     let(:open) { '{' }
     let(:close) { '}' }
     let(:a) { 'a: 1' }
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineHashBraceLayout, :config do
     let(:multi) { ['[', '1', ']'] }
   end
 
-  include_examples 'multiline literal brace layout trailing comma' do
+  it_behaves_like 'multiline literal brace layout trailing comma' do
     let(:open) { '{' }
     let(:close) { '}' }
     let(:a) { 'a: 1' }

--- a/spec/rubocop/cop/layout/multiline_method_call_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_brace_layout_spec.rb
@@ -31,12 +31,12 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallBraceLayout, :config do
     RUBY
   end
 
-  include_examples 'multiline literal brace layout' do
+  it_behaves_like 'multiline literal brace layout' do
     let(:open) { 'foo(' }
     let(:close) { ')' }
   end
 
-  include_examples 'multiline literal brace layout trailing comma' do
+  it_behaves_like 'multiline literal brace layout trailing comma' do
     let(:open) { 'foo(' }
     let(:close) { ')' }
   end

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -3,11 +3,6 @@
 RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
   subject(:cop) { described_class.new }
 
-  let(:error_message) do
-    'Parenthesize the param `%s` to make sure that the block will be ' \
-      'associated with the `%s` method call.'
-  end
-
   shared_examples 'accepts' do |code|
     it 'does not register an offense' do
       expect_no_offenses(code)

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
     let(:code) { code }
 
     it "accepts usages of #{name}" do
-      expect_no_offenses(code)
+      expect_no_offenses(source)
     end
   end
 

--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
   subject(:cop) { described_class.new(config) }
 
+  let(:cop_config) { { 'AllowImplicitReturn' => true } }
+
   shared_examples 'checks_common_offense' do |method|
     it "when using #{method} with arguments" do
       inspect_source("object.#{method}(name: 'Tom', age: 20)")
@@ -515,8 +517,6 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
   end
 
   described_class::MODIFY_PERSIST_METHODS.each do |method|
-    let(:cop_config) { { 'AllowImplicitReturn' => true } }
-
     context method.to_s do
       it_behaves_like('checks_common_offense', method)
       it_behaves_like('checks_variable_return_use_offense', method, true)
@@ -553,8 +553,6 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
   end
 
   described_class::CREATE_PERSIST_METHODS.each do |method|
-    let(:cop_config) { { 'AllowImplicitReturn' => true } }
-
     context method.to_s do
       it_behaves_like('checks_common_offense', method)
       it_behaves_like('checks_variable_return_use_offense', method, false)

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -2139,91 +2139,75 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
   context 'EndAlignment configured to start_of_line' do
     subject(:cop) { described_class.new(config) }
 
-    let(:config) do
-      RuboCop::Config.new('Style/ConditionalAssignment' => {
-                            'Enabled' => true,
-                            'SingleLineConditionsOnly' => false,
-                            'IncludeTernaryExpressions' => true
-                          },
-                          'Layout/EndAlignment' => {
-                            'EnforcedStyleAlignWith' => 'start_of_line',
-                            'Enabled' => true
-                          },
-                          'Metrics/LineLength' => {
-                            'Max' => 80,
-                            'Enabled' => true
-                          })
+    context 'auto-correct' do
+      it 'uses proper end alignment in if' do
+        source = <<-RUBY.strip_indent
+          if foo
+            a =  b
+          elsif bar
+            a = c
+          else
+            a = d
+          end
+        RUBY
 
-      context 'auto-correct' do
-        it 'uses proper end alignment in if' do
-          source = <<-RUBY.strip_indent
-            if foo
-              a =  b
-            elsif bar
-              a = c
-            else
-              a = d
-            end
-          RUBY
+        new_source = autocorrect_source(source)
 
-          new_source = autocorrect_source(source)
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          a = if foo
+            b
+          elsif bar
+            c
+          else
+            d
+          end
+        RUBY
+      end
 
-          expect(new_source).to eq(<<-RUBY.strip_indent)
-            a = if foo
-              b
-            elsif bar
-              c
-            else
-              d
-            end
-          RUBY
-        end
+      it 'uses proper end alignment in unless' do
+        source = <<-RUBY.strip_indent
+          unless foo
+            a = b
+          else
+            a = d
+          end
+        RUBY
 
-        it 'uses proper end alignment in unless' do
-          source = <<-RUBY.strip_indent
-            unless foo
-              a = b
-            else
-              a = d
-            end
-          RUBY
+        new_source = autocorrect_source(source)
 
-          new_source = autocorrect_source(source)
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          a = unless foo
+            b
+          else
+            d
+          end
+        RUBY
+      end
 
-          expect(new_source).to eq(<<-RUBY.strip_indent)
-            a = unless foo
-              b
-            else
-              d
-            end
-          RUBY
-        end
+      it 'uses proper end alignment in case' do
+        source = <<-RUBY.strip_indent
+          case foo
+          when bar
+            a = b
+          when baz
+            a = c
+          else
+            a = d
+          end
+        RUBY
 
-        it 'uses proper end alignment in case' do
-          source = <<-RUBY.strip_indent
-            case foo
-            when bar
-              a = b
-            when baz
-              a = c
-            else
-              a = d
-            end
-          RUBY
+        new_source = autocorrect_source(source)
 
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq(<<-RUBY.strip_indent)
-            a = case foo
-            when bar
-              b
-            when baz
-              c
-            else
-              d
-            end
-          RUBY
-        end
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          a = case foo
+          when bar
+            b
+          when baz
+            c
+          else
+            d
+          end
+        RUBY
       end
     end
   end

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -1089,7 +1089,6 @@ RSpec.describe RuboCop::NodePattern do
   describe 'commas' do
     context 'with commas randomly strewn around' do
       let(:pattern) { ',,(,send,, ,int,:+, int ), ' }
-      let(:ruby) { '1 + 2' }
 
       it_behaves_like 'invalid'
     end

--- a/spec/support/multiline_literal_brace_layout_method_argument_examples.rb
+++ b/spec/support/multiline_literal_brace_layout_method_argument_examples.rb
@@ -26,6 +26,8 @@ shared_examples_for 'multiline literal brace layout method argument' do
     end
 
     context 'but no comment after the last element' do
+      let(:b_comment) { '' }
+
       it 'autocorrects the closing brace' do
         new_source = autocorrect_source(source)
 


### PR DESCRIPTION
I tried running the amazing :sparkles:[rspectre](https://github.com/dgollahon/rspectre):sparkles: tool against our spec suite, and discovered a few different problems:

 - A few `let`s were no longer being used.
 - A `shared_context` was only being used once.
 - The same `let` was being defined twice within the same context.
 - One `let` had its `end` misplaced, and was thus wrapping an entire block of examples that have therefore never been run…
 - Some `shared_examples` called by `include_examples` caused the issue that [the RSpec documentation](https://relishapp.com/rspec/rspec-core/docs/example-groups/shared-examples) warns against:

> When you include parameterized examples in the current context multiple times, you may override previous method definitions and last declaration wins.

@dgollahon @Darhazer Would some of these issues be discoverable by rubocop-rspec? We could e.g. warn on a `let` inside a `shared_example`…

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
