### PR TITLE
Follow up "Drop support for Ruby 2.2"

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,9 +21,6 @@ Naming/PredicateName:
     - def_node_matcher
     - def_node_search
 
-Style/FrozenStringLiteralComment:
-  EnforcedStyle: always
-
 Style/FormatStringToken:
   # Because we parse a lot of source codes from strings. Percent arrays
   # look like unannotated format string tokens to this cop.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can read a ton more about RuboCop in its [official manual](https://docs.rubo
 RuboCop supports the following Ruby implementations:
 
 * MRI 2.3+
-* JRuby 9.0+
+* JRuby 9.1+
 
 The Rails cops support the following versions:
 

--- a/lib/rubocop/cop/layout/indent_heredoc.rb
+++ b/lib/rubocop/cop/layout/indent_heredoc.rb
@@ -98,13 +98,6 @@ module RuboCop
 
         private
 
-        def style
-          style = super
-          return style unless style == :auto_detection
-
-          :squiggly
-        end
-
         def message(node)
           case style
           when :squiggly
@@ -175,8 +168,6 @@ module RuboCop
         end
 
         def correct_by_squiggly(node)
-          return if target_ruby_version < 2.3
-
           lambda do |corrector|
             if heredoc_indent_type(node) == '~'
               adjust_squiggly(corrector, node)

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -86,7 +86,7 @@ module RuboCop
               predicate(node)
             end
 
-          return unless numeric && operator && replacement_supported?(operator)
+          return unless numeric && operator
 
           [numeric, replacement(numeric, operator)]
         end
@@ -110,14 +110,6 @@ module RuboCop
 
         def require_parentheses?(node)
           node.send_type? && node.binary_operation? && !node.parenthesized?
-        end
-
-        def replacement_supported?(operator)
-          if %i[> <].include?(operator)
-            target_ruby_version >= 2.3
-          else
-            true
-          end
         end
 
         def invert

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -119,7 +119,7 @@ module RuboCop
       private
 
       def compatible_external_encoding_for?(src)
-        src = src.dup if RUBY_VERSION < '2.3' || RUBY_ENGINE == 'jruby'
+        src = src.dup if RUBY_ENGINE == 'jruby'
         src.force_encoding(Encoding.default_external).valid_encoding?
       end
     end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -192,14 +192,9 @@ RSpec.describe 'RuboCop Project', type: :feature do
 
   describe 'requiring all of `lib` with verbose warnings enabled' do
     it 'emits no warnings' do
-      allowed = lambda do |line|
-        line =~ /warning: private attribute\?$/ && RUBY_VERSION < '2.3'
-      end
-
       warnings = `ruby -Ilib -w -W2 lib/rubocop.rb 2>&1`
                  .lines
                  .grep(%r{/lib/rubocop}) # ignore warnings from dependencies
-                 .reject(&allowed)
 
       expect(warnings.empty?).to be(true)
     end

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe RuboCop::AST::SendNode do
     end
 
     context 'with a safe navigation method send' do
-      let(:ruby_version) { 2.3 }
       let(:source) { 'foo&.bar(:baz)' }
 
       it { expect(send_node.is_a?(described_class)).to be(true) }

--- a/spec/rubocop/cop/layout/def_end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/def_end_alignment_spec.rb
@@ -34,16 +34,14 @@ RSpec.describe RuboCop::Cop::Layout::DefEndAlignment, :config do
     include_examples 'aligned', 'def',       'test',       'end'
     include_examples 'aligned', 'def',       'Test.test',  'end', 'defs'
 
-    context 'in ruby 2.2 or later' do
-      include_examples 'aligned', 'foo def', 'test', 'end'
-      include_examples 'aligned', 'foo bar def', 'test', 'end'
+    include_examples 'aligned', 'foo def', 'test', 'end'
+    include_examples 'aligned', 'foo bar def', 'test', 'end'
 
-      include_examples 'misaligned', <<-RUBY, :def
-        foo def test
-            end
-            ^^^ `end` at 2, 4 is not aligned with `foo def` at 1, 0.
-      RUBY
-    end
+    include_examples 'misaligned', <<-RUBY, :def
+      foo def test
+          end
+          ^^^ `end` at 2, 4 is not aligned with `foo def` at 1, 0.
+    RUBY
 
     context 'correct + opposite' do
       it 'registers an offense' do
