### PR TITLE
NodePattern: Fix complex ascend in sequence-head position

### DIFF
--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -160,7 +160,7 @@ module RuboCop
         when '['       then compile_intersect(tokens, cur_node, seq_head)
         when '!'       then compile_negation(tokens, cur_node, seq_head)
         when '$'       then compile_capture(tokens, cur_node, seq_head)
-        when '^'       then compile_ascend(tokens, cur_node, seq_head)
+        when '^'       then compile_ascend(tokens, cur_node)
         when WILDCARD  then compile_wildcard(cur_node, token[1..-1], seq_head)
         when FUNCALL   then compile_funcall(tokens, cur_node, token, seq_head)
         when LITERAL   then compile_literal(cur_node, token, seq_head)
@@ -324,9 +324,9 @@ module RuboCop
         "(!#{compile_expr(tokens, cur_node, seq_head)})"
       end
 
-      def compile_ascend(tokens, cur_node, seq_head)
+      def compile_ascend(tokens, cur_node)
         "(#{cur_node}.parent && " \
-          "#{compile_expr(tokens, "#{cur_node}.parent", seq_head)})"
+          "#{compile_expr(tokens, "#{cur_node}.parent", false)})"
       end
 
       def compile_wildcard(cur_node, name, seq_head)

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -1126,6 +1126,36 @@ RSpec.describe RuboCop::NodePattern do
       end
     end
 
+    context 'within sequence' do
+      let(:ruby) { '1.inc' }
+
+      context 'not in head' do
+        let(:ruby) { '1.inc' }
+        let(:pattern) { '(send ^send :inc)' }
+
+        it_behaves_like 'matching'
+
+        context 'of a sequence' do
+          let(:pattern) { '(send ^(send _ _) :inc)' }
+
+          it_behaves_like 'matching'
+        end
+      end
+
+      context 'in head' do
+        let(:node) { root_node.children[0] }
+        let(:pattern) { '(^send 1)' }
+
+        it_behaves_like 'matching'
+
+        context 'of a sequence' do
+          let(:pattern) { '(^(send _ _) 1)' }
+
+          it_behaves_like 'matching'
+        end
+      end
+    end
+
     context 'repeated twice' do
       # ascends to grandparent node
       let(:pattern) { '^^block' }


### PR DESCRIPTION
I noticed a subtle issue with `NodePattern` compiling ascend. If we write `^<something>`, the `<something>` should be about the parent's node, never about the parent's node's type.

So `seq_head` shouldn't be passed down.

This error wasn't too noticeable because matching on `node_type` works exactly the same in `seq_head` or not.

The added tests try to illustrate this. The first three were already passing, but the last one wasn't.