### PR TITLE
Fix false positive for `Rails/LinkToBlank` when rel is a symbol value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#6858](https://github.com/rubocop-hq/rubocop/issues/6858): Fix an incorrect auto-correct for `Lint/ToJSON` when there are no `to_json` arguments. ([@koic][])
 * [#6865](https://github.com/rubocop-hq/rubocop/pull/6865): Fix deactivated `StyleGuideBaseURL` for `Layout/ClassStructure`. ([@aeroastro][])
 * [#6868](https://github.com/rubocop-hq/rubocop/pull/6868): Fix `Rails/LinkToBlank` auto-correct bug when using symbol for target. ([@r7kamura][])
+* [#6869](https://github.com/rubocop-hq/rubocop/pull/6869): Fix false positive for `Rails/LinkToBlank` when rel is a symbol value. ([@r7kamura][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/link_to_blank.rb
+++ b/lib/rubocop/cop/rails/link_to_blank.rb
@@ -22,7 +22,7 @@ module RuboCop
         PATTERN
 
         def_node_matcher :includes_noopener?, <<-PATTERN
-          (pair {(sym :rel) (str "rel")} (str #contains_noopener?))
+          (pair {(sym :rel) (str "rel")} ({str sym} #contains_noopener?))
         PATTERN
 
         def_node_matcher :rel_node?, <<-PATTERN
@@ -80,10 +80,10 @@ module RuboCop
           corrector.insert_after(range, new_rel_exp)
         end
 
-        def contains_noopener?(str)
-          return false unless str
+        def contains_noopener?(value)
+          return false unless value
 
-          str.split(' ').include?('noopener')
+          value.to_s.split(' ').include?('noopener')
         end
       end
     end

--- a/spec/rubocop/cop/rails/link_to_blank_spec.rb
+++ b/spec/rubocop/cop/rails/link_to_blank_spec.rb
@@ -115,6 +115,14 @@ RSpec.describe RuboCop::Cop::Rails::LinkToBlank do
           RUBY
         end
       end
+
+      context 'when the rel is symbol noopener' do
+        it 'register no offence' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            link_to 'Click here', 'https://www.example.com', target: :_blank, rel: :noopener
+          RUBY
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This code should be valid on `Rails/LinkToBlank` cop, but it's not on rubocop v0.66.0 because rel value is a Symbol.

```rb
link_to 'Click here', 'https://www.example.com', target: :_blank, rel: :noopener
```

This PR is related to https://github.com/rubocop-hq/rubocop/pull/6868.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
