### PR TITLE
[Fixes #6939] Remove warn for rubocop-performance

### DIFF
--- a/exe/rubocop
+++ b/exe/rubocop
@@ -9,18 +9,6 @@ require 'benchmark'
 cli = RuboCop::CLI.new
 result = 0
 
-if defined?(Bundler)
-  gemfile_lock = Bundler.read_file(Bundler.default_lockfile)
-  parser = Bundler::LockfileParser.new(gemfile_lock)
-
-  unless parser.dependencies['rubocop-performance']
-    warn Rainbow(<<-MESSAGE.strip_indent).yellow.to_s
-      [Warn] Performance Cops will be removed from RuboCop 0.68. Use rubocop-performance gem instead.
-             https://github.com/rubocop-hq/rubocop/tree/master/manual/migrate_performance_cops.md
-    MESSAGE
-  end
-end
-
 time = Benchmark.realtime do
   result = cli.run
 end


### PR DESCRIPTION
Fixes #6939.
Fixes #6917.

This warning should not be displayed if users don't use Performance cops as follows:

- https://github.com/rubocop-hq/rubocop/pull/6845#issuecomment-481810841
- https://github.com/rubocop-hq/rubocop/pull/6919#issuecomment-483005401

In the future, it will be better to replace it with a mechanism that displays a warning only when the user need Performance cops.

This PR removes a warning for rubocop-performance when runinng `rubocop` command.

It just leave a warning just to `gem install rubocop`.
https://github.com/rubocop-hq/rubocop/blob/v0.67.2/rubocop.gemspec#L47

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
