### PR TITLE
Use squiggly heredoc instead of `String#strip_indent`

### DIFF
--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -399,21 +399,21 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
 
       include_examples 'UnneededCopDisableDirective not run',
-                       'individually disabled', <<-YAML.strip_indent
-        Lint/UnneededCopDisableDirective:
-          Enabled: false
-      YAML
+                       'individually disabled', <<~YAML
+                         Lint/UnneededCopDisableDirective:
+                           Enabled: false
+                       YAML
       include_examples 'UnneededCopDisableDirective not run',
-                       'individually excluded', <<-YAML.strip_indent
-        Lint/UnneededCopDisableDirective:
-          Exclude:
-            - example.rb
-      YAML
+                       'individually excluded', <<~YAML
+                         Lint/UnneededCopDisableDirective:
+                           Exclude:
+                             - example.rb
+                       YAML
       include_examples 'UnneededCopDisableDirective not run',
-                       'disabled through department', <<-YAML.strip_indent
-        Lint:
-          Enabled: false
-      YAML
+                       'disabled through department', <<~YAML
+                         Lint:
+                           Enabled: false
+                       YAML
     end
   end
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -699,23 +699,23 @@ RSpec.describe RuboCop::ConfigLoader do
 
       before do
         create_file("#{gem_root}/gemone/config/rubocop.yml",
-                    <<-YAML.strip_indent)
-          Metrics/MethodLength:
-            Enabled: false
-            Max: 200
-            CountComments: false
-        YAML
+                    <<~YAML)
+                      Metrics/MethodLength:
+                        Enabled: false
+                        Max: 200
+                        CountComments: false
+                    YAML
         create_file("#{gem_root}/gemtwo/config/default.yml",
-                    <<-YAML.strip_indent)
-          Metrics/LineLength:
-            Enabled: true
-        YAML
+                    <<~YAML)
+                      Metrics/LineLength:
+                        Enabled: true
+                    YAML
         create_file("#{gem_root}/gemtwo/config/strict.yml",
-                    <<-YAML.strip_indent)
-          Metrics/LineLength:
-            Max: 72
-            AllowHeredoc: false
-        YAML
+                    <<~YAML)
+                      Metrics/LineLength:
+                        Max: 72
+                        AllowHeredoc: false
+                    YAML
         create_file('local.yml', <<~YAML)
           Metrics/MethodLength:
             CountComments: true

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe RuboCop::Config do
 
     context 'when the configuration includes multiple valid EnforcedStyle' do
       before do
-        create_file(configuration_path, <<-YAML.strip_indent)
+        create_file(configuration_path, <<~YAML)
           Layout/AlignHash:
             EnforcedHashRocketStyle:
               - key
@@ -192,7 +192,7 @@ RSpec.describe RuboCop::Config do
     context 'when the configuration includes multiple valid EnforcedStyle '\
             'and one invalid style' do
       before do
-        create_file(configuration_path, <<-YAML.strip_indent)
+        create_file(configuration_path, <<~YAML)
           Layout/AlignHash:
             EnforcedHashRocketStyle:
               - key
@@ -209,7 +209,7 @@ RSpec.describe RuboCop::Config do
     context 'when the configuration includes multiple '\
             'but config does not allow' do
       before do
-        create_file(configuration_path, <<-YAML.strip_indent)
+        create_file(configuration_path, <<~YAML)
           Layout/SpaceAroundBlockParameters:
             EnforcedStyleInsidePipes:
               - space
@@ -224,7 +224,7 @@ RSpec.describe RuboCop::Config do
 
     context 'when the configuration includes multiple invalid EnforcedStyle' do
       before do
-        create_file(configuration_path, <<-YAML.strip_indent)
+        create_file(configuration_path, <<~YAML)
           Layout/AlignHash:
             EnforcedHashRocketStyle:
               - table

