### PR TITLE
[Fix #6950] Mark Rails/TimeZone as unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Changes
 
+* [#6966](https://github.com/rubocop-hq/rubocop/pull/6966): Mark Rails/TimeZone as unsafe. ([@vfonic][])
 * [#5977](https://github.com/rubocop-hq/rubocop/issues/5977): Remove Performance cops. ([@koic][])
 * Add auto-correction to `Naming/RescuedExceptionsVariableName`. ([@anthony-robin][])
 * [#6903](https://github.com/rubocop-hq/rubocop/issues/6903): Handle variables prefixed with `_` in `Naming/RescuedExceptionsVariableName` cop. ([@anthony-robin][])
@@ -3960,3 +3961,4 @@
 [@diachini]: https://github.com/diachini
 [@Mange]: https://github.com/Mange
 [@jmanian]: https://github.com/jmanian
+[@vfonic]: https://github.com/vfonic

--- a/config/default.yml
+++ b/config/default.yml
@@ -2424,8 +2424,9 @@ Rails/TimeZone:
   StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#time'
   Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
   Enabled: true
+  Safe: false
   VersionAdded: '0.30'
-  VersionChanged: '0.33'
+  VersionChanged: '0.68'
   # The value `strict` means that `Time` should be used with `zone`.
   # The value `flexible` allows usage of `in_time_zone` instead of `zone`.
   EnforcedStyle: flexible

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -2185,7 +2185,7 @@ Whitelist | `[]` | Array
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.30 | 0.33
+Enabled | No | Yes  | 0.30 | 0.68
 
 This cop checks for the use of Time methods without zone.
 


### PR DESCRIPTION
Note: This is the first time I'm sending a PR and marking a cop as unsafe. Please check if I missed anything!

Thanks!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/