### PR TITLE
[#5977] Warn for Performance Cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#5977](https://github.com/rubocop-hq/rubocop/issues/5977): Warn for Performance Cops. ([@koic][])
+
 ## 0.66.0 (2019-03-18)
 
 ### New features

--- a/exe/rubocop
+++ b/exe/rubocop
@@ -9,6 +9,18 @@ require 'benchmark'
 cli = RuboCop::CLI.new
 result = 0
 
+if defined?(Bundler)
+  gemfile_lock = Bundler.read_file(Bundler.default_lockfile)
+  parser = Bundler::LockfileParser.new(gemfile_lock)
+
+  unless parser.dependencies['rubocop-performance']
+    warn Rainbow(<<-MESSAGE.strip_indent).yellow.to_s
+      [Warn] Performance Cops will be removed from RuboCop 0.68. Use rubocop-performance gem instead.
+             https://github.com/rubocop-hq/rubocop/tree/master/manual/migrate_performance_cops.md
+    MESSAGE
+  end
+end
+
 time = Benchmark.realtime do
   result = cli.run
 end

--- a/manual/extensions.md
+++ b/manual/extensions.md
@@ -32,6 +32,8 @@ See [development](development.md).
 
 #### Known Custom Cops
 
+* [rubocop-performance](https://github.com/rubocop-hq/rubocop-performance) -
+  Performance optimization analysis
 * [rubocop-rspec](https://github.com/rubocop-hq/rubocop-rspec) -
   RSpec-specific analysis
 * [rubocop-thread_safety](https://github.com/covermymeds/rubocop-thread_safety) -

--- a/manual/migrate_performance_cops.md
+++ b/manual/migrate_performance_cops.md
@@ -1,0 +1,15 @@
+Performance Cops will be removed from RuboCop 0.68. Use rubocop-performance gem instead.
+
+Put this in your Gemfile.
+
+  gem 'rubocop-performance'
+
+And then execute:
+
+  $ bundle install
+
+Put this into your .rubocop.yml.
+
+  require: rubocop-performance
+
+More information: https://github.com/rubocop-hq/rubocop-performance

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -43,4 +43,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('bundler', '>= 1.3.0', '< 3.0')
   s.add_development_dependency('rack', '>= 2.0')
+
+  s.post_install_message = File.read('manual/migrate_performance_cops.md')
 end


### PR DESCRIPTION
### Summary

This PR warns for Performance Cops.

The following warning is displayed when the next released rubocop gem is installed.

```console
# The following is an example for operation check.
% rake build
% gem install pkg/rubocop-0.66.0.gem
Performance Cops will be removed from RuboCop 0.68. Use
rubocop-performance gem instead.

Put this in your Gemfile.

  gem 'rubocop-performance'

And then execute:

  $ bundle install

Put this into your .rubocop.yml.

  require: rubocop-performance

More information: https://github.com/rubocop-hq/rubocop-performance
Successfully installed rubocop-0.66.0
1 gem installed
```

The following warning is displayed if RuboCop is used with Bundler.

```consle
% bundle exec rubocop
[Warn] Performance Cops will be removed from RuboCop 0.68. Use rubocop-performance gem instead.
       https://github.com/rubocop-hq/rubocop/tree/master/manual/migrate_performance_cops.md
```

The above warning will disappear when rubocop-performance gem is written to Gemfile.
The rubocop-performance implementation takes precedence when rubocop-performance is written in Gemfile.

And I prepared a simple migration manual (migrate_performance_cops.md) because I think that long warning sentences are not preferred. I think that referring to the link is good when runnning rubocop command.

### Other Infromation

At first I tried to remove performance cops from RuboCop Core and add rubocop-performance gem as a dependency because of fallback.

```diff
% git diff
diff --git a/rubocop.gemspec b/rubocop.gemspec
index bbbcca33f..09882b063 100644
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('parser', '>= 2.5', '!= 2.5.1.1')
   s.add_runtime_dependency('psych', '>= 3.1.0')
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
+  s.add_runtime_dependency('rubocop-performance')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 1.6')
```

However, this cannot be resolved because it is cyclic.

```console
% bundle install
Fetching gem metadata from https://rubygems.org/........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Your bundle requires gems that depend on each other, creating an infinite loop.
Please remove either gem 'rubocop' or gem 'rubocop-performance' and try again.
```

So I'd like to display a warning before removing performance cops.

I'd like to mitigate the impact on users this way.

The next step is to remove performance cops and done #5977.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
