### PR TITLE
Switch to `receive` message expectation syntax

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -93,5 +93,8 @@ Metrics/ModuleLength:
 RSpec/PredicateMatcher:
   EnforcedStyle: explicit
 
+RSpec/MessageSpies:
+  EnforcedStyle: receive
+
 RSpec/NestedGroups:
   Max: 7

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1187,13 +1187,12 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           Exclude:
             - ignored/**
       YAML
-      allow(File).to receive(:open).and_call_original
+      expect(File).not_to receive(:open).with(%r{/ignored/})
       expect(cli.run(%w[--format simple example])).to eq(0)
       expect($stdout.string).to eq(<<~OUTPUT)
 
         0 files inspected, no offenses detected
       OUTPUT
-      expect(File).not_to have_received(:open).with(%r{/ignored/})
     end
 
     it 'can be configured with option to disable a certain error' do

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -947,23 +947,19 @@ RSpec.describe RuboCop::Config do
         }
       end
 
-      before do
-        allow(File).to receive(:file?).and_call_original
-      end
-
       it 'uses TargetRubyVersion' do
         expect(configuration.target_ruby_version).to eq ruby_version
       end
 
       it 'does not read .ruby-version' do
+        expect(File).not_to receive(:file?).with('.ruby-version')
         configuration.target_ruby_version
-        expect(File).not_to have_received(:file?).with('.ruby-version')
       end
 
       it 'does not read Gemfile.lock or gems.locked' do
+        expect(File).not_to receive(:file?).with('Gemfile')
+        expect(File).not_to receive(:file?).with('gems.locked')
         configuration.target_ruby_version
-        expect(File).not_to have_received(:file?).with('Gemfile')
-        expect(File).not_to have_received(:file?).with('gems.locked')
       end
     end
 
@@ -1029,10 +1025,9 @@ RSpec.describe RuboCop::Config do
         end
 
         it 'does not read Gemfile.lock or gems.locked' do
-          allow(File).to receive(:file?).and_call_original
+          expect(File).not_to receive(:file?).with('Gemfile')
+          expect(File).not_to receive(:file?).with('gems.locked')
           configuration.target_ruby_version
-          expect(File).not_to have_received(:file?).with('Gemfile')
-          expect(File).not_to have_received(:file?).with('gems.locked')
         end
       end
 

--- a/spec/rubocop/config_store_spec.rb
+++ b/spec/rubocop/config_store_spec.rb
@@ -30,43 +30,37 @@ RSpec.describe RuboCop::ConfigStore do
 
     context 'when no config specified in command line' do
       it 'gets config path and config from cache if available' do
+        expect(RuboCop::ConfigLoader)
+          .to receive(:configuration_file_for).with('dir').once
+        expect(RuboCop::ConfigLoader)
+          .to receive(:configuration_file_for).with('dir/subdir').once
+        # The stub returns the same config path for dir and dir/subdir.
+        expect(RuboCop::ConfigLoader)
+          .to receive(:configuration_from_file)
+          .with('dir/.rubocop.yml').once
+
         config_store.for('dir/file2')
         config_store.for('dir/file2')
         config_store.for('dir/subdir/file3')
-
-        expect(RuboCop::ConfigLoader)
-          .to have_received(:configuration_file_for).with('dir').once
-        expect(RuboCop::ConfigLoader)
-          .to have_received(:configuration_file_for).with('dir/subdir').once
-        # The stub returns the same config path for dir and dir/subdir.
-        expect(RuboCop::ConfigLoader)
-          .to have_received(:configuration_from_file)
-          .with('dir/.rubocop.yml').once
       end
 
       it 'searches for config path if not available in cache' do
-        allow(RuboCop::ConfigLoader).to receive(:configuration_file_for)
-        allow(RuboCop::ConfigLoader).to receive(:configuration_from_file)
+        expect(RuboCop::ConfigLoader)
+          .to receive(:configuration_file_for).once
+        expect(RuboCop::ConfigLoader)
+          .to receive(:configuration_from_file).once
 
         config_store.for('file1')
-
-        expect(RuboCop::ConfigLoader)
-          .to have_received(:configuration_file_for).once
-        expect(RuboCop::ConfigLoader)
-          .to have_received(:configuration_from_file).once
       end
 
       context 'when --force-default-config option is specified' do
         it 'uses default config without searching for config path' do
-          allow(RuboCop::ConfigLoader).to receive(:configuration_file_for)
-          allow(RuboCop::ConfigLoader).to receive(:configuration_from_file)
+          expect(RuboCop::ConfigLoader)
+            .not_to receive(:configuration_file_for)
+          expect(RuboCop::ConfigLoader)
+            .not_to receive(:configuration_from_file)
 
           config_store.force_default_config!
-
-          expect(RuboCop::ConfigLoader)
-            .not_to have_received(:configuration_file_for)
-          expect(RuboCop::ConfigLoader)
-            .not_to have_received(:configuration_from_file)
 
           expect(config_store.for('file1')).to eq('default config')
         end

--- a/spec/rubocop/cop/commissioner_spec.rb
+++ b/spec/rubocop/cop/commissioner_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::Cop::Commissioner do
     end
 
     it 'traverses the AST and invoke cops specific callbacks' do
-      allow(cop).to receive(:on_def)
+      expect(cop).to receive(:on_def).once
 
       commissioner = described_class.new([cop], [])
       source = <<~RUBY
@@ -50,23 +50,19 @@ RSpec.describe RuboCop::Cop::Commissioner do
       processed_source = parse_source(source)
 
       commissioner.investigate(processed_source)
-
-      expect(cop).to have_received(:on_def).once
     end
 
     it 'passes the input params to all cops/forces that implement their own' \
        ' #investigate method' do
       source = ''
       processed_source = parse_source(source)
-      allow(cop).to receive(:investigate)
-      allow(force).to receive(:investigate)
+
+      expect(cop).to receive(:investigate).with(processed_source)
+      expect(force).to receive(:investigate).with(processed_source)
 
       commissioner = described_class.new([cop], [force])
 
       commissioner.investigate(processed_source)
-
-      expect(cop).to have_received(:investigate).with(processed_source)
-      expect(force).to have_received(:investigate).with(processed_source)
     end
 
     it 'stores all errors raised by the cops' do

--- a/spec/rubocop/cop/force_spec.rb
+++ b/spec/rubocop/cop/force_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe RuboCop::Cop::Force do
 
   let(:cops) do
     [
-      instance_spy(RuboCop::Cop::Cop),
-      instance_spy(RuboCop::Cop::Cop)
+      instance_double(RuboCop::Cop::Cop),
+      instance_double(RuboCop::Cop::Cop)
     ]
   end
 
@@ -18,9 +18,9 @@ RSpec.describe RuboCop::Cop::Force do
 
   describe '#run_hook' do
     it 'invokes a hook in all cops' do
-      force.run_hook(:message, :foo)
+      expect(cops).to all receive(:message).with(:foo)
 
-      expect(cops).to all(have_received(:message).with(:foo))
+      force.run_hook(:message, :foo)
     end
   end
 end

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -81,11 +81,12 @@ RSpec.describe RuboCop::Cop::Generator do
         end
       RUBY
 
+      expect(File)
+        .to receive(:write)
+        .with('lib/rubocop/cop/style/fake_cop.rb', generated_source)
+
       generator.write_source
 
-      expect(File)
-        .to have_received(:write)
-        .with('lib/rubocop/cop/style/fake_cop.rb', generated_source)
       expect(stdout.string)
         .to eq("[create] lib/rubocop/cop/style/fake_cop.rb\n")
     end
@@ -131,11 +132,11 @@ RSpec.describe RuboCop::Cop::Generator do
         end
       SPEC
 
-      generator.write_spec
-
       expect(File)
-        .to have_received(:write)
+        .to receive(:write)
         .with('spec/rubocop/cop/style/fake_cop_spec.rb', generated_source)
+
+      generator.write_spec
     end
 
     it 'refuses to overwrite existing files' do
@@ -195,11 +196,7 @@ RSpec.describe RuboCop::Cop::Generator do
     it 'inserts the cop in alphabetical order' do
       stub_const('RuboCop::Version::STRING', '0.58.2')
 
-      allow(File).to receive(:write)
-
-      generator.inject_config(config_file_path: path)
-
-      expect(File).to have_received(:write).with(path, <<~YAML)
+      expect(File).to receive(:write).with(path, <<~YAML)
         Style/Alias:
           Enabled: true
 
@@ -214,6 +211,9 @@ RSpec.describe RuboCop::Cop::Generator do
         Style/SpecialGlobalVars:
           Enabled: true
       YAML
+
+      generator.inject_config(config_file_path: path)
+
       expect(stdout.string).to eq(<<~MESSAGE)
         [modify] A configuration for the cop is added into #{path}.
                  If you want to disable the cop by default, set `Enabled` option to false.
@@ -245,8 +245,6 @@ RSpec.describe RuboCop::Cop::Generator do
       example.run
       RuboCop::Cop::Cop.instance_variable_set(:@registry, orig_registry)
     end
-
-    before { allow(File).to receive(:write).and_call_original }
 
     let(:config) do
       config = RuboCop::ConfigStore.new

--- a/spec/rubocop/formatter/colorizable_spec.rb
+++ b/spec/rubocop/formatter/colorizable_spec.rb
@@ -105,11 +105,9 @@ RSpec.describe RuboCop::Formatter::Colorizable do
   ].each do |color|
     describe "##{color}" do
       it "invokes #colorize(string, #{color}" do
-        allow(formatter).to receive(:colorize)
+        expect(formatter).to receive(:colorize).with('foo', color)
 
         formatter.send(color, 'foo')
-
-        expect(formatter).to have_received(:colorize).with('foo', color)
       end
     end
   end

--- a/spec/rubocop/formatter/formatter_set_spec.rb
+++ b/spec/rubocop/formatter/formatter_set_spec.rb
@@ -10,21 +10,14 @@ RSpec.describe RuboCop::Formatter::FormatterSet do
   end
 
   describe 'formatter API method' do
-    before do
-      formatter_set.add_formatter('simple')
-      formatter_set.add_formatter('emacs')
-
-      formatter_set.each do |formatter|
-        allow(formatter).to receive(:started)
-      end
-    end
-
     let(:files) { ['/path/to/file1', '/path/to/file2'] }
 
-    it 'invokes same method of all containing formatters' do
+    it 'invokes the same method of all containing formatters' do
+      formatter_set.add_formatter('simple')
+      formatter_set.add_formatter('emacs')
+      expect(formatter_set[0]).to receive(:started).with(files)
+      expect(formatter_set[1]).to receive(:started).with(files)
       formatter_set.started(files)
-
-      expect(formatter_set).to all(have_received(:started).with(files))
     end
   end
 

--- a/spec/rubocop/formatter/progress_formatter_spec.rb
+++ b/spec/rubocop/formatter/progress_formatter_spec.rb
@@ -19,11 +19,9 @@ RSpec.describe RuboCop::Formatter::ProgressFormatter do
 
     shared_examples 'calls #report_file_as_mark' do
       it 'calls #report_as_with_mark' do
-        allow(formatter).to receive(:report_file_as_mark)
+        expect(formatter).to receive(:report_file_as_mark)
 
         formatter.file_finished(files.first, offenses)
-
-        expect(formatter).to have_received(:report_file_as_mark)
       end
     end
 
@@ -183,11 +181,9 @@ RSpec.describe RuboCop::Formatter::ProgressFormatter do
     end
 
     it 'calls #report_summary' do
-      allow(formatter).to receive(:report_summary)
+      expect(formatter).to receive(:report_summary)
 
       formatter.finished(files)
-
-      expect(formatter).to have_received(:report_summary)
     end
   end
 end

--- a/spec/rubocop/rake_task_spec.rb
+++ b/spec/rubocop/rake_task_spec.rb
@@ -44,12 +44,12 @@ RSpec.describe RuboCop::RakeTask do
     it 'runs with default options' do
       described_class.new
 
-      cli = instance_spy(RuboCop::CLI, run: 0)
-      allow(RuboCop::CLI).to receive(:new) { cli }
+      cli = instance_double(RuboCop::CLI, run: 0)
+      allow(RuboCop::CLI).to receive(:new).and_return(cli)
+
+      expect(cli).to receive(:run).with([])
 
       Rake::Task['rubocop'].execute
-
-      expect(cli).to have_received(:run).with([])
     end
 
     it 'runs with specified options if a block is given' do
@@ -61,13 +61,13 @@ RSpec.describe RuboCop::RakeTask do
         task.verbose = false
       end
 
-      cli = instance_spy(RuboCop::CLI, run: 0)
-      allow(RuboCop::CLI).to receive(:new) { cli }
+      cli = instance_double(RuboCop::CLI, run: 0)
+      allow(RuboCop::CLI).to receive(:new).and_return(cli)
       options = ['--format', 'files', '--display-cop-names', 'lib/**/*.rb']
 
