### PR TITLE
Add `EnforcedStyle` to `Layout/EmptyLinesAroundAccessModifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#6649](https://github.com/rubocop-hq/rubocop/pull/6649): `Layout/AlignHash` supports list of options. ([@stoivo][])
 * Add `IgnoreMethodPatterns` config option to `Style/MethodCallWithArgsParentheses`. ([@tejasbubane][])
+* [#7059](https://github.com/rubocop-hq/rubocop/pull/7059): Add `EnforcedStyle` to `Layout/EmptyLinesAroundAccessModifier`. ([@koic][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -509,6 +509,13 @@ Layout/EmptyLinesAroundAccessModifier:
   StyleGuide: '#empty-lines-around-access-modifier'
   Enabled: true
   VersionAdded: '0.49'
+  EnforcedStyle: around
+  SupportedStyles:
+    - around
+    - only_before
+  Reference:
+    # A reference to `EnforcedStyle: only_before`.
+    - https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions
 
 Layout/EmptyLinesAroundArguments:
   Description: "Keeps track of empty lines around method arguments."
@@ -781,6 +788,9 @@ Layout/IndentationConsistency:
   SupportedStyles:
     - normal
     - rails
+  Reference:
+    # A reference to `EnforcedStyle: rails`.
+    - https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions
 
 Layout/IndentationWidth:
   Description: 'Use 2 spaces for indentation.'

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -9,6 +9,7 @@ module RuboCop
       include MethodIdentifierPredicates
 
       ARITHMETIC_OPERATORS = %i[+ - * / % **].freeze
+      SPECIAL_MODIFIERS = %w[private protected].freeze
 
       # The receiving node of the method dispatch.
       #
@@ -73,6 +74,15 @@ module RuboCop
       #                   access modifier
       def non_bare_access_modifier?
         macro? && non_bare_access_modifier_declaration?
+      end
+
+      # Checks whether the dispatched method is a bare `private` or `protected`
+      # access modifier that affects all methods defined after the macro.
+      #
+      # @return [Boolean] whether the dispatched method is a bare
+      #                    `private` or `protected` access modifier
+      def special_modifier?
+        bare_access_modifier? && SPECIAL_MODIFIERS.include?(source)
       end
 
       # Checks whether the name of the dispatched method matches the argument

--- a/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Layout
       # Access modifiers should be surrounded by blank lines.
       #
-      # @example
+      # @example EnforcedStyle: around (default)
       #
       #   # bad
       #   class Foo
@@ -22,12 +22,34 @@ module RuboCop
       #
       #     def baz; end
       #   end
+      #
+      # @example EnforcedStyle: only_before
+      #
+      #   # bad
+      #   class Foo
+      #     def bar; end
+      #     private
+      #     def baz; end
+      #   end
+      #
+      #   # good
+      #   class Foo
+      #     def bar; end
+      #
+      #     private
+      #     def baz; end
+      #   end
+      #
       class EmptyLinesAroundAccessModifier < Cop
+        include ConfigurableEnforcedStyle
         include RangeHelp
 
         MSG_AFTER = 'Keep a blank line after `%<modifier>s`.'
         MSG_BEFORE_AND_AFTER = 'Keep a blank line before and after ' \
                                '`%<modifier>s`.'
+
+        MSG_BEFORE_FOR_ONLY_BEFORE = 'Keep a blank line before `%<modifier>s`.'
+        MSG_AFTER_FOR_ONLY_BEFORE = 'Remove a blank line after `%<modifier>s`.'
 
         def initialize(config = nil, options = nil)
           super
@@ -63,7 +85,12 @@ module RuboCop
         def on_send(node)
           return unless node.bare_access_modifier?
 
-          return if empty_lines_around?(node)
+          case style
+          when :around
+            return if empty_lines_around?(node)
+          when :only_before
+            return if allowed_only_before_style?(node)
+          end
 
           add_offense(node)
         end
@@ -76,13 +103,34 @@ module RuboCop
               corrector.insert_before(line, "\n")
             end
 
-            unless next_line_empty?(node.last_line)
-              corrector.insert_after(line, "\n")
-            end
+            correct_next_line_if_denied_style(corrector, node, line)
           end
         end
 
         private
+
+        def allowed_only_before_style?(node)
+          if node.special_modifier?
+            return false if next_line_empty?(node.last_line)
+          end
+
+          previous_line_empty?(node.first_line)
+        end
+
+        def correct_next_line_if_denied_style(corrector, node, line)
+          case style
+          when :around
+            unless next_line_empty?(node.last_line)
+              corrector.insert_after(line, "\n")
+            end
+          when :only_before
+            if next_line_empty?(node.last_line)
+              range = next_empty_line_range(node)
+
+              corrector.remove(range)
+            end
+          end
+        end
 
         def previous_line_ignoring_comments(processed_source, send_line)
           processed_source[0..send_line - 2].reverse.find do |line|
@@ -128,7 +176,20 @@ module RuboCop
           line == @class_or_module_def_last_line - 1
         end
 
+        def next_empty_line_range(node)
+          source_range(processed_source.buffer, node.last_line + 1, 0)
+        end
+
         def message(node)
+          case style
+          when :around
+            message_for_around_style(node)
+          when :only_before
+            message_for_only_before_style(node)
+          end
+        end
+
+        def message_for_around_style(node)
           send_line = node.first_line
 
           if block_start?(send_line) ||
@@ -136,6 +197,16 @@ module RuboCop
             format(MSG_AFTER, modifier: node.loc.selector.source)
           else
             format(MSG_BEFORE_AND_AFTER, modifier: node.loc.selector.source)
+          end
+        end
+
+        def message_for_only_before_style(node)
+          modifier = node.loc.selector.source
+
+          if next_line_empty?(node.last_line)
+            format(MSG_AFTER_FOR_ONLY_BEFORE, modifier: modifier)
+          else
+            format(MSG_BEFORE_FOR_ONLY_BEFORE, modifier: modifier)
           end
         end
       end

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -52,8 +52,6 @@ module RuboCop
         MSG = 'Use %<configured_indentation_width>d (not %<indentation>d) ' \
               'spaces for%<name>s indentation.'
 
-        SPECIAL_MODIFIERS = %w[private protected].freeze
-
         def_node_matcher :access_modifier?, <<-PATTERN
           [(send ...) access_modifier?]
         PATTERN
@@ -188,17 +186,13 @@ module RuboCop
         def each_member(members)
           previous_modifier = nil
           members.first.children.each do |member|
-            if member.send_type? && special_modifier?(member)
+            if member.send_type? && member.special_modifier?
               previous_modifier = member
             elsif previous_modifier
               yield member, previous_modifier.source_range
               previous_modifier = nil
             end
           end
-        end
-
-        def special_modifier?(node)
-          node.bare_access_modifier? && SPECIAL_MODIFIERS.include?(node.source)
         end
 
         def indentation_consistency_style

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -1347,6 +1347,8 @@ Access modifiers should be surrounded by blank lines.
 
 ### Examples
 
+#### EnforcedStyle: around (default)
+
 ```ruby
 # bad
 class Foo
