### PR TITLE
Refactor cops to use matching on children

### DIFF
--- a/lib/rubocop/cop/internal_affairs/redundant_location_argument.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_location_argument.rb
@@ -21,12 +21,10 @@ module RuboCop
 
         MSG = 'Redundant location argument to `#add_offense`.'.freeze
 
-        def_node_matcher :add_offense_kwargs, <<-PATTERN
-          (send nil? :add_offense _ $hash)
-        PATTERN
-
-        def_node_matcher :redundant_location_argument?, <<-PATTERN
-          (pair (sym :location) (sym :expression))
+        def_node_matcher :redundant_location_argument, <<-PATTERN
+          (send nil? :add_offense _
+            (hash <$(pair (sym :location) (sym :expression)) ...>)
+          )
         PATTERN
 
         def on_send(node)
@@ -37,17 +35,6 @@ module RuboCop
           range = offending_range(node)
 
           ->(corrector) { corrector.remove(range) }
-        end
-
-        private
-
-        def redundant_location_argument(node)
-          add_offense_kwargs(node) do |kwargs|
-            result =
-              kwargs.pairs.find { |arg| redundant_location_argument?(arg) }
-
-            yield result if result
-          end
         end
 
         def offending_range(node)

--- a/lib/rubocop/cop/rails/belongs_to.rb
+++ b/lib/rubocop/cop/rails/belongs_to.rb
@@ -66,52 +66,34 @@ module RuboCop
           'this option altogether'.freeze
 
         def_node_matcher :match_belongs_to_with_options, <<-PATTERN
-          (send $_ :belongs_to _ (hash $...))
-        PATTERN
-
-        def_node_matcher :match_required_false?, <<-PATTERN
-          (pair (sym :required) false)
-        PATTERN
-
-        def_node_matcher :match_required_true?, <<-PATTERN
-          (pair (sym :required) true)
+          (send _ :belongs_to _
+            (hash <$(pair (sym :required) ${true false}) ...>)
+          )
         PATTERN
 
         def on_send(node)
-          opt = extract_required_option(node)
-          return unless opt
-          return unless match_required_true?(opt) || match_required_false?(opt)
+          match_belongs_to_with_options(node) do |_option_node, option_value|
+            message =
+              if option_value.true_type?
+                SUPERFLOUS_REQUIRE_TRUE_MSG
+              elsif option_value.false_type?
+                SUPERFLOUS_REQUIRE_FALSE_MSG
+              end
 
-          message =
-            if match_required_true?(opt)
-              SUPERFLOUS_REQUIRE_TRUE_MSG
-            elsif match_required_false?(opt)
-              SUPERFLOUS_REQUIRE_FALSE_MSG
-            end
-
-          add_offense(node, message: message, location: :selector)
-        end
-
-        def autocorrect(node)
-          opt = extract_required_option(node)
-          return unless opt
-
-          lambda do |corrector|
-            if match_required_true?(opt)
-              corrector.replace(opt.loc.expression, 'optional: false')
-            elsif match_required_false?(opt)
-              corrector.replace(opt.loc.expression, 'optional: true')
-            end
+            add_offense(node, message: message, location: :selector)
           end
         end
 
-        def extract_required_option(node)
-          _, opts = match_belongs_to_with_options(node)
-          return unless opts
+        def autocorrect(node)
+          option_node, option_value = match_belongs_to_with_options(node)
+          return unless option_node
 
-          opts.find do |opt|
-            match_required_true?(opt) ||
-              match_required_false?(opt)
+          lambda do |corrector|
+            if option_value.true_type?
+              corrector.replace(option_node.loc.expression, 'optional: false')
+            elsif option_value.false_type?
+              corrector.replace(option_node.loc.expression, 'optional: true')
+            end
           end
         end
       end

--- a/lib/rubocop/cop/rails/delegate_allow_blank.rb
+++ b/lib/rubocop/cop/rails/delegate_allow_blank.rb
@@ -16,33 +16,19 @@ module RuboCop
       class DelegateAllowBlank < Cop
         MSG = '`allow_blank` is not a valid option, use `allow_nil`.'.freeze
 
-        def_node_matcher :delegate_options, <<-PATTERN
-          (send nil? :delegate _ $hash)
-        PATTERN
-
-        def_node_matcher :allow_blank_option?, <<-PATTERN
-          (pair (sym :allow_blank) true)
+        def_node_matcher :allow_blank_option, <<-PATTERN
+          (send nil? :delegate _ (hash <$(pair (sym :allow_blank) true) ...>))
         PATTERN
 
         def on_send(node)
-          offending_node = allow_blank_option(node)
-
-          return unless offending_node
-
-          add_offense(offending_node)
+          allow_blank_option(node) do |offending_node|
+            add_offense(offending_node)
+          end
         end
 
         def autocorrect(pair_node)
           lambda do |corrector|
             corrector.replace(pair_node.key.source_range, 'allow_nil')
-          end
-        end
-
-        private
-
-        def allow_blank_option(node)
-          delegate_options(node) do |hash|
-            hash.pairs.find { |opt| allow_blank_option?(opt) }
           end
         end
       end

--- a/lib/rubocop/cop/rails/http_status.rb
+++ b/lib/rubocop/cop/rails/http_status.rb
@@ -48,8 +48,8 @@ module RuboCop
           }
         PATTERN
 
-        def_node_matcher :status_pair?, <<-PATTERN
-          (pair (sym :status) ${int sym})
+        def_node_matcher :status_code, <<-PATTERN
+          (hash <(pair (sym :status) ${int sym}) ...>)
         PATTERN
 
         def on_send(node)
@@ -76,13 +76,6 @@ module RuboCop
         end
 
         private
-
-        def status_code(node)
-          node.each_pair.each do |pair|
-            status_pair?(pair) { |code| return code }
-          end
-          false
-        end
 
         def checker_class
           case style

--- a/lib/rubocop/cop/rails/reflection_class_name.rb
+++ b/lib/rubocop/cop/rails/reflection_class_name.rb
@@ -16,21 +16,20 @@ module RuboCop
       class ReflectionClassName < Cop
         MSG = 'Use a string value for `class_name`.'.freeze
 
-        def_node_matcher :association_with_options?, <<-PATTERN
-          (send nil? {:has_many :has_one :belongs_to} _ (hash $...))
+        def_node_matcher :association_with_reflection, <<-PATTERN
+          (send nil? {:has_many :has_one :belongs_to} _
+            (hash <$#reflection_class_name ...>)
+          )
         PATTERN
 
-        def_node_search :reflection_class_name, <<-PATTERN
+        def_node_matcher :reflection_class_name, <<-PATTERN
           (pair (sym :class_name) [!dstr !str !sym])
         PATTERN
 
         def on_send(node)
-          return unless association_with_options?(node)
-
-          reflection_class_name = reflection_class_name(node).first
-          return unless reflection_class_name
-
-          add_offense(node, location: reflection_class_name.loc.expression)
+          association_with_reflection(node) do |reflection_class_name|
+            add_offense(node, location: reflection_class_name.loc.expression)
+          end
         end
       end
     end


### PR DESCRIPTION
Following the great work in #6965 this refactors few cops to take advantage of the new node matching capabilities and removes the helper methods.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
