### PR TITLE
Move alignment examples out of lib/rubocop/rspec/

### DIFF
--- a/lib/rubocop/rspec/support.rb
+++ b/lib/rubocop/rspec/support.rb
@@ -5,7 +5,6 @@
 require_relative 'cop_helper'
 require_relative 'host_environment_simulation_helper'
 require_relative 'shared_contexts'
-require_relative 'shared_examples'
 require_relative 'expect_offense'
 
 RSpec.configure do |config|

--- a/spec/support/alignment_examples.rb
+++ b/spec/support/alignment_examples.rb
@@ -2,7 +2,7 @@
 
 # `cop` and `source` must be declared with #let.
 
-RSpec.shared_examples_for 'misaligned' do |annotated_source, used_style|
+shared_examples_for 'misaligned' do |annotated_source, used_style|
   config_to_allow_offenses = if used_style
                                { 'EnforcedStyleAlignWith' => used_style.to_s }
                              else
@@ -31,11 +31,11 @@ RSpec.shared_examples_for 'misaligned' do |annotated_source, used_style|
   end
 end
 
-RSpec.shared_examples_for 'aligned' do |alignment_base, arg, end_kw, name|
+shared_examples_for 'aligned' do |alignment_base, arg, end_kw, name|
   name ||= alignment_base
   name = name.gsub(/\n/, ' <newline>')
   it "accepts matching #{name} ... end" do
     inspect_source("#{alignment_base} #{arg}\n#{end_kw}")
-    expect(cop.offenses).to be_empty
+    expect(cop.offenses.empty?).to be(true)
   end
 end


### PR DESCRIPTION
These examples are only used in spec/rubocop/cop/layout/end_alignment_spec.rb and spec/rubocop/cop/layout/def_end_alignment_spec.rb, so let's remove them from the library code altogether.

Is it necessary to write a changelog entry for this PR?

Will probably conflict with #7145, but I’ll fix that after the 1st PR is merged.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
