### PR TITLE
[Fix #7023] Added auto-correction for `Lint/NumberConversion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * [#7013](https://github.com/rubocop-hq/rubocop/pull/7013): Respect DisabledByDefault for custom cops. ([@XrXr][])
 * [#7043](https://github.com/rubocop-hq/rubocop/issues/7043): Prevent RDoc error when installing RuboCop 0.69.0 on Ubuntu. ([@koic][])
+* [#7023](https://github.com/rubocop-hq/rubocop/issues/7023): Autocorrection for `Lint/NumberConversion`. ([@Bhacaz][])
 
 ## 0.69.0 (2019-05-13)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1463,6 +1463,8 @@ Lint/NumberConversion:
   Description: 'Checks unsafe usage of number conversion methods.'
   Enabled: false
   VersionAdded: '0.53'
+  VersionChanged: '0.70'
+  SafeAutoCorrect: false
 
 Lint/OrderedMagicComments:
   Description: 'Checks the proper ordering of magic comments and whether a magic comment is not placed before a shebang.'

--- a/lib/rubocop/cop/lint/number_conversion.rb
+++ b/lib/rubocop/cop/lint/number_conversion.rb
@@ -53,6 +53,13 @@ module RuboCop
           end
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(node.loc.expression,
+                              correct_method(node, node.receiver))
+          end
+        end
+
         private
 
         def date_time_object?(node)

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1380,7 +1380,7 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Disabled | Yes | No | 0.53 | -
+Disabled | Yes | Yes (Unsafe) | 0.53 | 0.70
 
 This cop warns the usage of unsafe number conversions. Unsafe
 number conversion can cause unexpected error if auto type conversion

--- a/spec/rubocop/cop/lint/number_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/number_conversion_spec.rb
@@ -11,12 +11,20 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion do
         "10".to_i
         ^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using "10".to_i, use stricter Integer("10", 10).
       RUBY
+
+      expect_correction(<<~RUBY.strip_indent)
+        Integer("10", 10)
+      RUBY
     end
 
     it 'when using `#to_i` for integer' do
       expect_offense(<<~RUBY)
         10.to_i
         ^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using 10.to_i, use stricter Integer(10, 10).
+      RUBY
+
+      expect_correction(<<~RUBY.strip_indent)
+        Integer(10, 10)
       RUBY
     end
 
@@ -25,12 +33,20 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion do
         "10.2".to_f
         ^^^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using "10.2".to_f, use stricter Float("10.2").
       RUBY
+
+      expect_correction(<<~RUBY.strip_indent)
+        Float("10.2")
+      RUBY
     end
 
     it 'when using `#to_c`' do
       expect_offense(<<~RUBY)
         "10".to_c
         ^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using "10".to_c, use stricter Complex("10").
+      RUBY
+
+      expect_correction(<<~RUBY.strip_indent)
+        Complex("10")
       RUBY
     end
 
@@ -40,6 +56,11 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion do
         string_value.to_i
         ^^^^^^^^^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using string_value.to_i, use stricter Integer(string_value, 10).
       RUBY
+
+      expect_correction(<<~RUBY.strip_indent)
+        string_value = '10'
+        Integer(string_value, 10)
+      RUBY
     end
 
     it 'when `#to_i` called on a hash value' do
@@ -48,6 +69,11 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion do
         params[:id].to_i
         ^^^^^^^^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using params[:id].to_i, use stricter Integer(params[:id], 10).
       RUBY
+
+      expect_correction(<<~RUBY.strip_indent)
+        params = { id: 10 }
+        Integer(params[:id], 10)
+      RUBY
     end
 
     it 'when `#to_i` called on a variable on a array' do
@@ -55,6 +81,11 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion do
         args = [1,2,3]
         args[0].to_i
         ^^^^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using args[0].to_i, use stricter Integer(args[0], 10).
+      RUBY
+
+      expect_correction(<<~RUBY.strip_indent)
+        args = [1,2,3]
+        Integer(args[0], 10)
       RUBY
     end
   end


### PR DESCRIPTION
Fix #7023, Added auto-correction for `Lint/NumberConversion`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
