### PR TITLE
[Fix #6926] Allow nil values to unset config defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Do not annotate message with cop name in JSON output. ([@elebow][])
 * [#6914](https://github.com/rubocop-hq/rubocop/issues/6914): [Fix #6914] Fix an error for `Rails/RedundantAllowNil` when with interpolations. ([@Blue-Pix][])
 * [#6941](https://github.com/rubocop-hq/rubocop/issues/6941): Add missing absence validations to `Rails/Validation`. ([@jmanian][])
+* [#6926](https://github.com/rubocop-hq/rubocop/issues/6926): [Fix #6926] Allow nil values to unset config defaults. ([@dduugg][])
 
 ### Changes
 

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -71,9 +71,8 @@ module RuboCop
         config = handle_disabled_by_default(config, default_configuration)
       end
 
-      Config.new(merge(default_configuration, config,
-                       inherit_mode: config['inherit_mode'] || {}),
-                 config_file)
+      opts = { inherit_mode: config['inherit_mode'] || {}, unset_nil: true }
+      Config.new(merge(default_configuration, config, opts), config_file)
     end
 
     # Return a recursive merge of two hashes. That is, a normal hash merge,
@@ -85,7 +84,9 @@ module RuboCop
       result = base_hash.merge(derived_hash)
       keys_appearing_in_both = base_hash.keys & derived_hash.keys
       keys_appearing_in_both.each do |key|
-        if base_hash[key].is_a?(Hash)
+        if opts[:unset_nil] && derived_hash[key].nil?
+          result.delete(key)
+        elsif base_hash[key].is_a?(Hash)
           result[key] = merge(base_hash[key], derived_hash[key], **opts)
         elsif should_union?(base_hash, key, opts[:inherit_mode])
           result[key] = base_hash[key] | derived_hash[key]


### PR DESCRIPTION
This PR adds the ability to unset default configuration values by using an explicit `nil` value (or `~`, in YAML). This is consistent with the [documented](https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md#inheritance-of-hashes-vs-other-types) behavior of hash inheritance.

Care must be taken when merging hashes that this only happens when merging into the *default* config hash, which is done by adding an opt to `ConfigLoaderResolver#merge_with_default` that is only enabled when calling from `ConfigLoaderResolver#merge_with_default`. (Otherwise, merging a config hash `B` with an explicit `nil` into `A` would leave an unset value for the config. When this merged hash is merged into the default config, the default value would be unchanged.)

Resolves https://github.com/rubocop-hq/rubocop/issues/6926

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
