### PR TITLE
[Fix #6985] Fix incorrect autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#6935](https://github.com/rubocop-hq/rubocop/issues/6935): `Layout/AccessModifierIndentation` should ignore access modifiers that apply to specific methods. ([@deivid-rodriguez][])
 * [#6956](https://github.com/rubocop-hq/rubocop/issues/6956): Prevent auto-correct confliction of `Lint/Lambda` and `Lint/UnusedBlockArgument`. ([@koic][])
 * [#6915](https://github.com/rubocop-hq/rubocop/issues/6915): Fix false positive in `Style/SafeNavigation` when a modifier if is safe guarding a method call being passed to `break`, `fail`, `next`, `raise`, `return`, `throw`, and `yield`. ([@rrosenblum][])
+* [#6985](https://github.com/rubocop-hq/rubocop/issues/6985): Fix an incorrect auto-correct for `Lint/LiteralInInterpolation` if contains array percent literal. ([@yakout][])
 
 ### Changes
 
@@ -3969,3 +3970,4 @@
 [@jmanian]: https://github.com/jmanian
 [@vfonic]: https://github.com/vfonic
 [@andreaseger]: https://github.com/andreaseger
+[@yakout]: https://github.com/yakout

--- a/lib/rubocop/cop/lint/literal_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/literal_in_interpolation.rb
@@ -18,6 +18,7 @@ module RuboCop
       #   "result is 10"
       class LiteralInInterpolation < Cop
         include RangeHelp
+        include PercentLiteral
 
         MSG = 'Literal interpolation detected.'.freeze
         COMPOSITE = %i[array hash pair irange erange].freeze
@@ -58,6 +59,8 @@ module RuboCop
             node.children.last
           when :sym
             autocorrected_value_for_symbol(node)
+          when :array
+            autocorrected_value_for_array(node)
           else
             node.source.gsub('"', '\"')
           end
@@ -68,6 +71,12 @@ module RuboCop
             node.loc.end ? node.loc.end.begin_pos : node.loc.expression.end_pos
 
           range_between(node.loc.begin.end_pos, end_pos).source
+        end
+
+        def autocorrected_value_for_array(node)
+          return node.source.gsub('"', '\"') unless node.percent_literal?
+
+          contents_range(node).source.split(' ').to_s.gsub('"', '\"')
         end
 
         # Does node print its own source when converted to a string?

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -90,6 +90,13 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
   it_behaves_like('literal interpolation', ':"symbol"', 'symbol')
   it_behaves_like('literal interpolation', 1..2)
   it_behaves_like('literal interpolation', 1...2)
+  it_behaves_like('literal interpolation', '%w[]', '[]')
+  it_behaves_like('literal interpolation', '%w[v1]', '[\"v1\"]')
+  it_behaves_like('literal interpolation', '%w[v1 v2]', '[\"v1\", \"v2\"]')
+  it_behaves_like('literal interpolation', '%i[s1 s2]', '[\"s1\", \"s2\"]')
+  it_behaves_like('literal interpolation', '%I[s1 s2]', '[\"s1\", \"s2\"]')
+  it_behaves_like('literal interpolation', '%i[s1     s2]', '[\"s1\", \"s2\"]')
+  it_behaves_like('literal interpolation', '%i[ s1   s2 ]', '[\"s1\", \"s2\"]')
 
   it 'handles nested interpolations when auto-correction' do
     corrected = autocorrect_source(%("this is \#{"\#{1}"} silly"))


### PR DESCRIPTION
Fixes #6985.

This PR fixes an incorrect auto-correct for Lint/LiteralInInterpolation if contains array percent literals.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
