### PR TITLE
[Fix #6777] Fix a false positive for `Style/TrivialAccessors`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#6699](https://github.com/rubocop-hq/rubocop/issues/6699): Fix infinite loop for `Layout/IndentationWidth` and `Layout/IndentationConsistency` when bad modifier indentation before good method definition. ([@koic][])
+* [#6777](https://github.com/rubocop-hq/rubocop/issues/6777): Fix a false positive for `Style/TrivialAccessors` when using trivial reader/writer methods at the top level. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -31,6 +31,7 @@ module RuboCop
         MSG = 'Use `attr_%<kind>s` to define trivial %<kind>s methods.'.freeze
 
         def on_def(node)
+          return if top_level_node?(node)
           return if in_module_or_instance_eval?(node)
           return if ignore_class_methods? && node.defs_type?
 
@@ -179,6 +180,10 @@ module RuboCop
                "#{indent}end"].join("\n")
             )
           end
+        end
+
+        def top_level_node?(node)
+          node.parent.nil?
         end
       end
     end

--- a/spec/rubocop/cop/style/trivial_accessors_spec.rb
+++ b/spec/rubocop/cop/style/trivial_accessors_spec.rb
@@ -7,50 +7,64 @@ RSpec.describe RuboCop::Cop::Style::TrivialAccessors, :config do
 
   it 'registers an offense on instance reader' do
     expect_offense(<<-RUBY.strip_indent)
-      def foo
-      ^^^ Use `attr_reader` to define trivial reader methods.
-        @foo
+      class Foo
+        def foo
+        ^^^ Use `attr_reader` to define trivial reader methods.
+          @foo
+        end
       end
     RUBY
 
     expect_correction(<<-RUBY.strip_indent)
-      attr_reader :foo
+      class Foo
+        attr_reader :foo
+      end
     RUBY
   end
 
   it 'registers an offense on instance writer' do
     expect_offense(<<-RUBY.strip_indent)
-      def foo=(val)
-      ^^^ Use `attr_writer` to define trivial writer methods.
-        @foo = val
+      class Foo
+        def foo=(val)
+        ^^^ Use `attr_writer` to define trivial writer methods.
+          @foo = val
+        end
       end
     RUBY
 
     expect_correction(<<-RUBY.strip_indent)
-      attr_writer :foo
+      class Foo
+        attr_writer :foo
+      end
     RUBY
   end
 
   it 'registers an offense on class reader' do
     expect_offense(<<-RUBY.strip_indent)
-      def self.foo
-      ^^^ Use `attr_reader` to define trivial reader methods.
-        @foo
+      class Foo
+        def self.foo
+        ^^^ Use `attr_reader` to define trivial reader methods.
+          @foo
+        end
       end
     RUBY
 
     expect_correction(<<-RUBY.strip_indent)
-      class << self
-        attr_reader :foo
+      class Foo
+        class << self
+          attr_reader :foo
+        end
       end
     RUBY
   end
 
   it 'registers an offense on class writer' do
     expect_offense(<<-RUBY.strip_indent)
-      def self.foo(val)
-      ^^^ Use `attr_writer` to define trivial writer methods.
-        @foo = val
+      class Foo
+        def self.foo(val)
+        ^^^ Use `attr_writer` to define trivial writer methods.
+          @foo = val
+        end
       end
     RUBY
 
@@ -59,45 +73,59 @@ RSpec.describe RuboCop::Cop::Style::TrivialAccessors, :config do
 
   it 'registers an offense on reader with braces' do
     expect_offense(<<-RUBY.strip_indent)
-      def foo()
-      ^^^ Use `attr_reader` to define trivial reader methods.
-        @foo
+      class Foo
+        def foo()
+        ^^^ Use `attr_reader` to define trivial reader methods.
+          @foo
+        end
       end
     RUBY
 
     expect_correction(<<-RUBY.strip_indent)
-      attr_reader :foo
+      class Foo
+        attr_reader :foo
+      end
     RUBY
   end
 
   it 'registers an offense on writer without braces' do
     expect_offense(<<-RUBY.strip_indent)
-      def foo= val
-      ^^^ Use `attr_writer` to define trivial writer methods.
-        @foo = val
+      class Foo
+        def foo= val
+        ^^^ Use `attr_writer` to define trivial writer methods.
+          @foo = val
+        end
       end
     RUBY
 
     expect_correction(<<-RUBY.strip_indent)
-      attr_writer :foo
+      class Foo
+        attr_writer :foo
+      end
     RUBY
   end
 
   it 'registers an offense on one-liner reader' do
     expect_offense(<<-RUBY.strip_indent)
