### PR TITLE
[Fix #7155] Handle URLs in inherit_from

### DIFF
--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -173,8 +173,8 @@ module RuboCop
 
       def existing_configuration(config_file)
         IO.read(config_file, encoding: Encoding::UTF_8)
-          .sub(%r{^inherit_from: *[.\/\w]+}, '')
-          .sub(%r{^inherit_from: *(\n *- *[.\/\w]+)+}, '')
+          .sub(/^inherit_from: *[^\n]+/, '')
+          .sub(/^inherit_from: *(\n *- *[^\n]+)+/, '')
       end
 
       def write_config_file(file_name, file_string, rubocop_yml_contents)


### PR DESCRIPTION
Previously, when adding the `.rubocop_todo.yml` entry to
`.rubocop.yml`, URLs were not removed correctly,
leaving remnants as follows:

```diff
 inherit_from:
+  - .rubocop_todo.yml
   - https://example.com/foo/bar
+
+://example.com/foo/bar
```

In order to reduce the complexity of the regex matches,
the approach is changed:
instead of replacing only specific characters, all text up the end of line,
independently of what characters it contains, is replaced.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
