### PR TITLE
[Fix #7130] Skip autocorrect in `Style/FormatString` if second argument is variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 * [#7151](https://github.com/rubocop-hq/rubocop/issues/7151): Fix `Style/WordArray` to also consider words containing hyphens. ([@fwitzke][])
 * [#6893](https://github.com/rubocop-hq/rubocop/issues/6893): Handle implicit rescue correctly in `Naming/RescuedExceptionsVariableName`. ([@pocke][], [@anthony-robin][])
 * [#7165](https://github.com/rubocop-hq/rubocop/issues/7165): Fix an auto-correct error for `Style/ConditionalAssignment` when without `else` branch'. ([@koic][])
+* [#7113](https://github.com/rubocop-hq/rubocop/pull/7113): This PR renames `EnforcedStyle: rails` to `EnabledStyle: outdented_access_modifiers` for `Layout/IndentationConsistency`. ([@koic][])
+* [#7130](https://github.com/rubocop-hq/rubocop/pull/7130): Skip autocorrect in `Style/FormatString` if second argument to `String#%` is a variable. ([@tejasbubane][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/format_string.rb
+++ b/lib/rubocop/cop/style/format_string.rb
@@ -48,6 +48,10 @@ module RuboCop
         }
         PATTERN
 
+        def_node_matcher :variable_argument?, <<-PATTERN
+          (send {str dstr} :% {send_type? lvar_type?})
+        PATTERN
+
         def on_send(node)
           formatter(node) do |selector|
             detected_style = selector == :% ? :percent : selector
@@ -70,10 +74,10 @@ module RuboCop
         end
 
         def autocorrect(node)
-          lambda do |corrector|
-            detected_method = node.method_name
+          return if variable_argument?(node)
 
-            case detected_method
+          lambda do |corrector|
+            case node.method_name
             when :%
               autocorrect_from_percent(corrector, node)
             when :format, :sprintf

--- a/spec/rubocop/cop/style/format_string_spec.rb
+++ b/spec/rubocop/cop/style/format_string_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
       RUBY
     end
 
+    it 'registers an offense for variable argument' do
+      expect_offense(<<~RUBY)
+        puts "%f" % a
+                  ^ Favor `sprintf` over `String#%`.
+      RUBY
+    end
+
     it 'does not register an offense for numbers' do
       expect_no_offenses('puts 10 % 4')
     end
@@ -68,6 +75,21 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
       corrected = autocorrect_source('puts x % { a: 10, b: 11 }')
       expect(corrected).to eq 'puts sprintf(x, a: 10, b: 11)'
     end
+
+    it 'does not auto-correct String#% with variable argument' do
+      source = <<~RUBY
+        puts "%d" % a
+      RUBY
+      expect(autocorrect_source(source)).to eq(source)
+    end
+
+    it 'does not auto-correct String#% with variable argument and assignment' do
+      source = <<~RUBY
+        a = something()
+        puts "%d" % a
+      RUBY
+      expect(autocorrect_source(source)).to eq(source)
+    end
   end
 
   context 'when enforced style is format' do
@@ -91,6 +113,13 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
       expect_offense(<<~RUBY)
         puts x % { a: 10, b: 11 }
                ^ Favor `format` over `String#%`.
+      RUBY
+    end
+
+    it 'registers an offense for variable argument' do
+      expect_offense(<<~RUBY)
+        puts "%f" % a
+                  ^ Favor `format` over `String#%`.
       RUBY
     end
 
@@ -141,6 +170,21 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
     it 'auto-corrects String#% with a hash argument' do
       corrected = autocorrect_source('puts x % { a: 10, b: 11 }')
       expect(corrected).to eq 'puts format(x, a: 10, b: 11)'
+    end
+
+    it 'does not auto-correct String#% with variable argument' do
+      source = <<~RUBY
+        puts "%d" % a
+      RUBY
+      expect(autocorrect_source(source)).to eq(source)
+    end
+
+    it 'does not auto-correct String#% with variable argument and assignment' do
+      source = <<~RUBY
+        a = something()
+        puts "%d" % a
+      RUBY
+      expect(autocorrect_source(source)).to eq(source)
     end
   end
 


### PR DESCRIPTION
For `String#%` is second argument is variable, flag offense but skip autocorrect. It is not possible for rubocop to know if variable is array in which case the autocorrect leads to invalid code.

Closes #7130.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/