### PR TITLE
Use Ruby 2.6 parser for `rake documentation_syntax_check`

### DIFF
--- a/lib/rubocop/cop/lint/useless_else_without_rescue.rb
+++ b/lib/rubocop/cop/lint/useless_else_without_rescue.rb
@@ -5,6 +5,9 @@ module RuboCop
     module Lint
       # This cop checks for useless `else` in `begin..end` without `rescue`.
       #
+      # Note: This syntax is no longer valid on Ruby 2.6 or higher and
+      # this cop is going to be removed at some point the future.
+      #
       # @example
       #
       #   # bad

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -2686,6 +2686,9 @@ Enabled | Yes | No | 0.17 | -
 
 This cop checks for useless `else` in `begin..end` without `rescue`.
 
+Note: This syntax is no longer valid on Ruby 2.6 or higher and
+this cop is going to be removed at some point the future.
+
 ### Examples
 
 ```ruby


### PR DESCRIPTION
### Summary

This PR uses Ruby 2.6 parser for `rake documentation_syntax_check`.

### Other Information

`Lint/UselessElseWithoutRescue` example code uses a syntax that is not supported in Ruby 2.6 or higher.

```consle
% cat example.rb
begin
else
end

% ruby -vc example.rb
ruby 2.5.5p157 (2019-03-15 revision 67260) [x86_64-darwin17]
example.rb:3: warning: else without rescue is useless
Syntax OKn

% ruby -vc example.rb
ruby 2.6.3p62 (2019-04-16 revision 67580) [x86_64-darwin17]
example.rb:2: else without rescue is useless
```

https://github.com/ruby/ruby/commit/140512d

Ruby 2.5 parser is used for `Lint/UselessElseWithoutRescue` example code to prevent the following error.

```console
% rake documentation_syntax_check
Files:         515
Modules:        81 (   10 undocumented)
Classes:       482 (    3 undocumented)
Constants:     733 (  726 undocumented)
Attributes:     26 (    0 undocumented)
Methods:      1160 ( 1029 undocumented)
 28.77% documented
lib/rubocop/cop/lint/useless_else_without_rescue.rb: Syntax Error in an
example. else without rescue is useless
```

In the future when Ruby 2.5 support is dropped it can be removed with `Lint/UselessElseWithoutRescue`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
