### PR TITLE
Exclude gemspec file by default for `Metrics/BlockLength`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,6 +81,7 @@ Metrics/BlockLength:
     - 'Rakefile'
     - '**/*.rake'
     - 'spec/**/*.rb'
+    - '**/*.gemspec'
 
 Metrics/ModuleLength:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 * [#6688](https://github.com/rubocop-hq/rubocop/pull/6688): Add `iterator?` to deprecated methods and prefer `block_given?` instead. ([@tejasbubane][])
 * [#6806](https://github.com/rubocop-hq/rubocop/pull/6806): Remove `powerpack` dependency. ([@dduugg][])
+* [#6810](https://github.com/rubocop-hq/rubocop/pull/6810): Exclude gemspec file by default for `Metrics/BlockLength` cop. ([@koic][])
 
 ## 0.65.0 (2019-02-19)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1643,13 +1643,15 @@ Metrics/BlockLength:
   Description: 'Avoid long blocks with many lines.'
   Enabled: true
   VersionAdded: '0.44'
-  VersionChanged: '0.58'
+  VersionChanged: '0.66'
   CountComments: false  # count full line comments?
   Max: 25
   ExcludedMethods:
     # By default, exclude the `#refine` method, as it tends to have larger
     # associated blocks.
     - refine
+  Exclude:
+    - '**/*.gemspec'
 
 Metrics/BlockNesting:
   Description: 'Avoid excessive block nesting'

--- a/manual/cops_metrics.md
+++ b/manual/cops_metrics.md
@@ -24,7 +24,7 @@ Max | `15` | Integer
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.44 | 0.58
+Enabled | Yes | No | 0.44 | 0.66
 
 This cop checks if the length of a block exceeds some maximum value.
 Comment lines can optionally be ignored.
@@ -38,6 +38,7 @@ Name | Default value | Configurable values
 CountComments | `false` | Boolean
 Max | `25` | Integer
 ExcludedMethods | `refine` | Array
+Exclude | `**/*.gemspec` | Array
 
 ## Metrics/BlockNesting
 

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -4,7 +4,6 @@ $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'rubocop/version'
 require 'English'
 
-# rubocop:disable Metrics/BlockLength
 Gem::Specification.new do |s|
   s.name = 'rubocop'
   s.version = RuboCop::Version::STRING
@@ -45,4 +44,3 @@ Gem::Specification.new do |s|
   s.add_development_dependency('bundler', '>= 1.3.0', '< 3.0')
   s.add_development_dependency('rack', '>= 2.0')
 end
-# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
This PR excludes gemspec file by default for `Metrics/BlockLength` cop.

When gemspec file is changed, it is mainly the increase / decrease for `add_runtime_dependency` and `add_development_dependency`.
There is no tendency to change with complicated logic.

Also gemspec file made with `bundle gem` is also warned by default.

```console
% bundle -v
Bundler version 2.0.1
% bundle gem foo
Creating gem 'foo'...
MIT License enabled in config
      create  foo/Gemfile
      create  foo/lib/foo.rb
      create  foo/lib/foo/version.rb
      create  foo/foo.gemspec
      create  foo/Rakefile
      create  foo/README.md
      create  foo/bin/console
      create  foo/bin/setup
      create  foo/.gitignore
      create  foo/.travis.yml
      create  foo/.rspec
      create  foo/spec/spec_helper.rb
      create  foo/spec/foo_spec.rb
      create  foo/LICENSE.txt
Initializing git repo in /private/tmp/foo

% rubocop -v
0.65.0
% rubocop --only Metrics/BlockLength
Inspecting 8 files
C.......

Offenses:

foo.gemspec:6:1: C: Metrics/BlockLength: Block has too many
lines. [26/25]
Gem::Specification.new do |spec| ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

8 files inspected, 1 offense detected
```

Therefore this PR excluded gemspec file by default.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
