### PR TITLE
Add `STDERR.puts` check to `Style/StderrPuts` cop

### DIFF
--- a/lib/rubocop/cop/style/stderr_puts.rb
+++ b/lib/rubocop/cop/style/stderr_puts.rb
@@ -17,12 +17,14 @@ module RuboCop
       class StderrPuts < Cop
         include RangeHelp
 
-        MSG = 'Use `warn` instead of `$stderr.puts` to allow such output ' \
-              'to be disabled.'.freeze
+        MSG =
+          'Use `warn` instead of `%<bad>s` to allow such output to be disabled.'
+          .freeze
 
         def_node_matcher :stderr_puts?, <<-PATTERN
           (send
-            (gvar #stderr_gvar?) :puts $_
+            {(gvar #stderr_gvar?) (const nil? :STDERR)}
+            :puts $_
             ...)
         PATTERN
 
@@ -39,6 +41,10 @@ module RuboCop
         end
 
         private
+
+        def message(node)
+          format(MSG, bad: "#{node.receiver.source}.#{node.method_name}")
+        end
 
         def stderr_gvar?(sym)
           sym == :$stderr

--- a/spec/rubocop/cop/style/stderr_puts_spec.rb
+++ b/spec/rubocop/cop/style/stderr_puts_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::Style::StderrPuts do
     RUBY
   end
 
-  it "autocorrects `warn('hello')`" do
+  it 'autocorrects `$stderr.puts` to `warn`' do
     new_source = autocorrect_source("$stderr.puts('hello')")
 
     expect(new_source).to eq "warn('hello')"
@@ -21,6 +21,25 @@ RSpec.describe RuboCop::Cop::Style::StderrPuts do
   it 'registers no offense when using `$stderr.puts` with no arguments' do
     expect_no_offenses(<<-RUBY.strip_indent)
       $stderr.puts
+    RUBY
+  end
+
+  it "registers an offense when using `STDERR.puts('hello')`" do
+    expect_offense(<<-RUBY.strip_indent)
+      STDERR.puts('hello')
+      ^^^^^^^^^^^ Use `warn` instead of `STDERR.puts` to allow such output to be disabled.
+    RUBY
+  end
+
+  it 'autocorrects `STDERR.puts` to `warn`' do
+    new_source = autocorrect_source("STDERR.puts('hello')")
+
+    expect(new_source).to eq "warn('hello')"
+  end
+
+  it 'registers no offense when using `STDERR.puts` with no arguments' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      STDERR.puts
     RUBY
   end
 end


### PR DESCRIPTION
`STDERR` is often equal to `$stderr` in Ruby programs. Writing to either one should be replaced by `warn`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
