### PR TITLE
Add initial autocorrection support to LineLength cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#6928](https://github.com/rubocop-hq/rubocop/pull/6928): Add `--init` option for generate `.rubocop.yml` file in the current directory. ([@koic][])
 * Add new `Layout/HeredocArgumentClosingParenthesis` cop. ([@maxh][])
 * [#6895](https://github.com/rubocop-hq/rubocop/pull/6895): Add support for XDG config home for user-config. ([@Mange][], [@tejasbubane][])
+* Add initial autocorrection support to `Metrics/LineLength`. ([@maxh][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1727,7 +1727,8 @@ Metrics/LineLength:
   StyleGuide: '#80-character-limits'
   Enabled: true
   VersionAdded: '0.25'
-  VersionChanged: '0.46'
+  VersionChanged: '0.68'
+  AutoCorrect: false
   Max: 80
   # To make it possible to copy or click on URIs in the code, we allow lines
   # containing a URI to be longer than Max.

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -93,6 +93,7 @@ require_relative 'rubocop/cop/mixin/array_min_size'
 require_relative 'rubocop/cop/mixin/array_syntax'
 require_relative 'rubocop/cop/mixin/alignment'
 require_relative 'rubocop/cop/mixin/check_assignment'
+require_relative 'rubocop/cop/mixin/check_line_breakable'
 require_relative 'rubocop/cop/mixin/configurable_max'
 require_relative 'rubocop/cop/mixin/code_length' # relies on configurable_max
 require_relative 'rubocop/cop/mixin/classish_length' # relies on code_length

--- a/lib/rubocop/cop/metrics/line_length.rb
+++ b/lib/rubocop/cop/metrics/line_length.rb
@@ -2,6 +2,7 @@
 
 require 'uri'
 
+# rubocop:disable Metrics/ClassLength
 module RuboCop
   module Cop
     module Metrics
@@ -9,21 +10,93 @@ module RuboCop
       # The maximum length is configurable.
       # The tab size is configured in the `IndentationWidth`
       # of the `Layout/Tab` cop.
+      #
+      # This cop has some autocorrection capabilities.
+      # It can programmatically shorten certain long lines by
+      # inserting line breaks into expressions that can be safely
+      # split across lines. These include arrays, hashes, and
+      # method calls with argument lists.
+      #
+      # If autocorrection is enabled, the following Layout cops
+      # are recommended to further format the broken lines.
+      #
+      #   - AlignArray
+      #   - AlignHash
+      #   - AlignParameters
+      #   - ClosingParenthesisIndentation
+      #   - FirstParameterIndentation
+      #   - IndentArray
+      #   - IndentHash
+      #   - MultilineArrayLineBreaks
+      #   - MultilineHashBraceLayout
+      #   - MultilineHashKeyLineBreaks
+      #   - MultilineMethodArgumentLineBreaks
+      #
+      # Together, these cops will pretty print hashes, arrays,
+      # method calls, etc. For example, let's say the max columns
+      # is 25:
+      #
+      # @example
+      #
+      #   # bad
+      #   {foo: "0000000000", bar: "0000000000", baz: "0000000000"}
+      #
+      #   # good
+      #   {foo: "0000000000",
+      #   bar: "0000000000", baz: "0000000000"}
+      #
+      #   # good (with recommended cops enabled)
+      #   {
+      #     foo: "0000000000",
+      #     bar: "0000000000",
+      #     baz: "0000000000",
+      #   }
       class LineLength < Cop
+        include CheckLineBreakable
         include ConfigurableMax
         include IgnoredPattern
         include RangeHelp
 
         MSG = 'Line is too long. [%<length>d/%<max>d]'.freeze
 
-        def investigate(processed_source)
-          heredocs = extract_heredocs(processed_source.ast) if allow_heredoc?
-          processed_source.lines.each_with_index do |line, index|
-            check_line(line, index, heredocs)
+        def on_potential_breakable_node(node)
+          check_for_breakable_node(node)
+        end
+        alias on_array on_potential_breakable_node
+        alias on_hash on_potential_breakable_node
+        alias on_send on_potential_breakable_node
+
+        def investigate_post_walk(processed_source)
+          processed_source.lines.each_with_index do |line, line_index|
+            check_line(line, line_index)
+          end
+        end
+
+        def autocorrect(range)
+          return if range.nil?
+
+          lambda do |corrector|
+            corrector.insert_before(range, "\n")
           end
         end
 
         private
+
+        def check_for_breakable_node(node)
+          breakable_node = extract_breakable_node(node, max)
+          return if breakable_node.nil?
+
+          line_index = breakable_node.first_line - 1
+          breakable_nodes_by_line_index[line_index] = breakable_node
+        end
+
+        def breakable_nodes_by_line_index
+          @breakable_nodes_by_line_index ||= {}
+        end
+
+        def heredocs
+          @heredocs ||= extract_heredocs(processed_source.ast)
+        end
 
         def tab_indentation_width
           config.for_cop('Layout/Tab')['IndentationWidth']
@@ -39,49 +112,72 @@ module RuboCop
           line.length + indentation_difference(line)
         end
 
-        def highligh_start(line)
+        def highlight_start(line)
           max - indentation_difference(line)
         end
 
-        def check_line(line, index, heredocs)
+        def check_line(line, line_index)
           return if line_length(line) <= max
-          return if ignored_line?(line, index, heredocs)
+          return if ignored_line?(line, line_index)
 
-          if ignore_cop_directives? && directive_on_source_line?(index)
-            return check_directive_line(line, index)
+          if ignore_cop_directives? && directive_on_source_line?(line_index)
+            return check_directive_line(line, line_index)
           end
-          return check_uri_line(line, index) if allow_uri?
+          return check_uri_line(line, line_index) if allow_uri?
 
           register_offense(
             source_range(
-              processed_source.buffer, index,
-              highligh_start(line)...line_length(line)
+              processed_source.buffer, line_index,
+              highlight_start(line)...line_length(line)
             ),
-            line
+            line,
+            line_index
           )
         end
 
-        def ignored_line?(line, index, heredocs)
+        def ignored_line?(line, line_index)
           matches_ignored_pattern?(line) ||
-            heredocs && line_in_permitted_heredoc?(heredocs, index.succ)
+            heredocs && line_in_permitted_heredoc?(line_index.succ)
         end
 
-        def register_offense(loc, line)
+        def register_offense(loc, line, line_index)
           message = format(MSG, length: line_length(line), max: max)
 
-          add_offense(nil, location: loc, message: message) do
+          breakable_range = breakable_range(line, line_index)
+          add_offense(breakable_range, location: loc, message: message) do
             self.max = line_length(line)
           end
         end
 
-        def excess_range(uri_range, line, index)
+        def breakable_range(line, line_index)
+          return if line_in_heredoc?(line_index + 1)
+
+          semicolon_range = breakable_semicolon_range(line, line_index)
+          return semicolon_range if semicolon_range
+
+          breakable_node = breakable_nodes_by_line_index[line_index]
+          return breakable_node.source_range if breakable_node
+        end
+
+        def breakable_semicolon_range(line, line_index)
+          semicolon_separated_parts = line.split(';')
+          return if semicolon_separated_parts.length <= 1
+
+          column = semicolon_separated_parts.first.length + 1
+          range = source_range(processed_source.buffer, line_index, column, 1)
+          return if processed_source.commented?(range)
+
+          range
+        end
+
+        def excess_range(uri_range, line, line_index)
           excessive_position = if uri_range && uri_range.begin < max
                                  uri_range.end
                                else
-                                 highligh_start(line)
+                                 highlight_start(line)
                                end
 
-          source_range(processed_source.buffer, index + 1,
+          source_range(processed_source.buffer, line_index + 1,
                        excessive_position...(line_length(line)))
         end
 
@@ -107,10 +203,18 @@ module RuboCop
           end
         end
 
-        def line_in_permitted_heredoc?(heredocs, line_number)
+        def line_in_permitted_heredoc?(line_number)
+          return false unless allowed_heredoc
+
           heredocs.any? do |range, delimiter|
             range.cover?(line_number) &&
               (allowed_heredoc == true || allowed_heredoc.include?(delimiter))
+          end
+        end
+
+        def line_in_heredoc?(line_number)
+          heredocs.any? do |range, _delimiter|
+            range.cover?(line_number)
           end
         end
 
@@ -161,22 +265,23 @@ module RuboCop
             URI::DEFAULT_PARSER.make_regexp(cop_config['URISchemes'])
         end
 
-        def check_directive_line(line, index)
+        def check_directive_line(line, line_index)
           return if line_length_without_directive(line) <= max
 
           range = max..(line_length_without_directive(line) - 1)
           register_offense(
             source_range(
               processed_source.buffer,
-              index + 1,
+              line_index + 1,
               range
             ),
-            line
+            line,
+            line_index
           )
         end
 
-        def directive_on_source_line?(index)
-          source_line_number = index + processed_source.buffer.first_line
+        def directive_on_source_line?(line_index)
+          source_line_number = line_index + processed_source.buffer.first_line
           comment =
             processed_source
             .comments
@@ -192,13 +297,18 @@ module RuboCop
           before_comment.rstrip.length
         end
 
-        def check_uri_line(line, index)
+        def check_uri_line(line, line_index)
           uri_range = find_excessive_uri_range(line)
           return if uri_range && allowed_uri_position?(line, uri_range)
 
-          register_offense(excess_range(uri_range, line, index), line)
+          register_offense(
+            excess_range(uri_range, line, line_index),
+            line,
+            line_index
+          )
         end
       end
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/lib/rubocop/cop/mixin/check_line_breakable.rb
+++ b/lib/rubocop/cop/mixin/check_line_breakable.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # This mixin detects collections that are safe to "break"
+    # by inserting new lines. This is useful for breaking
+    # up long lines.
+    #
+    # Let's look at hashes as an example:
+    #
+    # We know hash keys are safe to break across lines. We can add
+    # linebreaks into hashes on lines longer than the specified maximum.
+    # Then in further passes cops can clean up the multi-line hash.
+    # For example, say the maximum line length is as indicated below:
+    #
+    #                                         |
+    #                                         v
+    # {foo: "0000000000", bar: "0000000000", baz: "0000000000"}
+    #
+    # In a LineLength autocorrection pass, a line is added before
+    # the first key that exceeds the column limit:
+    #
+    # {foo: "0000000000", bar: "0000000000",
+    # baz: "0000000000"}
+    #
+    # In a MultilineHashKeyLineBreaks pass, lines are inserted
+    # before all keys:
+    #
+    # {foo: "0000000000",
+    # bar: "0000000000",
+    # baz: "0000000000"}
+    #
+    # Then in future passes FirstHashElementLineBreak,
+    # MultilineHashBraceLayout, and TrailingCommaInHashLiteral will
+    # manipulate as well until we get:
+    #
+    # {
+    #   foo: "0000000000",
+    #   bar: "0000000000",
+    #   baz: "0000000000",
+    # }
+    #
+    # (Note: Passes may not happen exactly in this sequence.)
+    module CheckLineBreakable
+      def extract_breakable_node(node, max)
+        if node.send_type?
+          args = process_args(node.arguments)
+          return extract_breakable_node_from_elements(node, args, max)
+        elsif node.array_type? || node.hash_type?
+          return extract_breakable_node_from_elements(node, node.children, max)
+        end
+        nil
+      end
+
+      private
+
+      def extract_breakable_node_from_elements(node, elements, max)
+        return unless breakable_collection?(node, elements)
+        return if safe_to_ignore?(node)
+
+        line = processed_source.lines[node.first_line - 1]
+        return if processed_source.commented?(node.loc.begin)
+        return if line.length <= max
+
+        extract_first_element_over_column_limit(node, elements, max)
+      end
+
+      def extract_first_element_over_column_limit(node, elements, max)
+        line = node.first_line
+        i = 0
+        i += 1 while within_column_limit?(elements[i], max, line)
+        return elements.first if i.zero?
+
+        elements[i - 1]
+      end
+
+      def within_column_limit?(element, max, line)
+        element && element.loc.column < max && element.loc.line == line
+      end
+
+      def safe_to_ignore?(node)
+        return true unless max
+        return true if already_on_multiple_lines?(node)
+
+        # If there's a containing breakable collection on the same
+        # line, we let that one get broken first. In a separate pass,
+        # this one might get broken as well, but to avoid conflicting
+        # or redundant edits, we only mark one offense at a time.
+        return true if contained_by_breakable_collection_on_same_line?(node)
+
+        if contained_by_multiline_collection_that_could_be_broken_up?(node)
+          return true
+        end
+
+        false
+      end
+
+      def breakable_collection?(node, elements)
+        # For simplicity we only want to insert breaks in normal
+        # hashes wrapped in a set of curly braces like {foo: 1}.
+        # That is, not a kwargs hash. For method calls, this ensures
+        # the method call is made with parens.
+        starts_with_bracket = node.loc.begin
+
+        # If the call has a second argument, we can insert a line
+        # break before the second argument and the rest of the
+        # argument will get auto-formatted onto separate lines
+        # by other cops.
+        has_second_element = elements.length >= 2
+
+        starts_with_bracket && has_second_element
+      end
+
+      def contained_by_breakable_collection_on_same_line?(node)
+        node.each_ancestor.find do |ancestor|
+          # Ignore ancestors on different lines.
+          break if ancestor.first_line != node.first_line
+
+          if ancestor.hash_type? || ancestor.array_type?
+            elements = ancestor.children
+          elsif ancestor.send_type?
+            elements = process_args(ancestor.arguments)
+          else
+            next
+          end
+
+          return true if breakable_collection?(ancestor, elements)
+        end
+
+        false
+      end
+
+      def contained_by_multiline_collection_that_could_be_broken_up?(node)
+        node.each_ancestor.find do |ancestor|
+          if ancestor.hash_type? || ancestor.array_type?
+            if breakable_collection?(ancestor, ancestor.children)
+              return children_could_be_broken_up?(ancestor.children)
+            end
+          end
+
+          next unless ancestor.send_type?
+
+          args = process_args(ancestor.arguments)
+          if breakable_collection?(ancestor, args)
+            return children_could_be_broken_up?(args)
+          end
+        end
+
+        false
+      end
+
+      def children_could_be_broken_up?(children)
+        return false if all_on_same_line?(children)
+
+        last_seen_line = -1
+        children.each do |child|
+          return true if last_seen_line >= child.first_line
+
+          last_seen_line = child.last_line
+        end
+        false
+      end
+
+      def all_on_same_line?(nodes)
+        return true if nodes.empty?
+
+        nodes.first.first_line == nodes.last.last_line
+      end
+
+      def process_args(args)
+        # If there is a trailing hash arg without explicit braces, like this:
+        #
+        #    method(1, 'key1' => value1, 'key2' => value2)
+        #
+        # ...then each key/value pair is treated as a method 'argument'
+        # when determining where line breaks should appear.
+        if (last_arg = args.last)
+          if last_arg.hash_type? && !last_arg.braces?
+            args = args.concat(args.pop.children)
+          end
+        end
+        args
+      end
+
+      def already_on_multiple_lines?(node)
+        node.first_line != node.last_line
+      end
+    end
+  end
+end

--- a/manual/cops_metrics.md
+++ b/manual/cops_metrics.md
@@ -112,17 +112,61 @@ Max | `6` | Integer
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.25 | 0.46
+Enabled | Yes | Yes  | 0.25 | 0.68
 
 This cop checks the length of lines in the source code.
 The maximum length is configurable.
 The tab size is configured in the `IndentationWidth`
 of the `Layout/Tab` cop.
 
+This cop has some autocorrection capabilities.
+It can programmatically shorten certain long lines by
+inserting line breaks into expressions that can be safely
+split across lines. These include arrays, hashes, and
+method calls with argument lists.
+
+If autocorrection is enabled, the following Layout cops
+are recommended to further format the broken lines.
+
+  - AlignArray
+  - AlignHash
+  - AlignParameters
+  - ClosingParenthesisIndentation
+  - FirstParameterIndentation
+  - IndentArray
+  - IndentHash
+  - MultilineArrayLineBreaks
+  - MultilineHashBraceLayout
+  - MultilineHashKeyLineBreaks
+  - MultilineMethodArgumentLineBreaks
+
+Together, these cops will pretty print hashes, arrays,
+method calls, etc. For example, let's say the max columns
+is 25:
+
+### Examples
+
+```ruby
+# bad
+{foo: "0000000000", bar: "0000000000", baz: "0000000000"}
+
+# good
+{foo: "0000000000",
+bar: "0000000000", baz: "0000000000"}
+
+# good (with recommended cops enabled)
+{
+  foo: "0000000000",
+  bar: "0000000000",
+  baz: "0000000000",
+}
+```
+
 ### Configurable attributes
 
 Name | Default value | Configurable values
 --- | --- | ---
+AutoCorrect | `false` | Boolean
 Max | `80` | Integer
 AllowHeredoc | `true` | Boolean
 AllowURI | `true` | Boolean

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -53,7 +53,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                   - 'example.rb'
 
               # Offense count: 2
-              # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
+              # Cop supports --auto-correct.
+              # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
               # URISchemes: http, https
               Metrics/LineLength:
                 Max: 99
@@ -166,7 +167,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             .to eq(<<-YAML.strip_indent)
 
               # Offense count: 1
-              # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
+              # Cop supports --auto-correct.
+              # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
               # URISchemes: http, https
               Metrics/LineLength:
                 Max: 99
@@ -304,8 +306,10 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                 "    - 'example1.rb'",
                 '',
                 '# Offense count: 1',
-                '# Configuration parameters: AllowHeredoc, AllowURI, ' \
-                'URISchemes, IgnoreCopDirectives, IgnoredPatterns.',
+                '# Cop supports --auto-correct.',
+                '# Configuration parameters: AutoCorrect, AllowHeredoc, ' \
+                'AllowURI, URISchemes, IgnoreCopDirectives, ' \
+                'IgnoredPatterns.',
                 '# URISchemes: http, https',
                 'Metrics/LineLength:',
                 '  Max: 85'])
@@ -341,8 +345,10 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                 '  MinDigits: 7',
                 '',
                 '# Offense count: 1',
-                '# Configuration parameters: AllowHeredoc, AllowURI, ' \
-                'URISchemes, IgnoreCopDirectives, IgnoredPatterns.',
+                '# Cop supports --auto-correct.',
+                '# Configuration parameters: AutoCorrect, AllowHeredoc, ' \
+                'AllowURI, URISchemes, IgnoreCopDirectives, ' \
+                'IgnoredPatterns.',
                 '# URISchemes: http, https',
                 'Metrics/LineLength:',
                 '  Max: 81',
@@ -508,8 +514,10 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
          "    - 'example1.rb'",
          '',
          '# Offense count: 2',
-         '# Configuration parameters: AllowHeredoc, AllowURI, URISchemes, ' \
-         'IgnoreCopDirectives, IgnoredPatterns.',
+         '# Cop supports --auto-correct.',
+         '# Configuration parameters: AutoCorrect, AllowHeredoc, ' \
+         'AllowURI, URISchemes, IgnoreCopDirectives, ' \
+         'IgnoredPatterns.',
          '# URISchemes: http, https',
          'Metrics/LineLength:',
          '  Max: 90']
@@ -593,8 +601,10 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
          "    - 'example1.rb'",
          '',
          '# Offense count: 3',
-         '# Configuration parameters: AllowHeredoc, AllowURI, URISchemes, ' \
-         'IgnoreCopDirectives, IgnoredPatterns.',
+         '# Cop supports --auto-correct.',
+         '# Configuration parameters: AutoCorrect, AllowHeredoc, ' \
+         'AllowURI, URISchemes, IgnoreCopDirectives, ' \
+         'IgnoredPatterns.',
          '# URISchemes: http, https',
          'Metrics/LineLength:',
          '  Max: 90']
