### PR TITLE
Remove workaround for unary plus

### DIFF
--- a/lib/rubocop/cop/layout/extra_spacing.rb
+++ b/lib/rubocop/cop/layout/extra_spacing.rb
@@ -84,7 +84,6 @@ module RuboCop
           extra_space_range(token1, token2) do |range|
             # Unary + doesn't appear as a token and needs special handling.
             next if ignored_range?(ast, range.begin_pos)
-            next if unary_plus_non_offense?(range)
 
             add_offense(range, location: range, message: MSG_UNNECESSARY)
           end
@@ -112,10 +111,6 @@ module RuboCop
 
         def ignored_range?(ast, start_pos)
           ignored_ranges(ast).any? { |r| r.include?(start_pos) }
-        end
-
-        def unary_plus_non_offense?(range)
-          range.resize(range.size + 1).source =~ /^ ?\+$/
         end
 
         # Returns an array of ranges that should not be reported. It's the


### PR DESCRIPTION
Workaround was introduced in e1552c53ef1caa98b1b101045db851c23c6db9ba because back then there was no token for unary plus. Nowadays parser has `tUNARY_NUM` (since v2.4.0.1; also see whitequark/parser#384).

```
$ ruby-parse _2.4_ -E -e '+42'
+42
 ^~ tINTEGER 42                                 expr_end     [0 <= cond] [0 <= cmdarg]
+42
   ^ false "$eof"                               expr_end     [0 <= cond] [0 <= cmdarg]
(int 42)

$ ruby-parse _2.6_ -E -e '+42'
+42
^ tUNARY_NUM "+"                                expr_end     [0 <= cond] [0 <= cmdarg]
+42
 ^~ tINTEGER 42                                 expr_end     [0 <= cond] [0 <= cmdarg]
+42
   ^ false "$eof"                               expr_end     [0 <= cond] [0 <= cmdarg]
(int 42)
```