### PR TITLE
Fix missing tick in documentation

### DIFF
--- a/lib/rubocop/cop/style/commented_keyword.rb
+++ b/lib/rubocop/cop/style/commented_keyword.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop checks for comments put on the same line as some keywords.
       # These keywords are: `begin`, `class`, `def`, `end`, `module`.
       #
-      # Note that some comments (`:nodoc:`, `:yields:, and `rubocop:disable`)
+      # Note that some comments (`:nodoc:`, `:yields:`, and `rubocop:disable`)
       # are allowed.
       #
       # @example

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1016,7 +1016,7 @@ Enabled | Yes | No | 0.51 | -
 This cop checks for comments put on the same line as some keywords.
 These keywords are: `begin`, `class`, `def`, `end`, `module`.
 
-Note that some comments (`:nodoc:`, `:yields:, and `rubocop:disable`)
+Note that some comments (`:nodoc:`, `:yields:`, and `rubocop:disable`)
 are allowed.
 
 ### Examples


### PR DESCRIPTION
I noticed the documentation at [this page](https://docs.rubocop.org/en/latest/cops_style/#stylecommentedkeyword) had a snippet that was formatted like this:
>Note that some comments (`:nodoc:`, `:yields:, and `rubocop:disable`) are allowed.

This fixes the formatting issue.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
