### PR TITLE
[Fix #7128] Make `Metrics/LineLength` aware of shebang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#7217](https://github.com/rubocop-hq/rubocop/pull/7217): Make `Style/TrailingMethodEndStatement` work on more than the first `def`. ([@buehmann][])
 * [#7190](https://github.com/rubocop-hq/rubocop/issues/7190): Support lower case drive letters on Windows. ([@jonas054][])
 * [#5628](https://github.com/rubocop-hq/rubocop/issues/5628): Fix an error of `Layout/SpaceInsideStringInterpolation` on interpolations with multiple statements. ([@buehmann][])
+* [#7128](https://github.com/rubocop-hq/rubocop/issues/7128): Make `Metrics/LineLength` aware of shebang. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/metrics/line_length.rb
+++ b/lib/rubocop/cop/metrics/line_length.rb
@@ -138,7 +138,12 @@ module RuboCop
 
         def ignored_line?(line, line_index)
           matches_ignored_pattern?(line) ||
+            shebang?(line, line_index) ||
             heredocs && line_in_permitted_heredoc?(line_index.succ)
+        end
+
+        def shebang?(line, line_index)
+          line_index.zero? && line.start_with?('#!')
         end
 
         def register_offense(loc, line, line_index)

--- a/spec/rubocop/cop/metrics/line_length_spec.rb
+++ b/spec/rubocop/cop/metrics/line_length_spec.rb
@@ -21,6 +21,14 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
     expect_no_offenses('#' * 80)
   end
 
+  it 'accepts the first line if it is a shebang line' do
+    expect_no_offenses(<<~RUBY)
+      #!/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/bin/ruby --disable-gems
+
+      do_something
+    RUBY
+  end
+
   it 'registers an offense for long line before __END__ but not after' do
     inspect_source(['#' * 150,
                     '__END__',


### PR DESCRIPTION
Fixes #7128.

This PR makes `Metrics/LineLength` aware of shebang.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
