### PR TITLE
Add missing absence validations to Rails/Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Do not annotate message with cop name in JSON output. ([@elebow][])
 * [#6914](https://github.com/rubocop-hq/rubocop/issues/6914): [Fix #6914] Fix an error for `Rails/RedundantAllowNil` when with interpolations. ([@Blue-Pix][])
+* [#6941](https://github.com/rubocop-hq/rubocop/issues/6941): Add missing absence validations to `Rails/Validation`. ([@jmanian][])
 
 ### Changes
 
@@ -3946,3 +3947,4 @@
 [@thomthom]: https://github.com/thomthom
 [@Blue-Pix]: https://github.com/Blue-Pix
 [@Mange]: https://github.com/Mange
+[@jmanian]: https://github.com/jmanian

--- a/lib/rubocop/cop/rails/validation.rb
+++ b/lib/rubocop/cop/rails/validation.rb
@@ -15,6 +15,7 @@ module RuboCop
       #   validates_length_of :foo
       #   validates_numericality_of :foo
       #   validates_presence_of :foo
+      #   validates_absence_of :foo
       #   validates_size_of :foo
       #   validates_uniqueness_of :foo
       #
@@ -27,6 +28,7 @@ module RuboCop
       #   validates :foo, length: true
       #   validates :foo, numericality: true
       #   validates :foo, presence: true
+      #   validates :foo, absence: true
       #   validates :foo, size: true
       #   validates :foo, uniqueness: true
       #
@@ -43,6 +45,7 @@ module RuboCop
           length
           numericality
           presence
+          absence
           size
           uniqueness
         ].freeze

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -2350,6 +2350,7 @@ validates_inclusion_of :foo
 validates_length_of :foo
 validates_numericality_of :foo
 validates_presence_of :foo
+validates_absence_of :foo
 validates_size_of :foo
 validates_uniqueness_of :foo
 
@@ -2362,6 +2363,7 @@ validates :foo, inclusion: true
 validates :foo, length: true
 validates :foo, numericality: true
 validates :foo, presence: true
+validates :foo, absence: true
 validates :foo, size: true
 validates :foo, uniqueness: true
 ```


### PR DESCRIPTION
`Rails/Validation` is missing the [`absence`](https://guides.rubyonrails.org/active_record_validations.html#absence) validation in its list of validations. (`absence` is absent.)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] `n/a` Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] `n/a` Added tests.
    * The existing test [has it covered](https://github.com/rubocop-hq/rubocop/blob/2814669f4c19d9f117b4291e9ae792d38dd198d9/spec/rubocop/cop/rails/validation_spec.rb#L36).
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
