### PR TITLE
[Fix #6882] Fix an error for `Rails/RedundantAllowNil`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#6882](https://github.com/rubocop-hq/rubocop/issues/6882): Fix an error for `Rails/RedundantAllowNil` when not using both `allow_nil` and `allow_blank`. ([@koic][])
+
 ## 0.67.1 (2019-04-04)
 
 ### Changes

--- a/lib/rubocop/cop/rails/redundant_allow_nil.rb
+++ b/lib/rubocop/cop/rails/redundant_allow_nil.rb
@@ -39,14 +39,12 @@ module RuboCop
           return unless node.method_name == :validates
 
           allow_nil, allow_blank = find_allow_nil_and_allow_blank(node)
+          return unless allow_nil && allow_blank
+
           allow_nil_val = allow_nil.children.last
           allow_blank_val = allow_blank.children.last
 
-          if allow_nil_val.type == allow_blank_val.type
-            add_offense(allow_nil, message: MSG_SAME)
-          elsif allow_nil_val.false_type? && allow_blank_val.true_type?
-            add_offense(allow_nil, message: MSG_ALLOW_NIL_FALSE)
-          end
+          offense(allow_nil_val, allow_blank_val, allow_nil)
         end
 
         def autocorrect(node)
@@ -65,6 +63,14 @@ module RuboCop
         end
 
         private
+
+        def offense(allow_nil_val, allow_blank_val, allow_nil)
+          if allow_nil_val.type == allow_blank_val.type
+            add_offense(allow_nil, message: MSG_SAME)
+          elsif allow_nil_val.false_type? && allow_blank_val.true_type?
+            add_offense(allow_nil, message: MSG_ALLOW_NIL_FALSE)
+          end
+        end
 
         def find_allow_nil_and_allow_blank(node)
           allow_nil = nil

--- a/spec/rubocop/cop/rails/redundant_allow_nil_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_allow_nil_spec.rb
@@ -3,6 +3,30 @@
 RSpec.describe RuboCop::Cop::Rails::RedundantAllowNil do
   subject(:cop) { described_class.new }
 
+  context 'when not using both `allow_nil` and `allow_blank`' do
+    it 'registers no offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        validates :email, presence: true
+      RUBY
+    end
+  end
+
+  context 'when using only `allow_nil`' do
+    it 'registers no offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        validates :email, allow_nil: true
+      RUBY
+    end
+  end
+
+  context 'when using only `allow_blank`' do
+    it 'registers no offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        validates :email, allow_blank: true
+      RUBY
+    end
+  end
+
   context 'when both allow_nil and allow_blank are true' do
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)


### PR DESCRIPTION
Fixes #6882.

This PR fixes the following error for `Rails/RedundantAllowNil` when not using both `allow_nil` and `allow_blank`.

```ruby
% cat app/models/user.rb
class User < ApplicationRecord
  validates :email, presence: true
end
```

```console
% rubocop app/models/user.rb --only Rails/RedundantAllowNil -d
For /private/tmp/6882: configuration from
/Users/koic/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rubocop-0.67.1/config/default.yml
Inspecting 1 file
Scanning /private/tmp/6882/app/models/user.rb
An error occurred while Rails/RedundantAllowNil cop was inspecting
/private/tmp/6882/app/models/user.rb:2:2.
undefined method `children' for nil:NilClass
/Users/koic/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rubocop-0.67.1/lib/rubocop/cop/rails/redundant_allow_nil.rb:42:in `on_send'

(snip)

1 file inspected, no offenses detected

1 error occurred:
An error occurred while Rails/RedundantAllowNil cop was inspecting
/private/tmp/6882/app/models/user.rb:2:2.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop-hq/rubocop/issues

Mention the following information in the issue report:
0.67.1 (using Parser 2.6.2.0, running on ruby 2.6.1 x86_64-darwin17)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
