### PR TITLE
Add `$stdout`/`$stderr` and `STDOUT`/`STDERR` method calls to `Rails/Output`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Changes
 
+* Add `$stdout`/`$stderr` and `STDOUT`/`STDERR` method calls to `Rails/Output`. ([@elebow][])
 * [#6688](https://github.com/rubocop-hq/rubocop/pull/6688): Add `iterator?` to deprecated methods and prefer `block_given?` instead. ([@tejasbubane][])
 * [#6806](https://github.com/rubocop-hq/rubocop/pull/6806): Remove `powerpack` dependency. ([@dduugg][])
 * [#6810](https://github.com/rubocop-hq/rubocop/pull/6810): Exclude gemspec file by default for `Metrics/BlockLength` cop. ([@koic][])

--- a/spec/rubocop/cop/rails/output_spec.rb
+++ b/spec/rubocop/cop/rails/output_spec.rb
@@ -9,9 +9,12 @@ RSpec.describe RuboCop::Cop::Rails::Output do
       puts "sinbad"
       print "abbe busoni"
       pp "monte cristo"
+      $stdout.write "lord wilmore"
+      $stderr.syswrite "faria"
+      STDOUT.write "bertuccio"
     RUBY
     inspect_source(source)
-    expect(cop.offenses.size).to eq(4)
+    expect(cop.offenses.size).to eq(7)
   end
 
   it 'does not record an offense for methods with a receiver' do
@@ -27,6 +30,8 @@ RSpec.describe RuboCop::Cop::Rails::Output do
       print
       pp
       puts
+      $stdout.write
+      STDERR.write
     RUBY
   end
 
@@ -34,6 +39,8 @@ RSpec.describe RuboCop::Cop::Rails::Output do
     expect_no_offenses(<<-RUBY.strip_indent)
       # print "test"
       # p
+      # $stdout.write
+      # STDERR.binwrite
     RUBY
   end
 end


### PR DESCRIPTION
The `Rails/Output` cop detects printing output to the console. In Rails applications, output should be done only through a mechanism like `Rails.logger`.

This PR adds detection of printing to the console by writing to `$stdout`, `$stderr`, `STDOUT`, or `STDERR`.


-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
