### PR TITLE
Drop development dependency on Rack gem

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -41,5 +41,4 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 1.7')
 
   s.add_development_dependency('bundler', '>= 1.15.0', '< 3.0')
-  s.add_development_dependency('rack', '>= 2.0')
 end


### PR DESCRIPTION
This PR drops development dependency on Rack gem.

This dependency was introduced at #5597 for `Rails/HttpStatus` cop.

Rails cops has been removed in #7095 from RuboCop core and the dependency on Rack gem is maintained by RuboCop Rails repo.
https://github.com/rubocop-hq/rubocop-rails/pull/68

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
