### PR TITLE
[Fix #6900] Rails/TimeZone cop in strict mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#6900](https://github.com/rubocop-hq/rubocop/issues/6900): Fix `Rails/TimeZone` autocorrect `Time.current` to `Time.zone.now`. ([@vfonic][])
+* [#6900](https://github.com/rubocop-hq/rubocop/issues/6900): Fix `Rails/TimeZone` to prefer `Time.zone.#{method}` over other acceptable corrections. ([@vfonic][])
+
 ## 0.68.0 (2019-04-29)
 
 ### New features

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -2190,7 +2190,7 @@ Enabled | No | Yes  | 0.30 | 0.68
 This cop checks for the use of Time methods without zone.
 
 Built on top of Ruby on Rails style guide (https://github.com/rubocop-hq/rails-style-guide#time)
-and the article http://danilenko.org/2012/7/6/rails_timezones/ .
+and the article http://danilenko.org/2012/7/6/rails_timezones/
 
 Two styles are supported for this cop. When EnforcedStyle is 'strict'
 then only use of Time.zone is allowed.


### PR DESCRIPTION
* Split tests for DANGEROUS_METHODS and :current, which is a special case
* Use preferred `#{klass}.zone.#{method}` style, as opposed to "acceptable" `#{klass}.#{method}.in_time_zone`
* Rename TIMECLASS contsant to TIMECLASSES as it represents more than one time class
* Prefer `Time` class over `DateTime` in strict mode
* Fix `Time.current` => `Time.zone.now` instead of `Time.zone.current` which raises error

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/