### PR TITLE
Unlimited terms after ellipsis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add new `Style/ConstantVisibility` cop for enforcing visibility declarations of class- and module constants. ([@drenmi][])
 * [#6378](https://github.com/rubocop-hq/rubocop/issues/6378): Add `Lint/ToJSON` cop to enforce an argument when overriding #to_json. ([@allcentury][])
 * [#6346](https://github.com/rubocop-hq/rubocop/issues/6346): Add auto-correction to `Rails/TimeZone`. ([@dcluna][])
+* [#6840](https://github.com/rubocop-hq/rubocop/issues/6840): Node patterns now allow unlimited elements after `...`. ([@marcandre][])
 
 ### Bug fixes
 

--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -199,6 +199,7 @@ module RuboCop
           compile_seq_terms_with_size(tokens, cur_node) do |token, terms, index|
             capture = next_capture if token == CAPTURED_REST
             if capture || token == REST
+              index = 0 if index == SEQ_HEAD_INDEX # Consider ($...) as (_ $...)
               return compile_ellipsis(tokens, cur_node, terms, index, capture)
             end
           end
@@ -210,7 +211,7 @@ module RuboCop
         index = SEQ_HEAD_INDEX
         terms = []
         until tokens.first == ')'
-          yield tokens.first, terms, [index, 0].max
+          yield tokens.first, terms, index
           term = compile_expr_with_index(tokens, cur_node, index)
           index += 1
           terms << term

--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -231,17 +231,11 @@ module RuboCop
 
       def compile_ellipsis(tokens, cur_node, terms, index, capture = nil)
         tail = compile_seq_tail(tokens, "#{cur_node}.children.last")
-        if !tail.empty?
-          terms << "(#{cur_node}.children.size > #{index})"
-          terms.concat tail
-          if capture
-            terms << "(#{capture} = #{cur_node}.children[#{index}..-2])"
-          end
-        else
-          terms << "(#{cur_node}.children.size >= #{index})" if index > 0
-          if capture
-            terms << "(#{capture} = #{cur_node}.children[#{index}..-1])"
-          end
+        terms << "(#{cur_node}.children.size >= #{index + tail.size})"
+        terms.concat tail
+        if capture
+          range = index..-tail.size - 1
+          terms << "(#{capture} = #{cur_node}.children[#{range}])"
         end
         terms
       end

--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -195,12 +195,9 @@ module RuboCop
       def compile_seq_terms(tokens, cur_node)
         ret, size =
           compile_seq_terms_with_size(tokens, cur_node) do |token, terms, index|
-            case token
-            when REST
-              return compile_ellipsis(tokens, cur_node, terms, index)
-            when CAPTURED_REST
-              return compile_ellipsis(tokens, cur_node, terms, index,
-                                      next_capture)
+            capture = next_capture if token == CAPTURED_REST
+            if capture || token == REST
+              return compile_ellipsis(tokens, cur_node, terms, index, capture)
             end
           end
 

--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -230,6 +230,7 @@ module RuboCop
       end
 
       def compile_ellipsis(tokens, cur_node, terms, index, capture = nil)
+        tokens.shift # drop ellipsis
         tail = compile_seq_tail(tokens, "#{cur_node}.children.last")
         terms << "(#{cur_node}.children.size >= #{index + tail.size})"
         terms.concat tail
@@ -241,7 +242,6 @@ module RuboCop
       end
 
       def compile_seq_tail(tokens, cur_node)
-        tokens.shift
         if tokens.first == ')'
           tokens.shift
           []

--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -199,7 +199,8 @@ module RuboCop
             when REST
               return compile_ellipsis(tokens, cur_node, terms, index)
             when CAPTURED_REST
-              return compile_capt_ellip(tokens, cur_node, terms, index)
+              return compile_ellipsis(tokens, cur_node, terms, index,
+                                      next_capture)
             end
           end
 
@@ -231,25 +232,18 @@ module RuboCop
         end
       end
 
-      def compile_ellipsis(tokens, cur_node, terms, index)
+      def compile_ellipsis(tokens, cur_node, terms, index, capture = nil)
         if (term = compile_seq_tail(tokens, "#{cur_node}.children.last"))
           terms << "(#{cur_node}.children.size > #{index})"
           terms << term
-        elsif index > 0
-          terms << "(#{cur_node}.children.size >= #{index})"
-        end
-        terms
-      end
-
-      def compile_capt_ellip(tokens, cur_node, terms, index)
-        capture = next_capture
-        if (term = compile_seq_tail(tokens, "#{cur_node}.children.last"))
-          terms << "(#{cur_node}.children.size > #{index})"
-          terms << term
-          terms << "(#{capture} = #{cur_node}.children[#{index}..-2])"
+          if capture
+            terms << "(#{capture} = #{cur_node}.children[#{index}..-2])"
+          end
         else
           terms << "(#{cur_node}.children.size >= #{index})" if index > 0
-          terms << "(#{capture} = #{cur_node}.children[#{index}..-1])"
+          if capture
+            terms << "(#{capture} = #{cur_node}.children[#{index}..-1])"
+          end
         end
         terms
       end

--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -230,9 +230,10 @@ module RuboCop
       end
 
       def compile_ellipsis(tokens, cur_node, terms, index, capture = nil)
-        if (term = compile_seq_tail(tokens, "#{cur_node}.children.last"))
+        tail = compile_seq_tail(tokens, "#{cur_node}.children.last")
+        if !tail.empty?
           terms << "(#{cur_node}.children.size > #{index})"
-          terms << term
+          terms.concat tail
           if capture
             terms << "(#{capture} = #{cur_node}.children[#{index}..-2])"
           end
@@ -249,11 +250,11 @@ module RuboCop
         tokens.shift
         if tokens.first == ')'
           tokens.shift
-          nil
+          []
         else
           expr = compile_expr(tokens, cur_node, false)
           fail_due_to('missing )') unless tokens.shift == ')'
-          expr
+          [expr]
         end
       end
 

--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -195,7 +195,7 @@ module RuboCop
       end
 
       def compile_seq_terms(tokens, cur_node)
-        ret, size =
+        ret =
           compile_seq_terms_with_size(tokens, cur_node) do |token, terms, index|
             capture = next_capture if token == CAPTURED_REST
             if capture || token == REST
@@ -203,8 +203,7 @@ module RuboCop
               return compile_ellipsis(tokens, cur_node, terms, index, capture)
             end
           end
-
-        ret << "(#{cur_node}.children.size == #{size})"
+        ret << "(#{cur_node}.children.size == #{ret.size - 1})"
       end
 
       def compile_seq_terms_with_size(tokens, cur_node)
@@ -218,7 +217,7 @@ module RuboCop
         end
 
         tokens.shift # drop concluding )
-        [terms, index]
+        terms
       end
 
       def compile_expr_with_index(tokens, cur_node, index)

--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -118,6 +118,9 @@ module RuboCop
       PARAM     = /\A#{PARAM_NUMBER}\Z/.freeze
       CLOSING   = /\A(?:\)|\}|\])\Z/.freeze
 
