### PR TITLE
[Fix #6778] Fix a false positive in `Style/HashSyntax` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#6941](https://github.com/rubocop-hq/rubocop/issues/6941): Add missing absence validations to `Rails/Validation`. ([@jmanian][])
 * [#6926](https://github.com/rubocop-hq/rubocop/issues/6926): [Fix #6926] Allow nil values to unset config defaults. ([@dduugg][])
 * [#6946](https://github.com/rubocop-hq/rubocop/pull/6946): Allow `Rails/ReflectionClassName` to use string interpolation for `class_name`. ([@r7kamura][])
+* [#6778](https://github.com/rubocop-hq/rubocop/issues/6778): Fix a false positive in `Style/HashSyntax` cop when a hash key is an interpolated string and EnforcedStyle is ruby19_no_mixed_keys. ([@tatsuyafw][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -132,7 +132,7 @@ module RuboCop
         end
 
         def word_symbol_pair?(pair)
-          return false unless pair.key.sym_type?
+          return false unless pair.key.sym_type? || pair.key.dsym_type?
 
           acceptable_19_syntax_symbol?(pair.key.source)
         end

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -387,6 +387,10 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
+      it 'accepts new syntax when keys are interpolated string' do
+        expect_no_offenses('{"#{foo}": 1, "#{@foo}": 2, "#@foo": 3}')
+      end
+
       it 'auto-corrects old to new style' do
         new_source = autocorrect_source('{ :a => 1, :b => 2 }')
         expect(new_source).to eq('{ a: 1, b: 2 }')
@@ -502,6 +506,10 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           x = { :"1" => 1 }
                 ^^^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+      end
+
+      it 'accepts new syntax when keys are interpolated string' do
+        expect_no_offenses('{"#{foo}": 1, "#{@foo}": 2, "#@foo": 3}')
       end
 
       it 'auto-corrects old to new style' do


### PR DESCRIPTION
Fixes #6778 

The `Style/HashSyntax` cop would register an offense when `EnforcedStyle` was `ruby19_no_mixed_keys` and a hash key was an interpolated string like the following code:

```
{"#{foo}": 1}
```

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
