### PR TITLE
[WIP] [Fix #5979] Introduce cops with special status

### DIFF
--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -125,10 +125,14 @@ module RuboCop
 
       def enabled?(cop, config, only_safe)
         cfg = config.for_cop(cop)
+
+        # cfg['Enabled'] might be a string `none`, which is considered disabled
+        cop_enabled = cfg.fetch('Enabled') == true
+
         if only_safe
-          cfg.fetch('Enabled') && cfg.fetch('Safe', true)
+          cop_enabled && cfg.fetch('Safe', true)
         else
-          cfg.fetch('Enabled')
+          cop_enabled
         end
       end
 

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -52,6 +52,7 @@ RSpec.shared_context 'config', :config do
       cop_name = described_class.cop_name
       hash[cop_name] = RuboCop::ConfigLoader
                        .default_configuration[cop_name]
+                       .merge('Enabled' => true) # in case it is set to 'none'
                        .merge(cop_config)
     end
 

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -208,13 +208,12 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         output =
           `ruby -I . "#{rubocop}" --require redirect.rb --only Style/SomeCop`
         expect($CHILD_STATUS.success?).to be_truthy
-        expect(output)
-          .to eq(<<~RESULT)
-            Inspecting 2 files
-            ..
+        expect(output).to include(<<~RESULT)
+          Inspecting 2 files
+          ..
 
-            2 files inspected, no offenses detected
-          RESULT
+          2 files inspected, no offenses detected
+        RESULT
       end
 
       context 'without using namespace' do

--- a/spec/rubocop/cop/registry_spec.rb
+++ b/spec/rubocop/cop/registry_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe RuboCop::Cop::Registry do
       .to eq(described_class.new(cops.drop(2)))
   end
 
-  context '#contains_cop_matching?' do
+  describe '#contains_cop_matching?' do
     it 'can find cops matching a given name' do
       result = registry.contains_cop_matching?(['Test/IndentFirstArrayElement'])
       expect(result).to be(true)
@@ -73,7 +73,7 @@ RSpec.describe RuboCop::Cop::Registry do
     end
   end
 
-  context '#qualified_cop_name' do
+  describe '#qualified_cop_name' do
     let(:origin) { '/app/.rubocop.yml' }
 
     it 'gives back already properly qualified names' do
@@ -135,7 +135,7 @@ RSpec.describe RuboCop::Cop::Registry do
     )
   end
 
-  context '#cops' do
+  describe '#cops' do
     it 'exposes a list of cops' do
       expect(registry.cops).to eql(cops)
     end
@@ -145,7 +145,7 @@ RSpec.describe RuboCop::Cop::Registry do
     expect(registry.length).to be(6)
   end
 
-  context '#enabled' do
+  describe '#enabled' do
     let(:config) do
       RuboCop::Config.new(
         'Test/IndentFirstArrayElement' => { 'Enabled' => false },
@@ -165,6 +165,24 @@ RSpec.describe RuboCop::Cop::Registry do
     it 'selects only safe cops if :safe passed' do
       enabled_cops = registry.enabled(config, [], true)
       expect(enabled_cops).not_to include(RuboCop::Cop::RSpec::Foo)
+    end
+
+    context 'when new cops are introduced' do
+      let(:config) do
+        RuboCop::Config.new(
+          'Test/IndentFirstArrayElement' => { 'Enabled' => 'none' }
+        )
+      end
+
+      it 'does not include them' do
+        expect(registry.enabled(config, []))
+          .not_to include(RuboCop::Cop::Test::IndentFirstArrayElement)
+      end
+
+      it 'overrides config if :only includes the cop' do
+        result = registry.enabled(config, ['Test/IndentFirstArrayElement'])
+        expect(result).to eql(cops)
+      end
     end
   end
 

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe RuboCop::TargetFinder, :isolated_environment do
   include FileHelper
+  include_context 'cli spec behavior'
 
   RUBY_EXTENSIONS = %w[.rb
                        .arb

--- a/spec/support/cli_spec_behavior.rb
+++ b/spec/support/cli_spec_behavior.rb
@@ -16,6 +16,8 @@ RSpec.shared_context 'cli spec behavior' do
     # OPTIMIZE: Makes these specs faster. Work directory (the parent of
     # .rubocop_cache) is removed afterwards anyway.
     RuboCop::ResultCache.inhibit_cleanup = true
+
+    RuboCop::Config.test = true
   end
 
   # Wrap all cli specs in `aggregate_failures` so that the expected and


### PR DESCRIPTION
Consider this a proof of concept. 

The approach I took creates a couple of problems I did not foresee.

First, the need to disable the warning in 'cli spec behavior' context, as otherwise, we are polluting the output with each new cop added.

The other issue is that the newly introduced cops would not be applied to the rubocop codebase as well unless we introduce an option to override the new status (e.g. enable all non-configured cops)

Let me know what you think and I can proceed with adding rake tasks for enabling new cops and any other supporting options.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
