### PR TITLE
[Fix #7029] Make `Style/Attr` not flag offense for custom `attr` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#7231](https://github.com/rubocop-hq/rubocop/issues/7231): Fix the exit code to be `2` rather when `0` when the config file contains an unknown cop. ([@jethroo][])
 * [#7513](https://github.com/rubocop-hq/rubocop/issues/7513): Fix abrupt error on autocorrecting with `--disable-uncorrectable`. ([@tejasbubane][])
 * [#7537](https://github.com/rubocop-hq/rubocop/issues/7537): Fix a false positive for `Layout/SpaceAroundOperators` when using a Rational literal with `/` (e.g. `2/3r`). ([@koic][])
+* [#7029](https://github.com/rubocop-hq/rubocop/issues/7029): Make `Style/Attr` not flag offense for custom `attr` method. ([@tejasbubane][])
 
 ## 0.77.0 (2019-11-27)
 

--- a/lib/rubocop/cop/style/attr.rb
+++ b/lib/rubocop/cop/style/attr.rb
@@ -21,6 +21,10 @@ module RuboCop
 
         def on_send(node)
           return unless node.command?(:attr) && node.arguments?
+          # check only for method definitions in class/module body
+          return if node.parent &&
+                    !node.parent.class_type? &&
+                    !class_eval?(node.parent)
 
           add_offense(node, location: :selector)
         end
@@ -56,6 +60,10 @@ module RuboCop
             'attr_reader'
           end
         end
+
+        def_node_matcher :class_eval?, <<~PATTERN
+          (block (send _ {:class_eval :module_eval}) ...)
+        PATTERN
       end
     end
   end

--- a/spec/rubocop/cop/style/attr_spec.rb
+++ b/spec/rubocop/cop/style/attr_spec.rb
@@ -12,12 +12,44 @@ RSpec.describe RuboCop::Cop::Style::Attr do
     RUBY
   end
 
+  it 'registers offense for attr within class_eval' do
+    expect_offense(<<~RUBY)
+      SomeClass.class_eval do
+        attr :name
+        ^^^^ Do not use `attr`. Use `attr_reader` instead.
+      end
+    RUBY
+  end
+
+  it 'registers offense for attr within module_eval' do
+    expect_offense(<<~RUBY)
+      SomeClass.module_eval do
+        attr :name
+        ^^^^ Do not use `attr`. Use `attr_reader` instead.
+      end
+    RUBY
+  end
+
   it 'accepts attr when it does not take arguments' do
     expect_no_offenses('func(attr)')
   end
 
   it 'accepts attr when it has a receiver' do
     expect_no_offenses('x.attr arg')
+  end
+
+  it 'does not register offense for custom `attr` method' do
+    expect_no_offenses(<<~RUBY)
+      class SomeClass
+        def attr(*args)
+          p args
+        end
+
+        def a
+          attr(1)
+        end
+      end
+    RUBY
   end
 
   context 'auto-corrects' do


### PR DESCRIPTION
Closes #7029 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
