### PR TITLE
Show warning message if passed string to 'Enabled' key in .rubocop.yml

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -17,7 +17,7 @@ Metrics/AbcSize:
 # Offense count: 47
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 174
+  Max: 182
 
 # Offense count: 219
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#7274](https://github.com/rubocop-hq/rubocop/issues/7274): Add new `Lint/SendWithMixinArgument` cop. ([@koic][])
+* [#7272](https://github.com/rubocop-hq/rubocop/pull/7272): Show warning message if passed string to `Enabled`, `Safe`, `SafeAutocorrect`, and `AutoCorrect` keys in .rubocop.yml. ([@unasuke][])
 
 ### Bug fixes
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -199,6 +199,8 @@ module RuboCop
           raise(TypeError, "Malformed configuration in #{absolute_path}")
         end
 
+        check_cop_config_value(hash)
+
         hash
       end
 
@@ -217,6 +219,22 @@ module RuboCop
                         "`#{value}` is concealed by duplicate"
                     end
           warn Rainbow(message).yellow
+        end
+      end
+
+      def check_cop_config_value(hash, parent = nil)
+        hash.each do |key, value|
+          check_cop_config_value(value, key) if value.is_a?(Hash)
+
+          next unless %w[Enabled
+                         Safe
+                         SafeAutoCorrect
+                         AutoCorrect].include?(key) && value.is_a?(String)
+
+          abort(
+            "Property #{Rainbow(key).yellow} of cop #{Rainbow(parent).yellow}" \
+            " is supposed to be a boolean and #{Rainbow(value).yellow} is not."
+          )
         end
       end
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -992,6 +992,24 @@ RSpec.describe RuboCop::ConfigLoader do
       end
     end
 
+    context 'set neither true nor false to value to Enabled' do
+      before do
+        create_file(configuration_path, <<~YAML)
+          Layout/AlignArray:
+            Enabled: disable
+        YAML
+      end
+
+      it 'gets a warning message' do
+        expect do
+          load_file
+        end.to raise_error(
+          SystemExit,
+          /supposed to be a boolean and disable is not/
+        )
+      end
+    end
+
     context 'when the file does not exist' do
       let(:configuration_path) { 'file_that_does_not_exist.yml' }
 


### PR DESCRIPTION
## feature
It causes unexpected cop warnings because treats as truthy value if passed neither true nor false in 'Enabled' key's value like "Enabled: disable".  

![](https://user-images.githubusercontent.com/4487291/62822043-06dcfa80-bbb9-11e9-81b1-ce52257e8388.png)

## motivation
Our team occurred a problem that, unexpected  cop was in effect.
The cause was the wrong config value like an "Enabled: disabled".

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
