### PR TITLE
[Fix #7043] Prevent RDoc error when installing on Ubuntu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * [#6649](https://github.com/rubocop-hq/rubocop/pull/6649): `Layout/AlignHash` supports list of options. ([@stoivo][])
 * Add `IgnoreMethodPatterns` config option to `Style/MethodCallWithArgsParentheses`. ([@tejasbubane][])
 
+### Bug fixes
+
+* [#7043](https://github.com/rubocop-hq/rubocop/issues/7043): Prevent RDoc error when installing RuboCop 0.69.0 on Ubuntu. ([@koic][])
+
 ## 0.69.0 (2019-05-13)
 
 ### New features

--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -7,7 +7,13 @@ module RuboCop
     # This generator will take a cop name and generate a source file
     # and spec file when given a valid qualified cop name.
     class Generator
-      SOURCE_TEMPLATE = <<~RUBY
+      # Note: RDoc 5.1.0 or lower has the following issue.
+      # https://github.com/rubocop-hq/rubocop/issues/7043
+      #
+      # The following `String#strip_indent` can be replaced with
+      # squiggly heredoc when RuboCop supports Ruby 2.5 or higher
+      # (RDoc 6.0 or higher).
+      SOURCE_TEMPLATE = <<-RUBY.strip_indent
         # frozen_string_literal: true
 
         # TODO: when finished, run `rake generate_cops_documentation` to update the docs


### PR DESCRIPTION
This PR prevents RDoc error when installing RuboCop 0.69.0 on Ubuntu.

The following is a reproduction procedure.

```console
% cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=12.04
DISTRIB_CODENAME=precise
DISTRIB_DESCRIPTION="Ubuntu 12.04 LTS"
```

### RDoc 5.1.0 or lower

The following error occurs in RDoc 5.1.0 or lower.

```console
% path/to/rubocop
% ruby -v
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-linux]

% gem install rdoc -v5.1.0
Fetching: rdoc-5.1.0.gem (100%)
Successfully installed rdoc-5.1.0
Parsing documentation for rdoc-5.1.0
Installing ri documentation for rdoc-5.1.0
Done installing documentation for rdoc after 7 seconds
1 gem installed

% rdoc lib/rubocop/cop/generator.rb
Parsing sources...
100% [ 1/ 1]  lib/rubocop/cop/generator.rb
RDoc::Parser::Ruby failure around line 15 of
lib/rubocop/cop/generator.rb

Before reporting this, could you check that the file you're documenting
has proper syntax:

  /home/vagrant/.rvm/rubies/ruby-2.3.1/bin/ruby -c
  lib/rubocop/cop/generator.rb

RDoc is not a full Ruby parser and will fail when fed invalid ruby
programs.

The internal error was:

        (NoMethodError) undefined method `name' for {TkSTRING 451, 15:19
        "%Q<department>"}:RDoc::RubyToken::TkSTRING

uh-oh! RDoc had a problem:
undefined method `name' for {TkSTRING 451, 15:19
"%Q<department>"}:RDoc::RubyToken::TkSTRING

run with --debug for full backtrace
```

### RDoc 6.0.0 or higher

Resolve with RDoc 6.0.0 or higher.

```console
% gem install rdoc -v6.0.0
Fetching: rdoc-6.0.0.gem (100%)
Successfully installed rdoc-6.0.0
Parsing documentation for rdoc-6.0.0
Installing ri documentation for rdoc-6.0.0
Done installing documentation for rdoc after 7 seconds
1 gem installed

% rdoc lib/rubocop/cop/generator.rb
Parsing sources...
100% [ 1/ 1]  lib/rubocop/cop/generator.rb

Generating Darkfish format into /home/vagrant/src/rubocop/doc...

  Files:       1

  Classes:     1 ( 0 undocumented)
  Modules:     2 ( 2 undocumented)
  Constants:   3 ( 3 undocumented)
  Attributes:  0 ( 0 undocumented)
  Methods:     6 ( 6 undocumented)

  Total:      12 (11 undocumented)
    8.33% documented

  Elapsed: 0.1s
```

RDoc 6 is attached as standard with Ruby 2.5.

```console
% rbenv local 2.4.6
% rdoc -v
5.0.0
% rbenv local 2.5.5
% rdoc -v
6.0.1
```
This PR prevents the issue by using `String#strip_indent` until RuboCop supports Ruby 2.5 or higher.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
