### PR TITLE
[Fix #6858] Fix an incorrect auto-correct for `Lint/ToJSON`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## master (unreleased)
 
 ### Bug fixes
+
 * [#6855](https://github.com/rubocop-hq/rubocop/pull/6855): Fix an exception in `Rails/RedundantReceiverInWithOptions` when the body is empty. ([@ericsullivan][])
 * [#6856](https://github.com/rubocop-hq/rubocop/pull/6856): Fix auto-correction for `Style/BlockComments` when the file is missing a trailing blank line. ([@ericsullivan][])
+* [#6858](https://github.com/rubocop-hq/rubocop/issues/6858): Fix an incorrect auto-correct for `Lint/ToJSON` when there are no `to_json` arguments. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/to_json.rb
+++ b/lib/rubocop/cop/lint/to_json.rb
@@ -14,7 +14,7 @@ module RuboCop
       #   end
       #
       #   # good
-      #   def to_json(_opts)
+      #   def to_json(*_args)
       #   end
       #
       class ToJSON < Cop
@@ -29,7 +29,10 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            corrector.insert_after(node.loc.name, '(_opts)')
+            # The following used `*_args` because `to_json(*args)` has
+            # an offense of `Lint/UnusedMethodArgument` cop if `*args`
+            # is not used.
+            corrector.insert_after(node.loc.name, '(*_args)')
           end
         end
       end

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -2064,7 +2064,7 @@ def to_json
 end
 
 # good
-def to_json(_opts)
+def to_json(*_args)
 end
 ```
 

--- a/spec/rubocop/cop/lint/to_json_spec.rb
+++ b/spec/rubocop/cop/lint/to_json_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe RuboCop::Cop::Lint::ToJSON do
 
   it 'does not register an offense when using `#to_json` with arguments' do
     expect_no_offenses(<<-RUBY.strip_indent)
-      def to_json(opts)
+      def to_json(*_args)
       end
     RUBY
   end
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::Lint::ToJSON do
       end
     RUBY
     expect(corrected).to eq(<<-RUBY.strip_indent)
-      def to_json(_opts)
+      def to_json(*_args)
       end
     RUBY
   end


### PR DESCRIPTION
Fixes #6858.

I think it was a mistake of multiple arguments.

## Before

```ruby
def to_json(_opts)
end
```

## After

```ruby
def to_json(*args)
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
