### PR TITLE
[Fix #5628] Rewrite SpaceInsideStringInterpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#7217](https://github.com/rubocop-hq/rubocop/pull/7217): Make `Style/TrailingMethodEndStatement` work on more than the first `def`. ([@buehmann][])
 * [#7190](https://github.com/rubocop-hq/rubocop/issues/7190): Support lower case drive letters on Windows. ([@jonas054][])
+* [#5628](https://github.com/rubocop-hq/rubocop/issues/5628): Fix an error of `Layout/SpaceInsideStringInterpolation` on interpolations with multiple statements. ([@buehmann][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/surrounding_space.rb
+++ b/lib/rubocop/cop/mixin/surrounding_space.rb
@@ -20,11 +20,11 @@ module RuboCop
         begin_pos = range.begin_pos
         end_pos = range.end_pos
         if side == :left
+          end_pos = begin_pos
           begin_pos = reposition(src, begin_pos, -1)
-          end_pos -= 1
         end
         if side == :right
-          begin_pos += 1
+          begin_pos = end_pos
           end_pos = reposition(src, end_pos, 1)
         end
         Parser::Source::Range.new(buffer, begin_pos, end_pos)

--- a/lib/rubocop/cop/mixin/surrounding_space.rb
+++ b/lib/rubocop/cop/mixin/surrounding_space.rb
@@ -9,6 +9,8 @@ module RuboCop
       NO_SPACE_COMMAND = 'Do not use'
       SPACE_COMMAND = 'Use'
 
+      SINGLE_SPACE_REGEXP = /[ \t]/.freeze
+
       private
 
       def side_space_range(range:, side:)
@@ -85,15 +87,15 @@ module RuboCop
         return false unless token
 
         if side == :left
-          String(token.space_after?) == ' '
+          String(token.space_after?) =~ SINGLE_SPACE_REGEXP
         else
-          String(token.space_before?) == ' '
+          String(token.space_before?) =~ SINGLE_SPACE_REGEXP
         end
       end
 
       def reposition(src, pos, step)
         offset = step == -1 ? -1 : 0
-        pos += step while src[pos + offset] =~ /[ \t]/
+        pos += step while src[pos + offset] =~ SINGLE_SPACE_REGEXP
         pos.negative? ? 0 : pos
       end
 


### PR DESCRIPTION
This fixes #5628 by rewriting `Layout/SpaceInsideStringInterpolation` in terms of the infrastructure used by similar `SpaceInside*` cops: `SurroundingSpace` and `SpaceCorrector`.

In order to to that I had to lift some limitations of  `SurroundingSpace`:
* Previously it assumed that each delimiter token was exactly 1 char wide. It can now handle wider tokens such as `#{`.
* Previously it scanned across tab characters when detecting surrounding space, but did not include them in the range to be removed. This mismatch is gone.

In style `space` there was an overlap in functionality with cop `ExtraSpace`: `Layout/SpaceInsideStringInterpolation` no longer removes excess whitespace and leaves that to `ExtraSpace`. That's why the specs needed to change.

Because of that slight change in functionality I was wondering whether to include this into the "bug fixes" or "changes" section in the change log. For now I just classified this as a bug fix.
