### PR TITLE
[Fix #7073] Fix false positive in Naming/RescuedExceptionsVariableName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#7073](https://github.com/rubocop-hq/rubocop/issues/7073): Fix false positive in `Naming/RescuedExceptionsVariableName` cop. ([@tejasbubane][])
+
 ### Changes
 
 * [#5976](https://github.com/rubocop-hq/rubocop/issues/5976): Warn for Rails Cops. ([@koic][])

--- a/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
+++ b/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
@@ -90,11 +90,8 @@ module RuboCop
         end
 
         def preferred_name
-          @preferred_name ||= begin
-            name = cop_config.fetch('PreferredName', 'e')
-            name = "_#{name}" if variable_name.to_s.start_with?('_')
-            name
-          end
+          name = cop_config.fetch('PreferredName', 'e')
+          variable_name.to_s.start_with?('_') ? "_#{name}" : name
         end
 
         def variable_name

--- a/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
@@ -88,6 +88,18 @@ RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
             end
           RUBY
         end
+
+        it 'does not register an offense when using _e followed by e' do
+          expect_no_offenses(<<~RUBY)
+            begin
+              something
+            rescue MyException => _e
+              # do something
+            rescue AnotherException => e
+              # do something
+            end
+          RUBY
+        end
       end
 
       context 'without `Exception` variable' do


### PR DESCRIPTION
Remove memoization of `preferred_name`.

Closes #7073

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
