### PR TITLE
Fix errors for `Style/ConditionalAssignment`, `Style/IdenticalConditionalBranches`, `Lint/ElseLayout`, and `Layout/IndentationWidth` with empty braces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#6699](https://github.com/rubocop-hq/rubocop/issues/6699): Fix infinite loop for `Layout/IndentationWidth` and `Layout/IndentationConsistency` when bad modifier indentation before good method definition. ([@koic][])
 * [#6777](https://github.com/rubocop-hq/rubocop/issues/6777): Fix a false positive for `Style/TrivialAccessors` when using trivial reader/writer methods at the top level. ([@koic][])
+* [#6799](https://github.com/rubocop-hq/rubocop/pull/6799): Fix errors for `Style/ConditionalAssignment`, `Style/IdenticalConditionalBranches`, `Lint/ElseLayout`, and `Layout/IndentationWidth` with empty braces. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -344,6 +344,8 @@ module RuboCop
           return unless body_node.begin_type?
 
           starting_node = body_node.children.first
+          return unless starting_node
+
           starting_node.send_type? && starting_node.bare_access_modifier?
         end
 

--- a/lib/rubocop/cop/lint/else_layout.rb
+++ b/lib/rubocop/cop/lint/else_layout.rb
@@ -55,6 +55,7 @@ module RuboCop
 
           first_else = else_branch.children.first
 
+          return unless first_else
           return unless first_else.source_range.line == node.loc.else.line
 
           add_offense(first_else)

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -350,6 +350,8 @@ module RuboCop
         end
 
         def lhs_all_match?(branches)
+          return true if branches.empty?
+
           first_lhs = lhs(branches.first)
           branches.all? { |branch| lhs(branch) == first_lhs }
         end
@@ -372,7 +374,7 @@ module RuboCop
         def allowed_statements?(branches)
           return false unless branches.all?
 
-          statements = branches.map { |branch| tail(branch) }
+          statements = branches.map { |branch| tail(branch) }.compact
 
           lhs_all_match?(statements) && statements.none?(&:masgn_type?) &&
             assignment_types_match?(*statements)

--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -69,11 +69,6 @@ module RuboCop
           return if node.elsif?
 
           branches = expand_elses(node.else_branch).unshift(node.if_branch)
-
-          # return if any branch is empty. An empty branch can be an `if`
-          # without an `else` or a branch that contains only comments.
-          return if branches.any?(&:nil?)
-
           check_branches(branches)
         end
 
@@ -81,19 +76,20 @@ module RuboCop
           return unless node.else? && node.else_branch
 
           branches = node.when_branches.map(&:body).push(node.else_branch)
-
-          return if branches.any?(&:nil?)
-
           check_branches(branches)
         end
 
         private
 
         def check_branches(branches)
-          tails = branches.compact.map { |branch| tail(branch) }
-          check_expressions(tails)
-          heads = branches.compact.map { |branch| head(branch) }
-          check_expressions(heads)
+          # return if any branch is empty. An empty branch can be an `if`
+          # without an `else` or a branch that contains only comments.
+          return if branches.any?(&:nil?)
+
+          tails = branches.map { |branch| tail(branch) }
+          check_expressions(tails) if tails.none?(&:nil?)
+          heads = branches.map { |branch| head(branch) }
+          check_expressions(heads) if tails.none?(&:nil?)
         end
 
         def check_expressions(expressions)

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -210,6 +210,16 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
         RUBY
       end
 
+      it 'does not raise any error with empty braces' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          if cond
+            ()
+          else
+            ()
+          end
+        RUBY
+      end
+
       describe '#autocorrect' do
         it 'corrects bad indentation' do
           corrected = autocorrect_source(<<-RUBY.strip_indent)

--- a/spec/rubocop/cop/lint/else_layout_spec.rb
+++ b/spec/rubocop/cop/lint/else_layout_spec.rb
@@ -56,4 +56,14 @@ RSpec.describe RuboCop::Cop::Lint::ElseLayout do
   it 'handles modifier forms' do
     expect_no_offenses('x if something')
   end
+
+  it 'handles empty braces' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      if something
+        ()
+      else
+        ()
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -94,6 +94,16 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
     RUBY
   end
 
+  it "doesn't crash with empty braces" do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      if condition
+        ()
+      else
+        ()
+      end
+    RUBY
+  end
+
   shared_examples 'comparison methods' do |method|
     it 'registers an offense for comparison methods in if else' do
       expect_offense(<<-RUBY.strip_indent)

--- a/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
+++ b/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
@@ -176,4 +176,16 @@ RSpec.describe RuboCop::Cop::Style::IdenticalConditionalBranches do
       RUBY
     end
   end
+
+  context 'with empty brace' do
+    it 'does not raise any error' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        if condition
+          ()
+        else
+          ()
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
`Style/ConditionalAssignment`, `Style/IdenticalConditionalBranches`, `Lint/ElseLayout`, and `Layout/IndentationWidth` raise errors with empty bracse.

```ruby
# test.rb
if cond
  bar
else
  ()
end
```


```bash
$ rubocop --debug
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/parser-2.6.0.0/lib/parser/lexer.rb:10836: warning: assigned but unused variable - testEof
An error occurred while Layout/IndentationWidth cop was inspecting /tmp/tmp.c4yKM0qozU/test.rb:2:0.
An error occurred while Lint/ElseLayout cop was inspecting /tmp/tmp.c4yKM0qozU/test.rb:2:0.
An error occurred while Style/ConditionalAssignment cop was inspecting /tmp/tmp.c4yKM0qozU/test.rb:2:0.
For /tmp/tmp.c4yKM0qozU: configuration from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/config/default.yml
Inspecting 1 file
Scanning /tmp/tmp.c4yKM0qozU/test.rb
undefined method `send_type?' for nil:NilClass
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/layout/indentation_width.rb:347:in `starts_with_access_modifier?'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/layout/indentation_width.rb:327:in `skip_check?'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/layout/indentation_width.rb:310:in `indentation_to_check?'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/layout/indentation_width.rb:254:in `check_indentation'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/layout/indentation_width.rb:250:in `check_if'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/layout/indentation_width.rb:158:in `on_if'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:58:in `block (2 levels) in trigger_responding_cops'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:106:in `with_cop_error_handling'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:57:in `block in trigger_responding_cops'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:56:in `each'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:56:in `trigger_responding_cops'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:34:in `block (2 levels) in <class:Commissioner>'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/ast/traversal.rb:13:in `walk'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:46:in `investigate'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:116:in `investigate'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:104:in `offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:44:in `inspect_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:280:in `inspect_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:227:in `block in do_inspection_loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:259:in `block in iterate_until_no_changes'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:252:in `loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:252:in `iterate_until_no_changes'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:223:in `do_inspection_loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:126:in `block in file_offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:144:in `file_offense_cache'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:124:in `file_offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:112:in `process_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:89:in `block in each_inspected_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:86:in `each'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:86:in `reduce'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:86:in `each_inspected_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:76:in `inspect_files'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:48:in `run'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cli.rb:174:in `execute_runner'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cli.rb:75:in `execute_runners'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cli.rb:47:in `run'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/exe/rubocop:13:in `block in <top (required)>'
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/benchmark.rb:308:in `realtime'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/exe/rubocop:12:in `<top (required)>'
/home/pocke/.rbenv/versions/trunk/bin/rubocop:23:in `load'
/home/pocke/.rbenv/versions/trunk/bin/rubocop:23:in `<main>'
undefined method `source_range' for nil:NilClass
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/lint/else_layout.rb:58:in `check_else'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/lint/else_layout.rb:45:in `check'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/lint/else_layout.rb:36:in `on_if'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:58:in `block (2 levels) in trigger_responding_cops'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:106:in `with_cop_error_handling'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:57:in `block in trigger_responding_cops'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:56:in `each'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:56:in `trigger_responding_cops'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:34:in `block (2 levels) in <class:Commissioner>'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/ast/traversal.rb:13:in `walk'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:46:in `investigate'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:116:in `investigate'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:104:in `offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:44:in `inspect_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:280:in `inspect_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:227:in `block in do_inspection_loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:259:in `block in iterate_until_no_changes'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:252:in `loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:252:in `iterate_until_no_changes'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:223:in `do_inspection_loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:126:in `block in file_offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:144:in `file_offense_cache'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:124:in `file_offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:112:in `process_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:89:in `block in each_inspected_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:86:in `each'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:86:in `reduce'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:86:in `each_inspected_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:76:in `inspect_files'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:48:in `run'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cli.rb:174:in `execute_runner'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cli.rb:75:in `execute_runners'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cli.rb:47:in `run'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/exe/rubocop:13:in `block in <top (required)>'
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/benchmark.rb:308:in `realtime'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/exe/rubocop:12:in `<top (required)>'
/home/pocke/.rbenv/versions/trunk/bin/rubocop:23:in `load'
/home/pocke/.rbenv/versions/trunk/bin/rubocop:23:in `<main>'
undefined method `type' for nil:NilClass
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/style/conditional_assignment.rb:38:in `lhs'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/style/conditional_assignment.rb:354:in `block in lhs_all_match?'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/style/conditional_assignment.rb:354:in `all?'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/style/conditional_assignment.rb:354:in `lhs_all_match?'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/style/conditional_assignment.rb:377:in `allowed_statements?'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/style/conditional_assignment.rb:365:in `check_node'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/style/conditional_assignment.rb:258:in `on_if'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:58:in `block (2 levels) in trigger_responding_cops'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:106:in `with_cop_error_handling'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:57:in `block in trigger_responding_cops'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:56:in `each'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:56:in `trigger_responding_cops'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:34:in `block (2 levels) in <class:Commissioner>'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/ast/traversal.rb:13:in `walk'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:46:in `investigate'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:116:in `investigate'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:104:in `offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:44:in `inspect_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:280:in `inspect_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:227:in `block in do_inspection_loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:259:in `block in iterate_until_no_changes'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:252:in `loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:252:in `iterate_until_no_changes'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:223:in `do_inspection_loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:126:in `block in file_offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:144:in `file_offense_cache'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:124:in `file_offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:112:in `process_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:89:in `block in each_inspected_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:86:in `each'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:86:in `reduce'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:86:in `each_inspected_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:76:in `inspect_files'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:48:in `run'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cli.rb:174:in `execute_runner'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cli.rb:75:in `execute_runners'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cli.rb:47:in `run'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/exe/rubocop:13:in `block in <top (required)>'
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/benchmark.rb:308:in `realtime'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/exe/rubocop:12:in `<top (required)>'
/home/pocke/.rbenv/versions/trunk/bin/rubocop:23:in `load'
/home/pocke/.rbenv/versions/trunk/bin/rubocop:23:in `<main>'
undefined method `loc' for nil:NilClass
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/cop.rb:140:in `find_location'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/cop.rb:122:in `add_offense'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/style/identical_conditional_branches.rb:103:in `block in check_expressions'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/style/identical_conditional_branches.rb:102:in `each'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/style/identical_conditional_branches.rb:102:in `check_expressions'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/style/identical_conditional_branches.rb:94:in `check_branches'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/style/identical_conditional_branches.rb:77:in `on_if'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:58:in `block (2 levels) in trigger_responding_cops'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:106:in `with_cop_error_handling'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:57:in `block in trigger_responding_cops'An error occurred while Style/IdenticalConditionalBranches cop was inspecting /tmp/tmp.c4yKM0qozU/test.rb:2:0.

4 errors occurred:
An error occurred while Layout/IndentationWidth cop was inspecting /tmp/tmp.c4yKM0qozU/test.rb:2:0.
An error occurred while Lint/ElseLayout cop was inspecting /tmp/tmp.c4yKM0qozU/test.rb:2:0.
An error occurred while Style/ConditionalAssignment cop was inspecting /tmp/tmp.c4yKM0qozU/test.rb:2:0.
An error occurred while Style/IdenticalConditionalBranches cop was inspecting /tmp/tmp.c4yKM0qozU/test.rb:2:0.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop-hq/rubocop/issues

Mention the following information in the issue report:
0.65.0 (using Parser 2.6.0.0, running on ruby 2.7.0 x86_64-linux)

/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:56:in `each'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:56:in `trigger_responding_cops'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:34:in `block (2 levels) in <class:Commissioner>'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/ast/traversal.rb:13:in `walk'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:46:in `investigate'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:116:in `investigate'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:104:in `offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:44:in `inspect_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:280:in `inspect_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:227:in `block in do_inspection_loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:259:in `block in iterate_until_no_changes'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:252:in `loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:252:in `iterate_until_no_changes'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:223:in `do_inspection_loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:126:in `block in file_offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:144:in `file_offense_cache'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:124:in `file_offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:112:in `process_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:89:in `block in each_inspected_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:86:in `each'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:86:in `reduce'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:86:in `each_inspected_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:76:in `inspect_files'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:48:in `run'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cli.rb:174:in `execute_runner'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cli.rb:75:in `execute_runners'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cli.rb:47:in `run'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/exe/rubocop:13:in `block in <top (required)>'
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/benchmark.rb:308:in `realtime'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/exe/rubocop:12:in `<top (required)>'
/home/pocke/.rbenv/versions/trunk/bin/rubocop:23:in `load'
/home/pocke/.rbenv/versions/trunk/bin/rubocop:23:in `<main>'
W

Offenses:

test.rb:3:3: C: Style/IdenticalConditionalBranches: Move bar out of the conditional.
  bar
  ^^^
test.rb:5:3: W: Lint/EmptyExpression: Avoid empty expressions.
  ()
  ^^

1 file inspected, 2 offenses detected
Finished in 0.16606626300199423 seconds
```

This pull request fixes the four cop's errors.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
