### PR TITLE
[Fix #7219] Support auto-correct for `Lint/ErbNewArguments`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#7219](https://github.com/rubocop-hq/rubocop/issues/7219): Support auto-correct for `Lint/ErbNewArguments`. ([@koic][])
+
 ### Bug fixes
 
 * [#7217](https://github.com/rubocop-hq/rubocop/pull/7217): Make `Style/TrailingMethodEndStatement` work on more than the first `def`. ([@buehmann][])

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -672,7 +672,7 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.56 | -
+Enabled | Yes | Yes  | 0.56 | -
 
 This cop emulates the following Ruby warnings in Ruby 2.6.
 

--- a/spec/rubocop/cop/lint/erb_new_arguments_spec.rb
+++ b/spec/rubocop/cop/lint/erb_new_arguments_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe RuboCop::Cop::Lint::ErbNewArguments, :config do
         ERB.new(str, nil)
                      ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
       RUBY
+
+      expect_correction(<<~RUBY)
+        ERB.new(str)
+      RUBY
     end
 
     it 'registers an offense when using `ERB.new` ' \
@@ -27,6 +31,10 @@ RSpec.describe RuboCop::Cop::Lint::ErbNewArguments, :config do
         ERB.new(str, nil, '-')
                           ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
                      ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ERB.new(str, trim_mode: '-')
       RUBY
     end
 
@@ -37,6 +45,10 @@ RSpec.describe RuboCop::Cop::Lint::ErbNewArguments, :config do
                                ^^^^^^^^^^^^^^^^ Passing eoutvar with the 4th argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, eoutvar: '@output_buffer')` instead.
                           ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
                      ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
       RUBY
     end
 
@@ -49,6 +61,10 @@ RSpec.describe RuboCop::Cop::Lint::ErbNewArguments, :config do
                           ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
                      ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
       RUBY
+
+      expect_correction(<<~RUBY)
+        ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
+      RUBY
     end
 
     it 'registers an offense when using `ERB.new` ' \
@@ -59,6 +75,10 @@ RSpec.describe RuboCop::Cop::Lint::ErbNewArguments, :config do
                           ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
                      ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
       RUBY
+
+      expect_correction(<<~RUBY)
+        ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
+      RUBY
     end
 
     it 'registers an offense when using `::ERB.new` ' \
@@ -68,6 +88,10 @@ RSpec.describe RuboCop::Cop::Lint::ErbNewArguments, :config do
                                  ^^^^^^^^^^^^^^^^ Passing eoutvar with the 4th argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, eoutvar: '@output_buffer')` instead.
                             ^^^ Passing trim_mode with the 3rd argument of `ERB.new` is deprecated. Use keyword argument like `ERB.new(str, trim_mode: '-')` instead.
                        ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ::ERB.new(str, trim_mode: '-', eoutvar: '@output_buffer')
       RUBY
     end
 


### PR DESCRIPTION
Fixes #7219.

This PR supports auto-correct for `Lint/ErbNewArguments`.

legacy `trim_mode` arg and legacy `eoutvar` arg take precedence over kwargs.
https://github.com/ruby/ruby/blob/v2_7_0_preview1/lib/erb.rb#L821-L828

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
