### PR TITLE
[Fix #7236] Prevent bad auto-correction from Style/InverseMethods and Style/SymbolProc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * [#6861](https://github.com/rubocop-hq/rubocop/issues/6861): Fix a false positive for `Layout/IndentationWidth` when using `EnforcedStyle: outdent` of `Layout/AccessModifierIndentation`. ([@koic][])
 * [#7235](https://github.com/rubocop-hq/rubocop/issues/7235): Fix an error where `Style/ConditionalAssignment` would swallow a nested `if` condition. ([@buehmann][])
 * [#7242](https://github.com/rubocop-hq/rubocop/issues/7242): Make `Style/ConstantVisibility` work on non-trivial class and module bodies. ([@buehmann][])
+* [#7236](https://github.com/rubocop-hq/rubocop/pull/7236): Mark `Style/InverseMethods` auto-correct as incompatible with `Style/SymbolProc`. ([@drenmi][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -44,7 +44,7 @@ module RuboCop
         CAMEL_CASE = /[A-Z]+[a-z]+/.freeze
 
         def self.autocorrect_incompatible_with
-          [Style::Not]
+          [Style::Not, Style::SymbolProc]
         end
 
         def_node_matcher :inverse_candidate?, <<~PATTERN


### PR DESCRIPTION
These two cops had an interaction between their auto-corrections which produced code that wasn't semantically equivalent to the original. Example:

```ruby
[].reject { |x| !x }
```

was being corrected to:

```ruby
[].select(&:!)
```

This change fixes that by marking `Style/InverseMethods` auto-correct as incompatible with that of `Style/SymbolProc`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
