### PR TITLE
Convert some tests to use expect_correction

### DIFF
--- a/spec/rubocop/cop/lint/big_decimal_new_spec.rb
+++ b/spec/rubocop/cop/lint/big_decimal_new_spec.rb
@@ -5,17 +5,25 @@ RSpec.describe RuboCop::Cop::Lint::BigDecimalNew do
 
   let(:config) { RuboCop::Config.new }
 
-  it 'registers an offense when using `BigDecimal.new()`' do
+  it 'registers an offense and corrects using `BigDecimal.new()`' do
     expect_offense(<<~RUBY)
       BigDecimal.new(123.456, 3)
                  ^^^ `BigDecimal.new()` is deprecated. Use `BigDecimal()` instead.
     RUBY
+
+    expect_correction(<<~RUBY)
+      BigDecimal(123.456, 3)
+    RUBY
   end
 
-  it 'registers an offense when using `::BigDecimal.new()`' do
+  it 'registers an offense and corrects using `::BigDecimal.new()`' do
     expect_offense(<<~RUBY)
       ::BigDecimal.new(123.456, 3)
                    ^^^ `::BigDecimal.new()` is deprecated. Use `::BigDecimal()` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ::BigDecimal(123.456, 3)
     RUBY
   end
 
@@ -23,11 +31,5 @@ RSpec.describe RuboCop::Cop::Lint::BigDecimalNew do
     expect_no_offenses(<<~RUBY)
       BigDecimal(123.456, 3)
     RUBY
-  end
-
-  it 'autocorrects `BigDecimal()`' do
-    new_source = autocorrect_source('BigDecimal.new(123.456, 3)')
-
-    expect(new_source).to eq 'BigDecimal(123.456, 3)'
   end
 end

--- a/spec/rubocop/cop/lint/deprecated_class_methods_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_class_methods_spec.rb
@@ -4,52 +4,58 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedClassMethods do
   subject(:cop) { described_class.new }
 
   context 'prefer `File.exist?` over `File.exists?`' do
-    it 'registers an offense for File.exists?' do
+    it 'registers an offense and corrects File.exists?' do
       expect_offense(<<~RUBY)
         File.exists?(o)
              ^^^^^^^ `File.exists?` is deprecated in favor of `File.exist?`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        File.exist?(o)
+      RUBY
     end
 
-    it 'registers an offense for ::File.exists?' do
+    it 'registers an offense and corrects ::File.exists?' do
       expect_offense(<<~RUBY)
         ::File.exists?(o)
                ^^^^^^^ `File.exists?` is deprecated in favor of `File.exist?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ::File.exist?(o)
       RUBY
     end
 
     it 'does not register an offense for File.exist?' do
       expect_no_offenses('File.exist?(o)')
     end
-
-    it 'auto-corrects File.exists? with File.exist?' do
-      new_source = autocorrect_source('File.exists?(something)')
-      expect(new_source).to eq('File.exist?(something)')
-    end
   end
 
   context 'prefer `Dir.exist?` over `Dir.exists?`' do
-    it 'registers an offense for Dir.exists?' do
+    it 'registers an offense and corrects Dir.exists?' do
       expect_offense(<<~RUBY)
         Dir.exists?(o)
             ^^^^^^^ `Dir.exists?` is deprecated in favor of `Dir.exist?`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        Dir.exist?(o)
+      RUBY
     end
 
-    it 'registers an offense for ::Dir.exists?' do
+    it 'registers an offense and corrects ::Dir.exists?' do
       expect_offense(<<~RUBY)
         ::Dir.exists?(o)
               ^^^^^^^ `Dir.exists?` is deprecated in favor of `Dir.exist?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ::Dir.exist?(o)
       RUBY
     end
 
     it 'does not register an offense for Dir.exist?' do
       expect_no_offenses('Dir.exist?(o)')
-    end
-
-    it 'auto-corrects Dir.exists? with Dir.exist?' do
-      new_source = autocorrect_source('Dir.exists?(something)')
-      expect(new_source).to eq('Dir.exist?(something)')
     end
 
     it 'does not register an offense for offensive method `exists?`'\
@@ -59,20 +65,19 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedClassMethods do
   end
 
   context 'prefer `block_given?` over `iterator?`' do
