### PR TITLE
Fix `Style/WordArray` with `encoding: binary` magic comment and non-ASCII string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#7063](https://github.com/rubocop-hq/rubocop/issues/7063): Fix autocorrect in `Style/TernaryParentheses` cop. ([@parkerfinch][])
 * [#7107](https://github.com/rubocop-hq/rubocop/issues/7107): Fix parentheses offence for numeric arguments with an operator in `Style/MethodCallWithArgsParentheses`. ([@gsamokovarov][])
 * [#7119](https://github.com/rubocop-hq/rubocop/pull/7119): Fix cache with non UTF-8 offense message. ([@pocke][])
+* [#7118](https://github.com/rubocop-hq/rubocop/pull/7118): Fix `Style/WordArray` with `encoding: binary` magic comment and non-ASCII string. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -71,8 +71,8 @@ module RuboCop
 
         def complex_content?(strings)
           strings.any? do |s|
-            string = s.str_content
-            !string.dup.force_encoding(::Encoding::UTF_8).valid_encoding? ||
+            string = s.str_content.dup.force_encoding(::Encoding::UTF_8)
+            !string.valid_encoding? ||
               string !~ word_regex || string =~ / /
           end
         end

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -278,17 +278,12 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       RUBY
     end
 
-    it "doesn't fail on strings which are not valid UTF-8" \
-       'and encoding: binary is specified' do
+    it "doesn't fail with `encoding: binary" do
       expect_no_offenses(<<~'RUBY')
         # -*- encoding: binary -*-
-        ["\xC0",
-         "\xC2\x4a",
-         "\xC2\xC2",
-         "\x4a\x82",
-         "\x82\x82",
-         "\xe1\x82\x4a",
-        ]
+        ["\xC0"] # Invalid as UTF-8
+        ['a']    # Valid as UTF-8 and ASCII
+        ["あ"]   # Valid as UTF-8
       RUBY
     end
   end


### PR DESCRIPTION
Problem
===

`Style/WordArray` cop works well with `encoding: binary` magic comment and a string that is invalid as UTF-8. But the cop fails with a string that is "valid" as UTF-8.




Reproduce
---

`test.rb`

```ruby
# -*- encoding: binary -*-
p ["あ"]
```

```console
$ rubocop --debug --only Style/WordArray test.rb --cache false
For /tmp/tmp.Xoioox1uyV: configuration from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/config/default.yml
Inspecting 1 file
Scanning /tmp/tmp.Xoioox1uyV/test.rb
incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string)
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cop/style/word_array.rb:76:in `=~'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cop/style/word_array.rb:76:in `!~'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cop/style/word_array.rb:76:in `block in complex_content?'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cop/style/word_array.rb:73:in `any?'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cop/style/word_array.rb:73:in `complex_content?'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cop/style/word_array.rb:45:in `on_array'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cop/commissioner.rb:59:in `block (2 levels) in trigger_responding_cops'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cop/commissioner.rb:130:in `with_cop_error_handling'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cop/commissioner.rb:58:in `block in trigger_responding_cops'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cop/commissioner.rb:57:in `each'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cop/commissioner.rb:57:in `trigger_responding_cops'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cop/commissioner.rb:34:in `block (2 levels) in <class:Commissioner>'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/ast/traversal.rb:107:in `block in on_send'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/ast/traversal.rb:104:in `each'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/ast/traversal.rb:104:in `each_with_index'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/ast/traversal.rb:104:in `on_send'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cop/commissioner.rb:35:in `block (2 levels) in <class:Commissioner>'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/ast/traversal.rb:13:in `walk'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cop/commissioner.rb:46:in `investigate'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cop/team.rb:116:in `investigate'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cop/team.rb:104:in `offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cop/team.rb:44:in `inspect_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:277:in `inspect_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:225:in `block in do_inspection_loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:257:in `block in iterate_until_no_changes'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:250:in `loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:250:in `iterate_until_no_changes'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:221:in `do_inspection_loop'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:124:in `block in file_offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:142:in `file_offense_cache'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:122:in `file_offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:110:in `process_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:87:in `block in each_inspected_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:86:in `each'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:86:in `reduce'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:86:in `each_inspected_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:73:in `inspect_files'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:39:in `run'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cli.rb:210:in `execute_runner'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cli.rb:80:in `execute_runners'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cli.rb:51:in `run'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/exe/rubocop:13:in `block in <top (required)>'
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/benchmark.rb:308:in `realtime'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/exe/rubocop:12:in `<top (required)>'
/home/pocke/.rbenv/versions/trunk/bin/rubocop:23:in `load'
/home/pocke/.rbenv/versions/trunk/bin/rubocop:23:in `<main>'
.

1 file inspected, no offenses detected
Finished in 0.04946950823068619 seconds
```


Solution
===

Change the encoding to UTF-8 before comparing with regexp.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
