### PR TITLE
[Fix #7271] Correct multiline braces and trailing commas together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#7252](https://github.com/rubocop-hq/rubocop/issues/7252): Prevent infinite loops by making `Layout/SpaceInsideStringInterpolation` skip over interpolations that start or end with a line break. ([@buehmann][])
 * [#7262](https://github.com/rubocop-hq/rubocop/issues/7262): `Lint/FormatParameterMismatch` did not recognize named format sequences like `%.2<name>f` where the name appears after some modifiers. ([@buehmann][])
 * [#7253](https://github.com/rubocop-hq/rubocop/issues/7253): Fix an error for `Lint/NumberConversion` when `#to_i` called without a receiver. ([@koic][])
+* [#7271](https://github.com/rubocop-hq/rubocop/issues/7271), [#6498](https://github.com/rubocop-hq/rubocop/issues/6498): Fix an interference between `Style/TrailingCommaIn*Literal` and `Layout/Multiline*BraceLayout` for arrays and hashes. ([@buehmann][])
 
 ### Changes
 

--- a/lib/rubocop/cop/correctors/multiline_literal_brace_corrector.rb
+++ b/lib/rubocop/cop/correctors/multiline_literal_brace_corrector.rb
@@ -40,8 +40,8 @@ module RuboCop
           range_with_surrounding_space(range: node.loc.end, side: :left)
         )
 
-        corrector.insert_after(
-          last_element_range_with_trailing_comma(node),
+        corrector.insert_before(
+          last_element_range_with_trailing_comma(node).end,
           node.loc.end.source
         )
       end

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1710,4 +1710,49 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         SQL
     RUBY
   end
+
+  it 'corrects TrailingCommaIn(Array|Hash)Literal and ' \
+     'Multiline(Array|Hash)BraceLayout offenses' do
+    create_file('.rubocop.yml', <<~YAML)
+      Style/TrailingCommaInArrayLiteral:
+        EnforcedStyleForMultiline: consistent_comma
+      Style/TrailingCommaInHashLiteral:
+        EnforcedStyleForMultiline: consistent_comma
+    YAML
+
+    source_file = Pathname('example.rb')
+    source = <<~RUBY
+      [ 1,
+        2
+      ].to_s
+
+      { foo: 1,
+        bar: 2
+      }.to_s
+    RUBY
+    create_file(source_file, source)
+
+    status = cli.run(
+      [
+        '--auto-correct',
+        '--only',
+        [
+          'Style/TrailingCommaInArrayLiteral',
+          'Style/TrailingCommaInHashLiteral',
+          'Layout/MultilineArrayBraceLayout',
+          'Layout/MultilineHashBraceLayout'
+        ].join(',')
+      ]
+    )
+    expect(status).to eq(0)
+
+    corrected = <<~RUBY
+      [ 1,
+        2,].to_s
+
+      { foo: 1,
+        bar: 2,}.to_s
+    RUBY
+    expect(source_file.read).to eq(corrected)
+  end
 end


### PR DESCRIPTION
This fixes #7271 and closes #6498 as well.

The problem during auto-correction was that both cops were inserting _after_ the last item of the array or hash: one was inserting a comma, the other the closing brace – and those might come out in the wrong order.

The solution is to still let them insert in the same location, but in different directions: The comma is inserted _after_ the last item and the brace _before_ the characters following the last item. That way, the comma always precedes the closing brace.