### PR TITLE
NodePattern improvements

### DIFF
--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -562,6 +562,14 @@ module RuboCop
       instance_eval(src)
     end
 
+    def marshal_load(pattern)
+      initialize pattern
+    end
+
+    def marshal_dump
+      pattern
+    end
+
     def to_s
       "#<#{self.class} #{pattern}>"
     end

--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -133,8 +133,7 @@ module RuboCop
       end
 
       def run(node_var)
-        tokens =
-          @string.scan(TOKEN).reject { |token| token =~ /\A#{SEPARATORS}\Z/ }
+        tokens = Compiler.tokens(@string)
 
         @match_code = compile_expr(tokens, node_var, false)
 
@@ -475,6 +474,10 @@ module RuboCop
       def next_temp_value
         @temps += 1
       end
+
+      def self.tokens(pattern)
+        pattern.scan(TOKEN).reject { |token| token =~ /\A#{SEPARATORS}\Z/ }
+      end
     end
     private_constant :Compiler
 
@@ -576,6 +579,12 @@ module RuboCop
     def marshal_dump
       pattern
     end
+
+    def ==(other)
+      other.is_a?(NodePattern) &&
+        Compiler.tokens(other.pattern) == Compiler.tokens(pattern)
+    end
+    alias eql? ==
 
     def to_s
       "#<#{self.class} #{pattern}>"

--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -562,6 +562,13 @@ module RuboCop
       instance_eval(src)
     end
 
+    def match(*args)
+      # If we're here, it's because the singleton method has not been defined,
+      # either because we've been dup'ed or serialized through YAML
+      initialize(pattern)
+      match(*args)
+    end
+
     def marshal_load(pattern)
       initialize pattern
     end

--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -552,7 +552,10 @@ module RuboCop
       end
     end
 
+    attr_reader :pattern
+
     def initialize(str)
+      @pattern = str
       compiler = Compiler.new(str)
       src = "def match(node0#{compiler.emit_trailing_params});" \
             "#{compiler.emit_method_code}end"

--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -561,6 +561,10 @@ module RuboCop
             "#{compiler.emit_method_code}end"
       instance_eval(src)
     end
+
+    def to_s
+      "#<#{self.class} #{pattern}>"
+    end
   end
 end
 # rubocop:enable Metrics/ClassLength, Metrics/CyclomaticComplexity

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -127,6 +127,17 @@ RSpec.describe RuboCop::NodePattern do
 
       it_behaves_like 'matching'
     end
+
+    describe '#==' do
+      let(:pattern) { "  (send  42 \n :to_s ) " }
+
+      it 'returns true iff the patterns are similar' do
+        expect(instance == instance.dup).to eq true
+        expect(instance == 42).to eq false
+        expect(instance == described_class.new('(send)')).to eq false
+        expect(instance == described_class.new('(send 42 :to_s)')).to eq true
+      end
+    end
   end
 
   describe 'literals' do

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -113,6 +113,20 @@ RSpec.describe RuboCop::NodePattern do
 
       it_behaves_like 'matching'
     end
+
+    describe '#dup' do
+      let(:instance) { super().dup }
+      let(:ruby) { 'obj.method' }
+
+      it_behaves_like 'matching'
+    end
+
+    describe 'yaml compatibility' do
+      let(:instance) { YAML.safe_load(YAML.dump(super()), [described_class]) }
+      let(:ruby) { 'obj.method' }
+
+      it_behaves_like 'matching'
+    end
   end
 
   describe 'literals' do

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -12,23 +12,24 @@ RSpec.describe RuboCop::NodePattern do
 
   let(:node) { root_node }
   let(:params) { [] }
+  let(:instance) { described_class.new(pattern) }
 
   shared_examples 'matching' do
     include RuboCop::AST::Sexp
     it 'matches' do
-      expect(described_class.new(pattern).match(node, *params)).to be true
+      expect(instance.match(node, *params)).to be true
     end
   end
 
   shared_examples 'nonmatching' do
     it "doesn't match" do
-      expect(described_class.new(pattern).match(node, *params).nil?).to be(true)
+      expect(instance.match(node, *params).nil?).to be(true)
     end
   end
 
   shared_examples 'invalid' do
     it 'is invalid' do
-      expect { described_class.new(pattern) }
+      expect { instance }
         .to raise_error(RuboCop::NodePattern::Invalid)
     end
   end
@@ -37,7 +38,7 @@ RSpec.describe RuboCop::NodePattern do
     include RuboCop::AST::Sexp
     it 'yields captured value(s) and returns true if there is a block' do
       expect do |probe|
-        compiled = described_class.new(pattern)
+        compiled = instance
         retval = compiled.match(node, *params) do |capture|
           probe.to_proc.call(capture)
           :retval_from_block
@@ -47,7 +48,7 @@ RSpec.describe RuboCop::NodePattern do
     end
 
     it 'returns captured values if there is no block' do
-      retval = described_class.new(pattern).match(node, *params)
+      retval = instance.match(node, *params)
       expect(retval).to eq captured_val
     end
   end
@@ -56,7 +57,7 @@ RSpec.describe RuboCop::NodePattern do
     include RuboCop::AST::Sexp
     it 'yields captured value(s) and returns true if there is a block' do
       expect do |probe|
-        compiled = described_class.new(pattern)
+        compiled = instance
         retval = compiled.match(node, *params) do |*captures|
           probe.to_proc.call(captures)
           :retval_from_block
@@ -66,7 +67,7 @@ RSpec.describe RuboCop::NodePattern do
     end
 
     it 'returns captured values if there is no block' do
-      retval = described_class.new(pattern).match(node, *params)
+      retval = instance.match(node, *params)
       expect(retval).to eq captured_vals
     end
   end

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -106,6 +106,13 @@ RSpec.describe RuboCop::NodePattern do
         expect(instance.to_s).to include pattern
       end
     end
+
+    describe 'marshal compatibility' do
+      let(:instance) { Marshal.load(Marshal.dump(super())) }
+      let(:ruby) { 'obj.method' }
+
+      it_behaves_like 'matching'
+    end
   end
 
   describe 'literals' do

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -100,6 +100,12 @@ RSpec.describe RuboCop::NodePattern do
         expect(instance.pattern).to eq pattern
       end
     end
+
+    describe '#to_s' do
+      it 'is instructive' do
+        expect(instance.to_s).to include pattern
+      end
+    end
   end
 
   describe 'literals' do

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -94,6 +94,12 @@ RSpec.describe RuboCop::NodePattern do
       # this is an (op-asgn ...) node
       it_behaves_like 'matching'
     end
+
+    describe '#pattern' do
+      it 'returns the pattern' do
+        expect(instance.pattern).to eq pattern
+      end
+    end
   end
 
   describe 'literals' do


### PR DESCRIPTION
This make `NodePattern` a better Ruby citizen:

* provides valuable information with `to_s` / `inspect`
* compatible with `dup`, `YAML` and `Marshal`.
* method `pattern` gives access to the original pattern given when calling `new`
* add comparison (`==`)
