### PR TITLE
[Fix #6761] Make UncommunicativeMethodParamName account for underscores.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* [#6761](https://github.com/rubocop-hq/rubocop/issues/6761): Make `Naming/UncommunicativeMethodParamName` account for param names prefixed with underscores. ([@thomthom][])
 * [#6855](https://github.com/rubocop-hq/rubocop/pull/6855): Fix an exception in `Rails/RedundantReceiverInWithOptions` when the body is empty. ([@ericsullivan][])
 * [#6856](https://github.com/rubocop-hq/rubocop/pull/6856): Fix auto-correction for `Style/BlockComments` when the file is missing a trailing blank line. ([@ericsullivan][])
 * [#6858](https://github.com/rubocop-hq/rubocop/issues/6858): Fix an incorrect auto-correct for `Lint/ToJSON` when there are no `to_json` arguments. ([@koic][])
@@ -3895,3 +3896,4 @@
 [@ericsullivan]: https://github.com/ericsullivan
 [@aeroastro]: https://github.com/aeroastro
 [@anuja-joshi]: https://github.com/anuja-joshi
+[@thomthom]: https://github.com/thomthom

--- a/lib/rubocop/cop/mixin/uncommunicative_name.rb
+++ b/lib/rubocop/cop/mixin/uncommunicative_name.rb
@@ -13,7 +13,12 @@ module RuboCop
 
       def check(node, args)
         args.each do |arg|
-          name = arg.children.first.to_s
+          # Argument names might be "_" or prefixed with "_" to indicate they
+          # are unused. Trim away this prefix and only analyse the basename.
+          full_name = arg.children.first.to_s
+          next if full_name == '_'
+
+          name = full_name.gsub(/\A([_]+)/, '')
           next if (arg.restarg_type? || arg.kwrestarg_type?) && name.empty?
           next if allowed_names.include?(name)
 

--- a/spec/rubocop/cop/naming/uncommunicative_method_param_name_spec.rb
+++ b/spec/rubocop/cop/naming/uncommunicative_method_param_name_spec.rb
@@ -147,6 +147,22 @@ RSpec.describe RuboCop::Cop::Naming::UncommunicativeMethodParamName, :config do
       RUBY
     end
 
+    it 'accepts param names prefixed with underscore' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def quux(_foo1, _foo2)
+          do_stuff
+        end
+      RUBY
+    end
+
+    it 'accepts underscore param names' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def quux(_)
+          do_stuff
+        end
+      RUBY
+    end
+
     it 'registers unlisted offensive names' do
       expect_offense(<<-RUBY.strip_indent)
         def quux(bar, bar1)


### PR DESCRIPTION
This change makes `Naming/UncommunicativeMethodParamName` understand the `_`-prefix convention annotation unused parameters. It also ignores parameters named `_`. This allowing usage of API interfaces where you don't use all the parameters provided by the interface.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
