### PR TITLE
 [Fix #7262] Detect more named format sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#7256](https://github.com/rubocop-hq/rubocop/issues/7256): Fix an error of `Style/RedundantParentheses` on method calls where the first argument begins with a hash literal. ([@halfwhole][])
 * [#7263](https://github.com/rubocop-hq/rubocop/issues/7263): Make `Layout/SpaceInsideArrayLiteralBrackets` properly handle tab-indented arrays. ([@buehmann][])
 * [#7252](https://github.com/rubocop-hq/rubocop/issues/7252): Prevent infinite loops by making `Layout/SpaceInsideStringInterpolation` skip over interpolations that start or end with a line break. ([@buehmann][])
+* [#7262](https://github.com/rubocop-hq/rubocop/issues/7262): `Lint/FormatParameterMismatch` did not recognize named format sequences like `%.2<name>f` where the name appears after some modifiers. ([@buehmann][])
 
 ## 0.74.0 (2019-07-31)
 

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -41,7 +41,6 @@ module RuboCop
         # @see https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-format
         FIELD_REGEX =
           /(%(?:(#{FLAG}*)#{WIDTH}?#{PRECISION}?#{TYPE}|%))/.freeze
-        NAMED_FIELD_REGEX = /%\{[_a-zA-Z][_a-zA-Z]+\}/.freeze
 
         NAME = /(?:<\w+>|\{\w+\})/.freeze
 
@@ -51,7 +50,6 @@ module RuboCop
 
         KERNEL = 'Kernel'
         SHOVEL = '<<'
-        PERCENT = '%'
         PERCENT_PERCENT = '%%'
         DIGIT_DOLLAR_FLAG = /%(\d+)\$/.freeze
         STRING_TYPES = %i[str dstr].freeze
@@ -67,7 +65,7 @@ module RuboCop
         def offending_node?(node)
           return false unless called_on_string?(node)
           return false unless method_with_format_args?(node)
-          return false if named_mode?(node) || splat_args?(node)
+          return false if splat_args?(node)
 
           num_of_format_args, num_of_expected_fields = count_matches(node)
 
@@ -91,16 +89,6 @@ module RuboCop
 
         def method_with_format_args?(node)
           sprintf?(node) || format?(node) || percent?(node)
-        end
-
-        def named_mode?(node)
-          relevant_node = if sprintf?(node) || format?(node)
-                            node.first_argument
-                          elsif percent?(node)
-                            node.receiver
-                          end
-
-          !relevant_node.source.scan(NAMED_FIELD_REGEX).empty?
         end
 
         def splat_args?(node)

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -341,4 +341,23 @@ RSpec.describe RuboCop::Cop::Lint::FormatParameterMismatch do
     expect('%+-d'.scan(described_class::FIELD_REGEX).size) # multiple flags
       .to eq(1)
   end
+
+  shared_examples 'named format sequence' do |format_string|
+    it 'detects named format sequence' do
+      expect(described_class::NAMED_INTERPOLATION).to match(format_string)
+    end
+
+    it 'does not detect escaped named format sequence' do
+      escaped = format_string.gsub(/%/, '%%')
+      regexp = described_class::NAMED_INTERPOLATION
+
+      expect(regexp).not_to match(escaped)
+      expect(regexp).not_to match('prefix:' + escaped)
+    end
+  end
+
+  it_behaves_like 'named format sequence', '%<greeting>2s'
+  it_behaves_like 'named format sequence', '%2<greeting>s'
+  it_behaves_like 'named format sequence', '%+0<num>8.2f'
+  it_behaves_like 'named format sequence', '%+08<num>.2f'
 end


### PR DESCRIPTION
This fixes #7262 and removes some obsolete code.
