### PR TITLE
Fix inconsistencies in Node Pattern manual

### DIFF
--- a/manual/node_pattern.md
+++ b/manual/node_pattern.md
@@ -238,7 +238,7 @@ $ ruby-parse -e 'Comment.new(user: current_user)'
 
 And we can also reuse this and check if it's a constructor:
 
-```
+```ruby
 def_node_matcher :initializing_with_user?, <<~PATTERN
   (send _ :new (hash (pair #user_symbol?)))
 PATTERN

--- a/manual/node_pattern.md
+++ b/manual/node_pattern.md
@@ -244,22 +244,6 @@ def_node_matcher :initializing_with_user?, <<~PATTERN
 PATTERN
 ```
 
-Improving a bit more, let's make it accepts `update`, and `create`.
-
-Instead of make our call more complex, we can define another matcher:
-
-```ruby
-def_node_matcher :model_methods?, '{:new :create :update}'
-```
-
-And combine again:
-
-```ruby
-def_node_matcher :model_method_called_with_user?, <<~PATTERN
-  (send ... #model_methods? (hash (pair #user_symbol?)))
-PATTERN
-```
-
 ## `nil` or `nil?`
 
 Take a special attention to nil behavior:

--- a/manual/node_pattern.md
+++ b/manual/node_pattern.md
@@ -72,6 +72,9 @@ value:
 
 Where `_` matches a single node, `...` eagerly matches zero or more subsequent nodes.
 
+`...` can only be used to match the last children, and can't be used to match
+children in the middle or the beginning.
+
 It's useful when you want to check some internal nodes but with a
 final with the same results. For example, let's use `sum(1,2)`.
 
@@ -237,7 +240,7 @@ And we can also reuse this and check if it's a constructor:
 
 ```
 def_node_matcher :initializing_with_user?, <<~PATTERN
-  (send ... :new (hash (pair #user_symbol?)))
+  (send _ :new (hash (pair #user_symbol?)))
 PATTERN
 ```
 


### PR DESCRIPTION
1. Removed a misleading example:

    def_node_matcher :model_methods?, '{:new :create :update}'

    def_node_matcher :model_method_called_with_user?, <<~PATTERN
      (send ... #model_methods? (hash (pair #user_symbol?)))
    PATTERN

It is impossible to use nested node matchers on children that are not nodes, like a `send` selector in this case.
This example is redundant anyway, since an example above it shows quite well how to compose node matchers.

2. Fixed broken syntax highlighting for one of the code examples.

3. Clarified how `...` works, and fixed one usage example.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/