### PR TITLE
[Fix #6937] Make Style/BlockDelimiters aware of safe navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#7007](https://github.com/rubocop-hq/rubocop/pull/7007): Fix `Style/BlockDelimiters` with `braces_for_chaining` style false positive, when chaining using safe navigation. ([@Darhazer][])
+
+
 ## 0.68.1 (2019-04-30)
 
 ### Bug fixes

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -459,8 +459,12 @@ module RuboCop
         loc.respond_to?(:begin) && loc.begin && loc.begin.is?('(')
       end
 
+      def call_type?
+        send_type? || csend_type?
+      end
+
       def chained?
-        parent && parent.send_type? && eql?(parent.receiver)
+        parent && parent.call_type? && eql?(parent.receiver)
       end
 
       def argument?

--- a/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
+++ b/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
@@ -56,7 +56,6 @@ module RuboCop
         MSG = 'Put the closing parenthesis for a method call with a ' \
         'HEREDOC parameter on the same line as the HEREDOC opening.'.freeze
 
-        STRING_TYPES = %i[str dstr xstr].freeze
         def on_send(node)
           heredoc_arg = extract_heredoc_argument(node)
           return unless heredoc_arg
@@ -123,16 +122,11 @@ module RuboCop
         end
 
         def send_missing_closing_parens?(parent, child, heredoc)
-          send_node?(parent) &&
+          parent &&
+            parent.call_type? &&
             parent.arguments.include?(child) &&
             parent.loc.begin &&
             parent.loc.end.line != heredoc.last_line
-        end
-
-        def send_node?(node)
-          return nil unless node
-
-          node.send_type? || node.csend_type?
         end
 
         def extract_heredoc_argument(node)
@@ -154,7 +148,7 @@ module RuboCop
         end
 
         def heredoc_node?(node)
-          node && STRING_TYPES.include?(node.type) && node.heredoc?
+          node.respond_to?(:heredoc?) && node.heredoc?
         end
 
         def single_line_send_with_heredoc_receiver?(node)

--- a/lib/rubocop/cop/lint/heredoc_method_call_position.rb
+++ b/lib/rubocop/cop/lint/heredoc_method_call_position.rb
@@ -36,7 +36,6 @@ module RuboCop
         MSG = 'Put a method call with a HEREDOC receiver on the ' \
         'same line as the HEREDOC opening.'.freeze
 
-        STRING_TYPES = %i[str dstr xstr].freeze
         def on_send(node)
           heredoc = heredoc_node_descendent_receiver(node)
           return unless heredoc
@@ -72,11 +71,11 @@ module RuboCop
         def send_node?(node)
           return nil unless node
 
-          node.send_type? || node.csend_type?
+          node.call_type?
         end
 
         def heredoc_node?(node)
-          node && STRING_TYPES.include?(node.type) && node.heredoc?
+          node.respond_to?(:heredoc?) && node.heredoc?
         end
 
         def call_after_heredoc_range(heredoc)

--- a/lib/rubocop/cop/mixin/check_assignment.rb
+++ b/lib/rubocop/cop/mixin/check_assignment.rb
@@ -31,7 +31,7 @@ module RuboCop
           _scope, _lhs, rhs = *node
         elsif node.op_asgn_type?
           _lhs, _op, rhs = *node
-        elsif node.send_type? || node.csend_type?
+        elsif node.call_type?
           rhs = node.last_argument
         elsif node.assignment?
           _lhs, rhs = *node

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -176,6 +176,10 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
             each { |x| puts x }
                  ^ Prefer `do...end` over `{...}` for procedural blocks.
           RUBY
+
+          expect_correction(<<-RUBY.strip_indent)
+            each do |x| puts x end
+          RUBY
         end
 
         it 'accepts a single line block with do-end if it is procedural' do
@@ -467,15 +471,8 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
              ^^ Prefer `{...}` over `do...end` for multi-line chained blocks.
         end.map(&:to_s)
       RUBY
-    end
 
-    it 'auto-corrects do-end for chained blocks' do
-      src = <<-RUBY.strip_indent
-        each do |x|
-        end.map(&:to_s)
-      RUBY
-      new_source = autocorrect_source(src)
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect_correction(<<-RUBY.strip_indent)
         each { |x|
         }.map(&:to_s)
       RUBY
@@ -545,6 +542,21 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
         RUBY
       end
     end
+
+    context 'with safe navigation', :ruby23 do
+      it 'registers an offense for multi-line chained do-end blocks' do
+        expect_offense(<<-RUBY.strip_indent)
+          arr&.each do |x|
+                    ^^ Prefer `{...}` over `do...end` for multi-line chained blocks.
+          end&.map(&:to_s)
+        RUBY
+
+        expect_correction(<<-RUBY.strip_indent)
+          arr&.each { |x|
+          }&.map(&:to_s)
+        RUBY
+      end
+    end
   end
 
   context 'always braces' do
@@ -560,6 +572,10 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
         each do |x| end
              ^^ Prefer `{...}` over `do...end` for blocks.
       RUBY
+
+      expect_correction(<<-RUBY.strip_indent)
+        each { |x| }
+      RUBY
     end
 
     it 'accepts a single line block with braces' do
@@ -572,11 +588,6 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
              ^^ Prefer `{...}` over `do...end` for blocks.
         end
       RUBY
-    end
-
-    it 'auto-corrects do and end for single line blocks to { and }' do
-      new_source = autocorrect_source('block do |x| end')
-      expect(new_source).to eq('block { |x| }')
     end
 
     it 'does not auto-correct do-end if {} would change the meaning' do
@@ -599,15 +610,8 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
              ^^ Prefer `{...}` over `do...end` for blocks.
         end.map(&:to_s)
       RUBY
-    end
 
-    it 'auto-corrects do-end for chained blocks' do
-      src = <<-RUBY.strip_indent
-        each do |x|
-        end.map(&:to_s)
-      RUBY
-      new_source = autocorrect_source(src)
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect_correction(<<-RUBY.strip_indent)
         each { |x|
         }.map(&:to_s)
       RUBY

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -253,6 +253,16 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier do
     RUBY
   end
 
+  context 'with safe navigation', :ruby23 do
+    it 'accepts if-end followed by a chained call' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        if test
+          something
+        end&.inspect
+      RUBY
+    end
+  end
+
   it "doesn't break if-end when used as RHS of local var assignment" do
     corrected = autocorrect_source(<<-RUBY.strip_indent)
       a = if b


### PR DESCRIPTION
We have cops that check for send_node. While for some cops it's perfectly fine to work only with send nodes, others were just made before csend type nodes appeared. This PR makes `node#chained?` aware of safe navigation.

I'm not sure for the name that checks for either send or csend. Such helper method, however, will help writing code that is aware of safe navigation. I've refactored few placed that have such checks.

We have to review cops that check explicitly for `send_type?` or have `on_send` but not `on_csend`. For the majority of them handling csend won't make sense, but I guess there might be few more cops that need to be updated.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
