### PR TITLE
[Fix #4719] Detect tabs between string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#7186](https://github.com/rubocop-hq/rubocop/issues/7186): Fix a false positive for `Style/MixinUsage` when using inside multiline block and `if` condition is after `include`. ([@koic][])
 * [#7099](https://github.com/rubocop-hq/rubocop/issues/7099): Fix an error of `Layout/RescueEnsureAlignment` on assigned blocks. ([@tatsuyafw][])
 * [#5088](https://github.com/rubocop-hq/rubocop/issues/5088): Fix an error of `Layout/MultilineMethodCallIndentation` on method chains inside an argument. ([@buehmann][])
+* [#4719](https://github.com/rubocop-hq/rubocop/issues/4719): Make `Layout/Tab` detect tabs between string literals. ([@buehmann][])
 
 ### Changes
 

--- a/spec/rubocop/cop/layout/tab_spec.rb
+++ b/spec/rubocop/cop/layout/tab_spec.rb
@@ -44,6 +44,13 @@ RSpec.describe RuboCop::Cop::Layout::Tab do
     RUBY
   end
 
+  it 'registers an offense for tabs between string literals' do
+    expect_offense(<<~RUBY)
+      'foo'\t'bar'
+           ^ Tab detected.
+    RUBY
+  end
+
   it 'accepts a line with tab in a string' do
     expect_no_offenses("(x = \"\t\")")
   end


### PR DESCRIPTION
This fixes #4719 and simplifies `Layout/Tab` code.

The problem was that entire `:dstr` expressions were considered "inside a string", whereas they can be composed of multiple individual string literals:

```ruby
"foo" \
	"bar"
```

```
s(:dstr,
  s(:str, "foo"),
  s(:str, "bar"))
"foo" \
~~~~~~~... expression

s(:str, "foo")
"foo" \
    ~ end
~ begin
~~~~~ expression

s(:str, "bar")
        "bar"
            ~ end
        ~ begin
        ~~~~~ expression
```
In the AST this looks very similar to a multiline string, but the `begin` (and `end`) locations differ:

```ruby
"foo
	bar"
```

```
s(:dstr,
  s(:str, "foo\n"),
  s(:str, "\tbar"))
"foo
~ begin
~~~~... expression
        bar"
           ~ end

s(:str, "foo\n")
"foo
 ~~~... expression

s(:str, "\tbar")
        bar"
       ~~~~ expression
```