### PR TITLE
[Fix #7063] Fix unsafe autocorrect for 'Style/TernaryParentheses'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#7063](https://github.com/rubocop-hq/rubocop/issues/7063): Fix autocorrect in `Style/TernaryParentheses` cop. ([@parkerfinch][])
+
 ### Changes
 
 * [#5976](https://github.com/rubocop-hq/rubocop/issues/5976): Remove Rails cops. ([@koic][])

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -110,6 +110,14 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
       it_behaves_like 'code with offense',
                       'foo = bar && (baz || bar) ? a : b',
                       'foo = (bar && (baz || bar)) ? a : b'
+
+      it_behaves_like 'code with offense',
+                      'foo = bar or baz ? a : b',
+                      'foo = bar or (baz) ? a : b'
+
+      it_behaves_like 'code with offense',
+                      'not bar ? a : b',
+                      'not (bar) ? a : b'
     end
 
     context 'with an assignment condition' do
@@ -168,6 +176,12 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
 
       it_behaves_like 'code without offense',
                       'foo = bar && (baz || bar) ? a : b'
+
+      it_behaves_like 'code with offense',
+                      'foo = (foo or bar) ? a : b'
+
+      it_behaves_like 'code with offense',
+                      'foo = (not bar) ? a : b'
     end
 
     context 'with an assignment condition' do
@@ -248,12 +262,19 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
       it_behaves_like 'code with offense',
                       'foo = (bar[:baz]) ? a : b',
                       'foo = bar[:baz] ? a : b'
+
+      it_behaves_like 'code with offense',
+                      'foo = bar or (baz) ? a : b',
+                      'foo = bar or baz ? a : b'
     end
 
     context 'with a complex condition' do
       it_behaves_like 'code with offense',
                       'foo = (bar.baz?) ? a : b',
                       'foo = bar.baz? ? a : b'
+
+      it_behaves_like 'code without offense',
+                      'foo = (baz or bar) ? a : b'
 
       it_behaves_like 'code without offense',
                       'foo = (bar && (baz || bar)) ? a : b'


### PR DESCRIPTION
This takes the precedence of operators used into account when deciding
to autocorrect. The issue is that if an operator of precedence below
that of the ternary operator (e.g. "or") is used, then the existing
autocorrect can change the semantics by removing parentheses. With
this change, the autocorrect will no longer attempt to make this
correction.

I'm thinking that this is a step in the right direction, but it would probably be better to even avoid reporting that this is an issue. Also, this problem will only manifest if the `Style/AndOr` or `Style/Not` cops aren't being followed, would it make sense to only include this check if those are disabled?

I wasn't sure how to handle the other [operators with low precedence](http://phrogz.net/programmingruby/language.html#table_18.4]), it seems like some might be handled already (e.g. I _think_ `defined?` is handled in the `method_name` node matcher?), and I wasn't sure if others even needed to be handled.

All feedback/ideas very welcome, I'm still not sure I totally grok this Cop but this is a stab at a fix!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