@@ -1364,10 +1366,35 @@ class Foo
   def baz; end
 end
 ```
+#### EnforcedStyle: only_before
+
+```ruby
+# bad
+class Foo
+  def bar; end
+  private
+  def baz; end
+end
+
+# good
+class Foo
+  def bar; end
+
+  private
+  def baz; end
+end
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `around` | `around`, `only_before`
 
 ### References
 
 * [https://github.com/rubocop-hq/ruby-style-guide#empty-lines-around-access-modifier](https://github.com/rubocop-hq/ruby-style-guide#empty-lines-around-access-modifier)
+* [https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions)
 
 ## Layout/EmptyLinesAroundArguments
 
@@ -2748,6 +2775,7 @@ EnforcedStyle | `normal` | `normal`, `rails`
 ### References
 
 * [https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation](https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
+* [https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions)
 
 ## Layout/IndentationWidth
 

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -1,335 +1,440 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
-  subject(:cop) { described_class.new }
+RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
+  subject(:cop) { described_class.new(config) }
 
-  %w[private protected public module_function].each do |access_modifier|
-    it "requires blank line before #{access_modifier}" do
-      inspect_source(<<~RUBY)
-        class Test
-          something
-          #{access_modifier}
+  context 'EnforcedStyle is `around`' do
+    let(:cop_config) { { 'EnforcedStyle' => 'around' } }
 
-          def test; end
-        end
-      RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(["Keep a blank line before and after `#{access_modifier}`."])
-    end
-
-    it "requires blank line after #{access_modifier}" do
-      inspect_source(<<~RUBY)
-        class Test
-          something
-
-          #{access_modifier}
-          def test; end
-        end
-      RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(["Keep a blank line before and after `#{access_modifier}`."])
-    end
-
-    it "ignores comment line before #{access_modifier}" do
-      expect_no_offenses(<<~RUBY)
-        class Test
-          something
-
-          # This comment is fine
-          #{access_modifier}
-
-          def test; end
-        end
-      RUBY
-    end
-
-    it "ignores #{access_modifier} inside a method call" do
-      expect_no_offenses(<<~RUBY)
-        class Test
-          def #{access_modifier}?
+    %w[private protected public module_function].each do |access_modifier|
+      it "requires blank line before #{access_modifier}" do
+        inspect_source(<<~RUBY)
+          class Test
+            something
             #{access_modifier}
-          end
-        end
-      RUBY
-    end
 
-    it "ignores #{access_modifier} deep inside a method call" do
-      expect_no_offenses(<<~RUBY)
-        class Test
-          def #{access_modifier}?
-            if true
+            def test; end
+          end
+        RUBY
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages)
+          .to eq(["Keep a blank line before and after `#{access_modifier}`."])
+      end
+
+      it "requires blank line after #{access_modifier}" do
+        inspect_source(<<~RUBY)
+          class Test
+            something
+
+            #{access_modifier}
+            def test; end
+          end
+        RUBY
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages)
+          .to eq(["Keep a blank line before and after `#{access_modifier}`."])
+      end
+
+      it "ignores comment line before #{access_modifier}" do
+        expect_no_offenses(<<~RUBY)
+          class Test
+            something
+
+            # This comment is fine
+            #{access_modifier}
+
+            def test; end
+          end
+        RUBY
+      end
+
+      it "ignores #{access_modifier} inside a method call" do
+        expect_no_offenses(<<~RUBY)
+          class Test
+            def #{access_modifier}?
               #{access_modifier}
             end
           end
