### PR TITLE
Add always_braces to Style/BlockDelimiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#6973](https://github.com/rubocop-hq/rubocop/pull/6973): Add `always_braces` to `Style/BlockDelimiter`. ([@iGEL][])
 * [#6841](https://github.com/rubocop-hq/rubocop/issues/6841): Node patterns can now match children in any order using `<>`. ([@marcandre][])
 * [#6928](https://github.com/rubocop-hq/rubocop/pull/6928): Add `--init` option for generate `.rubocop.yml` file in the current directory. ([@koic][])
 * Add new `Layout/HeredocArgumentClosingParenthesis` cop. ([@maxh][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2663,6 +2663,8 @@ Style/BlockDelimiters:
     # return value is being chained with another method (in which case braces
     # are enforced).
     - braces_for_chaining
+    # The `always_braces` style always enforces braces.
+    - always_braces
   ProceduralMethods:
     # Methods that are known to be procedural in nature but look functional from
     # their usage, e.g.

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -95,9 +95,23 @@ module RuboCop
       #     word.flip.flop
       #   }.join("-")
       #
+      # @example EnforcedStyle: always_braces
+      #   # bad
+      #   words.each do |word|
+      #     word.flip.flop
+      #   end
+      #
+      #   # good
+      #   words.each { |word|
+      #     word.flip.flop
+      #   }
+      #
       class BlockDelimiters < Cop
         include ConfigurableEnforcedStyle
         include IgnoredMethods
+
+        ALWAYS_BRACES_MESSAGE = 'Prefer `{...}` over `do...end` for blocks.'
+                                .freeze
 
         def on_send(node)
           return unless node.arguments?
@@ -166,6 +180,7 @@ module RuboCop
           when :line_count_based    then line_count_based_message(node)
           when :semantic            then semantic_message(node)
           when :braces_for_chaining then braces_for_chaining_message(node)
+          when :always_braces       then ALWAYS_BRACES_MESSAGE
           end
         end
 
@@ -229,6 +244,7 @@ module RuboCop
           when :line_count_based    then line_count_based_block_style?(node)
           when :semantic            then semantic_block_style?(node)
           when :braces_for_chaining then braces_for_chaining_style?(node)
+          when :always_braces       then braces_style?(node)
           end
         end
 
@@ -255,6 +271,10 @@ module RuboCop
                          else
                            '{'
                          end
+        end
+
+        def braces_style?(node)
+          node.loc.begin.source == '{'
         end
 
         def return_value_chaining?(node)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -460,12 +460,25 @@ words.each { |word|
   word.flip.flop
 }.join("-")
 ```
+#### EnforcedStyle: always_braces
+
+```ruby
+# bad
+words.each do |word|
+  word.flip.flop
+end
+
+# good
+words.each { |word|
+  word.flip.flop
+}
+```
 
 ### Configurable attributes
 
 Name | Default value | Configurable values
 --- | --- | ---
-EnforcedStyle | `line_count_based` | `line_count_based`, `semantic`, `braces_for_chaining`
+EnforcedStyle | `line_count_based` | `line_count_based`, `semantic`, `braces_for_chaining`, `always_braces`
 ProceduralMethods | `benchmark`, `bm`, `bmbm`, `create`, `each_with_object`, `measure`, `new`, `realtime`, `tap`, `with_object` | Array
 FunctionalMethods | `let`, `let!`, `subject`, `watch` | Array
 IgnoredMethods | `lambda`, `proc`, `it` | Array


### PR DESCRIPTION
This style always prefers braces over do...end.

This style always prefers braces over do...end. Similar to double quotes, some developers don't want to bother with changing the style when adding or removing a line or debate, whether a blocks like
    
```ruby
date = Timecop.freeze(1.year.ago) { format_date(Time.now) }
customer = Timecop.freeze(1.year.ago) { create(:customer) }
```
    
 are functional or procedual.
    
I didn't add a always_do_end style, as I don't think that someone wants to enforce this in all situation (chaining, ...).

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