-    it 'registers an offense for iterator?' do
+    it 'registers an offense and corrects iterator?' do
       expect_offense(<<~RUBY)
         iterator?
         ^^^^^^^^^ `iterator?` is deprecated in favor of `block_given?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        block_given?
       RUBY
     end
 
     it 'does not register an offense for block_given?' do
       expect_no_offenses('block_given?')
-    end
-
-    it 'autocorrects `iterator?` to `block_given?`' do
-      new_source = autocorrect_source('iterator?')
-      expect(new_source).to eq('block_given?')
     end
 
     it 'does not register an offense for offensive method `iterator?`'\

--- a/spec/rubocop/cop/lint/empty_ensure_spec.rb
+++ b/spec/rubocop/cop/lint/empty_ensure_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::Lint::EmptyEnsure do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for empty ensure' do
+  it 'registers an offense and corrects empty ensure' do
     expect_offense(<<~RUBY)
       begin
         something
@@ -11,16 +11,8 @@ RSpec.describe RuboCop::Cop::Lint::EmptyEnsure do
       ^^^^^^ Empty `ensure` block detected.
       end
     RUBY
-  end
 
-  it 'autocorrects for empty ensure' do
-    corrected = autocorrect_source(<<~RUBY)
-      begin
-        something
-      ensure
-      end
-    RUBY
-    expect(corrected).to eq(<<~RUBY)
+    expect_correction(<<~RUBY)
       begin
         something
 

--- a/spec/rubocop/cop/lint/empty_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/empty_interpolation_spec.rb
@@ -3,17 +3,25 @@
 RSpec.describe RuboCop::Cop::Lint::EmptyInterpolation do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for #{} in interpolation' do
+  it 'registers an offense and corrects #{} in interpolation' do
     expect_offense(<<-'RUBY'.strip_indent)
       "this is the #{}"
                    ^^^ Empty interpolation detected.
     RUBY
+
+    expect_correction(<<-'RUBY'.strip_indent)
+      "this is the "
+    RUBY
   end
 
-  it 'registers an offense for #{ } in interpolation' do
+  it 'registers an offense and corrects #{ } in interpolation' do
     expect_offense(<<-'RUBY'.strip_indent)
       "this is the #{ }"
                    ^^^^ Empty interpolation detected.
+    RUBY
+
+    expect_correction(<<-'RUBY'.strip_indent)
+      "this is the "
     RUBY
   end
 
@@ -30,15 +38,5 @@ RSpec.describe RuboCop::Cop::Lint::EmptyInterpolation do
 
   it 'accepts non-empty interpolation' do
     expect_no_offenses('"this is #{top} silly"')
-  end
-
-  it 'autocorrects empty interpolation' do
-    new_source = autocorrect_source('"this is the #{}"')
-    expect(new_source).to eq('"this is the "')
-  end
-
-  it 'autocorrects empty interpolation containing a space' do
-    new_source = autocorrect_source('"this is the #{ }"')
-    expect(new_source).to eq('"this is the "')
   end
 end

--- a/spec/rubocop/cop/lint/inherit_exception_spec.rb
+++ b/spec/rubocop/cop/lint/inherit_exception_spec.rb
@@ -7,31 +7,27 @@ RSpec.describe RuboCop::Cop::Lint::InheritException, :config do
     context 'with enforced style set to `runtime_error`' do
       let(:cop_config) { { 'EnforcedStyle' => 'runtime_error' } }
 
-      it 'registers an offense' do
+      it 'registers an offense and corrects' do
         expect_offense(<<~RUBY)
           class C < Exception; end
                     ^^^^^^^^^ Inherit from `RuntimeError` instead of `Exception`.
         RUBY
-      end
 
-      it 'auto-corrects' do
-        corrected = autocorrect_source('class C < Exception; end')
-
-        expect(corrected).to eq('class C < RuntimeError; end')
+        expect_correction(<<~RUBY)
+          class C < RuntimeError; end
+        RUBY
       end
 
       context 'when creating a subclass using Class.new' do
-        it 'registers an offense' do
+        it 'registers an offense and corrects' do
           expect_offense(<<~RUBY)
             Class.new(Exception)
                       ^^^^^^^^^ Inherit from `RuntimeError` instead of `Exception`.
           RUBY
-        end
 
-        it 'auto-corrects' do
-          corrected = autocorrect_source('Class.new(Exception)')
-
-          expect(corrected).to eq('Class.new(RuntimeError)')
+          expect_correction(<<~RUBY)
+            Class.new(RuntimeError)
+          RUBY
         end
       end
     end
@@ -39,31 +35,27 @@ RSpec.describe RuboCop::Cop::Lint::InheritException, :config do
     context 'with enforced style set to `standard_error`' do
       let(:cop_config) { { 'EnforcedStyle' => 'standard_error' } }
 
-      it 'registers an offense' do
+      it 'registers an offense and corrects' do
         expect_offense(<<~RUBY)
           class C < Exception; end
                     ^^^^^^^^^ Inherit from `StandardError` instead of `Exception`.
         RUBY
-      end
 
-      it 'auto-corrects' do
-        corrected = autocorrect_source('class C < Exception; end')
-
-        expect(corrected).to eq('class C < StandardError; end')
+        expect_correction(<<~RUBY)
+          class C < StandardError; end
+        RUBY
       end
 
       context 'when creating a subclass using Class.new' do
-        it 'registers an offense' do
+        it 'registers an offense and corrects' do
           expect_offense(<<~RUBY)
             Class.new(Exception)
                       ^^^^^^^^^ Inherit from `StandardError` instead of `Exception`.
           RUBY
-        end
 
-        it 'auto-corrects' do
-          corrected = autocorrect_source('Class.new(Exception)')
-
-          expect(corrected).to eq('Class.new(StandardError)')
+          expect_correction(<<~RUBY)
+            Class.new(StandardError)
+          RUBY
         end
       end
     end

--- a/spec/rubocop/cop/lint/ordered_magic_comments_spec.rb
+++ b/spec/rubocop/cop/lint/ordered_magic_comments_spec.rb
@@ -3,40 +3,61 @@
 RSpec.describe RuboCop::Cop::Lint::OrderedMagicComments, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense when `encoding` magic comment does not ' \
-     'precede all other magic comments' do
+  it 'registers an offense and corrects when an `encoding` magic comment ' \
+    'does not precede all other magic comments' do
     expect_offense(<<~RUBY)
       # frozen_string_literal: true
       # encoding: ascii
       ^^^^^^^^^^^^^^^^^ The encoding magic comment should precede all other magic comments.
     RUBY
+
+    expect_correction(<<~RUBY)
+      # encoding: ascii
+      # frozen_string_literal: true
+    RUBY
   end
 
-  it 'registers an offense when `coding` magic comment ' \
+  it 'registers an offense and corrects when `coding` magic comment ' \
      'does not precede all other magic comments' do
     expect_offense(<<~RUBY)
       # frozen_string_literal: true
       # coding: ascii
       ^^^^^^^^^^^^^^^ The encoding magic comment should precede all other magic comments.
     RUBY
+
+    expect_correction(<<~RUBY)
+      # coding: ascii
+      # frozen_string_literal: true
+    RUBY
   end
 
-  it 'registers an offense when `-*- encoding : ascii-8bit -*-` ' \
+  it 'registers an offense and corrects when `-*- encoding : ascii-8bit -*-` ' \
      'magic comment does not precede all other magic comments' do
     expect_offense(<<~RUBY)
       # frozen_string_literal: true
       # -*- encoding : ascii-8bit -*-
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The encoding magic comment should precede all other magic comments.
     RUBY
+
+    expect_correction(<<~RUBY)
+      # -*- encoding : ascii-8bit -*-
+      # frozen_string_literal: true
+    RUBY
   end
 
-  it 'registers an offense when using `frozen_string_literal` magic comment ' \
-     'is next of shebang' do
+  it 'registers an offense and corrects when using `frozen_string_literal` ' \
+    'magic comment is next of shebang' do
     expect_offense(<<~RUBY)
       #!/usr/bin/env ruby
       # frozen_string_literal: true
       # encoding: ascii
       ^^^^^^^^^^^^^^^^^ The encoding magic comment should precede all other magic comments.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      #!/usr/bin/env ruby
+      # encoding: ascii
+      # frozen_string_literal: true
     RUBY
   end
 
@@ -78,32 +99,6 @@ RSpec.describe RuboCop::Cop::Lint::OrderedMagicComments, :config do
 
       x = { encoding: Encoding::SJIS }
       puts x
-    RUBY
-  end
-
-  it 'autocorrects ordered magic comments' do
-    new_source = autocorrect_source(<<~RUBY)
-      # frozen_string_literal: true
-      # encoding: ascii
-    RUBY
-
-    expect(new_source).to eq <<~RUBY
-      # encoding: ascii
-      # frozen_string_literal: true
-    RUBY
-  end
-
-  it 'autocorrects ordered magic comments with shebang' do
-    new_source = autocorrect_source(<<~RUBY)
-      #!/usr/bin/env ruby
-      # frozen_string_literal: true
-      # encoding: ascii
-    RUBY
-
-    expect(new_source).to eq <<~RUBY
-      #!/usr/bin/env ruby
-      # encoding: ascii
-      # frozen_string_literal: true
     RUBY
   end
 end

--- a/spec/rubocop/cop/lint/percent_string_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_string_array_spec.rb
@@ -20,60 +20,65 @@ RSpec.describe RuboCop::Cop::Lint::PercentStringArray do
         end
       end
 
-      it 'adds an offense if tokens contain quotes and are comma separated' do
+      it 'adds an offense and corrects when tokens contain quotes ' \
+        'and are comma separated' do
         expect_offense(<<~RUBY)
           %#{char}('foo', 'bar', 'baz')
           ^^^^^^^^^^^^^^^^^^^^^^^ Within `%w`/`%W`, quotes and ',' are unnecessary and may be unwanted in the resulting strings.
         RUBY
+
+        expect_correction(<<~RUBY)
+          %#{char}(foo bar baz)
+        RUBY
       end
 
-      it 'adds an offense if tokens contain both types of quotes' do
+      it 'adds an offense and corrects when tokens contain ' \
+        'both types of quotes' do
         expect_offense(<<~RUBY)
           %#{char}('foo' "bar" 'baz')
           ^^^^^^^^^^^^^^^^^^^^^ Within `%w`/`%W`, quotes and ',' are unnecessary and may be unwanted in the resulting strings.
         RUBY
+
+        expect_correction(<<~RUBY)
+          %#{char}(foo bar baz)
+        RUBY
       end
 
-      it 'adds an offense if one token is quoted but there are no commas' do
+      it 'adds an offense and corrects when one token is quoted ' \
+        'but there are no commas' do
         expect_offense(<<~RUBY)
           %#{char}('foo' bar baz)
           ^^^^^^^^^^^^^^^^^ Within `%w`/`%W`, quotes and ',' are unnecessary and may be unwanted in the resulting strings.
         RUBY
+
+        expect_correction(<<~RUBY)
+          %#{char}(foo bar baz)
+        RUBY
       end
 
-      it 'adds an offense if there are no quotes but one comma' do
+      it 'adds an offense and corrects when there are no quotes ' \
+        'but one comma' do
         expect_offense(<<~RUBY)
           %#{char}(foo, bar baz)
           ^^^^^^^^^^^^^^^^ Within `%w`/`%W`, quotes and ',' are unnecessary and may be unwanted in the resulting strings.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          %#{char}(foo bar baz)
         RUBY
       end
     end
   end
 
-  context 'autocorrection' do
-    let(:source) do
-      <<-SOURCE
-      %w('a', "b", c', "d, e f)
-      %W('a', "b", c', "d, e f)
-      SOURCE
-    end
-    let(:expected_corrected_source) do
-      <<-CORRECTED_SOURCE
-      %w(a b c d e f)
-      %W(a b c d e f)
-      CORRECTED_SOURCE
-    end
-
-    it 'removes undesirable characters' do
-      expect(autocorrect_source(source)).to eq(expected_corrected_source)
-    end
-  end
-
   context 'with invalid byte sequence in UTF-8' do
-    it 'add an offense if tokens contain quotes' do
+    it 'add an offense and corrects when tokens contain quotes' do
       expect_offense(<<-RUBY)
         %W("a\\255\\255")
         ^^^^^^^^^^^^^^^ Within `%w`/`%W`, quotes and ',' are unnecessary and may be unwanted in the resulting strings.
+      RUBY
+
+      expect_correction(<<-RUBY)
+        %W(a\\255\\255)
       RUBY
     end
 
@@ -83,12 +88,18 @@ RSpec.describe RuboCop::Cop::Lint::PercentStringArray do
   end
 
   context 'with binary encoded source' do
-    it 'adds an offense if tokens contain quotes' do
+    it 'adds an offense and corrects when tokens contain quotes' do
       expect_offense(<<~RUBY.b)
         # encoding: BINARY
 
         %W[\xC0 "foo"]
         ^^^^^^^^^^^ Within `%w`/`%W`, quotes and ',' are unnecessary and may be unwanted in the resulting strings.
+      RUBY
+
+      expect_correction(<<~RUBY.b)
+        # encoding: BINARY
+
+        %W[\xC0 foo]
       RUBY
     end
 

--- a/spec/rubocop/cop/lint/redundant_with_index_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_with_index_spec.rb
@@ -5,60 +5,56 @@ RSpec.describe RuboCop::Cop::Lint::RedundantWithIndex do
 
   let(:config) { RuboCop::Config.new }
 
-  it 'registers an offense when using `ary.each_with_index { |v| v }`' do
+  it 'registers an offense for `ary.each_with_index { |v| v }` ' \
+    'and corrects to `ary.each`' do
     expect_offense(<<~RUBY)
       ary.each_with_index { |v| v }
           ^^^^^^^^^^^^^^^ Use `each` instead of `each_with_index`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      ary.each { |v| v }
+    RUBY
   end
 
-  it 'registers an offense when using `ary.each.with_index { |v| v }`' do
+  it 'registers an offense when using `ary.each.with_index { |v| v }` ' \
+    'and corrects to `ary.each`' do
     expect_offense(<<~RUBY)
       ary.each.with_index { |v| v }
                ^^^^^^^^^^ Remove redundant `with_index`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      ary.each { |v| v }
+    RUBY
   end
 
-  it 'registers an offense when using `ary.each.with_index(1) { |v| v }`' do
+  it 'registers an offense when using `ary.each.with_index(1) { |v| v }` ' \
+    'and correct to `ary.each { |v| v }`' do
     expect_offense(<<~RUBY)
       ary.each.with_index(1) { |v| v }
                ^^^^^^^^^^^^^ Remove redundant `with_index`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      ary.each { |v| v }
+    RUBY
   end
 
-  it 'registers an offense when using `ary.each_with_object([]).with_index ' \
-     '{ |v| v }`' do
+  it 'registers an offense when using ' \
+    '`ary.each_with_object([]).with_index { |v| v }` ' \
+    'and corrects to `ary.each_with_object([]) { |v| v }`' do
     expect_offense(<<~RUBY)
       ary.each_with_object([]).with_index { |v| v }
                                ^^^^^^^^^^ Remove redundant `with_index`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      ary.each_with_object([]) { |v| v }
+    RUBY
   end
 
-  it 'autocorrects to ary.each from ary.each_with_index' do
-    new_source = autocorrect_source('ary.each_with_index { |v| v }')
-
-    expect(new_source).to eq 'ary.each { |v| v }'
-  end
-
-  it 'autocorrects to ary.each from ary.each.with_index' do
-    new_source = autocorrect_source('ary.each.with_index { |v| v }')
-
-    expect(new_source).to eq 'ary.each { |v| v }'
-  end
-
-  it 'autocorrects to ary.each from ary.each.with_index(1)' do
-    new_source = autocorrect_source('ary.each.with_index(1) { |v| v }')
-
-    expect(new_source).to eq 'ary.each { |v| v }'
-  end
-
-  it 'autocorrects to ary.each from ary.each_with_object([]).with_index' do
-    new_source = autocorrect_source('ary.each_with_object([]) { |v| v }')
-
-    expect(new_source).to eq 'ary.each_with_object([]) { |v| v }'
-  end
-
-  it 'an index is used as a block argument' do
+  it 'accepts an index is used as a block argument' do
     expect_no_offenses('ary.each_with_index { |v, i| v; i }')
   end
 end

--- a/spec/rubocop/cop/lint/redundant_with_object_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_with_object_spec.rb
@@ -5,70 +5,60 @@ RSpec.describe RuboCop::Cop::Lint::RedundantWithObject do
 
   let(:config) { RuboCop::Config.new }
 
-  it 'registers an offense when using `ary.each_with_object { |v| v }`' do
+  it 'registers an offense and corrects when using ' \
+    '`ary.each_with_object { |v| v }`' do
     expect_offense(<<~RUBY)
       ary.each_with_object([]) { |v| v }
           ^^^^^^^^^^^^^^^^^^^^ Use `each` instead of `each_with_object`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      ary.each { |v| v }
+    RUBY
   end
 
-  it 'registers an offense when using `ary.each.with_object([]) { |v| v }`' do
+  it 'registers an offense and corrects when using ' \
+    '`ary.each.with_object([]) { |v| v }`' do
     expect_offense(<<~RUBY)
       ary.each.with_object([]) { |v| v }
                ^^^^^^^^^^^^^^^ Remove redundant `with_object`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      ary.each { |v| v }
+    RUBY
   end
 
-  it 'autocorrects to ary.each from ary.each_with_object([])' do
-    new_source = autocorrect_source('ary.each_with_object([]) { |v| v }')
-
-    expect(new_source).to eq 'ary.each { |v| v }'
-  end
-
-  it 'autocorrects to ary.each from ary.each_with_object []' do
-    new_source = autocorrect_source('ary.each_with_object [] { |v| v }')
-
-    expect(new_source).to eq 'ary.each { |v| v }'
-  end
-
-  it 'autocorrects to ary.each from ary.each_with_object([]) do-end block' do
-    new_source = autocorrect_source(<<~RUBY)
+  it 'registers an offense and corrects when using ' \
+    'ary.each_with_object([]) do-end block' do
+    expect_offense(<<~RUBY)
       ary.each_with_object([]) do |v|
+          ^^^^^^^^^^^^^^^^^^^^ Use `each` instead of `each_with_object`.
         v
       end
     RUBY
 
-    expect(new_source).to eq(<<~RUBY)
+    expect_correction(<<~RUBY)
       ary.each do |v|
         v
       end
     RUBY
   end
 
-  it 'autocorrects to ary.each from ary.each_with_object do-end block' do
-    new_source = autocorrect_source(<<~RUBY)
+  it 'registers an offense and corrects when using ' \
+    'ary.each_with_object do-end block without parentheses' do
+    expect_offense(<<~RUBY)
       ary.each_with_object [] do |v|
+          ^^^^^^^^^^^^^^^^^^^ Use `each` instead of `each_with_object`.
         v
       end
     RUBY
 
-    expect(new_source).to eq(<<~RUBY)
+    expect_correction(<<~RUBY)
       ary.each do |v|
         v
       end
     RUBY
-  end
-
-  it 'autocorrects to ary.each from ary.each.with_object([]) { |v| v }' do
-    new_source = autocorrect_source('ary.each.with_object([]) { |v| v }')
-
-    expect(new_source).to eq 'ary.each { |v| v }'
-  end
-
-  it 'autocorrects to ary.each from ary.each.with_object [] { |v| v }' do
-    new_source = autocorrect_source('ary.each.with_object [] { |v| v }')
-
-    expect(new_source).to eq 'ary.each { |v| v }'
   end
 
   it 'an object is used as a block argument' do

--- a/spec/rubocop/cop/lint/safe_navigation_consistency_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_consistency_spec.rb
@@ -31,266 +31,189 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationConsistency, :config do
     RUBY
   end
 
-  it 'registers an offense when using safe navigation on the left of &&' do
+  it 'registers an offense and corrects using safe navigation ' \
+    'on the left of &&' do
     expect_offense(<<~RUBY)
       foo&.bar && foo.baz
       ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.bar && foo&.baz
+    RUBY
   end
 
-  it 'registers an offense when using safe navigation on the right of &&' do
+  it 'registers an offense and corrects using safe navigation ' \
+    'on the right of &&' do
     expect_offense(<<~RUBY)
       foo.bar && foo&.baz
       ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.bar && foo&.baz
+    RUBY
   end
 
-  it 'registers an offense when using safe navigation on the left of ||' do
+  it 'registers an offense and corrects using safe navigation ' \
+    'on the left of ||' do
     expect_offense(<<~RUBY)
       foo&.bar || foo.baz
       ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.bar || foo&.baz
+    RUBY
   end
 
-  it 'registers an offense when using safe navigation on the right of ||' do
+  it 'registers an offense and corrects using safe navigation ' \
+    'on the right of ||' do
     expect_offense(<<~RUBY)
       foo.bar || foo&.baz
       ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.bar || foo&.baz
+    RUBY
   end
 
-  it 'registers an offense when there is code before or after ' \
-     'the condition' do
+  it 'registers an offense and corrects when there is code ' \
+    'before or after the condition' do
     expect_offense(<<~RUBY)
       foo = nil
       foo&.bar || foo.baz
       ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
       something
     RUBY
+
+    expect_correction(<<~RUBY)
+      foo = nil
+      foo&.bar || foo&.baz
+      something
+    RUBY
   end
 
-  it 'registers an offense for non dot method calls' do
+  it 'registers an offense but does not correct non dot method calls' do
     expect_offense(<<~RUBY)
       foo&.zero? || foo > 5
       ^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.zero? || foo > 5
+    RUBY
   end
 
-  it 'registers an offense for assignment' do
+  it 'registers an offense and corrects assignment' do
     expect_offense(<<~RUBY)
       foo&.bar && foo.baz = 1
       ^^^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.bar && foo&.baz = 1
+    RUBY
   end
 
-  it 'registers an offense when using safe navigation ' \
-     'inside of separated conditions' do
+  it 'registers an offense and corrects using safe navigation ' \
+    'inside of separated conditions' do
     expect_offense(<<~RUBY)
       foo&.bar && foobar.baz && foo.qux
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.bar && foobar.baz && foo&.qux
+    RUBY
   end
 
-  it 'registers an offense when using safe navigation ' \
-     'in conditions on the right hand side' do
+  it 'registers an offense and corrects using safe navigation in conditions ' \
+    'on the right hand side' do
     expect_offense(<<~RUBY)
       foobar.baz && foo&.bar && foo.qux
                     ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      foobar.baz && foo&.bar && foo&.qux
+    RUBY
   end
 
-  it 'registers multiple offenses' do
+  it 'registers and corrects multiple offenses' do
     expect_offense(<<~RUBY)
       foobar.baz && foo&.bar && foo.qux && foo.foobar
                     ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      foobar.baz && foo&.bar && foo&.qux && foo&.foobar
+    RUBY
   end
 
-  it 'registers an offense when using unsafe navigation ' \
-     'with both && and ||' do
+  it 'registers an offense and corrects using unsafe navigation ' \
+    'with both && and ||' do
     expect_offense(<<~RUBY)
       foo&.bar && foo.baz || foo.qux
       ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.bar && foo&.baz || foo&.qux
+    RUBY
   end
 
-  it 'registers an offense when using unsafe navigation with ' \
-     'grouped conditions' do
+  it 'registers an offense and corrects using unsafe navigation ' \
+    'with grouped conditions' do
     expect_offense(<<~RUBY)
       foo&.bar && (foo.baz || foo.qux)
       ^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.bar && (foo&.baz || foo&.qux)
+    RUBY
   end
 
-  it 'registers an offense when unsafe navigation appears before ' \
-     'safe navigation' do
+  it 'registers an offense and corrects unsafe navigation that appears ' \
+    'before safe navigation' do
     expect_offense(<<~RUBY)
       foo.bar && foo.baz || foo&.qux
                  ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.bar && foo&.baz || foo&.qux
+    RUBY
   end
 
-  it 'registers an offense when using unsafe navigation and ' \
-     'the safe navigation appears in a group' do
+  it 'registers an offense and corrects using unsafe navigation ' \
+    'and the safe navigation appears in a group' do
     expect_offense(<<~RUBY)
       (foo&.bar && foo.baz) || foo.qux
        ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      (foo&.bar && foo&.baz) || foo&.qux
+    RUBY
   end
 
-  it 'registers a single offense when safe navigation is ' \
+  it 'registers a single offense and corrects when safe navigation is ' \
      'used multiple times' do
     expect_offense(<<~RUBY)
       foo&.bar && foo&.baz || foo.qux
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
     RUBY
-  end
 
-  context 'auto-correct' do
-    it 'does not correct non dot methods' do
-      new_source = autocorrect_source(<<~RUBY)
-        foo&.start_with?('a') || foo =~ /b/
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        foo&.start_with?('a') || foo =~ /b/
-      RUBY
-    end
-
-    it 'corrects unsafe navigation on the rhs of &&' do
-      new_source = autocorrect_source(<<~RUBY)
-        foo&.bar && foo.baz
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        foo&.bar && foo&.baz
-      RUBY
-    end
-
-    it 'corrects unsafe navigation on the lhs of &&' do
-      new_source = autocorrect_source(<<~RUBY)
-        foo.bar && foo&.baz
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        foo&.bar && foo&.baz
-      RUBY
-    end
-
-    it 'corrects unsafe navigation on the rhs of ||' do
-      new_source = autocorrect_source(<<~RUBY)
-        foo&.bar || foo.baz
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        foo&.bar || foo&.baz
-      RUBY
-    end
-
-    it 'corrects unsafe navigation on the lhs of ||' do
-      new_source = autocorrect_source(<<~RUBY)
-        foo.bar || foo&.baz
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        foo&.bar || foo&.baz
-      RUBY
-    end
-
-    it 'corrects unsafe navigation inside of separated conditions' do
-      new_source = autocorrect_source(<<~RUBY)
-        foo&.bar && foobar.baz && foo.qux
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        foo&.bar && foobar.baz && foo&.qux
-      RUBY
-    end
-
-    it 'corrects unsafe navigation in conditions on the right hand side' do
-      new_source = autocorrect_source(<<~RUBY)
-        foobar.baz && foo&.bar && foo.qux
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        foobar.baz && foo&.bar && foo&.qux
-      RUBY
-    end
-
-    it 'corrects unsafe assignment' do
-      new_source = autocorrect_source(<<~RUBY)
-        foo&.bar && foo.baz = 1
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        foo&.bar && foo&.baz = 1
-      RUBY
-    end
-
-    it 'corrects multiple offenses' do
-      new_source = autocorrect_source(<<~RUBY)
-        foobar.baz && foo&.bar && foo.qux && foo.foobar
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        foobar.baz && foo&.bar && foo&.qux && foo&.foobar
-      RUBY
-    end
-
-    it 'corrects using unsafe navigation with both && and ||' do
-      new_source = autocorrect_source(<<~RUBY)
-        foo&.bar && foo.baz || foo.qux
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        foo&.bar && foo&.baz || foo&.qux
-      RUBY
-    end
-
-    it 'corrects using unsafe navigation with grouped conditions' do
-      new_source = autocorrect_source(<<~RUBY)
-        foo&.bar && (foo.baz || foo.qux)
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        foo&.bar && (foo&.baz || foo&.qux)
-      RUBY
-    end
-
-    it 'corrects unsafe navigation appears before safe navigation' do
-      new_source = autocorrect_source(<<~RUBY)
-        foo.bar && foo.baz || foo&.qux
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        foo&.bar && foo&.baz || foo&.qux
-      RUBY
-    end
-
-    it 'corrects unsafe navigation when the safe navigation ' \
-       'appears in a group' do
-      new_source = autocorrect_source(<<~RUBY)
-        (foo&.bar && foo.baz) || foo.qux
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        (foo&.bar && foo&.baz) || foo&.qux
-      RUBY
-    end
-
-    it 'correct unsafe navigation on a method chain' do
-      new_source = autocorrect_source(<<~RUBY)
-        foo.bar&.baz && foo.bar.qux
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        foo.bar&.baz && foo.bar&.qux
-      RUBY
-    end
+    expect_correction(<<~RUBY)
+      foo&.bar && foo&.baz || foo&.qux
+    RUBY
   end
 end

--- a/spec/rubocop/cop/lint/string_conversion_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/string_conversion_in_interpolation_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::Lint::StringConversionInInterpolation do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for #to_s in interpolation' do
+  it 'registers an offense and corrects `to_s` in interpolation' do
     expect_offense(<<-'RUBY'.strip_indent)
       "this is the #{result.to_s}"
                             ^^^^ Redundant use of `Object#to_s` in interpolation.
