### PR TITLE
[Fix #7275] Fix a false negative for `Style/VariableName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * [#7252](https://github.com/rubocop-hq/rubocop/issues/7252): Prevent infinite loops by making `Layout/SpaceInsideStringInterpolation` skip over interpolations that start or end with a line break. ([@buehmann][])
 * [#7262](https://github.com/rubocop-hq/rubocop/issues/7262): `Lint/FormatParameterMismatch` did not recognize named format sequences like `%.2<name>f` where the name appears after some modifiers. ([@buehmann][])
 
+### Changes
+
+* [#7275](https://github.com/rubocop-hq/rubocop/issues/7275): Make `Style/VariableName` aware argument names when invoking a method. ([@koic][])
+
 ## 0.74.0 (2019-07-31)
 
 ### New features

--- a/lib/rubocop/cop/naming/variable_name.rb
+++ b/lib/rubocop/cop/naming/variable_name.rb
@@ -39,6 +39,7 @@ module RuboCop
         alias on_kwarg     on_lvasgn
         alias on_kwrestarg on_lvasgn
         alias on_blockarg  on_lvasgn
+        alias on_lvar      on_lvasgn
 
         private
 

--- a/spec/rubocop/cop/naming/variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/variable_name_spec.rb
@@ -102,6 +102,19 @@ RSpec.describe RuboCop::Cop::Naming::VariableName, :config do
       RUBY
     end
 
+    it 'registers an offense for camel case when invoking method args' do
+      expect_offense(<<~RUBY)
+        firstArg = 'foo'
+        ^^^^^^^^ Use snake_case for variable names.
+        secondArg = 'foo'
+        ^^^^^^^^^ Use snake_case for variable names.
+
+        do_something(firstArg, secondArg)
+                     ^^^^^^^^ Use snake_case for variable names.
+                               ^^^^^^^^^ Use snake_case for variable names.
+      RUBY
+    end
+
     include_examples 'always accepted'
   end
 
@@ -178,6 +191,19 @@ RSpec.describe RuboCop::Cop::Naming::VariableName, :config do
       expect_offense(<<~RUBY)
         def foo(&block_arg); end
                  ^^^^^^^^^ Use camelCase for variable names.
+      RUBY
+    end
+
+    it 'registers an offense for camel case when invoking method args' do
+      expect_offense(<<~RUBY)
+        first_arg = 'foo'
+        ^^^^^^^^^ Use camelCase for variable names.
+        second_arg = 'foo'
+        ^^^^^^^^^^ Use camelCase for variable names.
+
+        do_something(first_arg, second_arg)
+                     ^^^^^^^^^ Use camelCase for variable names.
+                                ^^^^^^^^^^ Use camelCase for variable names.
       RUBY
     end
 


### PR DESCRIPTION
Fixes #7275.

This PR makes `Style/VariableName` aware of argument names when invoking a method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
