### PR TITLE
Add examples for rule PredicateName to better show its behavior 

### DIFF
--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -441,6 +441,9 @@ This cop makes sure that predicates are named properly.
 
 ```ruby
 # bad
+def is_even(value)
+end
+
 def is_even?(value)
 end
 
@@ -449,6 +452,9 @@ def even?(value)
 end
 
 # bad
+def has_value
+end
+
 def has_value?
 end
 


### PR DESCRIPTION
Makes it more obvious that the rule also applies to the methods that don't end with question mark, but to all the one starting with a specific prefix.

Having both "is_" and "?" question mark is undoubtedly redundant, but example don't reveal other aspect of this rule.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
