### PR TITLE
Clean up debugger spec

### DIFF
--- a/lib/rubocop/rspec/shared_examples.rb
+++ b/lib/rubocop/rspec/shared_examples.rb
@@ -39,21 +39,3 @@ RSpec.shared_examples_for 'aligned' do |alignment_base, arg, end_kw, name|
     expect(cop.offenses).to be_empty
   end
 end
-
-RSpec.shared_examples_for 'debugger' do |name, src|
-  it "reports an offense for a #{name} call" do
-    inspect_source(src)
-    src = [src] if src.is_a? String
-    expect(cop.offenses.size).to eq(src.size)
-    expect(cop.messages)
-      .to eq(src.map { |s| "Remove debugger entry point `#{s}`." })
-    expect(cop.highlights).to eq(src)
-  end
-end
-
-RSpec.shared_examples_for 'non-debugger' do |name, src|
-  it "does not report an offense for #{name}" do
-    inspect_source(src)
-    expect(cop.offenses).to be_empty
-  end
-end

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -89,10 +89,5 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
   context 'target_ruby_version >= 2.4', :ruby24 do
     include_examples 'debugger', 'irb binding', 'binding.irb'
     include_examples 'debugger', 'binding.irb with Kernel', 'Kernel.binding.irb'
-
-    ALL_COMMANDS.each do |src|
-      include_examples 'non-debugger', "a #{src} in comments", "# #{src}"
-      include_examples 'non-debugger', "a #{src} method", "code.#{src}"
-    end
   end
 end

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -13,13 +13,6 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
     end
   end
 
-  shared_examples_for 'non-debugger' do |name, src|
-    it "does not report an offense for #{name}" do
-      inspect_source(src)
-      expect(cop.offenses.empty?).to be(true)
-    end
-  end
-
   include_examples 'debugger', 'debugger', 'debugger'
   include_examples 'debugger', 'byebug', 'byebug'
   include_examples 'debugger', 'pry binding',
@@ -57,21 +50,31 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
   include_examples 'debugger',
                    'capybara debug method with an argument',
                    'save_screenshot foo'
-  include_examples 'non-debugger', 'a non-pry binding', 'binding.pirate'
+
+  it 'does not report an offense for a non-pry binding' do
+    expect_no_offenses('binding.pirate')
+  end
 
   include_examples 'debugger', 'debugger with Kernel', 'Kernel.debugger'
   include_examples 'debugger', 'debugger with ::Kernel', '::Kernel.debugger'
   include_examples 'debugger', 'binding.pry with Kernel', 'Kernel.binding.pry'
-  include_examples 'non-debugger', 'save_and_open_page with Kernel',
-                   'Kernel.save_and_open_page'
+
+  it 'does not report an offense for save_and_open_page with Kernel' do
+    expect_no_offenses('Kernel.save_and_open_page')
+  end
 
   ALL_COMMANDS = %w[debugger byebug pry remote_pry pry_remote irb
                     save_and_open_page save_and_open_screenshot
                     save_screenshot].freeze
 
   ALL_COMMANDS.each do |src|
-    include_examples 'non-debugger', "a #{src} in comments", "# #{src}"
-    include_examples 'non-debugger', "a #{src} method", "code.#{src}"
+    it "does not report an offense for a #{src} in comments" do
+      expect_no_offenses("# #{src}")
+    end
+
+    it "does not report an offense for a #{src} method" do
+      expect_no_offenses("code.#{src}")
+    end
   end
 
   it 'reports an offense for a Pry.rescue call' do

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -3,6 +3,24 @@
 RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
   subject(:cop) { described_class.new(config) }
 
+  shared_examples_for 'debugger' do |name, src|
+    it "reports an offense for a #{name} call" do
+      inspect_source(src)
+      src = [src] if src.is_a? String
+      expect(cop.offenses.size).to eq(src.size)
+      expect(cop.messages)
+        .to eq(src.map { |s| "Remove debugger entry point `#{s}`." })
+      expect(cop.highlights).to eq(src)
+    end
+  end
+
+  shared_examples_for 'non-debugger' do |name, src|
+    it "does not report an offense for #{name}" do
+      inspect_source(src)
+      expect(cop.offenses.empty?).to be(true)
+    end
+  end
+
   include_examples 'debugger', 'debugger', 'debugger'
   include_examples 'debugger', 'byebug', 'byebug'
   include_examples 'debugger', 'pry binding',

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -6,11 +6,10 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
   shared_examples_for 'debugger' do |name, src|
     it "reports an offense for a #{name} call" do
       inspect_source(src)
-      src = [src] if src.is_a? String
-      expect(cop.offenses.size).to eq(src.size)
+      expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
-        .to eq(src.map { |s| "Remove debugger entry point `#{s}`." })
-      expect(cop.highlights).to eq(src)
+        .to eq(["Remove debugger entry point `#{src}`."])
+      expect(cop.highlights).to eq([src])
     end
   end
 


### PR DESCRIPTION
Moving a couple of “shared examples” that were not shared with anyone. After moving them into debugger_spec.rb, I cleaned it up a bit more.

I have tested that all specs still pass for rubocop-performance, rubocop-rails and rubocop-rspec. Do you think it would be necessary to add an entry to the changelog?

Will probably conflict with #7146, but I’ll fix that after the 1st PR is merged.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
