### PR TITLE
[Fix #4321] Allow `self` to receive methods also defined on `Kernel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bug fixes
 
+* [#4321](https://github.com/rubocop-hq/rubocop/pull/4321): Fix false offense for Style/RedundantSelf when the method is also defined on `Kernel`. ([@mikegee][])
 * [#6821](https://github.com/rubocop-hq/rubocop/pull/6821): Fix false negative for Rails/LinkToBlank when `_blank` is a symbol. ([@Intrepidd][])
 * [#6699](https://github.com/rubocop-hq/rubocop/issues/6699): Fix infinite loop for `Layout/IndentationWidth` and `Layout/IndentationConsistency` when bad modifier indentation before good method definition. ([@koic][])
 * [#6777](https://github.com/rubocop-hq/rubocop/issues/6777): Fix a false positive for `Style/TrivialAccessors` when using trivial reader/writer methods at the top level. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -43,6 +43,7 @@ module RuboCop
       #   end
       class RedundantSelf < Cop
         MSG = 'Redundant `self` detected.'.freeze
+        KERNEL_METHODS = Kernel.methods(false)
 
         def self.autocorrect_incompatible_with
           [ColonMethodCall]
@@ -117,7 +118,8 @@ module RuboCop
 
         def allowed_send_node?(node)
           @allowed_send_nodes.include?(node) ||
-            @local_variables_scopes[node].include?(node.method_name)
+            @local_variables_scopes[node].include?(node.method_name) ||
+            KERNEL_METHODS.include?(node.method_name)
         end
 
         def regular_method_call?(node)

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -210,4 +210,8 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf do
     new_source = autocorrect_source('self.x')
     expect(new_source).to eq('x')
   end
+
+  it 'accepts a self receiver of methods also defined on `Kernel`' do
+    expect_no_offenses('self.open')
+  end
 end


### PR DESCRIPTION
Method calls with an explicit receiver of `self` are ok when a method with the same name is also defined on `Kernel`. Rubocop can't know if the explicit `self` is disambiguating a method call or not.


Fixes #4321 

(Perhaps there should be another cop warning about defining methods that are also defined on `Kernel`? 🤔 )

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
