### PR TITLE
[Fix #7252] Ignore space in multi-line interpolations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#7256](https://github.com/rubocop-hq/rubocop/issues/7256): Fix an error of `Style/RedundantParentheses` on method calls where the first argument begins with a hash literal. ([@halfwhole][])
 * [#7263](https://github.com/rubocop-hq/rubocop/issues/7263): Make `Layout/SpaceInsideArrayLiteralBrackets` properly handle tab-indented arrays. ([@buehmann][])
+* [#7252](https://github.com/rubocop-hq/rubocop/issues/7252): Prevent infinite loops by making `Layout/SpaceInsideStringInterpolation` skip over interpolations that start or end with a line break. ([@buehmann][])
 
 ## 0.74.0 (2019-07-31)
 

--- a/lib/rubocop/cop/layout/space_inside_string_interpolation.rb
+++ b/lib/rubocop/cop/layout/space_inside_string_interpolation.rb
@@ -28,6 +28,8 @@ module RuboCop
         SPACE_MSG = 'Missing space inside string interpolation detected.'
 
         def on_interpolation(begin_node)
+          return if begin_node.multiline?
+
           delims = delimiters(begin_node)
           return if empty_brackets?(*delims)
 

--- a/spec/rubocop/cop/layout/space_inside_string_interpolation_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_string_interpolation_spec.rb
@@ -104,6 +104,26 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
     it 'accepts empty interpolation' do
       expect_no_offenses("\"\#{}\"")
     end
+
+    context 'when interpolation starts or ends with a line break' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-'RUBY'.strip_indent)
+          "#{
+            code
+          }"
+        RUBY
+      end
+
+      it 'ignores comments and whitespace when looking for line breaks' do
+        expect_no_offenses(<<-'RUBY'.strip_indent)
+          def foo
+            "#{ # comment
+              code
+            }"
+          end
+        RUBY
+      end
+    end
   end
 
   context 'when EnforcedStyle is space' do


### PR DESCRIPTION
This closes #7252 and resolves #5620.

This is a quick solution that completely ignores leading/trailing space inside multi-line `#{…}` interpolations for now. I might refine it later: While browsing the `SpaceInside*` cops I noticed that most of them perform some kind of multi-line detection but each in a slightly different way. There seems to be potential for unification there.
