### PR TITLE
Add new cop `Rails/ActiveRecordOverride`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* Add new cop `Rails/ActiveRecordOverride` that checks for overriding Active Record methods instead of using callbacks. ([@elebow][])
 * Add new cop `Rails/RedundantAllowNil` that checks for cases when `allow_blank` makes `allow_nil` unnecessary in model validations. ([@elebow][])
 
 ### Bug fixes

--- a/config/default.yml
+++ b/config/default.yml
@@ -2229,6 +2229,15 @@ Rails/ActiveRecordAliases:
   Enabled: true
   VersionAdded: '0.53'
 
+Rails/ActiveRecordOverride:
+  Description: >-
+                  Check for overriding Active Record methods instead of using
+                  callbacks.
+  Enabled: true
+  VersionAdded: '0.67'
+  Include:
+    - app/models/**/*.rb
+
 Rails/ActiveSupportAliases:
   Description: >-
                   Avoid ActiveSupport aliases of standard ruby methods:

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -559,6 +559,7 @@ require_relative 'rubocop/cop/style/zero_length_predicate'
 
 require_relative 'rubocop/cop/rails/action_filter'
 require_relative 'rubocop/cop/rails/active_record_aliases'
+require_relative 'rubocop/cop/rails/active_record_override'
 require_relative 'rubocop/cop/rails/active_support_aliases'
 require_relative 'rubocop/cop/rails/application_job'
 require_relative 'rubocop/cop/rails/application_record'

--- a/lib/rubocop/cop/rails/active_record_override.rb
+++ b/lib/rubocop/cop/rails/active_record_override.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Rails
+      # Checks for overriding built-in Active Record methods instead of using
+      # callbacks.
+      #
+      # @example
+      #   # bad
+      #   class Book < ApplicationRecord
+      #     def save
+      #       self.title = title.upcase!
+      #       super
+      #     end
+      #   end
+      #
+      #   # good
+      #   class Book < ApplicationRecord
+      #     before_save :upcase_title
+      #
+      #     def upcase_title
+      #       self.title = title.upcase!
+      #     end
+      #   end
+      #
+      class ActiveRecordOverride < Cop
+        MSG =
+          'Use %<prefer>s callbacks instead of overriding the Active Record ' \
+          'method `%<bad>s`.'.freeze
+        BAD_METHODS = %i[create destroy save update].freeze
+
+        def on_def(node)
+          method_name = node.method_name
+          return unless BAD_METHODS.include?(node.method_name)
+
+          parent_parts = node.parent.node_parts
+          parent_class = parent_parts.take_while do |part|
+            !part.nil? && part.const_type?
+          end.last
+          return unless %w[ApplicationRecord ActiveModel::Base]
+                        .include?(parent_class.const_name)
+
+          return unless node.descendants.any?(&:zsuper_type?)
+
+          add_offense(node, message: message(method_name))
+        end
+
+        private
+
+        def callback_names(method_name)
+          names = %w[before_ around_ after_].map do |prefix|
+            "`#{prefix}#{method_name}`"
+          end
+
+          names[-1] = "or #{names.last}"
+
+          names.join(', ')
+        end
+
+        def message(method_name)
+          format(MSG, prefer: callback_names(method_name), bad: method_name)
+        end
+      end
+    end
+  end
+end

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -335,6 +335,7 @@ In the following section you find all available cops:
 
 * [Rails/ActionFilter](cops_rails.md#railsactionfilter)
 * [Rails/ActiveRecordAliases](cops_rails.md#railsactiverecordaliases)
+* [Rails/ActiveRecordOverride](cops_rails.md#railsactiverecordoverride)
 * [Rails/ActiveSupportAliases](cops_rails.md#railsactivesupportaliases)
 * [Rails/ApplicationJob](cops_rails.md#railsapplicationjob)
 * [Rails/ApplicationRecord](cops_rails.md#railsapplicationrecord)

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -69,6 +69,42 @@ Book.update_attributes!(author: 'Alice')
 Book.update!(author: 'Alice')
 ```
 
+## Rails/ActiveRecordOverride
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.67 | -
+
+Checks for overriding built-in Active Record methods instead of using
+callbacks.
+
+### Examples
+
+```ruby
+# bad
+class Book < ApplicationRecord
+  def save
+    self.title = title.upcase!
+    super
+  end
+end
+
+# good
+class Book < ApplicationRecord
+  before_save :upcase_title
+
+  def upcase_title
+    self.title = title.upcase!
+  end
+end
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `app/models/**/*.rb` | Array
+
 ## Rails/ActiveSupportAliases
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/spec/rubocop/cop/rails/active_record_override_spec.rb
+++ b/spec/rubocop/cop/rails/active_record_override_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Rails::ActiveRecordOverride do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers an offense when overriding create' do
+    expect_offense(<<-RUBY.strip_indent)
+      class X < ApplicationRecord
+        def create
+        ^^^^^^^^^^ Use `before_create`, `around_create`, or `after_create` callbacks instead of overriding the Active Record method `create`.
+          super
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when overriding destroy' do
+    expect_offense(<<-RUBY.strip_indent)
+      class X < ApplicationRecord
+        def destroy
+        ^^^^^^^^^^^ Use `before_destroy`, `around_destroy`, or `after_destroy` callbacks instead of overriding the Active Record method `destroy`.
+          super
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when overriding save' do
+    expect_offense(<<-RUBY.strip_indent)
+      class X < ApplicationRecord
+        def save
+        ^^^^^^^^ Use `before_save`, `around_save`, or `after_save` callbacks instead of overriding the Active Record method `save`.
+          super
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when overriding update' do
+    expect_offense(<<-RUBY.strip_indent)
+      class X < ActiveModel::Base
+        def update
+        ^^^^^^^^^^ Use `before_update`, `around_update`, or `after_update` callbacks instead of overriding the Active Record method `update`.
+          super
+        end
+      end
+    RUBY
+  end
+
+  context 'when overriding without a super call' do
+    it 'registers no offense when overriding save' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class X < ApplicationRecord
+          def save
+            @a = 5
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when class is not an ActiveRecord model' do
+    it 'registers no offense when overriding save' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class X
+          def save
+            super
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when class is not an ActiveRecord model' do
+    it 'registers no offense when overriding save' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class X < Y
+          def save
+            super
+          end
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
This cop checks for cases where an Active Record method like `save`, `update`, etc is overridden and includes a `super` statement. Instead, the user should use Active Record callbacks.

---

There is a limitation in this PR currently, where the cop will not register any offense if the class in question inherits indirectly from `ApplicationRecord` or `ActiveModel::Base`.  For example:

```ruby
class Book < ApplicationRecord
end

class Novel < Book
  # this should be an offense, but it will not be detected
  def update
    this.x = 5
    super
  end
end
```
It would be much more complicated to evaluate all the parent classes looking for  `ApplicationRecord` or `ActiveModel::Base`, so it seems more practical to accept this limitation. I'm open to advice, of course.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
