### PR TITLE
Add `--init` option to `rubocop` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#6928](https://github.com/rubocop-hq/rubocop/pull/6928): Add `--init` option for generate `.rubocop.yml` file in the current directory. ([@koic][])
+
 ### Bug fixes
 
 * [#6914](https://github.com/rubocop-hq/rubocop/issues/6914): [Fix #6914] Fix an error for `Rails/RedundantAllowNil` when with interpolations. ([@Blue-Pix][])

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -117,6 +117,8 @@ module RuboCop
       option(opts, '--no-auto-gen-timestamp') do
         @options[:no_auto_gen_timestamp] = true
       end
+
+      option(opts, '--init')
     end
 
     def add_formatting_options(opts)
@@ -435,7 +437,8 @@ module RuboCop
       parallel: ['Use available CPUs to execute inspection in',
                  'parallel.'],
       stdin: ['Pipe source from STDIN, using FILE in offense',
-              'reports. This is useful for editor integration.']
+              'reports. This is useful for editor integration.'],
+      init: 'Generate a .rubocop.yml file in the current directory.'
     }.freeze
   end
 end

--- a/manual/basic_usage.md
+++ b/manual/basic_usage.md
@@ -117,6 +117,7 @@ Command flag                    | Description
 `   --force-exclusion`          | Force excluding files specified in the configuration `Exclude` even if they are explicitly passed as arguments.
 `-h/--help`                     | Print usage information.
 `   --ignore-parent-exlusion`   | Ignores all Exclude: settings from all .rubocop.yml files present in parent folders. This is useful when you are importing submodules when you want to test them without being affected by the parent module's rubocop settings.
+`   --init`                     | Generate a .rubocop.yml file in the current directory.
 `-l/--lint`                     | Run only lint cops.
 `-L/--list-target-files`        | List all files RuboCop will inspect.
 `   --no-auto-gen-timestamp`    | Don't include the date and time when --auto-gen-config was run in the config file it generates

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -209,6 +209,36 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       RESULT
     end
 
+    describe 'Specify `--init` option to `rubocop` command' do
+      context 'when .rubocop.yml does not exist' do
+        it 'generate a .rubocop.yml file' do
+          expect(cli.run(['--init'])).to eq(0)
+          expect($stdout.string).to start_with('Writing new .rubocop.yml to')
+          expect(IO.read('.rubocop.yml')).to eq(<<-YAML.strip_indent)
+            # The behavior of RuboCop can be controlled via the .rubocop.yml
+            # configuration file. It makes it possible to enable/disable
+            # certain cops (checks) and to alter their behavior if they accept
+            # any parameters. The file can be placed either in your home
+            # directory or in some project directory.
+            #
+            # RuboCop will start looking for the configuration file in the directory
+            # where the inspected file is and continue its way up to the root directory.
+            #
+            # See https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md
+          YAML
+        end
+      end
+
+      context 'when .rubocop.yml already exists' do
+        it 'fails with an error message' do
+          create_empty_file('.rubocop.yml')
+
+          expect(cli.run(['--init'])).to eq(2)
+          expect($stderr.string).to start_with('.rubocop.yml already exists at')
+        end
+      end
+    end
+
     context 'when --auto-correct is given' do
       it 'does not trigger UnneededCopDisableDirective due to ' \
          'lines moving around' do

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                   --no-auto-gen-timestamp      Do not include the date and time when
                                                the --auto-gen-config was run in the file it
                                                generates.
+                  --init                       Generate a .rubocop.yml file in the current directory.
               -f, --format FORMATTER           Choose an output formatter. This option
                                                can be specified multiple times to enable
                                                multiple formatters at the same time.


### PR DESCRIPTION
This PR adds `--init` option to `rubocop` command.

```console
% mkdir example
% cd /tmp/example
% rubocop --init
Writing new .rubocop.yml to /private/tmp/example/.rubocop.yml
% cat .rubocop.yml
# The behavior of RuboCop can be controlled via the .rubocop.yml
# configuration file. It makes it possible to enable/disable
# certain cops (checks) and to alter their behavior if they accept
# any parameters. The file can be placed either in your home
# directory or in some project directory.
#
# RuboCop will start looking for the configuration file in the directory
# where the inspected file is and continue its way up to the root directory.
#
# See https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md
% rubocop --init # A warning will occur when .rubocop.yml already exists
.rubocop.yml already exists at /private/tmp/example/.rubocop.yml
```

It may be good to add a simple commented examples of basic configuration in the future.

First of all, this PR aims to generate .rubocop.yml which contains the following configuration URL.
https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md

And the generated .rubocop.yml text is quoted from the above URL.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
