### PR TITLE
[Fix #7106] Fix an error for `Lint/NumberConversion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * [#5976](https://github.com/rubocop-hq/rubocop/issues/5976): Remove Rails cops. ([@koic][])
 * [#5976](https://github.com/rubocop-hq/rubocop/issues/5976): Remove `rubocop -R/--rails` option. ([@koic][])
 
+### Bug fixes
+
+* [#7106](https://github.com/rubocop-hq/rubocop/issues/7106): Fix an error for `Lint/NumberConversion` when `#to_i` called on a variable on a hash. ([@koic][])
+
 ## 0.71.0 (2019-05-30)
 
 ### New features

--- a/lib/rubocop/cop/lint/number_conversion.rb
+++ b/lib/rubocop/cop/lint/number_conversion.rb
@@ -64,7 +64,7 @@ module RuboCop
 
         def date_time_object?(node)
           child = node
-          while child.send_type?
+          while child&.send_type?
             return true if datetime? child
 
             child = child.children[0]

--- a/spec/rubocop/cop/lint/number_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/number_conversion_spec.rb
@@ -88,6 +88,17 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion do
         Integer(args[0], 10)
       RUBY
     end
+
+    it 'when `#to_i` called on a variable on a hash' do
+      expect_offense(<<~RUBY)
+        params[:field].to_i
+        ^^^^^^^^^^^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using params[:field].to_i, use stricter Integer(params[:field], 10).
+      RUBY
+
+      expect_correction(<<~RUBY.strip_indent)
+        Integer(params[:field], 10)
+      RUBY
+    end
   end
 
   context 'does not register an offense' do


### PR DESCRIPTION
Fixes #7106.

This PR fixes an error for `Lint/NumberConversion` when `#to_i` called on a variable on a hash. It was a regression by #6676.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
