### PR TITLE
[Fix #1566] rubocop -a changes line endings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * [#7170](https://github.com/rubocop-hq/rubocop/issues/7170): Fix a false positive for `Layout/RescueEnsureAlignment` when def line is preceded with `private_class_method`. ([@tatsuyafw][])
 * [#7186](https://github.com/rubocop-hq/rubocop/issues/7186): Fix a false positive for `Style/MixinUsage` when using inside multiline block and `if` condition is after `include`. ([@koic][])
+* [#4374](https://github.com/rubocop-hq/rubocop/issues/4374): Fix Regression of [#1566](https://github.com/rubocop-hq/rubocop/issues/1566) --auto-correct on windows changes the line-ending. ([@dreamnite][], [@DavidS][])
 
 ### Changes
 
@@ -4119,3 +4120,5 @@
 [@malyshkosergey]: https://github.com/malyshkosergey
 [@fwitzke]: https://github.com/fwitzke
 [@okuramasafumi]: https://github.com/okuramasafumi
+[@dreamnite]: https://github.com/dreamnite
+[@DavidS]: https://github.com/DavidS

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -78,7 +78,7 @@ module RuboCop
           @options[:stdin] = new_source
         else
           filename = buffer.name
-          File.open(filename, 'w') { |f| f.write(new_source) }
+          File.open(filename, 'wb') { |f| f.write(new_source) }
         end
         @updated_source_file = true
       rescue RuboCop::ErrorWithAnalyzedFileLocation => e

--- a/spec/support/file_helper.rb
+++ b/spec/support/file_helper.rb
@@ -9,12 +9,13 @@ module FileHelper
     dir_path = File.dirname(file_path)
     FileUtils.makedirs dir_path unless File.exist?(dir_path)
 
-    File.open(file_path, 'w') do |file|
+    File.open(file_path, 'wb') do |file|
       case content
       when String
         file.puts content
       when Array
-        file.puts content.join("\n")
+        eol = RuboCop::Platform.windows? ? "\r\n" : "\n"
+        file.puts content.join(eol)
       end
     end
   end


### PR DESCRIPTION
This change fixes the main call site of `File.open` when autocorrecting
to use binary I/O, so no additional translation from ruby is happening.

Additionally there are some required changes to the test infrastructure
to keep everything aligned.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
