### PR TITLE
Allow Rails/ReflectionClassName to use string interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#6914](https://github.com/rubocop-hq/rubocop/issues/6914): [Fix #6914] Fix an error for `Rails/RedundantAllowNil` when with interpolations. ([@Blue-Pix][])
 * [#6941](https://github.com/rubocop-hq/rubocop/issues/6941): Add missing absence validations to `Rails/Validation`. ([@jmanian][])
 * [#6926](https://github.com/rubocop-hq/rubocop/issues/6926): [Fix #6926] Allow nil values to unset config defaults. ([@dduugg][])
+* [#6946](https://github.com/rubocop-hq/rubocop/pull/6946): Allow `Rails/ReflectionClassName` to use string interpolation for `class_name`. ([@r7kamura][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/reflection_class_name.rb
+++ b/lib/rubocop/cop/rails/reflection_class_name.rb
@@ -21,7 +21,7 @@ module RuboCop
         PATTERN
 
         def_node_search :reflection_class_name, <<-PATTERN
-          (pair (sym :class_name) [!str !sym])
+          (pair (sym :class_name) [!dstr !str !sym])
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/rails/reflection_class_name_spec.rb
+++ b/spec/rubocop/cop/rails/reflection_class_name_spec.rb
@@ -35,6 +35,12 @@ RSpec.describe RuboCop::Cop::Rails::ReflectionClassName do
     end
   end
 
+  it 'does not register an offense when using string with interpolation' do
+    expect_no_offenses(<<-'RUBY'.strip_indent)
+      has_many :accounts, class_name: "#{prefix}Account"
+    RUBY
+  end
+
   it 'does not register an offense when using `foreign_key :account_id`' do
     expect_no_offenses(<<-RUBY.strip_indent)
       has_many :accounts, class_name: 'Account', foreign_key: :account_id


### PR DESCRIPTION
Like this:

```rb
has_many :accounts, class_name: "#{prefix}Account"
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
