### PR TITLE
Sort analyzed file alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * Allow `#**` Doxygen comment style on `Layout/LeadingCommentSpace`. ([@anthony-robin][])
+* [#7181](https://github.com/rubocop-hq/rubocop/pull/7181): Sort analyzed file alphabetically. ([@pocke][])
 
 ## 0.72.0 (2019-06-25)
 

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -65,10 +65,12 @@ module RuboCop
         to_inspect?(file, hidden_files, base_dir_config)
       end
 
-      # Most recently modified file first.
-      target_files.sort_by! { |path| -Integer(File.mtime(path)) } if fail_fast?
-
-      target_files
+      if fail_fast?
+        # Most recently modified file first.
+        target_files.sort_by! { |path| -Integer(File.mtime(path)) }
+      else
+        target_files.sort!
+      end
     end
 
     def to_inspect?(file, hidden_files, base_dir_config)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -833,10 +833,10 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
       expect(cli.run(%w[--format simple])).to eq(1)
       expect($stdout.string).to eq(<<~RESULT)
-        == example1.rb ==
-        C:  3:  6: Layout/TrailingWhitespace: Trailing whitespace detected.
         == dir/example2.rb ==
         C:  3:  6: Trailing whitespace detected.
+        == example1.rb ==
+        C:  3:  6: Layout/TrailingWhitespace: Trailing whitespace detected.
 
         2 files inspected, 2 offenses detected
       RESULT
@@ -859,10 +859,10 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
       expect(cli.run(%w[--format simple])).to eq(1)
       expect($stdout.string).to eq(<<~RESULT)
-        == example1.rb ==
-        C:  3:  6: Layout/TrailingWhitespace: Trailing whitespace detected.
         == dir/example2.rb ==
         C:  3:  6: Layout/TrailingWhitespace: Trailing whitespace detected. (#{url})
+        == example1.rb ==
+        C:  3:  6: Layout/TrailingWhitespace: Trailing whitespace detected.
 
         2 files inspected, 2 offenses detected
       RESULT


### PR DESCRIPTION


The order of files that RuboCop analyzes is not fixed. Because RuboCop uses `Dir.glob` and the order of the `Dir.glob` is not fixed.

> Note that the pattern is not a regexp, it’s closer to a shell glob. See File.fnmatch for the meaning of the flags parameter. Case sensitivity depends on your system (File::FNM_CASEFOLD is ignored), as does the order in which the results are returned.
> http://ruby-doc.org/core-2.6.3/Dir.html#method-c-glob


It is not a bug, but it confused me while debugging the regression test. https://github.com/pocke/rubocop-regression-test/issues/12


I think sorted files is better than randomized. It will be easier to debug because everyone gets the same output by RuboCop.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
