### PR TITLE
Fix a typo

### DIFF
--- a/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
+++ b/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
@@ -54,7 +54,7 @@ module RuboCop
         include RangeHelp
 
         MSG = 'Put the closing parenthesis for a method call with a ' \
-        'HEREDOC paramater on the same line as the HEREDOC opening.'.freeze
+        'HEREDOC parameter on the same line as the HEREDOC opening.'.freeze
 
         STRING_TYPES = %i[str dstr xstr].freeze
         def on_send(node)

--- a/spec/rubocop/cop/layout/heredoc_argument_closing_parenthesis_spec.rb
+++ b/spec/rubocop/cop/layout/heredoc_argument_closing_parenthesis_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
             foo
           SQL
           )
-          ^ Put the closing parenthesis for a method call with a HEREDOC paramater on the same line as the HEREDOC opening.
+          ^ Put the closing parenthesis for a method call with a HEREDOC parameter on the same line as the HEREDOC opening.
         RUBY
 
         expect_correction(<<-RUBY.strip_indent)
@@ -108,7 +108,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
             foo
           SQL
           )
-          ^ Put the closing parenthesis for a method call with a HEREDOC paramater on the same line as the HEREDOC opening.
+          ^ Put the closing parenthesis for a method call with a HEREDOC parameter on the same line as the HEREDOC opening.
         RUBY
 
         expect_correction(<<-RUBY.strip_indent)
@@ -126,7 +126,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
             foo
           SQL
           )
-          ^ Put the closing parenthesis for a method call with a HEREDOC paramater on the same line as the HEREDOC opening.
+          ^ Put the closing parenthesis for a method call with a HEREDOC parameter on the same line as the HEREDOC opening.
         RUBY
 
         expect_correction(<<-RUBY.strip_indent)
@@ -144,7 +144,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
             foo
           SQL
           )
-          ^ Put the closing parenthesis for a method call with a HEREDOC paramater on the same line as the HEREDOC opening.
+          ^ Put the closing parenthesis for a method call with a HEREDOC parameter on the same line as the HEREDOC opening.
         RUBY
 
         expect_correction(<<-RUBY.strip_indent)
@@ -162,7 +162,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
             foo
           SQL
           )
-          ^ Put the closing parenthesis for a method call with a HEREDOC paramater on the same line as the HEREDOC opening.
+          ^ Put the closing parenthesis for a method call with a HEREDOC parameter on the same line as the HEREDOC opening.
         RUBY
 
         expect_correction(<<-RUBY.strip_indent)
@@ -180,7 +180,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
             foo
           SQL
           )
-          ^ Put the closing parenthesis for a method call with a HEREDOC paramater on the same line as the HEREDOC opening.
+          ^ Put the closing parenthesis for a method call with a HEREDOC parameter on the same line as the HEREDOC opening.
         RUBY
 
         expect_correction(<<-RUBY.strip_indent)
@@ -198,7 +198,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
             foo
           SQL
           )
-          ^ Put the closing parenthesis for a method call with a HEREDOC paramater on the same line as the HEREDOC opening.
+          ^ Put the closing parenthesis for a method call with a HEREDOC parameter on the same line as the HEREDOC opening.
         RUBY
 
         expect_correction(<<-RUBY.strip_indent)
@@ -216,7 +216,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
             foo
           SQL
           )
-          ^ Put the closing parenthesis for a method call with a HEREDOC paramater on the same line as the HEREDOC opening.
+          ^ Put the closing parenthesis for a method call with a HEREDOC parameter on the same line as the HEREDOC opening.
         RUBY
 
         expect_correction(<<-RUBY.strip_indent)
@@ -234,7 +234,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
             foo
           SQL
           )
-          ^ Put the closing parenthesis for a method call with a HEREDOC paramater on the same line as the HEREDOC opening.
+          ^ Put the closing parenthesis for a method call with a HEREDOC parameter on the same line as the HEREDOC opening.
         RUBY
 
         expect_correction(<<-RUBY.strip_indent)
@@ -254,7 +254,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
             bar
           NOSQL
           )
-          ^ Put the closing parenthesis for a method call with a HEREDOC paramater on the same line as the HEREDOC opening.
+          ^ Put the closing parenthesis for a method call with a HEREDOC parameter on the same line as the HEREDOC opening.
         RUBY
 
         expect_correction(<<-RUBY.strip_indent)
@@ -276,7 +276,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
             bar
           NOSQL
           ).bar(123).baz(456)
-          ^ Put the closing parenthesis for a method call with a HEREDOC paramater on the same line as the HEREDOC opening.
+          ^ Put the closing parenthesis for a method call with a HEREDOC parameter on the same line as the HEREDOC opening.
         RUBY
 
         expect_correction(<<-RUBY.strip_indent)
@@ -297,7 +297,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
             foo
           SQL
           )
-          ^ Put the closing parenthesis for a method call with a HEREDOC paramater on the same line as the HEREDOC opening.
+          ^ Put the closing parenthesis for a method call with a HEREDOC parameter on the same line as the HEREDOC opening.
         RUBY
 
         expect_correction(<<-RUBY.strip_indent)
@@ -315,7 +315,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
             foo
           SQL
           )
-          ^ Put the closing parenthesis for a method call with a HEREDOC paramater on the same line as the HEREDOC opening.
+          ^ Put the closing parenthesis for a method call with a HEREDOC parameter on the same line as the HEREDOC opening.
         RUBY
 
         expect_correction(<<-RUBY.strip_indent)
@@ -333,7 +333,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
             foo
           SQL
           )
-          ^ Put the closing parenthesis for a method call with a HEREDOC paramater on the same line as the HEREDOC opening.
+          ^ Put the closing parenthesis for a method call with a HEREDOC parameter on the same line as the HEREDOC opening.
         RUBY
 
         expect_correction(<<-RUBY.strip_indent)
@@ -351,7 +351,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
             foo
           SQL
           )
-          ^ Put the closing parenthesis for a method call with a HEREDOC paramater on the same line as the HEREDOC opening.
+          ^ Put the closing parenthesis for a method call with a HEREDOC parameter on the same line as the HEREDOC opening.
         RUBY
 
         expect_correction(<<-RUBY.strip_indent)
@@ -370,7 +370,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
               foo
             SQL
             ),
-            ^ Put the closing parenthesis for a method call with a HEREDOC paramater on the same line as the HEREDOC opening.
+            ^ Put the closing parenthesis for a method call with a HEREDOC parameter on the same line as the HEREDOC opening.
             456,
             789,
           )
@@ -396,7 +396,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
               foo
             SQL
             )      ,
-            ^ Put the closing parenthesis for a method call with a HEREDOC paramater on the same line as the HEREDOC opening.
+            ^ Put the closing parenthesis for a method call with a HEREDOC parameter on the same line as the HEREDOC opening.
             456,
             789,
           ]
@@ -424,7 +424,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
               bar
             NOSQL
             )      ,
-            ^ Put the closing parenthesis for a method call with a HEREDOC paramater on the same line as the HEREDOC opening.
+            ^ Put the closing parenthesis for a method call with a HEREDOC parameter on the same line as the HEREDOC opening.
             456,
             789,
           ]
@@ -454,7 +454,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
               bar
             NOSQL
             )      ,
-            ^ Put the closing parenthesis for a method call with a HEREDOC paramater on the same line as the HEREDOC opening.
+            ^ Put the closing parenthesis for a method call with a HEREDOC parameter on the same line as the HEREDOC opening.
             456,
             789,
           ]


### PR DESCRIPTION
This PR fixes the following typo.
```diff
-paramater
+parameter
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
