### PR TITLE
Respect DisabledByDefault for custom cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * [#6649](https://github.com/rubocop-hq/rubocop/pull/6649): `Layout/AlignHash` supports list of options. ([@stoivo][])
 * Add `IgnoreMethodPatterns` config option to `Style/MethodCallWithArgsParentheses`. ([@tejasbubane][])
 
+### Bug fixes
+
+* [#7013](https://github.com/rubocop-hq/rubocop/pull/7013): Respect DisabledByDefault for custom cops. ([@XrXr][])
+
 ## 0.69.0 (2019-05-13)
 
 ### New features

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -720,7 +720,7 @@ module RuboCop
         end
       end
 
-      cop_options.fetch('Enabled', true)
+      cop_options.fetch('Enabled') { !for_all_cops['DisabledByDefault'] }
     end
 
     def smart_loaded_path

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -730,6 +730,40 @@ RSpec.describe RuboCop::Config do
         expect(cop_enabled(cop_class)).to be true
       end
     end
+
+    context 'when configuration has no mention of a cop' do
+      let(:hash) do
+        {}
+      end
+
+      it 'enables the cop that is not mentioned' do
+        expect(cop_enabled('VeryCustomDepartment/CustomCop')).to be true
+      end
+
+      context 'when all cops are disabled by default' do
+        let(:hash) do
+          {
+            'AllCops' => { 'DisabledByDefault' => true }
+          }
+        end
+
+        it 'disables the cop that is not mentioned' do
+          expect(cop_enabled('VeryCustomDepartment/CustomCop')).to be false
+        end
+      end
+
+      context 'when all cops are explicitly enabled by default' do
+        let(:hash) do
+          {
+            'AllCops' => { 'EnabledByDefault' => true }
+          }
+        end
+
+        it 'enables the cop that is not mentioned' do
+          expect(cop_enabled('VeryCustomDepartment/CustomCop')).to be true
+        end
+      end
+    end
   end
 
   describe '#target_rails_version' do


### PR DESCRIPTION
Before this commit, DisabledByDefault has no effect on
custom cops and they are enabled when the config files
contain no mention of them. This is a problematic
behavior as CI servers might load multiple custom cop
and run Rubocop over multiple repos. Custom cops end
up enabled for repos that don't care about them, even
though DisabledByDefault is set to true.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
