### PR TITLE
[Fix #7151] Update default WordRegexp for Style/WordArray cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#7119](https://github.com/rubocop-hq/rubocop/pull/7119): Fix cache with non UTF-8 offense message. ([@pocke][])
 * [#7118](https://github.com/rubocop-hq/rubocop/pull/7118): Fix `Style/WordArray` with `encoding: binary` magic comment and non-ASCII string. ([@pocke][])
 * [#7159](https://github.com/rubocop-hq/rubocop/issues/7159): Fix an error for `Lint/DuplicatedKey` when using endless range. ([@koic][])
+* [#7151](https://github.com/rubocop-hq/rubocop/issues/7151): Fix `Style/WordArray` to also consider words containing hyphens. ([@fwitzke][])
 
 ### Changes
 
@@ -4090,3 +4091,4 @@
 [@fwininger]: https://github.com/fwininger
 [@stoivo]: https://github.com/stoivo
 [@eugeneius]: https://github.com/eugeneius
+[@fwitzke]: https://github.com/fwitzke

--- a/config/default.yml
+++ b/config/default.yml
@@ -3854,7 +3854,7 @@ Style/WordArray:
   # whose element count is greater than or equal to `MinSize`.
   MinSize: 2
   # The regular expression `WordRegex` decides what is considered a word.
-  WordRegex: !ruby/regexp '/\A[\p{Word}\n\t]+\z/'
+  WordRegex: !ruby/regexp '/\A(?:\p{Word}|\p{Word}-\p{Word}|\n|\t)+\z/'
 
 Style/YodaCondition:
   Description: 'Forbid or enforce yoda conditions.'

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -7086,7 +7086,7 @@ Name | Default value | Configurable values
 --- | --- | ---
 EnforcedStyle | `percent` | `percent`, `brackets`
 MinSize | `2` | Integer
-WordRegex | `(?-mix:\A[\p{Word}\n\t]+\z)` | 
+WordRegex | `(?-mix:\A(?:\p{Word}|\p{Word}-\p{Word}|\n|\t)+\z)` | 
 
 ### References
 


### PR DESCRIPTION
Updates `Style/WordArray` regular expression to also match on hyphenized words.

I'm not sure whether there is a better way to write that regex, looking for suggestions.

Side note: I was investigating an unrelated issue and decided to check the open issues on the repo to see if there was anything I could pick up to get started contributing, so thanks for labelling #7151 with [`good-first-issue`](https://github.com/rubocop-hq/rubocop/labels/good%20first%20issue).

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
