### PR TITLE
Upgrade to parser 2.6.x.x

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('jaro_winkler', '~> 1.5.1')
   s.add_runtime_dependency('parallel', '~> 1.10')
-  s.add_runtime_dependency('parser', '>= 2.5', '!= 2.5.1.1')
+  s.add_runtime_dependency('parser', '>= 2.6')
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 1.6')


### PR DESCRIPTION
This is needed to eliminate warnings when using Ruby 2.6.

