### PR TITLE
Use squiggly heredoc for node patterns and eval

### DIFF
--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -302,7 +302,7 @@ module RuboCop
 
       ## Destructuring
 
-      def_node_matcher :receiver, <<-PATTERN
+      def_node_matcher :receiver, <<~PATTERN
         {(send $_ ...) (block (send $_ ...) ...)}
       PATTERN
 
@@ -321,7 +321,7 @@ module RuboCop
         end
       end
 
-      def_node_matcher :defined_module0, <<-PATTERN
+      def_node_matcher :defined_module0, <<~PATTERN
         {(class (const $_ $_) ...)
          (module (const $_ $_) ...)
          (casgn $_ $_        (send (const nil? {:Class :Module}) :new ...))
@@ -367,7 +367,7 @@ module RuboCop
       end
 
       # Some cops treat the shovel operator as a kind of assignment.
-      def_node_matcher :assignment_or_similar?, <<-PATTERN
+      def_node_matcher :assignment_or_similar?, <<~PATTERN
         {assignment? (send _recv :<< ...)}
       PATTERN
 
@@ -479,11 +479,11 @@ module RuboCop
         irange_type? || erange_type?
       end
 
-      def_node_matcher :guard_clause?, <<-PATTERN
+      def_node_matcher :guard_clause?, <<~PATTERN
         [{(send nil? {:raise :fail} ...) return break next} single_line?]
       PATTERN
 
-      def_node_matcher :proc?, <<-PATTERN
+      def_node_matcher :proc?, <<~PATTERN
         {(block (send nil? :proc) ...)
          (block (send (const nil? :Proc) :new) ...)
          (send (const nil? :Proc) :new)}
@@ -492,12 +492,12 @@ module RuboCop
       def_node_matcher :lambda?, '(block (send nil? :lambda) ...)'
       def_node_matcher :lambda_or_proc?, '{lambda? proc?}'
 
-      def_node_matcher :class_constructor?, <<-PATTERN
+      def_node_matcher :class_constructor?, <<~PATTERN
         {       (send (const nil? {:Class :Module}) :new ...)
          (block (send (const nil? {:Class :Module}) :new ...) ...)}
       PATTERN
 
-      def_node_matcher :module_definition?, <<-PATTERN
+      def_node_matcher :module_definition?, <<~PATTERN
         {class module (casgn _ _ class_constructor?)}
       PATTERN
 
@@ -638,7 +638,7 @@ module RuboCop
         end
       end
 
-      def_node_matcher :new_class_or_module_block?, <<-PATTERN
+      def_node_matcher :new_class_or_module_block?, <<~PATTERN
         ^(casgn _ _ (block (send (const _ {:Class :Module}) :new) ...))
       PATTERN
     end

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -220,7 +220,7 @@ module RuboCop
 
       private
 
-      def_node_matcher :macro_scope?, <<-PATTERN
+      def_node_matcher :macro_scope?, <<~PATTERN
         {^{({sclass class module block} ...) class_constructor?}
          ^^{({sclass class module block} ... ({begin if} ...)) class_constructor?}
          ^#macro_kwbegin_wrapper?
@@ -245,15 +245,15 @@ module RuboCop
         node.parent.nil?
       end
 
-      def_node_matcher :adjacent_def_modifier?, <<-PATTERN
+      def_node_matcher :adjacent_def_modifier?, <<~PATTERN
         (send nil? _ ({def defs} ...))
       PATTERN
 
-      def_node_matcher :bare_access_modifier_declaration?, <<-PATTERN
+      def_node_matcher :bare_access_modifier_declaration?, <<~PATTERN
         (send nil? {:public :protected :private :module_function})
       PATTERN
 
-      def_node_matcher :non_bare_access_modifier_declaration?, <<-PATTERN
+      def_node_matcher :non_bare_access_modifier_declaration?, <<~PATTERN
         (send nil? {:public :protected :private :module_function} _)
       PATTERN
     end

--- a/lib/rubocop/ast/traversal.rb
+++ b/lib/rubocop/ast/traversal.rb
@@ -35,7 +35,7 @@ module RuboCop
       end
 
       ONE_CHILD_NODE.each do |type|
-        module_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+        module_eval(<<~RUBY, __FILE__, __LINE__ + 1)
           def on_#{type}(node)
             if (child = node.children[0])
               send(:"on_\#{child.type}", child)
@@ -45,7 +45,7 @@ module RuboCop
       end
 
       MANY_CHILD_NODES.each do |type|
-        module_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+        module_eval(<<~RUBY, __FILE__, __LINE__ + 1)
           def on_#{type}(node)
             node.children.each { |child| send(:"on_\#{child.type}", child) }
             nil
@@ -55,7 +55,7 @@ module RuboCop
 
       SECOND_CHILD_ONLY.each do |type|
         # Guard clause is for nodes nested within mlhs
-        module_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+        module_eval(<<~RUBY, __FILE__, __LINE__ + 1)
           def on_#{type}(node)
             if (child = node.children[1])
               send(:"on_\#{child.type}", child)

--- a/lib/rubocop/cop/bundler/insecure_protocol_source.rb
+++ b/lib/rubocop/cop/bundler/insecure_protocol_source.rb
@@ -33,7 +33,7 @@ module RuboCop
               "Please change your source to 'https://rubygems.org' " \
               "if possible, or 'http://rubygems.org' if not."
 
-        def_node_matcher :insecure_protocol_source?, <<-PATTERN
+        def_node_matcher :insecure_protocol_source?, <<~PATTERN
           (send nil? :source
             (sym ${:gemcutter :rubygems :rubyforge}))
         PATTERN

--- a/lib/rubocop/cop/bundler/ordered_gems.rb
+++ b/lib/rubocop/cop/bundler/ordered_gems.rb
@@ -64,7 +64,7 @@ module RuboCop
           declarations.to_a[node_index - 1]
         end
 
-        def_node_search :gem_declarations, <<-PATTERN
+        def_node_search :gem_declarations, <<~PATTERN
           (:send nil? :gem str ...)
         PATTERN
       end

--- a/lib/rubocop/cop/gemspec/duplicated_assignment.rb
+++ b/lib/rubocop/cop/gemspec/duplicated_assignment.rb
@@ -40,7 +40,7 @@ module RuboCop
         MSG = '`%<assignment>s` method calls already given on line '\
               '%<line_of_first_occurrence>d of the gemspec.'
 
-        def_node_search :gem_specification, <<-PATTERN
+        def_node_search :gem_specification, <<~PATTERN
           (block
             (send
               (const
@@ -49,7 +49,7 @@ module RuboCop
               (arg $_)) ...)
         PATTERN
 
-        def_node_search :assignment_method_declarations, <<-PATTERN
+        def_node_search :assignment_method_declarations, <<~PATTERN
           (send
             (lvar #match_block_variable_name?) #assignment_method? ...)
         PATTERN

--- a/lib/rubocop/cop/gemspec/ordered_dependencies.rb
+++ b/lib/rubocop/cop/gemspec/ordered_dependencies.rb
@@ -97,7 +97,7 @@ module RuboCop
           node.method_name
         end
 
-        def_node_search :dependency_declarations, <<-PATTERN
+        def_node_search :dependency_declarations, <<~PATTERN
           (send (lvar _) {:add_dependency :add_runtime_dependency :add_development_dependency} ...)
         PATTERN
       end

--- a/lib/rubocop/cop/gemspec/required_ruby_version.rb
+++ b/lib/rubocop/cop/gemspec/required_ruby_version.rb
@@ -41,7 +41,7 @@ module RuboCop
               '(%<target_ruby_version>s, which may be specified in ' \
               '.rubocop.yml) should be equal.'
 
-        def_node_search :required_ruby_version, <<-PATTERN
+        def_node_search :required_ruby_version, <<~PATTERN
           (send _ :required_ruby_version= ${(str _) (array (str _))})
         PATTERN
 

--- a/lib/rubocop/cop/gemspec/ruby_version_globals_usage.rb
+++ b/lib/rubocop/cop/gemspec/ruby_version_globals_usage.rb
@@ -30,7 +30,7 @@ module RuboCop
 
         def_node_matcher :ruby_version?, '(const nil? :RUBY_VERSION)'
 
-        def_node_search :gem_specification?, <<-PATTERN
+        def_node_search :gem_specification?, <<~PATTERN
           (block
             (send
               (const

--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -63,7 +63,7 @@ module RuboCop
                 # For example
                 MSG = 'Use `#good_method` instead of `#bad_method`.'.freeze
 
-                def_node_matcher :bad_method?, <<-PATTERN
+                def_node_matcher :bad_method?, <<~PATTERN
                   (send nil? :bad_method ...)
                 PATTERN
 

--- a/lib/rubocop/cop/internal_affairs/node_destructuring.rb
+++ b/lib/rubocop/cop/internal_affairs/node_destructuring.rb
@@ -19,11 +19,11 @@ module RuboCop
         MSG = 'Use the methods provided with the node extensions instead ' \
               'of manually destructuring nodes.'
 
-        def_node_matcher :node_variable?, <<-PATTERN
+        def_node_matcher :node_variable?, <<~PATTERN
           {(lvar [#node_suffix? _]) (send nil? [#node_suffix? _])}
         PATTERN
 
-        def_node_matcher :node_destructuring?, <<-PATTERN
+        def_node_matcher :node_destructuring?, <<~PATTERN
           {(masgn (mlhs ...) {(send #node_variable? :children) (array (splat #node_variable?))})}
         PATTERN
 

--- a/lib/rubocop/cop/internal_affairs/node_type_predicate.rb
+++ b/lib/rubocop/cop/internal_affairs/node_type_predicate.rb
@@ -16,7 +16,7 @@ module RuboCop
       class NodeTypePredicate < Cop
         MSG = 'Use `#%<type>s_type?` to check node type.'
 
-        def_node_matcher :node_type_check, <<-PATTERN
+        def_node_matcher :node_type_check, <<~PATTERN
           (send (send $_ :type) :== (sym $_))
         PATTERN
 

--- a/lib/rubocop/cop/internal_affairs/offense_location_keyword.rb
+++ b/lib/rubocop/cop/internal_affairs/offense_location_keyword.rb
@@ -33,11 +33,11 @@ module RuboCop
 
         private
 
-        def_node_matcher :node_type_check, <<-PATTERN
+        def_node_matcher :node_type_check, <<~PATTERN
           (send nil? :add_offense $_node $hash)
         PATTERN
 
-        def_node_matcher :offending_location_argument, <<-PATTERN
+        def_node_matcher :offending_location_argument, <<~PATTERN
           (pair (sym :location) $(send (send $_node :loc) $_keyword))
         PATTERN
 

--- a/lib/rubocop/cop/internal_affairs/redundant_location_argument.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_location_argument.rb
@@ -21,7 +21,7 @@ module RuboCop
 
         MSG = 'Redundant location argument to `#add_offense`.'
 
-        def_node_matcher :redundant_location_argument, <<-PATTERN
+        def_node_matcher :redundant_location_argument, <<~PATTERN
           (send nil? :add_offense _
             (hash <$(pair (sym :location) (sym :expression)) ...>)
           )

--- a/lib/rubocop/cop/internal_affairs/redundant_message_argument.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_message_argument.rb
@@ -24,11 +24,11 @@ module RuboCop
 
         MSG = 'Redundant message argument to `#add_offense`.'
 
-        def_node_matcher :node_type_check, <<-PATTERN
+        def_node_matcher :node_type_check, <<~PATTERN
           (send nil? :add_offense $_node $hash)
         PATTERN
 
-        def_node_matcher :redundant_message_argument, <<-PATTERN
+        def_node_matcher :redundant_message_argument, <<~PATTERN
           (pair
             (sym :message)
             ${(const nil? :MSG) (send nil? :message) (send nil? :message _)})

--- a/lib/rubocop/cop/internal_affairs/useless_message_assertion.rb
+++ b/lib/rubocop/cop/internal_affairs/useless_message_assertion.rb
@@ -16,11 +16,11 @@ module RuboCop
       class UselessMessageAssertion < Cop
         MSG = 'Do not specify cop behavior using `described_class::MSG`.'
 
-        def_node_search :described_class_msg, <<-PATTERN
+        def_node_search :described_class_msg, <<~PATTERN
           (const (send nil? :described_class) :MSG)
         PATTERN
 
-        def_node_matcher :rspec_expectation_on_msg?, <<-PATTERN
+        def_node_matcher :rspec_expectation_on_msg?, <<~PATTERN
           (send (send nil? :expect #contains_described_class_msg?) :to ...)
         PATTERN
 

--- a/lib/rubocop/cop/layout/block_alignment.rb
+++ b/lib/rubocop/cop/layout/block_alignment.rb
@@ -67,7 +67,7 @@ module RuboCop
 
         MSG = '%<current>s is not aligned with %<prefer>s%<alt_prefer>s.'
 
-        def_node_matcher :block_end_align_target?, <<-PATTERN
+        def_node_matcher :block_end_align_target?, <<~PATTERN
           {assignment?
            splat
            and

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -142,7 +142,7 @@ module RuboCop
         MSG = '`%<category>s` is supposed to appear before ' \
               '`%<previous>s`.'
 
-        def_node_matcher :visibility_block?, <<-PATTERN
+        def_node_matcher :visibility_block?, <<~PATTERN
           (send nil? { :private :protected :public })
         PATTERN
 

--- a/lib/rubocop/cop/layout/indent_first_argument.rb
+++ b/lib/rubocop/cop/layout/indent_first_argument.rb
@@ -204,7 +204,7 @@ module RuboCop
           node.source_range.begin_pos > parent.source_range.begin_pos
         end
 
-        def_node_matcher :eligible_method_call?, <<-PATTERN
+        def_node_matcher :eligible_method_call?, <<~PATTERN
           (send _ !:[]= ...)
         PATTERN
 

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -52,7 +52,7 @@ module RuboCop
         MSG = 'Use %<configured_indentation_width>d (not %<indentation>d) ' \
               'spaces for%<name>s indentation.'
 
-        def_node_matcher :access_modifier?, <<-PATTERN
+        def_node_matcher :access_modifier?, <<~PATTERN
           [(send ...) access_modifier?]
         PATTERN
 

--- a/lib/rubocop/cop/lint/big_decimal_new.rb
+++ b/lib/rubocop/cop/lint/big_decimal_new.rb
@@ -18,7 +18,7 @@ module RuboCop
         MSG = '`%<double_colon>sBigDecimal.new()` is deprecated. ' \
               'Use `%<double_colon>sBigDecimal()` instead.'
 
-        def_node_matcher :big_decimal_new, <<-PATTERN
+        def_node_matcher :big_decimal_new, <<~PATTERN
           (send
             (const ${nil? cbase} :BigDecimal) :new ...)
         PATTERN

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -35,14 +35,14 @@ module RuboCop
       class Debugger < Cop
         MSG = 'Remove debugger entry point `%<source>s`.'
 
-        def_node_matcher :kernel?, <<-PATTERN
+        def_node_matcher :kernel?, <<~PATTERN
           {
             (const nil? :Kernel)
             (const (cbase) :Kernel)
           }
         PATTERN
 
-        def_node_matcher :debugger_call?, <<-PATTERN
+        def_node_matcher :debugger_call?, <<~PATTERN
           {(send {nil? #kernel?} {:debugger :byebug} ...)
            (send (send {#kernel? nil?} :binding)
              {:pry :remote_pry :pry_remote} ...)
@@ -52,7 +52,7 @@ module RuboCop
                       :save_screenshot} ...)}
         PATTERN
 
-        def_node_matcher :binding_irb_call?, <<-PATTERN
+        def_node_matcher :binding_irb_call?, <<~PATTERN
           (send (send {#kernel? nil?} :binding) :irb ...)
         PATTERN
 

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -79,7 +79,7 @@ module RuboCop
           end
         end
 
-        def_node_matcher :method_alias?, <<-PATTERN
+        def_node_matcher :method_alias?, <<~PATTERN
           (alias (sym $_name) sym)
         PATTERN
 
@@ -91,11 +91,11 @@ module RuboCop
           found_instance_method(node, name)
         end
 
-        def_node_matcher :alias_method?, <<-PATTERN
+        def_node_matcher :alias_method?, <<~PATTERN
           (send nil? :alias_method (sym $_name) _)
         PATTERN
 
-        def_node_matcher :attr?, <<-PATTERN
+        def_node_matcher :attr?, <<~PATTERN
           (send nil? ${:attr_reader :attr_writer :attr_accessor :attr} $...)
         PATTERN
 

--- a/lib/rubocop/cop/lint/each_with_object_argument.rb
+++ b/lib/rubocop/cop/lint/each_with_object_argument.rb
@@ -24,7 +24,7 @@ module RuboCop
       class EachWithObjectArgument < Cop
         MSG = 'The argument to each_with_object can not be immutable.'
 
-        def_node_matcher :each_with_object?, <<-PATTERN
+        def_node_matcher :each_with_object?, <<~PATTERN
           ({send csend} _ :each_with_object $_)
         PATTERN
 

--- a/lib/rubocop/cop/lint/erb_new_arguments.rb
+++ b/lib/rubocop/cop/lint/erb_new_arguments.rb
@@ -76,7 +76,7 @@ module RuboCop
           '`ERB.new(str, eoutvar: %<arg_value>s)` instead.'
         ].freeze
 
-        def_node_matcher :erb_new_with_non_keyword_arguments, <<-PATTERN
+        def_node_matcher :erb_new_with_non_keyword_arguments, <<~PATTERN
           (send
             (const {nil? cbase} :ERB) :new $...)
         PATTERN

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -61,7 +61,7 @@ module RuboCop
           end
         end
 
-        def_node_matcher :called_on_string?, <<-PATTERN
+        def_node_matcher :called_on_string?, <<~PATTERN
           {(send {nil? const_type?} _ (str _) ...)
            (send (str ...) ...)}
         PATTERN

--- a/lib/rubocop/cop/lint/ineffective_access_modifier.rb
+++ b/lib/rubocop/cop/lint/ineffective_access_modifier.rb
@@ -53,7 +53,7 @@ module RuboCop
         ALTERNATIVE_PROTECTED = '`protected` inside a `class << self` ' \
                                 'block'
 
-        def_node_search :private_class_methods, <<-PATTERN
+        def_node_search :private_class_methods, <<~PATTERN
           (send nil? :private_class_method $...)
         PATTERN
 

--- a/lib/rubocop/cop/lint/inherit_exception.rb
+++ b/lib/rubocop/cop/lint/inherit_exception.rb
@@ -55,7 +55,7 @@ module RuboCop
           SystemExit
         ].freeze
 
-        def_node_matcher :class_new_call?, <<-PATTERN
+        def_node_matcher :class_new_call?, <<~PATTERN
           (send
             (const {cbase nil?} :Class) :new
             $(const {cbase nil?} _))

--- a/lib/rubocop/cop/lint/multiple_compare.rb
+++ b/lib/rubocop/cop/lint/multiple_compare.rb
@@ -24,7 +24,7 @@ module RuboCop
       class MultipleCompare < Cop
         MSG = 'Use the `&&` operator to compare multiple values.'
 
-        def_node_matcher :multiple_compare?, <<-PATTERN
+        def_node_matcher :multiple_compare?, <<~PATTERN
           (send (send _ {:< :> :<= :>=} $_) {:< :> :<= :>=} _)
         PATTERN
 

--- a/lib/rubocop/cop/lint/nested_method_definition.rb
+++ b/lib/rubocop/cop/lint/nested_method_definition.rb
@@ -87,15 +87,15 @@ module RuboCop
             class_or_module_or_struct_new_call?(child)
         end
 
-        def_node_matcher :eval_call?, <<-PATTERN
+        def_node_matcher :eval_call?, <<~PATTERN
           (block (send _ {:instance_eval :class_eval :module_eval} ...) ...)
         PATTERN
 
-        def_node_matcher :exec_call?, <<-PATTERN
+        def_node_matcher :exec_call?, <<~PATTERN
           (block (send _ {:instance_exec :class_exec :module_exec} ...) ...)
         PATTERN
 
-        def_node_matcher :class_or_module_or_struct_new_call?, <<-PATTERN
+        def_node_matcher :class_or_module_or_struct_new_call?, <<~PATTERN
           (block (send (const nil? {:Class :Module :Struct}) :new ...) ...)
         PATTERN
       end

--- a/lib/rubocop/cop/lint/next_without_accumulator.rb
+++ b/lib/rubocop/cop/lint/next_without_accumulator.rb
@@ -25,7 +25,7 @@ module RuboCop
       class NextWithoutAccumulator < Cop
         MSG = 'Use `next` with an accumulator argument in a `reduce`.'
 
-        def_node_matcher :on_body_of_reduce, <<-PATTERN
+        def_node_matcher :on_body_of_reduce, <<~PATTERN
           (block (send _recv {:reduce :inject} !sym) _blockargs $(begin ...))
         PATTERN
 

--- a/lib/rubocop/cop/lint/non_local_exit_from_iterator.rb
+++ b/lib/rubocop/cop/lint/non_local_exit_from_iterator.rb
@@ -74,7 +74,7 @@ module RuboCop
         end
 
         def_node_matcher :chained_send?, '(send !nil? ...)'
-        def_node_matcher :define_method?, <<-PATTERN
+        def_node_matcher :define_method?, <<~PATTERN
           (send _ {:define_method :define_singleton_method} _)
         PATTERN
       end

--- a/lib/rubocop/cop/lint/number_conversion.rb
+++ b/lib/rubocop/cop/lint/number_conversion.rb
@@ -31,11 +31,11 @@ module RuboCop
               '%<number_object>s.%<to_method>s, use stricter '\
               '%<corrected_method>s.'
 
-        def_node_matcher :to_method, <<-PATTERN
+        def_node_matcher :to_method, <<~PATTERN
           (send $_ ${:to_i :to_f :to_c})
         PATTERN
 
-        def_node_matcher :datetime?, <<-PATTERN
+        def_node_matcher :datetime?, <<~PATTERN
           (send (const {nil? (cbase)} {:Time :DateTime}) ...)
         PATTERN
 

--- a/lib/rubocop/cop/lint/rand_one.rb
+++ b/lib/rubocop/cop/lint/rand_one.rb
@@ -24,7 +24,7 @@ module RuboCop
         MSG = '`%<method>s` always returns `0`. ' \
               'Perhaps you meant `rand(2)` or `rand`?'
 
-        def_node_matcher :rand_one?, <<-PATTERN
+        def_node_matcher :rand_one?, <<~PATTERN
           (send {(const nil? :Kernel) nil?} :rand {(int {-1 1}) (float {-1.0 1.0})})
         PATTERN
 

--- a/lib/rubocop/cop/lint/redundant_with_index.rb
+++ b/lib/rubocop/cop/lint/redundant_with_index.rb
@@ -32,7 +32,7 @@ module RuboCop
         MSG_EACH_WITH_INDEX = 'Use `each` instead of `each_with_index`.'
         MSG_WITH_INDEX = 'Remove redundant `with_index`.'
 
-        def_node_matcher :redundant_with_index?, <<-PATTERN
+        def_node_matcher :redundant_with_index?, <<~PATTERN
           (block
             $(send
               _ {:each_with_index :with_index} ...)

--- a/lib/rubocop/cop/lint/redundant_with_object.rb
+++ b/lib/rubocop/cop/lint/redundant_with_object.rb
@@ -33,7 +33,7 @@ module RuboCop
 
         MSG_WITH_OBJECT = 'Remove redundant `with_object`.'
 
-        def_node_matcher :redundant_with_object?, <<-PATTERN
+        def_node_matcher :redundant_with_object?, <<~PATTERN
           (block
             $(send _ {:each_with_object :with_object}
               _)

--- a/lib/rubocop/cop/lint/safe_navigation_chain.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_chain.rb
@@ -29,11 +29,11 @@ module RuboCop
         MSG = 'Do not chain ordinary method call' \
               ' after safe navigation operator.'
 
-        def_node_matcher :bad_method?, <<-PATTERN
-        {
-          (send $(csend ...) $_ ...)
-          (send $(block (csend ...) ...) $_ ...)
-        }
+        def_node_matcher :bad_method?, <<~PATTERN
+          {
+            (send $(csend ...) $_ ...)
+            (send $(block (csend ...) ...) $_ ...)
+          }
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/lint/safe_navigation_with_empty.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_with_empty.rb
@@ -23,7 +23,7 @@ module RuboCop
         MSG = 'Avoid calling `empty?` with the safe navigation operator ' \
           'in conditionals.'
 
-        def_node_matcher :safe_navigation_empty_in_conditional?, <<-PATTERN
+        def_node_matcher :safe_navigation_empty_in_conditional?, <<~PATTERN
           (if (csend (send ...) :empty?) ...)
         PATTERN
 

--- a/lib/rubocop/cop/lint/unified_integer.rb
+++ b/lib/rubocop/cop/lint/unified_integer.rb
@@ -20,7 +20,7 @@ module RuboCop
       class UnifiedInteger < Cop
         MSG = 'Use `Integer` instead of `%<klass>s`.'
 
-        def_node_matcher :fixnum_or_bignum_const, <<-PATTERN
+        def_node_matcher :fixnum_or_bignum_const, <<~PATTERN
           (:const {nil? (:cbase)} ${:Fixnum :Bignum})
         PATTERN
 

--- a/lib/rubocop/cop/lint/unneeded_require_statement.rb
+++ b/lib/rubocop/cop/lint/unneeded_require_statement.rb
@@ -26,7 +26,7 @@ module RuboCop
 
         MSG = 'Remove unnecessary `require` statement.'
 
-        def_node_matcher :unnecessary_require_statement?, <<-PATTERN
+        def_node_matcher :unnecessary_require_statement?, <<~PATTERN
           (send nil? :require
             (str {"enumerator" "rational" "complex" "thread"}))
         PATTERN

--- a/lib/rubocop/cop/lint/unneeded_splat_expansion.rb
+++ b/lib/rubocop/cop/lint/unneeded_splat_expansion.rb
@@ -60,7 +60,7 @@ module RuboCop
 
         def_node_matcher :array_new?, '$(send (const nil? :Array) :new ...)'
 
-        def_node_matcher :literal_expansion, <<-PATTERN
+        def_node_matcher :literal_expansion, <<~PATTERN
           (splat {$({str dstr int float array} ...) (block $#array_new? ...) $#array_new?} ...)
         PATTERN
 

--- a/lib/rubocop/cop/lint/unreachable_code.rb
+++ b/lib/rubocop/cop/lint/unreachable_code.rb
@@ -51,7 +51,7 @@ module RuboCop
 
         private
 
-        def_node_matcher :flow_command?, <<-PATTERN
+        def_node_matcher :flow_command?, <<~PATTERN
           {
             return next break retry redo
             (send

--- a/lib/rubocop/cop/lint/uri_escape_unescape.rb
+++ b/lib/rubocop/cop/lint/uri_escape_unescape.rb
@@ -45,7 +45,7 @@ module RuboCop
               'Instead, use %<replacements>s depending on your specific use ' \
               'case.'
 
-        def_node_matcher :uri_escape_unescape?, <<-PATTERN
+        def_node_matcher :uri_escape_unescape?, <<~PATTERN
           (send
             (const ${nil? cbase} :URI) ${:escape :encode :unescape :decode}
             ...)

--- a/lib/rubocop/cop/lint/uri_regexp.rb
+++ b/lib/rubocop/cop/lint/uri_regexp.rb
@@ -18,13 +18,13 @@ module RuboCop
               'be used. Instead, use `%<top_level>sURI::DEFAULT_PARSER.' \
               'make_regexp%<arg>s`.'
 
-        def_node_matcher :uri_regexp_with_argument?, <<-PATTERN
+        def_node_matcher :uri_regexp_with_argument?, <<~PATTERN
           (send
             (const ${nil? cbase} :URI) :regexp
             (str $_))
         PATTERN
 
-        def_node_matcher :uri_regexp_without_argument?, <<-PATTERN
+        def_node_matcher :uri_regexp_without_argument?, <<~PATTERN
           (send
             (const ${nil? cbase} :URI) :regexp)
         PATTERN

--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -113,19 +113,19 @@ module RuboCop
 
         private
 
-        def_node_matcher :static_method_definition?, <<-PATTERN
+        def_node_matcher :static_method_definition?, <<~PATTERN
           {def (send nil? {:attr :attr_reader :attr_writer :attr_accessor} ...)}
         PATTERN
 
-        def_node_matcher :dynamic_method_definition?, <<-PATTERN
+        def_node_matcher :dynamic_method_definition?, <<~PATTERN
           {(send nil? :define_method ...) (block (send nil? :define_method ...) ...)}
         PATTERN
 
-        def_node_matcher :class_or_instance_eval?, <<-PATTERN
+        def_node_matcher :class_or_instance_eval?, <<~PATTERN
           (block (send _ {:class_eval :instance_eval}) ...)
         PATTERN
 
-        def_node_matcher :class_or_module_or_struct_new_call?, <<-PATTERN
+        def_node_matcher :class_or_module_or_struct_new_call?, <<~PATTERN
           (block (send (const nil? {:Class :Module :Struct}) :new ...) ...)
         PATTERN
 
@@ -202,7 +202,7 @@ module RuboCop
           cop_config.fetch('MethodCreatingMethods', []).any? do |m|
             matcher_name = "#{m}_method?".to_sym
             unless respond_to?(matcher_name)
-              self.class.def_node_matcher matcher_name, <<-PATTERN
+              self.class.def_node_matcher matcher_name, <<~PATTERN
                 {def (send nil? :#{m} ...)}
               PATTERN
             end
@@ -226,7 +226,7 @@ module RuboCop
           cop_config.fetch('ContextCreatingMethods', []).any? do |m|
             matcher_name = "#{m}_block?".to_sym
             unless respond_to?(matcher_name)
-              self.class.def_node_matcher matcher_name, <<-PATTERN
+              self.class.def_node_matcher matcher_name, <<~PATTERN
                 (block (send {nil? const} {:#{m}} ...) ...)
               PATTERN
             end

--- a/lib/rubocop/cop/lint/useless_setter_call.rb
+++ b/lib/rubocop/cop/lint/useless_setter_call.rb
@@ -49,7 +49,7 @@ module RuboCop
 
         private
 
-        def_node_matcher :setter_call_to_local_variable?, <<-PATTERN
+        def_node_matcher :setter_call_to_local_variable?, <<~PATTERN
           [(send (lvar _) ...) setter_method?]
         PATTERN
 

--- a/lib/rubocop/cop/metrics/class_length.rb
+++ b/lib/rubocop/cop/metrics/class_length.rb
@@ -21,7 +21,7 @@ module RuboCop
 
         private
 
-        def_node_matcher :class_definition?, <<-PATTERN
+        def_node_matcher :class_definition?, <<~PATTERN
           (casgn nil? _ (block (send (const nil? :Class) :new) ...))
         PATTERN
 

--- a/lib/rubocop/cop/metrics/module_length.rb
+++ b/lib/rubocop/cop/metrics/module_length.rb
@@ -21,7 +21,7 @@ module RuboCop
 
         private
 
-        def_node_matcher :module_definition?, <<-PATTERN
+        def_node_matcher :module_definition?, <<~PATTERN
           (casgn nil? _ (block (send (const nil? :Module) :new) ...))
         PATTERN
 

--- a/lib/rubocop/cop/metrics/parameter_lists.rb
+++ b/lib/rubocop/cop/metrics/parameter_lists.rb
@@ -25,7 +25,7 @@ module RuboCop
 
         private
 
-        def_node_matcher :argument_to_lambda_or_proc?, <<-PATTERN
+        def_node_matcher :argument_to_lambda_or_proc?, <<~PATTERN
           ^lambda_or_proc?
         PATTERN
 

--- a/lib/rubocop/cop/mixin/def_node.rb
+++ b/lib/rubocop/cop/mixin/def_node.rb
@@ -25,7 +25,7 @@ module RuboCop
         processed_source[0..index].map(&:strip)
       end
 
-      def_node_matcher :non_public_modifier?, <<-PATTERN
+      def_node_matcher :non_public_modifier?, <<~PATTERN
         (send nil? {:private :protected} ({def defs} ...))
       PATTERN
     end

--- a/lib/rubocop/cop/mixin/empty_parameter.rb
+++ b/lib/rubocop/cop/mixin/empty_parameter.rb
@@ -8,7 +8,7 @@ module RuboCop
 
       private
 
-      def_node_matcher :empty_arguments?, <<-PATTERN
+      def_node_matcher :empty_arguments?, <<~PATTERN
         (block _ $(args) _)
       PATTERN
 

--- a/lib/rubocop/cop/mixin/enforce_superclass.rb
+++ b/lib/rubocop/cop/mixin/enforce_superclass.rb
@@ -5,12 +5,12 @@ module RuboCop
     # Common functionality for enforcing a specific superclass
     module EnforceSuperclass
       def self.included(base)
-        base.def_node_matcher :class_definition, <<-PATTERN
-        (class (const _ !:#{base::SUPERCLASS}) #{base::BASE_PATTERN} ...)
+        base.def_node_matcher :class_definition, <<~PATTERN
+          (class (const _ !:#{base::SUPERCLASS}) #{base::BASE_PATTERN} ...)
         PATTERN
 
-        base.def_node_matcher :class_new_definition, <<-PATTERN
-        [!^(casgn nil? :#{base::SUPERCLASS} ...) (send (const nil? :Class) :new #{base::BASE_PATTERN})]
+        base.def_node_matcher :class_new_definition, <<~PATTERN
+          [!^(casgn nil? :#{base::SUPERCLASS} ...) (send (const nil? :Class) :new #{base::BASE_PATTERN})]
         PATTERN
       end
 

--- a/lib/rubocop/cop/mixin/method_complexity.rb
+++ b/lib/rubocop/cop/mixin/method_complexity.rb
@@ -20,7 +20,7 @@ module RuboCop
 
       private
 
-      def_node_matcher :define_method?, <<-PATTERN
+      def_node_matcher :define_method?, <<~PATTERN
         (block
          (send nil? :define_method ({sym str} $_))
          args

--- a/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
+++ b/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
@@ -20,7 +20,7 @@ module RuboCop
         OP_LIKE_METHODS = %i[eql? equal?].freeze
         BLACKLISTED = %i[+@ -@ [] []= << === `].freeze
 
-        def_node_matcher :op_method_candidate?, <<-PATTERN
+        def_node_matcher :op_method_candidate?, <<~PATTERN
           (def [#op_method? $_] (args $(arg [!:other !:_other])) _)
         PATTERN
 

--- a/lib/rubocop/cop/naming/constant_name.rb
+++ b/lib/rubocop/cop/naming/constant_name.rb
@@ -23,7 +23,7 @@ module RuboCop
         # than just standard ASCII characters
         SNAKE_CASE = /^[[:digit:][:upper:]_]+$/.freeze
 
-        def_node_matcher :class_or_struct_return_method?, <<-PATTERN
+        def_node_matcher :class_or_struct_return_method?, <<~PATTERN
           (send
             (const _ {:Class :Struct}) :new
             ...)
@@ -63,7 +63,7 @@ module RuboCop
             (node.receiver.nil? || !literal_receiver?(node))
         end
 
-        def_node_matcher :literal_receiver?, <<-PATTERN
+        def_node_matcher :literal_receiver?, <<~PATTERN
           {(send literal? ...)
            (send (begin literal?) ...)}
         PATTERN

--- a/lib/rubocop/cop/naming/predicate_name.rb
+++ b/lib/rubocop/cop/naming/predicate_name.rb
@@ -28,7 +28,7 @@ module RuboCop
       #   def value?
       #   end
       class PredicateName < Cop
-        def_node_matcher :dynamic_method_define, <<-PATTERN
+        def_node_matcher :dynamic_method_define, <<~PATTERN
           (send nil? #method_definition_macros
             (sym $_)
             ...)

--- a/lib/rubocop/cop/security/eval.rb
+++ b/lib/rubocop/cop/security/eval.rb
@@ -14,7 +14,7 @@ module RuboCop
       class Eval < Cop
         MSG = 'The use of `eval` is a serious security risk.'
 
-        def_node_matcher :eval?, <<-PATTERN
+        def_node_matcher :eval?, <<~PATTERN
           (send {nil? (send nil? :binding)} :eval $!str ...)
         PATTERN
 

--- a/lib/rubocop/cop/security/json_load.rb
+++ b/lib/rubocop/cop/security/json_load.rb
@@ -25,7 +25,7 @@ module RuboCop
       class JSONLoad < Cop
         MSG = 'Prefer `JSON.parse` over `JSON.%<method>s`.'
 
-        def_node_matcher :json_load, <<-PATTERN
+        def_node_matcher :json_load, <<~PATTERN
           (send (const {nil? cbase} :JSON) ${:load :restore} ...)
         PATTERN
 

--- a/lib/rubocop/cop/security/marshal_load.rb
+++ b/lib/rubocop/cop/security/marshal_load.rb
@@ -21,7 +21,7 @@ module RuboCop
       class MarshalLoad < Cop
         MSG = 'Avoid using `Marshal.%<method>s`.'
 
-        def_node_matcher :marshal_load, <<-PATTERN
+        def_node_matcher :marshal_load, <<~PATTERN
           (send (const {nil? cbase} :Marshal) ${:load :restore}
           !(send (const {nil? cbase} :Marshal) :dump ...))
         PATTERN

--- a/lib/rubocop/cop/security/open.rb
+++ b/lib/rubocop/cop/security/open.rb
@@ -22,7 +22,7 @@ module RuboCop
       class Open < Cop
         MSG = 'The use of `Kernel#open` is a serious security risk.'
 
-        def_node_matcher :open?, <<-PATTERN
+        def_node_matcher :open?, <<~PATTERN
           (send nil? :open $!str ...)
         PATTERN
 

--- a/lib/rubocop/cop/security/yaml_load.rb
+++ b/lib/rubocop/cop/security/yaml_load.rb
@@ -18,7 +18,7 @@ module RuboCop
       class YAMLLoad < Cop
         MSG = 'Prefer using `YAML.safe_load` over `YAML.load`.'
 
-        def_node_matcher :yaml_load, <<-PATTERN
+        def_node_matcher :yaml_load, <<~PATTERN
           (send (const {nil? cbase} :YAML) :load ...)
         PATTERN
 

--- a/lib/rubocop/cop/style/alias.rb
+++ b/lib/rubocop/cop/style/alias.rb
@@ -138,7 +138,7 @@ module RuboCop
           end
         end
 
-        def_node_matcher :identifier, <<-PATTERN
+        def_node_matcher :identifier, <<~PATTERN
           (sym $_)
         PATTERN
       end

--- a/lib/rubocop/cop/style/colon_method_call.rb
+++ b/lib/rubocop/cop/style/colon_method_call.rb
@@ -20,7 +20,7 @@ module RuboCop
       class ColonMethodCall < Cop
         MSG = 'Do not use `::` for method calls.'
 
-        def_node_matcher :java_type_node?, <<-PATTERN
+        def_node_matcher :java_type_node?, <<~PATTERN
           (send
             (const nil? :Java) _)
         PATTERN

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -223,7 +223,7 @@ module RuboCop
 
         # The shovel operator `<<` does not have its own type. It is a `send`
         # type.
-        def_node_matcher :assignment_type?, <<-PATTERN
+        def_node_matcher :assignment_type?, <<~PATTERN
           {
             #{ASSIGNMENT_TYPES.join(' ')}
             (send _recv {:[]= :<< :=~ :!~ :<=> #end_with_eq?} ...)

--- a/lib/rubocop/cop/style/constant_visibility.rb
+++ b/lib/rubocop/cop/style/constant_visibility.rb
@@ -57,7 +57,7 @@ module RuboCop
           end
         end
 
-        def_node_matcher :visibility_declaration_for?, <<-PATTERN
+        def_node_matcher :visibility_declaration_for?, <<~PATTERN
           (send nil? {:public_constant :private_constant} ({sym str} %1))
         PATTERN
       end

--- a/lib/rubocop/cop/style/date_time.rb
+++ b/lib/rubocop/cop/style/date_time.rb
@@ -45,15 +45,15 @@ module RuboCop
         CLASS_MSG = 'Prefer Time over DateTime.'
         COERCION_MSG = 'Do not use #to_datetime.'
 
-        def_node_matcher :date_time?, <<-PATTERN
+        def_node_matcher :date_time?, <<~PATTERN
           (send (const {nil? (cbase)} :DateTime) ...)
         PATTERN
 
-        def_node_matcher :historic_date?, <<-PATTERN
+        def_node_matcher :historic_date?, <<~PATTERN
           (send _ _ _ (const (const nil? :Date) _))
         PATTERN
 
-        def_node_matcher :to_datetime?, <<-PATTERN
+        def_node_matcher :to_datetime?, <<~PATTERN
           (send _ :to_datetime)
         PATTERN
 

--- a/lib/rubocop/cop/style/dir.rb
+++ b/lib/rubocop/cop/style/dir.rb
@@ -20,7 +20,7 @@ module RuboCop
         MSG = 'Use `__dir__` to get an absolute path to the current ' \
               "file's directory."
 
-        def_node_matcher :dir_replacement?, <<-PATTERN
+        def_node_matcher :dir_replacement?, <<~PATTERN
           {(send (const nil? :File) :expand_path (send (const nil? :File) :dirname  #file_keyword?))
            (send (const nil? :File) :dirname     (send (const nil? :File) :realpath #file_keyword?))}
         PATTERN

--- a/lib/rubocop/cop/style/documentation_method.rb
+++ b/lib/rubocop/cop/style/documentation_method.rb
@@ -53,7 +53,7 @@ module RuboCop
 
         MSG = 'Missing method documentation comment.'
 
-        def_node_matcher :module_function_node?, <<-PATTERN
+        def_node_matcher :module_function_node?, <<~PATTERN
           (send nil? :module_function ...)
         PATTERN
 

--- a/lib/rubocop/cop/style/each_for_simple_loop.rb
+++ b/lib/rubocop/cop/style/each_for_simple_loop.rb
@@ -49,7 +49,7 @@ module RuboCop
 
         private
 
-        def_node_matcher :offending_each_range, <<-PATTERN
+        def_node_matcher :offending_each_range, <<~PATTERN
           (block (send (begin (${irange erange} (int $_) (int $_))) :each) (args) ...)
         PATTERN
       end

--- a/lib/rubocop/cop/style/each_with_object.rb
+++ b/lib/rubocop/cop/style/each_with_object.rb
@@ -22,7 +22,7 @@ module RuboCop
         MSG = 'Use `each_with_object` instead of `%<method>s`.'
         METHODS = %i[inject reduce].freeze
 
-        def_node_matcher :each_with_object_candidate?, <<-PATTERN
+        def_node_matcher :each_with_object_candidate?, <<~PATTERN
           (block $(send _ {:inject :reduce} _) $_ $_)
         PATTERN
 

--- a/lib/rubocop/cop/style/eval_with_location.rb
+++ b/lib/rubocop/cop/style/eval_with_location.rb
@@ -37,7 +37,7 @@ module RuboCop
         MSG_INCORRECT_LINE = 'Use `%<expected>s` instead of `%<actual>s`, ' \
                              'as they are used by backtraces.'
 
-        def_node_matcher :eval_without_location?, <<-PATTERN
+        def_node_matcher :eval_without_location?, <<~PATTERN
           {
             (send nil? :eval ${str dstr})
             (send nil? :eval ${str dstr} _)
@@ -53,7 +53,7 @@ module RuboCop
           }
         PATTERN
 
-        def_node_matcher :line_with_offset?, <<-PATTERN
+        def_node_matcher :line_with_offset?, <<~PATTERN
           {
             (send #special_line_keyword? %1 (int %2))
             (send (int %2) %1 #special_line_keyword?)

--- a/lib/rubocop/cop/style/even_odd.rb
+++ b/lib/rubocop/cop/style/even_odd.rb
@@ -18,7 +18,7 @@ module RuboCop
       class EvenOdd < Cop
         MSG = 'Replace with `Integer#%<method>s?`.'
 
-        def_node_matcher :even_odd_candidate?, <<-PATTERN
+        def_node_matcher :even_odd_candidate?, <<~PATTERN
           (send
             {(send $_ :% (int 2))
              (begin (send $_ :% (int 2)))}

--- a/lib/rubocop/cop/style/expand_path_arguments.rb
+++ b/lib/rubocop/cop/style/expand_path_arguments.rb
@@ -51,21 +51,21 @@ module RuboCop
                            'instead of ' \
                            '`Pathname.new(__FILE__).parent.expand_path`.'
 
-        def_node_matcher :file_expand_path, <<-PATTERN
+        def_node_matcher :file_expand_path, <<~PATTERN
           (send
             (const nil? :File) :expand_path
             $_
             $_)
         PATTERN
 
-        def_node_matcher :pathname_parent_expand_path, <<-PATTERN
+        def_node_matcher :pathname_parent_expand_path, <<~PATTERN
           (send
             (send
               (send nil? :Pathname
                 $_) :parent) :expand_path)
         PATTERN
 
-        def_node_matcher :pathname_new_parent_expand_path, <<-PATTERN
+        def_node_matcher :pathname_new_parent_expand_path, <<~PATTERN
           (send
             (send
               (send

--- a/lib/rubocop/cop/style/float_division.rb
+++ b/lib/rubocop/cop/style/float_division.rb
@@ -42,16 +42,16 @@ module RuboCop
       class FloatDivision < Cop
         include ConfigurableEnforcedStyle
 
-        def_node_matcher :right_coerce?, <<-PATTERN
+        def_node_matcher :right_coerce?, <<~PATTERN
           (send _ :/ (send _ :to_f))
         PATTERN
-        def_node_matcher :left_coerce?, <<-PATTERN
+        def_node_matcher :left_coerce?, <<~PATTERN
           (send (send _ :to_f) :/ _)
         PATTERN
-        def_node_matcher :both_coerce?, <<-PATTERN
+        def_node_matcher :both_coerce?, <<~PATTERN
           (send (send _ :to_f) :/ (send _ :to_f))
         PATTERN
-        def_node_matcher :any_coerce?, <<-PATTERN
+        def_node_matcher :any_coerce?, <<~PATTERN
           {(send _ :/ (send _ :to_f)) (send (send _ :to_f) :/ _)}
         PATTERN
 

--- a/lib/rubocop/cop/style/format_string.rb
+++ b/lib/rubocop/cop/style/format_string.rb
@@ -40,15 +40,15 @@ module RuboCop
 
         MSG = 'Favor `%<prefer>s` over `%<current>s`.'
 
-        def_node_matcher :formatter, <<-PATTERN
-        {
-          (send nil? ${:sprintf :format} _ _ ...)
-          (send {str dstr} $:% ... )
-          (send !nil? $:% {array hash})
-        }
+        def_node_matcher :formatter, <<~PATTERN
+          {
+            (send nil? ${:sprintf :format} _ _ ...)
+            (send {str dstr} $:% ... )
+            (send !nil? $:% {array hash})
+          }
         PATTERN
 
-        def_node_matcher :variable_argument?, <<-PATTERN
+        def_node_matcher :variable_argument?, <<~PATTERN
           (send {str dstr} :% {send_type? lvar_type?})
         PATTERN
 

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -47,7 +47,7 @@ module RuboCop
           [Style::Not]
         end
 
-        def_node_matcher :inverse_candidate?, <<-PATTERN
+        def_node_matcher :inverse_candidate?, <<~PATTERN
           {
             (send $(send $(...) $_ $...) :!)
             (send (block $(send $(...) $_) $...) :!)
@@ -55,7 +55,7 @@ module RuboCop
           }
         PATTERN
 
-        def_node_matcher :inverse_block?, <<-PATTERN
+        def_node_matcher :inverse_block?, <<~PATTERN
           (block $(send (...) $_) ... { $(send ... :!)
                                         $(send (...) {:!= :!~} ...)
                                         (begin ... $(send ... :!))

--- a/lib/rubocop/cop/style/min_max.rb
+++ b/lib/rubocop/cop/style/min_max.rb
@@ -38,7 +38,7 @@ module RuboCop
 
         private
 
-        def_node_matcher :min_max_candidate, <<-PATTERN
+        def_node_matcher :min_max_candidate, <<~PATTERN
           ({array return} (send [$_receiver !nil?] :min) (send [$_receiver !nil?] :max))
         PATTERN
 

--- a/lib/rubocop/cop/style/mixin_usage.rb
+++ b/lib/rubocop/cop/style/mixin_usage.rb
@@ -44,7 +44,7 @@ module RuboCop
         MSG = '`%<statement>s` is used at the top level. Use inside `class` ' \
               'or `module`.'
 
-        def_node_matcher :include_statement, <<-PATTERN
+        def_node_matcher :include_statement, <<~PATTERN
           (send nil? ${:include :extend :prepend}
             const)
         PATTERN

--- a/lib/rubocop/cop/style/multiple_comparison.rb
+++ b/lib/rubocop/cop/style/multiple_comparison.rb
@@ -30,7 +30,7 @@ module RuboCop
         private
 
         def_node_matcher :simple_double_comparison?, '(send $lvar :== $lvar)'
-        def_node_matcher :simple_comparison?, <<-PATTERN
+        def_node_matcher :simple_comparison?, <<~PATTERN
           {(send $lvar :== _)
            (send _ :== $lvar)}
         PATTERN

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -143,13 +143,13 @@ module RuboCop
           end
         end
 
-        def_node_matcher :splat_value, <<-PATTERN
+        def_node_matcher :splat_value, <<~PATTERN
           (array (splat $_))
         PATTERN
 
         # Some of these patterns may not actually return an immutable object,
         # but we want to consider them immutable for this cop.
-        def_node_matcher :operation_produces_immutable_object?, <<-PATTERN
+        def_node_matcher :operation_produces_immutable_object?, <<~PATTERN
           {
             (const _ _)
             (send (const nil? :Struct) :new ...)
@@ -165,7 +165,7 @@ module RuboCop
           }
         PATTERN
 
-        def_node_matcher :range_enclosed_in_parentheses?, <<-PATTERN
+        def_node_matcher :range_enclosed_in_parentheses?, <<~PATTERN
           (begin ({irange erange} _ _))
         PATTERN
       end

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -120,15 +120,15 @@ module RuboCop
           end
         end
 
-        def_node_matcher :predicate, <<-PATTERN
+        def_node_matcher :predicate, <<~PATTERN
           (send $(...) ${:zero? :positive? :negative?})
         PATTERN
 
-        def_node_matcher :comparison, <<-PATTERN
+        def_node_matcher :comparison, <<~PATTERN
           (send [$(...) !gvar_type?] ${:== :> :<} (int 0))
         PATTERN
 
-        def_node_matcher :inverted_comparison, <<-PATTERN
+        def_node_matcher :inverted_comparison, <<~PATTERN
           (send (int 0) ${:== :> :<} [$(...) !gvar_type?])
         PATTERN
       end

--- a/lib/rubocop/cop/style/option_hash.rb
+++ b/lib/rubocop/cop/style/option_hash.rb
@@ -22,7 +22,7 @@ module RuboCop
       class OptionHash < Cop
         MSG = 'Prefer keyword arguments to options hashes.'
 
-        def_node_matcher :option_hash, <<-PATTERN
+        def_node_matcher :option_hash, <<~PATTERN
           (args ... $(optarg [#suspicious_name? _] (hash)))
         PATTERN
 

--- a/lib/rubocop/cop/style/or_assignment.rb
+++ b/lib/rubocop/cop/style/or_assignment.rb
@@ -29,7 +29,7 @@ module RuboCop
       class OrAssignment < Cop
         MSG = 'Use the double pipe equals operator `||=` instead.'
 
-        def_node_matcher :ternary_assignment?, <<-PATTERN
+        def_node_matcher :ternary_assignment?, <<~PATTERN
           ({lvasgn ivasgn cvasgn gvasgn} _var
             (if
               ({lvar ivar cvar gvar} _var)
@@ -37,7 +37,7 @@ module RuboCop
               _))
         PATTERN
 
-        def_node_matcher :unless_assignment?, <<-PATTERN
+        def_node_matcher :unless_assignment?, <<~PATTERN
           (if
             ({lvar ivar cvar gvar} _var) nil?
             ({lvasgn ivasgn cvasgn gvasgn} _var

--- a/lib/rubocop/cop/style/parentheses_around_condition.rb
+++ b/lib/rubocop/cop/style/parentheses_around_condition.rb
@@ -60,7 +60,7 @@ module RuboCop
 
         private
 
-        def_node_matcher :control_op_condition, <<-PATTERN
+        def_node_matcher :control_op_condition, <<~PATTERN
           (begin $_ ...)
         PATTERN
 

--- a/lib/rubocop/cop/style/random_with_offset.rb
+++ b/lib/rubocop/cop/style/random_with_offset.rb
@@ -27,7 +27,7 @@ module RuboCop
         MSG = 'Prefer ranges when generating random numbers instead of ' \
           'integers with offsets.'
 
-        def_node_matcher :integer_op_rand?, <<-PATTERN
+        def_node_matcher :integer_op_rand?, <<~PATTERN
           (send
             int {:+ :-}
             (send
@@ -36,7 +36,7 @@ module RuboCop
               {int irange erange}))
         PATTERN
 
-        def_node_matcher :rand_op_integer?, <<-PATTERN
+        def_node_matcher :rand_op_integer?, <<~PATTERN
           (send
             (send
               {nil? (const nil? :Random) (const nil? :Kernel)}
@@ -46,7 +46,7 @@ module RuboCop
             int)
         PATTERN
 
-        def_node_matcher :rand_modified?, <<-PATTERN
+        def_node_matcher :rand_modified?, <<~PATTERN
           (send
             (send
               {nil? (const nil? :Random) (const nil? :Kernel)}
@@ -80,7 +80,7 @@ module RuboCop
 
         private
 
-        def_node_matcher :random_call, <<-PATTERN
+        def_node_matcher :random_call, <<~PATTERN
           {(send (send $_ _ $_) ...)
            (send _ _ (send $_ _ $_))}
         PATTERN
@@ -128,7 +128,7 @@ module RuboCop
           end
         end
 
-        def_node_matcher :namespace, <<-PATTERN
+        def_node_matcher :namespace, <<~PATTERN
           {$nil? (const nil? $_)}
         PATTERN
 
@@ -149,7 +149,7 @@ module RuboCop
           end
         end
 
-        def_node_matcher :to_int, <<-PATTERN
+        def_node_matcher :to_int, <<~PATTERN
           (int $_)
         PATTERN
       end

--- a/lib/rubocop/cop/style/redundant_conditional.rb
+++ b/lib/rubocop/cop/style/redundant_conditional.rb
@@ -53,11 +53,11 @@ module RuboCop
           format(MSG, msg: msg)
         end
 
-        def_node_matcher :redundant_condition?, <<-RUBY
+        def_node_matcher :redundant_condition?, <<~RUBY
           (if (send _ {:#{COMPARISON_OPERATORS.join(' :')}} _) true false)
         RUBY
 
-        def_node_matcher :redundant_condition_inverted?, <<-RUBY
+        def_node_matcher :redundant_condition_inverted?, <<~RUBY
           (if (send _ {:#{COMPARISON_OPERATORS.join(' :')}} _) false true)
         RUBY
 

--- a/lib/rubocop/cop/style/redundant_exception.rb
+++ b/lib/rubocop/cop/style/redundant_exception.rb
@@ -47,11 +47,11 @@ module RuboCop
           end
         end
 
-        def_node_matcher :exploded?, <<-PATTERN
+        def_node_matcher :exploded?, <<~PATTERN
           (send nil? ${:raise :fail} (const nil? :RuntimeError) $_)
         PATTERN
 
-        def_node_matcher :compact?, <<-PATTERN
+        def_node_matcher :compact?, <<~PATTERN
           (send nil? {:raise :fail} $(send (const nil? :RuntimeError) :new $_))
         PATTERN
       end

--- a/lib/rubocop/cop/style/redundant_freeze.rb
+++ b/lib/rubocop/cop/style/redundant_freeze.rb
@@ -51,7 +51,7 @@ module RuboCop
           end
         end
 
-        def_node_matcher :operation_produces_immutable_object?, <<-PATTERN
+        def_node_matcher :operation_produces_immutable_object?, <<~PATTERN
           {
             (begin (send {float int} {:+ :- :* :** :/ :% :<<} _))
             (begin (send !(str _) {:+ :- :* :** :/ :%} {float int}))

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -203,11 +203,11 @@ module RuboCop
           first_send_argument?(node) || first_super_argument?(node)
         end
 
-        def_node_matcher :first_send_argument?, <<-PATTERN
+        def_node_matcher :first_send_argument?, <<~PATTERN
           ^(send _ _ equal?(%0) ...)
         PATTERN
 
-        def_node_matcher :first_super_argument?, <<-PATTERN
+        def_node_matcher :first_super_argument?, <<~PATTERN
           ^(super equal?(%0) ...)
         PATTERN
 

--- a/lib/rubocop/cop/style/redundant_sort_by.rb
+++ b/lib/rubocop/cop/style/redundant_sort_by.rb
@@ -20,7 +20,7 @@ module RuboCop
 
         MSG = 'Use `sort` instead of `sort_by { |%<var>s| %<var>s }`.'
 
-        def_node_matcher :redundant_sort_by, <<-PATTERN
+        def_node_matcher :redundant_sort_by, <<~PATTERN
           (block $(send _ :sort_by) (args (arg $_x)) (lvar _x))
         PATTERN
 

--- a/lib/rubocop/cop/style/rescue_standard_error.rb
+++ b/lib/rubocop/cop/style/rescue_standard_error.rb
@@ -80,11 +80,11 @@ module RuboCop
         MSG_EXPLICIT = 'Avoid rescuing without specifying ' \
           'an error class.'
 
-        def_node_matcher :rescue_without_error_class?, <<-PATTERN
+        def_node_matcher :rescue_without_error_class?, <<~PATTERN
           (resbody nil? _ _)
         PATTERN
 
-        def_node_matcher :rescue_standard_error?, <<-PATTERN
+        def_node_matcher :rescue_standard_error?, <<~PATTERN
           (resbody $(array (const nil? :StandardError)) _ _)
         PATTERN
 

--- a/lib/rubocop/cop/style/return_nil.rb
+++ b/lib/rubocop/cop/style/return_nil.rb
@@ -80,7 +80,7 @@ module RuboCop
         end
 
         def_node_matcher :chained_send?, '(send !nil? ...)'
-        def_node_matcher :define_method?, <<-PATTERN
+        def_node_matcher :define_method?, <<~PATTERN
           (send _ {:define_method :define_singleton_method} _)
         PATTERN
       end

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -69,7 +69,7 @@ module RuboCop
 
         # if format: (if checked_variable body nil)
         # unless format: (if checked_variable nil body)
-        def_node_matcher :modifier_if_safe_navigation_candidate, <<-PATTERN
+        def_node_matcher :modifier_if_safe_navigation_candidate, <<~PATTERN
           {
             (if {
                   (send $_ {:nil? :!})

--- a/lib/rubocop/cop/style/sample.rb
+++ b/lib/rubocop/cop/style/sample.rb
@@ -30,7 +30,7 @@ module RuboCop
       class Sample < Cop
         MSG = 'Use `%<correct>s` instead of `%<incorrect>s`.'
 
-        def_node_matcher :sample_candidate?, <<-PATTERN
+        def_node_matcher :sample_candidate?, <<~PATTERN
           (send $(send _ :shuffle $...) ${:first :last :[] :at :slice} $...)
         PATTERN
 

--- a/lib/rubocop/cop/style/stderr_puts.rb
+++ b/lib/rubocop/cop/style/stderr_puts.rb
@@ -20,7 +20,7 @@ module RuboCop
         MSG =
           'Use `warn` instead of `%<bad>s` to allow such output to be disabled.'
 
-        def_node_matcher :stderr_puts?, <<-PATTERN
+        def_node_matcher :stderr_puts?, <<~PATTERN
           (send
             {(gvar #stderr_gvar?) (const nil? :STDERR)}
             :puts $_

--- a/lib/rubocop/cop/style/string_hash_keys.rb
+++ b/lib/rubocop/cop/style/string_hash_keys.rb
@@ -15,11 +15,11 @@ module RuboCop
       class StringHashKeys < Cop
         MSG = 'Prefer symbols instead of strings as hash keys.'
 
-        def_node_matcher :string_hash_key?, <<-PATTERN
+        def_node_matcher :string_hash_key?, <<~PATTERN
           (pair (str _) _)
         PATTERN
 
-        def_node_matcher :receive_environments_method?, <<-PATTERN
+        def_node_matcher :receive_environments_method?, <<~PATTERN
           {
             ^^(send (const {nil? cbase} :IO) :popen ...)
             ^^(send (const {nil? cbase} :Open3)

--- a/lib/rubocop/cop/style/strip.rb
+++ b/lib/rubocop/cop/style/strip.rb
@@ -18,7 +18,7 @@ module RuboCop
 
         MSG = 'Use `strip` instead of `%<methods>s`.'
 
-        def_node_matcher :lstrip_rstrip, <<-PATTERN
+        def_node_matcher :lstrip_rstrip, <<~PATTERN
           {(send $(send _ $:rstrip) $:lstrip)
            (send $(send _ $:lstrip) $:rstrip)}
         PATTERN

--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -29,9 +29,9 @@ module RuboCop
           add_offense(node, location: node.parent_class.source_range)
         end
 
-        def_node_matcher :struct_constructor?, <<-PATTERN
-           {(send (const nil? :Struct) :new ...)
-            (block (send (const nil? :Struct) :new ...) ...)}
+        def_node_matcher :struct_constructor?, <<~PATTERN
+          {(send (const nil? :Struct) :new ...)
+           (block (send (const nil? :Struct) :new ...) ...)}
         PATTERN
       end
     end

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -20,7 +20,7 @@ module RuboCop
         SUPER_TYPES = %i[super zsuper].freeze
 
         def_node_matcher :proc_node?, '(send (const nil? :Proc) :new)'
-        def_node_matcher :symbol_proc?, <<-PATTERN
+        def_node_matcher :symbol_proc?, <<~PATTERN
           (block
             ${(send ...) (super ...) zsuper}
             $(args (arg _var))

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -167,7 +167,7 @@ module RuboCop
             (child.send_type? && child.prefix_not?)
         end
 
-        def_node_matcher :method_name, <<-PATTERN
+        def_node_matcher :method_name, <<~PATTERN
           {($:defined? (send nil? _) ...)
            (send {_ nil?} $_ _ ...)}
         PATTERN

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -118,7 +118,7 @@ module RuboCop
             !allowed_method?(node) && !allowed_writer?(node.method_name)
         end
 
-        def_node_matcher :looks_like_trivial_writer?, <<-PATTERN
+        def_node_matcher :looks_like_trivial_writer?, <<~PATTERN
           {(def    _ (args (arg ...)) (ivasgn _ (lvar _)))
            (defs _ _ (args (arg ...)) (ivasgn _ (lvar _)))}
         PATTERN

--- a/lib/rubocop/cop/style/unneeded_sort.rb
+++ b/lib/rubocop/cop/style/unneeded_sort.rb
@@ -55,7 +55,7 @@ module RuboCop
         MSG = 'Use `%<suggestion>s` instead of '\
               '`%<sorter>s...%<accessor_source>s`.'
 
-        def_node_matcher :unneeded_sort?, <<-MATCHER
+        def_node_matcher :unneeded_sort?, <<~MATCHER
           {
             (send $(send _ $:sort ...) ${:last :first})
             (send $(send _ $:sort ...) ${:[] :at :slice} {(int 0) (int -1)})

--- a/lib/rubocop/cop/style/unpack_first.rb
+++ b/lib/rubocop/cop/style/unpack_first.rb
@@ -25,7 +25,7 @@ module RuboCop
         MSG = 'Use `%<receiver>s.unpack1(%<format>s)` instead of '\
           '`%<receiver>s.unpack(%<format>s)%<method>s`.'
 
-        def_node_matcher :unpack_and_first_element?, <<-PATTERN
+        def_node_matcher :unpack_and_first_element?, <<~PATTERN
           {
             (send $(send (...) :unpack $(...)) :first)
             (send $(send (...) :unpack $(...)) {:[] :slice :at} (int 0))

--- a/lib/rubocop/cop/style/zero_length_predicate.rb
+++ b/lib/rubocop/cop/style/zero_length_predicate.rb
@@ -73,14 +73,14 @@ module RuboCop
           )
         end
 
-        def_node_matcher :zero_length_predicate, <<-PATTERN
+        def_node_matcher :zero_length_predicate, <<~PATTERN
           {(send (send (...) ${:length :size}) $:== (int $0))
            (send (int $0) $:== (send (...) ${:length :size}))
            (send (send (...) ${:length :size}) $:<  (int $1))
            (send (int $1) $:> (send (...) ${:length :size}))}
         PATTERN
 
-        def_node_matcher :nonzero_length_predicate, <<-PATTERN
+        def_node_matcher :nonzero_length_predicate, <<~PATTERN
           {(send (send (...) ${:length :size}) ${:> :!=} (int $0))
            (send (int $0) ${:< :!=} (send (...) ${:length :size}))}
         PATTERN
@@ -92,14 +92,14 @@ module RuboCop
           "!#{other_receiver(node).source}.empty?"
         end
 
-        def_node_matcher :zero_length_receiver, <<-PATTERN
+        def_node_matcher :zero_length_receiver, <<~PATTERN
           {(send (send $_ _) :== (int 0))
            (send (int 0) :== (send $_ _))
            (send (send $_ _) :<  (int 1))
            (send (int 1) :> (send $_ _))}
         PATTERN
 
-        def_node_matcher :other_receiver, <<-PATTERN
+        def_node_matcher :other_receiver, <<~PATTERN
           {(send (send $_ _) _ _)
            (send _ _ (send $_ _))}
         PATTERN
@@ -107,7 +107,7 @@ module RuboCop
         # Some collection like objects in the Ruby standard library
         # implement `#size`, but not `#empty`. We ignore those to
         # reduce false positives.
-        def_node_matcher :non_polymorphic_collection?, <<-PATTERN
+        def_node_matcher :non_polymorphic_collection?, <<~PATTERN
           {(send (send (send (const nil? :File) :stat _) ...) ...)
            (send (send (send (const nil? {:Tempfile :StringIO}) {:new :open} ...) ...) ...)}
         PATTERN

--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -612,7 +612,7 @@ module RuboCop
       end
 
       def emit_method_code
-        <<-RUBY
+        <<~RUBY
           return unless #{@match_code}
           block_given? ? #{emit_yield_capture} : (return #{emit_retval})
         RUBY
@@ -746,7 +746,7 @@ module RuboCop
 
       def node_search_body(method_name, trailing_params, prelude, match_code,
                            on_match)
-        <<-RUBY
+        <<~RUBY
           def #{method_name}(node0#{trailing_params})
             #{prelude}
             node0.each_node do |node|

--- a/manual/development.md
+++ b/manual/development.md
@@ -157,7 +157,7 @@ After the cop scaffold is generated, change the node matcher to match with
 the expression achieved previously:
 
 ```ruby
-def_node_matcher :not_empty_call?, <<-PATTERN
+def_node_matcher :not_empty_call?, <<~PATTERN
   (send (send (...) :empty?) :!)
 PATTERN
 ```
@@ -195,7 +195,7 @@ module RuboCop
       class SimplifyNotEmptyWithAny < Cop
         MSG = 'Use `.any?` and remove the negation part.'.freeze
 
-        def_node_matcher :not_empty_call?, <<-PATTERN
+        def_node_matcher :not_empty_call?, <<~PATTERN
           (send (send (...) :empty?) :!)
         PATTERN
 

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe RuboCop::Cop::Generator do
                 # For example
                 MSG = 'Use `#good_method` instead of `#bad_method`.'.freeze
 
-                def_node_matcher :bad_method?, <<-PATTERN
+                def_node_matcher :bad_method?, <<~PATTERN
                   (send nil? :bad_method ...)
                 PATTERN
 

--- a/spec/rubocop/cop/layout/closing_heredoc_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/closing_heredoc_indentation_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::Layout::ClosingHeredocIndentation do
   it 'accepts correctly indented closing heredoc when ' \
      'heredoc contents with blank line' do
     expect_no_offenses(<<~RUBY)
-      def_node_matcher :eval_without_location?, <<-PATTERN
+      def_node_matcher :eval_without_location?, <<~PATTERN
         {
           (send $(send _ $:sort ...) ${:[] :at :slice} {(int 0) (int -1)})
 

--- a/spec/rubocop/cop/naming/predicate_name_spec.rb
+++ b/spec/rubocop/cop/naming/predicate_name_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe RuboCop::Cop::Naming::PredicateName, :config do
 
     it 'registers an offense when using an internal affair macro' do
       expect_offense(<<~RUBY)
-        def_node_matcher :is_hello, <<-PATTERN
+        def_node_matcher :is_hello, <<~PATTERN
                          ^^^^^^^^^ Rename `is_hello` to `hello?`.
           (send
             (send nil? :method_name) :==
@@ -138,7 +138,7 @@ RSpec.describe RuboCop::Cop::Naming::PredicateName, :config do
 
     it 'does not register any offenses when using an internal affair macro' do
       expect_no_offenses(<<~RUBY)
-        def_node_matcher :is_hello, <<-PATTERN
+        def_node_matcher :is_hello, <<~PATTERN
                          ^^^^^^^^^ Rename `is_hello` to `hello?`.
           (send
             (send nil? :method_name) :==


### PR DESCRIPTION
Follow up https://github.com/rubocop-hq/rubocop/pull/7026.

This PR uses squiggly heredoc for node patterns and eval.

The following offenses were found as a result of this change.

```console
% bundle exec rake

(snip)

Offenses:

lib/rubocop/cop/lint/safe_navigation_chain.rb:33:1: C:
Layout/IndentHeredoc: Use 2 spaces for indentation in a heredoc.
        { ...
^^^^^^^^^
lib/rubocop/cop/mixin/enforce_superclass.rb:9:1: C:
Layout/IndentHeredoc: Use 2 spaces for indentation in a heredoc.
        (class (const _ !:#{base::SUPERCLASS}) #{base::BASE_PATTERN}...) ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/mixin/enforce_superclass.rb:13:1: C:
Layout/IndentHeredoc: Use 2 spaces for indentation in a heredoc.
        [!^(casgn nil? :#{base::SUPERCLASS} ...) (send (const nil?:Class)
:new #{base::BASE_PATTERN})] ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/style/struct_inheritance.rb:33:1: C:
Layout/IndentHeredoc: Use 2 spaces for indentation in a heredoc.
           {(send (const nil? :Struct) :new ...) ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/style/format_string.rb:44:1: C: Layout/IndentHeredoc:
Use 2 spaces for indentation in a heredoc.
        { ...
^^^^^^^^^

1083 files inspected, 5 offenses detected
RuboCop failed!
```

And the following is the difference of the cop code generated by `bundle exec rake new_cop[Department/CopName]`.

```diff
  class Foo < Cop
    # TODO: Implement the cop in here.
    #
    # In many cases, you can use a node matcher for matching node pattern.
    # See https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/node_pattern.rb
    #
    # For example
    MSG = 'Use `#good_method` instead of `#bad_method`.'.freeze

-   def_node_matcher :bad_method?, <<-PATTERN
+   def_node_matcher :bad_method?, <<~PATTERN

      (send nil? :bad_method ...)
    PATTERN

    def on_send(node)
      return unless bad_method?(node)

      add_offense(node)
    end
  end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