-      Rake::Task['rubocop'].execute
+      expect(cli).to receive(:run).with(options)
 
-      expect(cli).to have_received(:run).with(options)
+      Rake::Task['rubocop'].execute
     end
 
     it 'allows nested arrays inside formatters, options, and requires' do
@@ -77,14 +77,14 @@ RSpec.describe RuboCop::RakeTask do
         task.options = [['--display-cop-names']]
       end
 
-      cli = instance_spy(RuboCop::CLI, run: 0)
-      allow(RuboCop::CLI).to receive(:new) { cli }
+      cli = instance_double(RuboCop::CLI, run: 0)
+      allow(RuboCop::CLI).to receive(:new).and_return(cli)
       options = ['--format', 'files', '--require', 'library',
                  '--display-cop-names']
 
-      Rake::Task['rubocop'].execute
+      expect(cli).to receive(:run).with(options)
 
-      expect(cli).to have_received(:run).with(options)
+      Rake::Task['rubocop'].execute
     end
 
     it 'will not error when result is not 0 and fail_on_error is false' do
@@ -93,7 +93,7 @@ RSpec.describe RuboCop::RakeTask do
       end
 
       cli = instance_double(RuboCop::CLI, run: 1)
-      allow(RuboCop::CLI).to receive(:new) { cli }
+      allow(RuboCop::CLI).to receive(:new).and_return(cli)
 
       expect { Rake::Task['rubocop'].execute }.not_to raise_error
     end