-      def foo; @foo; end
-      ^^^ Use `attr_reader` to define trivial reader methods.
+      class Foo
+        def foo; @foo; end
+        ^^^ Use `attr_reader` to define trivial reader methods.
+      end
     RUBY
 
     expect_correction(<<-RUBY.strip_indent)
-      attr_reader :foo
+      class Foo
+        attr_reader :foo
+      end
     RUBY
   end
 
   it 'registers an offense on one-liner writer' do
     expect_offense(<<-RUBY.strip_indent)
-      def foo(val); @foo=val; end
-      ^^^ Use `attr_writer` to define trivial writer methods.
+      class Foo
+        def foo(val); @foo=val; end
+        ^^^ Use `attr_writer` to define trivial writer methods.
+      end
     RUBY
 
     expect_no_corrections
@@ -105,9 +133,11 @@ RSpec.describe RuboCop::Cop::Style::TrivialAccessors, :config do
 
   it 'registers an offense on DSL-style trivial writer' do
     expect_offense(<<-RUBY.strip_indent)
-      def foo(val)
-      ^^^ Use `attr_writer` to define trivial writer methods.
-        @foo = val
+      class Foo
+        def foo(val)
+        ^^^ Use `attr_writer` to define trivial writer methods.
+          @foo = val
+        end
       end
     RUBY
 
@@ -116,9 +146,11 @@ RSpec.describe RuboCop::Cop::Style::TrivialAccessors, :config do
 
   it 'registers an offense on reader with `private`' do
     expect_offense(<<-RUBY.strip_indent)
-      private def foo
-              ^^^ Use `attr_reader` to define trivial reader methods.
-        @foo
+      class Foo
+        private def foo
+                ^^^ Use `attr_reader` to define trivial reader methods.
+          @foo
+        end
       end
     RUBY
 
@@ -127,75 +159,93 @@ RSpec.describe RuboCop::Cop::Style::TrivialAccessors, :config do
 
   it 'accepts non-trivial reader' do
     expect_no_offenses(<<-RUBY.strip_indent)
-      def test
-        some_function_call
-        @test
+      class Foo
+        def test
+          some_function_call
+          @test
+        end
       end
     RUBY
   end
 
   it 'accepts non-trivial writer' do
     expect_no_offenses(<<-RUBY.strip_indent)
-      def test(val)
-        some_function_call(val)
-        @test = val
-        log(val)
+      class Foo
+        def test(val)
+          some_function_call(val)
+          @test = val
+          log(val)
+        end
       end
     RUBY
   end
 
   it 'accepts splats' do
     expect_no_offenses(<<-RUBY.strip_indent)
-      def splatomatic(*values)
-        @splatomatic = values
+      class Foo
+        def splatomatic(*values)
+          @splatomatic = values
+        end
       end
     RUBY
   end
 
   it 'accepts blocks' do
     expect_no_offenses(<<-RUBY.strip_indent)
-      def something(&block)
-        @b = block
+      class Foo
+        def something(&block)
+          @b = block
+        end
       end
     RUBY
   end
 
   it 'accepts expressions within reader' do
     expect_no_offenses(<<-RUBY.strip_indent)
-      def bar
-        @bar + foo
+      class Foo
+        def bar
+          @bar + foo
+        end
       end
     RUBY
   end
 
   it 'accepts expressions within writer' do
     expect_no_offenses(<<-RUBY.strip_indent)
-      def bar(val)
-        @bar = val + foo
+      class Foo
+        def bar(val)
+          @bar = val + foo
+        end
       end
     RUBY
   end
 
   it 'accepts an initialize method looking like a writer' do
     expect_no_offenses(<<-RUBY.strip_indent)
-       def initialize(value)
-         @top = value
+      class Foo
+         def initialize(value)
+           @top = value
+         end
        end
     RUBY
   end
 
   it 'accepts reader with different ivar name' do
     expect_no_offenses(<<-RUBY.strip_indent)
-      def foo
-        @fo
+      class Foo
+        def foo
+          @fo
+        end
       end
     RUBY
   end
 
   it 'accepts writer with different ivar name' do
     expect_no_offenses(<<-RUBY.strip_indent)
-      def foo(val)
-        @fo = val
+      class Foo
+        def foo(val)
+          @fo = val
+        end
       end
     RUBY
   end
@@ -230,6 +280,22 @@ RSpec.describe RuboCop::Cop::Style::TrivialAccessors, :config do
             @bar
           end
         end
+      end
+    RUBY
+  end
+
+  it 'accepts reader using top level' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def bar
+        @bar
+      end
+    RUBY
+  end
+
+  it 'accepts writer using top level' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def bar=(bar)
+        @bar = bar
       end
     RUBY
   end
@@ -288,9 +354,11 @@ RSpec.describe RuboCop::Cop::Style::TrivialAccessors, :config do
 
     it 'registers an offense when names mismatch in writer' do
       expect_offense(<<-RUBY.strip_indent)
