### PR TITLE
[Fix #7098] Remove post install message for RuboCop Rails

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -42,6 +42,4 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('bundler', '>= 1.15.0', '< 3.0')
   s.add_development_dependency('rack', '>= 2.0')
-
-  s.post_install_message = File.read('manual/migrate_rails_cops.md')
 end


### PR DESCRIPTION
Fixes #7098.

#7095 has been merged. It may be good to finish the message display when Rails cops is removed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
