### PR TITLE
Fix deactivated `StyleGuideBaseURL` for `Layout/ClassStructure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#6855](https://github.com/rubocop-hq/rubocop/pull/6855): Fix an exception in `Rails/RedundantReceiverInWithOptions` when the body is empty. ([@ericsullivan][])
 * [#6856](https://github.com/rubocop-hq/rubocop/pull/6856): Fix auto-correction for `Style/BlockComments` when the file is missing a trailing blank line. ([@ericsullivan][])
 * [#6858](https://github.com/rubocop-hq/rubocop/issues/6858): Fix an incorrect auto-correct for `Lint/ToJSON` when there are no `to_json` arguments. ([@koic][])
+* [#6865](https://github.com/rubocop-hq/rubocop/pull/6865): Fix deactivated `StyleGuideBaseURL` for `Layout/ClassStructure`. ([@aeroastro][])
 
 ### Changes
 
@@ -3889,3 +3890,4 @@
 [@luciamo]: https://github.com/luciamo
 [@dirtyharrycallahan]: https://github.com/dirtyharrycallahan
 [@ericsullivan]: https://github.com/ericsullivan
+[@aeroastro]: https://github.com/aeroastro

--- a/config/default.yml
+++ b/config/default.yml
@@ -368,7 +368,7 @@ Layout/CaseIndentation:
 
 Layout/ClassStructure:
   Description: 'Enforces a configured order of definitions within a class body.'
-  StyleGuide: 'https://github.com/rubocop-hq/ruby-style-guide#consistent-classes'
+  StyleGuide: '#consistent-classes'
   Enabled: false
   VersionAdded: '0.52'
   Categories:


### PR DESCRIPTION
`StyleGuide` config for `Layout/ClassStructure` was
written as an absolute URL instead of a relative URL.
This prevents custom `StyleGuideBaseURL` from taking precedence
over original rubocop-hq URL.

https://github.com/rubocop-hq/rubocop/blob/86f35b21a9de380028bc7bc7cf1a6e212106e6b9/config/default.yml#L74-L76

This patch fix the issue by specifying fragment as the
`StyleGuide` of `Layout/ClassStructure`.

Since this is a bug fix in default config, I think we can omit a test.
If required, please let me know.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.