### PR TITLE
Point to "Alias Method Lexically"

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -2126,7 +2126,7 @@ Style/AccessModifierDeclarations:
 
 Style/Alias:
   Description: 'Use alias instead of alias_method.'
-  StyleGuide: '#alias-method'
+  StyleGuide: '#alias-method-lexically'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.36'

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -105,7 +105,7 @@ EnforcedStyle | `prefer_alias` | `prefer_alias`, `prefer_alias_method`
 
 ### References
 
-* [https://rubystyle.guide#alias-method](https://rubystyle.guide#alias-method)
+* [https://rubystyle.guide#alias-method-lexically](https://rubystyle.guide#alias-method-lexically)
 
 ## Style/AndOr
 


### PR DESCRIPTION
* for clearer understanding why `alias` is default over `alias_method`

### Background

After getting the rubocop `Style/Alias` error, I clicked on the link suggested in the error message:
> Style/Alias: Use alias instead of alias_method in a module body. (https://github.com/rubocop-hq/ruby-style-guide#alias-method)

The link only confused me more, as it suggests using `alias_method` (but the cop reports that `alias` should be used instead).

After the little trip down the rabbit hole, I found couple of issues of other developers asking the same question: 
[Why prefer_alias is the enforced style in Style/Alias #4193
](https://github.com/rubocop-hq/rubocop/issues/4193)
[Default configuration of `Style/Alias` doesn't match the style guide recommendation #3619
 ](https://github.com/rubocop-hq/rubocop/issues/3619)

So, I think it's better to point to the anchor above `#alias-method`, that instead suggests that `alias` should be used (as is the cop's default).

NOTE: I didn't add an entry to CHANGELOG. Let me know if I should (it IS a user-observable change)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/