### PR TITLE
[Fix #6969] Fix a false positive in `Style/InverseMethods`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#5782](https://github.com/rubocop-hq/rubocop/issues/5782): Do not autocorrect `Lint/UnifiedInteger` if `TargetRubyVersion < 2.4`. ([@lavoiesl][])
 * [#6387](https://github.com/rubocop-hq/rubocop/issues/6387): Prevent `Lint/NumberConversion` from reporting error with `Time`/`DateTime`. ([@tejasbubane][])
 * [#6980](https://github.com/rubocop-hq/rubocop/issues/6980): Fix `Style/StringHashKeys` to allow string as keys for hash arguments to gsub methods. ([@tejasbubane][])
+* [#6969](https://github.com/rubocop-hq/rubocop/issues/6969): Fix a false positive with block methods in `Style/InverseMethods`. ([@dduugg][])
 
 ### Changes
 
@@ -33,7 +34,8 @@
 * [#6992](https://github.com/rubocop-hq/rubocop/pull/6992): Fix unknown default configuration for `Layout/IndentFirstParameter` cop. ([@drenmi][])
 * [#6972](https://github.com/rubocop-hq/rubocop/issues/6972): Fix a false positive for `Style/MixinUsage` when using inside block and `if` condition is after `include`. ([@koic][])
 * [#6738](https://github.com/rubocop-hq/rubocop/issues/6738): Prevent auto-correct conflict of `Style/Next` and `Style/SafeNavigation`. ([@hoshinotsuyoshi][])
-* [#6847](https://github.com/rubocop-hq/rubocop/pull/6847): Fix `Style/BlockDelimiters` to properly check if the node is chaned when `braces_for_chaining` is set. ([@att14][])
+* [#6847](https://github.com/rubocop-hq/rubocop/pull/6847): Fix `Style/BlockDelimiters` to properly check if the node is chained when `braces_for_chaining` is set. ([@att14][])
+
 ### Bug fixes
 
 * Replace `Time.zone.current` with `Time.zone.today` on `Rails::Date` cop message. ([@vfonic][])

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -28,6 +28,11 @@ module RuboCop
       #   foo == bar
       #   !!('foo' =~ /^\w+$/)
       #   !(foo.class < Numeric) # Checking class hierarchy is allowed
+      #   # Blocks with guard clauses are ignored:
+      #   foo.select do |f|
+      #     next if f.zero?
+      #     f != 1
+      #   end
       class InverseMethods < Cop
         include IgnoredNode
         include RangeHelp
@@ -76,6 +81,7 @@ module RuboCop
           inverse_block?(node) do |_method_call, method, block|
             return unless inverse_blocks.key?(method)
             return if negated?(node) && negated?(node.parent)
+            return if node.each_node(:next).any?
 
             # Inverse method offenses inside of the block of an inverse method
             # offense, such as `y.reject { |key, _value| !(key =~ /c\d/) }`,

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2641,6 +2641,11 @@ foo != bar
 foo == bar
 !!('foo' =~ /^\w+$/)
 !(foo.class < Numeric) # Checking class hierarchy is allowed
+# Blocks with guard clauses are ignored:
+foo.select do |f|
+  next if f.zero?
+  f != 1
+end
 ```
 
 ### Configurable attributes

--- a/spec/rubocop/cop/style/inverse_methods_spec.rb
+++ b/spec/rubocop/cop/style/inverse_methods_spec.rb
@@ -50,6 +50,20 @@ RSpec.describe RuboCop::Cop::Style::InverseMethods do
     expect_no_offenses('!!foo.reject { |e| !e }')
   end
 
+  it 'allows an inverse method in a block with next' do
+    expect_no_offenses(<<~RUBY)
+      class TestClass
+        def test_method
+          [1, 2, 3, 4].select do |number|
+            next if number == 4
+
+            number != 2
+          end
+        end
+      end
+    RUBY
+  end
+
   context 'auto-correct' do
     it 'corrects !.none? with a symbol proc to any?' do
       new_source = autocorrect_source('!foo.none?(&:even?)')


### PR DESCRIPTION
`Style/InverseMethods` does not contemplate guard clauses or other jumps within block methods. This PR updates the cop to skip further evaluation in such cases.

It was sufficient to consider `next` nodes in testing this over a large codebase, but it also guards agains `break` and `return` nodes, out of an abundance of caution.

The `contains_jump?` implementation feels suboptimal, and I'd like to know if there's a better approach. I could neither find an existing helper to look for node types within an AST, nor find a valid `def_node_matcher` that would do the trick.

Resolves https://github.com/rubocop-hq/rubocop/issues/6969

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
