### PR TITLE
Use absolute path to Gemfile.local in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,5 +19,5 @@ group :test do
   gem 'webmock', require: false
 end
 
-local_gemfile = 'Gemfile.local'
+local_gemfile = File.expand_path('Gemfile.local', __dir__)
 eval_gemfile local_gemfile if File.exist?(local_gemfile)


### PR DESCRIPTION
Basically this minor change allows using custom dependencies from Gemfile.local in the test suite (parser/master in my case), it fixes all issues from https://travis-ci.org/whitequark/parser/jobs/509161694. `ci/run_rubocop_specs` from parser finally works.

For more information see https://github.com/whitequark/parser/pull/531

/cc @bbatsov @Drenmi 

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
