### PR TITLE
Guard clause clarification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Changes
 
 * [#5265](https://github.com/rubocop-hq/rubocop/issues/5265): Improved `Layout/ExtraSpacing` cop to handle nested consecutive assignments. ([@jfelchner][])
+* [#7215](https://github.com/rubocop-hq/rubocop/issues/7215): Make it clear what's wrong in the message from `Style/GuardClause`. ([@jonas054][])
 
 ## 0.73.0 (2019-07-16)
 

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -480,7 +480,7 @@ module RuboCop
       end
 
       def_node_matcher :guard_clause?, <<~PATTERN
-        [{(send nil? {:raise :fail} ...) return break next} single_line?]
+        [${(send nil? {:raise :fail} ...) return break next} single_line?]
       PATTERN
 
       def_node_matcher :proc?, <<~PATTERN

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -933,8 +933,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             'def badName',
             '    ^^^^^^^',
             'example3.rb:2:3: C: Style/GuardClause: ' \
-            'Use a guard clause instead of wrapping the code inside a ' \
-            'conditional expression.',
+            'Use a guard clause (return unless something) instead of ' \
+            'wrapping the code inside a conditional expression.',
             '  if something',
             '  ^^',
             'example3.rb:2:3: C: Style/IfUnlessModifier: ' \

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -1,7 +1,17 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
+RSpec.describe RuboCop::Cop::Style::GuardClause do
   let(:cop) { described_class.new(config) }
+  let(:config) do
+    RuboCop::Config.new(
+      'Metrics/LineLength' => {
+        'Enabled' => line_length_enabled,
+        'Max' => 80
+      },
+      'Style/GuardClause' => cop_config
+    )
+  end
+  let(:line_length_enabled) { true }
   let(:cop_config) { {} }
 
   shared_examples 'reports offense' do |body|
@@ -271,6 +281,35 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
         else
           puts "hello" \\
                "blah blah blah"
+        end
+      RUBY
+    end
+  end
+
+  context 'with Metrics/MaxLineLength enabled' do
+    it 'registers an offense with non-modifier example code if too long for ' \
+       'single line' do
+      expect_offense(<<~RUBY)
+        def test
+          if something && something_that_makes_the_guard_clause_too_long_to_fit_on_one_line
+          ^^ Use a guard clause (`unless something && something_that_makes_the_guard_clause_too_long_to_fit_on_one_line; return; end`) instead of wrapping the code inside a conditional expression.
+            work
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'with Metrics/MaxLineLength disabled' do
+    let(:line_length_enabled) { false }
+
+    it 'registers an offense with modifier example code regardless of length' do
+      expect_offense(<<~RUBY)
+        def test
+          if something && something_that_makes_the_guard_clause_too_long_to_fit_on_one_line
+          ^^ Use a guard clause (`return unless something && something_that_makes_the_guard_clause_too_long_to_fit_on_one_line`) instead of wrapping the code inside a conditional expression.
+            work
+          end
         end
       RUBY
     end

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
       expect_offense(<<~RUBY)
         def func
           if something
-          ^^ Use a guard clause instead of wrapping the code inside a conditional expression.
+          ^^ Use a guard clause (`return unless something`) instead of wrapping the code inside a conditional expression.
             #{body}
           end
         end
 
         def func
           unless something
-          ^^^^^^ Use a guard clause instead of wrapping the code inside a conditional expression.
+          ^^^^^^ Use a guard clause (`return if something`) instead of wrapping the code inside a conditional expression.
             #{body}
           end
         end
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
         def func
           test
           if something
-          ^^ Use a guard clause instead of wrapping the code inside a conditional expression.
+          ^^ Use a guard clause (`return unless something`) instead of wrapping the code inside a conditional expression.
             #{body}
           end
         end
@@ -36,7 +36,7 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
         def func
           test
           unless something
-          ^^^^^^ Use a guard clause instead of wrapping the code inside a conditional expression.
+          ^^^^^^ Use a guard clause (`return if something`) instead of wrapping the code inside a conditional expression.
             #{body}
           end
         end
@@ -136,14 +136,14 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
       expect_offense(<<~RUBY)
         def func
           if something
-          ^^ Use a guard clause instead of wrapping the code inside a conditional expression.
+          ^^ Use a guard clause (`return unless something`) instead of wrapping the code inside a conditional expression.
             work
           end
         end
 
         def func
           unless something
-          ^^^^^^ Use a guard clause instead of wrapping the code inside a conditional expression.
+          ^^^^^^ Use a guard clause (`return if something`) instead of wrapping the code inside a conditional expression.
             work
           end
         end
@@ -200,7 +200,7 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
     it "registers an error with #{kw} in the if branch" do
       expect_offense(<<~RUBY)
         if something
-        ^^ Use a guard clause instead of wrapping the code inside a conditional expression.
+        ^^ Use a guard clause (`#{kw} if something`) instead of wrapping the code inside a conditional expression.
           #{kw}
         else
           puts "hello"
@@ -211,7 +211,7 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
     it "registers an error with #{kw} in the else branch" do
       expect_offense(<<~RUBY)
         if something
-        ^^ Use a guard clause instead of wrapping the code inside a conditional expression.
+        ^^ Use a guard clause (`#{kw} unless something`) instead of wrapping the code inside a conditional expression.
          puts "hello"
         else
           #{kw}
@@ -266,7 +266,7 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
     it 'registers an error if non-control-flow branch has multiple lines' do
       expect_offense(<<~RUBY)
         if something
-        ^^ Use a guard clause instead of wrapping the code inside a conditional expression.
+        ^^ Use a guard clause (`#{kw} if something`) instead of wrapping the code inside a conditional expression.
           #{kw}
         else
           puts "hello" \\
@@ -287,7 +287,7 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
         module CopTest
           def test
             if something
-            ^^ Use a guard clause instead of wrapping the code inside a conditional expression.
+            ^^ Use a guard clause (`return unless something`) instead of wrapping the code inside a conditional expression.
               work
             end
           end
@@ -299,8 +299,8 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
       expect_offense(<<~RUBY)
         module CopTest
           def self.test
-            if something
-            ^^ Use a guard clause instead of wrapping the code inside a conditional expression.
+            if something && something_else
+            ^^ Use a guard clause (`return unless something && something_else`) instead of wrapping the code inside a conditional expression.
               work
             end
           end


### PR DESCRIPTION
For ages people have misunderstood the message from `Style/GuardClause`, confusing guard clauses with modifier forms of `if`/`unless`. This change adds some code to the message, making it clear what the cop wants.