### PR TITLE
Mark Rails/DynamicFindBy not safe

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -2345,7 +2345,9 @@ Rails/DynamicFindBy:
   Description: 'Use `find_by` instead of dynamic `find_by_*`.'
   StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#find_by'
   Enabled: true
+  Safe: false
   VersionAdded: '0.44'
+  VersionChanged: '0.68'
   Whitelist:
     - find_by_sql
 


### PR DESCRIPTION
In the ruby stdlib, there's `Gem::Specification.find_by_name('...')` method which works without rails, but breaks if `Rails/DynamicFindBy` cop autocorrects it to `Gem::Specification.find_by(name: '...')`. This cop is therefore not safe.

From the rubydoc [find_by_name(name, *requirements)](https://ruby-doc.org/stdlib-2.6.1/libdoc/rubygems/rdoc/Gem/Specification.html#method-c-find_by_name):
> Find the best specification matching a name and requirements. Raises if the dependency doesn't resolve to a valid specification.

I'm using this method in my gem to find a path to another gem, from a file which doesn't necessarily load rails (think of a "fast" rspec test of a PORO object that doesn't need to load entire rails application; or in my case: a rake task that actually runs rubocop, and doesn't need to load rails to do so).

When I run `rubocop --safe-auto-correct`, the line:

```ruby
Gem::Specification.find_by_name('xxx_magic_gem').gem_dir
```

Gets autocorrected to:

```ruby
Gem::Specification.find_by(name: 'xxx_magic_gem').gem_dir
```

This breaks the code with the following error:
> NoMethodError: undefined method `find_by' for Gem::Specification:Class

I wanted to add to `Whitelist` the exact method name: `Gem::Specification.find_by_name`, but it seems like `Whitelist` config option only accepts method names, not the "full path" with module and class name.
