### PR TITLE
Suppress `Style/RedundantFreeze` warning for new cop

### DIFF
--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -61,7 +61,7 @@ module RuboCop
                 # See https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/node_pattern.rb
                 #
                 # For example
-                MSG = 'Use `#good_method` instead of `#bad_method`.'.freeze
+                MSG = 'Use `#good_method` instead of `#bad_method`.'
 
                 def_node_matcher :bad_method?, <<~PATTERN
                   (send nil? :bad_method ...)

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe RuboCop::Cop::Generator do
                 # See https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/node_pattern.rb
                 #
                 # For example
-                MSG = 'Use `#good_method` instead of `#bad_method`.'.freeze
+                MSG = 'Use `#good_method` instead of `#bad_method`.'
 
                 def_node_matcher :bad_method?, <<~PATTERN
                   (send nil? :bad_method ...)


### PR DESCRIPTION
This PR suppresses `Style/RedundantFreeze` warning for new cop generated by `rake new_cop` task.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
