### PR TITLE
Allow strings as keys for hash arguments to gsub methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#6880](https://github.com/rubocop-hq/rubocop/issues/6880): Fix `.rubocop` file parsing. ([@hoshinotsuyoshi][])
 * [#5782](https://github.com/rubocop-hq/rubocop/issues/5782): Do not autocorrect `Lint/UnifiedInteger` if `TargetRubyVersion < 2.4`. ([@lavoiesl][])
 * [#6387](https://github.com/rubocop-hq/rubocop/issues/6387): Prevent `Lint/NumberConversion` from reporting error with `Time`/`DateTime`. ([@tejasbubane][])
+* [#6980](https://github.com/rubocop-hq/rubocop/issues/6980): Fix `Style/StringHashKeys` to allow string as keys for hash arguments to gsub methods. ([@tejasbubane][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/string_hash_keys.rb
+++ b/lib/rubocop/cop/style/string_hash_keys.rb
@@ -27,6 +27,7 @@ module RuboCop
             ^^^(send (const {nil? cbase} :Open3)
                 {:pipeline :pipeline_r :pipeline_rw :pipeline_start :pipeline_w} ...)
             ^^(send {nil? (const {nil? cbase} :Kernel)} {:spawn :system} ...)
+            ^^(send _ {:gsub :gsub!} ...)
           }
         PATTERN
 

--- a/spec/rubocop/cop/style/string_hash_keys_spec.rb
+++ b/spec/rubocop/cop/style/string_hash_keys_spec.rb
@@ -57,4 +57,16 @@ RSpec.describe RuboCop::Cop::Style::StringHashKeys do
       Open3.pipeline([{"RUBYOPT" => '-w'}, 'ruby', 'foo.rb'], ['wc', '-l'])
     RUBY
   end
+
+  it 'does not register an offense when string key is used in gsub' do
+    expect_no_offenses(<<~RUBY)
+      "The sky is green.".gsub(/green/, "green" => "blue")
+    RUBY
+  end
+
+  it 'does not register an offense when string key is used in gsub!' do
+    expect_no_offenses(<<~RUBY)
+      "The sky is green.".gsub!(/green/, "green" => "blue")
+    RUBY
+  end
 end


### PR DESCRIPTION
In `Style/StringHashKeys`

Fixes #6980 

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.