### PR TITLE
Fix node pattern tutorial `...` matcher section

### DIFF
--- a/manual/node_pattern.md
+++ b/manual/node_pattern.md
@@ -70,7 +70,7 @@ value:
 
 ## `...` for several subsequent nodes
 
-Where `_` matches a single node, `...` eagerly matches one or more subsequent nodes.
+Where `_` matches a single node, `...` eagerly matches zero or more subsequent nodes.
 
 It's useful when you want to check some internal nodes but with a
 final with the same results. For example, let's use `sum(1,2)`.


### PR DESCRIPTION
`...` actually matches zero or more elements, not "one or more":

    > pattern = NodePattern.new('(send nil? :sum $...)')
    > pattern.match(RuboCop::ProcessedSource.new('sum(1,2,3,n)', 2.5).ast)
    => [s(:int, 1), s(:int, 2), s(:int, 3), s(:send, nil, :n)]
    > pattern.match(RuboCop::ProcessedSource.new('sum()', 2.5).ast)
    => []


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/