### PR TITLE
[Fix #7165] Fix an error for `Style/ConditionalAssignment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#7118](https://github.com/rubocop-hq/rubocop/pull/7118): Fix `Style/WordArray` with `encoding: binary` magic comment and non-ASCII string. ([@pocke][])
 * [#7159](https://github.com/rubocop-hq/rubocop/issues/7159): Fix an error for `Lint/DuplicatedKey` when using endless range. ([@koic][])
 * [#7151](https://github.com/rubocop-hq/rubocop/issues/7151): Fix `Style/WordArray` to also consider words containing hyphens. ([@fwitzke][])
+* [#7165](https://github.com/rubocop-hq/rubocop/issues/7165): Fix an auto-correct error for `Style/ConditionalAssignment` when without `else` branch'. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -596,7 +596,8 @@ module RuboCop
 
             remove_whitespace_in_branches(corrector, branch, condition, column)
 
-            branch_else = branch.parent.loc.else
+            return unless (branch_else = branch.parent.loc.else)
+
             corrector.remove_preceding(branch_else, branch_else.column - column)
           end
         end

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -829,6 +829,25 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
         RUBY
       end
     end
+
+    it 'corrects assignment when without `else` branch' do
+      expect_offense(<<~RUBY)
+        var = if foo
+        ^^^^^^^^^^^^ Assign variables inside of conditionals
+          bar
+        elsif baz
+          qux
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if foo
+          var = bar
+        elsif baz
+          var = qux
+        end
+      RUBY
+    end
   end
 
   context 'SingleLineConditionsOnly false' do


### PR DESCRIPTION
Fixes #7165.

This PR fixes an auto-correct error for `Style/ConditionalAssignment` when without `else` branch'.

This error occurs when `EnforcedStyle: assign_inside_condition`.

```yaml
# .rubocop.yml
Style/ConditionalAssignment:
  EnforcedStyle: assign_inside_condition
```

```ruby
# example.rb
var = if foo
        bar
      elsif baz
        qux
      end
```

```console
% rubocop -a --only Style/ConditionalAssignment
Inspecting 1 file

0 files inspected, no offenses detected
undefined method `column' for nil:NilClass
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.71.0/lib/rubocop/cop/style/conditional_assignment.rb:600:in
`move_branch_'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.71.0/lib/rubocop/cop/style/conditional_assignment.rb:576:in
`block (2 lev'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.71.0/lib/rubocop/cop/style/conditional_assignment.rb:575:in
`each'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.71.0/lib/rubocop/cop/style/conditional_assignment.rb:575:in
`block in mov'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.71.0/lib/rubocop/cop/corrector.rb:64:in
`block (2 levels) in rewrite'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/parser-2.6.3.0/lib/parser/source/tree_rewriter.rb:220:in
`transaction'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.71.0/lib/rubocop/cop/corrector.rb:63:in
`block in rewrite'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
