### PR TITLE
[Fix #6931] `Layout/AccessModifierIndentation` outdent style now ignores modifiers with parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#6778](https://github.com/rubocop-hq/rubocop/issues/6778): Fix a false positive in `Style/HashSyntax` cop when a hash key is an interpolated string and EnforcedStyle is ruby19_no_mixed_keys. ([@tatsuyafw][])
 * [#6902](https://github.com/rubocop-hq/rubocop/issues/6902): Fix a bug where `Naming/RescuedExceptionsVariableName` would handle an only first rescue for multiple rescue groups. ([@tatsuyafw][])
 * [#6860](https://github.com/rubocop-hq/rubocop/issues/6860): Prevent auto-correct conflict of `Style/InverseMethods` and `Style/Not`. ([@hoshinotsuyoshi][])
+* [#6935](https://github.com/rubocop-hq/rubocop/issues/6935): `Layout/AccessModifierIndentation` should ignore access modifiers that apply to specific methods. ([@deivid-rodriguez][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/access_modifier_indentation.rb
+++ b/lib/rubocop/cop/layout/access_modifier_indentation.rb
@@ -3,8 +3,9 @@
 module RuboCop
   module Cop
     module Layout
-      # Modifiers should be indented as deep as method definitions, or as deep
-      # as the class/module keyword, depending on configuration.
+      # Bare access modifiers (those not applying to specific methods) should be
+      # indented as deep as method definitions, or as deep as the class/module
+      # keyword, depending on configuration.
       #
       # @example EnforcedStyle: indent (default)
       #   # bad

--- a/lib/rubocop/cop/layout/access_modifier_indentation.rb
+++ b/lib/rubocop/cop/layout/access_modifier_indentation.rb
@@ -67,7 +67,8 @@ module RuboCop
           return if body.nil? # Empty class etc.
           return unless body.begin_type?
 
-          modifiers = body.each_child_node(:send).select(&:bare_access_modifier?)
+          modifiers = body.each_child_node(:send)
+                          .select(&:bare_access_modifier?)
           end_range = node.loc.end
 
           modifiers.each { |modifier| check_modifier(modifier, end_range) }

--- a/lib/rubocop/cop/layout/access_modifier_indentation.rb
+++ b/lib/rubocop/cop/layout/access_modifier_indentation.rb
@@ -67,7 +67,7 @@ module RuboCop
           return if body.nil? # Empty class etc.
           return unless body.begin_type?
 
-          modifiers = body.each_child_node(:send).select(&:access_modifier?)
+          modifiers = body.each_child_node(:send).select(&:bare_access_modifier?)
           end_range = node.loc.end
 
           modifiers.each { |modifier| check_modifier(modifier, end_range) }

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -6,8 +6,9 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 --- | --- | --- | --- | ---
 Enabled | Yes | Yes  | 0.49 | -
 
-Modifiers should be indented as deep as method definitions, or as deep
-as the class/module keyword, depending on configuration.
+Bare access modifiers (those not applying to specific methods) should be
+indented as deep as method definitions, or as deep as the class/module
+keyword, depending on configuration.
 
 ### Examples
 

--- a/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
@@ -316,6 +316,15 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
       RUBY
     end
 
+    it 'accepts private def indented to method depth in a class' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class Test
+
+          private def test; end
+        end
+      RUBY
+    end
+
     it 'registers offense for private indented to method depth in a module' do
       expect_offense(<<-RUBY.strip_indent)
         module Test
@@ -334,6 +343,15 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
 
           def test; end
           private :test
+        end
+      RUBY
+    end
+
+    it 'accepts private def indented to method depth in a module' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        module Test
+
+          private def test; end
         end
       RUBY
     end
@@ -357,6 +375,15 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
 
           def test; end
           module_function :test
+        end
+      RUBY
+    end
+
+    it 'accepts module fn def indented to method depth in a module' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        module Test
+
+          module_function def test; end
         end
       RUBY
     end
@@ -385,6 +412,15 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
       RUBY
     end
 
+    it 'accepts private def indented to method depth in singleton class' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class << self
+
+          private def test; end
+        end
+      RUBY
+    end
+
     it 'registers offense for private indented to method depth in class ' \
        'defined with Class.new' do
       expect_offense(<<-RUBY.strip_indent)
@@ -409,6 +445,16 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
       RUBY
     end
 
+    it 'accepts private def indented to method depth in class defined with ' \
+       'Class.new' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        Test = Class.new do
+
+          private def test; end
+        end
+      RUBY
+    end
+
     it 'registers offense for private indented to method depth in module ' \
        'defined with Module.new' do
       expect_offense(<<-RUBY.strip_indent)
@@ -429,6 +475,16 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
 
           def test; end
           private :test
+        end
+      RUBY
+    end
+
+    it 'accepts private def indented to method depth in module defined with ' \
+       'Module.new' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        Test = Module.new do
+
+          private def test; end
         end
       RUBY
     end

--- a/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
@@ -330,7 +330,7 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
       RUBY
     end
 
-    it 'registers offense for private indented to method depth in singleton' \
+    it 'registers offense for private indented to method depth in singleton ' \
        'class' do
       expect_offense(<<-RUBY.strip_indent)
         class << self

--- a/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
@@ -306,6 +306,16 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
       RUBY
     end
 
+    it 'accepts private with argument indented to method depth in a class' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class Test
+
+          def test; end
+          private :test
+        end
+      RUBY
+    end
+
     it 'registers offense for private indented to method depth in a module' do
       expect_offense(<<-RUBY.strip_indent)
         module Test
@@ -318,6 +328,16 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
       RUBY
     end
 
+    it 'accepts private with argument indented to method depth in a module' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        module Test
+
+          def test; end
+          private :test
+        end
+      RUBY
+    end
+
     it 'registers offense for module fn indented to method depth in a module' do
       expect_offense(<<-RUBY.strip_indent)
         module Test
@@ -326,6 +346,17 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
           ^^^^^^^^^^^^^^^ Outdent access modifiers like `module_function`.
 
           def test; end
+        end
+      RUBY
+    end
+
+    it 'accepts module fn with argument indented to ' \
+       'method depth in a module' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        module Test
+
+          def test; end
+          module_function :test
         end
       RUBY
     end
@@ -343,6 +374,17 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
       RUBY
     end
 
+    it 'accepts private with argument indented to ' \
+       'method depth in singleton class' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class << self
+
+          def test; end
+          private :test
+        end
+      RUBY
+    end
+
     it 'registers offense for private indented to method depth in class ' \
        'defined with Class.new' do
       expect_offense(<<-RUBY.strip_indent)
@@ -356,6 +398,17 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
       RUBY
     end
 
+    it 'accepts private with argument indented to method depth in class ' \
+       'defined with Class.new' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        Test = Class.new do
+
+          def test; end
+          private :test
+        end
+      RUBY
+    end
+
     it 'registers offense for private indented to method depth in module ' \
        'defined with Module.new' do
       expect_offense(<<-RUBY.strip_indent)
@@ -365,6 +418,17 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
           ^^^^^^^ Outdent access modifiers like `private`.
 
           def test; end
+        end
+      RUBY
+    end
+
+    it 'accepts private with argument indented to method depth in module ' \
+       'defined with Module.new' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        Test = Module.new do
+
+          def test; end
+          private :test
         end
       RUBY
     end


### PR DESCRIPTION
This is the fix I propose for #6931.

It doesn't include the remane of `Layout/AccessModifierIndentation` to `Layout/BareAccessModifierIndentation` though. I can add that if needed.

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
