### PR TITLE
[Fix #7242] Make Style/ConstantVisibility work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#7128](https://github.com/rubocop-hq/rubocop/issues/7128): Make `Metrics/LineLength` aware of shebang. ([@koic][])
 * [#6861](https://github.com/rubocop-hq/rubocop/issues/6861): Fix a false positive for `Layout/IndentationWidth` when using `EnforcedStyle: outdent` of `Layout/AccessModifierIndentation`. ([@koic][])
 * [#7235](https://github.com/rubocop-hq/rubocop/issues/7235): Fix an error where `Style/ConditionalAssignment` would swallow a nested `if` condition. ([@buehmann][])
+* [#7242](https://github.com/rubocop-hq/rubocop/issues/7242): Make `Style/ConstantVisibility` work on non-trivial class and module bodies. ([@buehmann][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/constant_visibility.rb
+++ b/lib/rubocop/cop/style/constant_visibility.rb
@@ -46,7 +46,14 @@ module RuboCop
         end
 
         def class_or_module_scope?(node)
-          node.parent && %i[class module].include?(node.parent.type)
+          return false unless node.parent
+
+          case node.parent.type
+          when :begin
+            class_or_module_scope?(node.parent)
+          when :class, :module
+            true
+          end
         end
 
         def visibility_declaration?(node)
@@ -58,8 +65,12 @@ module RuboCop
         end
 
         def_node_matcher :visibility_declaration_for?, <<~PATTERN
-          (send nil? {:public_constant :private_constant} ({sym str} %1))
+          (send nil? {:public_constant :private_constant} ({sym str} #match_name?(%1)))
         PATTERN
+
+        def match_name?(name, constant_name)
+          name.to_sym == constant_name.to_sym
+        end
       end
     end
   end

--- a/spec/rubocop/cop/style/constant_visibility_spec.rb
+++ b/spec/rubocop/cop/style/constant_visibility_spec.rb
@@ -6,22 +6,48 @@ RSpec.describe RuboCop::Cop::Style::ConstantVisibility do
   let(:config) { RuboCop::Config.new }
 
   context 'when defining a constant in a class' do
-    it 'registers an offense when not using a visibility declaration' do
-      expect_offense(<<~RUBY)
-        class Foo
-          BAR = 42
-          ^^^^^^^^ Explicitly make `BAR` public or private using either `#public_constant` or `#private_constant`.
-        end
-      RUBY
+    context 'with a single-statement body' do
+      it 'registers an offense when not using a visibility declaration' do
+        expect_offense(<<~RUBY)
+          class Foo
+            BAR = 42
+            ^^^^^^^^ Explicitly make `BAR` public or private using either `#public_constant` or `#private_constant`.
+          end
+        RUBY
+      end
     end
 
-    it 'does not register an offense when using a visibility declaration' do
-      expect_no_offenses(<<~RUBY)
-        class Foo
-          BAR = 42
-          private_constant :BAR
-        end
-      RUBY
+    context 'with a multi-statement body' do
+      it 'registers an offense when not using a visibility declaration' do
+        expect_offense(<<~RUBY)
+          class Foo
+            include Bar
+            BAR = 42
+            ^^^^^^^^ Explicitly make `BAR` public or private using either `#public_constant` or `#private_constant`.
+          end
+        RUBY
+      end
+
+      it 'registers an offense when there is ' \
+         'no matching visibility declaration' do
+        expect_offense(<<~RUBY)
+          class Foo
+            include Bar
+            BAR = 42
+            ^^^^^^^^ Explicitly make `BAR` public or private using either `#public_constant` or `#private_constant`.
+            private_constant :FOO
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when using a visibility declaration' do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            BAR = 42
+            private_constant :BAR
+          end
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
This closes #7242.

The cop was not able to deal with multi-statement bodies because it did
not know how to handle a `:begin` node inside a class or module body.
Fixing that revealed another pattern-matching bug that had been masked
before because the pattern was never actually used in the specs.