### PR TITLE
Improve ExtraSpacing Cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#5265](https://github.com/rubocop-hq/rubocop/issues/5265): Improved `Layout/ExtraSpacing` cop to handle nested consecutive assignments. ([@jfelchner][])
+
 ## 0.73.0 (2019-07-16)
 
 ### New features

--- a/lib/rubocop/cop/layout/extra_spacing.rb
+++ b/lib/rubocop/cop/layout/extra_spacing.rb
@@ -89,20 +89,34 @@ module RuboCop
           end
         end
 
+        # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         def check_assignment(token)
-          assignment_line = ''
-          message = ''
-          if should_aligned_with_preceding_line?(token)
-            assignment_line = processed_source.preceding_line(token)
-            message = format(MSG_UNALIGNED_ASGN, location: 'preceding')
-          else
-            assignment_line = processed_source.following_line(token)
-            message = format(MSG_UNALIGNED_ASGN, location: 'following')
-          end
+          token_line_indent              = processed_source
+                                           .line_indentation(token.line)
+
+          preceding_line_range           = token.line.downto(1)
+          preceding_assignment_lines     = \
+            relevant_assignment_lines(preceding_line_range)
+          preceding_relevant_line_number = preceding_assignment_lines[1]
+
+          return unless preceding_relevant_line_number
+
+          preceding_relevant_indent = \
+            processed_source
+            .line_indentation(preceding_relevant_line_number)
+
+          return if preceding_relevant_indent < token_line_indent
+
+          assignment_line = processed_source
+                            .lines[preceding_relevant_line_number - 1]
+          message         = format(MSG_UNALIGNED_ASGN, location: 'preceding')
+
+          return unless assignment_line
           return if aligned_assignment?(token.pos, assignment_line)
 
           add_offense(token.pos, location: token.pos, message: message)
         end
+        # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
         def should_aligned_with_preceding_line?(token)
           @asgn_lines.include?(token.line - 1)
@@ -188,7 +202,7 @@ module RuboCop
         end
 
         def align_equal_signs(range, corrector)
-          lines  = contiguous_assignment_lines(range)
+          lines  = all_relevant_assignment_lines(range.line)
           tokens = @asgn_tokens.select { |t| lines.include?(t.line) }
 
           columns  = tokens.map { |t| align_column(t) }
@@ -221,6 +235,48 @@ module RuboCop
 
           result.sort!
         end
+
+        def all_relevant_assignment_lines(line_number)
+          last_line_number = processed_source.lines.size
+
+          (
+            relevant_assignment_lines(line_number.downto(1)) +
+            relevant_assignment_lines(line_number.upto(last_line_number))
+          )
+            .uniq
+            .sort
+        end
+
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/PerceivedComplexity, Metrics/MethodLength
+        def relevant_assignment_lines(line_range)
+          result               = []
+          original_line_indent = processed_source
+                                 .line_indentation(line_range.first)
+          previous_line_indent_at_level = true
+
+          line_range.each do |line_number|
+            current_line_indent = processed_source.line_indentation(line_number)
+            blank_line          = processed_source.lines[line_number - 1].blank?
+
+            if (current_line_indent < original_line_indent && !blank_line) ||
+               (previous_line_indent_at_level && blank_line)
+              break
+            end
+
+            result << line_number if @asgn_lines.include?(line_number) &&
+                                     current_line_indent == original_line_indent
+
+            unless blank_line
+              previous_line_indent_at_level = \
+                current_line_indent == original_line_indent
+            end
+          end
+
+          result
+        end
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/PerceivedComplexity, Metrics/MethodLength
 
         def align_column(asgn_token)
           # if we removed unneeded spaces from the beginning of this =,

--- a/lib/rubocop/cop/layout/extra_spacing.rb
+++ b/lib/rubocop/cop/layout/extra_spacing.rb
@@ -41,12 +41,7 @@ module RuboCop
         def investigate(processed_source)
           return if processed_source.blank?
 
