### PR TITLE
Allow chained Hash#[] when BlockDelimiters braces_for_chaining is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#6998](https://github.com/rubocop-hq/rubocop/pull/6998): Fix autocorrect of `Naming/RescuedExceptionsVariableName` to also rename all references to the variable. ([@Darhazer][])
 * [#6992](https://github.com/rubocop-hq/rubocop/pull/6992): Fix unknown default configuration for `Layout/IndentFirstParameter` cop. ([@drenmi][])
 * [#6972](https://github.com/rubocop-hq/rubocop/issues/6972): Fix a false positive for `Style/MixinUsage` when using inside block and `if` condition is after `include`. ([@koic][])
+* [#6847](https://github.com/rubocop-hq/rubocop/pull/6847): Fix `Style/BlockDelimiters` to properly check if the node is chaned when `braces_for_chaining` is set. ([@att14][])
 
 ## 0.68.0 (2019-04-29)
 
@@ -3989,3 +3990,4 @@
 [@andreaseger]: https://github.com/andreaseger
 [@yakout]: https://github.com/yakout
 [@RicardoTrindade]: https://github.com/RicardoTrindade
+[@att14]: https://github.com/att14

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -165,7 +165,7 @@ module RuboCop
 
         def braces_for_chaining_message(node)
           if node.multiline?
-            if return_value_chaining?(node)
+            if node.chained?
               'Prefer `{...}` over `do...end` for multi-line chained blocks.'
             else
               'Prefer `do...end` for multi-line blocks without chaining.'
@@ -267,7 +267,7 @@ module RuboCop
           block_begin = node.loc.begin.source
 
           block_begin == if node.multiline?
-                           (return_value_chaining?(node) ? '{' : 'do')
+                           (node.chained? ? '{' : 'do')
                          else
                            '{'
                          end
@@ -275,10 +275,6 @@ module RuboCop
 
         def braces_style?(node)
           node.loc.begin.source == '{'
-        end
-
-        def return_value_chaining?(node)
-          node.parent && node.parent.send_type? && node.parent.dot?
         end
 
         def correction_would_break_code?(node)

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -490,6 +490,45 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       RUBY
     end
 
+    it 'allows when :[] is chained' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        foo = [{foo: :bar}].find { |h|
+          h.key?(:foo)
+        }[:foo]
+      RUBY
+    end
+
+    it 'allows do/end inside Hash[]' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        Hash[
+          {foo: :bar}.map do |k, v|
+            [k, v]
+          end
+        ]
+      RUBY
+    end
+
+    it 'allows chaining to } inside of Hash[]' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        Hash[
+          {foo: :bar}.map { |k, v|
+            [k, v]
+          }.uniq
+        ]
+      RUBY
+    end
+
+    it 'disallows {} with no chain inside of Hash[]' do
+      expect_offense(<<-RUBY.strip_indent)
+        Hash[
+          {foo: :bar}.map { |k, v|
+                          ^ Prefer `do...end` for multi-line blocks without chaining.
+            [k, v]
+          }
+        ]
+      RUBY
+    end
+
     context 'when there are braces around a multi-line block' do
       it 'registers an offense in the simple case' do
         expect_offense(<<-RUBY.strip_indent)


### PR DESCRIPTION
Sometimes the return of a block is a Hash and Ruby allows you to call `[]` without a dot. This means only checking `dot?` in `return_value_chaining?` does not allow chaining Hash element reference. I wasn't sure if checking the explicit method name was the best choice or if there is something that I missed in the documentation.

I did not add an entry to the Changelog in order to get feedback first. If this is an acceptable change I will do so.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
