### PR TITLE
Add bootsnap to optimize boot time.

### DIFF
--- a/exe/rubocop
+++ b/exe/rubocop
@@ -3,6 +3,24 @@
 
 $LOAD_PATH.unshift("#{__dir__}/../lib")
 
+require 'bootsnap'
+cache_dir = if ENV.key?('XDG_CACHE_HOME')
+              # Include user ID in the path to make sure the user has write
+              # access.
+              File.join(
+                ENV['XDG_CACHE_HOME'],
+                Process.uid.to_s,
+                'rubocop_bootsnap_cache'
+              )
+            else
+              File.join(ENV['HOME'], '.cache', 'rubocop_bootsnap_cache')
+            end
+Bootsnap.setup(
+  cache_dir: cache_dir,
+  load_path_cache: false,
+  autoload_paths_cache: false
+)
+
 require 'rubocop'
 require 'benchmark'
 

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => 'https://github.com/rubocop-hq/rubocop/issues'
   }
 
+  s.add_runtime_dependency('bootsnap')
   s.add_runtime_dependency('jaro_winkler', '~> 1.5.1')
   s.add_runtime_dependency('parallel', '~> 1.10')
   s.add_runtime_dependency('parser', '>= 2.6')


### PR DESCRIPTION
### before

```
    _╰╰,   /ﾊﾞｼｮ % ~/src/github.com/rubocop-hq/rubocop
  _/o ŏｧ  / ﾌﾞﾗﾝﾁ% master ﾔﾊﾞｲ
∈ミ;ﾉ,ﾉ   ＼ﾒｲﾚｲ% time bundle exec rubocop -v
0.70.0
bundle exec rubocop -v  0.79s user 0.12s system 95% cpu 0.952 total
    _╰╰,   /ﾊﾞｼｮ % ~/src/github.com/rubocop-hq/rubocop
  _/o ŏｧ  / ﾌﾞﾗﾝﾁ% master ﾔﾊﾞｲ
∈ミ;ﾉ,ﾉ   ＼ﾒｲﾚｲ% time bundle exec rubocop -v
0.70.0
bundle exec rubocop -v  0.75s user 0.06s system 97% cpu 0.832 total
    _╰╰,   /ﾊﾞｼｮ % ~/src/github.com/rubocop-hq/rubocop
  _/o ŏｧ  / ﾌﾞﾗﾝﾁ% master ﾔﾊﾞｲ
∈ミ;ﾉ,ﾉ   ＼ﾒｲﾚｲ% time bundle exec rubocop -v
0.70.0
bundle exec rubocop -v  0.78s user 0.10s system 95% cpu 0.923 tota
```

### after

```
    _╰╰,   /ﾊﾞｼｮ % ~/src/github.com/rubocop-hq/rubocop
  _/o ŏｧ  / ﾌﾞﾗﾝﾁ% master● ﾔﾊﾞｲ
∈ミ;ﾉ,ﾉ   ＼ﾒｲﾚｲ% time bundle exec rubocop -v
0.70.0
bundle exec rubocop -v  0.52s user 0.08s system 95% cpu 0.634 total
    _╰╰,   /ﾊﾞｼｮ % ~/src/github.com/rubocop-hq/rubocop
  _/o ŏｧ  / ﾌﾞﾗﾝﾁ% master● ﾔﾊﾞｲ
∈ミ;ﾉ,ﾉ   ＼ﾒｲﾚｲ% time bundle exec rubocop -v
0.70.0
bundle exec rubocop -v  0.55s user 0.10s system 93% cpu 0.689 total
    _╰╰,   /ﾊﾞｼｮ % ~/src/github.com/rubocop-hq/rubocop
  _/o ŏｧ  / ﾌﾞﾗﾝﾁ% master● ﾔﾊﾞｲ
∈ミ;ﾉ,ﾉ   ＼ﾒｲﾚｲ% time bundle exec rubocop -v
0.70.0
bundle exec rubocop -v  0.58s user 0.08s system 93% cpu 0
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
