### PR TITLE
[Fix #7167] Fix an error for `Naming/RescuedExceptionsVariableName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#7118](https://github.com/rubocop-hq/rubocop/pull/7118): Fix `Style/WordArray` with `encoding: binary` magic comment and non-ASCII string. ([@pocke][])
 * [#7159](https://github.com/rubocop-hq/rubocop/issues/7159): Fix an error for `Lint/DuplicatedKey` when using endless range. ([@koic][])
 * [#7151](https://github.com/rubocop-hq/rubocop/issues/7151): Fix `Style/WordArray` to also consider words containing hyphens. ([@fwitzke][])
+* [#7167](https://github.com/rubocop-hq/rubocop/issues/7167): Fix an auto-correct error for `Naming/RescuedExceptionsVariableName` when `rescue` without exception variable after `rescue` with a exception variable. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
+++ b/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
@@ -95,7 +95,7 @@ module RuboCop
         end
 
         def variable_name
-          location.source
+          @exception_name ? location.source : ''
         end
 
         def location

--- a/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
@@ -187,6 +187,31 @@ RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
           RUBY
         end
       end
+
+      context 'without exception variable after with exception variable' do
+        it 'registers an offense when using `ex`' do
+          expect_offense(<<~RUBY)
+            def foo
+            rescue => ex
+                      ^^ Use `e` instead of `ex`.
+            end
+
+            def bar
+            rescue
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            def foo
+            rescue => e
+            end
+
+            def bar
+            rescue
+            end
+          RUBY
+        end
+      end
     end
 
     context 'with variable being referenced' do


### PR DESCRIPTION
Fixes #7167.

This PR fixes an auto-correct error for `Naming/RescuedExceptionsVariableName` when `rescue` without exception variable after `rescue` with a exception variable

```ruby
# example.rb
def foo
rescue => ex
end

def bar
rescue
end
```

```console
% rubocop -a --only Naming/RescuedExceptionsVariableName
Inspecting 1 file

0 files inspected, no offenses detected
undefined method `loc' for nil:NilClass
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.71.0/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb:102:in
`lo
cation'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.71.0/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb:98:in
`var
iable_name'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.71.0/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb:94:in
`pre
ferred_name'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.71.0/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb:73:in
`blo
ck in autocorrect'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rubocop-0.71.0/lib/rubocop/cop/corrector.rb:64:in
`block (2 levels) in rewrite'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
