### PR TITLE
Allow `#**` Doxygen comment style on `Layout/LeadingCommentSpace`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* Allow `#**` Doxygen comment style on `Layout/LeadingCommentSpace`. ([@anthony-robin][])
+
 ## 0.72.0 (2019-06-25)
 
 ### New features

--- a/config/default.yml
+++ b/config/default.yml
@@ -816,6 +816,7 @@ Layout/LeadingCommentSpace:
   StyleGuide: '#hash-space'
   Enabled: true
   VersionAdded: '0.49'
+  VersionChanged: '0.73'
 
 Layout/MultilineArrayBraceLayout:
   Description: >-

--- a/lib/rubocop/cop/layout/leading_comment_space.rb
+++ b/lib/rubocop/cop/layout/leading_comment_space.rb
@@ -23,7 +23,7 @@ module RuboCop
 
         def investigate(processed_source)
           processed_source.each_comment do |comment|
-            next unless comment.text =~ /\A#+[^#\s=:+-]/
+            next unless comment.text =~ /\A#+[^#*\s=:+-]/
             next if comment.loc.line == 1 && allowed_on_first_line?(comment)
 
             add_offense(comment)

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2908,7 +2908,7 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.49 | -
+Enabled | Yes | Yes  | 0.49 | 0.73
 
 This cop checks whether comments have a leading space after the
 `#` denoting the start of the comment. The leading space is not

--- a/spec/rubocop/cop/layout/leading_comment_space_spec.rb
+++ b/spec/rubocop/cop/layout/leading_comment_space_spec.rb
@@ -84,6 +84,12 @@ RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace do
     RUBY
   end
 
+  it 'accepts Doxygen syntax' do
+    expect_no_offenses(<<~RUBY)
+      #**
+    RUBY
+  end
+
   it 'accepts sprockets directives' do
     expect_no_offenses('#= require_tree .')
   end


### PR DESCRIPTION
This PR remove the offense for comments that starts with `**` as this style is
a valid syntax to write block comments in Ruby.

### Motivation
The `apidocjs` package only specify `=begin/=end` block to define
the documentation in ruby. However, [this comment][1] explain that the `Doxygen`
style `#**` is also compatible to write the documentation so the `Layout/LeadingCommentSpace`
should not flag any offense for it.

My [first attempt][2] was to not flag `Style/BlockComments` if the `@api` annotation
was found inside the `=begin/=end` block but this solution is more elegant.

### Example:

#### Before (not clean solution)
```ruby
=begin
@api {get} /endpoint description of my endpoint
...
=end
```

#### After (elegant solution)
```ruby
#**
# @api {get} /endpoint description of my endpoint
# ...
#*
```

[1]: https://github.com/apidoc/apidoc/issues/620#issuecomment-494206190
[2]: https://github.com/rubocop-hq/rubocop/pull/6522

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
