### PR TITLE
Layout/RescueEnsureAlignment continuation of #6254 #6771

### DIFF
--- a/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
@@ -101,6 +101,8 @@ module RuboCop
               node.loc.begin
             when :def, :defs, :class, :module
               node.loc.name
+            when :lvasgn
+              node.child_nodes.first.loc.begin
             else
               # It is a wrapper with access modifier.
               node.child_nodes.first.loc.name
@@ -114,11 +116,15 @@ module RuboCop
         def alignment_node(node)
           ancestor_node = ancestor_node(node)
 
-          return ancestor_node if ancestor_node.nil? ||
-                                  ancestor_node.kwbegin_type?
+          return if ancestor_node.nil?
 
           assignment_node = assignment_node(ancestor_node)
-          return assignment_node if same_line?(ancestor_node, assignment_node)
+
+          if assignment_node && same_line?(ancestor_node, assignment_node)
+            return assignment_node
+          end
+
+          return ancestor_node if ancestor_node.kwbegin_type?
 
           access_modifier_node = access_modifier_node(ancestor_node)
           return access_modifier_node unless access_modifier_node.nil?

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -264,6 +264,28 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
     RUBY
   end
 
+  context 'rescue with assigned begin' do
+    it 'accepts variable-aligned rescue in or-assigned begin-end block' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        @bar ||= begin
+          expensive_method
+        rescue StandardError
+          fall_back
+        end
+      RUBY
+    end
+
+    it 'accepts variable-aligned rescue in assigned begin-end block' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        @bar = begin
+          expensive_method
+        rescue StandardError
+          fall_back
+        end
+      RUBY
+    end
+  end
+
   context '>= Ruby 2.5', :ruby25 do
     it 'accepts aligned rescue in do-end block' do
       expect_no_offenses(<<-RUBY.strip_indent)


### PR DESCRIPTION
This PR fix unexpected issues with Layout/RescueEnsureAlignment raised by #6771.
By implementing the solution for the related problems one pre-existing spec come to fail but I am not so sure if that has to pass as is or if that simply highlight the existence of two other possible conflicting layouts for rescue that were not being considered.

1.
```
a_variable = begin
               something
             rescue
               log_some_failure
             end
```

2.
```
a_variable = begin
  something
rescue
  log_some_failure
end
```
One of these 2 cases passes and the other fail after my changes but none of them fail before. I don't know if one of those styles should be selected over the other or if they should be considered equivalent and keep passing without error.
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
