### PR TITLE
[Fix #7253] Fix an error for `Lint/NumberConversion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#7263](https://github.com/rubocop-hq/rubocop/issues/7263): Make `Layout/SpaceInsideArrayLiteralBrackets` properly handle tab-indented arrays. ([@buehmann][])
 * [#7252](https://github.com/rubocop-hq/rubocop/issues/7252): Prevent infinite loops by making `Layout/SpaceInsideStringInterpolation` skip over interpolations that start or end with a line break. ([@buehmann][])
 * [#7262](https://github.com/rubocop-hq/rubocop/issues/7262): `Lint/FormatParameterMismatch` did not recognize named format sequences like `%.2<name>f` where the name appears after some modifiers. ([@buehmann][])
+* [#7253](https://github.com/rubocop-hq/rubocop/issues/7253): Fix an error for `Lint/NumberConversion` when `#to_i` called without a receiver. ([@koic][])
 
 ## 0.74.0 (2019-07-31)
 

--- a/lib/rubocop/cop/lint/number_conversion.rb
+++ b/lib/rubocop/cop/lint/number_conversion.rb
@@ -41,7 +41,7 @@ module RuboCop
 
         def on_send(node)
           to_method(node) do |receiver, to_method|
-            next if date_time_object?(receiver)
+            next if receiver.nil? || date_time_object?(receiver)
 
             message = format(
               MSG,

--- a/spec/rubocop/cop/lint/number_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/number_conversion_spec.rb
@@ -149,5 +149,11 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion do
                 .to_i
       RUBY
     end
+
+    it 'when `#to_i` called without a receiver' do
+      expect_no_offenses(<<~RUBY)
+        to_i
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Fixes #7253.

This PR fixes an error for `Lint/NumberConversion` when `#to_i` called without a receiver.

```ruby
# example.rb
class Time
  def mod(modulus)
    to_i % modulus
  end
end
```

```console
% rubocop --only Lint/NumberConversion -d
For /Users/koic/src/github.com/koic/rubocop-issues/7253: configuration
from /Users/koic/src/github.com/koic/rubocop-issues/.rubocop.yml
configuration from
/Users/koic/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/rubocop-performance-1.4.1/config/default.yml
configuration from
/Users/koic/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/rubocop-performance-1.4.1/config/default.yml
Default configuration from
/Users/koic/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/rubocop-0.73.0/config/default.yml
configuration from
/Users/koic/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/rubocop-rails-2.1.0/config/default.yml
configuration from
/Users/koic/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/rubocop-rails-2.1.0/config/default.yml
Inspecting 1 file
Scanning /Users/koic/src/github.com/koic/rubocop-issues/7253/example.rb
An error occurred while Lint/NumberConversion cop was inspecting
/Users/koic/src/github.com/koic/rubocop-issues/7253/example.rb:3:4.
undefined method `source' for nil:NilClass
/Users/koic/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/rubocop-0.73.0/lib/rubocop/cop/lint/number_conversion.rb:48:in
`block in on_send'
```

This PR accepts `to_i` when called without a receiver.

As an alternative, I thought about auto-correcting to `Integer (self, 10)`. However, type of `self` depends on the context. For example, the following error occurs when `self` is a `Time` object:

```ruby
class Time
  def do_something
    Integer(self, 10)
  end
end

Time.new.do_something # ArgumentError (base specified for non string value)
```

This has the same meaning as:

```ruby
Integer(Time.new, 10) # ArgumentError (base specified for non string value)
```

So I decided to leave it as `#to_i` when a receiver wasn't called.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
