### PR TITLE
Fix a typo for `Layout/IndentFirstParameter`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -739,7 +739,7 @@ Layout/IndentFirstHashElement:
 Layout/IndentFirstParameter:
   Description: >-
                  Checks the indentation of the first parameter in a
-                 method defintion.
+                 method definition.
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.68'


### PR DESCRIPTION
This PR fixes a typo for `Layout/IndentFirstParameter`.

```console
% misspell -i enviromnent .
config/default.yml:742:24: "defintion" is a misspelling of "definition"
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
