### PR TITLE
Set default `PreferredName` to `e` for `Naming/RescuedExceptionsVariableName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#6881](https://github.com/rubocop-hq/rubocop/pull/6881): Set default `PreferredName` to `e` for `Naming/RescuedExceptionsVariableName`. ([@koic][])
+
 ## 0.67.0 (2019-04-04)
 
 ### New features

--- a/Rakefile
+++ b/Rakefile
@@ -8,10 +8,10 @@ require 'bundler'
 require 'bundler/gem_tasks'
 begin
   Bundler.setup(:default, :development)
-rescue Bundler::BundlerError => ex
-  warn ex.message
+rescue Bundler::BundlerError => e
+  warn e.message
   warn 'Run `bundle install` to install missing gems'
-  exit ex.status_code
+  exit e.status_code
 end
 require 'rake'
 require 'rubocop/rake_task'
@@ -110,9 +110,9 @@ task documentation_syntax_check: :yard_for_generate_documentation do
         parser = Parser::Ruby25.new(RuboCop::AST::Builder.new)
         parser.diagnostics.all_errors_are_fatal = true
         parser.parse(buffer)
-      rescue Parser::SyntaxError => ex
+      rescue Parser::SyntaxError => e
         path = example.object.file
-        puts "#{path}: Syntax Error in an example. #{ex}"
+        puts "#{path}: Syntax Error in an example. #{e}"
         ok = false
       end
     end

--- a/config/default.yml
+++ b/config/default.yml
@@ -1939,7 +1939,7 @@ Naming/RescuedExceptionsVariableName:
   Description: 'Use consistent rescued exceptions variables naming.'
   Enabled: true
   VersionAdded: '0.67'
-  PreferredName: ex
+  PreferredName: e
 
 Naming/UncommunicativeBlockParamName:
   Description: >-

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -45,23 +45,21 @@ module RuboCop
       act_on_options
       apply_default_formatter
       execute_runners(paths)
-    rescue ConfigNotFoundError,
-           IncorrectCopNameError,
-           OptionArgumentError => ex
-      warn ex.message
+    rescue ConfigNotFoundError, IncorrectCopNameError, OptionArgumentError => e
+      warn e.message
       STATUS_ERROR
-    rescue RuboCop::Error => ex
-      warn Rainbow("Error: #{ex.message}").red
+    rescue RuboCop::Error => e
+      warn Rainbow("Error: #{e.message}").red
       STATUS_ERROR
     rescue Finished
       STATUS_SUCCESS
-    rescue OptionParser::InvalidOption => ex
-      warn ex.message
+    rescue OptionParser::InvalidOption => e
+      warn e.message
       warn 'For usage information, use --help'
       STATUS_ERROR
-    rescue StandardError, SyntaxError, LoadError => ex
-      warn ex.message
-      warn ex.backtrace
+    rescue StandardError, SyntaxError, LoadError => e
+      warn e.message
+      warn e.backtrace
       STATUS_ERROR
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -190,9 +190,9 @@ module RuboCop
     def gem_config_path(gem_name, relative_config_path)
       spec = Gem::Specification.find_by_name(gem_name)
       File.join(spec.gem_dir, relative_config_path)
-    rescue Gem::LoadError => ex
+    rescue Gem::LoadError => e
       raise Gem::LoadError,
-            "Unable to find gem #{gem_name}; is the gem installed? #{ex}"
+            "Unable to find gem #{gem_name}; is the gem installed? #{e}"
     end
   end
 end

--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -104,14 +104,14 @@ module RuboCop
       # cops' `#investigate` methods.
       def with_cop_error_handling(cop, node = nil)
         yield
-      rescue StandardError => ex
-        raise ex if @options[:raise_error]
+      rescue StandardError => e
+        raise e if @options[:raise_error]
 
         if node
           line = node.first_line
           column = node.loc.column
         end
-        error = CopError.new(ex, line, column)
+        error = CopError.new(e, line, column)
         @errors[cop] << error
       end
     end

--- a/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
+++ b/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
@@ -13,7 +13,7 @@ module RuboCop
       #   # bad
       #   begin
       #     # do something
-      #   rescue MyException => exc
+      #   rescue MyException => exception
       #     # do something
       #   end
       #
@@ -35,7 +35,7 @@ module RuboCop
       #   # good
       #   begin
       #     # do something
-      #   rescue MyException => ex
+      #   rescue MyException => exception
       #     # do something
       #   end
       #

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -41,10 +41,10 @@ module RuboCop
       when Regexp
         begin
           path =~ pattern
