### PR TITLE
Fix an incorrect auto-correct for `Style/RedundantParentheses`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#6995](https://github.com/rubocop-hq/rubocop/pull/6995): Fix an incorrect auto-correct for `Style/RedundantParentheses` when enclosed in parentheses at `while-post` or `until-post`. ([@koic][])
+
 ## 0.68.0 (2019-04-29)
 
 ### New features

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -28,6 +28,8 @@ module RuboCop
 
         def on_begin(node)
           return if !parentheses?(node) || parens_allowed?(node)
+          return if node.parent && (node.parent.while_post_type? ||
+                                    node.parent.until_post_type?)
 
           check(node)
         end

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -197,6 +197,22 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses do
     RUBY
   end
 
+  it 'accepts parentheses when enclosed in parentheses at `while-post`' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      begin
+        do_something
+      end while(bar)
+    RUBY
+  end
+
+  it 'accepts parentheses when enclosed in parentheses at `until-post`' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      begin
+        do_something
+      end until(bar)
+    RUBY
+  end
+
   it 'accepts parentheses when they touch the preceding keyword' do
     expect_no_offenses('if x; y else(1) end')
   end


### PR DESCRIPTION
This PR fixes an incorrect auto-correct for `Style/RedundantParentheses` when enclosed in parentheses at `while-post` or `until-post`.

The following is a reproduction step.

```console
% rubocop example1.rb --only Style/RedundantParentheses -a
Inspecting 1 file
E

Offenses:

example1.rb:3:5: E: Lint/Syntax: unexpected token tIDENTIFIER
(Using Ruby 2.2 parser; configure using TargetRubyVersion parameter,
under AllCops)
end whilefoo
    ^^^^^^^^
example1.rb:3:10: C: [Corrected] Style/RedundantParentheses:
Don't use parentheses around a method call.
end while(foo)
    ^^^^^

1 file inspected, 2 offenses detected, 1 offense corrected
```

This is a broken `while`.

```diff
% git diff
diff --git a/example1.rb b/example1.rb
index cf5523f..5f47ae4 100644
--- a/example1.rb
+++ b/example1.rb
@@ -1,3 +1,3 @@
 begin
   do_something
-end while(foo)
+end whilefoo
```

This will not be warned when `while` ... `end`.

```consle
% cat example2.rb
while(foo)
  do_something
end

% rubocop example2.rb --only Style/RedundantParentheses
Inspecting 1 file
.

1 file inspected, no offenses detected
```

So this PR changes to the same behavior.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
