### PR TITLE
Add link to Development docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ $ rubocop -V
 
 * Read [how to properly contribute to open source projects on GitHub][2].
 * Fork the project.
+* If you're adding or making changes to cops, read the [Development docs](https://docs.rubocop.org/en/latest/development/)
 * Use a topic/feature branch to easily amend a pull request later, if necessary.
 * Write [good commit messages][3].
 * Use the same coding conventions as the rest of the project.


### PR DESCRIPTION
I'm looking to add a cop so I went to `CONTRIBUTING.md` and couldn't find much information about adding a new cop. I found it in the docs site and thought it would be a good idea to include it in the `CONTRIBUTING.md` guide as well.