### PR TITLE
Support lower case drive letters on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 * [#7217](https://github.com/rubocop-hq/rubocop/pull/7217): Make `Style/TrailingMethodEndStatement` work on more than the first `def`. ([@buehmann][])
+* [#7190](https://github.com/rubocop-hq/rubocop/issues/7190): Support lower case drive letters on Windows. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -51,7 +51,7 @@ module RuboCop
 
     # Returns true for an absolute Unix or Windows path.
     def absolute?(path)
-      path =~ %r{\A([A-Z]:)?/}
+      path =~ %r{\A([A-Z]:)?/}i
     end
 
     def self.pwd

--- a/spec/rubocop/path_util_spec.rb
+++ b/spec/rubocop/path_util_spec.rb
@@ -23,6 +23,28 @@ RSpec.describe RuboCop::PathUtil do
     end
   end
 
+  describe '#absolute?' do
+    it 'returns a truthy value for a path beginning with slash' do
+      expect(described_class.absolute?('/Users/foo')).to be_truthy
+    end
+
+    it 'returns a falsey value for a path beginning with a directory name' do
+      expect(described_class.absolute?('Users/foo')).to be_falsey
+    end
+
+    if RuboCop::Platform.windows?
+      it 'returns a truthy value for a path beginning with an upper case ' \
+         'drive letter' do
+        expect(described_class.absolute?('C:/Users/foo')).to be_truthy
+      end
+
+      it 'returns a truthy value for a path beginning with a lower case ' \
+         'drive letter' do
+        expect(described_class.absolute?('d:/Users/foo')).to be_truthy
+      end
+    end
+  end
+
   describe '#match_path?', :isolated_environment do
     include FileHelper
 


### PR DESCRIPTION
The combination of running a Git Bash terminal in Visual Studio Code has turned out to produce current directories that start with a lower case drive letter when RuboCop reads it. For example, `c:/Users/me/project`.

This is not good since it will mess up the conversion of Exclude paths to absolute paths. We need to recognize the above path as already being absolute.