### PR TITLE
Deprecate the SafeMode module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * [#5265](https://github.com/rubocop-hq/rubocop/issues/5265): Improved `Layout/ExtraSpacing` cop to handle nested consecutive assignments. ([@jfelchner][])
 * [#7215](https://github.com/rubocop-hq/rubocop/issues/7215): Make it clear what's wrong in the message from `Style/GuardClause`. ([@jonas054][])
 * [#7245](https://github.com/rubocop-hq/rubocop/pull/7245): Make cops detect string interpolations in more contexts: inside of backticks, regular expressions, and symbols. ([@buehmann][])
+* Deprecate the `SafeMode` option. Users will need to upgrade `rubocop-performance` to 1.15.0+ before the `SafeMode` module is removed. ([@rrosenblum][])
 
 ## 0.73.0 (2019-07-16)
 

--- a/lib/rubocop/cop/mixin/safe_mode.rb
+++ b/lib/rubocop/cop/mixin/safe_mode.rb
@@ -4,6 +4,9 @@ module RuboCop
   module Cop
     # Common functionality for Rails safe mode.
     module SafeMode
+      warn 'The `SafeMode` option will be removed in `RuboCop` 0.76. ' \
+        'Please update `rubocop-performance` to 1.15.0 or higher.'
+
       private
 
       def rails_safe_mode?


### PR DESCRIPTION
Discussion in https://github.com/rubocop-hq/rubocop-performance/pull/72. It looks like `Performance/Count` and `Performance/Detect` were the only cops making use of the `SafeMode` feature. Rather than disabling the cops from running, we have flagged them as unsafe for auto-correction.

This will need to wait until the change is merged into RuboCop-Performance, and a new version of the gem is released.