### PR TITLE
Make it possible to set StyleGuideBaseURL per department

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#7274](https://github.com/rubocop-hq/rubocop/issues/7274): Add new `Lint/SendWithMixinArgument` cop. ([@koic][])
 * [#7272](https://github.com/rubocop-hq/rubocop/pull/7272): Show warning message if passed string to `Enabled`, `Safe`, `SafeAutocorrect`, and `AutoCorrect` keys in .rubocop.yml. ([@unasuke][])
+* [#7295](https://github.com/rubocop-hq/rubocop/pull/7295): Make it possible to set `StyleGuideBaseURL` per department. ([@koic][])
 
 ### Bug fixes
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -96,6 +96,10 @@ module RuboCop
       @for_cop[cop.respond_to?(:cop_name) ? cop.cop_name : cop]
     end
 
+    def for_department(department_name)
+      @for_cop[department_name]
+    end
+
     def for_all_cops
       @for_all_cops ||= self['AllCops'] || {}
     end

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -224,8 +224,8 @@ module RuboCop
 
       def annotate(message)
         RuboCop::Cop::MessageAnnotator.new(
-          config, cop_config, @options
-        ).annotate(message, name)
+          config, cop_name, cop_config, @options
+        ).annotate(message)
       end
 
       def file_name_matches_any?(file, parameter, default_result)

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -576,5 +576,39 @@ Running `rubocop --[safe-]auto-correct --disable-uncorrectable` will
 create comments to disable all offenses that can't be automatically
 corrected.
 
+### Setting the style guide URL
+
+You can specify the base URL of the style guide using `StyleGuideBaseURL`.
+If specified under `AllCops`, all cops are targeted.
+
+```yaml
+AllCops:
+  StyleGuideBaseURL: https://rubystyle.guide
+```
+
+`StyleGuideBaseURL` is combined with `StyleGuide` specified to the cop.
+
+```yaml
+Lint/UselessAssignment:
+  StyleGuide: '#underscore-unused-vars'
+```
+
+The style guide URL is https://rubystyle.guide#underscore-unused-vars.
+
+If specified under a specific department, it takes precedence over `AllCops`.
+The following is an example of specifying `Rails` department.
+
+```yaml
+Rails:
+  StyleGuideBaseURL: https://rails.rubystyle.guide
+```
+
+```yaml
+Rails/TimeZone:
+  StyleGuide: '#time'
+```
+
+The style guide URL is https://rails.rubystyle.guide#time.
+
 [1]: https://github.com/rubocop-hq/rubocop/blob/master/config/default.yml
 [xdg-basedir-spec]: https://specifications.freedesktop.org/basedir-spec/latest/index.html

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -155,7 +155,9 @@ task generate_cops_documentation: :yard_for_generate_documentation do
 
   def references(config, cop)
     cop_config = config.for_cop(cop)
-    urls = RuboCop::Cop::MessageAnnotator.new(config, cop_config, {}).urls
+    urls = RuboCop::Cop::MessageAnnotator.new(
+      config, cop.name, cop_config, {}
+    ).urls
     return '' if urls.empty?
 
     content = h3('References')


### PR DESCRIPTION
### Summary

Resolves https://github.com/rubocop-hq/rubocop-rails/issues/107 and follow up https://github.com/rubocop-hq/rubocop-rails/pull/109#issuecomment-521983107.

This PR makes it possible to set a style guide URL (`StyleGuideBaseURL`) for each department.

For example, RuboCop Rails gem (Rails department) supports The Rails Style Guide. In that case, set .rubocop.yml as follows.

```yaml
# .rubocop.yml
require:
  - rubocop-rails

AllCops:
  StyleGuideBaseURL:  https://rubystyle.guide

Rails:
  StyleGuideBaseURL:  https://rails.rubystyle.guide
```

In practice `Rails: StyleGuideBaseURL: https://rails.rubystyle.guide` will be set in config/default.yml of rubocop-rails.

```console
% cat example.rb
# frozen_string_literal: true

time = Time.new
```

```console
% bundle exec rubocop --display-style-guide example.rb
Inspecting 1 file
W

Offenses:

example.rb:3:1: W: Lint/UselessAssignment: Useless assignment to
variable - time. (https://rubystyle.guide#underscore-unused-vars)
time = Time.new
^^^^
example.rb:3:13: C: Rails/TimeZone: Do not use Time.new without
zone. Use one of Time.zone.now, Time.current, Time.new.in_time_zone,
Time.new.utc, Time.new.getlocal, Time.new.xmlschema, Time.new.iso8601,
Time.new.jisx0301, Time.new.rfc3339, Time.new.httpdate, Time.new.to_i,
Time.new.to_f instead. (https://rails.rubystyle.guide#time,
http://danilenko.org/2012/7/6/rails_timezones)
time = Time.new
            ^^^

1 file inspected, 2 offenses detected
```

The style guide URLs set for each department is displayed.

- https://rubystyle.guide#underscore-unused-vars for `Lint/UselessAssignment` cop
- https://rails.rubystyle.guide#time for for `Rails/TimeZone` cop

So `AllCops` style guide URL is used when there is no style guide URL for a specific department.

### Other Information

Note that tasks/cops_documentation.rake will require the following patch:

```diff
diff --git a/tasks/cops_documentation.rake
b/tasks/cops_documentation.rake
index bd93ffe31..751222fcb 100644
--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -155,7 +155,9 @@ task generate_cops_documentation:
:yard_for_generate_documentation do

   def references(config, cop)
     cop_config = config.for_cop(cop)
-    urls = RuboCop::Cop::MessageAnnotator.new(config, cop_config, {}).urls
+    urls = RuboCop::Cop::MessageAnnotator.new(
+      config, cop.name, cop_config, {}
+    ).urls
     return '' if urls.empty?

     content = h3('References')
```

AFAIK, rubocop-performance, rubocop-rails, rubocop-rspec, and rubocop-minitest repositories are targeted.

/cc @bquorning 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
