### PR TITLE
[Fix #6861] Fix a false positive for `Layout/IndentationWidth`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#7190](https://github.com/rubocop-hq/rubocop/issues/7190): Support lower case drive letters on Windows. ([@jonas054][])
 * [#5628](https://github.com/rubocop-hq/rubocop/issues/5628): Fix an error of `Layout/SpaceInsideStringInterpolation` on interpolations with multiple statements. ([@buehmann][])
 * [#7128](https://github.com/rubocop-hq/rubocop/issues/7128): Make `Metrics/LineLength` aware of shebang. ([@koic][])
+* [#6861](https://github.com/rubocop-hq/rubocop/issues/6861): Fix a false positive for `Layout/IndentationWidth` when using `EnforcedStyle: outdent` of `Layout/AccessModifierIndentation`. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -158,11 +158,7 @@ module RuboCop
           if indentation_consistency_style == 'indented_internal_methods'
             check_members_for_indented_internal_methods_style(members)
           else
-            members.first.children.each do |member|
-              next if member.send_type? && member.access_modifier?
-
-              check_indentation(base, member)
-            end
+            check_members_for_normal_style(base, members)
           end
         end
 
@@ -170,6 +166,8 @@ module RuboCop
           return unless member
 
           if access_modifier?(member.children.first)
+            return if access_modifier_indentation_style == 'outdent'
+
             member.children.first
           else
             member
@@ -180,6 +178,14 @@ module RuboCop
           each_member(members) do |member, previous_modifier|
             check_indentation(previous_modifier, member,
                               indentation_consistency_style)
+          end
+        end
+
+        def check_members_for_normal_style(base, members)
+          members.first.children.each do |member|
+            next if member.send_type? && member.access_modifier?
+
+            check_indentation(base, member)
           end
         end
 
@@ -197,6 +203,14 @@ module RuboCop
 
         def indented_internal_methods_style?
           indentation_consistency_style == 'indented_internal_methods'
+        end
+
+        def special_modifier?(node)
+          node.bare_access_modifier? && SPECIAL_MODIFIERS.include?(node.source)
+        end
+
+        def access_modifier_indentation_style
+          config.for_cop('Layout/AccessModifierIndentation')['EnforcedStyle']
         end
 
         def indentation_consistency_style

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -926,6 +926,49 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     expect(IO.read('example.rb')).to eq(corrected)
   end
 
+  it 'corrects IndentationWidth and IndentationConsistency offenses' \
+     'when using `EnforcedStyle: outdent` and ' \
+     '`EnforcedStyle: indented_internal_methods`' do
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/AccessModifierIndentation:
+        EnforcedStyle: outdent
+      Layout/IndentationConsistency:
+        EnforcedStyle: indented_internal_methods
+    YAML
+
+    source = <<-'RUBY'.strip_indent
+      class Foo
+                         private
+
+          def do_something
+            # something
+          end
+      end
+    RUBY
+    create_file('example.rb', source)
+
+    expect(cli.run([
+                     '--auto-correct',
+                     '--only',
+                     [
+                       'Layout/AccessModifierIndentation',
+                       'Layout/IndentationConsistency',
+                       'Layout/IndentationWidth'
+                     ].join(',')
+                   ])).to eq(0)
+
+    corrected = <<-'RUBY'.strip_indent
+      class Foo
+      private
+
+        def do_something
+          # something
+        end
+      end
+    RUBY
+    expect(IO.read('example.rb')).to eq(corrected)
+  end
+
   it 'corrects SymbolProc and SpaceBeforeBlockBraces offenses' do
     source = ['foo.map{ |a| a.nil? }']
     create_file('example.rb', source)

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -4,11 +4,15 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
   subject(:cop) { described_class.new(config) }
 
   let(:config) do
-    RuboCop::Config.new('Layout/IndentationWidth' => cop_config,
-                        'Layout/IndentationConsistency' => consistency_config,
-                        'Layout/EndAlignment' => end_alignment_config,
-                        'Layout/DefEndAlignment' => def_end_alignment_config)
+    RuboCop::Config.new(
+      'Layout/IndentationWidth' => cop_config,
+      'Layout/AccessModifierIndentation' => access_modifier_config,
+      'Layout/IndentationConsistency' => consistency_config,
+      'Layout/EndAlignment' => end_alignment_config,
+      'Layout/DefEndAlignment' => def_end_alignment_config
+    )
   end
+  let(:access_modifier_config) { { 'EnforcedStyle' => 'indent' } }
   let(:consistency_config) { { 'EnforcedStyle' => 'normal' } }
   let(:end_alignment_config) do
     { 'Enabled' => true, 'EnforcedStyleAlignWith' => 'variable' }
@@ -1148,6 +1152,21 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
                 def g
             ^^^^ Use 2 (not 4) spaces for indentation.
                 end
+            end
+          RUBY
+        end
+      end
+
+      context 'when consistency style is outdent' do
+        let(:access_modifier_config) { { 'EnforcedStyle' => 'outdent' } }
+
+        it 'accepts access modifier is outdent' do
+          expect_no_offenses(<<~RUBY)
+            class Test
+            private
+
+              def foo
+              end
             end
           RUBY
         end


### PR DESCRIPTION
Fixes #6861.

This is a regression by https://github.com/rubocop-hq/rubocop/pull/6792.

This PR fixes infinite loop for `Layout/IndentationWidth` cop and `Layout/AccessModifierIndentation` cop.

```ruby
# exmaple.rb
class Foo
private

  def do_something
  end
end
```

```yaml
# .rubocop.yml
% cat .rubocop.yml
Layout/AccessModifierIndentation:
  EnforcedStyle: outdent
```

First, auto-corrected by `Layout/IndentationWidth`.

```console
% rubocop -v
0.66.0
% rubocop -a --only Layout/IndentationWidth
Inspecting 1 file
C

Offenses:

example.rb:2:1: C: [Corrected] Layout/IndentationWidth: Use 2 (not 0)
spaces for indentation.
private

1 file inspected, 1 offense detected, 1 offense corrected
```

```diff
% git diff example.rb
diff --git a/example.rb b/example.rb
index 063e6a5..081b80a 100644
--- a/example.rb
+++ b/example.rb
@@ -1,5 +1,5 @@
 class Foo
-private
+  private

   def do_something
   end
```

Next, auto-corrected by `Layout/Layout/AccessModifierIndentation` (`EnforcedStyle: outdent`).

```console
% rubocop -a --only Layout/AccessModifierIndentation
Inspecting 1 file
C

Offenses:

example.rb:2:3: C: [Corrected] Layout/AccessModifierIndentation: Outdent
access modifiers like private.
  private
  ^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
```

This will return to the original code.

```diff
% git diff
diff --git a/example.rb b/example.rb
index 081b80a..063e6a5 100644
--- a/example.rb
+++ b/example.rb
@@ -1,5 +1,5 @@
 class Foo
-  private
+private

   def do_something
   end
```

That caused the infinite loop in `Layout/IndentationWidth` and `Layout/AccessModifierIndentation` (`EnforcedStyle: outdent`).

With this PR, `Layout/indentationWidth` cop makes aware of `Layout/AccessModifierIndentation` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
