### PR TITLE
Suppress `Psych.parse` args warn when using Psych 3.1.0

### DIFF
--- a/lib/rubocop/yaml_duplication_checker.rb
+++ b/lib/rubocop/yaml_duplication_checker.rb
@@ -4,8 +4,14 @@ module RuboCop
   # Find duplicated keys from YAML.
   module YAMLDuplicationChecker
     def self.check(yaml_string, filename, &on_duplicated)
-      # Specify filename to display helpful message when it raises an error.
-      tree = YAML.parse(yaml_string, filename)
+      # Ruby 2.6+
+      tree = if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0')
+               # Specify filename to display helpful message when it raises
+               # an error.
+               YAML.parse(yaml_string, filename: filename)
+             else
+               YAML.parse(yaml_string, filename)
+             end
       return unless tree
 
       traverse(tree, &on_duplicated)


### PR DESCRIPTION
This PR suppresses the following `Psych.parse` args warn when using Psych 3.1.0 (Ruby 2.6+).

```console
% ruby -v
ruby 2.6.3p62 (2019-04-16 revision 67580) [x86_64-darwin17]
% RUBYOPT=-w bundle exec rubocop
(snip)

/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.71.0/lib/
rubocop/yaml_duplication_checker.rb:8:
Passing filename with the 2nd argument of Psych.parse is deprecated. Use
keyword argument like Psych.parse(yaml, filename: ...) instead.
```

The above `Psych.parse` interface has been changed by the following link.
https://github.com/ruby/psych/commit/4d4439d6d0adfcbd211ea295779315f1baa7dadd

Related PR ... https://github.com/rubocop-hq/rubocop/pull/6470

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
