### PR TITLE
[Fix #6903] Handle variables with `_` for `Naming/RescuedExceptionsVariableName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#5977](https://github.com/rubocop-hq/rubocop/issues/5977): Remove Performance cops. ([@koic][])
 * Add auto-correction to `Naming/RescuedExceptionsVariableName`. ([@anthony-robin][])
+* [#6903](https://github.com/rubocop-hq/rubocop/issues/6903): Handle variables prefixed with `_` in `Naming/RescuedExceptionsVariableName` cop. ([@anthony-robin][])
 
 ## 0.67.2 (2019-04-05)
 

--- a/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
+++ b/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
@@ -24,6 +24,13 @@ module RuboCop
       #     # do something
       #   end
       #
+      #   # good
+      #   begin
+      #     # do something
+      #   rescue MyException => _e
+      #     # do something
+      #   end
+      #
       # @example PreferredName: exception
       #   # bad
       #   begin
@@ -36,6 +43,13 @@ module RuboCop
       #   begin
       #     # do something
       #   rescue MyException => exception
+      #     # do something
+      #   end
+      #
+      #   # good
+      #   begin
+      #     # do something
+      #   rescue MyException => _exception
       #     # do something
       #   end
       #
@@ -62,7 +76,11 @@ module RuboCop
         private
 
         def preferred_name
-          @preferred_name ||= cop_config.fetch('PreferredName', 'e')
+          @preferred_name ||= begin
+            name = cop_config.fetch('PreferredName', 'e')
+            name = "_#{name}" if variable_name.to_s.start_with?('_')
+            name
+          end
         end
 
         def variable_name

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -507,6 +507,13 @@ begin
 rescue MyException => e
   # do something
 end
+
+# good
+begin
+  # do something
+rescue MyException => _e
+  # do something
+end
 ```
 #### PreferredName: exception
 
@@ -522,6 +529,13 @@ end
 begin
   # do something
 rescue MyException => exception
+  # do something
+end
+
+# good
+begin
+  # do something
+rescue MyException => _exception
   # do something
 end
 ```

--- a/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
@@ -25,11 +25,40 @@ RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
           RUBY
         end
 
+        it 'registers an offense when using `_exc`' do
+          expect_offense(<<-RUBY.strip_indent)
+            begin
+              something
+            rescue MyException => _exc
+                                  ^^^^ Use `_e` instead of `_exc`.
+              # do something
+            end
+          RUBY
+
+          expect_correction(<<-RUBY.strip_indent)
+            begin
+              something
+            rescue MyException => _e
+              # do something
+            end
+          RUBY
+        end
+
         it 'does not register an offense when using `e`' do
           expect_no_offenses(<<-RUBY.strip_indent)
             begin
               something
             rescue MyException => e
+              # do something
+            end
+          RUBY
+        end
+
+        it 'does not register an offense when using `_e`' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            begin
+              something
+            rescue MyException => _e
               # do something
             end
           RUBY
@@ -70,11 +99,40 @@ RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
           RUBY
         end
 
+        it 'registers an offense when using `_exc`' do
+          expect_offense(<<-RUBY.strip_indent)
+            begin
+              something
+            rescue _exc
+                   ^^^^ Use `_e` instead of `_exc`.
+              # do something
+            end
+          RUBY
+
+          expect_correction(<<-RUBY.strip_indent)
+            begin
+              something
+            rescue _e
+              # do something
+            end
+          RUBY
+        end
+
         it 'does not register an offense when using `e`' do
           expect_no_offenses(<<-RUBY.strip_indent)
             begin
               something
             rescue e
+              # do something
+            end
+          RUBY
+        end
+
+        it 'does not register an offense when using `_e`' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            begin
+              something
+            rescue _e
               # do something
             end
           RUBY
@@ -121,11 +179,40 @@ RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
       RUBY
     end
 
+    it 'registers an offense when using `_e`' do
+      expect_offense(<<-RUBY.strip_indent)
+        begin
+          something
+        rescue MyException => _e
+                              ^^ Use `_exception` instead of `_e`.
+          # do something
+        end
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        begin
+          something
+        rescue MyException => _exception
+          # do something
+        end
+      RUBY
+    end
+
     it 'does not register an offense when using `exception`' do
       expect_no_offenses(<<-RUBY.strip_indent)
         begin
           something
         rescue MyException => exception
+          # do something
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when using `_exception`' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        begin
+          something
+        rescue MyException => _exception
           # do something
         end
       RUBY


### PR DESCRIPTION
Currently, this cop do not play nicely with variables that are prefixed by an `_`.

The message should take into consideration if the variable is going to be
used or not when showing the error.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
