### PR TITLE
[Fix #7256] Fix `Style/RedundantParentheses` for method calls beginning with hash literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#7256](https://github.com/rubocop-hq/rubocop/issues/7256): Fix an error of `Style/RedundantParentheses` on method calls where the first argument begins with a hash literal. ([@halfwhole][])
+
 ## 0.74.0 (2019-07-31)
 
 ### New features
@@ -4151,3 +4155,4 @@
 [@fwitzke]: https://github.com/fwitzke
 [@okuramasafumi]: https://github.com/okuramasafumi
 [@buehmann]: https://github.com/buehmann
+[@halfwhole]: https://github.com/halfwhole

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -221,9 +221,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses do
     expect_no_offenses('if x; y else (1)end')
   end
 
-  context 'when a hash literal is the first argument in a method call' do
+  context 'when the first argument in a method call begins with a hash '\
+          'literal' do
     it 'accepts parentheses if the argument list is not parenthesized ' do
       expect_no_offenses('x ({ y: 1 }), z')
+      expect_no_offenses('x ({ y: 1 }.merge({ y: 2 })), z')
+      expect_no_offenses('x ({ y: 1 }.merge({ y: 2 }).merge({ y: 3 })), z')
     end
 
     it 'registers an offense if the argument list is parenthesized ' do


### PR DESCRIPTION
`Style/RedundantParentheses` does not give an offense for method calls where the first argument is a hash literal, but it does so when the hash literal is called with methods. This fix allows for the detection of methods after the hash literal.

This closes https://github.com/rubocop-hq/rubocop/issues/7256.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
