### PR TITLE
[Fix #6785] Make Rails/Blank and Rails/Present aware of Style/UnlessElse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#6868](https://github.com/rubocop-hq/rubocop/pull/6868): Fix `Rails/LinkToBlank` auto-correct bug when using symbol for target. ([@r7kamura][])
 * [#6869](https://github.com/rubocop-hq/rubocop/pull/6869): Fix false positive for `Rails/LinkToBlank` when rel is a symbol value. ([@r7kamura][])
 * Add `IncludedMacros` param to default rubocop config for `Style/MethodCallWithArgsParentheses`. ([@maxh][])
+* [#6785](https://github.com/rubocop-hq/rubocop/issues/6785): Do not register an offense for `Rails/Present` or `Rails/Blank` in an `unless else` context when `Style/UnlessElse` is enabled. ([@rrosenblum][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -2254,6 +2254,7 @@ Rails/Blank:
   Description: 'Enforces use of `blank?`.'
   Enabled: true
   VersionAdded: '0.48'
+  VersionChanged: '0.67'
   # Convert usages of `nil? || empty?` to `blank?`
   NilOrEmpty: true
   # Convert usages of `!present?` to `blank?`
@@ -2473,6 +2474,7 @@ Rails/Present:
   Description: 'Enforces use of `present?`.'
   Enabled: true
   VersionAdded: '0.48'
+  VersionChanged: '0.67'
   # Convert usages of `!nil? && !empty?` to `present?`
   NotNilAndNotEmpty: true
   # Convert usages of `!blank?` to `present?`

--- a/lib/rubocop/cop/rails/blank.rb
+++ b/lib/rubocop/cop/rails/blank.rb
@@ -6,6 +6,11 @@ module RuboCop
       # This cop checks for code that can be written with simpler conditionals
       # using `Object#blank?` defined by Active Support.
       #
+      # Interaction with `Style/UnlessElse`:
+      # The configuration of `NotPresent` will not produce an offense in the
+      # context of `unless else` if `Style/UnlessElse` is inabled. This is
+      # to prevent interference between the auto-correction of the two cops.
+      #
       # @example NilOrEmpty: true (default)
       #   # Converts usages of `nil? || empty?` to `blank?`
       #
@@ -111,6 +116,7 @@ module RuboCop
         def on_if(node)
           return unless cop_config['UnlessPresent']
           return unless node.unless?
+          return if node.else? && config.for_cop('Style/UnlessElse')['Enabled']
 
           unless_present?(node) do |method_call, receiver|
             range = unless_condition(node, method_call)

--- a/lib/rubocop/cop/rails/present.rb
+++ b/lib/rubocop/cop/rails/present.rb
@@ -6,7 +6,10 @@ module RuboCop
       # This cop checks for code that can be written with simpler conditionals
       # using `Object#present?` defined by Active Support.
       #
-      # simpler conditionals.
+      # Interaction with `Style/UnlessElse`:
+      # The configuration of `NotBlank` will not produce an offense in the
+      # context of `unless else` if `Style/UnlessElse` is inabled. This is
+      # to prevent interference between the auto-correction of the two cops.
       #
       # @example NotNilAndNotEmpty: true (default)
       #   # Converts usages of `!nil? && !empty?` to `present?`
@@ -104,6 +107,7 @@ module RuboCop
         def on_if(node)
           return unless cop_config['UnlessBlank']
           return unless node.unless?
+          return if node.else? && config.for_cop('Style/UnlessElse')['Enabled']
 
           unless_blank?(node) do |method_call, receiver|
             range = unless_condition(node, method_call)

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -256,10 +256,15 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.48 | -
+Enabled | Yes | Yes  | 0.48 | 0.67
 
 This cop checks for code that can be written with simpler conditionals
 using `Object#blank?` defined by Active Support.
+
+Interaction with `Style/UnlessElse`:
+The configuration of `NotPresent` will not produce an offense in the
+context of `unless else` if `Style/UnlessElse` is inabled. This is
+to prevent interference between the auto-correction of the two cops.
 
 ### Examples
 
@@ -1477,12 +1482,15 @@ a.presence || b
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.48 | -
+Enabled | Yes | Yes  | 0.48 | 0.67
 
 This cop checks for code that can be written with simpler conditionals
 using `Object#present?` defined by Active Support.
 
-simpler conditionals.
+Interaction with `Style/UnlessElse`:
+The configuration of `NotBlank` will not produce an offense in the
+context of `unless else` if `Style/UnlessElse` is inabled. This is
+to prevent interference between the auto-correction of the two cops.
 
 ### Examples
 

--- a/spec/rubocop/cop/rails/blank_spec.rb
+++ b/spec/rubocop/cop/rails/blank_spec.rb
@@ -220,23 +220,59 @@ RSpec.describe RuboCop::Cop::Rails::Blank, :config do
     end
 
     context 'unless present? with an else' do
-      it 'registers an offense and corrects' do
-        expect_offense(<<-RUBY.strip_indent)
-          unless foo.present?
-          ^^^^^^^^^^^^^^^^^^^ Use `if foo.blank?` instead of `unless foo.present?`.
-            something
-          else
-            something_else
-          end
-        RUBY
+      context 'Style/UnlessElse disabled' do
+        let(:config) do
+          RuboCop::Config.new(
+            'Rails/Blank' => {
+              'UnlessPresent' => true
+            },
+            'Style/UnlessElse' => {
+              'Enabled' => false
+            }
+          )
+        end
 
-        expect_correction(<<-RUBY.strip_indent)
-          if foo.blank?
-            something
-          else
-            something_else
-          end
-        RUBY
+        it 'registers an offense and corrects' do
+          expect_offense(<<-RUBY.strip_indent)
+            unless foo.present?
+            ^^^^^^^^^^^^^^^^^^^ Use `if foo.blank?` instead of `unless foo.present?`.
+              something
+            else
+              something_else
+            end
+          RUBY
+
+          expect_correction(<<-RUBY.strip_indent)
+            if foo.blank?
+              something
+            else
+              something_else
+            end
+          RUBY
+        end
+      end
+
+      context 'Style/UnlessElse enabled' do
+        let(:config) do
+          RuboCop::Config.new(
+            'Rails/Blank' => {
+              'UnlessPresent' => true
+            },
+            'Style/UnlessElse' => {
+              'Enabled' => true
+            }
+          )
+        end
+
+        it 'does not register an offense' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            unless foo.present?
+              something
+            else
+              something_else
+            end
+          RUBY
+        end
       end
     end
   end

--- a/spec/rubocop/cop/rails/present_spec.rb
+++ b/spec/rubocop/cop/rails/present_spec.rb
@@ -198,23 +198,59 @@ RSpec.describe RuboCop::Cop::Rails::Present, :config do
       end
 
       context 'unless blank? with an else' do
-        it 'registers an offense' do
-          expect_offense(<<-RUBY.strip_indent)
-            unless foo.blank?
-            ^^^^^^^^^^^^^^^^^ Use `if foo.present?` instead of `unless foo.blank?`.
-              something
-            else
-              something_else
-            end
-          RUBY
+        context 'Style/UnlessElse disabled' do
+          let(:config) do
+            RuboCop::Config.new(
+              'Rails/Present' => {
+                'UnlessBlank' => true
+              },
+              'Style/UnlessElse' => {
+                'Enabled' => false
+              }
+            )
+          end
 
-          expect_correction(<<-RUBY.strip_indent)
-            if foo.present?
-              something
-            else
-              something_else
-            end
-          RUBY
+          it 'registers an offense' do
+            expect_offense(<<-RUBY.strip_indent)
+              unless foo.blank?
+              ^^^^^^^^^^^^^^^^^ Use `if foo.present?` instead of `unless foo.blank?`.
+                something
+              else
+                something_else
+              end
+            RUBY
+
+            expect_correction(<<-RUBY.strip_indent)
+              if foo.present?
+                something
+              else
+                something_else
+              end
+            RUBY
+          end
+        end
+
+        context 'Style/UnlessElse enabled' do
+          let(:config) do
+            RuboCop::Config.new(
+              'Rails/Present' => {
+                'UnlessBlank' => true
+              },
+              'Style/UnlessElse' => {
+                'Enabled' => true
+              }
+            )
+          end
+
+          it 'does not registers an offense' do
+            expect_no_offenses(<<-RUBY.strip_indent)
+              unless foo.blank?
+                something
+              else
+                something_else
+              end
+            RUBY
+          end
         end
       end
     end


### PR DESCRIPTION
This fixes #6785. If `Style/UnlessElse` is enabled, `Rails/Blank` will not register an offense for `UnlessPresent` and `Rails/Present` will not register an offense for `UnlessBlank` in the context of `unless else`.