-        end
-      RUBY
-    end
+        RUBY
+      end
 
-    it "ignores #{access_modifier} with a right-hand-side condition" do
-      expect_no_offenses(<<~RUBY)
-        class Test
-          def #{access_modifier}?
-            #{access_modifier} if true
-          end
-        end
-      RUBY
-    end
-
-    it "autocorrects blank line before #{access_modifier}" do
-      corrected = autocorrect_source(<<~RUBY)
-        class Test
-          something
-          #{access_modifier}
-
-          def test; end
-        end
-      RUBY
-      expect(corrected).to eq(<<~RUBY)
-        class Test
-          something
-
-          #{access_modifier}
-
-          def test; end
-        end
-      RUBY
-    end
-
-    it 'autocorrects blank line after #{access_modifier}' do
-      corrected = autocorrect_source(<<~RUBY)
-        class Test
-          something
-
-          #{access_modifier}
-          def test; end
-        end
-      RUBY
-      expect(corrected).to eq(<<~RUBY)
-        class Test
-          something
-
-          #{access_modifier}
-
-          def test; end
-        end
-      RUBY
-    end
-
-    it 'autocorrects blank line after #{access_modifier} with comment' do
-      corrected = autocorrect_source(<<~RUBY)
-        class Test
-          something
-
-          #{access_modifier} # let's modify the rest
-          def test; end
-        end
-      RUBY
-      expect(corrected).to eq(<<~RUBY)
-        class Test
-          something
-
-          #{access_modifier} # let's modify the rest
-
-          def test; end
-        end
-      RUBY
-    end
-
-    it 'accepts missing blank line when at the beginning of class' do
-      expect_no_offenses(<<~RUBY)
-        class Test
-          #{access_modifier}
-
-          def test; end
-        end
-      RUBY
-    end
-
-    it 'accepts missing blank line when at the beginning of module' do
-      expect_no_offenses(<<~RUBY)
-        module Test
-          #{access_modifier}
-
-          def test; end
-        end
-      RUBY
-    end
-
-    it 'accepts missing blank line when at the beginning of sclass' do
-      expect_no_offenses(<<~RUBY)
-        class << self
-          #{access_modifier}
-
-          def test; end
-        end
-      RUBY
-    end
-
-    it 'accepts missing blank line when specifying a superclass ' \
-       'that breaks the line' do
-      expect_no_offenses(<<~RUBY)
-        class Foo <
-              Bar
-          #{access_modifier}
-
-          def do_something
-          end
-        end
-      RUBY
-    end
-
-    it 'accepts missing blank line when specifying `self` ' \
-       'that breaks the line' do
-      expect_no_offenses(<<~RUBY)
-        class <<
-              self
-          #{access_modifier}
-
-          def do_something
-          end
-        end
-      RUBY
-    end
-
-    it 'accepts missing blank line when at the beginning of file' \
-       'when specifying a superclass that breaks the line' do
-      expect_no_offenses(<<~RUBY)
-        #{access_modifier}
-
-        def do_something
-        end
-      RUBY
-    end
-
-    it "requires blank line after, but not before, #{access_modifier} " \
-       'when at the beginning of class/module' do
-      inspect_source(<<~RUBY)
-        class Test
-          #{access_modifier}
-          def test
-          end
-        end
-      RUBY
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(["Keep a blank line after `#{access_modifier}`."])
-    end
-
-    context 'at the beginning of block' do
-      context 'for blocks defined with do' do
-        it 'accepts missing blank line' do
-          expect_no_offenses(<<~RUBY)
-            included do
-              #{access_modifier}
-
-              def test; end
-            end
-          RUBY
-        end
-
-        it 'accepts missing blank line with arguments' do
-          expect_no_offenses(<<~RUBY)
-            included do |foo|
-              #{access_modifier}
-
-              def test; end
-            end
-          RUBY
-        end
-
-        it "requires blank line after, but not before, #{access_modifier}" do
-          inspect_source(<<~RUBY)
-            included do
-              #{access_modifier}
-              def test
+      it "ignores #{access_modifier} deep inside a method call" do
+        expect_no_offenses(<<~RUBY)
+          class Test
+            def #{access_modifier}?
+              if true
+                #{access_modifier}
               end
             end
