### PR TITLE
Fix autocorrection of UnneededSplatExpasion when Array.new with a block is assigned to a variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#7217](https://github.com/rubocop-hq/rubocop/pull/7217): Make `Style/TrailingMethodEndStatement` work on more than the first `def`. ([@buehmann][])
 * [#7190](https://github.com/rubocop-hq/rubocop/issues/7190): Support lower case drive letters on Windows. ([@jonas054][])
+* Fix the auto-correction of `Lint/UnneededSplatExpansion` when the splat expansion of `Array.new` with a block is assigned to a variable. ([@rrosenblum][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1662,6 +1662,7 @@ Lint/UnneededSplatExpansion:
   Description: 'Checks for splat unnecessarily being called on literals.'
   Enabled: true
   VersionAdded: '0.43'
+  VersionChanged: '0.74'
 
 Lint/UnreachableCode:
   Description: 'Unreachable code.'

--- a/lib/rubocop/cop/lint/unneeded_splat_expansion.rb
+++ b/lib/rubocop/cop/lint/unneeded_splat_expansion.rb
@@ -58,7 +58,12 @@ module RuboCop
         PERCENT_CAPITAL_I = '%I'
         ASSIGNMENT_TYPES = %i[lvasgn ivasgn cvasgn gvasgn].freeze
 
-        def_node_matcher :array_new?, '$(send (const nil? :Array) :new ...)'
+        def_node_matcher :array_new?, <<~PATTERN
+          {
+            $(send (const nil? :Array) :new ...)
+            $(block (send (const nil? :Array) :new ...) ...)
+          }
+        PATTERN
 
         def_node_matcher :literal_expansion, <<~PATTERN
           (splat {$({str dstr int float array} ...) (block $#array_new? ...) $#array_new?} ...)

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -2331,7 +2331,7 @@ require 'unloaded_feature'
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.43 | -
+Enabled | Yes | Yes  | 0.43 | 0.74
 
 This cop checks for unneeded usages of splat expansion
 


### PR DESCRIPTION
I was working on converting tests to use `expect_correction` and came across this bug in the auto-correction of `Lint/UnneededSplatExpansion` when `Array.new` with a block is assigned to a variable. 