### PR TITLE
Mark Naming/RescuedExceptionsVariableName as unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#6994](https://github.com/rubocop-hq/rubocop/pull/6994): Mark Naming/RescuedExceptionsVariableName as unsafe. ([@vfonic][])
+
 ## 0.68.0 (2019-04-29)
 
 ### New features

--- a/config/default.yml
+++ b/config/default.yml
@@ -1997,8 +1997,9 @@ Naming/PredicateName:
 Naming/RescuedExceptionsVariableName:
   Description: 'Use consistent rescued exceptions variables naming.'
   Enabled: true
+  Safe: false
   VersionAdded: '0.67'
-  VersionChanged: '0.68'
+  VersionChanged: '0.69'
   PreferredName: e
 
 Naming/UncommunicativeBlockParamName:

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -481,7 +481,7 @@ Exclude | `spec/**/*` | Array
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.67 | 0.68
+Enabled | No | Yes  | 0.67 | 0.69
 
 This cop makes sure that rescued exceptions variables are named as
 expected.


### PR DESCRIPTION
I just ran `rubocop --safe-auto-correct` and it made this autocorrect change:

```ruby
-   rescue ActiveResource::Redirection => redirection
+   rescue ActiveResource::Redirection => e
      redirect_to redirection.response['Location']
    end
```

This is obviously a breaking change. I believe the easiest fix here is to mark this cop as unsafe, as, as far as I know, rubocop doesn't offer the extensive functionality for renaming a variable (`redirection`) across all of its usages.

I'm open for suggestions for better fix.

EDIT: I dug down and realized this has just recently been added by @anthony-robin (Thanks!) in this PR #6905. @anthony-robin, what do you think of marking this cop unsafe?

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/