### PR TITLE
[Fix #6914] Fix an error for `Rails/RedundantAllowNil` when with interpolations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#6914](https://github.com/rubocop-hq/rubocop/issues/6914): [Fix #6914] Fix an error for `Rails/RedundantAllowNil` when with interpolations. ([@Blue-Pix][])
+
 ### Changes
 
 * [#5977](https://github.com/rubocop-hq/rubocop/issues/5977): Remove Performance cops. ([@koic][])
@@ -3929,3 +3933,4 @@
 [@anuja-joshi]: https://github.com/anuja-joshi
 [@XrXr]: https://github.com/XrXr
 [@thomthom]: https://github.com/thomthom
+[@Blue-Pix]: https://github.com/Blue-Pix

--- a/lib/rubocop/cop/rails/redundant_allow_nil.rb
+++ b/lib/rubocop/cop/rails/redundant_allow_nil.rb
@@ -79,10 +79,10 @@ module RuboCop
           node.each_descendant do |descendant|
             next unless descendant.pair_type?
 
-            key = descendant.children.first.value
+            key = descendant.children.first.source
 
-            allow_nil = descendant if key == :allow_nil
-            allow_blank = descendant if key == :allow_blank
+            allow_nil = descendant if key == 'allow_nil'
+            allow_blank = descendant if key == 'allow_blank'
 
             break if allow_nil && allow_blank
           end

--- a/spec/rubocop/cop/rails/redundant_allow_nil_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_allow_nil_spec.rb
@@ -73,4 +73,12 @@ RSpec.describe RuboCop::Cop::Rails::RedundantAllowNil do
       RUBY
     end
   end
+
+  context 'when using string interpolation' do
+    it 'registers no offense' do
+      expect_no_offenses(<<-'RUBY'.strip_indent)
+        validates :details, "path_to_dynamic_validation/#{with_interpolation}": true
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #6914.

This PR fixes the following error for Rails/RedundantAllowNil when with interpolations.

```ruby
class Foo < ActiveRecord::Base
  BAR = "sample"
  validates :name, "#{self::BAR}": true
end
```

```ruby
class SampleValidator < ActiveModel::EachValidator
  def validate_each(record, attribute, value)
    if value.size > 3
      record.errors.add(attribute, 'too long')
    end
  end
end
```

This is stacktrace.
```bash
$ rubocop app/models/foo.rb --only Rails/RedundantAllowNil -d
An error occurred while Rails/RedundantAllowNil cop was inspecting /myapp/app/models/foo.rb:3:2.
undefined method `value' for "s(:dsym,\n  s(:begin,\n    s(:const,\n      s(:self), :BAR)))":RuboCop::AST::Node
```


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