@@ -102,7 +102,7 @@ RSpec.describe RuboCop::RakeTask do
       described_class.new
 
       cli = instance_double(RuboCop::CLI, run: 1)
-      allow(RuboCop::CLI).to receive(:new) { cli }
+      allow(RuboCop::CLI).to receive(:new).and_return(cli)
 
       expect { Rake::Task['rubocop'].execute }.to raise_error(SystemExit)
     end
@@ -137,13 +137,13 @@ RSpec.describe RuboCop::RakeTask do
       it 'runs with --auto-correct' do
         described_class.new
 
-        cli = instance_spy(RuboCop::CLI, run: 0)
-        allow(RuboCop::CLI).to receive(:new) { cli }
+        cli = instance_double(RuboCop::CLI, run: 0)
+        allow(RuboCop::CLI).to receive(:new).and_return(cli)
         options = ['--auto-correct']
 
-        Rake::Task['rubocop:auto_correct'].execute
+        expect(cli).to receive(:run).with(options)
 
-        expect(cli).to have_received(:run).with(options)
+        Rake::Task['rubocop:auto_correct'].execute
       end
 
       it 'runs with with the options that were passed to its parent task' do
@@ -156,12 +156,12 @@ RSpec.describe RuboCop::RakeTask do
         end
 
         cli = instance_double(RuboCop::CLI, run: 0)
