### PR TITLE
Correct method naming

### DIFF
--- a/lib/rubocop/cop/style/zero_length_predicate.rb
+++ b/lib/rubocop/cop/style/zero_length_predicate.rb
@@ -7,7 +7,7 @@ module RuboCop
       # by a predicate method, such as receiver.length == 0,
       # receiver.length > 0, receiver.length != 0,
       # receiver.length < 1 and receiver.size == 0 that can be
-      # replaced by receiver.empty? and !receiver.empty.
+      # replaced by receiver.empty? and !receiver.empty?.
       #
       # @example
       #   # bad

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -7137,7 +7137,7 @@ This cop checks for numeric comparisons that can be replaced
 by a predicate method, such as receiver.length == 0,
 receiver.length > 0, receiver.length != 0,
 receiver.length < 1 and receiver.size == 0 that can be
-replaced by receiver.empty? and !receiver.empty.
+replaced by receiver.empty? and !receiver.empty?.
 
 ### Examples
 


### PR DESCRIPTION
Added missing question mark to the predicate method `empty?`.