### PR TITLE
Fix a typo

### DIFF
--- a/spec/rubocop/cop/layout/multiline_method_argument_line_breaks_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_argument_line_breaks_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodArgumentLineBreaks do
     end
   end
 
-  context 'when many arguments are on mutliple lines, two on same line' do
+  context 'when many arguments are on multiple lines, two on same line' do
     it 'adds an offense' do
       expect_offense(
         <<-RUBY
@@ -56,7 +56,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodArgumentLineBreaks do
     end
   end
 
-  context 'when many arguments are on mutliple lines, three on same line' do
+  context 'when many arguments are on multiple lines, three on same line' do
     it 'adds an offense' do
       expect_offense(
         <<-RUBY
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodArgumentLineBreaks do
     end
   end
 
-  context 'when many arguments are on mutliple lines, three on same line' do
+  context 'when many arguments are on multiple lines, three on same line' do
     it 'adds an offense' do
       expect_offense(
         <<-RUBY


### PR DESCRIPTION
This PR fixes the following typo.

```diff
-mutliple
+multiple
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
