### PR TITLE
Allows for empty if blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* [#6993](https://github.com/rubocop-hq/rubocop/pull/6993): Allowing for empty if blocks, preventing `Style/SafeNavigation` from crashing. ([@RicardoTrindade][])
 * [#6995](https://github.com/rubocop-hq/rubocop/pull/6995): Fix an incorrect auto-correct for `Style/RedundantParentheses` when enclosed in parentheses at `while-post` or `until-post`. ([@koic][])
 * [#6996](https://github.com/rubocop-hq/rubocop/pull/6996): Fix a false positive for `Style/RedundantFreeze` when freezing the result of `String#*`. ([@bquorning][])
 * [#6998](https://github.com/rubocop-hq/rubocop/pull/6998): Fix autocorrect of `Naming/RescuedExceptionsVariableName` to also rename all references to the variable. ([@Darhazer][])
@@ -3985,3 +3986,4 @@
 [@vfonic]: https://github.com/vfonic
 [@andreaseger]: https://github.com/andreaseger
 [@yakout]: https://github.com/yakout
+[@RicardoTrindade]: https://github.com/RicardoTrindade

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -72,7 +72,7 @@ module RuboCop
 
         # if format: (if checked_variable body nil)
         # unless format: (if checked_variable nil body)
-        def_node_matcher :modifier_if_safe_navigation_candidate?, <<-PATTERN
+        def_node_matcher :modifier_if_safe_navigation_candidate, <<-PATTERN
           {
             (if {
                   (send $_ {:nil? :!})
@@ -147,7 +147,7 @@ module RuboCop
 
         def extract_parts_from_if(node)
           variable, receiver =
-            modifier_if_safe_navigation_candidate?(node)
+            modifier_if_safe_navigation_candidate(node)
 
           checked_variable, matching_receiver, method =
             extract_common_parts(receiver, variable)

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -151,7 +151,11 @@ module RuboCop
 
           checked_variable, matching_receiver, method =
             extract_common_parts(receiver, variable)
-          matching_receiver = nil if LOGIC_JUMP_KEYWORDS.include?(receiver.type)
+
+          if receiver && LOGIC_JUMP_KEYWORDS.include?(receiver.type)
+            matching_receiver = nil
+          end
+
           [checked_variable, matching_receiver, receiver, method]
         end
 

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -144,6 +144,15 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
       RUBY
     end
 
+    it 'allows for empty if blocks with comments' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        if foo
+          # a random commnet
+          # TODO: Implement this before
+        end
+      RUBY
+    end
+
     it 'allows a method call as a parameter when the parameter is ' \
       'safe guarded with an object check' do
       expect_no_offenses('foo(bar.baz) if bar')


### PR DESCRIPTION
On version 0.68, if you an empty if block, rubocop throws an error. This PR aims to fix this error, allowing for empty blocks with comments. Would like to get your opinion on this, do you think there's a need for a new cop that does not allow for empty if blocks, or if this fix is enough.
```
 NoMethodError:
       undefined method `type' for nil:NilClass
```
Error occured with:
0.68.0 (using Parser 2.6.3.0, running on ruby 2.3.7 x86_64-linux)
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
