### PR TITLE
Mark the default `EnforcedStyle` for `Layout/IndentFirstParameter`

### DIFF
--- a/lib/rubocop/cop/layout/indent_first_parameter.rb
+++ b/lib/rubocop/cop/layout/indent_first_parameter.rb
@@ -16,7 +16,7 @@ module RuboCop
       #     123
       #   end
       #
-      # @example EnforcedStyle: consistent
+      # @example EnforcedStyle: consistent (default)
       #   # The first parameter should always be indented one step more than the
       #   # preceding line.
       #

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2498,7 +2498,7 @@ second_param)
   123
 end
 ```
-#### EnforcedStyle: consistent
+#### EnforcedStyle: consistent (default)
 
 ```ruby
 # The first parameter should always be indented one step more than the


### PR DESCRIPTION
Follow up #6982 and #7002.

This PR marks the default `EnforcedStyle` for `Layout/IndentFirstParameter`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
