### PR TITLE
[CHANGELOG] Minor CHANGELOG update (little typo in new cop name)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### New features
 
 * Add support for subclassing using `Class.new` to `Lint/InheritException`. ([@houli][])
-* [#6779](https://github.com/rubocop-hq/rubocop/issues/6779): Add new cop `Style/NegativeUnless` that checks for unless with negative condition. ([@tejasbubane][])
+* [#6779](https://github.com/rubocop-hq/rubocop/issues/6779): Add new cop `Style/NegatedUnless` that checks for unless with negative condition. ([@tejasbubane][])
 
 ### Bug fixes
 


### PR DESCRIPTION
Minor CHANGELOG text update: Fixed `Style/NegatedUnless` cop name from the last release (confuses when you check the documentation - you cant find this new cop cuz it named as `Style/NegativeUnless` in changelog :))