### PR TITLE
[Fix #6746] Avoid offense on `$stderr.puts` with no arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [#6810](https://github.com/rubocop-hq/rubocop/pull/6810): Exclude gemspec file by default for `Metrics/BlockLength` cop. ([@koic][])
 * [#6813](https://github.com/rubocop-hq/rubocop/pull/6813): Allow unicode/display_width dependency version 1.5.0. ([@tagliala][])
 * [#6675](https://github.com/rubocop-hq/rubocop/issues/6675): Avoid printing deprecation warnings about constants. ([@elmasantos][])
+* [#6746](https://github.com/rubocop-hq/rubocop/issues/6746): Avoid offense on `$stderr.puts` with no arguments. ([@luciamo][])
 
 ## 0.65.0 (2019-02-19)
 
@@ -3862,3 +3863,4 @@
 [@tagliala]: https://github.com/tagliala
 [@unasuke]: https://github.com/unasuke
 [@elmasantos]: https://github.com/elmasantos
+[@luciamo]: https://github.com/luciamo

--- a/lib/rubocop/cop/style/stderr_puts.rb
+++ b/lib/rubocop/cop/style/stderr_puts.rb
@@ -22,7 +22,7 @@ module RuboCop
 
         def_node_matcher :stderr_puts?, <<-PATTERN
           (send
-            (gvar #stderr_gvar?) :puts
+            (gvar #stderr_gvar?) :puts $_
             ...)
         PATTERN
 

--- a/spec/rubocop/cop/style/stderr_puts_spec.rb
+++ b/spec/rubocop/cop/style/stderr_puts_spec.rb
@@ -17,4 +17,10 @@ RSpec.describe RuboCop::Cop::Style::StderrPuts do
 
     expect(new_source).to eq "warn('hello')"
   end
+
+  it 'registers no offense when using `$stderr.puts` with no arguments' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      $stderr.puts
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR closes issue #6746. The applied changes will avoid offense on `$stderr.puts` with no arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
