### PR TITLE
Fix an incorrect auto-correct for `Style/InverseMethods`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [#6956](https://github.com/rubocop-hq/rubocop/issues/6956): Prevent auto-correct confliction of `Lint/Lambda` and `Lint/UnusedBlockArgument`. ([@koic][])
 * [#6915](https://github.com/rubocop-hq/rubocop/issues/6915): Fix false positive in `Style/SafeNavigation` when a modifier if is safe guarding a method call being passed to `break`, `fail`, `next`, `raise`, `return`, `throw`, and `yield`. ([@rrosenblum][])
 * [#6985](https://github.com/rubocop-hq/rubocop/issues/6985): Fix an incorrect auto-correct for `Lint/LiteralInInterpolation` if contains array percent literal. ([@yakout][])
+* [#7003](https://github.com/rubocop-hq/rubocop/pull/7003): Fix an incorrect auto-correct for `Style/InverseMethods` when using `BasicObject#!`. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -30,6 +30,7 @@ module RuboCop
       #   !(foo.class < Numeric) # Checking class hierarchy is allowed
       class InverseMethods < Cop
         include IgnoredNode
+        include RangeHelp
 
         MSG = 'Use `%<inverse>s` instead of inverting `%<method>s`.'.freeze
         CLASS_COMPARISON_METHODS = %i[<= >= < >].freeze
@@ -121,6 +122,11 @@ module RuboCop
             selector[0] = '='
             corrector.replace(block.loc.selector, selector)
           else
+            if block.loc.dot
+              range = dot_range(block.loc)
+              corrector.remove(range)
+            end
+
             corrector.remove(block.loc.selector)
           end
         end
@@ -164,6 +170,10 @@ module RuboCop
 
         def camel_case_constant?(node)
           node.const_type? && node.source =~ CAMEL_CASE
+        end
+
+        def dot_range(loc)
+          range_between(loc.dot.begin_pos, loc.expression.end_pos)
         end
       end
     end

--- a/spec/rubocop/cop/style/inverse_methods_spec.rb
+++ b/spec/rubocop/cop/style/inverse_methods_spec.rb
@@ -254,6 +254,18 @@ RSpec.describe RuboCop::Cop::Style::InverseMethods do
         expect(new_source).to eq("foo.#{inverse} { |e| e.bar? }")
       end
 
+      it 'corrects an inverted method call when using `BasicObject#!`' do
+        new_source = autocorrect_source("foo.#{method} { |e| e.bar?.! }")
+
+        expect(new_source).to eq("foo.#{inverse} { |e| e.bar? }")
+      end
+
+      it 'corrects an inverted method call when using `BasicObject#  !`' do
+        new_source = autocorrect_source("foo.#{method} { |e| e.bar?.  ! }")
+
+        expect(new_source).to eq("foo.#{inverse} { |e| e.bar? }")
+      end
+
       it 'corrects a complex inverted method call' do
         source = "puts 1 if !foo.#{method} { |e| !e.bar? }"
         new_source = autocorrect_source(source)


### PR DESCRIPTION
This PR fixes an incorrect auto-correct for `Style/InverseMethods`
when using `BasicObject#!`.

The following is a reproduction step.

```ruby
# example.rb
foo.reject { |e| e.bar?.! }
```

```console
% rubocop example.rb --only Style/InverseMethods -a
Inspecting 1 file
E

Offenses:

example.rb:1:1: C: [Corrected] Style/InverseMethods: Use select instead
of inverting reject.
foo.reject { |e| e.bar?.! }
^^^^^^^^^^^^^^^^^^^^^^^^^^^
example.rb:1:26: E: Lint/Syntax: unexpected token tRCURLY
(Using Ruby 2.4 parser; configure using TargetRubyVersion parameter,
under AllCops)
foo.select { |e| e.bar?. }
                         ^

1 file inspected, 2 offenses detected, 1 offense corrected
```

## Before

The following is an invalid syntax.

```diff
% g diff
diff --git a/example.rb b/example.rb
index 3efc6bf..cc6cf14 100644
--- a/example.rb
+++ b/example.rb
@@ -1 +1 @@
-foo.reject { |e| e.bar?.! }
+foo.select { |e| e.bar?. }
```

## After

The following si a valid syntax.

```diff
% g diff
diff --git a/example.rb b/example.rb
index 3efc6bf..cc6cf14 100644
--- a/example.rb
+++ b/example.rb
@@ -1 +1 @@
-foo.reject { |e| e.bar?.! }
+foo.select { |e| e.bar? }
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
