### PR TITLE
Remove the warning about `rubocop-performance` from non-related output formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#6914](https://github.com/rubocop-hq/rubocop/issues/6914): [Fix #6914] Fix an error for `Rails/RedundantAllowNil` when with interpolations. ([@Blue-Pix][])
+* Remove the warning about `rubocop-performance` from non-related output formats. ([@AlexWayfer][])
 
 ### Changes
 

--- a/exe/rubocop
+++ b/exe/rubocop
@@ -9,18 +9,6 @@ require 'benchmark'
 cli = RuboCop::CLI.new
 result = 0
 
-if defined?(Bundler)
-  gemfile_lock = Bundler.read_file(Bundler.default_lockfile)
-  parser = Bundler::LockfileParser.new(gemfile_lock)
-
-  unless parser.dependencies['rubocop-performance']
-    warn Rainbow(<<-MESSAGE.strip_indent).yellow.to_s
-      [Warn] Performance Cops will be removed from RuboCop 0.68. Use rubocop-performance gem instead.
-             https://github.com/rubocop-hq/rubocop/tree/master/manual/migrate_performance_cops.md
-    MESSAGE
-  end
-end
-
 time = Benchmark.realtime do
   result = cli.run
 end

--- a/lib/rubocop/formatter/simple_text_formatter.rb
+++ b/lib/rubocop/formatter/simple_text_formatter.rb
@@ -23,6 +23,18 @@ module RuboCop
       def started(_target_files)
         @total_offense_count = 0
         @total_correction_count = 0
+
+        return unless defined?(Bundler)
+
+        gemfile_lock = Bundler.read_file(Bundler.default_lockfile)
+        parser = Bundler::LockfileParser.new(gemfile_lock)
+
+        return if parser.dependencies['rubocop-performance']
+
+        warn Rainbow(<<-MESSAGE.strip_indent).yellow.to_s
+          [Warn] Performance Cops will be removed from RuboCop 0.68. Use rubocop-performance gem instead.
+                 https://github.com/rubocop-hq/rubocop/tree/master/manual/migrate_performance_cops.md
+        MESSAGE
       end
 
       def file_finished(file, offenses)


### PR DESCRIPTION
Fix https://github.com/AtomLinter/linter-rubocop/issues/309 after #6845

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
