### PR TITLE
Add new cop `Metrics/PerceivedMethodLength`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1848,6 +1848,12 @@ Metrics/PerceivedComplexity:
   VersionAdded: '0.25'
   Max: 7
 
+Metrics/PerceivedMethodLength:
+  Description: 'Avoid methods with more than 14 statements.'
+  Enabled: true
+  Max: 14
+  VersionAdded: '0.72'
+
 #################### Naming ##############################
 
 Naming/AccessorMethodName:

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -353,6 +353,7 @@ require_relative 'rubocop/cop/lint/useless_setter_call'
 require_relative 'rubocop/cop/lint/void'
 
 require_relative 'rubocop/cop/metrics/cyclomatic_complexity'
+require_relative 'rubocop/cop/metrics/perceived_method_length'
 # relies on cyclomatic_complexity
 require_relative 'rubocop/cop/metrics/utils/abc_size_calculator'
 require_relative 'rubocop/cop/metrics/abc_size'

--- a/lib/rubocop/cop/metrics/perceived_method_length.rb
+++ b/lib/rubocop/cop/metrics/perceived_method_length.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Metrics
+      # This cop checks if the number of statements of the method
+      # exceeds some maximum value.
+      # The maximum allowed length is configurable.
+      class PerceivedMethodLength < Cop
+        MSG = 'Method has too many statements. [%<length>d/%<max>d]'
+
+        def on_def(node)
+          check_code_statements(node)
+        end
+
+        def on_block(node)
+          return unless node.send_node.method_name == :define_method
+
+          check_code_statements(node)
+        end
+
+        def check_code_statements(node)
+          @statements = 0
+          return unless count_statements(node.body) > max_statements
+
+          location = node.casgn_type? ? :name : :expression
+
+          add_offense(node, location: location, message: message(@statements))
+        end
+
+        private
+
+        def max_statements
+          cop_config['Max']
+        end
+
+        def message(length)
+          format(MSG, length: length, max: max_statements)
+        end
+
+        def count_statements(node)
+          return 0 unless node
+
+          if compound_statement?(node)
+            node.node_parts.each(&method(:count))
+          else
+            count(node)
+          end
+
+          @statements
+        end
+
+        def count(node)
+          @statements += 1
+
+          count_statements(node.body) if body?(node)
+        end
+
+        def compound_statement?(node)
+          node.begin_type? || node.kwbegin_type?
+        end
+
+        def body?(node)
+          node.respond_to?(:body)
+        end
+      end
+    end
+  end
+end

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -268,6 +268,7 @@ In the following section you find all available cops:
 * [Metrics/ModuleLength](cops_metrics.md#metricsmodulelength)
 * [Metrics/ParameterLists](cops_metrics.md#metricsparameterlists)
 * [Metrics/PerceivedComplexity](cops_metrics.md#metricsperceivedcomplexity)
+* [Metrics/PerceivedMethodLength](cops_metrics.md#metricsperceivedmethodlength)
 
 #### Department [Naming](cops_naming.md)
 

--- a/manual/cops_metrics.md
+++ b/manual/cops_metrics.md
@@ -276,3 +276,19 @@ end                             # 7 complexity points
 Name | Default value | Configurable values
 --- | --- | ---
 Max | `7` | Integer
+
+## Metrics/PerceivedMethodLength
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.72 | -
+
+This cop checks if the number of statements of the method
+exceeds some maximum value.
+The maximum allowed length is configurable.
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+Max | `14` | Integer

--- a/spec/rubocop/cop/metrics/perceived_method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/perceived_method_length_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Metrics::PerceivedMethodLength, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:cop_config) { { 'Max' => 5 } }
+
+  context 'when method is an instance method' do
+    it 'register an  offense' do
+      expect_offense(<<~RUBY)
+        def m
+        ^^^^^ Method has too many statements. [6/5]
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      RUBY
+    end
+
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        def m
+          [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+          ]
+        end
+      RUBY
+    end
+  end
+
+  context 'when method is defined with `define_method`' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        define_method(:m) do
+        ^^^^^^^^^^^^^^^^^^^^ Method has too many statements. [6/5]
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      RUBY
+    end
+
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        define_method(:m) do
+          {
+            a: 1,
+            b: 2,
+            c: 3,
+            d: 4,
+            e: 5,
+            f: 6
+          }
+        end
+      RUBY
+    end
+  end
+
+  context 'when method has a block inside' do
+    it 'register an offense' do
+      expect_offense(<<~RUBY)
+        def m
+        ^^^^^ Method has too many statements. [6/5]
+          my_block do
+            a = 1
+            a = 2
+            a = 3
+            a = 4
+            a = 5
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        def m
+          my_block do
+            a = 1
+            a = 2
+            a = 3
+            a = 4
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when method is a one-liner method' do
+    it 'register an offense' do
+      expect_offense(<<~RUBY)
+        def m
+        ^^^^^ Method has too many statements. [6/5]
+          a = 1; a = 2; a = 3; a = 4; a = 5; a = 6;
+        end
+      RUBY
+    end
+
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        def m
+          a = 1; a = 2; a = 3; a = 4; a = 5
+        end
+      RUBY
+    end
+  end
+
+  context 'when method has a if statement' do
+    it 'register an offense' do
+      expect_offense(<<~RUBY)
+        def m
+        ^^^^^ Method has too many statements. [6/5]
+          if a
+            a = 1
+            a = 2
+            a = 3
+            a = 4
+            a = 5
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        def m
+          if a
+            a = 1
+            a = 2
+            a = 3
+            a = 4
+          end
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
This cop checks if the number of statements of the method exceeds some maximum value.

There are more than one issue on rubocop talking about the `Metrics/MethodLength` not being good enough because it does count literal line breaks so methods with large array or hash literals would be catch. 

I know about `CyclomaticComplexity` but i still thinks a cop that counts statements is a great alternative to `Metrics/MethodLength` so i decided to implement it.

Issues: #494, #1077, #1361(Probably to have more issues talking about it)

I don't have too much experience with opensource contributing so if i forgot anything  please let me know, thanks :D 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
