### PR TITLE
Improve Naming/RescuedExceptionsVariableName autocorrection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#6995](https://github.com/rubocop-hq/rubocop/pull/6995): Fix an incorrect auto-correct for `Style/RedundantParentheses` when enclosed in parentheses at `while-post` or `until-post`. ([@koic][])
+* [#6998](https://github.com/rubocop-hq/rubocop/pull/6998): Fix autocorrect of `Naming/RescuedExceptionsVariableName` to also rename all references to the variable. ([@Darhazer][])
 
 ## 0.68.0 (2019-04-29)
 

--- a/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
+++ b/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
@@ -69,7 +69,16 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
+            offending_name = node.exception_variable.children.first
             corrector.replace(offense_range(node), preferred_name)
+
+            return unless node.body
+
+            node.body.each_descendant(:lvar) do |var|
+              next unless var.children.first == offending_name
+
+              corrector.replace(var.loc.expression, preferred_name)
+            end
           end
         end
 

--- a/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
@@ -176,6 +176,27 @@ RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
         end
       end
     end
+
+    context 'with variable being referenced' do
+      it 'renames the variable references when auto-correcting' do
+        expect_offense(<<-RUBY.strip_indent)
+          begin
+            get something
+          rescue ActiveResource::Redirection => redirection
+                                                ^^^^^^^^^^^ Use `e` instead of `redirection`.
+            redirect_to redirection.response['Location']
+          end
+        RUBY
+
+        expect_correction(<<-RUBY.strip_indent)
+          begin
+            get something
+          rescue ActiveResource::Redirection => e
+            redirect_to e.response['Location']
+          end
+        RUBY
+      end
+    end
   end
 
   context 'with the `PreferredName` setup' do


### PR DESCRIPTION
Follow up on #6994, this PR adds renaming of the variable references inside the resbody

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
