### PR TITLE
Permit to specify TargetRubyVersion 2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#7084](https://github.com/rubocop-hq/rubocop/pull/7084): Permit to specify TargetRubyVersion 2.7. ([@koic][])
+
 ### Bug fixes
 
 * [#7066](https://github.com/rubocop-hq/rubocop/issues/7066): Fix `Layout/AlignHash` when mixed Hash styles are used. ([@rmm5t][])

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -21,7 +21,7 @@ module RuboCop
 
     # 2.3 is the oldest officially supported Ruby version.
     DEFAULT_RUBY_VERSION = 2.3
-    KNOWN_RUBIES = [2.3, 2.4, 2.5, 2.6].freeze
+    KNOWN_RUBIES = [2.3, 2.4, 2.5, 2.6, 2.7].freeze
     OBSOLETE_RUBIES = {
       1.9 => '0.50', 2.0 => '0.50', 2.1 => '0.58', 2.2 => '0.69'
     }.freeze

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -183,6 +183,9 @@ module RuboCop
       when 2.6
         require 'parser/ruby26'
         Parser::Ruby26
+      when 2.7
+        require 'parser/ruby27'
+        Parser::Ruby27
       else
         raise ArgumentError, "Unknown Ruby version: #{ruby_version.inspect}"
       end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1773,14 +1773,14 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       it 'fails with an error message' do
         create_file('.rubocop.yml', <<~YAML)
           AllCops:
-            TargetRubyVersion: 2.7
+            TargetRubyVersion: 2.8
         YAML
         expect(cli.run([])).to eq(2)
         expect($stderr.string.strip).to match(
-          /\AError: Unknown Ruby version 2.7 found in `TargetRubyVersion`/
+          /\AError: Unknown Ruby version 2.8 found in `TargetRubyVersion`/
         )
         expect($stderr.string.strip).to match(
-          /Supported versions: 2.3, 2.4, 2.5, 2.6/
+          /Supported versions: 2.3, 2.4, 2.5, 2.6, 2.7/
         )
       end
     end


### PR DESCRIPTION
Parser gem has been started development for Ruby 2.7 (edge Ruby).
https://github.com/whitequark/parser/pull/546

This PR permits Ruby 2.7, the early adapters will be able to try edge Ruby with RuboCop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
