### PR TITLE
Fix Rails/LinkToBlank auto-correct bug when using symbol for target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#6856](https://github.com/rubocop-hq/rubocop/pull/6856): Fix auto-correction for `Style/BlockComments` when the file is missing a trailing blank line. ([@ericsullivan][])
 * [#6858](https://github.com/rubocop-hq/rubocop/issues/6858): Fix an incorrect auto-correct for `Lint/ToJSON` when there are no `to_json` arguments. ([@koic][])
 * [#6865](https://github.com/rubocop-hq/rubocop/pull/6865): Fix deactivated `StyleGuideBaseURL` for `Layout/ClassStructure`. ([@aeroastro][])
+* [#6868](https://github.com/rubocop-hq/rubocop/pull/6868): Fix `Rails/LinkToBlank` auto-correct bug when using symbol for target. ([@r7kamura][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/link_to_blank.rb
+++ b/lib/rubocop/cop/rails/link_to_blank.rb
@@ -72,8 +72,9 @@ module RuboCop
         end
 
         def add_rel(send_node, offence_node, corrector)
-          quote_style = offence_node.children.last.source[0]
-          new_rel_exp = ", rel: #{quote_style}noopener#{quote_style}"
+          opening_quote = offence_node.children.last.source[0]
+          closing_quote = opening_quote == ':' ? '' : opening_quote
+          new_rel_exp = ", rel: #{opening_quote}noopener#{closing_quote}"
           range = send_node.arguments.last.source_range
 
           corrector.insert_after(range, new_rel_exp)

--- a/spec/rubocop/cop/rails/link_to_blank_spec.rb
+++ b/spec/rubocop/cop/rails/link_to_blank_spec.rb
@@ -81,6 +81,17 @@ RSpec.describe RuboCop::Cop::Rails::LinkToBlank do
           end
         RUBY
       end
+
+      it 'autocorrects with a new rel when using a symbol for the target \
+          value' do
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+          link_to 'Click here', 'https://www.example.com', target: :_blank
+        RUBY
+
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          link_to 'Click here', 'https://www.example.com', target: :_blank, rel: :noopener
+        RUBY
+      end
     end
 
     context 'when using rel' do


### PR DESCRIPTION
I fixed a bug on `Rails/LinkToBlank` auto-correction logic when using a symbol literal for the target value.

### Source

```rb
link_to 'Click here', 'https://www.example.com', target: :_blank
```

### Expected

```rb
link_to 'Click here', 'https://www.example.com', target: :_blank, rel: :noopener
```

### Actual

```rb
link_to 'Click here', 'https://www.example.com', target: :_blank, rel: :noopener:
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
