### PR TITLE
Bump RuboCop Performance to 1.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'bump', require: false
 gem 'pry'
 gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.7'
-gem 'rubocop-performance', '~> 1.1.0'
+gem 'rubocop-performance', '~> 1.2.0'
 gem 'rubocop-rspec', '~> 1.32.0'
 gem 'simplecov', '~> 0.10'
 gem 'test-queue'


### PR DESCRIPTION
RuboCop Performance 1.2.0 has been released.
https://rubygems.org/gems/rubocop-performance/versions/1.2.0

This version includes the following fix false negative to `Performance/RegexpMatch` cop.
https://github.com/rubocop-hq/rubocop-performance/pull/47

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
