### PR TITLE
Fix auto-correction of `Style/NumericLiterals` on numeric literal with exponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#6797](https://github.com/rubocop-hq/rubocop/pull/6797): Fix false negative for Layout/SpaceAroundBlockParameters on block parameter with parens. ([@pocke][])
 * [#6803](https://github.com/rubocop-hq/rubocop/pull/6803): Fix error for `Style/NumericLiterals` on a literal that contains spaces. ([@pocke][])
 * [#6801](https://github.com/rubocop-hq/rubocop/pull/6801): Fix auto-correction for `Style/Lambda` with no-space argument. ([@pocke][])
+* [#6804](https://github.com/rubocop-hq/rubocop/pull/6804): Fix auto-correction of `Style/NumericLiterals` on numeric literal with exponent. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/integer_node.rb
+++ b/lib/rubocop/cop/mixin/integer_node.rb
@@ -7,7 +7,7 @@ module RuboCop
       private
 
       def integer_part(node)
-        node.source.sub(/^[+-]/, '').split('.').first
+        node.source.sub(/^[+-]/, '').split(/[eE.]/, 2).first
       end
     end
   end

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -65,6 +65,16 @@ RSpec.describe RuboCop::Cop::Style::NumericLiterals, :config do
     RUBY
   end
 
+  it 'handles numeric literal with exponent' do
+    expect_offense(<<-RUBY.strip_indent)
+      a = 10e10
+      b = 3e12345
+      c = 12.345e3
+      d = 12345e3
+          ^^^^^^^ Use underscores(_) as thousands separator and separate every 3 digits with them.
+    RUBY
+  end
+
   it 'autocorrects a long integer offense' do
     corrected = autocorrect_source('a = 123456')
     expect(corrected).to eq 'a = 123_456'
@@ -93,6 +103,21 @@ RSpec.describe RuboCop::Cop::Style::NumericLiterals, :config do
   it 'autocorrects numbers with spaces between leading minus and numbers' do
     corrected = autocorrect_source("a = -\n  12345")
     expect(corrected).to eq 'a = -12_345'
+  end
+
+  it 'autocorrects numeric literal with exponent' do
+    corrected = autocorrect_source('a = 12345e3')
+    expect(corrected).to eq 'a = 12_345e3'
+  end
+
+  it 'autocorrects numeric literal with exponent and dot' do
+    corrected = autocorrect_source('a = 12345.6e3')
+    expect(corrected).to eq 'a = 12_345.6e3'
+  end
+
+  it 'autocorrects numeric literal with exponent (large E) and dot' do
+    corrected = autocorrect_source('a = 12345.6E3')
+    expect(corrected).to eq 'a = 12_345.6E3'
   end
 
   context 'strict' do


### PR DESCRIPTION
Problem
===

Style/NumericLiterals cop's auto-correction raises an error on numeric literal with exponent.
It passes "12345e6" to `Integer()` method. It is not valid as an integer, so it raises an error.

Example:

```ruby
12345e6
```

```bash
$ rubocop -a --only NumericLiterals
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/parser-2.6.0.0/lib/parser/lexer.rb:10836: warning: assigned but unused variable - testEof
invalid value for Integer(): "12345e6"
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/style/numeric_literals.rb:79:in `Integer'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/style/numeric_literals.rb:79:in `format_number'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/style/numeric_literals.rb:46:in `block in autocorrect'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/corrector.rb:64:in `block (2 levels) in rewrite'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/parser-2.6.0.0/lib/parser/source/tree_rewriter.rb:220:in `transaction'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/corrector.rb:63:in `block in rewrite'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/corrector.rb:61:in `each'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/corrector.rb:61:in `rewrite'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:128:in `autocorrect_all_cops'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:72:in `autocorrect'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:100:in `block in offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:117:in `investigate'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:96:in `offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cop/team.rb:44:in `inspect_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:280:in `inspect_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:227:in `block in do_inspection_loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:259:in `block in iterate_until_no_changes'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:252:in `loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:252:in `iterate_until_no_changes'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:223:in `do_inspection_loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:126:in `block in file_offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:144:in `file_offense_cache'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:124:in `file_offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:112:in `process_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:89:in `block in each_inspected_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:86:in `each'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:86:in `reduce'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:86:in `each_inspected_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:76:in `inspect_files'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/runner.rb:48:in `run'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cli.rb:174:in `execute_runner'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cli.rb:75:in `execute_runners'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/lib/rubocop/cli.rb:47:in `run'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/exe/rubocop:13:in `block in <top (required)>'
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/benchmark.rb:308:in `realtime'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.65.0/exe/rubocop:12:in `<top (required)>'
/home/pocke/.rbenv/versions/trunk/bin/rubocop:23:in `load'
/home/pocke/.rbenv/versions/trunk/bin/rubocop:23:in `<main>'
Inspecting 1 file

0 files inspected, no offenses detected
```


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
