### PR TITLE
Fix false negative for Layout/SpaceAroundBlockParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#6777](https://github.com/rubocop-hq/rubocop/issues/6777): Fix a false positive for `Style/TrivialAccessors` when using trivial reader/writer methods at the top level. ([@koic][])
 * [#6799](https://github.com/rubocop-hq/rubocop/pull/6799): Fix errors for `Style/ConditionalAssignment`, `Style/IdenticalConditionalBranches`, `Lint/ElseLayout`, and `Layout/IndentationWidth` with empty braces. ([@pocke][])
 * [#6802](https://github.com/rubocop-hq/rubocop/pull/6802): Fix auto-correction for `Style/SymbolArray` with array contains interpolation when `EnforcedStyle` is `brackets`. ([@pocke][])
+* [#6797](https://github.com/rubocop-hq/rubocop/pull/6797): Fix false negative for Layout/SpaceAroundBlockParameters on block parameter with parens. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/space_around_block_parameters.rb
+++ b/lib/rubocop/cop/layout/space_around_block_parameters.rb
@@ -120,14 +120,20 @@ module RuboCop
         end
 
         def check_each_arg(args)
-          args.children.butfirst.each do |arg|
-            expr = arg.source_range
-            check_no_space(
-              range_with_surrounding_space(range: expr, side: :left).begin_pos,
-              expr.begin_pos - 1,
-              'Extra space before'
-            )
+          args.children.each do |arg|
+            check_arg(arg)
           end
+        end
+
+        def check_arg(arg)
+          arg.children.each { |a| check_arg(a) } if arg.mlhs_type?
+
+          expr = arg.source_range
+          check_no_space(
+            range_with_surrounding_space(range: expr, side: :left).begin_pos,
+            expr.begin_pos - 1,
+            'Extra space before'
+          )
         end
 
         def check_space(space_begin_pos, space_end_pos, range, msg)

--- a/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
@@ -89,6 +89,15 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
       RUBY
     end
 
+    it 'registers an offense for space with parens' do
+      expect_offense(<<-RUBY.strip_indent)
+        {}.each { |a,  (x,  y),  z| puts x }
+                     ^ Extra space before block parameter detected.
+                          ^ Extra space before block parameter detected.
+                               ^ Extra space before block parameter detected.
+      RUBY
+    end
+
     context 'trailing comma' do
       it 'registers an offense for space after the last comma' do
         expect_offense(<<-RUBY.strip_indent)
@@ -212,6 +221,16 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
       expect_offense(<<-RUBY.strip_indent)
         {}.each { | x,   y | puts x }
                       ^^ Extra space before block parameter detected.
+      RUBY
+    end
+
+    it 'registers an offense for space with parens at middle' do
+      expect_offense(<<-RUBY.strip_indent)
+        {}.each { |(x,  y),  z| puts x }
+                   ^^^^^^^ Space before first block parameter missing.
+                      ^ Extra space before block parameter detected.
+                           ^ Extra space before block parameter detected.
+                             ^ Space after last block parameter missing.
       RUBY
     end
 


### PR DESCRIPTION
The cop is not aware of parens in block parameter. This pull request fixes this problem.


Example

```ruby
{}.each { |x, (x,  y)| nothing}
#                ^ The cop should detect this space, but acutally it does not.
```



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
