### PR TITLE
Change "Official manual" => "Documentation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ $ cd my/cool/ruby/project
 $ rubocop
 ```
 
-## Official manual
+## Documentation
 
-You can read a ton more about RuboCop in its [official manual](https://docs.rubocop.org).
+You can read a lot more about RuboCop in its [official docs](https://docs.rubocop.org).
 
 ## Compatibility
 


### PR DESCRIPTION
Related to our discussion in this issue: [Would it make sense to mention/list rubocop extensions #7133](https://github.com/rubocop-hq/rubocop/issues/7133)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