@@ -14,12 +14,24 @@ RSpec.describe RuboCop::Cop::Lint::StringConversionInInterpolation do
       `backticks #{result.to_s}`
                           ^^^^ Redundant use of `Object#to_s` in interpolation.
     RUBY
+
+    expect_correction(<<-'RUBY'.strip_indent)
+      "this is the #{result}"
+      /regexp #{result}/
+      :"symbol #{result}"
+      `backticks #{result}`
+    RUBY
   end
 
-  it 'detects #to_s in an interpolation with several expressions' do
+  it 'registers an offense and corrects `to_s` in an interpolation ' \
+    'with several expressions' do
     expect_offense(<<-'RUBY'.strip_indent)
       "this is the #{top; result.to_s}"
                                  ^^^^ Redundant use of `Object#to_s` in interpolation.
+    RUBY
+
+    expect_correction(<<-'RUBY'.strip_indent)
+      "this is the #{top; result}"
     RUBY
   end
 
@@ -31,24 +43,18 @@ RSpec.describe RuboCop::Cop::Lint::StringConversionInInterpolation do
     expect_no_offenses('"this is the #{result}"')
   end
 
-  it 'does not explode on implicit receiver' do
+  it 'registers an offense and corrects an implicit receiver' do
     expect_offense(<<-'RUBY'.strip_indent)
       "#{to_s}"
          ^^^^ Use `self` instead of `Object#to_s` in interpolation.