-        def foo(val)
-        ^^^ Use `attr_writer` to define trivial writer methods.
-          @f = val
+        class Foo
+          def foo(val)
+          ^^^ Use `attr_writer` to define trivial writer methods.
+            @f = val
+          end
         end
       RUBY
 
@@ -299,9 +367,11 @@ RSpec.describe RuboCop::Cop::Style::TrivialAccessors, :config do
 
     it 'registers an offense when names mismatch in reader' do
       expect_offense(<<-RUBY.strip_indent)
-        def foo
-        ^^^ Use `attr_reader` to define trivial reader methods.
-          @f
+        class Foo
+          def foo
+          ^^^ Use `attr_reader` to define trivial reader methods.
+            @f
+          end
         end
       RUBY
 
@@ -314,9 +384,11 @@ RSpec.describe RuboCop::Cop::Style::TrivialAccessors, :config do
 
     it 'does not accept predicate-like reader' do
       expect_offense(<<-RUBY.strip_indent)
-        def foo?
-        ^^^ Use `attr_reader` to define trivial reader methods.
-          @foo
+        class Foo
+          def foo?
+          ^^^ Use `attr_reader` to define trivial reader methods.
+            @foo
+          end
         end
       RUBY
 
@@ -329,8 +401,10 @@ RSpec.describe RuboCop::Cop::Style::TrivialAccessors, :config do
 
     it 'accepts predicate-like reader' do
       expect_no_offenses(<<-RUBY.strip_indent)
-        def foo?
-          @foo
+        class Foo
+          def foo?
+            @foo
+          end
         end
       RUBY
     end
@@ -341,17 +415,21 @@ RSpec.describe RuboCop::Cop::Style::TrivialAccessors, :config do
 
     it 'accepts whitelisted reader' do
       expect_no_offenses(<<-RUBY.strip_indent)
-         def to_foo
-           @foo
-         end
+        class Foo
+          def to_foo
+            @foo
+          end
+        end
       RUBY
     end
 
     it 'accepts whitelisted writer' do
       expect_no_offenses(<<-RUBY.strip_indent)
-         def bar=(bar)
-           @bar = bar
-         end
+        class Foo
+          def bar=(bar)
+            @bar = bar
+          end
+        end
       RUBY
     end
 
@@ -363,9 +441,11 @@ RSpec.describe RuboCop::Cop::Style::TrivialAccessors, :config do
 
       it 'accepts whitelisted predicate' do
         expect_no_offenses(<<-RUBY.strip_indent)
-           def foo?
-             @foo
-           end
+          class Foo
+            def foo?
+              @foo
+            end
+          end
         RUBY
       end
     end
@@ -376,8 +456,10 @@ RSpec.describe RuboCop::Cop::Style::TrivialAccessors, :config do
 
     it 'accepts DSL-style writer' do
       expect_no_offenses(<<-RUBY.strip_indent)
-        def foo(val)
-         @foo = val
+        class Foo
+          def foo(val)
+            @foo = val
+          end
         end
       RUBY
     end
@@ -388,16 +470,20 @@ RSpec.describe RuboCop::Cop::Style::TrivialAccessors, :config do
 
     it 'accepts class reader' do
       expect_no_offenses(<<-RUBY.strip_indent)
-        def self.foo
-          @foo
+        class Foo
+          def self.foo
+            @foo
+          end
         end
       RUBY
     end
 
     it 'accepts class writer' do
       expect_no_offenses(<<-RUBY.strip_indent)
-        def self.foo(val)
-          @foo = val
+        class Foo
+          def self.foo(val)
+            @foo = val
+          end
         end
       RUBY
     end


### PR DESCRIPTION
Fixes #6777.

This PR fixes a false positive for `Style/TrivialAccessors` when using reader / writer at the top level.

The following is a reproduction code.

```ruby
# example.rb
def foo
  @foo
end
```

```console
% rubocop example.rb --only Style/TrivialAccessors -a
Inspecting 1 file
C

Offenses:

example.rb:1:1: C: [Corrected] Style/TrivialAccessors: Use attr_reader
to define trivial reader methods.
def response
^^^

1 file inspected, 1 offense detected, 1 offense corrected
```

An error occurs in the auto-corrected code.

```diff
% git diff
diff --git a/example.rb b/example.rb
index b26fec0..1868b1d 100644
--- a/example.rb
+++ b/example.rb
@@ -1,5 +1,3 @@
-def response
-  @response
-end
+attr_reader :response
```

```console
% ruby example.rb
Traceback (most recent call last):
example.rb:1:in `<main>': undefined method `attr_reader' for main:Object (NoMethodError)
```

This also occurs with writer. This PR will allow these cases.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
