### PR TITLE
[Fix #6992] Fix unknown default configuration for Layout/IndentFirstParameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#6995](https://github.com/rubocop-hq/rubocop/pull/6995): Fix an incorrect auto-correct for `Style/RedundantParentheses` when enclosed in parentheses at `while-post` or `until-post`. ([@koic][])
 * [#6996](https://github.com/rubocop-hq/rubocop/pull/6996): Fix a false positive for `Style/RedundantFreeze` when freezing the result of `String#*`. ([@bquorning][])
 * [#6998](https://github.com/rubocop-hq/rubocop/pull/6998): Fix autocorrect of `Naming/RescuedExceptionsVariableName` to also rename all references to the variable. ([@Darhazer][])
+* [#6992](https://github.com/rubocop-hq/rubocop/pull/6992): Fix unknown default configuration for `Layout/IndentFirstParameter` cop. ([@drenmi][])
 
 ## 0.68.0 (2019-04-29)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -743,7 +743,7 @@ Layout/IndentFirstParameter:
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.68'
-  EnforcedStyle: special_for_inner_method_call_in_parentheses
+  EnforcedStyle: consistent
   SupportedStyles:
     - consistent
     - align_parentheses

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2529,7 +2529,7 @@ end
 
 Name | Default value | Configurable values
 --- | --- | ---
-EnforcedStyle | `special_for_inner_method_call_in_parentheses` | `consistent`, `align_parentheses`
+EnforcedStyle | `consistent` | `consistent`, `align_parentheses`
 IndentationWidth | `<none>` | Integer
 
 ## Layout/IndentHeredoc


### PR DESCRIPTION
Looks like most likely a mistake when copying the configuration from `Layout/IndentFirstArgument` to `Layout/IndentFirstParameter`.

**Note:** This fixes the crashing, but doesn't dig deeper into whether the new cop works as intended.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
