### PR TITLE
NodePattern: Allow numerals in identifiers

### DIFF
--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -96,11 +96,11 @@ module RuboCop
     # Builds Ruby code which implements a pattern
     class Compiler
       SYMBOL       = %r{:(?:[\w+@*/?!<>=~|%^-]+|\[\]=?)}.freeze
-      IDENTIFIER   = /[a-zA-Z_-]/.freeze
+      IDENTIFIER   = /[a-zA-Z_][a-zA-Z0-9_-]*/.freeze
       META         = /\(|\)|\{|\}|\[|\]|\$\.\.\.|\$|!|\^|\.\.\./.freeze
       NUMBER       = /-?\d+(?:\.\d+)?/.freeze
       STRING       = /".+?"/.freeze
-      METHOD_NAME  = /\#?#{IDENTIFIER}+[\!\?]?\(?/.freeze
+      METHOD_NAME  = /\#?#{IDENTIFIER}[\!\?]?\(?/.freeze
       PARAM_NUMBER = /%\d*/.freeze
 
       SEPARATORS = /[\s]+/.freeze
@@ -109,9 +109,10 @@ module RuboCop
 
       TOKEN = /\G(?:#{SEPARATORS}|#{TOKENS}|.)/.freeze
 
-      NODE      = /\A#{IDENTIFIER}+\Z/.freeze
-      PREDICATE = /\A#{IDENTIFIER}+\?\(?\Z/.freeze
-      WILDCARD  = /\A_#{IDENTIFIER}*\Z/.freeze
+      NODE      = /\A#{IDENTIFIER}\Z/.freeze
+      PREDICATE = /\A#{IDENTIFIER}\?\(?\Z/.freeze
+      WILDCARD  = /\A_(?:#{IDENTIFIER})?\Z/.freeze
+
       FUNCALL   = /\A\##{METHOD_NAME}/.freeze
       LITERAL   = /\A(?:#{SYMBOL}|#{NUMBER}|#{STRING})\Z/.freeze
       PARAM     = /\A#{PARAM_NUMBER}\Z/.freeze

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -908,6 +908,14 @@ RSpec.describe RuboCop::NodePattern do
       let(:ruby) { '1.inc' }
 
       it_behaves_like 'matching'
+
+      context 'with name containing a numeral' do
+        before { RuboCop::AST::Node.def_node_matcher :custom_42?, 'send_type?' }
+
+        let(:pattern) { 'custom_42?' }
+
+        it_behaves_like 'matching'
+      end
     end
 
     context 'at head position of a sequence' do


### PR DESCRIPTION
This PR allows using digits in NodePatterns (e.g. `_arg0`, `custom_node_matcher_42?`).

It also paves the way to support the node type `procarg0`, which are not emitted by default (see #5999).

I didn't test for it, but it also forbids non sensical identifiers starting with `-` or consisting only of `-`.

Note that `Node` already states that [numerals are allowed](https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/ast/node.rb#L15-L16)