### PR TITLE
Add obsolete message for renaming `Layout/FirstParameterIndentation`

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -52,6 +52,9 @@ module RuboCop
         'The `Lint/SpaceBeforeFirstArg` cop has been removed, since it was a ' \
         'duplicate of `Layout/SpaceBeforeFirstArg`. Please use ' \
         '`Layout/SpaceBeforeFirstArg` instead.',
+      'Layout/FirstParameterIndentation' =>
+        'The `Layout/FirstParameterIndentation` cop has been renamed to ' \
+        '`Layout/IndentFirstArgument`.',
       'Layout/SpaceAfterControlKeyword' =>
         'The `Layout/SpaceAfterControlKeyword` cop has been removed. Please ' \
         'use `Layout/SpaceAroundKeyword` instead.',


### PR DESCRIPTION
Follow up #6982.

This PR adds obsolete message for renaming `Layout/FirstParameterIndentation`.

The following is when `Layout/FirstParameterIndentation` is specified in .rubocop.yml.

## Before

```console
% rubocop
Warning: unrecognized cop Layout/FirstParameterIndentation found in
.rubocop.yml
```

## After

```console
% rubocop
Error: The `Layout/FirstParameterIndentation` cop has been renamed to
`Layout/IndentFirstArgument`.
(obsolete configuration found in .rubocop.yml, please update it)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
