### PR TITLE
[Fix #6860] Prevent auto-correct confliction of Style::InverseMethods and Style::Not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#6946](https://github.com/rubocop-hq/rubocop/pull/6946): Allow `Rails/ReflectionClassName` to use string interpolation for `class_name`. ([@r7kamura][])
 * [#6778](https://github.com/rubocop-hq/rubocop/issues/6778): Fix a false positive in `Style/HashSyntax` cop when a hash key is an interpolated string and EnforcedStyle is ruby19_no_mixed_keys. ([@tatsuyafw][])
 * [#6902](https://github.com/rubocop-hq/rubocop/issues/6902): Fix a bug where `Naming/RescuedExceptionsVariableName` would handle an only first rescue for multiple rescue groups. ([@tatsuyafw][])
+* [#6860](https://github.com/rubocop-hq/rubocop/issues/6860): Prevent auto-correct conflict of `Style/InverseMethods` and `Style/Not`. ([@hoshinotsuyoshi][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -37,6 +37,10 @@ module RuboCop
         NEGATED_EQUALITY_METHODS = %i[!= !~].freeze
         CAMEL_CASE = /[A-Z]+[a-z]+/.freeze
 
+        def self.autocorrect_incompatible_with
+          [Style::Not]
+        end
+
         def_node_matcher :inverse_candidate?, <<-PATTERN
           {
             (send $(send $(...) $_ $...) :!)

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -452,6 +452,21 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     expect(IO.read('example.rb')).to eq(corrected)
   end
 
+  it 'corrects Style/InverseMethods and Style/Not offenses' do
+    source = <<-'RUBY'.strip_indent
+      x.select {|y| not y.z }
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run([
+                     '--auto-correct',
+                     '--only', 'Style/InverseMethods,Style/Not'
+                   ])).to eq(0)
+    corrected = <<-'RUBY'.strip_indent
+      x.reject {|y|  y.z }
+    RUBY
+    expect(IO.read('example.rb')).to eq(corrected)
+  end
+
   describe 'caching' do
     let(:cache) do
       instance_double(RuboCop::ResultCache, 'valid?' => true,


### PR DESCRIPTION
Fix #6860. 

Prevent confliction problem like below:

file:
```
x.select { |y| not y.z }
```

auto-correct:
```
$ bundle exec rubocop -a c.rb --only Style/InverseMethods,Style/Not
Inspecting 1 file
C

Offenses:

c.rb:1:1: C: [Corrected] Style/InverseMethods: Use reject instead of inverting select.
x.select { |y| not y.z }
^^^^^^^^^^^^^^^^^^^^^^^^
c.rb:1:1: C: [Corrected] Style/InverseMethods: Use select instead of inverting reject.
x.reject { |y| !y.z }
^^^^^^^^^^^^^^^^^^^^^
c.rb:1:16: C: [Corrected] Style/Not: Use ! instead of not.
x.select { |y| not y.z }
               ^^^

1 file inspected, 3 offenses detected, 3 offenses corrected
```

corrected badly:
```
x.select { |y| y.z }
```


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
