### PR TITLE
Revert "Test with JIT compiler on latest Ruby"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,24 +182,6 @@ jobs:
     steps:
       *rubocop_steps
 
-  # With JIT compiler enabled!
-  ruby-head-spec-with-jit:
-    docker:
-      - image: rubocophq/circleci-ruby-snapshot:latest
-    environment:
-      RUBYOPT: '--jit'
-      <<: *common_env
-    steps:
-      *spec_steps
-  ruby-head-rubocop-with-jit:
-    docker:
-      - image: rubocophq/circleci-ruby-snapshot:latest
-    environment:
-      RUBYOPT: '--jit'
-      <<: *common_env
-    steps:
-      *rubocop_steps
-
   # JRuby 9.2
   jruby-9.2-spec:
     docker:
@@ -311,12 +293,8 @@ workflows:
       - ruby-head-spec:
           requires:
             - cc-setup
-      - ruby-head-spec-with-jit:
-          requires:
-            - cc-setup
       - ruby-head-ascii_spec
       - ruby-head-rubocop
-      - ruby-head-rubocop-with-jit
       - jruby-9.2-spec:
           requires:
             - cc-setup


### PR DESCRIPTION
This reverts commit b00329ebf3542cff2dc1ed3abadfded73f09f356 / PR #6456.

I don't think we have seen any value from running tests with the JIT compiler enabled – so let’s just disable it again.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
