### PR TITLE
Fix false negative for Rails/LinkToBlank when _blank is a symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* [#6821](https://github.com/rubocop-hq/rubocop/pull/6821): Fix false negative for Rails/LinkToBlank when `_blank` is a symbol. ([@Intrepidd][])
 * [#6699](https://github.com/rubocop-hq/rubocop/issues/6699): Fix infinite loop for `Layout/IndentationWidth` and `Layout/IndentationConsistency` when bad modifier indentation before good method definition. ([@koic][])
 * [#6777](https://github.com/rubocop-hq/rubocop/issues/6777): Fix a false positive for `Style/TrivialAccessors` when using trivial reader/writer methods at the top level. ([@koic][])
 * [#6799](https://github.com/rubocop-hq/rubocop/pull/6799): Fix errors for `Style/ConditionalAssignment`, `Style/IdenticalConditionalBranches`, `Lint/ElseLayout`, and `Layout/IndentationWidth` with empty braces. ([@pocke][])

--- a/lib/rubocop/cop/rails/link_to_blank.rb
+++ b/lib/rubocop/cop/rails/link_to_blank.rb
@@ -18,7 +18,7 @@ module RuboCop
         MSG = 'Specify a `:rel` option containing noopener.'.freeze
 
         def_node_matcher :blank_target?, <<-PATTERN
-          (pair {(sym :target) (str "target")} (str "_blank"))
+          (pair {(sym :target) (str "target")} {(str "_blank") (sym :_blank)})
         PATTERN
 
         def_node_matcher :includes_noopener?, <<-PATTERN

--- a/spec/rubocop/cop/rails/link_to_blank_spec.rb
+++ b/spec/rubocop/cop/rails/link_to_blank_spec.rb
@@ -45,6 +45,13 @@ RSpec.describe RuboCop::Cop::Rails::LinkToBlank do
         RUBY
       end
 
+      it 'registers an offence when using a symbol for the target value' do
+        expect_offense(<<-RUBY.strip_indent)
+          link_to 'Click here', 'https://www.example.com', target: :_blank
+                                                           ^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
+        RUBY
+      end
+
       it 'registers an offence and auto-corrects when using the block syntax' do
         expect_offense(<<-RUBY.strip_indent)
           link_to 'https://www.example.com', target: '_blank' do


### PR DESCRIPTION
when using `target: :_blank`, the `Rails/LinkToBlank` cop does not register an offence when it should.