### PR TITLE
[Fix #5975] Add beginning_of_first_line mode to ClosingParenthesisIndentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#5975](https://github.com/rubocop-hq/rubocop/issues/5975): [Fix #5975] Add `beginning_of_first_line` mode to `Layout/ClosingParenthesisIndentation`. ([@maxh][])
+
 ### Bug fixes
 
 * [#6914](https://github.com/rubocop-hq/rubocop/issues/6914): [Fix #6914] Fix an error for `Rails/RedundantAllowNil` when with interpolations. ([@Blue-Pix][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -394,6 +394,10 @@ Layout/ClosingParenthesisIndentation:
   Description: 'Checks the indentation of hanging closing parentheses.'
   Enabled: true
   VersionAdded: '0.49'
+  EnforcedStyle: consistent
+  SupportedStyles:
+    - consistent
+    - beginning_of_first_line
 
 Layout/CommentIndentation:
   Description: 'Indentation of comments.'

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -747,11 +747,21 @@ This cop checks the indentation of hanging closing parentheses in
 method calls, method definitions, and grouped expressions. A hanging
 closing parenthesis means `)` preceded by a line break.
 
+The default style is called 'consistent'. An alternative
+style is 'beginning_of_first_line'. The examples below illustrates
+the expected behavior.
+
+Note that the behavior in `consistent` mode is dependent on the
+indentation of the parameters in the method call. You can use other
+cops such as `FirstParameterIndentation` to adjust that.
+
 ### Examples
+
+#### EnforcedStyle: consistent (default)
 
 ```ruby
 # bad
-some_method(
+foo = some_method(
   a,
   b
   )
@@ -760,7 +770,7 @@ some_method(
   a, b
   )
 
-some_method(a, b, c
+foo = some_method(a, b, c
   )
 
 some_method(a,
@@ -777,7 +787,7 @@ some_method(a,
 
 # good: when first param is on a new line, right paren is *always*
 #       outdented by IndentationWidth
-some_method(
+foo = some_method(
   a,
   b
 )
@@ -808,6 +818,70 @@ some_method(a,
   y: 2
 )
 ```
+#### EnforcedStyle: beginning_of_first_line
+
+```ruby
+# bad
+foo = some_method(
+  a,
+  b
+  )
+
+some_method(
+  a, b
+  )
+
+some_method(a, b, c
+  )
+
+some_method(a,
+            b,
+            c
+  )
+
+some_method(a,
+  x: 1,
+  y: 2
+  )
+
+# good: closing paren aligns with the beginning of the first line
+#       containing the expression (even when the first
+#       first parameter is on the same line as the opening
+#       parenthesis, or when the parameters are indented
+#       in a non-standard way)
+foo = some_method(
+  a,
+  b
+)
+
+some_method(
+  a, b
+)
+
+some_method(a, b, c
+)
+
+some_method(a,
+            b,
+            c
+)
+
+some_method(a,
+  x: 1,
+  y: 2
+)
+
+some_method(a,
+    x: 1,
+    y: 2
+)
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `consistent` | `consistent`, `beginning_of_first_line`
 
 ## Layout/CommentIndentation
 


### PR DESCRIPTION
As a follow-up to https://github.com/rubocop-hq/rubocop/pull/6826, this PR adds `beginning_of_first_line` mode to support the behavior desired by commenters here:

https://github.com/rubocop-hq/rubocop/issues/5975 "Layout/ClosingParenthesisIndentation is incorrect in 0.57.1 even on basic case"

Open sourced from a Flexport-internal Ruby formatting project.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
