### PR TITLE
[Fix #6917] Bump Bundler dependency to >= 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#5977](https://github.com/rubocop-hq/rubocop/issues/5977): Remove Performance cops. ([@koic][])
 * Add auto-correction to `Naming/RescuedExceptionsVariableName`. ([@anthony-robin][])
 * [#6903](https://github.com/rubocop-hq/rubocop/issues/6903): Handle variables prefixed with `_` in `Naming/RescuedExceptionsVariableName` cop. ([@anthony-robin][])
+* [#6917](https://github.com/rubocop-hq/rubocop/issues/6917): Bump Bundler dependency to >= 1.15.0. ([@koic][])
 
 ## 0.67.2 (2019-04-05)
 

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 1.6')
 
-  s.add_development_dependency('bundler', '>= 1.3.0', '< 3.0')
+  s.add_development_dependency('bundler', '>= 1.15.0', '< 3.0')
   s.add_development_dependency('rack', '>= 2.0')
 
   s.post_install_message = File.read('manual/migrate_performance_cops.md')


### PR DESCRIPTION
Fixes #6917.

This PR bumps Bundler dependency to >= 1.15.0.

Bundler 2 has already been released.
This PR drops old Bundler versions (1.14 or lower) to prevent the following error.

## Bundler 1.14

An unexpected error occurs.

```console
% bundle _1.14.6_ exec rubocop
bundler: failed to load command:
rubocop (/Users/koic/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/bin/rubocop)
TypeError: no implicit conversion of String into Integer
  /Users/koic/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/rubocop-0.67.1/exe/rubocop:16:in
  `<top (required)>'
  /Users/koic/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/bin/rubocop:23:in
  `load'
  /Users/koic/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/bin/rubocop:23:in
  `<top (required)>'
```

## Bundler 1.15

Errors does not occur as expected.

```console
% bundle _1.15.0_ exec rubocop
[Warn] Performance Cops will be removed from RuboCop 0.68. Use
rubocop-performance gem instead.
       https://github.com/rubocop-hq/rubocop/tree/master/manual/migrate_performance_cops.md

(snip)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
