### PR TITLE
Clarify dangers of Rails/LexicallyScopedActionFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Changes
 
+* [#6854](https://github.com/rubocop-hq/rubocop/pull/6854): Mark Rails/LexicallyScopedActionFilter as unsafe and document risks. ([@urbanautomaton][])
 * [#5977](https://github.com/rubocop-hq/rubocop/issues/5977): Warn for Performance Cops. ([@koic][])
 * [#6637](https://github.com/rubocop-hq/rubocop/issues/6637): Move `LstripRstrip` from `Performance` to `Style` department and rename it to `Strip`. ([@anuja-joshi][])
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -2445,6 +2445,7 @@ Rails/LexicallyScopedActionFilter:
   Description: "Checks that methods specified in the filter's `only` or `except` options are explicitly defined in the controller."
   StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#lexically-scoped-action-filter'
   Enabled: true
+  Safe: false
   VersionAdded: '0.52'
   Include:
     - app/controllers/**/*.rb

--- a/lib/rubocop/cop/rails/lexically_scoped_action_filter.rb
+++ b/lib/rubocop/cop/rails/lexically_scoped_action_filter.rb
@@ -6,10 +6,13 @@ module RuboCop
       # This cop checks that methods specified in the filter's `only` or
       # `except` options are defined within the same class or module.
       #
-      # You can technically specify methods of superclass or methods added
-      # by mixins on the filter, but these confuse developers. If you
-      # specify methods that are defined in other classes or modules, you
-      # should define the filter in that class or module.
+      # You can technically specify methods of superclass or methods added by
+      # mixins on the filter, but these can confuse developers. If you specify
+      # methods that are defined in other classes or modules, you should
+      # define the filter in that class or module.
+      #
+      # If you rely on behaviour defined in the superclass actions, you must
+      # remember to invoke `super` in the subclass actions.
       #
       # @example
       #   # bad
@@ -54,6 +57,29 @@ module RuboCop
       #
       #     def foo
       #       # something
+      #     end
+      #   end
+      #
+      # @example
+      #   class ContentController < ApplicationController
+      #     def update
+      #       @content.update(content_attributes)
+      #     end
+      #   end
+      #
+      #   class ArticlesController < ContentController
+      #     before_action :load_article, only: [:update]
+      #
+      #     # the cop requires this method, but it relies on behaviour defined
+      #     # in the superclass, so needs to invoke `super`
+      #     def update
+      #       super
+      #     end
+      #
+      #     private
+      #
+      #     def load_article
+      #       @content = Article.find(params[:article_id])
       #     end
       #   end
       class LexicallyScopedActionFilter < Cop

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1169,10 +1169,13 @@ Enabled | Yes | No | 0.52 | -
 This cop checks that methods specified in the filter's `only` or
 `except` options are defined within the same class or module.
 
-You can technically specify methods of superclass or methods added
-by mixins on the filter, but these confuse developers. If you
-specify methods that are defined in other classes or modules, you
-should define the filter in that class or module.
+You can technically specify methods of superclass or methods added by
+mixins on the filter, but these can confuse developers. If you specify
+methods that are defined in other classes or modules, you should
+define the filter in that class or module.
+
+If you rely on behaviour defined in the superclass actions, you must
+remember to invoke `super` in the subclass actions.
 
 ### Examples
 
@@ -1219,6 +1222,29 @@ module FooMixin
 
   def foo
     # something
+  end
+end
+```
+```ruby
+class ContentController < ApplicationController
+  def update
+    @content.update(content_attributes)
+  end
+end
+
+class ArticlesController < ContentController
+  before_action :load_article, only: [:update]
+
+  # the cop requires this method, but it relies on behaviour defined
+  # in the superclass, so needs to invoke `super`
+  def update
+    super
+  end
+
+  private
+
+  def load_article
+    @content = Article.find(params[:article_id])
   end
 end
 ```

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1164,7 +1164,7 @@ Include | `app/models/**/*.rb` | Array
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.52 | -
+Enabled | No | No | 0.52 | -
 
 This cop checks that methods specified in the filter's `only` or
 `except` options are defined within the same class or module.


### PR DESCRIPTION
This cop insists that users define action methods in the same controller class as any `before_`, `after_` or `around_action`s that refer to the action.

However, the examples given don't account for the fact that behaviour might be defined in the superclass. Indeed, this is one of the main use cases for action decorators: customisations can be applied to superclass behaviour without redefining the whole action in the subclass.

If this is the case, then the empty action definitions shown in the docs will override the desired behaviour, and lead users to introduce bugs.

```ruby
class ContentController < ApplicationController
  def update
    @content.update(content_attributes)
  end
end

class ArticlesController < ContentController
  before_action :load_article, only: [:update]

  # the cop says add this, but it breaks the update
  def update
  end

  private

  def load_article
    @content = Article.find(params[:article_id])
  end
end
```

In this PR I've tried to emphasise this in the docs, and have added an example to encourage users to think about the inheritance chain. The example is slightly awkward because the superclass in this case is `ApplicationController`, which is pretty unlikely to define actions in most apps; I wasn't sure about this, but also felt that introducing a different named superclass might also be confusing. An alternative might be to add the above snippet as a third, more realistic example case. What do people think?

I'd also be interested in people's thoughts about whether this cop should be disabled by default. My view is that it encourages semantically meaningful changes, and is therefore quite risky no matter how clear the documentation is, so I'd be tempted to disable it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] ~Added tests.~
* [ ] ~Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).~
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