+    RUBY
+
+    expect_correction(<<-'RUBY'.strip_indent)
+      "#{self}"
     RUBY
   end
 
   it 'does not explode on empty interpolation' do
     expect_no_offenses('"this is #{} silly"')
-  end
-
-  it 'autocorrects by removing the redundant to_s' do
-    corrected = autocorrect_source('"some #{something.to_s}"')
-    expect(corrected).to eq '"some #{something}"'
-  end
-
-  it 'autocorrects implicit receiver by replacing to_s with self' do
-    corrected = autocorrect_source('"some #{to_s}"')
-    expect(corrected).to eq '"some #{self}"'
   end
 end

--- a/spec/rubocop/cop/lint/to_json_spec.rb
+++ b/spec/rubocop/cop/lint/to_json_spec.rb
@@ -5,27 +5,21 @@ RSpec.describe RuboCop::Cop::Lint::ToJSON do
 
   let(:config) { RuboCop::Config.new }
 
-  it 'registers an offense when using `#to_json` without arguments' do
+  it 'registers an offense and corrects using `#to_json` without arguments' do
     expect_offense(<<~RUBY)
       def to_json
       ^^^^^^^^^^^  `#to_json` requires an optional argument to be parsable via JSON.generate(obj).
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def to_json(*_args)
       end
     RUBY
   end
 
   it 'does not register an offense when using `#to_json` with arguments' do
     expect_no_offenses(<<~RUBY)
