### PR TITLE
[#5976] Warn for Rails Cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#5976](https://github.com/rubocop-hq/rubocop/issues/5976): Warn for Rails Cops. ([@koic][])
+
 ## 0.70.0 (2019-05-21)
 
 ### New features

--- a/manual/migrate_rails_cops.md
+++ b/manual/migrate_rails_cops.md
@@ -1,0 +1,21 @@
+Rails cops will be removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.
+
+Put this in your `Gemfile`.
+
+```rb
+gem 'rubocop-rails'
+```
+
+And then execute:
+
+```sh
+$ bundle install
+```
+
+Put this into your `.rubocop.yml`.
+
+```yaml
+require: rubocop-rails
+```
+
+More information: https://github.com/rubocop-hq/rubocop-rails

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -42,4 +42,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('bundler', '>= 1.15.0', '< 3.0')
   s.add_development_dependency('rack', '>= 2.0')
+
+  s.post_install_message = File.read('manual/migrate_rails_cops.md')
 end


### PR DESCRIPTION
This PR warns for Rails Cops.

The following warning is displayed when the next released rubocop gem is installed.

```console
# The following is an example for operation check.
% rake build
Rails cops have been removed from RuboCop 0.71. Use the `rubocop-rails`
gem instead.

Put this in your `Gemfile`.

gem 'rubocop-rails'

And then execute:

$ bundle install

Put this into your `.rubocop.yml`.

require: rubocop-rails

More information: https://github.com/rubocop-hq/rubocop-rails
    exists /Users/koic/src/github.com/rubocop-hq/rubocop
Successfully installed rubocop-0.70.0
1 gem installed
```

Based on the migration of RuboCop Performance I am considering the following transition schedule.

- 0.70 ... Current version
- Next release ... Display a warning and prepare a transition period for users
- 0.72 ... Remove the Rails cops from RuboCop Core

https://github.com/rubocop-hq/rubocop/pull/6845#issuecomment-474277118

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
