### PR TITLE
Add `AllowIfModifier` option to `Style/IfInsideElse` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#7150](https://github.com/rubocop-hq/rubocop/pull/7150): Add `AllowIfModifier` option to `Style/IfInsideElse` cop. ([@koic][])
+
 ### Bug fixes
 
 * [#7063](https://github.com/rubocop-hq/rubocop/issues/7063): Fix autocorrect in `Style/TernaryParentheses` cop. ([@parkerfinch][])
@@ -9,12 +13,12 @@
 * [#7107](https://github.com/rubocop-hq/rubocop/issues/7107): Fix parentheses offence for numeric arguments with an operator in `Style/MethodCallWithArgsParentheses`. ([@gsamokovarov][])
 * [#7119](https://github.com/rubocop-hq/rubocop/pull/7119): Fix cache with non UTF-8 offense message. ([@pocke][])
 * [#7118](https://github.com/rubocop-hq/rubocop/pull/7118): Fix `Style/WordArray` with `encoding: binary` magic comment and non-ASCII string. ([@pocke][])
-* [#7113](https://github.com/rubocop-hq/rubocop/pull/7113): This PR renames `EnforcedStyle: rails` to `EnabledStyle: outdented_access_modifiers` for `Layout/IndentationConsistency`. ([@koic][])
 
 ### Changes
 
 * [#5976](https://github.com/rubocop-hq/rubocop/issues/5976): Remove Rails cops. ([@koic][])
 * [#5976](https://github.com/rubocop-hq/rubocop/issues/5976): Remove `rubocop -R/--rails` option. ([@koic][])
+* [#7113](https://github.com/rubocop-hq/rubocop/pull/7113): Rename `EnforcedStyle: rails` to `EnabledStyle: outdented_access_modifiers` for `Layout/IndentationConsistency`. ([@koic][])
 
 ## 0.71.0 (2019-05-30)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -2751,6 +2751,7 @@ Style/IdenticalConditionalBranches:
 Style/IfInsideElse:
   Description: 'Finds if nodes inside else, which can be converted to elsif.'
   Enabled: true
+  AllowIfModifier: false
   VersionAdded: '0.36'
 
 Style/IfUnlessModifier:

--- a/lib/rubocop/cop/style/if_inside_else.rb
+++ b/lib/rubocop/cop/style/if_inside_else.rb
@@ -27,6 +27,37 @@ module RuboCop
       #   else
       #     action_c
       #   end
+      #
+      # @example AllowIfModifier: false (default)
+      #   # bad
+      #   if condition_a
+      #     action_a
+      #   else
+      #     action_b if condition_b
+      #   end
+      #
+      #   # good
+      #   if condition_a
+      #     action_a
+      #   elsif condition_b
+      #     action_b
+      #   end
+      #
+      # @example AllowIfModifier: true
+      #   # good
+      #   if condition_a
+      #     action_a
+      #   else
+      #     action_b if condition_b
+      #   end
+      #
+      #   # good
+      #   if condition_a
+      #     action_a
+      #   elsif condition_b
+      #     action_b
+      #   end
+      #
       class IfInsideElse < Cop
         MSG = 'Convert `if` nested inside `else` to `elsif`.'
 
@@ -36,8 +67,19 @@ module RuboCop
           else_branch = node.else_branch
 
           return unless else_branch&.if_type? && else_branch&.if?
+          return if allow_if_modifier_in_else_branch?(else_branch)
 
           add_offense(else_branch, location: :keyword)
+        end
+
+        private
+
+        def allow_if_modifier_in_else_branch?(else_branch)
+          allow_if_modifier? && else_branch&.modifier_form?
+        end
+
+        def allow_if_modifier?
+          cop_config['AllowIfModifier']
         end
       end
     end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2455,6 +2455,46 @@ else
   action_c
 end
 ```
+#### AllowIfModifier: false (default)
+
+```ruby
+# bad
+if condition_a
+  action_a
+else
+  action_b if condition_b
+end
+
+# good
+if condition_a
+  action_a
+elsif condition_b
+  action_b
+end
+```
+#### AllowIfModifier: true
+
+```ruby
+# good
+if condition_a
+  action_a
+else
+  action_b if condition_b
+end
+
+# good
+if condition_a
+  action_a
+elsif condition_b
+  action_b
+end
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AllowIfModifier | `false` | Boolean
 
 ## Style/IfUnlessModifier
 

--- a/spec/rubocop/cop/style/if_inside_else_spec.rb
+++ b/spec/rubocop/cop/style/if_inside_else_spec.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Style::IfInsideElse do
-  subject(:cop) { described_class.new }
+RSpec.describe RuboCop::Cop::Style::IfInsideElse, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:cop_config) do
+    { 'AllowIfModifier' => false }
+  end
 
   it 'catches an if node nested inside an else' do
     expect_offense(<<~RUBY)
@@ -31,15 +35,33 @@ RSpec.describe RuboCop::Cop::Style::IfInsideElse do
     RUBY
   end
 
-  it 'catches a modifier if nested inside an else' do
-    expect_offense(<<~RUBY)
-      if a
-        blah
-      else
-        foo if b
-            ^^ Convert `if` nested inside `else` to `elsif`.
-      end
-    RUBY
+  context 'when AllowIfModifier is false' do
+    it 'catches a modifier if nested inside an else' do
+      expect_offense(<<~RUBY)
+        if a
+          blah
+        else
+          foo if b
+              ^^ Convert `if` nested inside `else` to `elsif`.
+        end
+      RUBY
+    end
+  end
+
+  context 'when AllowIfModifier is true' do
+    let(:cop_config) do
+      { 'AllowIfModifier' => true }
+    end
+
+    it 'accepts a modifier if nested inside an else' do
+      expect_no_offenses(<<~RUBY)
+        if a
+          blah
+        else
+          foo if b
+        end
+      RUBY
+    end
   end
 
   it "isn't offended if there is a statement following the if node" do


### PR DESCRIPTION
This PR adds `AllowIfModifier` option to `Style/IfInsideElse` cop.

This new option is based on rails/rails repo use case shown at the following URL.
https://github.com/rails/rails/pull/36495.

This option works as follows.

### AllowIfModifier: false (default)

`AllowIfModifier` is false by default. So breaking change will not happen.

```ruby
# bad
if condition_a
  action_a
else
  action_b if condition_b
end
```

### AllowIfModifier: true

It allows the following case when `AllowIfModifier` is true.

```ruby
# good
if condition_a
  action_a
else
  action_b if condition_b
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
