### PR TITLE
Support Class.new subclass in Lint/InheritException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+### New features
+* Add support for subclassing using `Class.new` to `Lint/InheritException`. ([@houli][])
+
 ### Bug fixes
 
 * [#7007](https://github.com/rubocop-hq/rubocop/pull/7007): Fix `Style/BlockDelimiters` with `braces_for_chaining` style false positive, when chaining using safe navigation. ([@Darhazer][])
@@ -3999,3 +4002,4 @@
 [@yakout]: https://github.com/yakout
 [@RicardoTrindade]: https://github.com/RicardoTrindade
 [@att14]: https://github.com/att14
+[@houli]: https://github.com/houli

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -988,9 +988,13 @@ and its standard library subclasses, excluding subclasses of
 
 class C < Exception; end
 
+C = Class.new(Exception)
+
 # good
 
 class C < RuntimeError; end
+
+C = Class.new(RuntimeError)
 ```
 #### EnforcedStyle: standard_error
 
@@ -999,9 +1003,13 @@ class C < RuntimeError; end
 
 class C < Exception; end
 
+C = Class.new(Exception)
+
 # good
 
 class C < StandardError; end
+
+C = Class.new(StandardError)
 ```
 
 ### Configurable attributes

--- a/spec/rubocop/cop/lint/inherit_exception_spec.rb
+++ b/spec/rubocop/cop/lint/inherit_exception_spec.rb
@@ -19,6 +19,21 @@ RSpec.describe RuboCop::Cop::Lint::InheritException, :config do
 
         expect(corrected).to eq('class C < RuntimeError; end')
       end
+
+      context 'when creating a subclass using Class.new' do
+        it 'registers an offense' do
+          expect_offense(<<-RUBY.strip_indent)
+            Class.new(Exception)
+                      ^^^^^^^^^ Inherit from `RuntimeError` instead of `Exception`.
+          RUBY
+        end
+
+        it 'auto-corrects' do
+          corrected = autocorrect_source('Class.new(Exception)')
+
+          expect(corrected).to eq('Class.new(RuntimeError)')
+        end
+      end
     end
 
     context 'with enforced style set to `standard_error`' do
@@ -35,6 +50,21 @@ RSpec.describe RuboCop::Cop::Lint::InheritException, :config do
         corrected = autocorrect_source('class C < Exception; end')
 
         expect(corrected).to eq('class C < StandardError; end')
+      end
+
+      context 'when creating a subclass using Class.new' do
+        it 'registers an offense' do
+          expect_offense(<<-RUBY.strip_indent)
+            Class.new(Exception)
+                      ^^^^^^^^^ Inherit from `StandardError` instead of `Exception`.
+          RUBY
+        end
+
+        it 'auto-corrects' do
+          corrected = autocorrect_source('Class.new(Exception)')
+
+          expect(corrected).to eq('Class.new(StandardError)')
+        end
       end
     end
   end


### PR DESCRIPTION
The [`Class.new`](https://ruby-doc.org/core-2.6.3/Class.html#method-c-new) class method allows you to create subclasses that can be assigned to variables or constants. This PR adds support for detecting this way of creating subclasses in the `Lint/InheritException` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
