### PR TITLE
[Fix #7159] Fix an error for `Lint/DuplicatedKey`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#7107](https://github.com/rubocop-hq/rubocop/issues/7107): Fix parentheses offence for numeric arguments with an operator in `Style/MethodCallWithArgsParentheses`. ([@gsamokovarov][])
 * [#7119](https://github.com/rubocop-hq/rubocop/pull/7119): Fix cache with non UTF-8 offense message. ([@pocke][])
 * [#7118](https://github.com/rubocop-hq/rubocop/pull/7118): Fix `Style/WordArray` with `encoding: binary` magic comment and non-ASCII string. ([@pocke][])
+* [#7159](https://github.com/rubocop-hq/rubocop/issues/7159): Fix an error for `Lint/DuplicatedKey` when using endless range. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -405,7 +405,7 @@ module RuboCop
               receiver.send(recursive_kind) &&
               arguments.all?(&recursive_kind)
           when :begin, :pair, *OPERATOR_KEYWORDS, *COMPOSITE_LITERALS
-            children.all?(&recursive_kind)
+            children.compact.all?(&recursive_kind)
           else
             send(kind_filter)
           end

--- a/spec/rubocop/cop/lint/duplicated_key_spec.rb
+++ b/spec/rubocop/cop/lint/duplicated_key_spec.rb
@@ -67,6 +67,10 @@ RSpec.describe RuboCop::Cop::Lint::DuplicatedKey do
   it_behaves_like 'duplicated literal key', 'nil'
   it_behaves_like 'duplicated literal key', "'str'"
 
+  context 'target ruby version >= 2.6', :ruby26 do
+    it_behaves_like 'duplicated literal key', '(42..)'
+  end
+
   shared_examples 'duplicated non literal key' do |key|
     it "does not register an offense for duplicated `#{key}` hash keys" do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #7159.

This PR fixes the following error for `Lint/DuplicatedKey` when using endless range in Ruby 2.6.

```console
% rubocop -V
0.71.0 (using Parser 2.6.3.0, running on ruby 2.6.3 x86_64-darwin17)
% cat example.rb
{
  42.. => false
}
% rubocop --only Lint/DuplicatedKey -d
For /private/tmp/7159: configuration from
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.71.0/config/default.yml
Inspecting 1 file
Scanning /private/tmp/7159/example.rb
An error occurred while Lint/DuplicatedKey cop was inspecting
/private/tmp/7159/example.rb:1:0.
undefined method `recursive_basic_literal?' for nil:NilClass
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.71.0/lib/rubocop/ast/node.rb:408:in
`all?'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.71.0/lib/rubocop/ast/node.rb:408:in
`block (2 levels) in <class:Node>'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.71.0/lib/rubocop/cop/lint/duplicated_key.rb:27:in
`select'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.71.0/lib/rubocop/cop/lint/duplicated_key.rb:27:in
`on_hash'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.71.0/lib/rubocop/cop/commissioner.rb:59:in
`block (2 levels) in trigger_re
sponding_cops'

(snip)
```

There are the following differences in the AST generated by Parser gem.

```console
% ruby-parse -e '(42..nil)'
(begin
  (irange
    (int 42)
    (nil)))

% ruby-parse -e '(42..)'
(begin
  (irange
    (int 42) nil))
```

This PR works with `nil` representing the endless range.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
