### PR TITLE
Add rubocop-sequel and rubocop-md extensions

### DIFF
--- a/manual/extensions.md
+++ b/manual/extensions.md
@@ -34,14 +34,20 @@ See [development](development.md).
 
 * [rubocop-performance](https://github.com/rubocop-hq/rubocop-performance) -
   Performance optimization analysis
-* [rubocop-rails](https://github.com/rubocop-hq/rubocop-rails) - Rails-specific analysis
+* [rubocop-rails](https://github.com/rubocop-hq/rubocop-rails) -
+  Rails-specific analysis
 * [rubocop-rspec](https://github.com/rubocop-hq/rubocop-rspec) -
   RSpec-specific analysis
 * [rubocop-thread_safety](https://github.com/covermymeds/rubocop-thread_safety) -
   Thread-safety analysis
 * [rubocop-require_tools](https://github.com/milch/rubocop-require_tools) -
   Dynamic analysis for missing require statements
-* [rubocop-i18n](https://github.com/puppetlabs/rubocop-i18n) - i18n wrapper function analysis (gettext and rails-i18n)
+* [rubocop-i18n](https://github.com/puppetlabs/rubocop-i18n) -
+  i18n wrapper function analysis (gettext and rails-i18n)
+* [rubocop-sequel](https://github.com/rubocop-hq/rubocop-sequel) -
+  Code style checking for Sequel gem
+
+Any extensions missing? Send us a Pull Request!
 
 ### Custom Formatters
 


### PR DESCRIPTION
Related to our discussion here [Would it make sense to mention/list rubocop extensions #7133](https://github.com/rubocop-hq/rubocop/issues/7133)

I also added a note about adding any missing extensions.

Not sure if it's necessary. I can remove it. Thoughts?

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
