### PR TITLE
Add links to Ruby style guide for new heredoc cops

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -650,6 +650,7 @@ Layout/HeredocArgumentClosingParenthesis:
                  Checks for the placement of the closing parenthesis in a
                  method call that passes a HEREDOC string as an argument.
   Enabled: false
+  StyleGuide: '#heredoc-argument-closing-parentheses'
   VersionAdded: '0.68'
 
 Layout/IndentAssignment:
@@ -1365,6 +1366,7 @@ Lint/HeredocMethodCallPosition:
                  Checks for the ordering of a method call where
                  the receiver of the call is a HEREDOC.
   Enabled: false
+  StyleGuide: '#heredoc-method-calls'
   VersionAdded: '0.68'
 
 Lint/ImplicitStringConcatenation:

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2091,6 +2091,10 @@ opening HEREDOC tag.
    )
 ```
 
+### References
+
+* [https://github.com/rubocop-hq/ruby-style-guide#heredoc-argument-closing-parentheses](https://github.com/rubocop-hq/ruby-style-guide#heredoc-argument-closing-parentheses)
+
 ## Layout/IndentAssignment
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -892,6 +892,10 @@ the receiver of the call is a HEREDOC.
    SQL
 ```
 
+### References
+
+* [https://github.com/rubocop-hq/ruby-style-guide#heredoc-method-calls](https://github.com/rubocop-hq/ruby-style-guide#heredoc-method-calls)
+
 ## Lint/ImplicitStringConcatenation
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged


### PR DESCRIPTION
Following up a suggestion in https://github.com/rubocop-hq/ruby-style-guide/pull/746#issuecomment-488081323

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
