### PR TITLE
Fix mention of XDG env variable

### DIFF
--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -35,8 +35,8 @@ dotfile or a config file inside the [XDG Base Directory
 specification][xdg-basedir-spec].
 
 * `~/.rubocop.yml`
-* `$XDG_HOME/rubocop/config.yml` (expands to `~/.config/rubocop/config.yml` if
-  `$XDG_CONFIG_HOME` is not set)
+* `$XDG_CONFIG_HOME/rubocop/config.yml` (expands to `~/.config/rubocop/config.yml`
+  if `$XDG_CONFIG_HOME` is not set)
 
 If both files exist, the dotfile will be selected.
 


### PR DESCRIPTION
I made a mistake in #6895, which should be corrected to avoid confusion on how to use the XDG directory specification.

Thank you @FranklinYu for bringing this to my attention.