### PR TITLE
[Fix #6972] Fix a false positive for `Style/MixinUsage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#6996](https://github.com/rubocop-hq/rubocop/pull/6996): Fix a false positive for `Style/RedundantFreeze` when freezing the result of `String#*`. ([@bquorning][])
 * [#6998](https://github.com/rubocop-hq/rubocop/pull/6998): Fix autocorrect of `Naming/RescuedExceptionsVariableName` to also rename all references to the variable. ([@Darhazer][])
 * [#6992](https://github.com/rubocop-hq/rubocop/pull/6992): Fix unknown default configuration for `Layout/IndentFirstParameter` cop. ([@drenmi][])
+* [#6972](https://github.com/rubocop-hq/rubocop/issues/6972): Fix a false positive for `Style/MixinUsage` when using inside block and `if` condition is after `include`. ([@koic][])
 
 ## 0.68.0 (2019-04-29)
 

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -212,7 +212,7 @@ module RuboCop
 
       def_node_matcher :macro_scope?, <<-PATTERN
         {^{({sclass class module block} ...) class_constructor?}
-         ^^{({sclass class module block} ... (begin ...)) class_constructor?}
+         ^^{({sclass class module block} ... ({begin if} ...)) class_constructor?}
          ^#macro_kwbegin_wrapper?
          #root_node?}
       PATTERN

--- a/spec/rubocop/cop/style/mixin_usage_spec.rb
+++ b/spec/rubocop/cop/style/mixin_usage_spec.rb
@@ -62,6 +62,15 @@ RSpec.describe RuboCop::Cop::Style::MixinUsage do
       RUBY
     end
 
+    it 'does not register an offense when using inside block ' \
+       'and `if` condition is after `include`' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        klass.class_eval do
+          include M if defined?(M)
+        end
+      RUBY
+    end
+
     it "doesn't register an offense when `include` call is a method argument" do
       expect_no_offenses(<<-RUBY.strip_indent)
         do_something(include(M))


### PR DESCRIPTION
Fixes #6972

This PR fixes a false positive for `Style/MixinUsage` when using inside block and `if` condition is after `include`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
