### PR TITLE
[Fix #7099] Fix an error in `Layout/RescueEnsureAlignment` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * [#7170](https://github.com/rubocop-hq/rubocop/issues/7170): Fix a false positive for `Layout/RescueEnsureAlignment` when def line is preceded with `private_class_method`. ([@tatsuyafw][])
 * [#7186](https://github.com/rubocop-hq/rubocop/issues/7186): Fix a false positive for `Style/MixinUsage` when using inside multiline block and `if` condition is after `include`. ([@koic][])
+* [#7099](https://github.com/rubocop-hq/rubocop/issues/7099): Fix an error of `Layout/RescueEnsureAlignment` on assigned blocks. ([@tatsuyafw][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
@@ -101,8 +101,12 @@ module RuboCop
             case node.type
             when :block, :kwbegin
               node.loc.begin
-            when :def, :defs, :class, :module
+            when :def, :defs, :class, :module,
+                 :lvasgn, :ivasgn, :cvasgn, :gvasgn, :casgn
               node.loc.name
+            when :masgn
+              mlhs_node, = *node
+              mlhs_node.loc.expression
             else
               # It is a wrapper with access modifier.
               node.child_nodes.first.loc.name

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -430,6 +430,182 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
         RUBY
       end
     end
+
+    context 'rescue in do-end block assigned to local variable' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          result = [1, 2, 3].map do |el|
+            rescue StandardError => _exception
+            ^^^^^^ `rescue` at 2, 2 is not aligned with `result` at 1, 0.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          result = [1, 2, 3].map do |el|
+          rescue StandardError => _exception
+          end
+        RUBY
+      end
+    end
+
+    context 'rescue in do-end block assigned to instance variable' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          @instance = [1, 2, 3].map do |el|
+            rescue StandardError => _exception
+            ^^^^^^ `rescue` at 2, 2 is not aligned with `@instance` at 1, 0.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          @instance = [1, 2, 3].map do |el|
+          rescue StandardError => _exception
+          end
+        RUBY
+      end
+    end
+
+    context 'rescue in do-end block assigned to class variable' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          @@class = [].map do |_|
+            rescue StandardError => _
+            ^^^^^^ `rescue` at 2, 2 is not aligned with `@@class` at 1, 0.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          @@class = [].map do |_|
+          rescue StandardError => _
+          end
+        RUBY
+      end
+    end
+
+    context 'rescue in do-end block assigned to global variable' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          $global = [].map do |_|
+            rescue StandardError => _
+            ^^^^^^ `rescue` at 2, 2 is not aligned with `$global` at 1, 0.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          $global = [].map do |_|
+          rescue StandardError => _
+          end
+        RUBY
+      end
+    end
+
+    context 'rescue in do-end block assigned to class' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          CLASS = [].map do |_|
+            rescue StandardError => _
+            ^^^^^^ `rescue` at 2, 2 is not aligned with `CLASS` at 1, 0.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          CLASS = [].map do |_|
+          rescue StandardError => _
+          end
+        RUBY
+      end
+    end
+
+    context 'rescue in do-end block on multi-assignment' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          a, b = [].map do |_|
+            rescue StandardError => _
+            ^^^^^^ `rescue` at 2, 2 is not aligned with `a, b` at 1, 0.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a, b = [].map do |_|
+          rescue StandardError => _
+          end
+        RUBY
+      end
+    end
+
+    context 'rescue in do-end block on operation assignment' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          a += [].map do |_|
+            rescue StandardError => _
+            ^^^^^^ `rescue` at 2, 2 is not aligned with `a` at 1, 0.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a += [].map do |_|
+          rescue StandardError => _
+          end
+        RUBY
+      end
+    end
+
+    context 'rescue in do-end block on and-assignment' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          a &&= [].map do |_|
+            rescue StandardError => _
+            ^^^^^^ `rescue` at 2, 2 is not aligned with `a` at 1, 0.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a &&= [].map do |_|
+          rescue StandardError => _
+          end
+        RUBY
+      end
+    end
+
+    context 'rescue in do-end block on or-assignment' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          a ||= [].map do |_|
+            rescue StandardError => _
+            ^^^^^^ `rescue` at 2, 2 is not aligned with `a` at 1, 0.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a ||= [].map do |_|
+          rescue StandardError => _
+          end
+        RUBY
+      end
+    end
+
+    context 'rescue in assigned do-end block starting on newline' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          valid =
+            proc do |bar|
+              baz
+              rescue
+              ^^^^^^ `rescue` at 4, 4 is not aligned with `proc do` at 2, 2.
+              qux
+            end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          valid =
+            proc do |bar|
+              baz
+            rescue
+              qux
+            end
+        RUBY
+      end
+    end
   end
 
   describe 'excluded file' do


### PR DESCRIPTION
Fixes #7099.

When running rubocop against the below code where the block was assigned to a variable, it was expected that `Layout/RescueEnsureAlignment` cop would register an offense, but an error occurred in the cop.

```
result = [1, 2, 3].map do |el|
  rescue StandardError => _exception
end
```

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