-        allow(RuboCop::CLI).to receive(:new) { cli }
+        allow(RuboCop::CLI).to receive(:new).and_return(cli)
         options = ['--auto-correct', '--format', 'files', '-D', 'lib/**/*.rb']
 
-        Rake::Task['rubocop:auto_correct'].execute
+        expect(cli).to receive(:run).with(options)
 
-        expect(cli).to have_received(:run).with(options)
+        Rake::Task['rubocop:auto_correct'].execute
       end
     end
   end

--- a/spec/rubocop/runner_formatter_invocation_spec.rb
+++ b/spec/rubocop/runner_formatter_invocation_spec.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Formatter::BaseFormatter do
-  include_context 'cli spec behavior'
+RSpec.describe RuboCop::Runner, :isolated_environment do
+  describe 'how formatter is invoked' do
+    include_context 'cli spec behavior'
 
-  describe 'how the API methods are invoked', :isolated_environment do
-    subject(:formatter) { instance_double(described_class).as_null_object }
+    subject(:runner) { described_class.new({}, RuboCop::ConfigStore.new) }
 
-    let(:runner) { RuboCop::Runner.new({}, RuboCop::ConfigStore.new) }
+    let(:formatter) do
+      instance_double(RuboCop::Formatter::BaseFormatter).as_null_object
+    end
     let(:output) { $stdout.string }
 
     before do
       create_file('2_offense.rb', '#' * 90)
