### PR TITLE
Handle array spread for `change_column_default` in `Rails/ReversibleMigration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#6387](https://github.com/rubocop-hq/rubocop/issues/6387): Prevent `Lint/NumberConversion` from reporting error with `Time`/`DateTime`. ([@tejasbubane][])
 * [#6980](https://github.com/rubocop-hq/rubocop/issues/6980): Fix `Style/StringHashKeys` to allow string as keys for hash arguments to gsub methods. ([@tejasbubane][])
 * [#6969](https://github.com/rubocop-hq/rubocop/issues/6969): Fix a false positive with block methods in `Style/InverseMethods`. ([@dduugg][])
+* [#6729](https://github.com/rubocop-hq/rubocop/pull/6729): Handle array spread for `change_column_default` in `Rails/ReversibleMigration` cop. ([@tejasbubane][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -140,7 +140,7 @@ module RuboCop
         PATTERN
 
         def_node_matcher :change_column_default_call, <<-PATTERN
-          (send nil? :change_column_default _ _ $...)
+          (send nil? :change_column_default {[(sym _) (sym _)] (splat _)} $...)
         PATTERN
 
         def_node_matcher :remove_column_call, <<-PATTERN
@@ -195,7 +195,7 @@ module RuboCop
 
         def check_change_column_default_node(node)
           change_column_default_call(node) do |args|
-            unless all_hash_key?(args.first, :from, :to)
+            unless all_hash_key?(args.last, :from, :to)
               add_offense(
                 node,
                 message: format(

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -114,6 +114,12 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
       change_column_default(:posts, :state, from: nil, to: "draft")
     RUBY
 
+    it_behaves_like 'accepts',
+                    'change_column_default(*column :from and :to)', <<-RUBY
+      columns = [:foo, :bar]
+      change_column_default(*columns, from: nil, to: "draft")
+    RUBY
+
     it_behaves_like 'offense',
                     'change_column_default(without :from and :to)', <<-RUBY
       change_column_default(:suppliers, :qualification, 'new')


### PR DESCRIPTION
Closes #6729 

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.