### PR TITLE
handle autocorrect exception in Style/BlockComments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 * [#6855](https://github.com/rubocop-hq/rubocop/pull/6855): Fix an exception in `Rails/RedundantReceiverInWithOptions` when the body is empty. ([@ericsullivan][])
+* [#6856](https://github.com/rubocop-hq/rubocop/pull/6856): Fix auto-correction for `Style/BlockComments` when the file is missing a trailing blank line. ([@ericsullivan][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/block_comments.rb
+++ b/lib/rubocop/cop/style/block_comments.rb
@@ -52,9 +52,17 @@ module RuboCop
         def parts(comment)
           expr = comment.loc.expression
           eq_begin = expr.resize(BEGIN_LENGTH)
-          eq_end = range_between(expr.end_pos - END_LENGTH, expr.end_pos)
+          eq_end = eq_end_part(comment, expr)
           contents = range_between(eq_begin.end_pos, eq_end.begin_pos)
           [eq_begin, eq_end, contents]
+        end
+
+        def eq_end_part(comment, expr)
+          if comment.text.chomp == comment.text
+            range_between(expr.end_pos - END_LENGTH - 1, expr.end_pos - 2)
+          else
+            range_between(expr.end_pos - END_LENGTH, expr.end_pos)
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/block_comments_spec.rb
+++ b/spec/rubocop/cop/style/block_comments_spec.rb
@@ -47,4 +47,25 @@ RSpec.describe RuboCop::Cop::Style::BlockComments do
       end
     RUBY
   end
+
+  it 'auto-corrects a block comment into a regular comment (without trailing' \
+    'newline)' do
+    source = <<-RUBY.strip_indent
+      =begin
+      comment line 1
+
+      comment line 2
+      =end
+    RUBY
+
+    new_source = autocorrect_source(source.chomp)
+
+    expected_source = <<-RUBY.strip_indent
+      # comment line 1
+      #
+      # comment line 2
+    RUBY
+
+    expect(new_source).to eq(expected_source)
+  end
 end


### PR DESCRIPTION
When a file ends with `=end` and does not have a final newline, the
autocorrect code of Style/BlockComments was producing an exception.
This change handles the exception and adds a final newline.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
