### PR TITLE
[Fix #6699] Fix a false negative for `Layout/IndentationWidth`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#6699](https://github.com/rubocop-hq/rubocop/issues/6699): Fix infinite loop for `Layout/IndentationWidth` and `Layout/IndentationConsistency` when bad modifier indentation before good method definition. ([@koic][])
+
 ### Changes
 
 * [#6688](https://github.com/rubocop-hq/rubocop/pull/6688): Add `iterator?` to deprecated methods and prefer `block_given?` instead. ([@tejasbubane][])

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -54,6 +54,10 @@ module RuboCop
 
         SPECIAL_MODIFIERS = %w[private protected].freeze
 
+        def_node_matcher :access_modifier?, <<-PATTERN
+          [(send ...) access_modifier?]
+        PATTERN
+
         def on_rescue(node)
           _begin_node, *_rescue_nodes, else_node = *node
           check_indentation(node.loc.else, else_node)
@@ -161,21 +165,35 @@ module RuboCop
         private
 
         def check_members(base, members)
-          check_indentation(base, members.first)
+          check_indentation(base, select_check_member(members.first))
 
           return unless members.any? && members.first.begin_type?
 
           if indentation_consistency_style == 'rails'
-            each_member(members) do |member, previous_modifier|
-              check_indentation(previous_modifier, member,
-                                indentation_consistency_style)
-            end
+            check_members_for_rails_style(members)
           else
             members.first.children.each do |member|
               next if member.send_type? && member.access_modifier?
 
               check_indentation(base, member)
             end
+          end
+        end
+
+        def select_check_member(member)
+          return unless member
+
+          if access_modifier?(member.children.first)
+            member.children.first
+          else
+            member
+          end
+        end
+
+        def check_members_for_rails_style(members)
+          each_member(members) do |member, previous_modifier|
+            check_indentation(previous_modifier, member,
+                              indentation_consistency_style)
           end
         end
 

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -986,12 +986,18 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       #{e}:1:1: C: Style/Documentation: Missing top-level class documentation comment.
       #{e}:2:1: C: [Corrected] Layout/AccessModifierIndentation: Indent access modifiers like `private`.
       #{e}:2:1: C: [Corrected] Layout/EmptyLinesAroundAccessModifier: Keep a blank line after `private`.
+      #{e}:2:1: C: [Corrected] Layout/IndentationWidth: Use 2 (not 0) spaces for indentation.
+      #{e}:2:1: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
       #{e}:2:3: W: Lint/UselessAccessModifier: Useless `private` access modifier.
+      #{e}:2:5: C: [Corrected] Layout/AccessModifierIndentation: Indent access modifiers like `private`.
       #{e}:3:7: C: [Corrected] Style/MutableConstant: Freeze mutable objects assigned to constants.
       #{e}:3:7: C: [Corrected] Style/WordArray: Use `%w` or `%W` for an array of words.
       #{e}:3:8: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
       #{e}:3:15: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
       #{e}:3:21: C: [Corrected] Style/TrailingCommaInArrayLiteral: Avoid comma after the last item of an array.
+      #{e}:4:1: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
+      #{e}:4:3: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected.
+      #{e}:4:5: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected.
       #{e}:4:7: C: [Corrected] Style/WordArray: Use `%w` or `%W` for an array of words.
     RESULT
   end

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -1072,6 +1072,28 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
             end
           RUBY
         end
+
+        it 'registers an offense and corrects for bad modifier indentation ' \
+           'before good method definition' do
+          expect_offense(<<-RUBY.strip_indent)
+            class Foo
+                  private
+            ^^^^^^ Use 2 (not 6) spaces for indentation.
+
+              def foo
+              end
+            end
+          RUBY
+
+          expect_correction(<<-RUBY.strip_indent)
+            class Foo
+              private
+
+              def foo
+              end
+            end
+          RUBY
+        end
       end
 
       context 'when consistency style is normal' do


### PR DESCRIPTION
Fixes #6699.

This PR fixes infinite loop for `Layout/IndentationWidth` and `Layout/IndentationConsistency` when bad modifier indentation before good method definition.

```ruby
# exmaple.rb
class Foo
      private

  def foo
  end
end
```

First, auto-corrected by `Layout/IndentationConsistency`.

```console
% rubocop -v
0.65.0
% rubocop -a --only Layout/IndentationConsistency example.rb
Inspecting 1 file
C

Offenses:

example.rb:4:3: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected.
  def foo ...
  ^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
```

```diff
% g diff
diff --git a/example.rb b/example.rb
index 23d3556..974f101 100644
--- a/example.rb
+++ b/example.rb
@@ -1,6 +1,6 @@
 class Foo
       private

-  def foo
-  end
+      def foo
+      end
 end
```

Next, auto-corrected by `Layout/IndentationWidth`.

```console
% rubocop -a --only Layout/IndentationWidth example.rb
Inspecting 1 file
C

Offenses:

example.rb:4:1: C: [Corrected] Layout/IndentationWidth: Use 2 (not 6)
spaces for indentation.
      def foo
^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
```

This will return to the original code.

```diff
% g diff
diff --git a/example.rb b/example.rb
index 974f101..23d3556 100644
--- a/example.rb
+++ b/example.rb
@@ -1,6 +1,6 @@
 class Foo
       private

-      def foo
-      end
+  def foo
+  end
 end
```

That caused the infinite loop in `Layout/IndentationConsistency` and `Layout/IndentationWidth`.

With this PR, `Layout/indentationWidth` cop makes aware of the bad modifier indentation before good method definition.

```console
% rubocop -a --only Layout/IndentationWidth example.rb
Inspecting 1 file
C

Offenses:

example.rb:2:1: C: [Corrected] Layout/IndentationWidth: Use 2 (not 6)
spaces for indentation.
      private
^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
```

```diff
diff --git a/example.rb b/example.rb
index 23d3556..07525ec 100644
--- a/example.rb
+++ b/example.rb
@@ -1,5 +1,5 @@
 class Foo
-      private
+  private

   def foo
   end
```

This PR fixes the above false negative. That would be an auto-correct expected.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