-          RUBY
-          expect(cop.offenses.size).to eq(1)
-          expect(cop.messages)
-            .to eq(["Keep a blank line after `#{access_modifier}`."])
+          end
+        RUBY
+      end
+
+      it "ignores #{access_modifier} with a right-hand-side condition" do
+        expect_no_offenses(<<~RUBY)
+          class Test
+            def #{access_modifier}?
+              #{access_modifier} if true
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects blank line before #{access_modifier}" do
+        corrected = autocorrect_source(<<~RUBY)
+          class Test
+            something
+            #{access_modifier}
+
+            def test; end
+          end
+        RUBY
+        expect(corrected).to eq(<<~RUBY)
+          class Test
+            something
+
+            #{access_modifier}
+
+            def test; end
+          end
+        RUBY
+      end
+
+      it 'autocorrects blank line after #{access_modifier}' do
+        corrected = autocorrect_source(<<~RUBY)
+          class Test
+            something
+
+            #{access_modifier}
+            def test; end
+          end
+        RUBY
+        expect(corrected).to eq(<<~RUBY)
+          class Test
+            something
+
+            #{access_modifier}
+
+            def test; end
+          end
+        RUBY
+      end
+
+      it 'autocorrects blank line after #{access_modifier} with comment' do
+        corrected = autocorrect_source(<<~RUBY)
+          class Test
+            something
+
+            #{access_modifier} # let's modify the rest
+            def test; end
+          end
+        RUBY
+        expect(corrected).to eq(<<~RUBY)
+          class Test
+            something
+
+            #{access_modifier} # let's modify the rest
+
+            def test; end
+          end
+        RUBY
+      end
+
+      it 'accepts missing blank line when at the beginning of class' do
+        expect_no_offenses(<<~RUBY)
+          class Test
+            #{access_modifier}
+
+            def test; end
+          end
+        RUBY
+      end
+
+      it 'accepts missing blank line when at the beginning of module' do
+        expect_no_offenses(<<~RUBY)
+          module Test
+            #{access_modifier}
+
+            def test; end
+          end
+        RUBY
+      end
+
+      it 'accepts missing blank line when at the beginning of sclass' do
+        expect_no_offenses(<<~RUBY)
+          class << self
+            #{access_modifier}
+
+            def test; end
+          end
+        RUBY
+      end
+
+      it 'accepts missing blank line when specifying a superclass ' \
+         'that breaks the line' do
+        expect_no_offenses(<<~RUBY)
+          class Foo <
+                Bar
+            #{access_modifier}
+
+            def do_something
+            end
+          end
+        RUBY
+      end
+
+      it 'accepts missing blank line when specifying `self` ' \
+         'that breaks the line' do
+        expect_no_offenses(<<~RUBY)
+          class <<
+                self
+            #{access_modifier}
+
+            def do_something
+            end
+          end
+        RUBY
+      end
+
+      it 'accepts missing blank line when at the beginning of file' \
+         'when specifying a superclass that breaks the line' do
+        expect_no_offenses(<<~RUBY)
+          #{access_modifier}
+
+          def do_something
+          end
+        RUBY
+      end
+
+      it "requires blank line after, but not before, #{access_modifier} " \
+         'when at the beginning of class/module' do
+        inspect_source(<<~RUBY)
+          class Test
+            #{access_modifier}
+            def test
+            end
+          end
+        RUBY
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages)
+          .to eq(["Keep a blank line after `#{access_modifier}`."])
+      end
+
+      context 'at the beginning of block' do
+        context 'for blocks defined with do' do
+          it 'accepts missing blank line' do
+            expect_no_offenses(<<~RUBY)
+              included do
+                #{access_modifier}
+
+                def test; end
+              end
+            RUBY
+          end
+
+          it 'accepts missing blank line with arguments' do
+            expect_no_offenses(<<~RUBY)
+              included do |foo|
+                #{access_modifier}
+
+                def test; end
+              end
+            RUBY
+          end
+
+          it "requires blank line after, but not before, #{access_modifier}" do
+            inspect_source(<<~RUBY)
+              included do
+                #{access_modifier}
+                def test
+                end
+              end
+            RUBY
+            expect(cop.offenses.size).to eq(1)
+            expect(cop.messages)
+              .to eq(["Keep a blank line after `#{access_modifier}`."])
+          end
+        end
+
+        context 'for blocks defined with {}' do
+          it 'accepts missing blank line' do
+            expect_no_offenses(<<~RUBY)
+              included {
+                #{access_modifier}
+
+                def test; end
+              }
+            RUBY
+          end
+
+          it 'accepts missing blank line with arguments' do
+            expect_no_offenses(<<~RUBY)
+              included { |foo|
+                #{access_modifier}
+
+                def test; end
+              }
+            RUBY
+          end
         end
       end
 