-          if force_equal_sign_alignment?
-            @asgn_tokens = assignment_tokens
-            @asgn_lines  = @asgn_tokens.map(&:line)
-            # Don't attempt to correct the same = more than once
-            @corrected   = Set.new
-          end
+          @corrected = Set.new if force_equal_sign_alignment?
 
           processed_source.tokens.each_cons(2) do |token1, token2|
             check_tokens(processed_source.ast, token1, token2)
@@ -65,61 +60,21 @@ module RuboCop
 
         private
 
-        def assignment_tokens
-          tokens = processed_source.tokens.select(&:equal_sign?)
-          # we don't want to operate on equals signs which are part of an
-          #   optarg in a method definition
-          # e.g.: def method(optarg = default_val); end
-          tokens = remove_optarg_equals(tokens, processed_source)
-
-          # Only attempt to align the first = on each line
-          Set.new(tokens.uniq(&:line))
-        end
-
         def check_tokens(ast, token1, token2)
           return if token2.type == :tNL
 
-          if force_equal_sign_alignment? &&
-             @asgn_tokens.include?(token2) &&
-             (@asgn_lines.include?(token2.line - 1) ||
-              @asgn_lines.include?(token2.line + 1))
+          if force_equal_sign_alignment? && assignment_tokens.include?(token2)
             check_assignment(token2)
           else
             check_other(token1, token2, ast)
           end
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         def check_assignment(token)
-          token_line_indent              = processed_source
-                                           .line_indentation(token.line)
+          return unless aligned_with_preceding_assignment(token) == :no
 
-          preceding_line_range           = token.line.downto(1)
-          preceding_assignment_lines     = \
-            relevant_assignment_lines(preceding_line_range)
-          preceding_relevant_line_number = preceding_assignment_lines[1]
-
-          return unless preceding_relevant_line_number
-
-          preceding_relevant_indent = \
-            processed_source
-            .line_indentation(preceding_relevant_line_number)
-
-          return if preceding_relevant_indent < token_line_indent
-
-          assignment_line = processed_source
-                            .lines[preceding_relevant_line_number - 1]
-          message         = format(MSG_UNALIGNED_ASGN, location: 'preceding')
-
-          return unless assignment_line
-          return if aligned_assignment?(token.pos, assignment_line)
-
+          message = format(MSG_UNALIGNED_ASGN, location: 'preceding')
           add_offense(token.pos, location: token.pos, message: message)
-        end
-        # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
-
-        def should_aligned_with_preceding_line?(token)
-          @asgn_lines.include?(token.line - 1)
         end
 
         def check_other(token1, token2, ast)
@@ -203,7 +158,7 @@ module RuboCop
 
         def align_equal_signs(range, corrector)
           lines  = all_relevant_assignment_lines(range.line)
-          tokens = @asgn_tokens.select { |t| lines.include?(t.line) }
+          tokens = assignment_tokens.select { |t| lines.include?(t.line) }
 
           columns  = tokens.map { |t| align_column(t) }
           align_to = columns.max
@@ -223,19 +178,6 @@ module RuboCop
           end
         end
 
-        def contiguous_assignment_lines(range)
-          result = [range.line]
-
-          range.line.downto(1) do |lineno|
-            @asgn_lines.include?(lineno) ? result << lineno : break
-          end
-          range.line.upto(processed_source.lines.size) do |lineno|
-            @asgn_lines.include?(lineno) ? result << lineno : break
-          end
-
-          result.sort!
-        end
-
         def all_relevant_assignment_lines(line_number)
           last_line_number = processed_source.lines.size
 
@@ -247,37 +189,6 @@ module RuboCop
             .sort
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
-        # rubocop:disable Metrics/PerceivedComplexity, Metrics/MethodLength
-        def relevant_assignment_lines(line_range)
-          result               = []
-          original_line_indent = processed_source
-                                 .line_indentation(line_range.first)
-          previous_line_indent_at_level = true
-
-          line_range.each do |line_number|
-            current_line_indent = processed_source.line_indentation(line_number)
-            blank_line          = processed_source.lines[line_number - 1].blank?
-
-            if (current_line_indent < original_line_indent && !blank_line) ||
-               (previous_line_indent_at_level && blank_line)
-              break
-            end
-
-            result << line_number if @asgn_lines.include?(line_number) &&
-                                     current_line_indent == original_line_indent
-
-            unless blank_line
-              previous_line_indent_at_level = \
-                current_line_indent == original_line_indent
-            end
-          end
-
-          result
-        end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
-        # rubocop:enable Metrics/PerceivedComplexity, Metrics/MethodLength
-
         def align_column(asgn_token)
           # if we removed unneeded spaces from the beginning of this =,
           # what column would it end from?
