### PR TITLE
Revert __RUBY__ to __END__ token in specs

### DIFF
--- a/spec/rubocop/cop/layout/comment_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/comment_indentation_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::Layout::CommentIndentation do
     end
   end
 
-  it 'registers offenses before __RUBY__ but not after' do
+  it 'registers offenses before __END__ but not after' do
     expect_offense(<<~RUBY)
        #
        ^ Incorrect indentation detected (column 1 instead of 0).

--- a/spec/rubocop/cop/layout/tab_spec.rb
+++ b/spec/rubocop/cop/layout/tab_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::Layout::Tab do
     RUBY
   end
 
-  it 'registers offenses before __RUBY__ but not after' do
+  it 'registers offenses before __END__ but not after' do
     expect_offense(<<~RUBY)
       \tx = 0
       ^ Tab detected.

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
 
   it_behaves_like('special keywords', '__FILE__')
   it_behaves_like('special keywords', '__LINE__')
-  it_behaves_like('special keywords', '__RUBY__')
+  it_behaves_like('special keywords', '__END__')
   it_behaves_like('special keywords', '__ENCODING__')
 
   shared_examples 'non-special string literal interpolation' do |string|


### PR DESCRIPTION
I stumbled across these wrong occurrences of `__RUBY__` in the specs.

They were caused by an overzealous substitution in
8f37b7f2f0f4b01c2afa83fffdf531dfb4dce057, where heredoc delimiters such
as `END` were replaced – even inside `__END__`.