### PR TITLE
Fix auto-correction for `Style/Lambda` with no-space argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#6802](https://github.com/rubocop-hq/rubocop/pull/6802): Fix auto-correction for `Style/SymbolArray` with array contains interpolation when `EnforcedStyle` is `brackets`. ([@pocke][])
 * [#6797](https://github.com/rubocop-hq/rubocop/pull/6797): Fix false negative for Layout/SpaceAroundBlockParameters on block parameter with parens. ([@pocke][])
 * [#6803](https://github.com/rubocop-hq/rubocop/pull/6803): Fix error for `Style/NumericLiterals` on a literal that contains spaces. ([@pocke][])
+* [#6801](https://github.com/rubocop-hq/rubocop/pull/6801): Fix auto-correction for `Style/Lambda` with no-space argument. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/correctors/lambda_literal_to_method_corrector.rb
+++ b/lib/rubocop/cop/correctors/lambda_literal_to_method_corrector.rb
@@ -31,7 +31,7 @@ module RuboCop
       attr_reader :block_node, :method, :arguments
 
       def remove_unparenthesized_whitespace(corrector)
-        return unless !arguments.empty? && !arguments.parenthesized_call?
+        return if arguments.empty? || arguments.parenthesized_call?
 
         remove_leading_whitespace(corrector)
         remove_trailing_whitespace(corrector)
@@ -69,10 +69,8 @@ module RuboCop
       end
 
       def remove_trailing_whitespace(corrector)
-        corrector.remove_preceding(
-          block_begin,
-          block_begin.begin_pos - arguments.source_range.end_pos - 1
-        )
+        size = block_begin.begin_pos - arguments.source_range.end_pos - 1
+        corrector.remove_preceding(block_begin, size) if size > 0
       end
 
       def replace_delimiters(corrector)

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe RuboCop::Cop::Style::Lambda, :config do
                         'Use the `lambda` method for all lambdas.'
         it_behaves_like 'auto-correct', 'f = lambda { x }'
       end
+
+      context 'without argument parens and spaces' do
+        let(:source) { 'f = ->x{ p x }' }
+
+        it_behaves_like 'registers an offense',
+                        'Use the `lambda` method for all lambdas.'
+        it_behaves_like 'auto-correct', 'f = lambda{ |x| p x }'
+      end
     end
 
     context 'with a multiline lambda literal' do


### PR DESCRIPTION
Auto-correction of `Style/Lambda` breaks on no-space and no-parens lambda literal.

For example:

```ruby
# test.rb
->a{
  p a
}
```

```bash
$ rubocop --debug --only Style/Lambda -a
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/parser-2.6.0.0/lib/parser/lexer.rb:10836: warning: assigned but unused variable - testEof
Parser::Source::Range: end_pos must not be less than begin_pos
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/parser-2.6.0.0/lib/parser/source/range.rb:39:in `initialize'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/corrector.rb:120:in `new'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/corrector.rb:120:in `remove_preceding'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/correctors/lambda_literal_to_method_corrector.rb:72:in `remove_trailing_whitespace'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/correctors/lambda_literal_to_method_corrector.rb:37:in `remove_unparenthesized_whitespace'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/correctors/lambda_literal_to_method_corrector.rb:15:in `call'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/corrector.rb:64:in `block (2 levels) in rewrite'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/parser-2.6.0.0/lib/parser/source/tree_rewriter.rb:220:in `transaction'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/corrector.rb:63:in `block in rewrite'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/corrector.rb:61:in `each'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/corrector.rb:61:in `rewrite'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:128:in `autocorrect_all_cops'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:72:in `autocorrect'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:100:in `block in offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:117:in `investigate'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:96:in `offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:44:in `inspect_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:280:in `inspect_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:227:in `block in do_inspection_loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:259:in `block in iterate_until_no_changes'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:252:in `loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:252:in `iterate_until_no_changes'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:223:in `do_inspection_loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:126:in `block in file_offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:144:in `file_offense_cache'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:124:in `file_offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:112:in `process_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:89:in `block in each_inspected_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:86:in `each'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:86:in `reduce'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:86:in `each_inspected_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:76:in `inspect_files'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:48:in `run'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cli.rb:174:in `execute_runner'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cli.rb:75:in `execute_runners'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cli.rb:47:in `run'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/exe/rubocop:13:in `block in <top (required)>'
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/benchmark.rb:308:in `realtime'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/exe/rubocop:12:in `<top (required)>'
/home/pocke/.rbenv/versions/trunk/bin/rubocop:23:in `load'
/home/pocke/.rbenv/versions/trunk/bin/rubocop:23:in `<main>'
For /tmp/tmp.JB7uPXvAYC: configuration from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/config/default.yml
Inspecting 1 file
Scanning /tmp/tmp.JB7uPXvAYC/test.rb


0 files inspected, no offenses detected
Finished in 0.16065635700942948 seconds
```

This pull request will fix this problem.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
