### PR TITLE
[Fix #6956] Prevent auto-correct confliction of `Lint/Lambda` and `Lint/UnusedBlockArgument`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#6902](https://github.com/rubocop-hq/rubocop/issues/6902): Fix a bug where `Naming/RescuedExceptionsVariableName` would handle an only first rescue for multiple rescue groups. ([@tatsuyafw][])
 * [#6860](https://github.com/rubocop-hq/rubocop/issues/6860): Prevent auto-correct conflict of `Style/InverseMethods` and `Style/Not`. ([@hoshinotsuyoshi][])
 * [#6935](https://github.com/rubocop-hq/rubocop/issues/6935): `Layout/AccessModifierIndentation` should ignore access modifiers that apply to specific methods. ([@deivid-rodriguez][])
+* [#6956](https://github.com/rubocop-hq/rubocop/issues/6956): Prevent auto-correct confliction of `Lint/Lambda` and `Lint/UnusedBlockArgument`. ([@koic][])
 
 ### Changes
 

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -467,6 +467,25 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     expect(IO.read('example.rb')).to eq(corrected)
   end
 
+  it 'corrects `Lint/Lambda` and `Lint/UnusedBlockArgument` offenses' do
+    source = <<-'RUBY'.strip_indent
+      c = -> event do
+        puts 'Hello world'
+      end
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run([
+                     '--auto-correct',
+                     '--only', 'Lint/Lambda,Lint/UnusedBlockArgument'
+                   ])).to eq(0)
+    corrected = <<-'RUBY'.strip_indent
+      c = lambda do |_event|
+        puts 'Hello world'
+      end
+    RUBY
+    expect(IO.read('example.rb')).to eq(corrected)
+  end
+
   describe 'caching' do
     let(:cache) do
       instance_double(RuboCop::ResultCache, 'valid?' => true,


### PR DESCRIPTION
Fixes #6956.

This PR prevents auto-correct confliction of `Lint/Lambda` and `Lint/UnusedBlockArgument`.

The following is the reproduction procedure.

```ruby
# example.rb
c = -> event do
  puts 'Hello world'
end
```

```console
% rubocop example.rb -a --only Style/Lambda,Lint/UnusedBlockArgument
```

## Before

A reserved word `lambda` is broken.

```diff
% git diff
diff --git a/example.rb b/example.rb
index 3445c6f..b8e24f4 100644
--- a/example.rb
+++ b/example.rb
@@ -1,3 +1,3 @@
-c = -> event do
+c = lambda_ do |_event|
   puts 'Hello world'
 end
```

## After

It will be a valid code.

```diff
% git diff
diff --git a/example.rb b/example.rb
index 3445c6f..9c22b37 100644
--- a/example.rb
+++ b/example.rb
@@ -1,3 +1,3 @@
-c = -> event do
+c = lambda do |_event|
   puts 'Hello world'
 end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
