### PR TITLE
Do not autocorrect UnifiedInteger if TargetRubyVersion < 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#6900](https://github.com/rubocop-hq/rubocop/issues/6900): Fix `Rails/TimeZone` to prefer `Time.zone.#{method}` over other acceptable corrections. ([@vfonic][])
 * [#7007](https://github.com/rubocop-hq/rubocop/pull/7007): Fix `Style/BlockDelimiters` with `braces_for_chaining` style false positive, when chaining using safe navigation. ([@Darhazer][])
 * [#6880](https://github.com/rubocop-hq/rubocop/issues/6880): Fix `.rubocop` file parsing. ([@hoshinotsuyoshi][])
+* [#5782](https://github.com/rubocop-hq/rubocop/issues/5782): Do not autocorrect `Lint/UnifiedInteger` if `TargetRubyVersion < 2.4`. ([@lavoiesl][])
 
 ## 0.68.1 (2019-04-30)
 
@@ -4008,3 +4009,4 @@
 [@RicardoTrindade]: https://github.com/RicardoTrindade
 [@att14]: https://github.com/att14
 [@houli]: https://github.com/houli
+[@lavoiesl]: https://github.com/lavoiesl

--- a/lib/rubocop/cop/lint/unified_integer.rb
+++ b/lib/rubocop/cop/lint/unified_integer.rb
@@ -33,6 +33,8 @@ module RuboCop
         end
 
         def autocorrect(node)
+          return false if target_ruby_version <= 2.3
+
           lambda do |corrector|
             corrector.replace(node.loc.name, 'Integer')
           end

--- a/spec/rubocop/cop/lint/unified_integer_spec.rb
+++ b/spec/rubocop/cop/lint/unified_integer_spec.rb
@@ -1,45 +1,85 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Lint::UnifiedInteger do
+RSpec.describe RuboCop::Cop::Lint::UnifiedInteger, :config do
   subject(:cop) { described_class.new(config) }
 
-  let(:config) { RuboCop::Config.new }
-
   shared_examples 'registers an offense' do |klass|
-    context "when #{klass}" do
-      context 'without any decorations' do
-        let(:source) { "1.is_a?(#{klass})" }
+    context 'target ruby version < 2.4', :ruby23 do
+      context "when #{klass}" do
+        context 'without any decorations' do
+          let(:source) { "1.is_a?(#{klass})" }
 
-        it 'registers an offense' do
-          inspect_source(source)
-          expect(cop.offenses.size).to eq(1)
-          expect(cop.messages).to eq(["Use `Integer` instead of `#{klass}`."])
+          it 'registers an offense' do
+            inspect_source(source)
+            expect(cop.offenses.size).to eq(1)
+            expect(cop.messages).to eq(["Use `Integer` instead of `#{klass}`."])
+          end
+
+          it 'does not autocorrect' do
+            new_source = autocorrect_source(source)
+            expect(new_source).to eq(source)
+          end
         end
 
-        it 'autocorrects' do
-          new_source = autocorrect_source(source)
-          expect(new_source).to eq('1.is_a?(Integer)')
+        context 'when explicitly specified as toplevel constant' do
+          let(:source) { "1.is_a?(::#{klass})" }
+
+          it 'registers an offense' do
+            inspect_source(source)
+            expect(cop.offenses.size).to eq(1)
+            expect(cop.messages).to eq(["Use `Integer` instead of `#{klass}`."])
+          end
+
+          it 'autocorrects' do
+            new_source = autocorrect_source(source)
+            expect(new_source).to eq(source)
+          end
+        end
+
+        context 'with MyNamespace' do
+          it 'does not register an offense' do
+            expect_no_offenses("1.is_a?(MyNamespace::#{klass})")
+          end
         end
       end
+    end
 
-      context 'when explicitly specified as toplevel constant' do
-        let(:source) { "1.is_a?(::#{klass})" }
+    context 'target ruby version >= 2.4', :ruby24 do
+      context "when #{klass}" do
+        context 'without any decorations' do
+          let(:source) { "1.is_a?(#{klass})" }
 
-        it 'registers an offense' do
-          inspect_source(source)
-          expect(cop.offenses.size).to eq(1)
-          expect(cop.messages).to eq(["Use `Integer` instead of `#{klass}`."])
+          it 'registers an offense' do
+            inspect_source(source)
+            expect(cop.offenses.size).to eq(1)
+            expect(cop.messages).to eq(["Use `Integer` instead of `#{klass}`."])
+          end
+
+          it 'autocorrects' do
+            new_source = autocorrect_source(source)
+            expect(new_source).to eq('1.is_a?(Integer)')
+          end
         end
 
-        it 'autocorrects' do
-          new_source = autocorrect_source(source)
-          expect(new_source).to eq('1.is_a?(::Integer)')
-        end
-      end
+        context 'when explicitly specified as toplevel constant' do
+          let(:source) { "1.is_a?(::#{klass})" }
 
-      context 'with MyNamespace' do
-        it 'does not register an offense' do
-          expect_no_offenses("1.is_a?(MyNamespace::#{klass})")
+          it 'registers an offense' do
+            inspect_source(source)
+            expect(cop.offenses.size).to eq(1)
+            expect(cop.messages).to eq(["Use `Integer` instead of `#{klass}`."])
+          end
+
+          it 'autocorrects' do
+            new_source = autocorrect_source(source)
+            expect(new_source).to eq('1.is_a?(::Integer)')
+          end
+        end
+
+        context 'with MyNamespace' do
+          it 'does not register an offense' do
+            expect_no_offenses("1.is_a?(MyNamespace::#{klass})")
+          end
         end
       end
     end


### PR DESCRIPTION
Fix https://github.com/rubocop-hq/rubocop/issues/5782

Before 2.4, this changes the semantics, the change is not safe to do automatically, the user should do so manually.

The test modifications are inspired from https://github.com/rubocop-hq/rubocop/commit/23f2652c1ceffe53b496b24943c290bbea8a54a3
@koic 

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
