### PR TITLE
Use bundle in bin/console

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'bundler/setup'
 require 'pry'
 require 'rubocop'
 


### PR DESCRIPTION
I've fallen for the following once too often: I launched `bin/console` during development and wondered sooner or later why my changes are not visible … because the released gem of `rubocop` was used.

One way of fixing this is to remember to call `bundle exec bin/console` all the time (and update the [manual](
https://github.com/rubocop-hq/rubocop/blob/faf8d7e16b31b50b160c2b9ba75f4b8776c5141e/manual/development.md#inspecting-the-ast-representation)).

The other one is to set up the bundle directly in `bin/console`; this matches what `bundle gem` generates in its templates for new gems.
