### PR TITLE
[Fix #7161] Fix `Style/SafeNavigation` cop to preserve comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#7305](https://github.com/rubocop-hq/rubocop/issues/7305): Register `Style/BlockDelimiters` offense when block result is assigned to an attribute. ([@mvz][])
 * [#4802](https://github.com/rubocop-hq/rubocop/issues/4802): Don't leave any `Lint/UnneededCopEnableDirective` offenses undetected/uncorrected. ([@jonas054][])
 * [#7326](https://github.com/rubocop-hq/rubocop/issues/7326): Fix a false positive for `Style/AccessModifierDeclarations` when access modifier name is used for hash literal value. ([@koic][])
+* [#7161](https://github.com/rubocop-hq/rubocop/issues/7161): Fix `Style/SafeNavigation` cop for preserve comments inside if expression. ([@tejasbubane][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -120,12 +120,21 @@ module RuboCop
             corrector.remove(begin_range(node, body))
             corrector.remove(end_range(node, body))
             corrector.insert_before(method_call.loc.dot, '&')
+            handle_comments(corrector, method_call)
 
             add_safe_nav_to_all_methods_in_chain(corrector, method_call, body)
           end
         end
 
         private
+
+        def handle_comments(corrector, method_call)
+          return if processed_source.comments.empty?
+
+          comments = processed_source.comments.map(&:text).join("\n")
+          corrector.insert_before(method_call.loc.expression,
+                                  comments + "\n")
+        end
 
         def allowed_if_condition?(node)
           node.else? || node.elsif? || node.ternary?

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -933,6 +933,23 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
           expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }\n")
         end
 
+        it 'does not lose comments within if expression' do
+          new_source = autocorrect_source(<<~RUBY)
+            if #{variable}
+              # this is a comment
+              # another comment
+              #{variable}.bar
+            end
+          RUBY
+
+          expected_source = <<~RUBY
+            # this is a comment
+            # another comment
+            #{variable}&.bar
+          RUBY
+          expect(new_source).to eq(expected_source)
+        end
+
         it 'corrects a single method call inside of an unless nil check ' \
            'for the object' do
           new_source = autocorrect_source(<<~RUBY)


### PR DESCRIPTION
Closes #7161.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/