### PR TITLE
[Fix #7241] Make `Style/FrozenStringLiteralComment` match only true & false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#7262](https://github.com/rubocop-hq/rubocop/issues/7262): `Lint/FormatParameterMismatch` did not recognize named format sequences like `%.2<name>f` where the name appears after some modifiers. ([@buehmann][])
 * [#7253](https://github.com/rubocop-hq/rubocop/issues/7253): Fix an error for `Lint/NumberConversion` when `#to_i` called without a receiver. ([@koic][])
 * [#7271](https://github.com/rubocop-hq/rubocop/issues/7271), [#6498](https://github.com/rubocop-hq/rubocop/issues/6498): Fix an interference between `Style/TrailingCommaIn*Literal` and `Layout/Multiline*BraceLayout` for arrays and hashes. ([@buehmann][])
+* [#7241](https://github.com/rubocop-hq/rubocop/issues/7241): Make `Style/FrozenStringLiteralComment` match only true & false. ([@tejasbubane][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/frozen_string_literal.rb
+++ b/lib/rubocop/cop/mixin/frozen_string_literal.rb
@@ -12,7 +12,7 @@ module RuboCop
 
       def frozen_string_literal_comment_exists?
         leading_comment_lines.any? do |line|
-          MagicComment.parse(line).frozen_string_literal_specified?
+          MagicComment.parse(line).valid_literal_value?
         end
       end
 

--- a/lib/rubocop/magic_comment.rb
+++ b/lib/rubocop/magic_comment.rb
@@ -42,6 +42,10 @@ module RuboCop
       frozen_string_literal == true
     end
 
+    def valid_literal_value?
+      [true, false].include?(frozen_string_literal)
+    end
+
     # Was a magic comment for the frozen string literal found?
     #
     # @return [Boolean]

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
       RUBY
     end
 
+    it 'registers an offense for arbitrary tokens' do
+      expect_offense(<<~RUBY)
+        # frozen_string_literal: token
+        ^ Missing magic comment `# frozen_string_literal: true`.
+        puts 1
+      RUBY
+    end
+
     it 'registers an offense for not having a frozen string literal comment ' \
        'on the top line' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Closes #7241

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/