### PR TITLE
Recognize rails/web-console debug calls in Lint/Debugger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#7296](https://github.com/rubocop-hq/rubocop/issues/7296): Recognize `console` and `binding.console` ([rails/web-console](https://github.com/rails/web-console)) calls in `Lint/Debuggers`. ([@gsamokovarov][])
 * [#7567](https://github.com/rubocop-hq/rubocop/pull/7567): Introduce new `pending` status for new cops. ([@Darhazer][], [@pirj][])
 
 ### Bug fixes

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -43,9 +43,9 @@ module RuboCop
         PATTERN
 
         def_node_matcher :debugger_call?, <<~PATTERN
-          {(send {nil? #kernel?} {:debugger :byebug :remote_byebug} ...)
+          {(send {nil? #kernel?} {:debugger :byebug :remote_byebug :console} ...)
            (send (send {#kernel? nil?} :binding)
-             {:pry :remote_pry :pry_remote} ...)
+             {:pry :remote_pry :pry_remote :console} ...)
            (send (const {nil? (cbase)} :Pry) :rescue ...)
            (send nil? {:save_and_open_page
                       :save_and_open_screenshot

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -50,7 +50,10 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
   include_examples 'debugger',
                    'capybara debug method with an argument',
                    'save_screenshot foo'
+
   include_examples 'debugger', 'remote_byebug', 'remote_byebug'
+  include_examples 'debugger', 'web console', 'console'
+  include_examples 'debugger', 'web console binding', 'binding.console'
 
   it 'does not report an offense for a non-pry binding' do
     expect_no_offenses('binding.pirate')
@@ -59,12 +62,13 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
   include_examples 'debugger', 'debugger with Kernel', 'Kernel.debugger'
   include_examples 'debugger', 'debugger with ::Kernel', '::Kernel.debugger'
   include_examples 'debugger', 'binding.pry with Kernel', 'Kernel.binding.pry'
+  include_examples 'debugger', 'web console with Kernel', 'Kernel.console'
 
   it 'does not report an offense for save_and_open_page with Kernel' do
     expect_no_offenses('Kernel.save_and_open_page')
   end
 
-  ALL_COMMANDS = %w[debugger byebug pry remote_pry pry_remote irb
+  ALL_COMMANDS = %w[debugger byebug console pry remote_pry pry_remote irb
                     save_and_open_page save_and_open_screenshot
                     save_screenshot remote_byebug].freeze
 


### PR DESCRIPTION
Rails' [Web Console](https://github.com/rails/web-console) has been around for a while now and I like debugging my applications with it. I recently shipped a `console` call in production (this is what spawns it). While the `console` call is not a security vulnerability, it results in a `NoMethodError` as Web Console is not available in production, I would have loved to have this caught by a linter. 

Do you think it has a place in `Lint/Debugger`?