@@ -285,12 +196,6 @@ module RuboCop
           leading = line[0...asgn_token.column]
           spaces  = leading.size - (leading =~ / *\Z/)
           asgn_token.pos.last_column - spaces + 1
-        end
-
-        def remove_optarg_equals(asgn_tokens, processed_source)
-          optargs    = processed_source.ast.each_node(:optarg)
-          optarg_eql = optargs.map { |o| o.loc.operator.begin_pos }.to_set
-          asgn_tokens.reject { |t| optarg_eql.include?(t.begin_pos) }
         end
 
         def allow_for_trailing_comments?

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -149,9 +149,18 @@ module RuboCop
           end
         end
 
-        def excess_leading_space?(operator, with_space)
-          with_space.source.start_with?(EXCESSIVE_SPACE) &&
-            (!allow_for_alignment? || !aligned_with_operator?(operator))
+        def excess_leading_space?(type, operator, with_space)
+          return false unless allow_for_alignment?
+          return false unless with_space.source.start_with?(EXCESSIVE_SPACE)
+
+          return !aligned_with_operator?(operator) unless type == :assignment
+
+          token            = Token.new(operator, nil, operator.source)
+          align_preceding  = aligned_with_preceding_assignment(token)
+
+          return align_preceding == :no unless align_preceding == :none
+
+          aligned_with_subsequent_assignment(token) != :yes
         end
 
         def excess_trailing_space?(right_operand, with_space)

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -34,14 +34,14 @@ module RuboCop
 
           return if hash_table_style? && !node.parent.pairs_on_same_line?
 
-          check_operator(node.loc.operator, node.source_range)
+          check_operator(:pair, node.loc.operator, node.source_range)
         end
 
         def on_if(node)
           return unless node.ternary?
 
-          check_operator(node.loc.question, node.if_branch.source_range)
-          check_operator(node.loc.colon, node.else_branch.source_range)
+          check_operator(:if, node.loc.question, node.if_branch.source_range)
+          check_operator(:if, node.loc.colon, node.else_branch.source_range)
         end
 
         def on_resbody(node)
@@ -49,15 +49,25 @@ module RuboCop
 
           _, variable, = *node
 
-          check_operator(node.loc.assoc, variable.source_range)
+          check_operator(:resbody, node.loc.assoc, variable.source_range)
         end
 
         def on_send(node)
           if node.setter_method?
             on_special_asgn(node)
           elsif regular_operator?(node)
-            check_operator(node.loc.selector, node.first_argument.source_range)
+            check_operator(:send,
+                           node.loc.selector,
+                           node.first_argument.source_range)
           end
+        end
+
+        def on_assignment(node)
+          _, rhs, = *node
+
+          return unless rhs
+
+          check_operator(:assignment, node.loc.operator, rhs.source_range)
         end
 
         def on_binary(node)
@@ -65,7 +75,7 @@ module RuboCop
 
           return unless rhs
 
-          check_operator(node.loc.operator, rhs.source_range)
+          check_operator(:binary, node.loc.operator, rhs.source_range)
         end
 
         def on_special_asgn(node)
@@ -73,20 +83,20 @@ module RuboCop
 
           return unless right
 
-          check_operator(node.loc.operator, right.source_range)
+          check_operator(:special_asgn, node.loc.operator, right.source_range)
         end
 
         alias on_or       on_binary
         alias on_and      on_binary
-        alias on_lvasgn   on_binary
-        alias on_masgn    on_binary
+        alias on_lvasgn   on_assignment
+        alias on_masgn    on_assignment
         alias on_casgn    on_special_asgn
