### PR TITLE
Fix # 6793 Explained remedy for new ruby version

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -591,6 +591,7 @@ module RuboCop
             end
 
       msg += "\nSupported versions: #{KNOWN_RUBIES.join(', ')}"
+      msg += "\nTry updatiing Rubocop to a newer version"
 
       raise ValidationError, msg
     end

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -591,6 +591,7 @@ module RuboCop
             end
 
       msg += "\nSupported versions: #{KNOWN_RUBIES.join(', ')}"
+      
       msg += "\nTry updatiing Rubocop to a newer version"
 
       raise ValidationError, msg

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1624,6 +1624,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect($stderr.string.strip).to match(
           /Supported versions: 2.2, 2.3, 2.4, 2.5, 2.6/
         )
+        expect($stderr.string.strip).to match(
+          /Try updatiing Rubocop to a newer version/
+        )
       end
     end
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1625,7 +1625,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           /Supported versions: 2.2, 2.3, 2.4, 2.5, 2.6/
         )
         expect($stderr.string.strip).to match(
-          /Try updatiing Rubocop to a newer version/
+            /Try updatiing Rubocop to a newer version/
         )
       end
     end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1625,7 +1625,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           /Supported versions: 2.2, 2.3, 2.4, 2.5, 2.6/
         )
         expect($stderr.string.strip).to match(
-            /Try updatiing Rubocop to a newer version/
+            /Try updating Rubocop to a newer version/
         )
       end
     end


### PR DESCRIPTION
Added message for when Rubocop comes across a newer version of Ruby. Old message doesn't clarify that is was Rubocop that didn't know the ruby version.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
