### PR TITLE
Add `AllowComments` option to ` Lint/HandleExceptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#6649](https://github.com/rubocop-hq/rubocop/pull/6649): `Layout/AlignHash` supports list of options. ([@stoivo][])
 * Add `IgnoreMethodPatterns` config option to `Style/MethodCallWithArgsParentheses`. ([@tejasbubane][])
+* [#7052](https://github.com/rubocop-hq/rubocop/issues/7052): Add `AllowComments` option to ` Lint/HandleExceptions`. ([@tejasbubane][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1360,7 +1360,9 @@ Lint/HandleExceptions:
   Description: "Don't suppress exception."
   StyleGuide: '#dont-hide-exceptions'
   Enabled: true
+  AllowComments: false
   VersionAdded: '0.9'
+  VersionChanged: '0.70'
 
 Lint/HeredocMethodCallPosition:
   Description: >-

--- a/lib/rubocop/cop/lint/handle_exceptions.rb
+++ b/lib/rubocop/cop/lint/handle_exceptions.rb
@@ -5,50 +5,89 @@ module RuboCop
     module Lint
       # This cop checks for *rescue* blocks with no body.
       #
-      # @example
+      # @example AllowComments: false (default)
       #
       #   # bad
+      #   def some_method
+      #     do_something
+      #   rescue
+      #   end
       #
+      #   # bad
       #   def some_method
       #     do_something
       #   rescue
       #     # do nothing
       #   end
       #
-      # @example
+      #   # bad
+      #   begin
+      #     do_something
+      #   rescue
+      #   end
       #
       #   # bad
-      #
       #   begin
       #     do_something
       #   rescue
       #     # do nothing
       #   end
       #
-      # @example
-      #
       #   # good
-      #
       #   def some_method
       #     do_something
       #   rescue
       #     handle_exception
       #   end
       #
-      # @example
-      #
       #   # good
-      #
       #   begin
       #     do_something
       #   rescue
       #     handle_exception
+      #   end
+      #
+      # @example AllowComments: true
+      #
+      #   # bad
+      #   def some_method
+      #     do_something
+      #   rescue
+      #   end
+      #
+      #   # bad
+      #   begin
+      #     do_something
+      #   rescue
+      #   end
+      #
+      #   # good
+      #   def some_method
+      #     do_something
+      #   rescue
+      #     # do nothing but comment
+      #   end
+      #
+      #   # good
+      #   begin
+      #     do_something
+      #   rescue
+      #     # do nothing but comment
       #   end
       class HandleExceptions < Cop
         MSG = 'Do not suppress exceptions.'
 
         def on_resbody(node)
-          add_offense(node) unless node.body
+          return if node.body
+          return if cop_config['AllowComments'] && comment_lines?(node)
+
+          add_offense(node)
+        end
+
+        private
+
+        def comment_lines?(node)
+          processed_source[line_range(node)].any? { |line| comment_line?(line) }
         end
       end
     end

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -809,48 +809,90 @@ format('A value: %s and another: %i', a_value, another)
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.9 | -
+Enabled | Yes | No | 0.9 | 0.70
 
 This cop checks for *rescue* blocks with no body.
 
 ### Examples
 
+#### AllowComments: false (default)
+
 ```ruby
 # bad
+def some_method
+  do_something
+rescue
+end
 
+# bad
 def some_method
   do_something
 rescue
   # do nothing
 end
-```
-```ruby
-# bad
 
+# bad
+begin
+  do_something
+rescue
+end
+
+# bad
 begin
   do_something
 rescue
   # do nothing
 end
-```
-```ruby
-# good
 
+# good
 def some_method
   do_something
 rescue
   handle_exception
 end
-```
-```ruby
-# good
 
+# good
 begin
   do_something
 rescue
   handle_exception
 end
 ```
+#### AllowComments: true
+
+```ruby
+# bad
+def some_method
+  do_something
+rescue
+end
+
+# bad
+begin
+  do_something
+rescue
+end
+
+# good
+def some_method
+  do_something
+rescue
+  # do nothing but comment
+end
+
+# good
+begin
+  do_something
+rescue
+  # do nothing but comment
+end
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AllowComments | `false` | Boolean
 
 ### References
 

--- a/spec/rubocop/cop/lint/handle_exceptions_spec.rb
+++ b/spec/rubocop/cop/lint/handle_exceptions_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Lint::HandleExceptions do
-  subject(:cop) { described_class.new }
+RSpec.describe RuboCop::Cop::Lint::HandleExceptions, :config do
+  subject(:cop) { described_class.new(config) }
 
   it 'registers an offense for empty rescue block' do
     expect_offense(<<~RUBY)
@@ -23,5 +23,20 @@ RSpec.describe RuboCop::Cop::Lint::HandleExceptions do
         file.close
       end
     RUBY
+  end
+
+  context 'AllowComments' do
+    let(:cop_config) { { 'AllowComments' => true } }
+
+    it 'does not register an offense for empty rescue with comment' do
+      expect_no_offenses(<<~RUBY)
+        begin
+          something
+          return
+        rescue
+          # do nothing
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Issue: https://github.com/rubocop-hq/rubocop/issues/7052

To allow empty rescue blocks with comments

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/