### PR TITLE
Fix misdetection in Naming/RescuedExceptionsVariableName

### DIFF
--- a/lib/rubocop/ast/node/resbody_node.rb
+++ b/lib/rubocop/ast/node/resbody_node.rb
@@ -17,12 +17,7 @@ module RuboCop
       #
       # @return [Node, nil] The exception variable of the `resbody`.
       def exception_variable
-        variable = node_parts[1]
-        return variable if variable
-
-        # When resbody is an implicit rescue (i.e. `rescue e` style),
-        # the exception variable is descendants[1].
-        descendants[1]
+        node_parts[1]
       end
     end
   end

--- a/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
+++ b/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
@@ -57,12 +57,10 @@ module RuboCop
         MSG = 'Use `%<preferred>s` instead of `%<bad>s`.'
 
         def on_resbody(node)
-          exception_type, @exception_name = *node
-          return unless exception_type || @exception_name
+          @exception_variable = node.exception_variable
+          return unless @exception_variable
 
-          @exception_name ||= exception_type.children.first
-          return if @exception_name.const_type? ||
-                    variable_name == preferred_name
+          return if variable_name == preferred_name
 
           add_offense(node, location: offense_range(node))
         end
@@ -99,7 +97,7 @@ module RuboCop
         end
 
         def location
-          @exception_name.loc.expression
+          @exception_variable.loc.expression
         end
 
         def message(_node = nil)

--- a/spec/rubocop/ast/resbody_node_spec.rb
+++ b/spec/rubocop/ast/resbody_node_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::AST::ResbodyNode do
     context 'for an implicit rescue' do
       let(:source) { 'begin; beginbody; rescue ex; rescuebody; end' }
 
-      it { expect(resbody_node.exception_variable.source).to eq('ex') }
+      it { expect(resbody_node.exception_variable).to be(nil) }
     end
 
     context 'when an exception variable is not given' do

--- a/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
@@ -117,59 +117,11 @@ RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
 
     context 'with implicit rescue' do
       context 'with `Exception` variable' do
-        it 'registers an offense when using `exc`' do
-          expect_offense(<<~RUBY)
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
             begin
               something
             rescue exc
-                   ^^^ Use `e` instead of `exc`.
-              # do something
-            end
-          RUBY
-
-          expect_correction(<<~RUBY)
-            begin
-              something
-            rescue e
-              # do something
-            end
-          RUBY
-        end
-
-        it 'registers an offense when using `_exc`' do
-          expect_offense(<<~RUBY)
-            begin
-              something
-            rescue _exc
-                   ^^^^ Use `_e` instead of `_exc`.
-              # do something
-            end
-          RUBY
-
-          expect_correction(<<~RUBY)
-            begin
-              something
-            rescue _e
-              # do something
-            end
-          RUBY
-        end
-
-        it 'does not register an offense when using `e`' do
-          expect_no_offenses(<<~RUBY)
-            begin
-              something
-            rescue e
-              # do something
-            end
-          RUBY
-        end
-
-        it 'does not register an offense when using `_e`' do
-          expect_no_offenses(<<~RUBY)
-            begin
-              something
-            rescue _e
               # do something
             end
           RUBY


### PR DESCRIPTION
The RescuedExceptionsVariableName cop wrongly finds an offense and tries to correct a local variable name in the exception list of a rescue clause, which could never be a proper operation.

  ```ruby
  # `exception` is defined here.

  begin

  rescue exception
       # ^--- This should never be corrected.
  end
  ```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
