### PR TITLE
[Fix #6808] Prevent false positive in Naming/ConstantName when assigning frozen range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#6801](https://github.com/rubocop-hq/rubocop/pull/6801): Fix auto-correction for `Style/Lambda` with no-space argument. ([@pocke][])
 * [#6804](https://github.com/rubocop-hq/rubocop/pull/6804): Fix auto-correction of `Style/NumericLiterals` on numeric literal with exponent. ([@pocke][])
 * [#6800](https://github.com/rubocop-hq/rubocop/issues/6800): Fix an incorrect auto-correct for `Rails/Validation` when method arguments are enclosed in parentheses. ([@koic][])
+* [#6808](https://github.com/rubocop-hq/rubocop/issues/6808): Prevent false positive in `Naming/ConstantName` when assigning a frozen range. ([@drenmi][])
 
 ### Changes
 

--- a/lib/rubocop/cop/naming/constant_name.rb
+++ b/lib/rubocop/cop/naming/constant_name.rb
@@ -60,8 +60,13 @@ module RuboCop
 
         def allowed_method_call_on_rhs?(node)
           node && node.send_type? &&
-            (node.receiver.nil? || !node.receiver.literal?)
+            (node.receiver.nil? || !literal_receiver?(node))
         end
+
+        def_node_matcher :literal_receiver?, <<-PATTERN
+          {(send literal? ...)
+           (send (begin literal?) ...)}
+        PATTERN
 
         def allowed_conditional_expression_on_rhs?(node)
           node && node.if_type? && contains_contant?(node)

--- a/spec/rubocop/cop/naming/constant_name_spec.rb
+++ b/spec/rubocop/cop/naming/constant_name_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe RuboCop::Cop::Naming::ConstantName do
   end
 
   it 'registers an offense for camel case in const name' \
+     'when using frozen range assignment' do
+    expect_offense(<<-RUBY.strip_indent)
+      TopCase = (1..5).freeze
+      ^^^^^^^ Use SCREAMING_SNAKE_CASE for constants.
+    RUBY
+  end
+
+  it 'registers an offense for camel case in const name' \
      'when using frozen object assignment' do
     expect_offense(<<-RUBY.strip_indent)
       TopCase = 5.freeze


### PR DESCRIPTION
This cop would fail to report offenses on code like:

```
FooBar = (1..5).freeze
```

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
