### PR TITLE
[Fix #7033] Fix an error for `Layout/EmptyLineAfterGuardClause`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#6980](https://github.com/rubocop-hq/rubocop/issues/6980): Fix `Style/StringHashKeys` to allow string as keys for hash arguments to gsub methods. ([@tejasbubane][])
 * [#6969](https://github.com/rubocop-hq/rubocop/issues/6969): Fix a false positive with block methods in `Style/InverseMethods`. ([@dduugg][])
 * [#6729](https://github.com/rubocop-hq/rubocop/pull/6729): Handle array spread for `change_column_default` in `Rails/ReversibleMigration` cop. ([@tejasbubane][])
+* [#7033](https://github.com/rubocop-hq/rubocop/issues/7033): Fix an error for `Layout/EmptyLineAfterGuardClause` when guard clause is a ternary operator. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
@@ -130,7 +130,7 @@ module RuboCop
         end
 
         def offense_location(node)
-          if node.loc&.end
+          if node.loc.respond_to?(:end) && node.loc.end
             :end
           else
             :expression

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -274,6 +274,28 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
+  it 'registers an offense when guard clause is a ternary operator' do
+    expect_offense(<<~RUBY)
+      def foo
+        puts 'some action happens here'
+      rescue => e
+        a_check ? raise(e) : other_thing
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
+        true
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        puts 'some action happens here'
+      rescue => e
+        a_check ? raise(e) : other_thing
+
+        true
+      end
+    RUBY
+  end
+
   it 'registers an offense for methods starting with end_' do
     expect_offense(<<~RUBY)
       def foo


### PR DESCRIPTION
Fixes #7033.

This PR fixes an error for `Layout/EmptyLineAfterGuardClause` when guard clause is a ternary operator.

The following is a reproduction step.

```console
% rubocop -V
0.68.1 (using Parser 2.6.3.0, running on ruby 2.6.3 x86_64-darwin17)

% cat example.rb
def foo
  puts 'some action happens here'
rescue  => e
  a_check ? raise(e) : other_thing
  true
end

% rubocop --only Layout/EmptyLineAfterGuardClause -d
For /private/tmp/7033: configuration from
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.68.1/config/default.yml
Inspecting 1 file
Scanning /private/tmp/7033/example.rb
An error occurred while Layout/EmptyLineAfterGuardClause cop was
inspecting /private/tmp/7033/example.rb:4:2.
undefined method `end' for
#<Parser::Source::Map::Ternary:0x00007fd3be9fca10>
Did you mean?  send
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.68.1/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb:133:in
`offense_location'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.68.1/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb:56:in
`on_if'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.68.1/lib/rubocop/cop/commissioner.rb:59:in
`block (2 levels) in trigger_responding_cops'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.68.1/lib/rubocop/cop/commissioner.rb:130:in
`with_cop_error_handling'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.68.1/lib/rubocop/cop/commissioner.rb:58:in
`block in trigger_responding_cops'

(snip)

1 file inspected, no offenses detected

1 error occurred:
An error occurred while Layout/EmptyLineAfterGuardClause cop was
inspecting /private/tmp/7033/example.rb:4:2.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop-hq/rubocop/issues

Mention the following information in the issue report:
0.68.1 (using Parser 2.6.3.0, running on ruby 2.6.3 x86_64-darwin17)
Finished in 0.7535030001308769 seconds
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
