### PR TITLE
CI against Ruby 2.6 on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,5 +19,5 @@ test_script:
 
 environment:
   matrix:
-    - ruby_version: '25'
-    - ruby_version: 25-x64
+    - ruby_version: '26'
+    - ruby_version: 26-x64


### PR DESCRIPTION
Ruby 2.6 has been released and this Ruby version is available on Appveyor.
https://www.appveyor.com/docs/windows-images-software/#ruby

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
