### PR TITLE
ADD auto-correction to `Naming/RescuedExceptionsVariableName` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [#5977](https://github.com/rubocop-hq/rubocop/issues/5977): Remove Performance cops. ([@koic][])
+* Add auto-correction to `Naming/RescuedExceptionsVariableName`. ([@anthony-robin][])
 
 ## 0.67.2 (2019-04-05)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1939,6 +1939,7 @@ Naming/RescuedExceptionsVariableName:
   Description: 'Use consistent rescued exceptions variables naming.'
   Enabled: true
   VersionAdded: '0.67'
+  VersionChanged: '0.68'
   PreferredName: e
 
 Naming/UncommunicativeBlockParamName:

--- a/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
+++ b/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
@@ -53,6 +53,12 @@ module RuboCop
           add_offense(node, location: location)
         end
 
+        def autocorrect(_node)
+          lambda do |corrector|
+            corrector.replace(location, preferred_name)
+          end
+        end
+
         private
 
         def preferred_name

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -481,7 +481,7 @@ Exclude | `spec/**/*` | Array
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.67 | -
+Enabled | Yes | Yes  | 0.67 | 0.68
 
 This cop makes sure that rescued exceptions variables are named as
 expected.

--- a/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
               # do something
             end
           RUBY
+
+          expect_correction(<<-RUBY.strip_indent)
+            begin
+              something
+            rescue MyException => e
+              # do something
+            end
+          RUBY
         end
 
         it 'does not register an offense when using `e`' do
@@ -49,6 +57,14 @@ RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
               something
             rescue exc
                    ^^^ Use `e` instead of `exc`.
+              # do something
+            end
+          RUBY
+
+          expect_correction(<<-RUBY.strip_indent)
+            begin
+              something
+            rescue e
               # do something
             end
           RUBY
@@ -92,6 +108,14 @@ RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
           something
         rescue MyException => e
                               ^ Use `exception` instead of `e`.
+          # do something
+        end
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        begin
+          something
+        rescue MyException => exception
           # do something
         end
       RUBY


### PR DESCRIPTION
This PR adds ability to auto-correct offenses flagged by the new `Naming/RescuedExceptionsVariableName` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
