### PR TITLE
[Speed up] Skip calling `ResultCache.cleanup` when files size is 1

### DIFF
--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -72,7 +72,12 @@ module RuboCop
 
       each_inspected_file(files) { |file| inspected_files << file }
     ensure
-      ResultCache.cleanup(@config_store, @options[:debug]) if cached_run?
+      # OPTIMIZE: Calling `ResultCache.cleanup` takes time. This optimization
+      # mainly targets editors that integrates RuboCop. When RuboCop is run
+      # by an editor, it should be inspecting only one file.
+      if files.size > 1 && cached_run?
+        ResultCache.cleanup(@config_store, @options[:debug])
+      end
       formatter_set.finished(inspected_files.freeze)
       formatter_set.close_output_files
     end


### PR DESCRIPTION

## Summary

Skip calling `ResultCache.cleanup` when the inspecting file is only one. 
For performance 🚀. 

* `ResultCache.cleanup` takes time.
  * If there are 8000 cache files, it takes about 200ms.
* It is meaningful to save as much as 200ms when integrating text editors.
* When rubocop called by text editor, this `files.size` will be always 1.

If this PR is merged, we will lose the opportunity for cleaning when the cache file is increased by 1, but I believe it is not important. :)


## Speed difference test


### 1. Do `gem build rubocop.gemspec`
### 2. Do `gem i rubocop-0.70.0.gem`
### 3. Create 8000+ cache objects

<details><summary>How?</summary>

```bash
# First, ensure there is no caches.
$ rm -rf ~/.cache/rubocop_cache 

# Then, run rubocop 8 times with different options.
$ rubocop -P --only=Metrics/AbcSize
$ rubocop -P --only=Metrics/BlockLength
$ rubocop -P --only=Metrics/BlockNesting
$ rubocop -P --only=Metrics/ClassLength
$ rubocop -P --only=Metrics/CyclomaticComplexity
$ rubocop -P --only=Metrics/LineLength
$ rubocop -P --only=Metrics/MethodLength

# Now you get 8000+ cache files.
$ tree ~/.cache/rubocop_cache | tail -1
9 directories, 8268 files
```

</details>

### 4. Do `time rubocop -a -d Gemfile` 11times(1 rehearsal + 10 attempts)  at top directory of rubocop repository.

result:

| time(1)   | average  | min | max |
|-----|----:|-----:|----:|
| rubocop 0.70.0 (959f215)  | 1.4613 | 1.398 | 1.529 |
| This PR(4ec7a3ba) | 1.2363 | 1.199 | 1.309 | 

∴ **220ms faster !!** 🚀 

tested by:  `ruby 2.6.3p62 (2019-04-16 revision 67580) [x86_64-darwin17]`

## Is it normal to have 8000+ cache files?

I think, yes. Default limit is 20000.

See also:

* https://github.com/rubocop-hq/rubocop/blob/v0.70.0/lib/rubocop/result_cache.rb#L13-L18
* https://github.com/rubocop-hq/rubocop/blob/v0.70.0/config/default.yml#L103-L107


## Why `ResultCache.cleanup` is slow?

I think it is because ["File.file?"](https://github.com/rubocop-hq/rubocop/blob/v0.70.0/lib/rubocop/result_cache.rb#L25) is called many times.

It is a robust implementation, it works well without knowing how deep the directory hierarchy is in advance. 

If you prefer a naive implementation, there may be room for even faster.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x]  Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
