### PR TITLE
NodePattern: Add repeated patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#7084](https://github.com/rubocop-hq/rubocop/pull/7084): Permit to specify TargetRubyVersion 2.7. ([@koic][])
+* [#7092](https://github.com/rubocop-hq/rubocop/pull/7092): Node patterns can now use `*`, `+` and `?` for repetitions.  ([@marcandre][])
 
 ### Bug fixes
 


### PR DESCRIPTION
This closes #6726 by introducing tokens for repeating patterns: `*` (0 or more), `+` (1 or more) and `?` (0 or 1).

Subject to the same features and limitations as other variadic tokens `...` and `< ...>`, i.e.:
* can be preceded/succeeded by any number of no terms
* can be nested
* but only one variadic token per sequence

