### PR TITLE
Remove unused node matchers

### DIFF
--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -56,8 +56,6 @@ module RuboCop
           (send (send {#kernel? nil?} :binding) :irb ...)
         PATTERN
 
-        def_node_matcher :pry_rescue?, '(send (const nil? :Pry) :rescue ...)'
-
         def on_send(node)
           return unless debugger_call?(node) || binding_irb?(node)
 

--- a/lib/rubocop/cop/mixin/documentation_comment.rb
+++ b/lib/rubocop/cop/mixin/documentation_comment.rb
@@ -9,8 +9,6 @@ module RuboCop
 
       private
 
-      def_node_matcher :constant_definition?, '{class module casgn}'
-
       def documentation_comment?(node)
         preceding_lines = preceding_lines(node)
 

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -219,8 +219,6 @@ module RuboCop
         SINGLE_LINE_CONDITIONS_ONLY = 'SingleLineConditionsOnly'
         WIDTH = 'Width'
 
-        def_node_matcher :condition?, '{if case}'
-
         # The shovel operator `<<` does not have its own type. It is a `send`
         # type.
         def_node_matcher :assignment_type?, <<~PATTERN

--- a/lib/rubocop/cop/style/lambda.rb
+++ b/lib/rubocop/cop/style/lambda.rb
@@ -62,8 +62,6 @@ module RuboCop
           }
         }.freeze
 
-        def_node_matcher :lambda_node?, '(block $(send nil? :lambda) ...)'
-
         def on_block(node)
           return unless node.lambda?
 


### PR DESCRIPTION
Speaking of deleting code, here are some node matchers that are not used at all.