### PR TITLE
Add configurable option for Doxygen style to `Layout/LeadingCommentSpace`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## master (unreleased)
 
+### New features
+
+* Add `AllowDoxygenCommentStyle` configuration on `Layout/LeadingCommentSpace`. ([@anthony-robin][])
+
 ### Changes
 
-* Allow `#**` Doxygen comment style on `Layout/LeadingCommentSpace`. ([@anthony-robin][])
 * [#7181](https://github.com/rubocop-hq/rubocop/pull/7181): Sort analyzed file alphabetically. ([@pocke][])
 
 ## 0.72.0 (2019-06-25)

--- a/config/default.yml
+++ b/config/default.yml
@@ -817,6 +817,7 @@ Layout/LeadingCommentSpace:
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.73'
+  AllowDoxygenCommentStyle: false
 
 Layout/MultilineArrayBraceLayout:
   Description: >-

--- a/lib/rubocop/cop/layout/leading_comment_space.rb
+++ b/lib/rubocop/cop/layout/leading_comment_space.rb
@@ -16,6 +16,25 @@ module RuboCop
       #
       #   # good
       #   # Some comment
+      #
+      # @example AllowDoxygenCommentStyle: false (default)
+      #
+      #   # bad
+      #
+      #   #**
+      #   # Some comment
+      #   # Another line of comment
+      #   #*
+      #
+      # @example AllowDoxygenCommentStyle: true
+      #
+      #   # good
+      #
+      #   #**
+      #   # Some comment
+      #   # Another line of comment
+      #   #*
+      #
       class LeadingCommentSpace < Cop
         include RangeHelp
 
@@ -23,8 +42,9 @@ module RuboCop
 
         def investigate(processed_source)
           processed_source.each_comment do |comment|
-            next unless comment.text =~ /\A#+[^#*\s=:+-]/
+            next unless comment.text =~ /\A#+[^#\s=:+-]/
             next if comment.loc.line == 1 && allowed_on_first_line?(comment)
+            next if allow_doxygen_comment? && doxygen_comment_style?(comment)
 
             add_offense(comment)
           end
@@ -53,6 +73,14 @@ module RuboCop
 
         def rackup_config_file?
           File.basename(processed_source.file_path).eql?('config.ru')
+        end
+
+        def allow_doxygen_comment?
+          cop_config['AllowDoxygenCommentStyle']
+        end
+
+        def doxygen_comment_style?(comment)
+          comment.text.start_with?('#*')
         end
       end
     end

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2925,6 +2925,32 @@ or rackup options.
 # good
 # Some comment
 ```
+#### AllowDoxygenCommentStyle: false (default)
+
+```ruby
+# bad
+
+#**
+# Some comment
+# Another line of comment
+#*
+```
+#### AllowDoxygenCommentStyle: true
+
+```ruby
+# good
+
+#**
+# Some comment
+# Another line of comment
+#*
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AllowDoxygenCommentStyle | `false` | Boolean
 
 ### References
 

--- a/spec/rubocop/cop/layout/leading_comment_space_spec.rb
+++ b/spec/rubocop/cop/layout/leading_comment_space_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace do
-  subject(:cop) { described_class.new }
+RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace, :config do
+  subject(:cop) { described_class.new(config) }
 
   it 'registers an offense for comment without leading space' do
     expect_offense(<<~RUBY)
@@ -76,17 +76,41 @@ RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace do
     end
   end
 
+  describe 'Doxygen style' do
+    context 'when config option is disabled' do
+      let(:cop_config) { { 'AllowDoxygenCommentStyle' => false } }
+
+      it 'registers an offense when using Doxygen style' do
+        expect_offense(<<~RUBY)
+          #**
+          ^^^ Missing space after `#`.
+          # Some comment
+          # Another comment on a second line
+          #*
+          ^^ Missing space after `#`.
+        RUBY
+      end
+    end
+
+    context 'when config option is enabled' do
+      let(:cop_config) { { 'AllowDoxygenCommentStyle' => true } }
+
+      it 'does not register offense when using Doxygen style' do
+        expect_no_offenses(<<~RUBY)
+          #**
+          # Some comment
+          # Another comment on a second line
+          #*
+        RUBY
+      end
+    end
+  end
+
   it 'accepts rdoc syntax' do
     expect_no_offenses(<<~RUBY)
       #++
       #--
       #:nodoc:
-    RUBY
-  end
-
-  it 'accepts Doxygen syntax' do
-    expect_no_offenses(<<~RUBY)
-      #**
     RUBY
   end
 


### PR DESCRIPTION
Follows #7183 to take care of @koic's [comment][1].

Instead of allowing by default Doxygen comment syntax, we should use a configurable
option in the cop configuration to enable or not this behavior.

[1]: https://github.com/rubocop-hq/rubocop/pull/7183#issuecomment-506573743

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/