### PR TITLE
revert adding psych as runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [#6917](https://github.com/rubocop-hq/rubocop/issues/6917): Bump Bundler dependency to >= 1.15.0. ([@koic][])
 * Add `--auto-gen-only-exclude` to the command outputted in `rubocop_todo.yml` if the option is specified. ([@dvandersluis][])
 * [#6887](https://github.com/rubocop-hq/rubocop/pull/6887): Allow `Lint/UnderscorePrefixedVariableName` cop to be configured to allow use of block keyword args. ([@dduugg][])
+* [#6885](https://github.com/rubocop-hq/rubocop/pull/6885): Revert adding psych >= 3.1 as runtime dependency. ([@andreaseger][])
 
 ## 0.67.2 (2019-04-05)
 
@@ -3963,3 +3964,4 @@
 [@Mange]: https://github.com/Mange
 [@jmanian]: https://github.com/jmanian
 [@vfonic]: https://github.com/vfonic
+[@andreaseger]: https://github.com/andreaseger

--- a/lib/rubocop/yaml_duplication_checker.rb
+++ b/lib/rubocop/yaml_duplication_checker.rb
@@ -5,7 +5,7 @@ module RuboCop
   module YAMLDuplicationChecker
     def self.check(yaml_string, filename, &on_duplicated)
       # Specify filename to display helpful message when it raises an error.
-      tree = YAML.parse(yaml_string, filename: filename)
+      tree = YAML.parse(yaml_string, filename)
       return unless tree
 
       traverse(tree, &on_duplicated)

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('jaro_winkler', '~> 1.5.1')
   s.add_runtime_dependency('parallel', '~> 1.10')
   s.add_runtime_dependency('parser', '>= 2.5', '!= 2.5.1.1')
-  s.add_runtime_dependency('psych', '>= 3.1.0')
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 1.6')

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1049,19 +1049,39 @@ RSpec.describe RuboCop::ConfigLoader do
       end
     end
 
-    context 'when the file has duplicated keys' do
-      it 'outputs a warning' do
-        create_file(configuration_path, <<-YAML.strip_indent)
-          Style/Encoding:
-            Enabled: true
+    context '< Ruby 2.5', if: RUBY_VERSION < '2.5' do
+      context 'when the file has duplicated keys' do
+        it 'outputs a warning' do
+          create_file(configuration_path, <<-YAML.strip_indent)
+            Style/Encoding:
+              Enabled: true
 
-          Style/Encoding:
-            Enabled: false
-        YAML
+            Style/Encoding:
+              Enabled: false
+          YAML
 
-        expect do
-          load_file
-        end.to output(%r{`Style/Encoding` is concealed by line 4}).to_stderr
+          expect do
+            load_file
+          end.to output(%r{`Style/Encoding` is concealed by duplicat}).to_stderr
+        end
+      end
+    end
+
+    context '>= Ruby 2.5', if: RUBY_VERSION >= '2.5' do
+      context 'when the file has duplicated keys' do
+        it 'outputs a warning' do
+          create_file(configuration_path, <<-YAML.strip_indent)
+            Style/Encoding:
+              Enabled: true
+
+            Style/Encoding:
+              Enabled: false
+          YAML
+
+          expect do
+            load_file
+          end.to output(%r{`Style/Encoding` is concealed by line 4}).to_stderr
+        end
       end
     end
   end

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -127,8 +127,7 @@ RSpec.describe RuboCop::NodePattern do
 
     describe 'yaml compatibility' do
       let(:instance) do
-        YAML.safe_load(YAML.dump(super()),
-                       permitted_classes: [described_class])
+        YAML.safe_load(YAML.dump(super()), [described_class])
       end
       let(:ruby) { 'obj.method' }
 

--- a/spec/rubocop/yaml_duplication_checker_spec.rb
+++ b/spec/rubocop/yaml_duplication_checker_spec.rb
@@ -26,17 +26,32 @@ RSpec.describe RuboCop::YAMLDuplicationChecker do
 
     include_examples 'call block'
 
-    it 'calls block with keys' do
-      key1 = nil
-      key2 = nil
-      check(yaml) do |key_a, key_b|
-        key1 = key_a
-        key2 = key_b
+    context '< Ruby 2.5', if: RUBY_VERSION < '2.5' do
+      it 'calls block with keys' do
+        key1 = nil
+        key2 = nil
+        check(yaml) do |key_a, key_b|
+          key1 = key_a
+          key2 = key_b
+        end
+        expect(key1.value).to eq('Layout/Tab')
+        expect(key2.value).to eq('Layout/Tab')
       end
-      expect(key1.start_line).to eq(0)
-      expect(key2.start_line).to eq(3)
-      expect(key1.value).to eq('Layout/Tab')
-      expect(key2.value).to eq('Layout/Tab')
+    end
+
+    context '>= Ruby 2.5', if: RUBY_VERSION >= '2.5' do
+      it 'calls block with keys' do
+        key1 = nil
+        key2 = nil
+        check(yaml) do |key_a, key_b|
+          key1 = key_a
+          key2 = key_b
+        end
+        expect(key1.start_line).to eq(0)
+        expect(key2.start_line).to eq(3)
+        expect(key1.value).to eq('Layout/Tab')
+        expect(key2.value).to eq('Layout/Tab')
+      end
     end
   end
 
@@ -49,17 +64,32 @@ RSpec.describe RuboCop::YAMLDuplicationChecker do
 
     include_examples 'call block'
 
-    it 'calls block with keys' do
-      key1 = nil
-      key2 = nil
-      check(yaml) do |key_a, key_b|
-        key1 = key_a
-        key2 = key_b
+    context '< Ruby 2.5', if: RUBY_VERSION < '2.5' do
+      it 'calls block with keys' do
+        key1 = nil
+        key2 = nil
+        check(yaml) do |key_a, key_b|
+          key1 = key_a
+          key2 = key_b
+        end
+        expect(key1.value).to eq('Enabled')
+        expect(key2.value).to eq('Enabled')
       end
-      expect(key1.start_line).to eq(1)
-      expect(key2.start_line).to eq(2)
-      expect(key1.value).to eq('Enabled')
-      expect(key2.value).to eq('Enabled')
+    end
+
+    context '>= Ruby 2.5', if: RUBY_VERSION >= '2.5' do
+      it 'calls block with keys' do
+        key1 = nil
+        key2 = nil
+        check(yaml) do |key_a, key_b|
+          key1 = key_a
+          key2 = key_b
+        end
+        expect(key1.start_line).to eq(1)
+        expect(key2.start_line).to eq(2)
+        expect(key1.value).to eq('Enabled')
+        expect(key2.value).to eq('Enabled')
+      end
     end
   end
 


### PR DESCRIPTION
This reverts parts of #6766 by removing the psych runtime dependency again. This in term should fix #6781 and other issues regarding installation of psych from source on jruby.

From what I understand and is also written [here](https://github.com/rubocop-hq/rubocop/issues/6781#issuecomment-471061171) the psych version is tightly coupled to the ruby version. Especially in this case I do not really see a good enough reason to explicitly require a newer version of psych.

Note I had to make a small change in the YAMLDuplicationChecker