### PR TITLE
[Fix #7235] Tell `elsif` from nested `if` in ConditionalAssignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#5628](https://github.com/rubocop-hq/rubocop/issues/5628): Fix an error of `Layout/SpaceInsideStringInterpolation` on interpolations with multiple statements. ([@buehmann][])
 * [#7128](https://github.com/rubocop-hq/rubocop/issues/7128): Make `Metrics/LineLength` aware of shebang. ([@koic][])
 * [#6861](https://github.com/rubocop-hq/rubocop/issues/6861): Fix a false positive for `Layout/IndentationWidth` when using `EnforcedStyle: outdent` of `Layout/AccessModifierIndentation`. ([@koic][])
+* [#7235](https://github.com/rubocop-hq/rubocop/issues/7235): Fix an error where `Style/ConditionalAssignment` would swallow a nested `if` condition. ([@buehmann][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -68,7 +68,7 @@ module RuboCop
         private
 
         def expand_elsif(node, elsif_branches = [])
-          return [] if node.nil? || !node.if_type?
+          return [] if node.nil? || !node.if_type? || !node.elsif?
 
           elsif_branches << node.if_branch
 


### PR DESCRIPTION
This closes #7235. 

`Style/ConditionalAssignment` was mistaking a nested `if` for an `elsif`,
which broke autocorrection completely and swallowed some of the nested
code.