### PR TITLE
Make list render correctly on caching page

### DIFF
--- a/manual/caching.md
+++ b/manual/caching.md
@@ -11,6 +11,7 @@ Later runs will be able to retrieve this information and present the
 stored information instead of inspecting the file again. This will be
 done if the cache for the file is still valid, which it is if there
 are no changes in:
+
 * the contents of the inspected file
 * RuboCop configuration for the file
 * the options given to `rubocop`, with some exceptions that have no


### PR DESCRIPTION
We just need another space between the paragraphs to make the list render correctly on the [caching page](https://docs.rubocop.org/en/latest/caching/).

-----------------

Before submitting the PR make sure the following are checked:

* [✅] Wrote [good commit messages][1].
* [n/a] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [✅] Feature branch is up-to-date with `master` (if not - rebase it).
* [n/a] Squashed related commits together.
* [n/a] Added tests.
* [n/a] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [✅] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [✅] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
