### PR TITLE
When --auto-gen-only-exclude is specified, output it in .rubocop_todo.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add auto-correction to `Naming/RescuedExceptionsVariableName`. ([@anthony-robin][])
 * [#6903](https://github.com/rubocop-hq/rubocop/issues/6903): Handle variables prefixed with `_` in `Naming/RescuedExceptionsVariableName` cop. ([@anthony-robin][])
 * [#6917](https://github.com/rubocop-hq/rubocop/issues/6917): Bump Bundler dependency to >= 1.15.0. ([@koic][])
+* Add `--auto-gen-only-exclude` to the command outputted in `rubocop_todo.yml` if the option is specified. ([@dvandersluis][])
 
 ## 0.67.2 (2019-04-05)
 

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -58,6 +58,11 @@ module RuboCop
 
       def command
         command = 'rubocop --auto-gen-config'
+
+        if @options[:auto_gen_only_exclude]
+          command += ' --auto-gen-only-exclude'
+        end
+
         if @exclude_limit_option
           command +=
             format(' --exclude-limit %<limit>d',

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -845,6 +845,16 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       YAML
     end
 
+    it 'includes --auto-gen-only-exclude in the command comment when given' do
+      create_file('example1.rb', ['$!'])
+      expect(cli.run(['--auto-gen-config', '--auto-gen-only-exclude',
+                      '--exclude-limit', '1'])).to eq(0)
+
+      command = '# `rubocop --auto-gen-config --auto-gen-only-exclude ' \
+                '--exclude-limit 1`'
+      expect(IO.readlines('.rubocop_todo.yml')[1].chomp).to eq(command)
+    end
+
     it 'does not include a timestamp when --no-auto-gen-timestamp is used' do
       create_file('example1.rb', ['$!'])
       expect(cli.run(['--auto-gen-config', '--no-auto-gen-timestamp'])).to eq(0)


### PR DESCRIPTION
Developers at my company use the outputted comment at the top of `rubocop_todo.yml` to regenerate the config, but `--auto-gen-only-exclude` wasn't being included there. This change adds it in.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