-      context 'for blocks defined with {}' do
-        it 'accepts missing blank line' do
-          expect_no_offenses(<<~RUBY)
-            included {
-              #{access_modifier}
+      it 'accepts missing blank line when at the end of block' do
+        expect_no_offenses(<<~RUBY)
+          class Test
+            def test; end
 
-              def test; end
-            }
-          RUBY
-        end
+            #{access_modifier}
+          end
+        RUBY
+      end
 
-        it 'accepts missing blank line with arguments' do
-          expect_no_offenses(<<~RUBY)
-            included { |foo|
-              #{access_modifier}
+      it 'accepts missing blank line when at the end of specifying ' \
+         'a superclass' do
+        expect_no_offenses(<<~RUBY)
+          class Test < Base
+            def test; end
 
-              def test; end
-            }
-          RUBY
-        end
+            #{access_modifier}
+          end
+        RUBY
+      end
+
+      it 'accepts missing blank line when at the end of specifying ' \
+         '`self`' do
+        expect_no_offenses(<<~RUBY)
+          class << self
+            def test; end
+
+            #{access_modifier}
+          end
+        RUBY
+      end
+
+      it 'requires blank line when next line started with end' do
+        inspect_source(<<~RUBY)
+          class Test
+            #{access_modifier}
+            end_this!
+          end
+        RUBY
+
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages)
+          .to eq(["Keep a blank line after `#{access_modifier}`."])
+      end
+
+      it 'recognizes blank lines with DOS style line endings' do
+        expect_no_offenses(<<~RUBY)
+          class Test\r
+          \r
+            #{access_modifier}\r
+          \r
+            def test; end\r
+          end\r
+        RUBY
+      end
+    end
+  end
+
+  context 'EnforcedStyle is `only_before`' do
+    let(:cop_config) { { 'EnforcedStyle' => 'only_before' } }
+
+    %w[private protected].each do |access_modifier|
+      it "accepts missing blank line after #{access_modifier}" do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          class Test
+            something
+
+            #{access_modifier}
+            def test; end
+          end
+        RUBY
+      end
+
+      it "registers an offense for blank line after #{access_modifier}" do
+        inspect_source(<<-RUBY.strip_indent)
+          class Test
+            something
+
+            #{access_modifier}
+
+            def test; end
+          end
+        RUBY
+
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages)
+          .to eq(["Remove a blank line after `#{access_modifier}`."])
+      end
+
+      it "autocorrects remove blank line after #{access_modifier}" do
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
+          class Test
+            something
+
+            #{access_modifier}
+
+            def test; end
+          end
+        RUBY
+
+        expect(corrected).to eq(<<-RUBY.strip_indent)
+          class Test
+            something
+
+            #{access_modifier}
+            def test; end
+          end
+        RUBY
       end
     end
 
