### PR TITLE
[Fix #6738] Prevent auto-correct conflict of `Style/Next` and `Style/SafeNavigation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#6998](https://github.com/rubocop-hq/rubocop/pull/6998): Fix autocorrect of `Naming/RescuedExceptionsVariableName` to also rename all references to the variable. ([@Darhazer][])
 * [#6992](https://github.com/rubocop-hq/rubocop/pull/6992): Fix unknown default configuration for `Layout/IndentFirstParameter` cop. ([@drenmi][])
 * [#6972](https://github.com/rubocop-hq/rubocop/issues/6972): Fix a false positive for `Style/MixinUsage` when using inside block and `if` condition is after `include`. ([@koic][])
+* [#6738](https://github.com/rubocop-hq/rubocop/issues/6738): Prevent auto-correct conflict of `Style/Next` and `Style/SafeNavigation`. ([@hoshinotsuyoshi][])
 
 ## 0.68.0 (2019-04-29)
 

--- a/lib/rubocop/cop/style/next.rb
+++ b/lib/rubocop/cop/style/next.rb
@@ -54,6 +54,10 @@ module RuboCop
         MSG = 'Use `next` to skip iteration.'.freeze
         EXIT_TYPES = %i[break return].freeze
 
+        def self.autocorrect_incompatible_with
+          [Style::SafeNavigation]
+        end
+
         def investigate(_processed_source)
           # When correcting nested offenses, we need to keep track of how much
           # we have adjusted the indentation of each line

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -467,6 +467,36 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     expect(IO.read('example.rb')).to eq(corrected)
   end
 
+  it 'corrects Style/Next and Style/SafeNavigation offenses' do
+    create_file('.rubocop.yml', <<-YAML.strip_indent)
+      AllCops:
+        TargetRubyVersion: 2.3
+    YAML
+    source = <<-'RUBY'.strip_indent
+      until x
+        if foo
+          foo.some_method do
+            y
+          end
+        end
+      end
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run([
+                     '--auto-correct',
+                     '--only', 'Style/Next,Style/SafeNavigation'
+                   ])).to eq(0)
+    corrected = <<-'RUBY'.strip_indent
+      until x
+        next unless foo
+        foo.some_method do
+          y
+        end
+      end
+    RUBY
+    expect(IO.read('example.rb')).to eq(corrected)
+  end
+
   it 'corrects `Lint/Lambda` and `Lint/UnusedBlockArgument` offenses' do
     source = <<-'RUBY'.strip_indent
       c = -> event do


### PR DESCRIPTION


Fixes #6738

Solves problem like below:

### problem

  ```ruby
  until x
    if foo
      foo.some_method do
        y
      end
    end
  end
  ```

  auto-corrects badly;

  ```ruby
  # frozen_string_literal: true

  until x
    next unless foofoo&.some_method do
      y
    end
  end
  ```

( in rubocop.yml, TargetRubyVersion: 2.3 needed(2.3 or higher version). )


### new behavior


auto-corrects:

```ruby
# frozen_string_literal: true

until x
  next unless foo

  foo.some_method do
    y
  end
end
```


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
