### PR TITLE
Fix auto-correction for Style/SymbolArray with array contains interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#6699](https://github.com/rubocop-hq/rubocop/issues/6699): Fix infinite loop for `Layout/IndentationWidth` and `Layout/IndentationConsistency` when bad modifier indentation before good method definition. ([@koic][])
 * [#6777](https://github.com/rubocop-hq/rubocop/issues/6777): Fix a false positive for `Style/TrivialAccessors` when using trivial reader/writer methods at the top level. ([@koic][])
 * [#6799](https://github.com/rubocop-hq/rubocop/pull/6799): Fix errors for `Style/ConditionalAssignment`, `Style/IdenticalConditionalBranches`, `Lint/ElseLayout`, and `Layout/IndentationWidth` with empty braces. ([@pocke][])
+* [#6802](https://github.com/rubocop-hq/rubocop/pull/6802): Fix auto-correction for `Style/SymbolArray` with array contains interpolation when `EnforcedStyle` is `brackets`. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/symbol_array.rb
+++ b/lib/rubocop/cop/style/symbol_array.rb
@@ -70,7 +70,15 @@ module RuboCop
         end
 
         def correct_bracketed(node)
-          syms = node.children.map { |c| to_symbol_literal(c.value.to_s) }
+          syms = node.children.map do |c|
+            if c.dsym_type?
+              string_literal = to_string_literal(c.source)
+
+              ':' + trim_string_interporation_escape_character(string_literal)
+            else
+              to_symbol_literal(c.value.to_s)
+            end
+          end
 
           lambda do |corrector|
             corrector.replace(node.source_range, "[#{syms.join(', ')}]")

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -96,10 +96,6 @@ module RuboCop
             corrector.replace(node.source_range, "[#{words.join(', ')}]")
           end
         end
-
-        def trim_string_interporation_escape_character(str)
-          str.gsub(/\\\#{(.*?)\}/) { "\#{#{Regexp.last_match(1)}}" }
-        end
       end
     end
   end

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -85,6 +85,10 @@ module RuboCop
         end
       end
 
+      def trim_string_interporation_escape_character(str)
+        str.gsub(/\\\#{(.*?)\}/) { "\#{#{Regexp.last_match(1)}}" }
+      end
+
       def interpret_string_escapes(string)
         StringInterpreter.interpret(string)
       end

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
     end
   end
 
-  context 'when EnforcedStyle is array' do
+  context 'when EnforcedStyle is brackets' do
     let(:cop_config) { { 'EnforcedStyle' => 'brackets', 'MinSize' => 0 } }
 
     it 'does not register an offense for arrays of symbols' do
@@ -166,6 +166,11 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
     it 'autocorrects an array starting with %i' do
       new_source = autocorrect_source('%i(one @two $three four-five)')
       expect(new_source).to eq("[:one, :@two, :$three, :'four-five']")
+    end
+
+    it 'autocorrects an array has interpolations' do
+      new_source = autocorrect_source('%I(#{foo} #{foo}bar foo#{bar} foo)')
+      expect(new_source).to eq('[:"#{foo}", :"#{foo}bar", :"foo#{bar}", :foo]')
     end
   end
 


### PR DESCRIPTION

Problem
===

`Style/SymbolArray` cop's auto-correction breaks on an array that contains an interpolation when `EnforcedStyle` is `bracktes`

Example

```ruby
# test.rb
%I[#{foo}]
```

```yaml
# .rubocop.yml
Style/SymbolArray:
  EnforcedStyle: brackets
```

```bash
$ rubocop --debug -a --only Style/SymbolArray
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/parser-2.6.0.0/lib/parser/lexer.rb:10836: warning: assigned but unused variable - testEof
An error occurred while Style/SymbolArray cop was inspecting /tmp/tmp.1xg8JstsGV/test.rb:2:0.

1 error occurred:
An error occurred while Style/SymbolArray cop was inspecting /tmp/tmp.1xg8JstsGV/test.rb:2:0.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop-hq/rubocop/issues

Mention the following information in the issue report:
0.65.0 (using Parser 2.6.0.0, running on ruby 2.7.0 x86_64-linux)
For /tmp/tmp.1xg8JstsGV: configuration from /tmp/tmp.1xg8JstsGV/.rubocop.yml
Default configuration from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/config/default.yml
Inspecting 1 file
Scanning /tmp/tmp.1xg8JstsGV/test.rb
undefined method `value' for s(:dsym,
  s(:begin,
    s(:send, nil, :foo))):RuboCop::AST::Node
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/style/symbol_array.rb:73:in `block in correct_bracketed'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/style/symbol_array.rb:73:in `map'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/style/symbol_array.rb:73:in `correct_bracketed'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/style/symbol_array.rb:59:in `autocorrect'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/cop.rb:153:in `correct'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/cop.rb:131:in `add_offense'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/mixin/percent_array.rb:41:in `check_percent_array'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/style/symbol_array.rb:49:in `on_array'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:58:in `block (2 levels) in trigger_responding_cops'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:106:in `with_cop_error_handling'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:57:in `block in trigger_responding_cops'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:56:in `each'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:56:in `trigger_responding_cops'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:34:in `block (2 levels) in <class:Commissioner>'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/ast/traversal.rb:13:in `walk'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/commissioner.rb:46:in `investigate'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:116:in `investigate'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:96:in `offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:44:in `inspect_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:280:in `inspect_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:227:in `block in do_inspection_loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:259:in `block in iterate_until_no_changes'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:252:in `loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:252:in `iterate_until_no_changes'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:223:in `do_inspection_loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:126:in `block in file_offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:144:in `file_offense_cache'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:124:in `file_offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:112:in `process_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:89:in `block in each_inspected_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:86:in `each'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:86:in `reduce'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:86:in `each_inspected_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:76:in `inspect_files'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:48:in `run'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cli.rb:174:in `execute_runner'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cli.rb:75:in `execute_runners'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cli.rb:47:in `run'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/exe/rubocop:13:in `block in <top (required)>'
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/benchmark.rb:308:in `realtime'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/exe/rubocop:12:in `<top (required)>'
/home/pocke/.rbenv/versions/trunk/bin/rubocop:23:in `load'
/home/pocke/.rbenv/versions/trunk/bin/rubocop:23:in `<main>'
.

1 file inspected, no offenses detected
Finished in 0.17103776399744675 seconds
```

This pull request will fix this problem.

Note
===

`Style/WordArray` treats interpolation already, so it's no problem.
https://github.com/rubocop-hq/rubocop/blob/d3a894a7fc9848d12ef06634f231dae73a4016f6/lib/rubocop/cop/style/word_array.rb#L86



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
