### PR TITLE
[Fix #6675] Avoid printing deprecation warnings about constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#6806](https://github.com/rubocop-hq/rubocop/pull/6806): Remove `powerpack` dependency. ([@dduugg][])
 * [#6810](https://github.com/rubocop-hq/rubocop/pull/6810): Exclude gemspec file by default for `Metrics/BlockLength` cop. ([@koic][])
 * [#6813](https://github.com/rubocop-hq/rubocop/pull/6813): Allow unicode/display_width dependency version 1.5.0. ([@tagliala][])
+* [#6675](https://github.com/rubocop-hq/rubocop/issues/6675): Avoid printing deprecation warnings about constants. ([@elmasantos][])
 
 ## 0.65.0 (2019-02-19)
 
@@ -3855,3 +3856,4 @@
 [@enkessler]: https://github.com/enkessler
 [@tagliala]: https://github.com/tagliala
 [@unasuke]: https://github.com/unasuke
+[@elmasantos]: https://github.com/elmasantos

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -30,6 +30,18 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedException do
       RUBY
     end
 
+    it 'rescue a exception without causing constant name deprecation warning' do
+      expect do
+        inspect_source(<<-RUBY.strip_indent)
+          def foo
+            something
+          rescue TimeoutError
+            handle_exception
+          end
+        RUBY
+      end.not_to output(/.*TimeoutError is deprecated/).to_stderr
+    end
+
     it 'accepts rescuing a single custom exception' do
       expect_no_offenses(<<-RUBY.strip_indent)
         begin


### PR DESCRIPTION
This PR prevents deprecation warnings about constants to be shown (issue #6675).

It was needed to implement a method called `silence_warnings`, since `Kernel::silence_warnings` was hiding RuboCop's warnings.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
