### PR TITLE
Fix a CI error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * [#6649](https://github.com/rubocop-hq/rubocop/pull/6649): `Layout/AlignHash` supports list of options. ([@stoivo][])
 * Add `IgnoreMethodPatterns` config option to `Style/MethodCallWithArgsParentheses`. ([@tejasbubane][])
 * [#7059](https://github.com/rubocop-hq/rubocop/pull/7059): Add `EnforcedStyle` to `Layout/EmptyLinesAroundAccessModifier`. ([@koic][])
-* [#7052](https://github.com/rubocop-hq/rubocop/issues/7052): Add `AllowComments` option to ` Lint/HandleExceptions`. ([@tejasbubane][]) 
+* [#7052](https://github.com/rubocop-hq/rubocop/issues/7052): Add `AllowComments` option to ` Lint/HandleExceptions`. ([@tejasbubane][])
 
 ### Bug fixes
 


### PR DESCRIPTION
Follow up https://github.com/rubocop-hq/rubocop/commit/8a7ee84eca14f801a8dfb7f44f758bc29c7f4d75.

This PR fixes the following CI errors.

```console
bundle exec rake

(snip)

  1) RuboCop Project changelog entry after version 0.14.0 has a link to
  the contributors at the end
     Failure/Error: expect(entries).to all(match(/\(\[@\S+\]\[\](?:,
  \[@\S+\]\[\])*\)$/))

       expected ["*
       [#6649](https://github.com/rubocop-hq/rubocop/pull/6649):
       `Layout/AlignHash` supports list of opt...552): `RaiseArgs`
       allows exception constructor calls with more than one 1
       argument. ([@bbatsov][])"] to all match /\(\[@\S+\]\[\](?:,
       \[@\S+\]\[\])*\)$/

          object at index 3 failed to match:
             expected "*
             [#7052](https://github.com/rubocop-hq/rubocop/issues/7052):
             Add `AllowComments` option to `
             Lint/HandleExceptions`. ([@tejasbubane][]) " to match
             /\(\[@\S+\]\[\](?:, \[@\S+\]\[\])*\)$/
     # ./spec/project_spec.rb:128:in `block (5 levels) in <top (required)>'

(snip)

  2) RuboCop Project changelog entry body ends with a punctuation
     Failure/Error: expect(bodies).to all(match(/[\.\!]$/))

       expected ["`` supports list of options.", "Add `` config option
       to ``.", "Add `` to ``.", "Add `` option to ``...nclosed in
       braces are not noticed.", "Received malformed format string
       ArgumentError from rubocop."] to all match /[\.\!]$/

          object at index 3 failed to match:
             expected "Add `` option to ``. ([@tejasbubane][]) " to
             match /[\.\!]$/
     # ./spec/project_spec.rb:187:in `block (5 levels) in <top (required)>'
```

https://circleci.com/gh/rubocop-hq/rubocop/55378

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