+      REST      = '...'.freeze
+      CAPTURED_REST = '$...'.freeze
+
       attr_reader :match_code
 
       def initialize(str, node_var = 'node0')
@@ -193,9 +196,9 @@ module RuboCop
         ret, size =
           compile_seq_terms_with_size(tokens, cur_node) do |token, terms, index|
             case token
-            when '...'.freeze
+            when REST
               return compile_ellipsis(tokens, cur_node, terms, index)
-            when '$...'.freeze
+            when CAPTURED_REST
               return compile_capt_ellip(tokens, cur_node, terms, index)
             end
           end

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -1173,6 +1173,18 @@ RSpec.describe RuboCop::NodePattern do
       it_behaves_like 'invalid'
     end
 
+    context 'with unmatched opening paren and `...`' do
+      let(:pattern) { '(send ...' }
+
+      it_behaves_like 'invalid'
+    end
+
+    context 'with too many terms after `...`' do
+      let(:pattern) { '(send ... 1 2)' }
+
+      it_behaves_like 'invalid'
+    end
+
     context 'with unmatched closing paren' do
       let(:pattern) { '(send (const)))' }
 

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -585,6 +585,14 @@ RSpec.describe RuboCop::NodePattern do
       it_behaves_like 'single capture'
     end
 
+    context 'with remaining patterns at the end' do
+      let(:pattern) { '(send $... int int)' }
+      let(:ruby) { '[].push(1, 2, 3)' }
+      let(:captured_val) { [s(:array), :push, s(:int, 1)] }
+
+      it_behaves_like 'single capture'
+    end
+
     context 'with a remaining sequence at the end' do
       let(:pattern) { '(send $... (int 4))' }
       let(:ruby) { '5 + 4' }
@@ -800,6 +808,14 @@ RSpec.describe RuboCop::NodePattern do
       let(:captured_val) { s(:int, 4) }
 
       it_behaves_like 'single capture'
+    end
+
+    context 'preceding multiple captures' do
+      let(:pattern) { '(send array :push ... $_ $_)' }
+      let(:ruby) { '[1].push(2, 3, 4, 5)' }
+      let(:captured_vals) { [s(:int, 4), s(:int, 5)] }
+
+      it_behaves_like 'multiple capture'
     end
 
     context 'with a wildcard at the end, but no remaining child to match it' do
@@ -1175,12 +1191,6 @@ RSpec.describe RuboCop::NodePattern do
 
     context 'with unmatched opening paren and `...`' do
       let(:pattern) { '(send ...' }
-
-      it_behaves_like 'invalid'
-    end
-
-    context 'with too many terms after `...`' do
-      let(:pattern) { '(send ... 1 2)' }
 
       it_behaves_like 'invalid'
     end


### PR DESCRIPTION
This makes it possible to have node patterns with as many terms as wanted after an `...` or an `$...`.

The initial commits are refactoring the code to make small improvements, factorize common code. Overall code is shorter.

Fixes #6840. Should help for #6841 too.