### PR TITLE
Remove a Rails cops manual

### DIFF
--- a/manual/cops.md
+++ b/manual/cops.md
@@ -56,22 +56,6 @@ name, file name, etc.
 Security cops checks for method calls and constructs which are known to be
 associated with potential security issues.
 
-### Rails
-
-Rails cops are specific to the Ruby on Rails framework. Unlike all other cop
-types they are not used by default, and you have to request them explicitly:
-
-```sh
-$ rubocop -R
-```
-
-or add the following directive to your `.rubocop.yml`:
-
-```yaml
-Rails:
-  Enabled: true
-```
-
 ### Bundler
 
 Bundler cops check for style and bad practices in Bundler files, e.g. `Gemfile`.


### PR DESCRIPTION
Follow up #7095.

This description that is already outdated.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
