### PR TITLE
Extract AlignArguments out from AlignParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Add `--auto-gen-only-exclude` to the command outputted in `rubocop_todo.yml` if the option is specified. ([@dvandersluis][])
 * [#6887](https://github.com/rubocop-hq/rubocop/pull/6887): Allow `Lint/UnderscorePrefixedVariableName` cop to be configured to allow use of block keyword args. ([@dduugg][])
 * [#6885](https://github.com/rubocop-hq/rubocop/pull/6885): Revert adding psych >= 3.1 as runtime dependency. ([@andreaseger][])
+* Extract method call argument alignment behavior from `Layout/AlignParameters` into `Layout/AlignArguments`. ([@maxh][])
 
 ## 0.67.2 (2019-04-05)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -219,6 +219,34 @@ Layout/AccessModifierIndentation:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
+Layout/AlignArguments:
+  Description: >-
+                 Align the arguments of a method call if they span more
+                 than one line.
+  StyleGuide: '#no-double-indent'
+  Enabled: true
+  VersionAdded: '0.68'
+  # Alignment of arguments in multi-line method calls.
+  #
+  # The `with_first_argument` style aligns the following lines along the same
+  # column as the first parameter.
+  #
+  #     method_call(a,
+  #                 b)
+  #
+  # The `with_fixed_indentation` style aligns the following lines with one
+  # level of indentation relative to the start of the line with the method call.
+  #
+  #     method_call(a,
+  #       b)
+  EnforcedStyle: with_first_argument
+  SupportedStyles:
+    - with_first_argument
+    - with_fixed_indentation
+  # By default, the indentation width from Layout/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
 Layout/AlignArray:
   Description: >-
                  Align the elements of an array literal if they span more than
@@ -305,23 +333,24 @@ Layout/AlignHash:
 
 Layout/AlignParameters:
   Description: >-
-                 Align the parameters of a method call if they span more
+                 Align the parameters of a method definition if they span more
                  than one line.
   StyleGuide: '#no-double-indent'
   Enabled: true
   VersionAdded: '0.49'
+  VersionChanged: '0.68'
   # Alignment of parameters in multi-line method calls.
   #
   # The `with_first_parameter` style aligns the following lines along the same
   # column as the first parameter.
   #
-  #     method_call(a,
-  #                 b)
+  #     def method_foo(a,
+  #                    b)
   #
   # The `with_fixed_indentation` style aligns the following lines with one
   # level of indentation relative to the start of the line with the method call.
   #
-  #     method_call(a,
+  #     def method_foo(a,
   #       b)
   EnforcedStyle: with_first_parameter
   SupportedStyles:

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -180,6 +180,7 @@ require_relative 'rubocop/cop/gemspec/ordered_dependencies'
 require_relative 'rubocop/cop/gemspec/required_ruby_version'
 
 require_relative 'rubocop/cop/layout/access_modifier_indentation'
+require_relative 'rubocop/cop/layout/align_arguments'
 require_relative 'rubocop/cop/layout/align_array'
 require_relative 'rubocop/cop/layout/align_hash'
 require_relative 'rubocop/cop/layout/align_parameters'

--- a/lib/rubocop/cop/layout/align_arguments.rb
+++ b/lib/rubocop/cop/layout/align_arguments.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Layout
+      # Here we check if the arguments on a multi-line method
+      # definition are aligned.
+      #
+      # @example EnforcedStyle: with_first_argument (default)
+      #   # good
+      #
+      #   foo :bar,
+      #       :baz
+      #
+      #   foo(
+      #     :bar,
+      #     :baz
+      #   )
+      #
+      #   # bad
+      #
+      #   foo :bar,
+      #     :baz
+      #
+      #   foo(
+      #     :bar,
+      #       :baz
+      #   )
+      #
+      # @example EnforcedStyle: with_fixed_indentation
+      #   # good
+      #
+      #   foo :bar,
+      #     :baz
+      #
+      #   # bad
+      #
+      #   foo :bar,
+      #       :baz
+      class AlignArguments < Cop
+        include Alignment
+
+        ALIGN_PARAMS_MSG = 'Align the arguments of a method call if ' \
+          'they span more than one line.'.freeze
+
+        FIXED_INDENT_MSG = 'Use one level of indentation for arguments ' \
+          'following the first line of a multi-line method call.'.freeze
+
+        def on_send(node)
+          return if node.arguments.size < 2 ||
+                    node.send_type? && node.method?(:[]=)
+
+          check_alignment(node.arguments, base_column(node, node.arguments))
+        end
+        alias on_csend on_send
+
+        def autocorrect(node)
+          AlignmentCorrector.correct(processed_source, node, column_delta)
+        end
+
+        private
+
+        def message(_node)
+          fixed_indentation? ? FIXED_INDENT_MSG : ALIGN_PARAMS_MSG
+        end
+
+        def fixed_indentation?
+          cop_config['EnforcedStyle'] == 'with_fixed_indentation'
+        end
+
+        def base_column(node, args)
+          if fixed_indentation?
+            lineno = target_method_lineno(node)
+            line = node.source_range.source_buffer.source_line(lineno)
+            indentation_of_line = /\S.*/.match(line).begin(0)
+            indentation_of_line + configured_indentation_width
+          else
+            display_column(args.first.source_range)
+          end
+        end
+
+        def target_method_lineno(node)
+          if node.loc.selector
+            node.loc.selector.line
+          else
+            # l.(1) has no selector, so we use the opening parenthesis instead
+            node.loc.begin.line
+          end
+        end
+      end
+    end
+  end
+end

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -101,6 +101,7 @@ In the following section you find all available cops:
 #### Department [Layout](cops_layout.md)
 
 * [Layout/AccessModifierIndentation](cops_layout.md#layoutaccessmodifierindentation)
+* [Layout/AlignArguments](cops_layout.md#layoutalignarguments)
 * [Layout/AlignArray](cops_layout.md#layoutalignarray)
 * [Layout/AlignHash](cops_layout.md#layoutalignhash)
 * [Layout/AlignParameters](cops_layout.md#layoutalignparameters)

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -54,6 +54,65 @@ IndentationWidth | `<none>` | Integer
 
 * [https://github.com/rubocop-hq/ruby-style-guide#indent-public-private-protected](https://github.com/rubocop-hq/ruby-style-guide#indent-public-private-protected)
 
+## Layout/AlignArguments
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.68 | -
+
+Here we check if the arguments on a multi-line method
+definition are aligned.
+
+### Examples
+
+#### EnforcedStyle: with_first_argument (default)
+
+```ruby
+# good
+
+foo :bar,
+    :baz
+
+foo(
+  :bar,
+  :baz
+)
+
+# bad
+
+foo :bar,
+  :baz
+
+foo(
+  :bar,
+    :baz
+)
+```
+#### EnforcedStyle: with_fixed_indentation
+
+```ruby
+# good
+
+foo :bar,
+  :baz
+
+# bad
+
+foo :bar,
+    :baz
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `with_first_argument` | `with_first_argument`, `with_fixed_indentation`
+IndentationWidth | `<none>` | Integer
+
+### References
+
+* [https://github.com/rubocop-hq/ruby-style-guide#no-double-indent](https://github.com/rubocop-hq/ruby-style-guide#no-double-indent)
+
 ## Layout/AlignArray
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
@@ -296,10 +355,13 @@ EnforcedLastArgumentHashStyle | `always_inspect` | `always_inspect`, `always_ign
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.49 | -
+Enabled | Yes | Yes  | 0.49 | 0.68
 
 Here we check if the parameters on a multi-line method call or
 definition are aligned.
+
+To set the alignment of the first argument, use the cop
+FirstParameterIndentation.
 
 ### Examples
 
@@ -308,26 +370,64 @@ definition are aligned.
 ```ruby
 # good
 
-foo :bar,
-    :baz
+def foo(bar,
+        baz)
+  123
+end
+
+def foo(
+  bar,
+  baz
+)
+  123
+end
 
 # bad
 
-foo :bar,
-  :baz
+def foo(bar,
+     baz)
+  123
+end
+
+# bad
+
+def foo(
+  bar,
+     baz)
+  123
+end
 ```
 #### EnforcedStyle: with_fixed_indentation
 
 ```ruby
 # good
 
-foo :bar,
-  :baz
+def foo(bar,
+  baz)
+  123
+end
+
+def foo(
+  bar,
+  baz
+)
+  123
+end
 
 # bad
 
-foo :bar,
-    :baz
+def foo(bar,
+        baz)
+  123
+end
+
+# bad
+
+def foo(
+  bar,
+     baz)
+  123
+end
 ```
 
 ### Configurable attributes

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1109,7 +1109,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       example.rb:1:1: C: [Corrected] Style/SignalException: Always use raise to signal exceptions.
       fail NotImplementedError,
       ^^^^
-      example.rb:2:6: C: [Corrected] Layout/AlignParameters: Align the parameters of a method call if they span more than one line.
+      example.rb:2:6: C: [Corrected] Layout/AlignArguments: Align the arguments of a method call if they span more than one line.
            'Method should be overridden in child classes'
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/spec/rubocop/cop/layout/align_arguments_spec.rb
+++ b/spec/rubocop/cop/layout/align_arguments_spec.rb
@@ -1,0 +1,525 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Layout::AlignArguments do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) do
+    RuboCop::Config.new('Layout/AlignArguments' => cop_config,
+                        'Layout/IndentationWidth' => {
+                          'Width' => indentation_width
+                        })
+  end
+  let(:indentation_width) { 2 }
+
+  context 'aligned with first argument' do
+    let(:cop_config) do
+      {
+        'EnforcedStyle' => 'with_first_argument'
+      }
+    end
+
+    it 'registers an offense for arguments with single indent' do
+      expect_offense(<<-RUBY.strip_indent)
+        function(a,
+          if b then c else d end)
+          ^^^^^^^^^^^^^^^^^^^^^^ Align the arguments of a method call if they span more than one line.
+      RUBY
+    end
+
+    it 'registers an offense for arguments with double indent' do
+      expect_offense(<<-RUBY.strip_indent)
+        function(a,
+            if b then c else d end)
+            ^^^^^^^^^^^^^^^^^^^^^^ Align the arguments of a method call if they span more than one line.
+      RUBY
+    end
+
+    it 'accepts multiline []= method call' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        Test.config["something"] =
+         true
+      RUBY
+    end
+
+    it 'accepts correctly aligned arguments' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        function(a,
+                 0, 1,
+                 (x + y),
+                 if b then c else d end)
+      RUBY
+    end
+
+    it 'accepts correctly aligned arguments with fullwidth characters' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        f 'Ｒｕｂｙ', g(a,
+                        b)
+      RUBY
+    end
+
+    it 'accepts calls that only span one line' do
+      expect_no_offenses('find(path, s, @special[sexp[0]])')
+    end
+
+    it "doesn't get confused by a symbol argument" do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        add_offense(index,
+                    MSG % kind)
+      RUBY
+    end
+
+    it "doesn't get confused by splat operator" do
+      expect_offense(<<-RUBY.strip_indent)
+        func1(*a,
+              *b,
+              c)
+        func2(a,
+             *b,
+             ^^ Align the arguments of a method call if they span more than one line.
+              c)
+        func3(*a)
+      RUBY
+    end
+
+    it "doesn't get confused by extra comma at the end" do
+      expect_offense(<<-RUBY.strip_indent)
+        func1(a,
+             b,)
+             ^ Align the arguments of a method call if they span more than one line.
+      RUBY
+    end
+
+    it 'can handle a correctly aligned string literal as first argument' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        add_offense(x,
+                    a)
+      RUBY
+    end
+
+    it 'can handle a string literal as other argument' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        add_offense(
+                    "", a)
+      RUBY
+    end
+
+    it "doesn't get confused by a line break inside a parameter" do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        read(path, { headers:    true,
+                     converters: :numeric })
+      RUBY
+    end
+
+    it "doesn't get confused by symbols with embedded expressions" do
+      expect_no_offenses('send(:"#{name}_comments_path")')
+    end
+
+    it "doesn't get confused by regexen with embedded expressions" do
+      expect_no_offenses('a(/#{name}/)')
+    end
+
+    it 'accepts braceless hashes' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        run(collection, :entry_name => label,
+                        :paginator  => paginator)
+      RUBY
+    end
+
+    it 'accepts the first parameter being on a new row' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        match(
+          a,
+          b
+        )
+      RUBY
+    end
+
+    it 'can handle heredoc strings' do
+      expect_no_offenses(<<-'RUBY'.strip_indent)
+        class_eval(<<-EOS, __FILE__, __LINE__ + 1)
+                    def run_#{name}_callbacks(*args)
+                      a = 1
+                      return value
+                    end
+                    EOS
+      RUBY
+    end
+
+    it 'can handle a method call within a method call' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        a(a1,
+          b(b1,
+            b2),
+          a2)
+      RUBY
+    end
+
+    it 'can handle a call embedded in a string' do
+      expect_no_offenses('model("#{index(name)}", child)')
+    end
+
+    it 'can handle do-end' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        run(lambda do |e|
+          w = e['warden']
+        end)
+      RUBY
+    end
+
+    it 'can handle a call with a block inside another call' do
+      expect_no_offenses(<<-'RUBY'.strip_indent)
+        new(table_name,
+            exec_query("info('#{row['name']}')").map { |col|
+              col['name']
+            })
+      RUBY
+    end
+
+    it 'can handle a ternary condition with a block reference' do
+      expect_no_offenses('cond ? a : func(&b)')
+    end
+
+    it 'can handle parentheses used with no arguments' do
+      expect_no_offenses('func()')
+    end
+
+    it 'can handle a multiline hash as second parameter' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        tag(:input, {
+          :value => value
+        })
+      RUBY
+    end
+
+    it 'can handle method calls without parentheses' do
+      expect_no_offenses('a(b c, d)')
+    end
+
+    it 'can handle other method calls without parentheses' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        chars(Unicode.apply_mapping @wrapped_string, :uppercase)
+      RUBY
+    end
+
+    it "doesn't crash and burn when there are nested issues" do
+      # regression test; see GH issue 2441
+      src = <<-RUBY.strip_indent
+        build(:house,
+          :rooms => [
+            build(:bedroom,
+              :bed => build(:bed,
+                :occupants => [],
+                :size => "king"
+              )
+            )
+          ]
+        )
+      RUBY
+      expect { inspect_source(src) }.not_to raise_error
+    end
+
+    context 'assigned methods' do
+      it 'accepts the first parameter being on a new row' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+           assigned_value = match(
+             a,
+             b,
+             c
+           )
+        RUBY
+      end
+
+      it 'accepts the first parameter being on method row' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+           assigned_value = match(a,
+                                  b,
+                                  c
+                            )
+        RUBY
+      end
+    end
+
+    it 'auto-corrects alignment' do
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        func(a,
+               b,
+        c)
+      RUBY
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        func(a,
+             b,
+             c)
+      RUBY
+    end
+
+    it 'auto-corrects each line of a multi-line parameter to the right' do
+      new_source =
+        autocorrect_source(<<-RUBY.strip_indent)
+          create :transaction, :closed,
+                account:          account,
+                open_price:       1.29,
+                close_price:      1.30
+        RUBY
+      expect(new_source)
+        .to eq(<<-RUBY.strip_indent)
+          create :transaction, :closed,
+                 account:          account,
+                 open_price:       1.29,
+                 close_price:      1.30
+        RUBY
+    end
+
+    it 'auto-corrects each line of a multi-line parameter to the left' do
+      new_source =
+        autocorrect_source(<<-RUBY.strip_indent)
+          create :transaction, :closed,
+                   account:          account,
+                   open_price:       1.29,
+                   close_price:      1.30
+        RUBY
+      expect(new_source)
+        .to eq(<<-RUBY.strip_indent)
+          create :transaction, :closed,
+                 account:          account,
+                 open_price:       1.29,
+                 close_price:      1.30
+        RUBY
+    end
+
+    it 'auto-corrects only arguments that begin a line' do
+      original_source = <<-RUBY.strip_indent
+        foo(:bar, {
+            whiz: 2, bang: 3 }, option: 3)
+      RUBY
+      new_source = autocorrect_source(original_source)
+      expect(new_source).to eq(original_source)
+    end
+
+    it 'does not crash in autocorrect on dynamic string in parameter value' do
+      src = <<-'RUBY'.strip_indent
+        class MyModel < ActiveRecord::Base
+          has_many :other_models,
+            class_name: "legacy_name",
+            order: "#{legacy_name.table_name}.published DESC"
+
+        end
+      RUBY
+      new_source = autocorrect_source(src)
+      expect(new_source)
+        .to eq <<-'RUBY'.strip_indent
+          class MyModel < ActiveRecord::Base
+            has_many :other_models,
+                     class_name: "legacy_name",
+                     order: "#{legacy_name.table_name}.published DESC"
+
+          end
+        RUBY
+    end
+
+    context 'when using safe navigation operator', :ruby23 do
+      it 'registers an offense for arguments with single indent' do
+        expect_offense(<<-RUBY.strip_indent)
+          receiver&.function(a,
+            if b then c else d end)
+            ^^^^^^^^^^^^^^^^^^^^^^ Align the arguments of a method call if they span more than one line.
+        RUBY
+      end
+    end
+  end
+
+  context 'aligned with fixed indentation' do
+    let(:cop_config) do
+      {
+        'EnforcedStyle' => 'with_fixed_indentation'
+      }
+    end
+
+    let(:correct_source) do
+      <<-RUBY.strip_indent
+        create :transaction, :closed,
+          account:     account,
+          open_price:  1.29,
+          close_price: 1.30
+      RUBY
+    end
+
+    it 'does not autocorrect correct source' do
+      expect(autocorrect_source(correct_source))
+        .to eq(correct_source)
+    end
+
+    it 'autocorrects by outdenting when indented too far' do
+      original_source = <<-RUBY.strip_indent
+        create :transaction, :closed,
+               account:     account,
+               open_price:  1.29,
+               close_price: 1.30
+      RUBY
+
+      expect(autocorrect_source(original_source))
+        .to eq(correct_source)
+    end
+
+    it 'autocorrects by indenting when not indented' do
+      original_source = <<-RUBY.strip_indent
+        create :transaction, :closed,
+        account:     account,
+        open_price:  1.29,
+        close_price: 1.30
+      RUBY
+
+      expect(autocorrect_source(original_source))
+        .to eq(correct_source)
+    end
+
+    it 'autocorrects when first line is indented' do
+      original_source = <<-RUBY.strip_margin('|')
+        |  create :transaction, :closed,
+        |  account:     account,
+        |  open_price:  1.29,
+        |  close_price: 1.30
+      RUBY
+
+      correct_source = <<-RUBY.strip_margin('|')
+        |  create :transaction, :closed,
+        |    account:     account,
+        |    open_price:  1.29,
+        |    close_price: 1.30
+      RUBY
+
+      expect(autocorrect_source(original_source))
+        .to eq(correct_source)
+    end
+
+    context 'multi-line method calls' do
+      it 'can handle existing indentation from multi-line method calls' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+           something
+             .method_name(
+               a,
+               b,
+               c
+             )
+        RUBY
+      end
+
+      it 'registers offenses for double indentation from relevant method' do
+        expect_offense(<<-RUBY.strip_indent)
+           something
+             .method_name(
+                 a,
+                 ^ Use one level of indentation for arguments following the first line of a multi-line method call.
+                 b,
+                 ^ Use one level of indentation for arguments following the first line of a multi-line method call.
+                 c
+                 ^ Use one level of indentation for arguments following the first line of a multi-line method call.
+             )
+        RUBY
+      end
+
+      it 'does not err on method call without a method name' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+           something
+             .(
+               a,
+               b,
+               c
+             )
+        RUBY
+      end
+
+      it 'autocorrects relative to position of relevant method call' do
+        original_source = <<-RUBY.strip_margin('|')
+          | something
+          |   .method_name(
+          |       a,
+          |          b,
+          |            c
+          |   )
+        RUBY
+        correct_source = <<-RUBY.strip_margin('|')
+          | something
+          |   .method_name(
+          |     a,
+          |     b,
+          |     c
+          |   )
+        RUBY
+        expect(autocorrect_source(original_source))
+          .to eq(correct_source)
+      end
+    end
+
+    context 'assigned methods' do
+      context 'with IndentationWidth:Width set to 4' do
+        let(:indentation_width) { 4 }
+
+        it 'accepts the first parameter being on a new row' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+             assigned_value = match(
+                 a,
+                 b,
+                 c
+             )
+          RUBY
+        end
+
+        it 'accepts the first parameter being on method row' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+             assigned_value = match(a,
+                 b,
+                 c
+             )
+          RUBY
+        end
+
+        it 'autocorrects even when first argument is in wrong position' do
+          original_source = <<-RUBY.strip_margin('|')
+            | assigned_value = match(
+            |         a,
+            |            b,
+            |                    c
+            | )
+          RUBY
+
+          correct_source = <<-RUBY.strip_margin('|')
+            | assigned_value = match(
+            |     a,
+            |     b,
+            |     c
+            | )
+          RUBY
+
+          expect(autocorrect_source(original_source))
+            .to eq(correct_source)
+        end
+      end
+
+      context 'with AlignArguments:IndentationWidth set to 4' do
+        let(:config) do
+          RuboCop::Config.new('Layout/AlignArguments' =>
+                              cop_config.merge('IndentationWidth' => 4))
+        end
+
+        it 'accepts the first parameter being on a new row' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+             assigned_value = match(
+                 a,
+                 b,
+                 c
+             )
+          RUBY
+        end
+
+        it 'accepts the first parameter being on method row' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+             assigned_value = match(a,
+                 b,
+                 c
+             )
+          RUBY
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/layout/align_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/align_parameters_spec.rb
@@ -20,416 +20,123 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
 
     it 'registers an offense for parameters with single indent' do
       expect_offense(<<-RUBY.strip_indent)
-        function(a,
-          if b then c else d end)
-          ^^^^^^^^^^^^^^^^^^^^^^ Align the parameters of a method call if they span more than one line.
+        def method(a,
+          b)
+          ^ Align the parameters of a method definition if they span more than one line.
+        end
       RUBY
     end
 
     it 'registers an offense for parameters with double indent' do
       expect_offense(<<-RUBY.strip_indent)
-        function(a,
-            if b then c else d end)
-            ^^^^^^^^^^^^^^^^^^^^^^ Align the parameters of a method call if they span more than one line.
+        def method(a,
+            b)
+            ^ Align the parameters of a method definition if they span more than one line.
+        end
       RUBY
     end
 
-    it 'accepts multiline []= method call' do
+    it 'accepts parameter lists on a single line' do
       expect_no_offenses(<<-RUBY.strip_indent)
-        Test.config["something"] =
-         true
+        def method(a, b)
+        end
       RUBY
     end
 
-    it 'accepts correctly aligned parameters' do
+    it 'accepts proper indentation' do
       expect_no_offenses(<<-RUBY.strip_indent)
-        function(a,
-                 0, 1,
-                 (x + y),
-                 if b then c else d end)
-      RUBY
-    end
-
-    it 'accepts correctly aligned parameters with fullwidth characters' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        f 'Ｒｕｂｙ', g(a,
-                        b)
-      RUBY
-    end
-
-    it 'accepts calls that only span one line' do
-      expect_no_offenses('find(path, s, @special[sexp[0]])')
-    end
-
-    it "doesn't get confused by a symbol argument" do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        add_offense(index,
-                    MSG % kind)
-      RUBY
-    end
-
-    it "doesn't get confused by splat operator" do
-      expect_offense(<<-RUBY.strip_indent)
-        func1(*a,
-              *b,
-              c)
-        func2(a,
-             *b,
-             ^^ Align the parameters of a method call if they span more than one line.
-              c)
-        func3(*a)
-      RUBY
-    end
-
-    it "doesn't get confused by extra comma at the end" do
-      expect_offense(<<-RUBY.strip_indent)
-        func1(a,
-             b,)
-             ^ Align the parameters of a method call if they span more than one line.
-      RUBY
-    end
-
-    it 'can handle a correctly aligned string literal as first argument' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        add_offense(x,
-                    a)
-      RUBY
-    end
-
-    it 'can handle a string literal as other argument' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        add_offense(
-                    "", a)
-      RUBY
-    end
-
-    it "doesn't get confused by a line break inside a parameter" do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        read(path, { headers:    true,
-                     converters: :numeric })
-      RUBY
-    end
-
-    it "doesn't get confused by symbols with embedded expressions" do
-      expect_no_offenses('send(:"#{name}_comments_path")')
-    end
-
-    it "doesn't get confused by regexen with embedded expressions" do
-      expect_no_offenses('a(/#{name}/)')
-    end
-
-    it 'accepts braceless hashes' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        run(collection, :entry_name => label,
-                        :paginator  => paginator)
+        def method(a,
+                   b)
+        end
       RUBY
     end
 
     it 'accepts the first parameter being on a new row' do
       expect_no_offenses(<<-RUBY.strip_indent)
-        match(
+        def method(
           a,
-          b
-        )
+          b)
+        end
       RUBY
     end
 
-    it 'can handle heredoc strings' do
-      expect_no_offenses(<<-'RUBY'.strip_indent)
-        class_eval(<<-EOS, __FILE__, __LINE__ + 1)
-                    def run_#{name}_callbacks(*args)
-                      a = 1
-                      return value
-                    end
-                    EOS
-      RUBY
-    end
-
-    it 'can handle a method call within a method call' do
+    it 'accepts a method definition without parameters' do
       expect_no_offenses(<<-RUBY.strip_indent)
-        a(a1,
-          b(b1,
-            b2),
-          a2)
+        def method
+        end
       RUBY
     end
 
-    it 'can handle a call embedded in a string' do
-      expect_no_offenses('model("#{index(name)}", child)')
-    end
-
-    it 'can handle do-end' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        run(lambda do |e|
-          w = e['warden']
-        end)
+    it "doesn't get confused by splat" do
+      expect_offense(<<-RUBY.strip_indent)
+        def func2(a,
+                 *b,
+                 ^^ Align the parameters of a method definition if they span more than one line.
+                  c)
+        end
       RUBY
     end
 
-    it 'can handle a call with a block inside another call' do
-      expect_no_offenses(<<-'RUBY'.strip_indent)
-        new(table_name,
-            exec_query("info('#{row['name']}')").map { |col|
-              col['name']
-            })
+    it 'auto-corrects alignment' do
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        def method(a,
+            b)
+        end
+      RUBY
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        def method(a,
+                   b)
+        end
       RUBY
     end
 
-    it 'can handle a ternary condition with a block reference' do
-      expect_no_offenses('cond ? a : func(&b)')
-    end
-
-    it 'can handle parentheses used with no parameters' do
-      expect_no_offenses('func()')
-    end
-
-    it 'can handle a multiline hash as second parameter' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        tag(:input, {
-          :value => value
-        })
-      RUBY
-    end
-
-    it 'can handle method calls without parentheses' do
-      expect_no_offenses('a(b c, d)')
-    end
-
-    it 'can handle other method calls without parentheses' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        chars(Unicode.apply_mapping @wrapped_string, :uppercase)
-      RUBY
-    end
-
-    it "doesn't crash and burn when there are nested issues" do
-      # regression test; see GH issue 2441
-      src = <<-RUBY.strip_indent
-        build(:house,
-          :rooms => [
-            build(:bedroom,
-              :bed => build(:bed,
-                :occupants => [],
-                :size => "king"
-              )
-            )
-          ]
-        )
-      RUBY
-      expect { inspect_source(src) }.not_to raise_error
-    end
-
-    context 'method definitions' do
+    context 'defining self.method' do
       it 'registers an offense for parameters with single indent' do
         expect_offense(<<-RUBY.strip_indent)
-          def method(a,
+          def self.method(a,
             b)
             ^ Align the parameters of a method definition if they span more than one line.
           end
         RUBY
       end
 
-      it 'registers an offense for parameters with double indent' do
-        expect_offense(<<-RUBY.strip_indent)
-          def method(a,
-              b)
-              ^ Align the parameters of a method definition if they span more than one line.
-          end
-        RUBY
-      end
-
-      it 'accepts parameter lists on a single line' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          def method(a, b)
-          end
-        RUBY
-      end
-
       it 'accepts proper indentation' do
         expect_no_offenses(<<-RUBY.strip_indent)
-          def method(a,
-                     b)
-          end
-        RUBY
-      end
-
-      it 'accepts the first parameter being on a new row' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          def method(
-            a,
-            b)
-          end
-        RUBY
-      end
-
-      it 'accepts a method definition without parameters' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          def method
-          end
-        RUBY
-      end
-
-      it "doesn't get confused by splat" do
-        expect_offense(<<-RUBY.strip_indent)
-          def func2(a,
-                   *b,
-                   ^^ Align the parameters of a method definition if they span more than one line.
-                    c)
+          def self.method(a,
+                          b)
           end
         RUBY
       end
 
       it 'auto-corrects alignment' do
         new_source = autocorrect_source(<<-RUBY.strip_indent)
-          def method(a,
+          def self.method(a,
               b)
           end
         RUBY
         expect(new_source).to eq(<<-RUBY.strip_indent)
-          def method(a,
-                     b)
+          def self.method(a,
+                          b)
           end
         RUBY
       end
-
-      context 'defining self.method' do
-        it 'registers an offense for parameters with single indent' do
-          expect_offense(<<-RUBY.strip_indent)
-            def self.method(a,
-              b)
-              ^ Align the parameters of a method definition if they span more than one line.
-            end
-          RUBY
-        end
-
-        it 'accepts proper indentation' do
-          expect_no_offenses(<<-RUBY.strip_indent)
-            def self.method(a,
-                            b)
-            end
-          RUBY
-        end
-
-        it 'auto-corrects alignment' do
-          new_source = autocorrect_source(<<-RUBY.strip_indent)
-            def self.method(a,
-                b)
-            end
-          RUBY
-          expect(new_source).to eq(<<-RUBY.strip_indent)
-            def self.method(a,
-                            b)
-            end
-          RUBY
-        end
-      end
     end
 
-    context 'assigned methods' do
-      it 'accepts the first parameter being on a new row' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-           assigned_value = match(
-             a,
-             b,
-             c
-           )
-        RUBY
-      end
-
-      it 'accepts the first parameter being on method row' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-           assigned_value = match(a,
-                                  b,
-                                  c
-                            )
-        RUBY
-      end
-    end
-
-    it 'auto-corrects alignment' do
+    it 'auto-corrects alignment in simple case' do
       new_source = autocorrect_source(<<-RUBY.strip_indent)
-        func(a,
+        def func(a,
                b,
         c)
-      RUBY
-      expect(new_source).to eq(<<-RUBY.strip_indent)
-        func(a,
-             b,
-             c)
-      RUBY
-    end
-
-    it 'auto-corrects each line of a multi-line parameter to the right' do
-      new_source =
-        autocorrect_source(<<-RUBY.strip_indent)
-          create :transaction, :closed,
-                account:          account,
-                open_price:       1.29,
-                close_price:      1.30
-        RUBY
-      expect(new_source)
-        .to eq(<<-RUBY.strip_indent)
-          create :transaction, :closed,
-                 account:          account,
-                 open_price:       1.29,
-                 close_price:      1.30
-        RUBY
-    end
-
-    it 'auto-corrects each line of a multi-line parameter to the left' do
-      new_source =
-        autocorrect_source(<<-RUBY.strip_indent)
-          create :transaction, :closed,
-                   account:          account,
-                   open_price:       1.29,
-                   close_price:      1.30
-        RUBY
-      expect(new_source)
-        .to eq(<<-RUBY.strip_indent)
-          create :transaction, :closed,
-                 account:          account,
-                 open_price:       1.29,
-                 close_price:      1.30
-        RUBY
-    end
-
-    it 'auto-corrects only parameters that begin a line' do
-      original_source = <<-RUBY.strip_indent
-        foo(:bar, {
-            whiz: 2, bang: 3 }, option: 3)
-      RUBY
-      new_source = autocorrect_source(original_source)
-      expect(new_source).to eq(original_source)
-    end
-
-    it 'does not crash in autocorrect on dynamic string in parameter value' do
-      src = <<-'RUBY'.strip_indent
-        class MyModel < ActiveRecord::Base
-          has_many :other_models,
-            class_name: "legacy_name",
-            order: "#{legacy_name.table_name}.published DESC"
-
+          123
         end
       RUBY
-      new_source = autocorrect_source(src)
-      expect(new_source)
-        .to eq <<-'RUBY'.strip_indent
-          class MyModel < ActiveRecord::Base
-            has_many :other_models,
-                     class_name: "legacy_name",
-                     order: "#{legacy_name.table_name}.published DESC"
-
-          end
-        RUBY
-    end
-
-    context 'when using safe navigation operator', :ruby23 do
-      it 'registers an offense for parameters with single indent' do
-        expect_offense(<<-RUBY.strip_indent)
-          receiver&.function(a,
-            if b then c else d end)
-            ^^^^^^^^^^^^^^^^^^^^^^ Align the parameters of a method call if they span more than one line.
-        RUBY
-      end
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        def func(a,
+                 b,
+                 c)
+          123
+        end
+      RUBY
     end
   end
 
@@ -440,298 +147,108 @@ RSpec.describe RuboCop::Cop::Layout::AlignParameters do
       }
     end
 
-    let(:correct_source) do
-      <<-RUBY.strip_indent
-        create :transaction, :closed,
-          account:     account,
-          open_price:  1.29,
-          close_price: 1.30
+    it 'registers an offense for parameters aligned to first param' do
+      expect_offense(<<-RUBY.strip_indent)
+        def method(a,
+                   b)
+                   ^ Use one level of indentation for parameters following the first line of a multi-line method definition.
+        end
       RUBY
     end
 
-    it 'does not autocorrect correct source' do
-      expect(autocorrect_source(correct_source))
-        .to eq(correct_source)
-    end
-
-    it 'autocorrects by outdenting when indented too far' do
-      original_source = <<-RUBY.strip_indent
-        create :transaction, :closed,
-               account:     account,
-               open_price:  1.29,
-               close_price: 1.30
+    it 'registers an offense for parameters with double indent' do
+      expect_offense(<<-RUBY.strip_indent)
+        def method(a,
+            b)
+            ^ Use one level of indentation for parameters following the first line of a multi-line method definition.
+        end
       RUBY
-
-      expect(autocorrect_source(original_source))
-        .to eq(correct_source)
     end
 
-    it 'autocorrects by indenting when not indented' do
-      original_source = <<-RUBY.strip_indent
-        create :transaction, :closed,
-        account:     account,
-        open_price:  1.29,
-        close_price: 1.30
+    it 'accepts parameter lists on a single line' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def method(a, b)
+        end
       RUBY
-
-      expect(autocorrect_source(original_source))
-        .to eq(correct_source)
     end
 
-    it 'autocorrects when first line is indented' do
-      original_source = <<-RUBY.strip_margin('|')
-        |  create :transaction, :closed,
-        |  account:     account,
-        |  open_price:  1.29,
-        |  close_price: 1.30
+    it 'accepts proper indentation' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def method(a,
+          b)
+        end
       RUBY
+    end
 
-      correct_source = <<-RUBY.strip_margin('|')
-        |  create :transaction, :closed,
-        |    account:     account,
-        |    open_price:  1.29,
-        |    close_price: 1.30
+    it 'accepts the first parameter being on a new row' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def method(
+          a,
+          b)
+        end
       RUBY
-
-      expect(autocorrect_source(original_source))
-        .to eq(correct_source)
     end
 
-    context 'multi-line method calls' do
-      it 'can handle existing indentation from multi-line method calls' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-           something
-             .method_name(
-               a,
-               b,
-               c
-             )
-        RUBY
-      end
-
-      it 'registers offenses for double indentation from relevant method' do
-        expect_offense(<<-RUBY.strip_indent)
-           something
-             .method_name(
-                 a,
-                 ^ Use one level of indentation for parameters following the first line of a multi-line method call.
-                 b,
-                 ^ Use one level of indentation for parameters following the first line of a multi-line method call.
-                 c
-                 ^ Use one level of indentation for parameters following the first line of a multi-line method call.
-             )
-        RUBY
-      end
-
-      it 'does not err on method call without a method name' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-           something
-             .(
-               a,
-               b,
-               c
-             )
-        RUBY
-      end
-
-      it 'autocorrects relative to position of relevant method call' do
-        original_source = <<-RUBY.strip_margin('|')
-          | something
-          |   .method_name(
-          |       a,
-          |          b,
-          |            c
-          |   )
-        RUBY
-        correct_source = <<-RUBY.strip_margin('|')
-          | something
-          |   .method_name(
-          |     a,
-          |     b,
-          |     c
-          |   )
-        RUBY
-        expect(autocorrect_source(original_source))
-          .to eq(correct_source)
-      end
+    it 'accepts a method definition without parameters' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def method
+        end
+      RUBY
     end
 
-    context 'method definitions' do
+    it "doesn't get confused by splat" do
+      expect_offense(<<-RUBY.strip_indent)
+        def func2(a,
+                 *b,
+                 ^^ Use one level of indentation for parameters following the first line of a multi-line method definition.
+                  c)
+                  ^ Use one level of indentation for parameters following the first line of a multi-line method definition.
+        end
+      RUBY
+    end
+
+    it 'auto-corrects alignment' do
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        def method(a,
+            b)
+        end
+      RUBY
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        def method(a,
+          b)
+        end
+      RUBY
+    end
+
+    context 'defining self.method' do
       it 'registers an offense for parameters aligned to first param' do
         expect_offense(<<-RUBY.strip_indent)
-          def method(a,
-                     b)
-                     ^ Use one level of indentation for parameters following the first line of a multi-line method definition.
-          end
-        RUBY
-      end
-
-      it 'registers an offense for parameters with double indent' do
-        expect_offense(<<-RUBY.strip_indent)
-          def method(a,
-              b)
-              ^ Use one level of indentation for parameters following the first line of a multi-line method definition.
-          end
-        RUBY
-      end
-
-      it 'accepts parameter lists on a single line' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          def method(a, b)
+          def self.method(a,
+                          b)
+                          ^ Use one level of indentation for parameters following the first line of a multi-line method definition.
           end
         RUBY
       end
 
       it 'accepts proper indentation' do
         expect_no_offenses(<<-RUBY.strip_indent)
-          def method(a,
+          def self.method(a,
             b)
-          end
-        RUBY
-      end
-
-      it 'accepts the first parameter being on a new row' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          def method(
-            a,
-            b)
-          end
-        RUBY
-      end
-
-      it 'accepts a method definition without parameters' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          def method
-          end
-        RUBY
-      end
-
-      it "doesn't get confused by splat" do
-        expect_offense(<<-RUBY.strip_indent)
-          def func2(a,
-                   *b,
-                   ^^ Use one level of indentation for parameters following the first line of a multi-line method definition.
-                    c)
-                    ^ Use one level of indentation for parameters following the first line of a multi-line method definition.
           end
         RUBY
       end
 
       it 'auto-corrects alignment' do
         new_source = autocorrect_source(<<-RUBY.strip_indent)
-          def method(a,
+          def self.method(a,
               b)
           end
         RUBY
         expect(new_source).to eq(<<-RUBY.strip_indent)
-          def method(a,
+          def self.method(a,
             b)
           end
         RUBY
-      end
-
-      context 'defining self.method' do
-        it 'registers an offense for parameters aligned to first param' do
-          expect_offense(<<-RUBY.strip_indent)
-            def self.method(a,
-                            b)
-                            ^ Use one level of indentation for parameters following the first line of a multi-line method definition.
-            end
-          RUBY
-        end
-
-        it 'accepts proper indentation' do
-          expect_no_offenses(<<-RUBY.strip_indent)
-            def self.method(a,
-              b)
-            end
-          RUBY
-        end
-
-        it 'auto-corrects alignment' do
-          new_source = autocorrect_source(<<-RUBY.strip_indent)
-            def self.method(a,
-                b)
-            end
-          RUBY
-          expect(new_source).to eq(<<-RUBY.strip_indent)
-            def self.method(a,
-              b)
-            end
-          RUBY
-        end
-      end
-    end
-
-    context 'assigned methods' do
-      context 'with IndentationWidth:Width set to 4' do
-        let(:indentation_width) { 4 }
-
-        it 'accepts the first parameter being on a new row' do
-          expect_no_offenses(<<-RUBY.strip_indent)
-             assigned_value = match(
-                 a,
-                 b,
-                 c
-             )
-          RUBY
-        end
-
-        it 'accepts the first parameter being on method row' do
-          expect_no_offenses(<<-RUBY.strip_indent)
-             assigned_value = match(a,
-                 b,
-                 c
-             )
-          RUBY
-        end
-
-        it 'autocorrects even when first argument is in wrong position' do
-          original_source = <<-RUBY.strip_margin('|')
-            | assigned_value = match(
-            |         a,
-            |            b,
-            |                    c
-            | )
-          RUBY
-
-          correct_source = <<-RUBY.strip_margin('|')
-            | assigned_value = match(
-            |     a,
-            |     b,
-            |     c
-            | )
-          RUBY
-
-          expect(autocorrect_source(original_source))
-            .to eq(correct_source)
-        end
-      end
-
-      context 'with AlignParameters:IndentationWidth set to 4' do
-        let(:config) do
-          RuboCop::Config.new('Layout/AlignParameters' =>
-                              cop_config.merge('IndentationWidth' => 4))
-        end
-
-        it 'accepts the first parameter being on a new row' do
-          expect_no_offenses(<<-RUBY.strip_indent)
-             assigned_value = match(
-                 a,
-                 b,
-                 c
-             )
-          RUBY
-        end
-
-        it 'accepts the first parameter being on method row' do
-          expect_no_offenses(<<-RUBY.strip_indent)
-             assigned_value = match(a,
-                 b,
-                 c
-             )
-          RUBY
-        end
       end
     end
   end


### PR DESCRIPTION
As suggested in https://github.com/rubocop-hq/rubocop/pull/6929, this PR extracts method call argument alignment logic from method definition parameter alignment logic and cleans ups the messages a bit. Also added a few more examples.

Both of these cops are enabled by default, so this should not be a breaking change in the default configuration. However, if folks override the default behavior for `Layout/AlignParameters`, they'll need to update their configs to override for this new `Layout/AlignArguments` as well.

I suggest releasing this in the same version as https://github.com/rubocop-hq/rubocop/pull/6982 and https://github.com/rubocop-hq/rubocop/pull/6983 so that folks only have to go through one set of breaking changes.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
