### PR TITLE
[Fix #6653] IndentHeredoc: Do not run into next line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#5088](https://github.com/rubocop-hq/rubocop/issues/5088): Fix an error of `Layout/MultilineMethodCallIndentation` on method chains inside an argument. ([@buehmann][])
 * [#4719](https://github.com/rubocop-hq/rubocop/issues/4719): Make `Layout/Tab` detect tabs between string literals. ([@buehmann][])
 * [#7203](https://github.com/rubocop-hq/rubocop/pull/7203): Fix an infinite loop error for `Layout/SpaceInsideBlockBraces` when `EnforcedStyle: no_space` with `SpaceBeforeBlockParameters: false` are set in multiline block. ([@koic][])
+* [#6653](https://github.com/rubocop-hq/rubocop/issues/6653): Fix a bug where `Layout/IndentHeredoc` would remove empty lines when autocorrecting heredocs. ([@buehmann][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/indent_heredoc.rb
+++ b/lib/rubocop/cop/layout/indent_heredoc.rb
@@ -37,7 +37,7 @@ module RuboCop
       #   # good
       #   # When EnforcedStyle is powerpack, bad code is auto-corrected to
       #   # the following code.
-      #   <<~RUBY
+      #   <<-RUBY.strip_indent
       #     something
       #   RUBY
       #
@@ -206,7 +206,8 @@ module RuboCop
           body = heredoc_body(node)
           body_indent_level = indent_level(body)
           correct_indent_level = base_indent_level(node) + indentation_width
-          body.gsub(/^\s{#{body_indent_level}}/, ' ' * correct_indent_level)
+          body.gsub(/^[^\S\r\n]{#{body_indent_level}}/,
+                    ' ' * correct_indent_level)
         end
 
         def indented_end(node)

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2621,7 +2621,7 @@ RUBY
 # good
 # When EnforcedStyle is powerpack, bad code is auto-corrected to
 # the following code.
-<<~RUBY
+<<-RUBY.strip_indent
   something
 RUBY
 ```

--- a/spec/rubocop/cop/layout/indent_heredoc_spec.rb
+++ b/spec/rubocop/cop/layout/indent_heredoc_spec.rb
@@ -274,6 +274,25 @@ RSpec.describe RuboCop::Cop::Layout::IndentHeredoc, :config do
           MSG
         RUBY
 
+        include_examples 'offense', 'not indented enough with empty lines',
+                         <<-RUBY, <<-CORRECTION
+          def baz
+            <<~#{quote}MSG#{quote}
+            foo
+
+              bar
+            MSG
+          end
+        RUBY
+          def baz
+            <<~#{quote}MSG#{quote}
+              foo
+
+                bar
+            MSG
+          end
+        CORRECTION
+
         it 'displays message to use `<<~` instead of `<<`' do
           expect_offense(<<~RUBY)
             <<RUBY2


### PR DESCRIPTION
This closes #6653 (if it were open; I was not able to open it again after the stale bot had closed it).

When finding the indentation whitespace to be replaced in a multiline
string, the regexp `/\s*/` could run into the next line (because it
matches `\n`).

I also fixed across a tiny bug in the documentation of the cop.