-        alias on_ivasgn   on_binary
-        alias on_cvasgn   on_binary
-        alias on_gvasgn   on_binary
+        alias on_ivasgn   on_assignment
+        alias on_cvasgn   on_assignment
+        alias on_gvasgn   on_assignment
         alias on_class    on_binary
-        alias on_or_asgn  on_binary
-        alias on_and_asgn on_binary
+        alias on_or_asgn  on_assignment
+        alias on_and_asgn on_assignment
         alias on_op_asgn  on_special_asgn
 
         def autocorrect(range)
@@ -113,26 +123,26 @@ module RuboCop
             !IRREGULAR_METHODS.include?(send_node.method_name)
         end
 
-        def check_operator(operator, right_operand)
+        def check_operator(type, operator, right_operand)
           with_space = range_with_surrounding_space(range: operator)
           return if with_space.source.start_with?("\n")
 
-          offense(operator, with_space, right_operand) do |msg|
+          offense(type, operator, with_space, right_operand) do |msg|
             add_offense(with_space, location: operator, message: msg)
           end
         end
 
-        def offense(operator, with_space, right_operand)
-          msg = offense_message(operator, with_space, right_operand)
+        def offense(type, operator, with_space, right_operand)
+          msg = offense_message(type, operator, with_space, right_operand)
           yield msg if msg
         end
 
-        def offense_message(operator, with_space, right_operand)
+        def offense_message(type, operator, with_space, right_operand)
           if operator.is?('**')
             'Space around operator `**` detected.' unless with_space.is?('**')
           elsif with_space.source !~ /^\s.*\s$/
             "Surrounding space missing for operator `#{operator.source}`."
-          elsif excess_leading_space?(operator, with_space) ||
+          elsif excess_leading_space?(type, operator, with_space) ||
                 excess_trailing_space?(right_operand, with_space)
             "Operator `#{operator.source}` should be surrounded " \
             'by a single space.'

--- a/lib/rubocop/cop/mixin/preceding_following_alignment.rb
+++ b/lib/rubocop/cop/mixin/preceding_following_alignment.rb
@@ -25,6 +25,12 @@ module RuboCop
         aligned_with_assignment(token, preceding_line_range)
       end
 
+      def aligned_with_subsequent_assignment(token)
+        subsequent_line_range = token.line.upto(processed_source.lines.length)
+
+        aligned_with_assignment(token, subsequent_line_range)
+      end
+
       def aligned_with_adjacent_line?(range, predicate)
         # minus 2 because node.loc.line is zero-based
         pre  = (range.line - 2).downto(0)

--- a/lib/rubocop/cop/mixin/preceding_following_alignment.rb
+++ b/lib/rubocop/cop/mixin/preceding_following_alignment.rb
@@ -22,7 +22,7 @@ module RuboCop
       def aligned_with_preceding_assignment(token)
         preceding_line_range = token.line.downto(1)
 
-        aligned_with_assignment(token, :preceding, preceding_line_range)
+        aligned_with_assignment(token, preceding_line_range)
       end
 
       def aligned_with_adjacent_line?(range, predicate)

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -123,6 +123,10 @@ module RuboCop
       lines[token.line - 2]
     end
 
+    def current_line(token)
+      lines[token.line - 1]
+    end
+
     def following_line(token)
       lines[token.line]
     end

--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -132,7 +132,10 @@ module RuboCop
       def expect_no_offenses(source, file = nil)
         inspect_source(source, file)
 
-        expect(cop.offenses).to be_empty
+        expected_annotations = AnnotatedSource.parse(source)
+        actual_annotations =
+          expected_annotations.with_offense_annotations(cop.offenses)
+        expect(actual_annotations.to_s).to eq(source)
       end
 
       # Parsed representation of code annotated with the `^^^ Message` style

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -33,6 +33,79 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     expect(IO.read('example.rb')).to eq(source)
   end
 