-
       create_file('5_offenses.rb', ['puts x ', 'test;', 'top;', '#' * 90])
-
       create_file('no_offense.rb', '# frozen_string_literal: true')
 
       allow(RuboCop::Formatter::SimpleTextFormatter)
@@ -28,8 +28,8 @@ RSpec.describe RuboCop::Formatter::BaseFormatter do
     end
 
     describe 'invocation order' do
-      subject(:formatter) do
-        formatter = instance_spy(described_class)
+      let(:formatter) do
+        formatter = instance_spy(RuboCop::Formatter::BaseFormatter)
         %i[started file_started file_finished finished output]
           .each do |message|
           allow(formatter).to receive(message) do
@@ -54,106 +54,116 @@ RSpec.describe RuboCop::Formatter::BaseFormatter do
       end
     end
 
-    shared_examples 'receives all file paths' do |method_name|
-      before { run }
-
-      it 'receives all file paths' do
+    shared_examples 'sends all file paths' do |method_name|
+      it 'sends all file paths' do
         expected_paths = [
           '2_offense.rb',
           '5_offenses.rb',
           'no_offense.rb'
         ].map { |path| File.expand_path(path) }.sort
 
-        expect(formatter).to have_received(method_name) do |all_files|
+        expect(formatter).to receive(method_name) do |all_files|
           expect(all_files.sort).to eq(expected_paths)
         end
+
+        run
       end
 
       describe 'the passed files paths' do
         it 'is frozen' do
-          expect(formatter).to have_received(method_name) do |all_files|
+          expect(formatter).to receive(method_name) do |all_files|
             all_files.each do |path|
               expect(path.frozen?).to be(true)
             end
           end
+
+          run
         end
       end
     end
 
     describe '#started' do
-      include_examples 'receives all file paths', :started
+      include_examples 'sends all file paths', :started
     end
 
     describe '#finished' do
       context 'when RuboCop finished inspecting all files normally' do
-        include_examples 'receives all file paths', :started
+        include_examples 'sends all file paths', :started
       end
 
       context 'when RuboCop is interrupted by user' do
-        it 'receives only processed file paths' do
+        it 'sends only processed file paths' do
           class << formatter
-            attr_reader :processed_file_count
+            attr_reader :reported_file_count
 
             def file_finished(_file, _offenses)
-              @processed_file_count ||= 0
-              @processed_file_count += 1
+              @reported_file_count ||= 0
+              @reported_file_count += 1
             end
           end
 
-          allow(runner).to receive(:process_file)
-            .and_wrap_original do |m, *args|
-              raise Interrupt if formatter.processed_file_count == 2
+          class << runner
+            attr_reader :processed_file_count
 
-              m.call(*args)
+            def process_file(_file)
+              raise Interrupt if processed_file_count == 2
+
+              @processed_file_count ||= 0
+              @processed_file_count += 1
+
+              super
             end
+          end
 
           run
 
-          expect(formatter).to have_received(:finished) do |processed_files|
-            expect(processed_files.size).to eq(2)
-          end
+          expect(formatter.reported_file_count).to eq(2)
         end
       end
     end
 
-    shared_examples 'receives a file path' do |method_name|
-      before { run }
-
-      it 'receives a file path' do
-        expect(formatter).to have_received(method_name)
+    shared_examples 'sends a file path' do |method_name|
+      it 'sends a file path' do
+        expect(formatter).to receive(method_name)
           .with(File.expand_path('2_offense.rb'), anything)
 
-        expect(formatter).to have_received(method_name)
+        expect(formatter).to receive(method_name)
           .with(File.expand_path('5_offenses.rb'), anything)
 
-        expect(formatter).to have_received(method_name)
+        expect(formatter).to receive(method_name)
           .with(File.expand_path('no_offense.rb'), anything)
