### PR TITLE
Allow Rails associations to reference `class_name: self`

### DIFF
--- a/lib/rubocop/cop/rails/reflection_class_name.rb
+++ b/lib/rubocop/cop/rails/reflection_class_name.rb
@@ -13,6 +13,7 @@ module RuboCop
       #
       #   # good
       #   has_many :accounts, class_name: 'Account'
+      #   has_many :children, class_name: self.name
       class ReflectionClassName < Cop
         MSG = 'Use a string value for `class_name`.'.freeze
 
@@ -21,7 +22,7 @@ module RuboCop
         PATTERN
 
         def_node_search :reflection_class_name, <<-PATTERN
-          (pair (sym :class_name) [!str !sym !self])
+          (pair (sym :class_name) {const (send const ...)})
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/rails/reflection_class_name.rb
+++ b/lib/rubocop/cop/rails/reflection_class_name.rb
@@ -21,7 +21,7 @@ module RuboCop
         PATTERN
 
         def_node_search :reflection_class_name, <<-PATTERN
-          (pair (sym :class_name) [!str !sym])
+          (pair (sym :class_name) [!str !sym !self])
         PATTERN
 
         def on_send(node)

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1590,6 +1590,7 @@ has_many :accounts, class_name: Account.name
 
 # good
 has_many :accounts, class_name: 'Account'
+has_many :children, class_name: self.name
 ```
 
 ## Rails/RefuteMethods

--- a/spec/rubocop/cop/rails/reflection_class_name_spec.rb
+++ b/spec/rubocop/cop/rails/reflection_class_name_spec.rb
@@ -50,4 +50,12 @@ RSpec.describe RuboCop::Cop::Rails::ReflectionClassName do
       belongs_to :account, class_name: :Account
     RUBY
   end
+
+  it 'does not register an offense when using self for `class_name`' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      has_many :accounts, class_name: self, foreign_key: :account_id
+      has_one :account, class_name: self
+      belongs_to :account, class_name: self
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/rails/reflection_class_name_spec.rb
+++ b/spec/rubocop/cop/rails/reflection_class_name_spec.rb
@@ -51,11 +51,19 @@ RSpec.describe RuboCop::Cop::Rails::ReflectionClassName do
     RUBY
   end
 
-  it 'does not register an offense when using self for `class_name`' do
+  it 'does not register an offense when using self.name for `class_name`' do
     expect_no_offenses(<<-RUBY.strip_indent)
-      has_many :accounts, class_name: self, foreign_key: :account_id
-      has_one :account, class_name: self
-      belongs_to :account, class_name: self
+      has_many :accounts, class_name: self.name, foreign_key: :account_id
+      has_one :account, class_name: self.name
+      belongs_to :account, class_name: self.name
+    RUBY
+  end
+
+  it 'does not register an offense when using own name for `class_name`' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      has_many :accounts, class_name: name, foreign_key: :account_id
+      has_one :account, class_name: name
+      belongs_to :account, class_name: name
     RUBY
   end
 end


### PR DESCRIPTION
When used in concern mixins, the class name that the association is included in
may be declared dynamically, instead of a static string.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
