### PR TITLE
[Fix #6893] FIX bug with splat or methods exceptions on `RescuedExceptionsVariableName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#5977](https://github.com/rubocop-hq/rubocop/issues/5977): Remove Performance cops. ([@koic][])
 * Add auto-correction to `Naming/RescuedExceptionsVariableName`. ([@anthony-robin][])
 * [#6903](https://github.com/rubocop-hq/rubocop/issues/6903): Handle variables prefixed with `_` in `Naming/RescuedExceptionsVariableName` cop. ([@anthony-robin][])
+* [#6893](https://github.com/rubocop-hq/rubocop/issues/6893): Fix bug with splat or method exceptions on `Naming/RescuedExceptionsVariableName` cop. ([@anthony-robin][])
 * [#6917](https://github.com/rubocop-hq/rubocop/issues/6917): Bump Bundler dependency to >= 1.15.0. ([@koic][])
 * Add `--auto-gen-only-exclude` to the command outputted in `rubocop_todo.yml` if the option is specified. ([@dvandersluis][])
 

--- a/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
+++ b/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
@@ -61,7 +61,8 @@ module RuboCop
           return unless exception_type || @exception_name
 
           @exception_name ||= exception_type.children.first
-          return if @exception_name.const_type? ||
+
+          return if !@exception_name.lvasgn_type? ||
                     variable_name == preferred_name
 
           add_offense(node, location: offense_range(node))

--- a/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
@@ -101,6 +101,88 @@ RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
           RUBY
         end
       end
+
+      context 'with method as `Exception`' do
+        it 'does not register an offense without variable name' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            begin
+              something
+            rescue ActiveSupport::JSON.my_method
+              # do something
+            end
+          RUBY
+        end
+
+        it 'does not register an offense with expected variable name' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            begin
+              something
+            rescue ActiveSupport::JSON.my_method => e
+              # do something
+            end
+          RUBY
+        end
+
+        it 'registers an offense with unexpected variable name' do
+          expect_offense(<<-RUBY.strip_indent)
+            begin
+              something
+            rescue ActiveSupport::JSON.my_method => exc
+                                                    ^^^ Use `e` instead of `exc`.
+              # do something
+            end
+          RUBY
+
+          expect_correction(<<-RUBY.strip_indent)
+            begin
+              something
+            rescue ActiveSupport::JSON.my_method => e
+              # do something
+            end
+          RUBY
+        end
+      end
+
+      context 'with splat operator as `Exception` list' do
+        it 'does not register an offense without variable name' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            begin
+              something
+            rescue *handled
+              # do something
+            end
+          RUBY
+        end
+
+        it 'does not register an offense with expected variable name' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            begin
+              something
+            rescue *handled => e
+              # do something
+            end
+          RUBY
+        end
+
+        it 'registers an offense with unexpected variable name' do
+          expect_offense(<<-RUBY.strip_indent)
+            begin
+              something
+            rescue *handled => exc
+                               ^^^ Use `e` instead of `exc`.
+              # do something
+            end
+          RUBY
+
+          expect_correction(<<-RUBY.strip_indent)
+            begin
+              something
+            rescue *handled => e
+              # do something
+            end
+          RUBY
+        end
+      end
     end
 
     context 'with implicit rescue' do


### PR DESCRIPTION
This PR makes the `Naming/RescuedExceptionsVariableName` cop to play friendly
with exceptions listed using the splat operator or calling a method on a class.

```ruby
handled = [StandardError]

begin
  something
rescue *handled
  # do something
end
```

```ruby
begin
  something
rescue ActiveSupport::JSON.my_method
  # do something
end
```

Fix #6893
Fix #6907
Fix #6912

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
