### PR TITLE
[Fix #7170] Fix a false positive in `Layout/RescueEnsureAlignment` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Add `AllowDoxygenCommentStyle` configuration on `Layout/LeadingCommentSpace`. ([@anthony-robin][])
 
+### Bug fixes
+
+* [#7170](https://github.com/rubocop-hq/rubocop/issues/7170): Fix a false positive for `Layout/RescueEnsureAlignment` when def line is preceded with `private_class_method`. ([@tatsuyafw][])
+
 ### Changes
 
 * [#7181](https://github.com/rubocop-hq/rubocop/pull/7181): Sort analyzed file alphabetically. ([@pocke][])

--- a/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
@@ -30,6 +30,8 @@ module RuboCop
         ANCESTOR_TYPES = %i[kwbegin def defs class module].freeze
         RUBY_2_5_ANCESTOR_TYPES = (ANCESTOR_TYPES + %i[block]).freeze
         ANCESTOR_TYPES_WITH_ACCESS_MODIFIERS = %i[def defs].freeze
+        ALTERNATIVE_ACCESS_MODIFIERS = %i[public_class_method
+                                          private_class_method].freeze
 
         def on_resbody(node)
           check(node) unless modifier?(node)
@@ -150,9 +152,7 @@ module RuboCop
             ANCESTOR_TYPES_WITH_ACCESS_MODIFIERS.include?(node.type)
 
           access_modifier_node = node.ancestors.first
-          return nil unless
-            access_modifier_node.respond_to?(:access_modifier?) &&
-            access_modifier_node.access_modifier?
+          return nil unless access_modifier?(access_modifier_node)
 
           access_modifier_node
         end
@@ -168,6 +168,16 @@ module RuboCop
           current_column = node.loc.keyword.column
 
           range_between(begin_pos - current_column, begin_pos)
+        end
+
+        def access_modifier?(node)
+          return true if node.respond_to?(:access_modifier?) &&
+                         node.access_modifier?
+
+          return true if node.respond_to?(:method_name) &&
+                         ALTERNATIVE_ACCESS_MODIFIERS.include?(node.method_name)
+
+          false
         end
       end
     end

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -460,128 +460,142 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
       }
     end
 
-    context 'rescue with def' do
-      it 'registers an offense' do
-        expect_offense(<<~RUBY)
-          private def test
-            'foo'
+    shared_examples 'access modifier' do |modifier|
+      context 'rescue with def' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            #{modifier} def test
+              'foo'
+              rescue
+              ^^^^^^ `rescue` at 3, 2 is not aligned with `#{modifier} def test` at 1, 0.
+              'baz'
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            #{modifier} def test
+              'foo'
             rescue
-            ^^^^^^ `rescue` at 3, 2 is not aligned with `private def test` at 1, 0.
-            'baz'
-          end
-        RUBY
+              'baz'
+            end
+          RUBY
+        end
 
-        expect_correction(<<~RUBY)
-          private def test
-            'foo'
-          rescue
-            'baz'
-          end
-        RUBY
-      end
-
-      it 'correct alignment' do
-        expect_no_offenses(<<~RUBY)
-          private def test
-            'foo'
-          rescue
-            'baz'
-          end
-        RUBY
-      end
-    end
-
-    context 'rescue with defs' do
-      it 'registers an offense' do
-        expect_offense(<<~RUBY)
-          private def Test.test
-            'foo'
+        it 'correct alignment' do
+          expect_no_offenses(<<~RUBY)
+            #{modifier} def test
+              'foo'
             rescue
-            ^^^^^^ `rescue` at 3, 2 is not aligned with `private def Test.test` at 1, 0.
-            'baz'
-          end
-        RUBY
-
-        expect_correction(<<~RUBY)
-          private def Test.test
-            'foo'
-          rescue
-            'baz'
-          end
-        RUBY
+              'baz'
+            end
+          RUBY
+        end
       end
 
-      it 'correct alignment' do
-        expect_no_offenses(<<~RUBY)
-          private def Test.test
-            'foo'
-          rescue
-            'baz'
-          end
-        RUBY
+      context 'rescue with defs' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            #{modifier} def Test.test
+              'foo'
+              rescue
+              ^^^^^^ `rescue` at 3, 2 is not aligned with `#{modifier} def Test.test` at 1, 0.
+              'baz'
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            #{modifier} def Test.test
+              'foo'
+            rescue
+              'baz'
+            end
+          RUBY
+        end
+
+        it 'correct alignment' do
+          expect_no_offenses(<<~RUBY)
+            #{modifier} def Test.test
+              'foo'
+            rescue
+              'baz'
+            end
+          RUBY
+        end
+      end
+
+      context 'ensure with def' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            #{modifier} def test
+              'foo'
+              ensure
+              ^^^^^^ `ensure` at 3, 2 is not aligned with `#{modifier} def test` at 1, 0.
+              'baz'
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            #{modifier} def test
+              'foo'
+            ensure
+              'baz'
+            end
+          RUBY
+        end
+
+        it 'correct alignment' do
+          expect_no_offenses(<<~RUBY)
+            #{modifier} def test
+              'foo'
+            ensure
+              'baz'
+            end
+          RUBY
+        end
+      end
+
+      context 'ensure with defs' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            #{modifier} def Test.test
+              'foo'
+              ensure
+              ^^^^^^ `ensure` at 3, 2 is not aligned with `#{modifier} def Test.test` at 1, 0.
+              'baz'
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            #{modifier} def Test.test
+              'foo'
+            ensure
+              'baz'
+            end
+          RUBY
+        end
+
+        it 'correct alignment' do
+          expect_no_offenses(<<~RUBY)
+            #{modifier} def Test.test
+              'foo'
+            ensure
+              'baz'
+            end
+          RUBY
+        end
       end
     end
 
-    context 'ensure with def' do
-      it 'registers an offense' do
-        expect_offense(<<~RUBY)
-          private def test
-            'foo'
-            ensure
-            ^^^^^^ `ensure` at 3, 2 is not aligned with `private def test` at 1, 0.
-            'baz'
-          end
-        RUBY
-
-        expect_correction(<<~RUBY)
-          private def test
-            'foo'
-          ensure
-            'baz'
-          end
-        RUBY
-      end
-
-      it 'correct alignment' do
-        expect_no_offenses(<<~RUBY)
-          private def test
-            'foo'
-          ensure
-            'baz'
-          end
-        RUBY
-      end
+    context 'with private modifier' do
+      include_examples 'access modifier', 'private'
     end
 
-    context 'ensure with defs' do
-      it 'registers an offense' do
-        expect_offense(<<~RUBY)
-          private def Test.test
-            'foo'
-            ensure
-            ^^^^^^ `ensure` at 3, 2 is not aligned with `private def Test.test` at 1, 0.
-            'baz'
-          end
-        RUBY
+    context 'with private_class_method modifier' do
+      include_examples 'access modifier', 'private_class_method'
+    end
 
-        expect_correction(<<~RUBY)
-          private def Test.test
-            'foo'
-          ensure
-            'baz'
-          end
-        RUBY
-      end
-
-      it 'correct alignment' do
-        expect_no_offenses(<<~RUBY)
-          private def Test.test
-            'foo'
-          ensure
-            'baz'
-          end
-        RUBY
-      end
+    context 'with public_class_method modifier' do
+      include_examples 'access modifier', 'public_class_method'
     end
   end
 


### PR DESCRIPTION
Fixes #7170.

The `Layout/RescueEnsureAlignment` would register an offense when `private_class_method` and def are on the same line as below:

```console
$ cat foo.rb
private_class_method def self.foo
  puts 'foo'
rescue StandardError
  puts 'bar'
end
$
```

```console
$ rubocop --only 'Layout/RescueEnsureAlignment' foo.rb
Inspecting 1 file
C

Offenses:

foo.rb:3:1: C: Layout/RescueEnsureAlignment: rescue at 3, 0 is not aligned with def self.foo at 1, 21.
rescue StandardError
^^^^^^

1 file inspected, 1 offense detected
$
```

This change makes sure the cop recognizes def lines preceded with private_class_method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/