+
+        run
       end
 
       describe 'the passed path' do
         it 'is frozen' do
           expect(formatter)
-            .to have_received(method_name).exactly(3).times do |path|
+            .to receive(method_name).exactly(3).times do |path|
             expect(path.frozen?).to be(true)
           end
+
+          run
         end
       end
     end
 
     describe '#file_started' do
-      include_examples 'receives a file path', :file_started
+      include_examples 'sends a file path', :file_started
 
-      it 'receives file specific information hash' do
-        expect(formatter).to have_received(:file_started)
+      it 'sends file specific information hash' do
+        expect(formatter).to receive(:file_started)
           .with(anything, an_instance_of(Hash)).exactly(3).times
+
+        run
       end
     end
 
     describe '#file_finished' do
-      include_examples 'receives a file path', :file_finished
+      include_examples 'sends a file path', :file_finished
 
-      it 'receives an array of detected offenses for the file' do
-        expect(formatter).to have_received(:file_finished)
+      it 'sends an array of detected offenses for the file' do
+        expect(formatter).to receive(:file_finished)
           .exactly(3).times do |file, offenses|
           case File.basename(file)
           when '2_offense.rb'
@@ -165,9 +175,10 @@ RSpec.describe RuboCop::Formatter::BaseFormatter do
           else
             raise
           end
-          expect(offenses.all? { |o| o.is_a?(RuboCop::Cop::Offense) })
-            .to be_truthy
+          expect(offenses).to all be_a(RuboCop::Cop::Offense)
         end
+
+        run
       end
     end
   end


### PR DESCRIPTION
I started off [improving `RSpec/SubjectStub` cop](https://github.com/rubocop-hq/rubocop-rspec/pull/770/) that had a special case of dealing with `expect(subject).to all receive(...)` that was originally present in RuboCop, and I've removed this special case in [this commit](https://github.com/rubocop-hq/rubocop-rspec/pull/770/commits/779c95e206c8beb539a3a970b362ff639323f430), since according to an experiment, it's not raising any single offence for repositories from [`real-world-ruby-apps`](https://github.com/jeromedalbert/real-world-ruby-apps) (11k files) and [`real-world-rails`](https://github.com/eliotsykes/real-world-rails) (79k files).

Original line when a special case was introduced:

    expect(formatter_set).to all(receive(:started).with(files))

later reworked to:

    expect(formatter_set).to all(have_received(:started).with(files))


I've replaced this with:

    expect(formatter_set[0]).to receive(:started).with(files)
    expect(formatter_set[1]).to receive(:started).with(files)

that is quite consistent with the style used in the rest of that spec file.

Also, using spies is not justified in this case.

It doesn't make much sense to use a `before` hook that is only run along with a single example, so I've simplified it as well.


However, I've faced another cop, `RSpec/MessageSpies`, that complains that `receive` is used instead of `have_received`. What confuses me is that according to [the chat from 10 Oct 2016](https://gitter.im/rubocop-rspec/Lobby):

> If a spec example has multiple stubs (allow) and you want a focused spec with just one expectation per example – and RuboCop is now telling you that you must change all those stubs into expectations. Not good.

However, [in `rubocop`](https://github.com/rubocop-hq/rubocop/blob/master/.rubocop_todo.yml#L67) this is not a problem, as multiple expectations per example are allowed:
```
RSpec/MultipleExpectations:
  Max: 25
```

So I decided to give it a shot and take a look what happens if I switch the default enforced style of `RSpec/MessageSpies` from `have_received` to `receive`, and this pull request is the result of this switch.

### Why it makes sense to merge this?

1. `rubocop-rspec`'s `SubjectStub` has a special case that deals with a single known example, here, in `rubocop`'s `formatter_set_spec.rb`.
2. Less hooks are used, the specs are more straightforward.
3. Spies have to be additionally instantiated, but now anymore.
4. Base formatter spec is now "Runner formatter invocation spec", which reflects what it tests.

### Why it wouldn't make sense to merge this?

1. Usage of `expect(...).to receive` breaks Arrange-Act-Assert pattern.

### What is redundant

I've made a couple of changes along the way not directly related to this change, specifically changed `receive { ... }` to `.and_return`. Don't remember the details, but I think it's recommended to use this syntax.



Appreciate any feedback on this.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/