+  it 'plays nicely with default cops in complex ExtraSpacing scenarios' do
+    create_file('.rubocop.yml', <<-YAML.strip_indent)
+      # These cops change indentation and thus need disabling in order for the
+      # ExtraSpacing rules to apply to this scenario.
+
+      Layout/BlockAlignment:
+        Enabled: false
+
+      Layout/ExtraSpacing:
+        ForceEqualSignAlignment: true
+
+      Layout/MultilineMethodCallBraceLayout:
+        Enabled: false
+    YAML
+
+    source = <<-RUBY.strip_indent
+      def batch
+        @areas = params[:param].map do
+                        var_1 = 123_456
+                        variable_2 = 456_123
+                   end
+        @another = params[:param].map do
+                     char_1 = begin
+                                variable_1_1     = 'a'
+                                variable_1_20  = 'b'
+
+                                variable_1_300    = 'c'
+                                # A Comment
+                                variable_1_4000      = 'd'
+
+                                variable_1_50000     = 'e'
+                                puts 'a non-assignment statement without a blank line'
+                                some_other_length_variable     = 'f'
+                              end
+                     var_2 = 456_123
+                   end
+
+        render json: @areas
+      end
+    RUBY
+
+    create_file('example.rb', source)
+    expect(cli.run(['--auto-correct'])).to eq(1)
+
+    expect(IO.read('example.rb')).to eq(<<-RUBY.strip_indent)
+      # frozen_string_literal: true
+
+      def batch
+        @areas   = params[:param].map do
+                     var_1      = 123_456
+                     variable_2 = 456_123
+                   end
+        @another = params[:param].map do
+                     char_1 = begin
+                                variable_1_1  = 'a'
+                                variable_1_20 = 'b'
+
+                                variable_1_300  = 'c'
+                                # A Comment
+                                variable_1_4000 = 'd'
+
+                                variable_1_50000           = 'e'
+                                puts 'a non-assignment statement without a blank line'
+                                some_other_length_variable = 'f'
+                              end
+                     var_2  = 456_123
+                   end
+
+        render json: @areas
+      end
+    RUBY
+  end
+
   it 'does not correct SpaceAroundOperators in a hash that would be ' \
      'changed back' do
     create_file('.rubocop.yml', <<~YAML)

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -326,11 +326,36 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
     it 'registers an offense if consecutive assignments are not aligned' do
       expect_offense(<<~RUBY)
         a = 1
-          ^ `=` is not aligned with the following assignment.
         bb = 2
            ^ `=` is not aligned with the preceding assignment.
         ccc = 3
             ^ `=` is not aligned with the preceding assignment.
+      RUBY
+    end
+
+    it 'does not register offenses for multiple complex nested assignments' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def batch
+          @areas   = params[:param].map {
+                       var_1      = 123_456
+                       variable_2 = 456_123 }
+          @another = params[:param].map {
+                       char_1 = begin
+                                  variable_1_1  = 'a'
+                                  variable_1_20 = 'b'
+
+                                  variable_1_300  = 'c'
+                                  # A Comment
+                                  variable_1_4000 = 'd'
+
+                                  variable_1_50000           = 'e'
+                                  puts 'a non-assignment statement without a blank line'
+                                  some_other_length_variable = 'f'
+                                end
+                       var_2  = 456_123 }
+
+          render json: @areas
+        end
       RUBY
     end
 
@@ -357,6 +382,14 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
         # comment
         a   = 1
         bb  = 2
+      RUBY
+    end
+
+    it 'does not register alignment errors on outdented lines' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        @areas = params[:param].map do |ca_params|
+                   ca_params = ActionController::Parameters.new(stuff)
+                 end
       RUBY
     end
 
@@ -441,6 +474,56 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
         abcde.blah       = 1
         a.attribute_name = 2
         abc[1]           = 3
