### PR TITLE
Fix a false positive for `Layout/EmptyLinesAroundAccessModifier`

### DIFF
--- a/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
@@ -53,7 +53,7 @@ module RuboCop
           @class_or_module_def_first_line =
             node.identifier.source_range.first_line
           @class_or_module_def_last_line =
-            node.identifier.source_range.last_line
+            node.source_range.last_line
         end
 
         def on_block(node)

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -297,6 +297,17 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
       RUBY
     end
 
+    it 'accepts missing blank line when at the end of specifying ' \
+       '`self`' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class << self
+          def test; end
+
+          #{access_modifier}
+        end
+      RUBY
+    end
+
     it 'requires blank line when next line started with end' do
       inspect_source(<<-RUBY.strip_indent)
         class Test


### PR DESCRIPTION
This PR fixes a false positive for `Layout/EmptyLinesAroundAccessModifier` when at the end of specifying `self` is missing blank line.

It is a regression with the following commits.
https://github.com/rubocop-hq/rubocop/commit/4d709506a26bf3ed00aca7a2898db426d3bdb79a

This PR fixes an infinite loop similar to #6576.

This issue occurred only on master branch, it will not be described in the changelog.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