@@ -791,8 +801,10 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
          '  Exclude:',
          "    - 'example1.rb'",
          '',
-         '# Configuration parameters: AllowHeredoc, AllowURI, URISchemes, ' \
-         'IgnoreCopDirectives, IgnoredPatterns.',
+         '# Cop supports --auto-correct.',
+         '# Configuration parameters: AutoCorrect, AllowHeredoc, ' \
+         'AllowURI, URISchemes, IgnoreCopDirectives, ' \
+         'IgnoredPatterns.',
          '# URISchemes: http, https',
          'Metrics/LineLength:',
          '  Max: 90']

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1480,6 +1480,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         |Supported parameters are:
         |
         |  - Enabled
+        |  - AutoCorrect
         |  - Max
         |  - AllowHeredoc
         |  - AllowURI

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -531,6 +531,7 @@ RSpec.describe RuboCop::ConfigLoader do
               default_config['Metrics/LineLength']['VersionAdded'],
               'VersionChanged' =>
               default_config['Metrics/LineLength']['VersionChanged'],
+              'AutoCorrect' => false,
               'Max' => 77,
               'AllowHeredoc' => true,
               'AllowURI' => true,
@@ -634,6 +635,7 @@ RSpec.describe RuboCop::ConfigLoader do
               default_config['Metrics/LineLength']['VersionAdded'],
               'VersionChanged' =>
               default_config['Metrics/LineLength']['VersionChanged'],
+              'AutoCorrect' => false,
               'Max' => 120,             # overridden in line_length.yml
               'AllowHeredoc' => false,  # overridden in rubocop.yml
               'AllowURI' => true,


### PR DESCRIPTION
Per feedback on https://github.com/rubocop-hq/rubocop/pull/6883 "Add new `Layout/AutocorrectableLineLength` cop", this PR adds the autocorrect functionality from that cop into the existing `Metrics/LineLength` cop.

Notes:
- Added a `investigate_post_walk` hook to the commissioner. See comments in that file for motivation.
- Fixed typo `highligh` => `highlight` in LineLength.
- Switched from reserved word `index` to `line_index` in LineLength.

Open sourced from a Flexport-internal Ruby formatting project.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
