### PR TITLE
Add a validation for RuboCop's own config/default.yml for supported styles other than EnforcedStyle

### DIFF
--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -40,10 +40,16 @@ RSpec.describe 'RuboCop Project', type: :feature do
       cop_names.each do |name|
         enforced_styles = config[name]
                           .select { |key, _| key.start_with?('Enforced') }
-        enforced_styles.each_key do |style_name|
+        enforced_styles.each do |style_name, style|
           supported_key = RuboCop::Cop::Util.to_supported_styles(style_name)
           valid = config[name][supported_key]
-          errors.push("#{supported_key} is missing for #{name}") unless valid
+          unless valid
+            errors.push("#{supported_key} is missing for #{name}")
+            next
+          end
+          next if valid.include?(style)
+
+          errors.push("invalid #{style_name} '#{style}' for #{name} found")
         end
       end
 


### PR DESCRIPTION


I added same validation to RuboCop::Config#validate_enforced_styles.

https://github.com/rubocop-hq/rubocop/blob/v0.68.0/lib/rubocop/config.rb#L545-L550

----

If accidentally typos committed, 

```diff
--- a/config/default.yml
+++ b/config/default.yml
@@ -211,7 +211,7 @@ Layout/AccessModifierIndentation:
   StyleGuide: '#indent-public-private-protected'
   Enabled: true
   VersionAdded: '0.49'
-  EnforcedStyle: indent
+  EnforcedStyle: indenttttttttt
   SupportedStyles:
     - outdent
     - indent
```

CI will fail.

```
$ bundle exec rspec spec/project_spec.rb
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 2116
..F...............

Failures:

  1) RuboCop Project default configuration file has a SupportedStyles for all EnforcedStyle and EnforcedStyle is valid
     Failure/Error: raise errors.join("\n") unless errors.empty?

     RuntimeError:
       invalid EnforcedStyle 'indenttttttttt' for Layout/AccessModifierIndentation found
     # ./spec/project_spec.rb:56:in `block (3 levels) in <top (required)>'

Finished in 1.36 seconds (files took 1.28 seconds to load)
18 examples, 1 failure

Failed examples:

rspec ./spec/project_spec.rb:37 # RuboCop Project default configuration file has a SupportedStyles for all EnforcedStyle and EnforcedStyle is valid

Randomized with seed 2116
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