-      def to_json(*_args)
-      end
-    RUBY
-  end
-
-  it 'autocorrects' do
-    corrected = autocorrect_source(<<~RUBY)
-      def to_json
-      end
-    RUBY
-    expect(corrected).to eq(<<~RUBY)
       def to_json(*_args)
       end
     RUBY

--- a/spec/rubocop/cop/lint/unneeded_cop_enable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/unneeded_cop_enable_directive_spec.rb
@@ -3,20 +3,31 @@
 RSpec.describe RuboCop::Cop::Lint::UnneededCopEnableDirective do
   subject(:cop) { described_class.new }
 
-  it 'registers offense for unnecessary enable' do
+  it 'registers offense and corrects unnecessary enable' do
     expect_offense(<<~RUBY)
       foo
       # rubocop:enable Metrics/LineLength
                        ^^^^^^^^^^^^^^^^^^ Unnecessary enabling of Metrics/LineLength.
     RUBY
+
+    expect_correction(<<~RUBY)
+      foo
+
+    RUBY
   end
 
-  it 'registers multiple offenses for same comment' do
+  it 'registers multiple offenses and corrects the same comment' do
     expect_offense(<<~RUBY)
       foo
       # rubocop:enable Metrics/ModuleLength, Metrics/AbcSize
                                              ^^^^^^^^^^^^^^^ Unnecessary enabling of Metrics/AbcSize.
                        ^^^^^^^^^^^^^^^^^^^^ Unnecessary enabling of Metrics/ModuleLength.
+      bar
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo
+      # rubocop:enable
       bar
     RUBY
   end
@@ -29,9 +40,16 @@ RSpec.describe RuboCop::Cop::Lint::UnneededCopEnableDirective do
                        ^^^^^^^^^^^^^^^ Unnecessary enabling of Metrics/AbcSize.
       bar
     RUBY
+
+    expect_correction(<<~RUBY)
+      # rubocop:disable Metrics/LineLength
+      fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo = barrrrrrrrrrrrrrrrrrrrrrrrrr
+      # rubocop:enable Metrics/LineLength
+      bar
+    RUBY
   end
 
-  it 'registers offense for redundant enabling of same cop' do
+  it 'registers offense and corrects redundant enabling of same cop' do
     expect_offense(<<~RUBY)
       # rubocop:disable Metrics/LineLength
       fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo = barrrrrrrrrrrrrrrrrrrrrrrrrr
@@ -43,14 +61,30 @@ RSpec.describe RuboCop::Cop::Lint::UnneededCopEnableDirective do
                        ^^^^^^^^^^^^^^^^^^ Unnecessary enabling of Metrics/LineLength.
       bar
     RUBY
