### PR TITLE
NodePattern: Optimize by using placeholders for post processing

### DIFF
--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -223,6 +223,21 @@ RSpec.describe RuboCop::NodePattern do
 
       it_behaves_like 'matching'
     end
+
+    describe 'bare literal' do
+      let(:ruby) { ':bar' }
+      let(:pattern) { ':bar' }
+
+      context 'on a node' do
+        it_behaves_like 'nonmatching'
+      end
+
+      context 'on a matching literal' do
+        let(:node) { root_node.children[0] }
+
+        it_behaves_like 'matching'
+      end
+    end
   end
 
   describe 'nil' do
@@ -469,6 +484,13 @@ RSpec.describe RuboCop::NodePattern do
       context 'containing integer literals' do
         let(:pattern) { '(send (int {1 10}) :abs)' }
         let(:ruby) { '10.abs' }
+
+        it_behaves_like 'matching'
+      end
+
+      context 'containing mixed node and literals' do
+        let(:pattern) { '(send {int nil?} ...)' }
+        let(:ruby) { 'obj' }
 
         it_behaves_like 'matching'
       end


### PR DESCRIPTION
The improved handling of `...` had to use some post-processing of the `cur_node` (#6843)
The easiest way to provide other "multiple match" patterns (e.g. #6841) would involve similar post-processing. This PR paves the way by using post processing of the current node pattern everywhere.

This as other multiple benefits:
- deals automatically and better with generated temporary variables
- much less argument passing to the various compiling methods
- factorizes the `#{'.type' if seq_head}` pattern that was everywhere.
- makes debugging easier with simpler & nicer generated code

I had hoped to be able to minimize the number of node guards, but unions make it tricky.

For the record, here's an example of the code generated before & after.

```ruby
### Pattern:
($_ {:a :b} nil?)

### Before:
(temp1 = node0; temp1 = temp1;temp1.is_a?(RuboCop::AST::Node) &&
(capture1 = temp1.type; true) &&
(temp2 = temp1.children[0]; temp2 = temp2;(temp2 == :a) || (temp2 == :b)) &&
(temp1.children[1].nil?) &&
(temp1.children.size == 2))

### After:
node0.is_a?(RuboCop::AST::Node) &&
(capture1 = node0.type; true) &&
((temp1 = node0.children[0]) == :a || temp1 == :b) &&
node0.children[1].nil? &&
node0.children.size == 2
```
