### PR TITLE
[Fix #7052] Make `Lint/HandleExceptions` register offense for rescue nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#7274](https://github.com/rubocop-hq/rubocop/issues/7274): Add new `Lint/SendWithMixinArgument` cop. ([@koic][])
 * [#7272](https://github.com/rubocop-hq/rubocop/pull/7272): Show warning message if passed string to `Enabled`, `Safe`, `SafeAutocorrect`, and `AutoCorrect` keys in .rubocop.yml. ([@unasuke][])
 * [#7295](https://github.com/rubocop-hq/rubocop/pull/7295): Make it possible to set `StyleGuideBaseURL` per department. ([@koic][])
+* [#7052](https://github.com/rubocop-hq/rubocop/issues/7052): Make `Lint/HandleExceptions` register offense for rescue nil. ([@tejasbubane][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/lint/handle_exceptions.rb
+++ b/lib/rubocop/cop/lint/handle_exceptions.rb
@@ -78,7 +78,7 @@ module RuboCop
         MSG = 'Do not suppress exceptions.'
 
         def on_resbody(node)
-          return if node.body
+          return if node.body && !node.body.nil_type?
           return if cop_config['AllowComments'] && comment_lines?(node)
 
           add_offense(node)

--- a/spec/rubocop/cop/lint/handle_exceptions_spec.rb
+++ b/spec/rubocop/cop/lint/handle_exceptions_spec.rb
@@ -14,6 +14,24 @@ RSpec.describe RuboCop::Cop::Lint::HandleExceptions, :config do
     RUBY
   end
 
+  it 'registers an offense for rescue nil' do
+    expect_offense(<<~RUBY)
+      begin
+        something
+      rescue
+      ^^^^^^ Do not suppress exceptions.
+        nil
+      end
+    RUBY
+  end
+
+  it 'registers an offense for inline nil rescue' do
+    expect_offense(<<~RUBY)
+      something rescue nil
+                ^^^^^^^^^^ Do not suppress exceptions.
+    RUBY
+  end
+
   it 'does not register an offense for rescue with body' do
     expect_no_offenses(<<~RUBY)
       begin


### PR DESCRIPTION
#7052 had 2 changes:

1. Add config option AllowComments - done in #7060 
2. Do not allow rescue blocks consisting of nil (especially single line rescue) - fixed in this PR

Closes #7052 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/