+
+    expect_correction(<<~RUBY)
+      # rubocop:disable Metrics/LineLength
+      fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo = barrrrrrrrrrrrrrrrrrrrrrrrrr
+      # rubocop:enable Metrics/LineLength
+
+      bar
+
+
+      bar
+    RUBY
   end
 
   context 'all switch' do
-    it 'registers offense for unnecessary enable all' do
+    it 'registers offense and corrects unnecessary enable all' do
       expect_offense(<<~RUBY)
         foo
         # rubocop:enable all
                          ^^^ Unnecessary enabling of all cops.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo
+
       RUBY
     end
 
@@ -66,23 +100,6 @@ RSpec.describe RuboCop::Cop::Lint::UnneededCopEnableDirective do
   end
 
   context 'autocorrection' do
-    context 'when entire comment unnecessarily enables' do
-      let(:source) do
-        <<~RUBY
-          foo
-          # rubocop:enable Metrics/LineLength
-        RUBY
-      end
-
-      it 'removes unnecessary enables' do
-        corrected = autocorrect_source(source)
-        expect(corrected).to eq(<<~RUBY)
-          foo
-
-        RUBY
-      end
-    end
-
     context 'when first cop unnecessarily enables' do
       let(:source) do
         <<~RUBY

--- a/spec/rubocop/cop/lint/unneeded_require_statement_spec.rb
+++ b/spec/rubocop/cop/lint/unneeded_require_statement_spec.rb
@@ -3,20 +3,14 @@
 RSpec.describe RuboCop::Cop::Lint::UnneededRequireStatement, :config do
   subject(:cop) { described_class.new(config) }
 
-  it "registers an offense when using `require 'enumerator'`" do
+  it "registers an offense and corrects when using `require 'enumerator'`" do
     expect_offense(<<~RUBY)
       require 'enumerator'
       ^^^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
-    RUBY
-  end
-
-  it 'autocorrects remove unnecessary require statement' do
-    new_source = autocorrect_source(<<~RUBY)
-      require 'enumerator'
       require 'uri'
     RUBY
 
-    expect(new_source).to eq(<<~RUBY)
+    expect_correction(<<~RUBY)
       require 'uri'
     RUBY
   end

--- a/spec/rubocop/cop/lint/uri_regexp_spec.rb
+++ b/spec/rubocop/cop/lint/uri_regexp_spec.rb
@@ -5,59 +5,48 @@ RSpec.describe RuboCop::Cop::Lint::UriRegexp do
 
   let(:config) { RuboCop::Config.new }
 
-  it 'registers an offense when using `URI.regexp` with argument' do
+  it 'registers an offense and corrects using `URI.regexp` with argument' do
     expect_offense(<<~RUBY)
       URI.regexp('http://example.com')
           ^^^^^^ `URI.regexp('http://example.com')` is obsolete and should not be used. Instead, use `URI::DEFAULT_PARSER.make_regexp('http://example.com')`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      URI::DEFAULT_PARSER.make_regexp('http://example.com')
+    RUBY
   end
 
-  it 'registers an offense when using `::URI.regexp` with argument' do
+  it 'registers an offense and corrects using `::URI.regexp` with argument' do
     expect_offense(<<~RUBY)
       ::URI.regexp('http://example.com')
             ^^^^^^ `::URI.regexp('http://example.com')` is obsolete and should not be used. Instead, use `::URI::DEFAULT_PARSER.make_regexp('http://example.com')`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      ::URI::DEFAULT_PARSER.make_regexp('http://example.com')
+    RUBY
   end
 
-  it 'registers an offense when using `URI.regexp` without argument' do
+  it 'registers an offense and corrects using `URI.regexp` without argument' do
     expect_offense(<<~RUBY)
       URI.regexp
           ^^^^^^ `URI.regexp` is obsolete and should not be used. Instead, use `URI::DEFAULT_PARSER.make_regexp`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      URI::DEFAULT_PARSER.make_regexp
+    RUBY
   end
 
-  it 'registers an offense when using `::URI.regexp` without argument' do
+  it 'registers an offense and corrects using `::URI.regexp` ' \
+    'without argument' do
     expect_offense(<<~RUBY)
       ::URI.regexp
             ^^^^^^ `::URI.regexp` is obsolete and should not be used. Instead, use `::URI::DEFAULT_PARSER.make_regexp`.
     RUBY
-  end
 
-  it "autocorrects URI::DEFAULT_PARSER.make_regexp('http://example.com')" do
-    new_source = autocorrect_source("URI.regexp('http://example.com')")
-
-    expect(
-      new_source
-    ).to eq "URI::DEFAULT_PARSER.make_regexp('http://example.com')"
-  end
-
-  it "autocorrects ::URI::DEFAULT_PARSER.make_regexp('http://example.com')" do
-    new_source = autocorrect_source("::URI.regexp('http://example.com')")
-
-    expect(
-      new_source
-    ).to eq "::URI::DEFAULT_PARSER.make_regexp('http://example.com')"
-  end
-
-  it 'autocorrects URI::DEFAULT_PARSER.make_regexp' do
-    new_source = autocorrect_source('URI.regexp')
-
-    expect(new_source).to eq 'URI::DEFAULT_PARSER.make_regexp'
-  end
-
-  it 'autocorrects ::URI::DEFAULT_PARSER.make_regexp' do
-    new_source = autocorrect_source('::URI.regexp')
-
-    expect(new_source).to eq '::URI::DEFAULT_PARSER.make_regexp'
+    expect_correction(<<~RUBY)
+      ::URI::DEFAULT_PARSER.make_regexp
+    RUBY
   end
 end

--- a/spec/rubocop/cop/metrics/line_length_spec.rb
+++ b/spec/rubocop/cop/metrics/line_length_spec.rb
@@ -434,23 +434,15 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
       end
 
       context 'when over limit because of a comment' do
-        it 'adds offense' do
+        it 'adds an offense and does not autocorrect' do
           expect_offense(<<~RUBY)
             { # supersupersupersupersupersupersupersupersupersupersupersuperlongcomment
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [75/40]
               baz: "10000",
               bar: "10000"}
           RUBY
-        end
 
-        it 'does not autocorrect the offense' do
-          new_source = autocorrect_source(<<~RUBY)
-            { # supersupersupersupersupersupersupersupersupersupersupersuperlongcomment
-              baz: "10000",
-              bar: "10000"}
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
+          expect_correction(<<~RUBY)
             { # supersupersupersupersupersupersupersupersupersupersupersuperlongcomment
               baz: "10000",
               bar: "10000"}
@@ -459,23 +451,15 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
       end
 
       context 'when over limit and already on multiple lines long key' do
-        it 'adds offense' do
+        it 'adds an offense and does not autocorrect' do
           expect_offense(<<~RUBY)
             {supersupersupersupersupersupersupersupersupersupersupersuperfirstarg: 10,
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [74/40]
               baz: "10000",
               bar: "10000"}
           RUBY
-        end
 
-        it 'does not autocorrect the offense' do
-          new_source = autocorrect_source(<<~RUBY)
-            {supersupersupersupersupersupersupersupersupersupersupersuperfirstarg: 10,
-              baz: "10000",
-              bar: "10000"}
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
+          expect_correction(<<~RUBY)
             {supersupersupersupersupersupersupersupersupersupersupersuperfirstarg: 10,
               baz: "10000",
               bar: "10000"}
@@ -484,7 +468,7 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
       end
 
       context 'when over limit and keys already on multiple lines' do
-        it 'adds offense' do
+        it 'adds an offense and does not autocorrect' do
           expect_offense(<<~RUBY)
             {
               baz0: "10000",
@@ -493,18 +477,8 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
                                                     ^^^^^^^^^^^^^^^^^^^^^ Line is too long. [61/40]
               bar: "10000"}
           RUBY
