### PR TITLE
[Fix #7186] Fix a false positive for `Style/MixinUsage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug fixes
 
 * [#7170](https://github.com/rubocop-hq/rubocop/issues/7170): Fix a false positive for `Layout/RescueEnsureAlignment` when def line is preceded with `private_class_method`. ([@tatsuyafw][])
+* [#7186](https://github.com/rubocop-hq/rubocop/issues/7186): Fix a false positive for `Style/MixinUsage` when using inside multiline block and `if` condition is after `include`. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -222,10 +222,21 @@ module RuboCop
 
       def_node_matcher :macro_scope?, <<~PATTERN
         {^{({sclass class module block} ...) class_constructor?}
-         ^^{({sclass class module block} ... ({begin if} ...)) class_constructor?}
+         ^^#ascend_macro_scope?
          ^#macro_kwbegin_wrapper?
          #root_node?}
       PATTERN
+
+      def_node_matcher :wrapped_macro_scope?, <<~PATTERN
+        {({sclass class module block} ... ({begin if} ...)) class_constructor?}
+      PATTERN
+
+      def ascend_macro_scope?(ancestor)
+        return true if wrapped_macro_scope?(ancestor)
+        return false if root_node?(ancestor)
+
+        ascend_macro_scope?(ancestor.parent)
+      end
 
       # Check if a node's parent is a kwbegin wrapper within a macro scope
       #

--- a/spec/rubocop/cop/style/mixin_usage_spec.rb
+++ b/spec/rubocop/cop/style/mixin_usage_spec.rb
@@ -66,7 +66,8 @@ RSpec.describe RuboCop::Cop::Style::MixinUsage do
        'and `if` condition is after `include`' do
       expect_no_offenses(<<~RUBY)
         klass.class_eval do
-          include M if defined?(M)
+          include M1
+          include M2 if defined?(M)
         end
       RUBY
     end


### PR DESCRIPTION
Fixes #7186.

This PR fixes a false positive for `Style/MixinUsage` when using inside multiline block and `if` condition is after `include`.

And this PR is a additional patch of #7000.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