@@ -88,39 +86,37 @@ RSpec.describe RuboCop::Cop::Layout::DefEndAlignment, :config do
     include_examples 'aligned', 'def', 'test',      'end'
     include_examples 'aligned', 'def', 'Test.test', 'end', 'defs'
 
-    context 'in ruby 2.2 or later' do
-      include_examples('aligned',
-                       'foo def', 'test',
-                       '    end')
+    include_examples('aligned',
+                     'foo def', 'test',
+                     '    end')
 
-      include_examples 'misaligned', <<-RUBY, :start_of_line
-        foo def test
-        end
-        ^^^ `end` at 2, 0 is not aligned with `def` at 1, 4.
-      RUBY
+    include_examples 'misaligned', <<-RUBY, :start_of_line
+      foo def test
+      end
+      ^^^ `end` at 2, 0 is not aligned with `def` at 1, 4.
+    RUBY
 
-      context 'correct + opposite' do
-        it 'registers an offense' do
-          inspect_source(source)
-          expect(cop.offenses.size).to eq(1)
-          expect(cop.messages.first)
-            .to eq('`end` at 3, 0 is not aligned with `def` at 1, 4.')
-          expect(cop.highlights.first).to eq('end')
-          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-        end
+    context 'correct + opposite' do
+      it 'registers an offense' do
+        inspect_source(source)
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages.first)
+          .to eq('`end` at 3, 0 is not aligned with `def` at 1, 4.')
+        expect(cop.highlights.first).to eq('end')
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      end
 
-        it 'does auto-correction' do
-          corrected = autocorrect_source(source)
-          expect(corrected).to eq(<<~RUBY)
-            foo def a
-              a1
-                end
+      it 'does auto-correction' do
+        corrected = autocorrect_source(source)
+        expect(corrected).to eq(<<~RUBY)
+          foo def a
+            a1
+              end
 
-            foo def b
-                  b1
-                end
-          RUBY
-        end
+          foo def b
+                b1
+              end
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -184,8 +184,6 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral do
     end
 
     context 'when frozen string literals is enabled' do
-      let(:ruby_version) { 2.3 }
-
       it 'does not register an offense for String.new' do
         expect_no_offenses(<<~RUBY)
           # frozen_string_literal: true

--- a/spec/rubocop/cop/style/for_spec.rb
+++ b/spec/rubocop/cop/style/for_spec.rb
@@ -282,8 +282,6 @@ RSpec.describe RuboCop::Cop::Style::For, :config do
     end
 
     context 'when using safe navigation operator' do
-      let(:ruby_version) { 2.3 }
-
       it 'does not break' do
         expect_no_offenses(<<~RUBY)
           def func

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -475,8 +475,6 @@ RSpec.describe RuboCop::Cop::Style::Lambda, :config do
   end
 
   context 'when using safe navigation operator' do
-    let(:ruby_version) { 2.3 }
-
     it 'does not break' do
       expect_no_offenses(<<~RUBY)
         foo&.bar do |_|

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -159,24 +159,20 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
         end
       end
 
-      context 'when the target ruby version >= 2.3' do
-        let(:ruby_version) { 2.3 }
+      context 'when the frozen string literal comment is missing' do
+        it_behaves_like 'mutable objects', '"#{a}"'
+      end
 
-        context 'when the frozen string literal comment is missing' do
-          it_behaves_like 'mutable objects', '"#{a}"'
-        end
+      context 'when the frozen string literal comment is true' do
+        let(:prefix) { '# frozen_string_literal: true' }
 
-        context 'when the frozen string literal comment is true' do
-          let(:prefix) { '# frozen_string_literal: true' }
+        it_behaves_like 'immutable objects', '"#{a}"'
+      end
 
-          it_behaves_like 'immutable objects', '"#{a}"'
-        end
+      context 'when the frozen string literal comment is false' do
+        let(:prefix) { '# frozen_string_literal: false' }
 
-        context 'when the frozen string literal comment is false' do
-          let(:prefix) { '# frozen_string_literal: false' }
-
-          it_behaves_like 'mutable objects', '"#{a}"'
-        end
+        it_behaves_like 'mutable objects', '"#{a}"'
       end
     end
   end
@@ -392,24 +388,20 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
       RUBY
     end
 
