### PR TITLE
Replace `Time.zone.current` with `Time.zone.today` on `Rails::Date` message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
 * [#6972](https://github.com/rubocop-hq/rubocop/issues/6972): Fix a false positive for `Style/MixinUsage` when using inside block and `if` condition is after `include`. ([@koic][])
 * [#6738](https://github.com/rubocop-hq/rubocop/issues/6738): Prevent auto-correct conflict of `Style/Next` and `Style/SafeNavigation`. ([@hoshinotsuyoshi][])
 * [#6847](https://github.com/rubocop-hq/rubocop/pull/6847): Fix `Style/BlockDelimiters` to properly check if the node is chaned when `braces_for_chaining` is set. ([@att14][])
+### Bug fixes
+
+* Replace `Time.zone.current` with `Time.zone.today` on `Rails::Date` cop message. ([@vfonic][])
 
 ## 0.68.0 (2019-04-29)
 

--- a/lib/rubocop/cop/rails/date.rb
+++ b/lib/rubocop/cop/rails/date.rb
@@ -46,7 +46,7 @@ module RuboCop
       class Date < Cop
         include ConfigurableEnforcedStyle
 
-        MSG = 'Do not use `Date.%<day>s` without zone. Use ' \
+        MSG = 'Do not use `Date.%<method_called>s` without zone. Use ' \
               '`Time.zone.%<day>s` instead.'.freeze
 
         MSG_SEND = 'Do not use `%<method>s` on Date objects, because they ' \
@@ -101,8 +101,13 @@ module RuboCop
 
           method_name = (chain & bad_days).join('.')
 
+          day = method_name
+          day = 'today' if method_name == 'current'
+
           add_offense(node, location: :selector,
-                            message: format(MSG, day: method_name.to_s))
+                            message: format(MSG,
+                                            method_called: method_name,
+                                            day: day))
         end
 
         def extract_method_chain(node)


### PR DESCRIPTION
The default message for the `strict` style mentions `Time.zone.current`
(e.g. "Do not use `Date.current` without zone. Use `Time.zone.current`
instead.").

Calling `Time.zone.current` causes a `NoMethodError` since there's no `current`
method on `ActiveSupport::TimeZone`. Instead, the message should mention
`Time.zone.today`, which is probably the intended call that takes the time zone
in account.

With this change the message would change to "Do not use `Date.current` without
zone. Use `Time.zone.today` instead."

```ruby
pry(main)> Date.current
Sun, 07 Apr 2019
pry(main)> Time.zone.today
Sun, 07 Apr 2019
pry(main)> Time.zone.current
NoMethodError: undefined method `current' for #<ActiveSupport::TimeZone:0x00007fed55407668>
from (pry):13:in `<main>'
```

NOTE: I took a lot from a similar commit: [Replace `Time.zone.current` with `Time.current` on Rails::TimeZone message](https://github.com/rubocop-hq/rubocop/commit/678228e410b462c33acd62c6604967bbfda39a00)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/