### PR TITLE
[Fix #7263] Support tab-indented array literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#7256](https://github.com/rubocop-hq/rubocop/issues/7256): Fix an error of `Style/RedundantParentheses` on method calls where the first argument begins with a hash literal. ([@halfwhole][])
+* [#7263](https://github.com/rubocop-hq/rubocop/issues/7263): Make `Layout/SpaceInsideArrayLiteralBrackets` properly handle tab-indented arrays. ([@buehmann][])
 
 ## 0.74.0 (2019-07-31)
 

--- a/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
@@ -132,7 +132,7 @@ module RuboCop
           line, col = line_and_column_for(token)
           return true if col == -1
 
-          processed_source.lines[line][0..col].delete(' ').empty?
+          processed_source.lines[line][0..col] !~ /\S/
         end
 
         def index_for(node, token)

--- a/spec/rubocop/cop/layout/space_inside_array_literal_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_array_literal_brackets_spec.rb
@@ -134,6 +134,16 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       RUBY
     end
 
+    it 'does not register offense when bottom bracket gets its ' \
+       'own line indented with tabs' do
+      expect_no_offenses(<<~RUBY)
+        a =
+        \t[
+        \t1, 2, nil
+        \t].compact
+      RUBY
+    end
+
     it 'does not register offense for valid multiline array' do
       expect_no_offenses(<<~RUBY)
         ['Encoding:',


### PR DESCRIPTION
Before 6840af5cda4cce4bf7bf32e9bf477a6a6eea0b51 it did not matter that `Layout/SpaceInsideArrayLiteralBrackets` did not know tabs could occur in indentation. Now it does.

This closes #7263.