### PR TITLE
[Fix #6936] Fix MultilineMethodArgumentLineBreaks when bracket hash assignment on multiple lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#5976](https://github.com/rubocop-hq/rubocop/issues/5976): Warn for Rails Cops. ([@koic][])
 
+### Bug fixes
+
+* [#6936](https://github.com/rubocop-hq/rubocop/issues/6936): Fix `Layout/MultilineMethodArgumentLineBreaks` when bracket hash assignment on multiple lines. ([@maxh][])
+
 ## 0.70.0 (2019-05-21)
 
 ### New features

--- a/lib/rubocop/cop/layout/multiline_method_argument_line_breaks.rb
+++ b/lib/rubocop/cop/layout/multiline_method_argument_line_breaks.rb
@@ -26,6 +26,8 @@ module RuboCop
           'on a separate line.'
 
         def on_send(node)
+          return if node.method_name == :[]=
+
           args = node.arguments
 
           # If there is a trailing hash arg without explicit braces, like this:

--- a/spec/rubocop/cop/layout/multiline_method_argument_line_breaks_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_argument_line_breaks_spec.rb
@@ -13,6 +13,33 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodArgumentLineBreaks do
     end
   end
 
+  context 'when bracket hash assignment on multiple lines' do
+    it 'does not add any offenses' do
+      expect_no_offenses(
+        <<-RUBY
+          class Thing
+            def call
+              bar['foo'] = ::Time.zone.at(
+                             huh['foo'],
+                           )
+            end
+          end
+        RUBY
+      )
+    end
+  end
+
+  context 'when bracket hash assignment key on multiple lines' do
+    it 'does not add any offenses' do
+      expect_no_offenses(
+        <<-RUBY
+          a['b',
+              'c', 'd'] = e
+        RUBY
+      )
+    end
+  end
+
   context 'when two arguments are on next line' do
     it 'does not add any offenses' do
       expect_no_offenses(


### PR DESCRIPTION
Fixes https://github.com/rubocop-hq/rubocop/issues/6936 by handling this case:

```rb
a['b'] = c(
  1,
)
```

The `[]` assignment is represented in the AST by a send node with `b` as an argument and the expression on the right as an argument. It's ok that these are on the same line.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
