### PR TITLE
Allow split parameters that would not fit on one line in MultilineBlockLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#7271](https://github.com/rubocop-hq/rubocop/issues/7271), [#6498](https://github.com/rubocop-hq/rubocop/issues/6498): Fix an interference between `Style/TrailingCommaIn*Literal` and `Layout/Multiline*BraceLayout` for arrays and hashes. ([@buehmann][])
 * [#7241](https://github.com/rubocop-hq/rubocop/issues/7241): Make `Style/FrozenStringLiteralComment` match only true & false. ([@tejasbubane][])
 * [#7290](https://github.com/rubocop-hq/rubocop/issues/7290): Handle inner conditional inside `else` in `Style/ConditionalAssignment`. ([@jonas054][])
+* [#5788](https://github.com/rubocop-hq/rubocop/issues/5788): Allow block arguments on separate lines if line would be too long in `Layout/MultilineBlockLayout`. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/space_around_block_parameters.rb
+++ b/lib/rubocop/cop/layout/space_around_block_parameters.rb
@@ -3,7 +3,9 @@
 module RuboCop
   module Cop
     module Layout
-      # Checks the spacing inside and after block parameters pipes.
+      # Checks the spacing inside and after block parameters pipes. Line breaks
+      # inside parameter pipes are checked by `Layout/MultilineBlockLayout` and
+      # not by this cop.
       #
       # @example EnforcedStyleInsidePipes: no_space (default)
       #   # bad
@@ -156,6 +158,8 @@ module RuboCop
           return if space_begin_pos >= space_end_pos
 
           range = range_between(space_begin_pos, space_end_pos)
+          return if range.source.include?("\n")
+
           add_offense(range, location: range,
                              message: "#{msg} block parameter detected.")
         end

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -3843,7 +3843,9 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 --- | --- | --- | --- | ---
 Enabled | Yes | Yes  | 0.49 | -
 
-Checks the spacing inside and after block parameters pipes.
+Checks the spacing inside and after block parameters pipes. Line breaks
+inside parameter pipes are checked by `Layout/MultilineBlockLayout` and
+not by this cop.
 
 ### Examples
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -3149,7 +3149,9 @@ Enabled | Yes | Yes  | 0.49 | -
 
 This cop checks whether the multiline do end blocks have a newline
 after the start of the block. Additionally, it checks whether the block
-arguments, if any, are on the same line as the start of the block.
+arguments, if any, are on the same line as the start of the
+block. Putting block arguments on separate lines, because the whole
+line would otherwise be too long, is accepted.
 
 ### Examples
 
@@ -3178,6 +3180,17 @@ blah { |i| foo(i)
 
 # good
 blah { |i|
+  foo(i)
+  bar(i)
+}
+
+# good
+blah { |
+  long_list,
+  of_parameters,
+  that_would_not,
+  fit_on_one_line
+|
   foo(i)
   bar(i)
 }

--- a/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
@@ -51,6 +51,20 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
     RUBY
   end
 
+  it 'does not register offenses when there are too many parameters to fit ' \
+     'on one line' do
+    expect_no_offenses(<<~RUBY)
+      some_result = lambda do |
+        so_many,
+        parameters,
+        it_will,
+        be_too_long,
+        for_one_line|
+        do_something
+      end
+    RUBY
+  end
+
   it 'does not error out when the block is empty' do
     expect_no_offenses(<<~RUBY)
       test do |x|

--- a/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
@@ -35,6 +35,22 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
       expect_no_offenses('{}.each { |x,y| puts x }')
     end
 
+    it 'accepts block parameters with surrounding space that includes line ' \
+       'breaks' do
+      # This is checked by Layout/MultilineBlockLayout.
+      expect_no_offenses(<<~RUBY)
+        some_result = lambda do |
+          so_many,
+          parameters,
+          it_will,
+          be_too_long,
+          for_one_line
+        |
+          do_something
+        end
+      RUBY
+    end
+
     it 'accepts a lambda with spaces in the right places' do
       expect_no_offenses('->(x, y) { puts x }')
     end


### PR DESCRIPTION
This fixes #5788, which talks about auto-correct introducing `Metrics/LineLength` offenses. I took the approach of changing, not only auto-correct, but the reporting of the offense. Parameter lists that would be too long for one line are just left alone.

The `Layout/SpaceAroundBlockParameters` cop had to be updated too, if we're to accept these parameter lists with line breaks in them.