### PR TITLE
Allow Rails/ReflectionClassName to use symbol argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#6800](https://github.com/rubocop-hq/rubocop/issues/6800): Fix an incorrect auto-correct for `Rails/Validation` when method arguments are enclosed in parentheses. ([@koic][])
 * [#6808](https://github.com/rubocop-hq/rubocop/issues/6808): Prevent false positive in `Naming/ConstantName` when assigning a frozen range. ([@drenmi][])
 * Fix the calculation of `Metrics/AbcSize`. Comparison methods and `else` branches add to the comparison count. ([@rrosenblum][])
+* [#6791](https://github.com/rubocop-hq/rubocop/pull/6791): Allow `Rails/ReflectionClassName` to use symbol argument for `class_name`. ([@unasuke][])
 
 ### Changes
 
@@ -3853,3 +3854,4 @@
 [@Bhacaz]: https://github.com/bhacaz
 [@enkessler]: https://github.com/enkessler
 [@tagliala]: https://github.com/tagliala
+[@unasuke]: https://github.com/unasuke

--- a/lib/rubocop/cop/rails/reflection_class_name.rb
+++ b/lib/rubocop/cop/rails/reflection_class_name.rb
@@ -21,7 +21,7 @@ module RuboCop
         PATTERN
 
         def_node_search :reflection_class_name, <<-PATTERN
-          (pair (sym :class_name) !str)
+          (pair (sym :class_name) [!str !sym])
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/rails/reflection_class_name_spec.rb
+++ b/spec/rubocop/cop/rails/reflection_class_name_spec.rb
@@ -42,4 +42,12 @@ RSpec.describe RuboCop::Cop::Rails::ReflectionClassName do
       belongs_to :account, class_name: 'Account'
     RUBY
   end
+
+  it 'does not register an offense when using symbol for `class_name`' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      has_many :accounts, class_name: :Account, foreign_key: :account_id
+      has_one :account, class_name: :Account
+      belongs_to :account, class_name: :Account
+    RUBY
+  end
 end


### PR DESCRIPTION
```ruby
belongs_to :account, class_name: :Account
```

Rails/ReflectionClassName ( introduced from #6704 ) offences that code, but symbol is also uses as string so I think this code has no offences by the cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
