### PR TITLE
Make TrailingMethodEndStatement actually work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#7217](https://github.com/rubocop-hq/rubocop/pull/7217): Make `Style/TrailingMethodEndStatement` work on more than the first `def`. ([@buehmann][])
+
 ## 0.73.0 (2019-07-16)
 
 ### New features

--- a/lib/rubocop/cop/style/trailing_method_end_statement.rb
+++ b/lib/rubocop/cop/style/trailing_method_end_statement.rb
@@ -42,7 +42,7 @@ module RuboCop
         def on_def(node)
           return unless trailing_end?(node)
 
-          add_offense(node.to_a.last, location: end_token(node).pos)
+          add_offense(node, location: end_token(node).pos)
         end
 
         def autocorrect(node)
@@ -61,7 +61,7 @@ module RuboCop
         end
 
         def end_token(node)
-          @end_token ||= tokens(node).reverse.find(&:end?)
+          tokens(node).reverse.find(&:end?)
         end
 
         def body_and_end_on_same_line?(node)
@@ -69,10 +69,8 @@ module RuboCop
         end
 
         def token_before_end(node)
-          @token_before_end ||= begin
-            i = tokens(node).index(end_token(node))
-            tokens(node)[i - 1]
-          end
+          i = tokens(node).index(end_token(node))
+          tokens(node)[i - 1]
         end
 
         def break_line_before_end(node, corrector)

--- a/spec/rubocop/cop/style/trailing_method_end_statement_spec.rb
+++ b/spec/rubocop/cop/style/trailing_method_end_statement_spec.rb
@@ -121,17 +121,22 @@ RSpec.describe RuboCop::Cop::Style::TrailingMethodEndStatement do
     RUBY
   end
 
-  it 'auto-corrects trailing end for larger example' do
+  it 'auto-corrects all trailing ends for larger example' do
     corrected = autocorrect_source(<<~RUBY)
       class Foo
         def some_method
           []; end
+        def another_method
+          {}; end
       end
     RUBY
     expect(corrected).to eq(<<~RUBY)
       class Foo
         def some_method
           [] 
+        end
+        def another_method
+          {} 
         end
       end
     RUBY


### PR DESCRIPTION
I stumbled across this bug by accident while looking at how different cops navigate within tokens. And I thought: This cannot work …

The cop was using cached tokens from the first `def` when checking and autocorrecting the next ones.

For example none of the two offenses was discovered in
```
def bar
  0
end

def foo
  1; end

def foo
  2; end
```
because the right placement of `end` in the first `def` "leaked" into the following ones.