--- a/spec/rubocop/cop/layout/align_hash_spec.rb
+++ b/spec/rubocop/cop/layout/align_hash_spec.rb
@@ -718,7 +718,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'accepts aligned hash keys, by keys' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         hash1 = {
           a: 0,
           bbb: 1
@@ -731,7 +731,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'accepts aligned hash keys, by table' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         hash1 = {
           a:   0,
           bbb: 1
@@ -744,7 +744,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'accepts aligned hash keys, by both' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         hash1 = {
           a:   0,
           bbb: 1
@@ -780,7 +780,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
 
     describe 'registers an offense' do
       it 'for misaligned hash values' do
-        expect_offense(<<-RUBY.strip_indent)
+        expect_offense(<<~RUBY)
           hash = {
               'a' =>  0,
               ^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
@@ -791,7 +791,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       end
 
       it 'for misaligned hash values, prefer table when least offenses' do
-        expect_offense(<<-RUBY.strip_indent)
+        expect_offense(<<~RUBY)
           hash = {
             'abcdefg' => 0,
             'abcdef'  => 0,
@@ -806,7 +806,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       end
 
       it 'for misaligned hash values, prefer key when least offenses' do
-        expect_offense(<<-RUBY.strip_indent)
+        expect_offense(<<~RUBY)
           hash = {
             'abcdefg' => 0,
             'abcdef'  => 0,
@@ -831,7 +831,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
       end
 
       it 'for misaligned hash values, works separate for each hash' do
-        expect_offense(<<-RUBY.strip_indent)
+        expect_offense(<<~RUBY)
           hash = {
             'abcdefg' => 0,
             'abcdef'  => 0,
@@ -850,14 +850,14 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
 
       describe 'auto-corrects an offense' do
         it 'for misaligned hash values' do
-          new_source = autocorrect_source(<<-RUBY.strip_indent)
+          new_source = autocorrect_source(<<~RUBY)
             hash = {
                 'a' =>  0,
               'bbb' => 1
             }
           RUBY
 
-          expect(new_source).to eq(<<-RUBY.strip_indent)
+          expect(new_source).to eq(<<~RUBY)
             hash = {
                 'a' => 0,
                 'bbb' => 1
@@ -875,7 +875,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
 
           it 'for misaligned hash values, '\
              'prefer table because it is specified first' do
-            new_source = autocorrect_source(<<-RUBY.strip_indent)
+            new_source = autocorrect_source(<<~RUBY)
               hash = {
                 'abcdefg' => 0,
                 'abcdef'  => 0,
@@ -886,7 +886,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
               }
             RUBY
 
-            expect(new_source).to eq(<<-RUBY.strip_indent)
+            expect(new_source).to eq(<<~RUBY)
               hash = {
                 'abcdefg' => 0,
                 'abcdef'  => 0,
@@ -901,7 +901,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
 
         it 'for misaligned hash values, '\
            'prefer key because it is specified first' do
-          new_source = autocorrect_source(<<-RUBY.strip_indent)
+          new_source = autocorrect_source(<<~RUBY)
             hash = {
               'abcdefg' => 0,
               'abcdef'  => 0,
@@ -912,7 +912,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignHash, :config do
             }
           RUBY
 
-          expect(new_source).to eq(<<-RUBY.strip_indent)
+          expect(new_source).to eq(<<~RUBY)
             hash = {
               'abcdefg' => 0,
               'abcdef' => 0,

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -342,7 +342,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
 
     %w[private protected].each do |access_modifier|
       it "accepts missing blank line after #{access_modifier}" do
-        expect_no_offenses(<<-RUBY.strip_indent)
+        expect_no_offenses(<<~RUBY)
           class Test
             something
 
@@ -353,7 +353,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
       end
 
       it "registers an offense for blank line after #{access_modifier}" do
-        inspect_source(<<-RUBY.strip_indent)
+        inspect_source(<<~RUBY)
           class Test
             something
 
@@ -369,7 +369,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
       end
 
       it "autocorrects remove blank line after #{access_modifier}" do
-        corrected = autocorrect_source(<<-RUBY.strip_indent)
+        corrected = autocorrect_source(<<~RUBY)
           class Test
             something
 
@@ -379,7 +379,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
           end
         RUBY
 
-        expect(corrected).to eq(<<-RUBY.strip_indent)
+        expect(corrected).to eq(<<~RUBY)
           class Test
             something
 
@@ -392,7 +392,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
 
     %w[public module_function].each do |access_modifier|
       it "accepts missing blank line after #{access_modifier}" do
-        expect_no_offenses(<<-RUBY.strip_indent)
+        expect_no_offenses(<<~RUBY)
           module Kernel
             #{access_modifier}
 
@@ -418,7 +418,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
       end
 
       it 'autocorrects blank line before #{access_modifier}' do
-        corrected = autocorrect_source(<<-RUBY.strip_indent)
+        corrected = autocorrect_source(<<~RUBY)
           class Test
             something
             #{access_modifier}
@@ -426,7 +426,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
           end
         RUBY
 
-        expect(corrected).to eq(<<-RUBY.strip_indent)
+        expect(corrected).to eq(<<~RUBY)
           class Test
             something
 

--- a/spec/rubocop/cop/layout/indent_heredoc_spec.rb
+++ b/spec/rubocop/cop/layout/indent_heredoc_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentHeredoc, :config do
   shared_examples 'warning' do |message|
     it 'warns' do
       correct = lambda do
-        autocorrect_source(<<-RUBY.strip_indent)
+        autocorrect_source(<<~RUBY)
           <<-RUBY2
           foo
           RUBY2

--- a/spec/rubocop/cop/lint/number_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/number_conversion_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion do
         ^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using "10".to_i, use stricter Integer("10", 10).
       RUBY
 
-      expect_correction(<<~RUBY.strip_indent)
+      expect_correction(<<~RUBY)
         Integer("10", 10)
       RUBY
     end
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion do
         ^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using 10.to_i, use stricter Integer(10, 10).
       RUBY
 
-      expect_correction(<<~RUBY.strip_indent)
+      expect_correction(<<~RUBY)
         Integer(10, 10)
       RUBY
     end
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion do
         ^^^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using "10.2".to_f, use stricter Float("10.2").
       RUBY
 
-      expect_correction(<<~RUBY.strip_indent)
+      expect_correction(<<~RUBY)
         Float("10.2")
       RUBY
     end
@@ -45,7 +45,7 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion do
         ^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using "10".to_c, use stricter Complex("10").
       RUBY
 
-      expect_correction(<<~RUBY.strip_indent)
+      expect_correction(<<~RUBY)
         Complex("10")
       RUBY
     end
@@ -57,7 +57,7 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion do
         ^^^^^^^^^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using string_value.to_i, use stricter Integer(string_value, 10).
       RUBY
 
-      expect_correction(<<~RUBY.strip_indent)
+      expect_correction(<<~RUBY)
         string_value = '10'
         Integer(string_value, 10)
       RUBY
@@ -70,7 +70,7 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion do
         ^^^^^^^^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using params[:id].to_i, use stricter Integer(params[:id], 10).
       RUBY
 
-      expect_correction(<<~RUBY.strip_indent)
+      expect_correction(<<~RUBY)
         params = { id: 10 }
         Integer(params[:id], 10)
       RUBY
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion do
         ^^^^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using args[0].to_i, use stricter Integer(args[0], 10).
       RUBY
 
-      expect_correction(<<~RUBY.strip_indent)
+      expect_correction(<<~RUBY)
         args = [1,2,3]
         Integer(args[0], 10)
       RUBY
@@ -95,7 +95,7 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion do
         ^^^^^^^^^^^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using params[:field].to_i, use stricter Integer(params[:field], 10).
       RUBY
 
-      expect_correction(<<~RUBY.strip_indent)
+      expect_correction(<<~RUBY)
         Integer(params[:field], 10)
       RUBY
     end
@@ -121,7 +121,7 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion do
     end
 
     it 'when using Time' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         Time.now.to_i
         Time.now.to_f
         Time.strptime("2000-10-31", "%Y-%m-%d").to_i
@@ -131,14 +131,14 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion do
     end
 
     it 'when using DateTime' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         DateTime.new(2012, 8, 29, 22, 35, 0).to_i
         DateTime.new(2012, 8, 29, 22, 35, 0).to_f
       RUBY
     end
 
     it 'when using Time/DateTime with multiple method calls' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         Time.now.to_datetime.to_i
         DateTime.civil(2005, 2, 21, 10, 11, 12, Rational(-6, 24)).utc.to_f
         Time.zone.now.to_datetime.to_f

--- a/spec/rubocop/cop/style/command_literal_spec.rb
+++ b/spec/rubocop/cop/style/command_literal_spec.rb
@@ -451,7 +451,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
 
       it 'auto-corrects' do
         new_source = autocorrect_source(source)
-        expect(new_source).to eq(<<-RUBY.strip_indent)
+        expect(new_source).to eq(<<~RUBY)
           foo = %x(
             ls
             ls -l

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -380,7 +380,7 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
 
     describe 'a multi-line %r regex without slashes' do
       it 'is accepted' do
-        expect_no_offenses(<<-RUBY.strip_indent)
+        expect_no_offenses(<<~RUBY)
           foo = %r{
             foo
             bar
@@ -391,7 +391,7 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
 
     describe 'a multi-line %r regex with slashes' do
       it 'is accepted' do
-        expect_no_offenses(<<-RUBY.strip_indent)
+        expect_no_offenses(<<~RUBY)
           foo = %r{
             https?://
             example\.com

--- a/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
@@ -28,14 +28,14 @@ RSpec.describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
     end
 
     it 'accepts double quotes on a broken static string' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         "A" \
           "B"
       RUBY
     end
 
     it 'accepts double quotes on static strings within a method' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         def m
           puts "A"
           puts "B"


### PR DESCRIPTION
RuboCop supports Ruby 2.3 or higher, so we can use squiggly heredoc (`<<~`) :heart:






Basically, I used the following commands.

```bash
$ cd spec/
$ git grep -lE '<<-\w+\.strip_indent' | xargs sed -i -E 's/<<-(\w+)\.strip_indent/<<~\1/g'
$ git grep -lE '<<~\w+\.strip_indent' | xargs sed -i -E 's/<<~(\w+)\.strip_indent/<<~\1/g'

# Do not replace `<<-'RUBY'` to avoid JRuby bug
# $ git grep -lE "<<-'\w+'\.strip_indent" | xargs sed -i -E "s/<<-('\w+')\.strip_indent/<<~\1/g"
```


Note
---



RuboCop has `String#strip_indent` even if this pull request is applied.
I think we can replace the other `strip_indent` also, but this pull request is good for the first step of replacing `strip_indent`.
I guess we need to replace the other `strip_indent` by hand.

---

ref https://github.com/rubocop-hq/rubocop/pull/7122#discussion_r297025089

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
