### PR TITLE
[#5976] Warn for `rubocop -R/--rails` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Changes
 
 * [#5976](https://github.com/rubocop-hq/rubocop/issues/5976): Warn for Rails Cops. ([@koic][])
+* [#5976](https://github.com/rubocop-hq/rubocop/issues/5976): Warn for `rubocop -R/--rails` option. ([@koic][])
 * [#7078](https://github.com/rubocop-hq/rubocop/issues/7078): Mark `Lint/PercentStringArray` as unsafe. ([@mikegee][])
 
 ### Bug fixes

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -144,6 +144,10 @@ module RuboCop
         puts "Added inheritance from `#{AUTO_GENERATED_FILE}` in `#{DOTFILE}`."
       end
 
+      def required_features
+        resolver.required_features
+      end
+
       private
 
       def find_project_dotfile(target_dir)

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -6,9 +6,17 @@ require 'pathname'
 module RuboCop
   # A help class for ConfigLoader that handles configuration resolution.
   class ConfigLoaderResolver
+    attr_reader :required_features
+
+    def initialize
+      @required_features = []
+    end
+
     def resolve_requires(path, hash)
       config_dir = File.dirname(path)
       Array(hash.delete('require')).each do |r|
+        @required_features << r
+
         if r.start_with?('.')
           require(File.join(config_dir, r))
         else

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -24,6 +24,14 @@ module RuboCop
 
     def initialize(options, config_store)
       @options = options
+
+      if @options.key?(:rails)
+        warn <<~MESSAGE
+          `-R/--rails` option and Rails cops will be removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.
+          https://github.com/rubocop-hq/rubocop/blob/master/manual/migrate_rails_cops.md
+        MESSAGE
+      end
+
       @config_store = config_store
       @errors = []
       @warnings = []
@@ -273,7 +281,10 @@ module RuboCop
 
     def inspect_file(processed_source)
       config = @config_store.for(processed_source.path)
-      enable_rails_cops(config) if @options[:rails]
+      if @options[:rails] ||
+         ConfigLoader.required_features.include?('rubocop-rails')
+        enable_rails_cops(config)
+      end
       team = Cop::Team.new(mobilized_cop_classes(config), config, @options)
       offenses = team.inspect_file(processed_source)
       @errors.concat(team.errors)


### PR DESCRIPTION
This PR warns for `rubocop -R/--rails` option.

Here is an example using `-R/--rails` option:

```console
% cat app/models/user.rb
class User < ActiveRecord::Base
end
```

```console
% rubocop -R
`-R/--rails` option and Rails cops will be removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.
https://github.com/rubocop-hq/rubocop/blob/master/manual/migrate_rails_cops.md
Inspecting 2 files
.C

Offenses:

(snip)

app/models/user.rb:1:14: C: Rails/ApplicationRecord: Models should
subclass ApplicationRecord.
class User < ActiveRecord::Base
             ^^^^^^^^^^^^^^^^^^
```

This PR provides a way to dismiss the above warning. Specify `require: rubocop-rails` in .rubocop.yml (or command option) instead of the `-R/-rails` option as indicated in the above URL of warning.

And this means that it will be used the same way as RuboCop RSpec and RuboCop Performance.

This is a migration path to remove Rails cops from the RuboCop core, Rails cops will still be disabled by default for compatibility.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
