### PR TITLE
[Fix #6800] Fix an incorrect auto-correct for `Rails/Validation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#6803](https://github.com/rubocop-hq/rubocop/pull/6803): Fix error for `Style/NumericLiterals` on a literal that contains spaces. ([@pocke][])
 * [#6801](https://github.com/rubocop-hq/rubocop/pull/6801): Fix auto-correction for `Style/Lambda` with no-space argument. ([@pocke][])
 * [#6804](https://github.com/rubocop-hq/rubocop/pull/6804): Fix auto-correction of `Style/NumericLiterals` on numeric literal with exponent. ([@pocke][])
+* [#6800](https://github.com/rubocop-hq/rubocop/issues/6800): Fix an incorrect auto-correct for `Rails/Validation` when method arguments are enclosed in parentheses. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/validation.rb
+++ b/lib/rubocop/cop/rails/validation.rb
@@ -87,8 +87,9 @@ module RuboCop
               "#{validate_type}: #{braced_options(last_argument)}"
             )
           else
-            corrector.insert_after(node.loc.expression,
-                                   ", #{validate_type}: true")
+            range = last_argument.source_range
+
+            corrector.insert_after(range, ", #{validate_type}: true")
           end
         end
 

--- a/spec/rubocop/cop/rails/validation_spec.rb
+++ b/spec/rubocop/cop/rails/validation_spec.rb
@@ -45,6 +45,19 @@ RSpec.describe RuboCop::Cop::Rails::Validation do
 
         include_examples 'auto-corrects'
       end
+
+      context "with validates_#{type}_of " \
+              'when method arguments are enclosed in parentheses' do
+        let(:auto_corrected_source) do
+          "validates(:full_name, :birth_date, #{type}: true)"
+        end
+
+        let(:source) do
+          "validates_#{type}_of(:full_name, :birth_date)"
+        end
+
+        include_examples 'auto-corrects'
+      end
     end
 
     context 'with single attribute name' do


### PR DESCRIPTION
Fixes #6800.

This PR fixes an incorrect auto-correct for `Rails/Validation` when method arguments are enclosed in parentheses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
