### PR TITLE
handle exception in Rails/RedundantReceiverInWithOptions with empty body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+### Bug fixes
+* [#6855](https://github.com/rubocop-hq/rubocop/pull/6855): Fix an exception in `Rails/RedundantReceiverInWithOptions` when the body is empty. ([@ericsullivan][])
+
 ### Changes
 
 * [#5977](https://github.com/rubocop-hq/rubocop/issues/5977): Warn for Performance Cops. ([@koic][])
@@ -3882,3 +3885,4 @@
 [@elmasantos]: https://github.com/elmasantos
 [@luciamo]: https://github.com/luciamo
 [@dirtyharrycallahan]: https://github.com/dirtyharrycallahan
+[@ericsullivan]: https://github.com/ericsullivan

--- a/lib/rubocop/cop/rails/redundant_receiver_in_with_options.rb
+++ b/lib/rubocop/cop/rails/redundant_receiver_in_with_options.rb
@@ -81,6 +81,7 @@ module RuboCop
 
         def on_block(node)
           with_options?(node) do |arg, body|
+            return if body.nil?
             return unless all_block_nodes_in(body).count.zero?
 
             send_nodes = all_send_nodes_in(body)

--- a/spec/rubocop/cop/rails/redundant_receiver_in_with_options_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_receiver_in_with_options_spec.rb
@@ -87,12 +87,20 @@ RSpec.describe RuboCop::Cop::Rails::RedundantReceiverInWithOptions, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense when empty' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        with_options options: false do |merger|
+        end
+      RUBY
+    end
   end
 
   context 'rails <= 4.1' do
     let(:rails_version) { 4.1 }
 
-    it 'registers an offense when using explicit receiver in `with_options`' do
+    it 'does not register an offense when using explicit receiver in ' \
+       '`with_options`' do
       expect_no_offenses(<<-RUBY.strip_indent)
         class Account < ApplicationRecord
           with_options dependent: :destroy do |assoc|


### PR DESCRIPTION
I ran rubocop on our test suite and encountered an exception in Rails/RedundantReceiverInWithOptions caused by the block:
```
with_options if: :state? do |_object|
end
```
I'm not sure if it should ignore the block (the approach I took here) or flag it as unnecessary. In either case, I don't think it should raise an exception so I wanted to add this PR now, and if it should produce an error I can open an issue.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