-    context 'when the target ruby version >= 2.3' do
-      let(:ruby_version) { 2.3 }
+    context 'when the frozen string literal comment is missing' do
+      it_behaves_like 'mutable objects', '"#{a}"'
+    end
 
-      context 'when the frozen string literal comment is missing' do
-        it_behaves_like 'mutable objects', '"#{a}"'
-      end
+    context 'when the frozen string literal comment is true' do
+      let(:prefix) { '# frozen_string_literal: true' }
 
-      context 'when the frozen string literal comment is true' do
-        let(:prefix) { '# frozen_string_literal: true' }
+      it_behaves_like 'immutable objects', '"#{a}"'
+    end
 
-        it_behaves_like 'immutable objects', '"#{a}"'
-      end
+    context 'when the frozen string literal comment is false' do
+      let(:prefix) { '# frozen_string_literal: false' }
 
-      context 'when the frozen string literal comment is false' do
-        let(:prefix) { '# frozen_string_literal: false' }
-
-        it_behaves_like 'mutable objects', '"#{a}"'
-      end
+      it_behaves_like 'mutable objects', '"#{a}"'
     end
   end
 end

--- a/spec/rubocop/cop/style/redundant_freeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_freeze_spec.rb
@@ -76,24 +76,20 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze do
       end
     end
 
-    context 'when the target ruby version >= 2.3' do
-      let(:ruby_version) { 2.3 }
+    context 'when the frozen string literal comment is missing' do
+      it_behaves_like 'mutable objects', '"#{a}"'
+    end
 
-      context 'when the frozen string literal comment is missing' do
-        it_behaves_like 'mutable objects', '"#{a}"'
-      end
+    context 'when the frozen string literal comment is true' do
+      let(:prefix) { '# frozen_string_literal: true' }
 
-      context 'when the frozen string literal comment is true' do
-        let(:prefix) { '# frozen_string_literal: true' }
+      it_behaves_like 'immutable objects', '"#{a}"'
+    end
 
-        it_behaves_like 'immutable objects', '"#{a}"'
-      end
+    context 'when the frozen string literal comment is false' do
+      let(:prefix) { '# frozen_string_literal: false' }
 
-      context 'when the frozen string literal comment is false' do
-        let(:prefix) { '# frozen_string_literal: false' }
-
-        it_behaves_like 'mutable objects', '"#{a}"'
-      end
+      it_behaves_like 'mutable objects', '"#{a}"'
     end
   end
 end

--- a/spec/rubocop/cop/style/yoda_condition_spec.rb
+++ b/spec/rubocop/cop/style/yoda_condition_spec.rb
@@ -5,9 +5,6 @@ RSpec.describe RuboCop::Cop::Style::YodaCondition, :config do
 
   let(:error_message) { 'Reverse the order of the operands `%s`.' }
 
-  # needed because of usage of safe navigation operator
-  let(:ruby_version) { 2.3 }
-
   shared_examples 'accepts' do |code|
     let(:source) { code }
 


### PR DESCRIPTION
Follow up #7026.

This PR updates the following deficiencies.

- The default `EnforcedStyle` of `Style/FrozenStringLiteralComment is `always`,  so duplicate settings are removed from .rubocop.yml.
- Remove unnecessary logic because `SupportedStyles: auto_detection` has been removed from `Layout/IndentHeredoc`.
- Remove the check for warn introduced in #6227.
- Remove specification of `let(:ruby_version) { 2.3 }` written in spec.
- Remove unnecessary code using Ruby version
- Updated the README to make JRuby support 9.1 or higher because JRuby  9.0 compatible with Ruby 2.2.

```console
% ruby -v
jruby 9.0.5.0 (2.2.3) 2016-01-26 7bee00d Java HotSpot(TM) 64-Bit Server
VM 25.5-b02 on 1.8.0_05-b13 +jit [darwin-x86_64]
% ruby -v
jruby 9.1.17.0 (2.3.3) 2018-04-20 d8b1ff9 Java HotSpot(TM) 64-Bit Server
VM 25.5-b02 on 1.8.0_05-b13 +jit [darwin-x86_64]
% ruby -v
jruby 9.2.7.0 (2.5.3) 2019-04-09 8a269e3 Java HotSpot(TM) 64-Bit Server
VM 25.5-b02 on 1.8.0_05-b13 +jit [darwin-x86_64]
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