+      RUBY
+    end
+
+    it 'autocorrects complex nested assignments' do
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        def batch
+          @areas = params[:param].map {
+                       var_1 = 123_456
+                       variable_2 = 456_123 }
+          @another = params[:param].map {
+                       char_1 = begin
+                                  variable_1_1     = 'a'
+                                  variable_1_20  = 'b'
+
+                                  variable_1_300    = 'c'
+                                  # A Comment
+                                  variable_1_4000      = 'd'
+
+                                  variable_1_50000     = 'e'
+                                  puts 'a non-assignment statement without a blank line'
+                                  some_other_length_variable     = 'f'
+                                end
+                       var_2 = 456_123 }
+
+          render json: @areas
+        end
+      RUBY
+
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        def batch
+          @areas   = params[:param].map {
+                       var_1      = 123_456
+                       variable_2 = 456_123 }
+          @another = params[:param].map {
+                       char_1 = begin
+                                  variable_1_1  = 'a'
+                                  variable_1_20 = 'b'
+
+                                  variable_1_300  = 'c'
+                                  # A Comment
+                                  variable_1_4000 = 'd'
+
+                                  variable_1_50000           = 'e'
+                                  puts 'a non-assignment statement without a blank line'
+                                  some_other_length_variable = 'f'
+                                end
+                       var_2  = 456_123 }
+
+          render json: @areas
+        end
       RUBY
     end
 

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
   let(:config) do
     RuboCop::Config
       .new(
+        'Layout/ExtraSpacing' => { 'ForceEqualSignAlignment' => true },
         'Layout/AlignHash' => { 'EnforcedHashRocketStyle' => hash_style },
         'Layout/SpaceAroundOperators' => {
           'AllowForAlignment' => allow_for_alignment
@@ -46,6 +47,34 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
     expect_no_offenses(<<~RUBY)
       def !
         !__getobj__
+      end
+    RUBY
+  end
+
+  it 'accepts the result of the ExtraSpacing Cop' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def batch
+        @areas   = params[:param].map do
+                     var_1      = 123_456
+                     variable_2 = 456_123
+                   end
+        @another = params[:param].map do
+                     char_1 = begin
+                                variable_1_1  = 'a'
+                                variable_1_20 = 'b'
+
+                                variable_1_300  = 'c'
+                                # A Comment
+                                variable_1_4000 = 'd'
+
+                                variable_1_50000           = 'e'
+                                puts 'a non-assignment statement without a blank line'
+                                some_other_length_variable = 'f'
+                              end
+                     var_2  = 456_123
+                   end
+
+        render json: @areas
       end
     RUBY
   end

--- a/spec/rubocop/cop/naming/predicate_name_spec.rb
+++ b/spec/rubocop/cop/naming/predicate_name_spec.rb
@@ -139,7 +139,6 @@ RSpec.describe RuboCop::Cop::Naming::PredicateName, :config do
     it 'does not register any offenses when using an internal affair macro' do
       expect_no_offenses(<<~RUBY)
         def_node_matcher :is_hello, <<~PATTERN
-                         ^^^^^^^^^ Rename `is_hello` to `hello?`.
           (send
             (send nil? :method_name) :==
             (str 'hello'))


### PR DESCRIPTION
A continuation of #5696 

This allows for more complex `=` alignments which previously either caused false positives or autocorrected to the wrong result, or both.

The ultimate result is to be able to give Rubocop something like this:

```ruby
def batch
  @areas = params[:param].map do
               var_1 = 123_456
               variable_2 = 456_123
           end
  @another = params[:param].map do
               char_1 = begin
                          variable_1_1     = 'a'
                          variable_1_20  = 'b'

                          variable_1_300    = 'c'
                          # A Comment
                          variable_1_4000      = 'd'

                          variable_1_50000     = 'e'
                          puts 'a non-assignment statement without a blank line'
                          some_other_length_variable     = 'f'
                        end
               var_2 = 456_123
             end

  render json: @areas
end
```

and have it autocorrect it to:

```ruby
def batch
  @areas   = params[:param].map do
                 var_1      = 123_456
                 variable_2 = 456_123
             end
  @another = params[:param].map do
               char_1 = begin
                          variable_1_1  = 'a'
                          variable_1_20 = 'b'

                          variable_1_300  = 'c'
                          # A Comment
                          variable_1_4000 = 'd'

                          variable_1_50000           = 'e'
                          puts 'a non-assignment statement without a blank line'
                          some_other_length_variable = 'f'
                        end
               var_2  = 456_123
             end

  render json: @areas
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/