-    it 'accepts missing blank line when at the end of block' do
-      expect_no_offenses(<<~RUBY)
-        class Test
-          def test; end
+    %w[public module_function].each do |access_modifier|
+      it "accepts missing blank line after #{access_modifier}" do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          module Kernel
+            #{access_modifier}
 
-          #{access_modifier}
-        end
-      RUBY
+            def do_something
+            end
+          end
+        RUBY
+      end
     end
 
-    it 'accepts missing blank line when at the end of specifying ' \
-       'a superclass' do
-      expect_no_offenses(<<~RUBY)
-        class Test < Base
-          def test; end
+    %w[private protected public module_function].each do |access_modifier|
+      it "registers an offense for blank line before #{access_modifier}" do
+        inspect_source(<<~RUBY)
+          class Test
+            something
+            #{access_modifier}
+            def test; end
+          end
+        RUBY
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages)
+          .to eq(["Keep a blank line before `#{access_modifier}`."])
+      end
 
-          #{access_modifier}
-        end
-      RUBY
-    end
+      it 'autocorrects blank line before #{access_modifier}' do
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
+          class Test
+            something
+            #{access_modifier}
+            def test; end
+          end
+        RUBY
 
-    it 'accepts missing blank line when at the end of specifying ' \
-       '`self`' do
-      expect_no_offenses(<<~RUBY)
-        class << self
-          def test; end
+        expect(corrected).to eq(<<-RUBY.strip_indent)
+          class Test
+            something
 
-          #{access_modifier}
-        end
-      RUBY
-    end
-
-    it 'requires blank line when next line started with end' do
-      inspect_source(<<~RUBY)
-        class Test
-          #{access_modifier}
-          end_this!
-        end
-      RUBY
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(["Keep a blank line after `#{access_modifier}`."])
-    end
-
-    it 'recognizes blank lines with DOS style line endings' do
-      expect_no_offenses(<<~RUBY)
-        class Test\r
-        \r
-          #{access_modifier}\r
-        \r
-          def test; end\r
-        end\r
-      RUBY
+            #{access_modifier}
+            def test; end
+          end
+        RUBY
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds `EnforcedStyle` to `Layout/EmptyLinesAroundAccessModifier` cop.
This makes it possible to select the following Rails coding convention.

> Indent and no blank line after private/protected.

https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions

"Indenting" is already implemented by `Layout/IndentationConsistency` cop.
This PR implements "no blank line after private/protected" by `Layout/IndentationConsistency` cop.

The EnforcedStyle names are `normal` and `rails` which are the same as `Layout/IndentationConsistency` cop.

The default `EnforceStyle` is "`normal`", which keeps the current style so that no breaking changes occur.

I was told about this style by Rails committer @kamipo. Thanks!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
