### PR TITLE
Update gem dependecy version unicode-display_width to 1.5.0

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('psych', '>= 3.1.0')
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
-  s.add_runtime_dependency('unicode-display_width', '~> 1.4.0')
+  s.add_runtime_dependency('unicode-display_width', '~> 1.5.0')
 
   s.add_development_dependency('bundler', '>= 1.3.0', '< 3.0')
   s.add_development_dependency('rack', '>= 2.0')


### PR DESCRIPTION
This PR updates gem unicode-display_width into rubocop.gemspec from 1.4.0 to 1.5.0 version.
