### PR TITLE
[Fix #6974] Make `Layout/FirstMethodArgumentLineBreak` aware of calling using `super`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add new `Layout/HeredocArgumentClosingParenthesis` cop. ([@maxh][])
 * [#6895](https://github.com/rubocop-hq/rubocop/pull/6895): Add support for XDG config home for user-config. ([@Mange][], [@tejasbubane][])
 * Add initial autocorrection support to `Metrics/LineLength`. ([@maxh][])
+* [#6974](https://github.com/rubocop-hq/rubocop/issues/6974): Make `Layout/FirstMethodArgumentLineBreak` aware of calling using `super`. ([@koic][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/layout/first_method_argument_line_break.rb
+++ b/lib/rubocop/cop/layout/first_method_argument_line_break.rb
@@ -44,6 +44,7 @@ module RuboCop
           check_method_line_break(node, args)
         end
         alias on_csend on_send
+        alias on_super on_send
 
         def autocorrect(node)
           EmptyLineCorrector.insert_before(node)

--- a/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
@@ -25,6 +25,20 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak do
       RUBY
     end
 
+    it 'detects the offense when using `super`' do
+      expect_offense(<<-RUBY.strip_indent)
+        super(bar,
+              ^^^ Add a line break before the first argument of a multi-line method argument list.
+          baz)
+      RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        super(
+        bar,
+          baz)
+      RUBY
+    end
+
     context 'when using safe navigation operator', :ruby23 do
       it 'detects the offense' do
         expect_offense(<<-RUBY.strip_indent)


### PR DESCRIPTION
Fixes #6974.

This PR makes `Layout/FirstMethodArgumentLineBreak` aware of calling using `super`.

```ruby
# example.rb
super(:foo,
  :bar
  )
```

## Before

```console
% rubocop --only Layout/FirstMethodArgumentLineBreak
Inspecting 1 file
.

1 file inspected, no offenses detected
```

## After

```console
% rubocop --only Layout/FirstMethodArgumentLineBreak
Inspecting 1 file
C

Offenses:

example.rb:1:7: C: Layout/FirstMethodArgumentLineBreak: Add a line break
before the first argument of a multi-line method argument list.
super(:foo,
      ^^^^

1 file inspected, 1 offense detected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
