### PR TITLE
Fix Layout/EmptyLinesAroundBlockBody for multi-line method calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#7066](https://github.com/rubocop-hq/rubocop/issues/7066): Fix `Layout/AlignHash` when mixed Hash styles are used. ([@rmm5t][])
 * [#7073](https://github.com/rubocop-hq/rubocop/issues/7073): Fix false positive in `Naming/RescuedExceptionsVariableName` cop. ([@tejasbubane][])
+* [#7090](https://github.com/rubocop-hq/rubocop/pull/7090): Fix `Layout/EmptyLinesAroundBlockBody` for multi-line method calls. ([@eugeneius][])
 
 ### Changes
 
@@ -4067,3 +4068,4 @@
 [@lavoiesl]: https://github.com/lavoiesl
 [@fwininger]: https://github.com/fwininger
 [@stoivo]: https://github.com/stoivo
+[@eugeneius]: https://github.com/eugeneius

--- a/lib/rubocop/cop/layout/empty_lines_around_block_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_block_body.rb
@@ -27,7 +27,9 @@ module RuboCop
         KIND = 'block'
 
         def on_block(node)
-          check(node, node.body)
+          first_line = node.send_node.last_line
+
+          check(node, node.body, adjusted_first_line: first_line)
         end
 
         def autocorrect(node)

--- a/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
@@ -54,6 +54,20 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBlockBody, :config do
         RUBY
       end
 
+      it 'registers an offense for block body starting with a blank passed to '\
+         'a multi-line method call' do
+        inspect_source(<<~RUBY)
+          some_method arg,
+            another_arg #{open}
+
+            do_something
+          #{close}
+        RUBY
+
+        expect(cop.messages)
+          .to eq(['Extra empty line detected at block body beginning.'])
+      end
+
       it 'is not fooled by single line blocks' do
         expect_no_offenses(<<~RUBY)
           some_method #{open} do_something #{close}

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -394,7 +394,6 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
 
     it 'registers an offense for a non-empty method with a single unused ' \
         'parameter' do
-
       message = "Unused method argument - `arg`. If it's necessary, use " \
                   '`_` or `_arg` as an argument name to indicate that it ' \
                   "won't be used. You can also write as `method(*)` if you " \

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   context 'when an access modifier is followed by a ' \
     'class method defined on constant' do
-
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         class SomeClass

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -326,7 +326,6 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
 
   context "when a variable is reassigned in loop body but won't " \
           'be referenced either next iteration or loop condition' do
-
     it 'registers an offense' do
       pending 'Requires an advanced logic that checks whether the return ' \
               'value of an operator assignment is used or not.'


### PR DESCRIPTION
This cop currently looks for blank lines following the first line of the block node. When the block is passed to a multi-line method call, the send node spans multiple lines, and the wrong line is inspected.

This is a similar problem to https://github.com/rubocop-hq/rubocop/pull/6236, where a class definition can span multiple lines.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/