### PR TITLE
Add support for method definition parameters to Layout/FirstParameterIndentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* Add `IgnoreMethodDefinitions` option to `Layout/FirstParameterIndentation` to support indent method definition params. ([@maxh][])
+
 ### Bug fixes
 
 * [#6914](https://github.com/rubocop-hq/rubocop/issues/6914): [Fix #6914] Fix an error for `Rails/RedundantAllowNil` when with interpolations. ([@Blue-Pix][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -622,6 +622,7 @@ Layout/FirstParameterIndentation:
   VersionAdded: '0.49'
   VersionChanged: '0.56'
   EnforcedStyle: special_for_inner_method_call_in_parentheses
+  IgnoreMethodDefinitions: true
   SupportedStyles:
     # The first parameter should always be indented one step more than the
     # preceding line.

--- a/lib/rubocop/cop/layout/align_parameters.rb
+++ b/lib/rubocop/cop/layout/align_parameters.rb
@@ -6,6 +6,9 @@ module RuboCop
       # Here we check if the parameters on a multi-line method call or
       # definition are aligned.
       #
+      # To set the alignment of the first parameter, use the cop
+      # FirstParameterIndentation.
+      #
       # @example EnforcedStyle: with_first_parameter (default)
       #   # good
       #

--- a/lib/rubocop/cop/layout/first_parameter_indentation.rb
+++ b/lib/rubocop/cop/layout/first_parameter_indentation.rb
@@ -4,9 +4,13 @@ module RuboCop
   module Cop
     # rubocop:disable Metrics/LineLength
     module Layout
-      # This cop checks the indentation of the first parameter in a method call.
-      # Parameters after the first one are checked by Layout/AlignParameters,
-      # not by this cop.
+      # This cop checks the indentation of the first parameter in a method call
+      # or definition. Parameters after the first one are checked by
+      # Layout/AlignParameters, not by this cop.
+      #
+      # By default, this cop is enabled for method calls and disabled for
+      # method definitions. To enable it for method definitions, set the param
+      # `IgnoreMethodDefinitions` to false.
       #
       # @example
       #
@@ -156,6 +160,13 @@ module RuboCop
         end
         alias on_csend on_send
 
+        def on_def(node)
+          return if ignore_method_definitions?
+
+          on_send(node)
+        end
+        alias on_defs on_def
+
         def autocorrect(node)
           AlignmentCorrector.correct(processed_source, node, column_delta)
         end
@@ -237,6 +248,10 @@ module RuboCop
             line = processed_source.lines[line_number - 1]
           end
           line
+        end
+
+        def ignore_method_definitions?
+          cop_config['IgnoreMethodDefinitions']
         end
       end
     end

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -300,6 +300,9 @@ Enabled | Yes | Yes  | 0.49 | -
 Here we check if the parameters on a multi-line method call or
 definition are aligned.
 
+To set the alignment of the first parameter, use the cop
+FirstParameterIndentation.
+
 ### Examples
 
 #### EnforcedStyle: with_first_parameter (default)
@@ -1940,9 +1943,13 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 --- | --- | --- | --- | ---
 Enabled | Yes | Yes  | 0.49 | 0.56
 
-This cop checks the indentation of the first parameter in a method call.
-Parameters after the first one are checked by Layout/AlignParameters,
-not by this cop.
+This cop checks the indentation of the first parameter in a method call
+or definition. Parameters after the first one are checked by
+Layout/AlignParameters, not by this cop.
+
+By default, this cop is enabled for method calls and disabled for
+method definitions. To enable it for method definitions, set the param
+`IgnoreMethodDefinitions` to false.
 
 ### Examples
 
@@ -2090,6 +2097,7 @@ second_param
 Name | Default value | Configurable values
 --- | --- | ---
 EnforcedStyle | `special_for_inner_method_call_in_parentheses` | `consistent`, `consistent_relative_to_receiver`, `special_for_inner_method_call`, `special_for_inner_method_call_in_parentheses`
+IgnoreMethodDefinitions | `true` | Boolean
 IndentationWidth | `<none>` | Integer
 
 ## Layout/IndentArray


### PR DESCRIPTION
Add `IgnoreMethodDefinitions` parameter to `Layout/FirstParameterIndentation` cop and set it to `true` by default to preserve backwards compatibility. When set to `false`, this cop will align the first parameter of method definitions (in addition to method calls).

This change fills a gap in this otherwise complementary suite of cops:

* `AlignHash` and `IndentHash`
* `AlignArray` and `IndentArray`
* `AlignParameters` (both method defs and calls) and `FirstParameterIndentation` (only method calls)

Together, these cops properly indent most multi-line expressions. The gap is that `FirstParameterIndentation` does not operate on method definitions. This PR fixes that.

Side note: if we were not constrained by the existing names, I would suggest breaking out into `AlignArguments` and `IndentArgument` (for method calls) and `AlignParameters` and `IndentParameter` (for method defs). However, working within the confines of the existing API surface, I think this PR is the cleanest way to add support for this feature.

Open sourced from a Flexport-internal Ruby formatting project.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
