### PR TITLE
[Fix #6880] Fix RuboCop::Options#parse for `.rubocop` file parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#6900](https://github.com/rubocop-hq/rubocop/issues/6900): Fix `Rails/TimeZone` autocorrect `Time.current` to `Time.zone.now`. ([@vfonic][])
 * [#6900](https://github.com/rubocop-hq/rubocop/issues/6900): Fix `Rails/TimeZone` to prefer `Time.zone.#{method}` over other acceptable corrections. ([@vfonic][])
 * [#7007](https://github.com/rubocop-hq/rubocop/pull/7007): Fix `Style/BlockDelimiters` with `braces_for_chaining` style false positive, when chaining using safe navigation. ([@Darhazer][])
+* [#6880](https://github.com/rubocop-hq/rubocop/issues/6880): Fix `.rubocop` file parsing. ([@hoshinotsuyoshi][])
 
 ## 0.68.1 (2019-04-30)
 

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -45,7 +45,7 @@ module RuboCop
 
     def args_from_file
       if File.exist?('.rubocop') && !File.directory?('.rubocop')
-        IO.readlines('.rubocop').map(&:strip)
+        File.read('.rubocop').shellsplit
       else
         []
       end

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
 
     context '.rubocop file' do
       before do
-        create_file('.rubocop', %w[--color --fail-level C])
+        create_file('.rubocop', '--color --fail-level C')
       end
 
       it 'has lower precedence then command line options' do
@@ -378,7 +378,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       end
 
       it 'has higher precedence then options from .rubocop file' do
-        create_file('.rubocop', %w[--color --fail-level C])
+        create_file('.rubocop', '--color --fail-level C')
 
         with_env_options '--fail-level W' do
           expect(parsed_options).to eq(color: false, fail_level: :warning)


### PR DESCRIPTION
Fixes #6880 

* After this commit, RuboCop parses `.rubocop`(even if content is like `--format progress`) correctly.
* More natural test case of `.rubocop` file content.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
