### PR TITLE
Remove unused node matchers in Node

### DIFF
--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -306,8 +306,6 @@ module RuboCop
         {(send $_ ...) (block (send $_ ...) ...)}
       PATTERN
 
-      # Note: for masgn, #asgn_rhs will be an array node
-      def_node_matcher :asgn_rhs, '[assignment? (... $_)]'
       def_node_matcher :str_content, '(str $_)'
 
       def const_name
@@ -495,10 +493,6 @@ module RuboCop
       def_node_matcher :class_constructor?, <<~PATTERN
         {       (send (const nil? {:Class :Module}) :new ...)
          (block (send (const nil? {:Class :Module}) :new ...) ...)}
-      PATTERN
-
-      def_node_matcher :module_definition?, <<~PATTERN
-        {class module (casgn _ _ class_constructor?)}
       PATTERN
 
       # Some expressions are evaluated for their value, some for their side


### PR DESCRIPTION
Two more node matchers that are not used in any of the 3 "official" extensions:
```
$ for r in rubocop{,-performance,-rspec,-rails}; do echo "==== $r" ; git -C $r grep -P 'asgn_rhs|module_definition\?' origin/master; done
==== rubocop
origin/master:lib/rubocop/ast/node.rb:      # Note: for masgn, #asgn_rhs will be an array node
origin/master:lib/rubocop/ast/node.rb:      def_node_matcher :asgn_rhs, '[assignment? (... $_)]'
origin/master:lib/rubocop/ast/node.rb:      def_node_matcher :module_definition?, <<~PATTERN
origin/master:lib/rubocop/cop/metrics/module_length.rb:          module_definition?(node) do
origin/master:lib/rubocop/cop/metrics/module_length.rb:        def_node_matcher :module_definition?, <<~PATTERN
==== rubocop-performance
==== rubocop-rspec
==== rubocop-rails
```
See https://github.com/rubocop-hq/rubocop/pull/7239#issuecomment-515892563