### PR TITLE
Add a Note for Including/Excluding files

### DIFF
--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -271,6 +271,31 @@ AllCops:
 # ...
 ```
 
+**Note**: When inspecting a certain directory(or file)
+given as RuboCop's command line arguments,
+patterns listed under `AllCops` / `Exclude` are also inspected.
+If you want to apply `AllCops` / `Exclude` rules in this circumstance,
+add `--force-exclusion` to the command line argument.
+
+Here is an example:
+
+```yaml
+# .rubocop.yml
+AllCops:
+  Exclude:
+    - foo.rb
+```
+
+If `foo.rb` specified as a RuboCop's command line argument, the result is:
+
+```sh
+# RuboCop inspects foo.rb.
+$ bundle exec rubocop foo.rb
+
+# RuboCop does not inspect foo.rb.
+$ bundle exec rubocop --force-exclusion foo.rb
+```
+
 #### Path relativity
 
 In `.rubocop.yml` and any other configuration file beginning with `.rubocop`,


### PR DESCRIPTION
**Add a Note of `AllCops` / `Exclude`**  

I think that It would be helpful to document cases where the `AllCops`/`Exclude` rules do not apply.
[rubocop-hq/ruby-style-guide#2492 (comment)](https://github.com/rubocop-hq/rubocop/issues/2492#issuecomment-164375887)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
