### PR TITLE
Remove an unneeded `include` for `Layout/IndentHeredoc`

### DIFF
--- a/lib/rubocop/cop/layout/indent_heredoc.rb
+++ b/lib/rubocop/cop/layout/indent_heredoc.rb
@@ -52,7 +52,6 @@ module RuboCop
       class IndentHeredoc < Cop
         include Heredoc
         include ConfigurableEnforcedStyle
-        include SafeMode
 
         RUBY23_TYPE_MSG = 'Use %<indentation_width>d spaces for indentation ' \
                           'in a heredoc by using `<<~` instead of ' \


### PR DESCRIPTION
Follow up https://github.com/rubocop-hq/rubocop/pull/7026/files#diff-e874291b0f90e09a05cf52715a768e87.

It is no longer necessary to judge `rails (Active Support)` style or not when Ruby version supported by RuboCop is Ruby 2.3 or higher.

The following is the changes in PR #7026.

```diff
- if target_ruby_version >= 2.3
-   :squiggly
- elsif rails?
-   :active_support
- end
+ :squiggly
```

With this change, cops using `SafeMode` module have been removed from RuboCop core.

And I investigated RuboCop Performance, RuboCop Rails and RuboCop RSpec about using `SafeMode` module. As a result, only RuboCop Performance uses `SafeMode` module now. I'd like to think separately about what to do with `SafeMode` module. It is not yet known if `SafeMode` module has been moved to RuboCop Performance and there are no problems.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
