### PR TITLE
Fix NodePattern of node type on a literal

### DIFF
--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -372,7 +372,8 @@ module RuboCop
       end
 
       def compile_nodetype(cur_node, type)
-        "(#{cur_node} && #{cur_node}.#{type.tr('-', '_')}_type?)"
+        "(#{cur_node}.is_a?(RuboCop::AST::Node) && " \
+          "#{cur_node}.#{type.tr('-', '_')}_type?)"
       end
 
       def compile_param(cur_node, number, seq_head)

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -140,6 +140,47 @@ RSpec.describe RuboCop::NodePattern do
     end
   end
 
+  describe 'node type' do
+    describe 'in seq head' do
+      let(:pattern) { '(send ...)' }
+
+      context 'on a node with the same type' do
+        let(:ruby) { '@ivar + 2' }
+
+        it_behaves_like 'matching'
+      end
+
+      context 'on a child with a different type' do
+        let(:ruby) { '@ivar += 2' }
+
+        it_behaves_like 'nonmatching'
+      end
+    end
+
+    describe 'for a child' do
+      let(:pattern) { '(_ send ...)' }
+
+      context 'on a child with the same type' do
+        let(:ruby) { 'foo.bar' }
+
+        it_behaves_like 'matching'
+      end
+
+      context 'on a child with a different type' do
+        let(:ruby) { '@ivar.bar' }
+
+        it_behaves_like 'nonmatching'
+      end
+
+      context 'on a child litteral' do
+        let(:pattern) { '(_ _ send)' }
+        let(:ruby) { '42.bar' }
+
+        it_behaves_like 'nonmatching'
+      end
+    end
+  end
+
   describe 'literals' do
     context 'negative integer literals' do
       let(:pattern) { '(int -100)' }


### PR DESCRIPTION
Without this fix, one can get errors raised like:

```
     NoMethodError:
       undefined method `send_type?' for :bar:Symbol
```