-        rescue ArgumentError => ex
-          return false if ex.message.start_with?('invalid byte sequence')
+        rescue ArgumentError => e
+          return false if e.message.start_with?('invalid byte sequence')
 
-          raise exception
+          raise e
         end
       end
     end

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -146,8 +146,8 @@ module RuboCop
 
       begin
         @buffer.source = source
-      rescue EncodingError => ex
-        @parser_error = ex
+      rescue EncodingError => e
+        @parser_error = e
         return
       end
 

--- a/lib/rubocop/remote_config.rb
+++ b/lib/rubocop/remote_config.rb
@@ -47,8 +47,8 @@ module RuboCop
       generate_request(uri) do |request|
         begin
           handle_response(http.request(request), limit, &block)
-        rescue SocketError => ex
-          handle_response(ex, limit, &block)
+        rescue SocketError => e
+          handle_response(e, limit, &block)
         end
       end
     end
@@ -72,10 +72,10 @@ module RuboCop
       else
         begin
           response.error!
-        rescue StandardError => ex
-          message = "#{ex.message} while downloading remote config"\
+        rescue StandardError => e
+          message = "#{e.message} while downloading remote config"\
             " file #{uri}"
-          raise ex, message
+          raise e, message
         end
       end
     end

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -100,9 +100,9 @@ module RuboCop
 
       begin
         FileUtils.mkdir_p(dir)
-      rescue Errno::EACCES => ex
+      rescue Errno::EACCES => e
         warn "Couldn't create cache directory. Continuing without cache."\
-             "\n  #{ex.message}"
+             "\n  #{e.message}"
         return
       end
 

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -108,8 +108,8 @@ module RuboCop
       end
       formatter_set.file_finished(file, offenses)
       offenses
-    rescue InfiniteCorrectionLoop => ex
-      formatter_set.file_finished(file, ex.offenses.compact.sort.freeze)
+    rescue InfiniteCorrectionLoop => e
+      formatter_set.file_finished(file, e.offenses.compact.sort.freeze)
       raise
     end
 

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -145,12 +145,8 @@ module RuboCop
 
       first_line = File.open(file, &:readline)
       !(first_line =~ /#!.*(#{ruby_interpreters(file).join('|')})/).nil?
-    rescue EOFError, ArgumentError => ex
-      if debug?
-        warn(
-          "Unprocessable file #{file}: #{ex.class}, #{ex.message}"
-        )
-      end
+    rescue EOFError, ArgumentError => e
+      warn("Unprocessable file #{file}: #{e.class}, #{e.message}") if debug?
 
       false
     end

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -497,7 +497,7 @@ the required name of the variable. Its default is `e`.
 # bad
 begin
   # do something
-rescue MyException => exc
+rescue MyException => exception
   # do something
 end
 
@@ -521,7 +521,7 @@ end
 # good
 begin
   # do something
-rescue MyException => ex
+rescue MyException => exception
   # do something
 end
 ```
@@ -530,7 +530,7 @@ end
 
 Name | Default value | Configurable values
 --- | --- | ---
-PreferredName | `ex` | String
+PreferredName | `e` | String
 
 ## Naming/UncommunicativeBlockParamName
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1602,9 +1602,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     it 'shows an error if the input file cannot be found' do
       begin
         cli.run(%w[/tmp/not_a_file])
-      rescue SystemExit => ex
-        expect(ex.status).to eq(1)
-        expect(ex.message)
+      rescue SystemExit => e
+        expect(e.status).to eq(1)
+        expect(e.message)
           .to eq 'rubocop: No such file or directory -- /tmp/not_a_file'
       end
     end

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -8,8 +8,8 @@ RSpec::Matchers.define :exit_with_code do |code|
   match do |block|
     begin
       block.call
-    rescue SystemExit => ex
-      actual = ex.status
+    rescue SystemExit => e
+      actual = e.status
     end
     actual && actual == code
   end


### PR DESCRIPTION
Follow up https://github.com/rubocop-hq/rubocop/commit/f0959e8eda5b8f45956cd127fd18389a5a9594c8.

The default `PreferredName` of `Naming/RescuedExceptionsVariableName` cop is `e` in the following discussion.
https://github.com/rubocop-hq/rubocop/pull/6460#discussion_r232705359

This PR sets default `PreferredName` to `e` for `Naming/RescuedExceptionsVariableName`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
