### PR TITLE
Fix cache with non UTF-8 offense message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#7063](https://github.com/rubocop-hq/rubocop/issues/7063): Fix autocorrect in `Style/TernaryParentheses` cop. ([@parkerfinch][])
 * [#7107](https://github.com/rubocop-hq/rubocop/issues/7107): Fix parentheses offence for numeric arguments with an operator in `Style/MethodCallWithArgsParentheses`. ([@gsamokovarov][])
+* [#7119](https://github.com/rubocop-hq/rubocop/pull/7119): Fix cache with non UTF-8 offense message. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cached_data.rb
+++ b/lib/rubocop/cached_data.rb
@@ -38,7 +38,7 @@ module RuboCop
     def message(offense)
       # JSON.dump will fail if the offense message contains text which is not
       # valid UTF-8
-      offense.message.scrub
+      offense.message.dup.force_encoding(::Encoding::UTF_8).scrub
     end
 
     # Restore an offense object loaded from a JSON file.

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -213,8 +213,13 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
   describe '#save' do
     context 'when the default internal encoding is UTF-8' do
       let(:offenses) do
-        [RuboCop::Cop::Offense.new(:warning, location, "unused var \xF0",
-                                   'Lint/UselessAssignment')]
+        [
+          "unused var \xF0",
+          (+'unused var あ').force_encoding(::Encoding::ASCII_8BIT)
+        ].map do |message|
+          RuboCop::Cop::Offense.new(:warning, location, message,
+                                    'Lint/UselessAssignment')
+        end
       end
 
       before { Encoding.default_internal = Encoding::UTF_8 }


### PR DESCRIPTION
Problem
===


If offense message's encoding is not UTF-8, the cache system raises an error.

Offense message can be an ASCII-8BIT if the offense message is constructed with ASCII-8BIT source code.
For example, YodCondition cop's message will be it.


`test.rb`

```ruby
# encoding: ascii-8bit

x = ''

if "あ" == x
end
```


```console
$ rubocop --only YodaCondition
"\xE3" from ASCII-8BIT to UTF-8
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/json/common.rb:224:in `encode'
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/json/common.rb:224:in `generate'
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/json/common.rb:224:in `generate'
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/json/common.rb:394:in `dump'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cached_data.rb:17:in `to_json'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/result_cache.rb:116:in `block in save'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/result_cache.rb:115:in `open'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/result_cache.rb:115:in `save'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:211:in `save_in_cache'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:143:in `file_offense_cache'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:122:in `file_offenses'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:110:in `process_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:87:in `block in each_inspected_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:86:in `each'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:86:in `reduce'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:86:in `each_inspected_file'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:73:in `inspect_files'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/runner.rb:39:in `run'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cli.rb:210:in `execute_runner'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cli.rb:80:in `execute_runners'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/lib/rubocop/cli.rb:51:in `run'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/exe/rubocop:13:in `block in <top (required)>'
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/benchmark.rb:308:in `realtime'
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rubocop-0.71.0/exe/rubocop:12:in `<top (required)>'
/home/pocke/.rbenv/versions/trunk/bin/rubocop:23:in `load'
/home/pocke/.rbenv/versions/trunk/bin/rubocop:23:in `<main>'
Inspecting 1 file


0 files inspected, no offenses detected
```


---


This change will fix the problem.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
