### PR TITLE
Do not annotate messages in JSON output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug fixes
 
+* Do not annotate message with cop name in JSON output. ([@elebow][])
 * [#6914](https://github.com/rubocop-hq/rubocop/issues/6914): [Fix #6914] Fix an error for `Rails/RedundantAllowNil` when with interpolations. ([@Blue-Pix][])
 
 ### Changes

--- a/lib/rubocop/cop/message_annotator.rb
+++ b/lib/rubocop/cop/message_annotator.rb
@@ -106,6 +106,7 @@ module RuboCop
         return true if debug?
         return false if options[:display_cop_names] == false
         return true if options[:display_cop_names]
+        return false if options[:format] == 'json'
 
         config.for_all_cops['DisplayCopNames']
       end

--- a/spec/rubocop/cop/message_annotator_spec.rb
+++ b/spec/rubocop/cop/message_annotator_spec.rb
@@ -16,6 +16,18 @@ RSpec.describe RuboCop::Cop::MessageAnnotator do
       end
     end
 
+    context 'when the output format is JSON' do
+      let(:options) do
+        {
+          format: 'json'
+        }
+      end
+
+      it 'returns the message unannotated' do
+        expect(annotate).to eq('message')
+      end
+    end
+
     context 'with options on' do
       let(:options) do
         {


### PR DESCRIPTION
The JSON formatter has a separate field for `cop_name`, so the message should be unannotated by default.

This matches the output described at https://github.com/rubocop-hq/rubocop/blob/master/manual/formatters.md#json-formatter.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