-        end
 
-        it 'does not autocorrect the offense' do
-          new_source = autocorrect_source(<<~RUBY)
-            {
-              baz0: "10000",
-              baz1: "10000",
-              baz2: "10000", baz2: "10000", baz3: "10000", baz4: "10000",
-              bar: "10000"}
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
+          expect_correction(<<~RUBY)
             {
               baz0: "10000",
               baz1: "10000",
@@ -515,19 +489,13 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
       end
 
       context 'when over limit' do
-        it 'adds an offense' do
+        it 'adds an offense and autocorrects it' do
           expect_offense(<<~RUBY)
             {abc: "100000", def: "100000", ghi: "100000", jkl: "100000", mno: "100000"}
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [75/40]
           RUBY
-        end
 
-        it 'autocorrects the offense' do
-          new_source = autocorrect_source(<<~RUBY)
-            {abc: "100000", def: "100000", ghi: "100000", jkl: "100000", mno: "100000"}
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
+          expect_correction(<<~RUBY)
             {abc: "100000", def: "100000",\s
             ghi: "100000", jkl: "100000", mno: "100000"}
           RUBY
@@ -535,19 +503,13 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
       end
 
       context 'when over limit rocket' do
-        it 'adds an offense' do
+        it 'adds an offense and autocorrects it' do
           expect_offense(<<~RUBY)
             {"abc" => "100000", "def" => "100000", "casd" => "100000", "asdf" => "100000"}
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [78/40]
           RUBY
-        end
 
-        it 'autocorrects the offense' do
-          new_source = autocorrect_source(<<~RUBY)
-            {"abc" => "100000", "def" => "100000", "casd" => "100000", "asdf" => "100000"}
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
+          expect_correction(<<~RUBY)
             {"abc" => "100000", "def" => "100000",\s
             "casd" => "100000", "asdf" => "100000"}
           RUBY
@@ -555,19 +517,13 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
       end
 
       context 'when over limit rocket symbol' do
-        it 'adds an offense' do
+        it 'adds an offense and autocorrects it' do
           expect_offense(<<~RUBY)
             {:abc => "100000", :asd => "100000", :asd => "100000", :fds => "100000"}
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [72/40]
           RUBY
-        end
 
-        it 'autocorrects the offense' do
-          new_source = autocorrect_source(<<~RUBY)
-            {:abc => "100000", :asd => "100000", :asd => "100000", :fds => "100000"}
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
+          expect_correction(<<~RUBY)
             {:abc => "100000", :asd => "100000",\s
             :asd => "100000", :fds => "100000"}
           RUBY
@@ -575,19 +531,13 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
       end
 
       context 'when nested hashes on same line' do
-        it 'adds an offense only to outer' do
+        it 'adds an offense only to outer and autocorrects it' do
           expect_offense(<<~RUBY)
             {abc: "100000", def: "100000", ghi: {abc: "100000"}, jkl: "100000", mno: "100000"}
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [82/40]
           RUBY
-        end
 
-        it 'autocorrects the offense' do
-          new_source = autocorrect_source(<<~RUBY)
-            {abc: "100000", def: "100000", ghi: {abc: "100000"}, jkl: "100000", mno: "100000"}
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
+          expect_correction(<<~RUBY)
             {abc: "100000", def: "100000",\s
             ghi: {abc: "100000"}, jkl: "100000", mno: "100000"}
           RUBY
@@ -595,7 +545,7 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
       end
 
       context 'when hash in method call' do
-        it 'adds an offense only to outer' do
+        it 'adds an offense only to outer and autocorrects it' do
           expect_offense(<<~RUBY)
             get(
               :index,
@@ -603,17 +553,8 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [109/40]
               xhr: true)
           RUBY
-        end
 
-        it 'autocorrects the offense' do
-          new_source = autocorrect_source(<<~RUBY)
-            get(
-              :index,
-              params: {driver_id: driver.id, from_date: "2017-08-18T15:09:04.000Z", to_date: "2017-09-19T15:09:04.000Z"},
-              xhr: true)
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
+          expect_correction(<<~RUBY)
             get(
               :index,
               params: {driver_id: driver.id,\s
@@ -645,19 +586,13 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
       end
 
       context 'when over limit' do
-        it 'adds an offense' do
+        it 'adds an offense and autocorrects it' do
           expect_offense(<<~RUBY)
             foo(abc: "100000", def: "100000", ghi: "100000", jkl: "100000", mno: "100000")
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [78/40]
           RUBY
-        end
 
-        it 'autocorrects the offense' do
-          new_source = autocorrect_source(<<~RUBY)
-            foo(abc: "100000", def: "100000", ghi: "100000", jkl: "100000", mno: "100000")
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
+          expect_correction(<<~RUBY)
             foo(abc: "100000", def: "100000",\s
             ghi: "100000", jkl: "100000", mno: "100000")
           RUBY
@@ -665,19 +600,13 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
       end
 
       context 'when call with hash on same line' do
-        it 'adds an offense only to outer' do
+        it 'adds an offense only to outer and autocorrects it' do
           expect_offense(<<~RUBY)
             foo(abc: "100000", def: "100000", ghi: {abc: "100000"}, jkl: "100000", mno: "100000")
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [85/40]
           RUBY
-        end
 
-        it 'autocorrects the offense' do
-          new_source = autocorrect_source(<<~RUBY)
-            foo(abc: "100000", def: "100000", ghi: {abc: "100000"}, jkl: "100000", mno: "100000")
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
+          expect_correction(<<~RUBY)
             foo(abc: "100000", def: "100000",\s
             ghi: {abc: "100000"}, jkl: "100000", mno: "100000")
           RUBY
@@ -685,19 +614,13 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
       end
 
       context 'when two method calls' do
-        it 'adds an offense only to outer' do
+        it 'adds an offense only to outer and autocorrects it' do
           expect_offense(<<~RUBY)
             get(1000000, 30000, foo(44440000, 30000, 39999, 19929120312093))
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [64/40]
           RUBY
-        end
 
-        it 'autocorrects the offense' do
-          new_source = autocorrect_source(<<~RUBY)
-            get(1000000, 30000, foo(44440000, 30000, 39999, 19929120312093))
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
+          expect_correction(<<~RUBY)
             get(1000000, 30000,\s
             foo(44440000, 30000, 39999, 19929120312093))
           RUBY
@@ -705,21 +628,14 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
       end
 
       context 'when nested method calls allows outer to get broken up first' do
-        it 'adds offense' do
+        it 'adds offense and does not autocorrect' do
           expect_offense(<<~RUBY)
             get(1000000,
             foo(44440000, 30000, 39999, 1992), foo(44440000, 30000, 39999, 12093))
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [70/40]
           RUBY
-        end
 
-        it 'does not autocorrect the offense' do
-          new_source = autocorrect_source(<<~RUBY)
-            get(1000000,
-            foo(44440000, 30000, 39999, 1992), foo(44440000, 30000, 39999, 12093))
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
+          expect_correction(<<~RUBY)
             get(1000000,
             foo(44440000, 30000, 39999, 1992), foo(44440000, 30000, 39999, 12093))
           RUBY
@@ -746,19 +662,13 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
       end
 
       context 'when over limit' do
-        it 'adds an offense' do
+        it 'adds an offense and autocorrects it' do
           expect_offense(<<~RUBY)
             ["1111", "100000", "100000", "100000", "100000", "100000"]
                                                     ^^^^^^^^^^^^^^^^^^ Line is too long. [58/40]
           RUBY
-        end
 
-        it 'autocorrects the offense' do
-          new_source = autocorrect_source(<<~RUBY)
-            ["1111", "100000", "100000", "100000", "100000", "100000"]
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
+          expect_correction(<<~RUBY)
             ["1111", "100000", "100000", "100000",\s
             "100000", "100000"]
           RUBY
@@ -766,19 +676,13 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
       end
 
       context 'when has inside array' do
-        it 'adds an offense only to outer' do
+        it 'adds an offense only to outer and autocorrects it' do
           expect_offense(<<~RUBY)
             ["1111", "100000", "100000", "100000", {abc: "100000", b: "2"}, "100000", "100000"]
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [83/40]
           RUBY
-        end
 
-        it 'autocorrects the offense' do
-          new_source = autocorrect_source(<<~RUBY)
-            ["1111", "100000", "100000", "100000", {abc: "100000", b: "2"}, "100000", "100000"]
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
+          expect_correction(<<~RUBY)
             ["1111", "100000", "100000", "100000",\s
             {abc: "100000", b: "2"}, "100000", "100000"]
           RUBY
@@ -786,23 +690,15 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
       end
 
       context 'when two arrays on two lines allows outer to get broken first' do
-        it 'adds an offense only to inner' do
+        it 'adds an offense only to inner and does not autocorrect it' do
           expect_offense(<<~RUBY)
             [1000000, 3912312312999,
               [44440000, 3912312312999, 3912312312999, 1992912031231232131312093],
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [70/40]
             100, 100]
           RUBY
-        end
 
-        it 'does not autocorrect the offense' do
-          new_source = autocorrect_source(<<~RUBY)
-            [1000000, 3912312312999,
-              [44440000, 3912312312999, 3912312312999, 1992912031231232131312093],
-            100, 100]
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
+          expect_correction(<<~RUBY)
             [1000000, 3912312312999,
               [44440000, 3912312312999, 3912312312999, 1992912031231232131312093],
             100, 100]
@@ -812,23 +708,15 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
     end
 
     context 'no breakable collections' do
-      it 'adds an offense' do
+      it 'adds an offense and does not autocorrect it' do
         expect_offense(<<~RUBY)
           10000003912312312999
             # 444400003912312312999391231231299919929120312312321313120933333333
                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [70/40]
           456
         RUBY
-      end
 
-      it 'does not autocorrect the offense' do
-        new_source = autocorrect_source(<<~RUBY)
-          10000003912312312999
-            # 444400003912312312999391231231299919929120312312321313120933333333
-          456
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
+        expect_correction(<<~RUBY)
           10000003912312312999
             # 444400003912312312999391231231299919929120312312321313120933333333
           456
@@ -846,19 +734,14 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
       end
 
       context 'when over limit' do
-        it 'adds offense' do
+        it 'adds offense and autocorrects it by breaking the semicolon ' \
+          'before the hash' do
           expect_offense(<<~RUBY)
             {foo: 1, bar: "2"}; a = 400000000000 + 500000000000000
                                                     ^^^^^^^^^^^^^^ Line is too long. [54/40]
           RUBY
-        end
 
-        it 'breaks the semicolon before breaking the hash' do
-          new_source = autocorrect_source(<<~RUBY)
-            {foo: 1, bar: "2"}; a = 400000000000 + 500000000000000
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
+          expect_correction(<<~RUBY)
             {foo: 1, bar: "2"};
              a = 400000000000 + 500000000000000
           RUBY
@@ -872,25 +755,17 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
       end
 
       context 'when over limit with semi-colon' do
-        it 'adds offense' do
+        it 'adds offense and does not autocorrect' do
           expect_offense(<<~RUBY)
             foo = <<-SQL
               SELECT a b c d a b FROM c d a b c d ; COUNT(*) a b
                                        ^^^^^^^^^^^^ Line is too long. [52/40]
             SQL
           RUBY
-        end
 
-        it 'does not autocorrect' do
-          new_source = autocorrect_source(<<~RUBY)
+          expect_correction(<<~RUBY)
             foo = <<-SQL
-              SELECT a b c d a b FROM c d a b c d ; COUNT(*) a b c
-            SQL
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
-            foo = <<-SQL
-              SELECT a b c d a b FROM c d a b c d ; COUNT(*) a b c
+              SELECT a b c d a b FROM c d a b c d ; COUNT(*) a b
             SQL
           RUBY
         end
@@ -899,19 +774,13 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
 
     context 'comments' do
       context 'when over limit with semi-colon' do
-        it 'adds offense' do
+        it 'adds offense and does not autocorrect' do
           expect_offense(<<~RUBY)
             # a b c d a b c d a b c d ; a b c d a b c d a b c d a
                                                     ^^^^^^^^^^^^^ Line is too long. [53/40]
           RUBY
-        end
 
-        it 'does not autocorrect' do
-          new_source = autocorrect_source(<<~RUBY)
-            # a b c d a b c d a b c d ; a b c d a b c d a b c d a
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
+          expect_correction(<<~RUBY)
             # a b c d a b c d a b c d ; a b c d a b c d a b c d a
           RUBY
         end

--- a/spec/rubocop/cop/security/json_load_spec.rb
+++ b/spec/rubocop/cop/security/json_load_spec.rb
@@ -3,21 +3,31 @@
 RSpec.describe RuboCop::Cop::Security::JSONLoad, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense for JSON.load' do
+  it 'registers an offense and corrects JSON.load' do
     expect_offense(<<~RUBY)
       JSON.load(arg)
            ^^^^ Prefer `JSON.parse` over `JSON.load`.
       ::JSON.load(arg)
              ^^^^ Prefer `JSON.parse` over `JSON.load`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      JSON.parse(arg)
+      ::JSON.parse(arg)
+    RUBY
   end
 
-  it 'registers an offense for JSON.restore' do
+  it 'registers an offense and corrects JSON.restore' do
     expect_offense(<<~RUBY)
       JSON.restore(arg)
            ^^^^^^^ Prefer `JSON.parse` over `JSON.restore`.
       ::JSON.restore(arg)
              ^^^^^^^ Prefer `JSON.parse` over `JSON.restore`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      JSON.parse(arg)
+      ::JSON.parse(arg)
     RUBY
   end
 
@@ -40,9 +50,5 @@ RSpec.describe RuboCop::Cop::Security::JSONLoad, :config do
       JSON.dump(arg)
       ::JSON.dump(arg)
     RUBY
-  end
-
-  it 'autocorrects .load to .parse' do
-    expect(autocorrect_source('JSON.load(arg)')).to eq 'JSON.parse(arg)'
   end
 end

--- a/spec/rubocop/cop/security/yaml_load_spec.rb
+++ b/spec/rubocop/cop/security/yaml_load_spec.rb
@@ -15,23 +15,25 @@ RSpec.describe RuboCop::Cop::Security::YAMLLoad, :config do
     expect_no_offenses('Module::YAML.load("foo")')
   end
 
-  it 'registers an offense for load with a literal string' do
+  it 'registers an offense and corrects load with a literal string' do
     expect_offense(<<~RUBY)
       YAML.load("--- foo")
            ^^^^ Prefer using `YAML.safe_load` over `YAML.load`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      YAML.safe_load("--- foo")
+    RUBY
   end
 
-  it 'registers an offense for a fully qualified ::YAML.load' do
+  it 'registers an offense and corrects a fully qualified ::YAML.load' do
     expect_offense(<<~RUBY)
       ::YAML.load("--- foo")
              ^^^^ Prefer using `YAML.safe_load` over `YAML.load`.
     RUBY
-  end
 
-  it 'autocorrects load to safe_load' do
-    expect(autocorrect_source('::YAML.load("-- foo")')).to eq(
-      '::YAML.safe_load("-- foo")'
-    )
+    expect_correction(<<~RUBY)
+      ::YAML.safe_load("--- foo")
+    RUBY
   end
 end


### PR DESCRIPTION
This covers the easy to convert tests from metrics, security, and lint. There will be more changes to come.