### PR TITLE
Add AllowKeywordBlockArguments option to UnderscorePrefixedVariableName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#6903](https://github.com/rubocop-hq/rubocop/issues/6903): Handle variables prefixed with `_` in `Naming/RescuedExceptionsVariableName` cop. ([@anthony-robin][])
 * [#6917](https://github.com/rubocop-hq/rubocop/issues/6917): Bump Bundler dependency to >= 1.15.0. ([@koic][])
 * Add `--auto-gen-only-exclude` to the command outputted in `rubocop_todo.yml` if the option is specified. ([@dvandersluis][])
+* [#6887](https://github.com/rubocop-hq/rubocop/pull/6887): Allow `Lint/UnderscorePrefixedVariableName` cop to be configured to allow use of block keyword args. ([@dduugg][])
 
 ## 0.67.2 (2019-04-05)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1564,6 +1564,7 @@ Lint/UnderscorePrefixedVariableName:
   Description: 'Do not use prefix `_` for a variable that is used.'
   Enabled: true
   VersionAdded: '0.21'
+  AllowKeywordBlockArguments: false
 
 Lint/UnifiedInteger:
   Description: 'Use Integer instead of Fixnum or Bignum'

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -2077,7 +2077,13 @@ Enabled | Yes | No | 0.21 | -
 This cop checks for underscore-prefixed variables that are actually
 used.
 
+Since block keyword arguments cannot be arbitrarily named at call
+sites, the `AllowKeywordBlockArguments` will allow use of underscore-
+prefixed block keyword arguments.
+
 ### Examples
+
+#### AllowKeywordBlockArguments: false (default)
 
 ```ruby
 # bad
@@ -2085,21 +2091,36 @@ used.
 [1, 2, 3].each do |_num|
   do_something(_num)
 end
-```
-```ruby
+
+query(:sales) do |_id:, revenue:, cost:|
+  {_id: _id, profit: revenue - cost}
+end
+
 # good
 
 [1, 2, 3].each do |num|
   do_something(num)
 end
-```
-```ruby
-# good
 
 [1, 2, 3].each do |_num|
   do_something # not using `_num`
 end
 ```
+#### AllowKeywordBlockArguments: true
+
+```ruby
+# good
+
+query(:sales) do |_id:, revenue:, cost:|
+  {_id: _id, profit: revenue - cost}
+end
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AllowKeywordBlockArguments | `false` | Boolean
 
 ## Lint/UnifiedInteger
 


### PR DESCRIPTION
This adds an `AllowKeywordBlockArguments` to the `Lint/UnderscorePrefixedVariableName` cop. When enabled, it permits use of underscore-prefixed keyword arguments in blocks.

It is inspired by the `AllowUnusedKeywordArguments` option in the `Lint/Unused{Block,Method}Argument` cops.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
