### PR TITLE
[Fix #5088] Fix bug in argument_in_method_call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#7170](https://github.com/rubocop-hq/rubocop/issues/7170): Fix a false positive for `Layout/RescueEnsureAlignment` when def line is preceded with `private_class_method`. ([@tatsuyafw][])
 * [#7186](https://github.com/rubocop-hq/rubocop/issues/7186): Fix a false positive for `Style/MixinUsage` when using inside multiline block and `if` condition is after `include`. ([@koic][])
 * [#7099](https://github.com/rubocop-hq/rubocop/issues/7099): Fix an error of `Layout/RescueEnsureAlignment` on assigned blocks. ([@tatsuyafw][])
+* [#5088](https://github.com/rubocop-hq/rubocop/issues/5088): Fix an error of `Layout/MultilineMethodCallIndentation` on method chains inside an argument. ([@buehmann][])
 
 ### Changes
 
@@ -4120,3 +4121,4 @@
 [@malyshkosergey]: https://github.com/malyshkosergey
 [@fwitzke]: https://github.com/fwitzke
 [@okuramasafumi]: https://github.com/okuramasafumi
+[@buehmann]: https://github.com/buehmann

--- a/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
+++ b/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
@@ -159,11 +159,11 @@ module RuboCop
           break false if a.block_type?
 
           next if a.setter_method?
+          next unless kind == :with_or_without_parentheses ||
+                      kind == :with_parentheses && parentheses?(a)
 
           a.arguments.any? do |arg|
-            within_node?(node, arg) && (kind == :with_or_without_parentheses ||
-                                        kind == :with_parentheses &&
-                                        parentheses?(node.parent))
+            within_node?(node, arg)
           end
         end
       end

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -199,17 +199,19 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
         RUBY
       end
 
-      it 'accepts method being aligned with method that is an argument' do
+      it 'accepts methods being aligned with method that is an argument' do
         expect_no_offenses(<<~RUBY)
           authorize scope.includes(:user)
+                         .where(name: 'Bob')
                          .order(:name)
         RUBY
       end
 
-      it 'accepts method being aligned with method that is an argument in ' \
+      it 'accepts methods being aligned with method that is an argument in ' \
          'assignment' do
         expect_no_offenses(<<~RUBY)
           user = authorize scope.includes(:user)
+                                .where(name: 'Bob')
                                 .order(:name)
         RUBY
       end


### PR DESCRIPTION
This fixes #5088.

When trying to determine if a method call to be aligned occurs inside the argument of another method call, the wrong `:send` node was being checked for parenthesized arguments. It
must the one whose arguments are being looked at.
