### PR TITLE
Use squiggly heredoc instead of strip_indent

### DIFF
--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
   end
 
   it 'plays nicely with default cops in complex ExtraSpacing scenarios' do
-    create_file('.rubocop.yml', <<-YAML.strip_indent)
+    create_file('.rubocop.yml', <<~YAML)
       # These cops change indentation and thus need disabling in order for the
       # ExtraSpacing rules to apply to this scenario.
 
@@ -48,7 +48,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         Enabled: false
     YAML
 
-    source = <<-RUBY.strip_indent
+    source = <<~RUBY
       def batch
         @areas = params[:param].map do
                         var_1 = 123_456
@@ -77,7 +77,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     create_file('example.rb', source)
     expect(cli.run(['--auto-correct'])).to eq(1)
 
-    expect(IO.read('example.rb')).to eq(<<-RUBY.strip_indent)
+    expect(IO.read('example.rb')).to eq(<<~RUBY)
       # frozen_string_literal: true
 
       def batch
@@ -531,7 +531,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
      'UnneededInterpolation offense unchanged' do
     # If we change string concatenation from plus to backslash, the string
     # literal that follows must remain a string literal.
-    source = <<-'RUBY'.strip_indent
+    source = <<~'RUBY'
       puts 'foo' +
            "#{bar}"
       puts 'a' +
@@ -554,7 +554,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
   end
 
   it 'corrects Style/InverseMethods and Style/Not offenses' do
-    source = <<-'RUBY'.strip_indent
+    source = <<~'RUBY'
       x.select {|y| not y.z }
     RUBY
     create_file('example.rb', source)
@@ -562,7 +562,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                      '--auto-correct',
                      '--only', 'Style/InverseMethods,Style/Not'
                    ])).to eq(0)
-    corrected = <<-'RUBY'.strip_indent
+    corrected = <<~'RUBY'
       x.reject {|y|  y.z }
     RUBY
     expect(IO.read('example.rb')).to eq(corrected)
@@ -573,7 +573,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       AllCops:
         TargetRubyVersion: 2.3
     YAML
-    source = <<-'RUBY'.strip_indent
+    source = <<~'RUBY'
       until x
         if foo
           foo.some_method do
@@ -587,7 +587,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                      '--auto-correct',
                      '--only', 'Style/Next,Style/SafeNavigation'
                    ])).to eq(0)
-    corrected = <<-'RUBY'.strip_indent
+    corrected = <<~'RUBY'
       until x
         next unless foo
         foo.some_method do
@@ -599,7 +599,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
   end
 
   it 'corrects `Lint/Lambda` and `Lint/UnusedBlockArgument` offenses' do
-    source = <<-'RUBY'.strip_indent
+    source = <<~'RUBY'
       c = -> event do
         puts 'Hello world'
       end
@@ -609,7 +609,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                      '--auto-correct',
                      '--only', 'Lint/Lambda,Lint/UnusedBlockArgument'
                    ])).to eq(0)
-    corrected = <<-'RUBY'.strip_indent
+    corrected = <<~'RUBY'
       c = lambda do |_event|
         puts 'Hello world'
       end
@@ -936,7 +936,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         EnforcedStyle: indented_internal_methods
     YAML
 
-    source = <<-'RUBY'.strip_indent
+    source = <<~'RUBY'
       class Foo
                          private
 
@@ -957,7 +957,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                      ].join(',')
                    ])).to eq(0)
 
-    corrected = <<-'RUBY'.strip_indent
+    corrected = <<~'RUBY'
       class Foo
       private
 

--- a/spec/rubocop/cli/cli_disable_uncorrectable_spec.rb
+++ b/spec/rubocop/cli/cli_disable_uncorrectable_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       create_file('example.rb', 'puts 1==2')
       expect(exit_code).to eq(0)
       expect($stderr.string).to eq('')
-      expect($stdout.string).to eq(<<-OUTPUT.strip_indent)
+      expect($stdout.string).to eq(<<~OUTPUT)
         == example.rb ==
         C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
         C:  1:  7: [Corrected] Layout/SpaceAroundOperators: Surrounding space missing for operator ==.
 
         1 file inspected, 2 offenses detected, 2 offenses corrected
       OUTPUT
-      expect(IO.read('example.rb')).to eq(<<-RUBY.strip_indent)
+      expect(IO.read('example.rb')).to eq(<<~RUBY)
         # frozen_string_literal: true
 
         puts 1 == 2
@@ -30,21 +30,21 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
     context 'if one one-line disable statement fits' do
       it 'adds it' do
-        create_file('example.rb', <<-RUBY.strip_indent)
+        create_file('example.rb', <<~RUBY)
           def is_example
             true
           end
         RUBY
         expect(exit_code).to eq(0)
         expect($stderr.string).to eq('')
-        expect($stdout.string).to eq(<<-OUTPUT.strip_indent)
+        expect($stdout.string).to eq(<<~OUTPUT)
           == example.rb ==
           C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
           C:  1:  5: [Corrected] Naming/PredicateName: Rename is_example to example?.
 
           1 file inspected, 2 offenses detected, 2 offenses corrected
         OUTPUT
-        expect(IO.read('example.rb')).to eq(<<-RUBY.strip_indent)
+        expect(IO.read('example.rb')).to eq(<<~RUBY)
           # frozen_string_literal: true
 
           def is_example # rubocop:disable Naming/PredicateName
@@ -55,16 +55,16 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
       context 'and there are two offenses of the same kind on one line' do
         it 'adds a single one-line disable statement' do
-          create_file('.rubocop.yml', <<-YAML.strip_indent)
+          create_file('.rubocop.yml', <<~YAML)
             Style/IpAddresses:
               Enabled: true
           YAML
-          create_file('example.rb', <<-RUBY.strip_indent)
+          create_file('example.rb', <<~RUBY)
             ip('1.2.3.4', '5.6.7.8')
           RUBY
           expect(exit_code).to eq(0)
           expect($stderr.string).to eq('')
-          expect($stdout.string).to eq(<<-OUTPUT.strip_indent)
+          expect($stdout.string).to eq(<<~OUTPUT)
             == example.rb ==
             C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
             C:  1:  4: [Corrected] Style/IpAddresses: Do not hardcode IP addresses.
@@ -72,7 +72,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
             1 file inspected, 3 offenses detected, 3 offenses corrected
           OUTPUT
-          expect(IO.read('example.rb')).to eq(<<-RUBY.strip_indent)
+          expect(IO.read('example.rb')).to eq(<<~RUBY)
             # frozen_string_literal: true
 
             ip('1.2.3.4', '5.6.7.8') # rubocop:disable Style/IpAddresses
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       context "but there are more offenses on the line and they don't all " \
               'fit' do
         it 'adds both one-line and before-and-after disable statements' do
-          create_file('example.rb', <<-RUBY.strip_indent)
+          create_file('example.rb', <<~RUBY)
             # Chess engine.
             class Chess
               def choose_move(who_to_move)
@@ -106,7 +106,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           RUBY
           expect(exit_code).to eq(0)
           expect($stderr.string).to eq('')
-          expect($stdout.string).to eq(<<-OUTPUT.strip_indent)
+          expect($stdout.string).to eq(<<~OUTPUT)
             == example.rb ==
             C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
             C:  3:  3: [Corrected] Metrics/AbcSize: Assignment Branch Condition size for choose_move is too high. [15.62/15]
@@ -118,7 +118,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
             1 file inspected, 7 offenses detected, 7 offenses corrected
           OUTPUT
-          expect(IO.read('example.rb')).to eq(<<-RUBY.strip_indent)
+          expect(IO.read('example.rb')).to eq(<<~RUBY)
             # frozen_string_literal: true
 
             # Chess engine.
@@ -151,11 +151,11 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
     context "if a one-line disable statement doesn't fit" do
       it 'adds before-and-after disable statement' do
-        create_file('.rubocop.yml', <<-YAML.strip_indent)
+        create_file('.rubocop.yml', <<~YAML)
           Metrics/MethodLength:
             Max: 1
         YAML
-        create_file('example.rb', <<-RUBY.strip_indent)
+        create_file('example.rb', <<~RUBY)
           def long_method_name(_taking, _a_few, _parameters, _resulting_in_a_long_line)
             puts 'line 1'
             puts 'line 2'
@@ -163,14 +163,14 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         RUBY
         expect(exit_code).to eq(0)
         expect($stderr.string).to eq('')
-        expect($stdout.string).to eq(<<-OUTPUT.strip_indent)
+        expect($stdout.string).to eq(<<~OUTPUT)
           == example.rb ==
           C:  1:  1: [Corrected] Metrics/MethodLength: Method has too many lines. [2/1]
           C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
 
           1 file inspected, 2 offenses detected, 2 offenses corrected
         OUTPUT
-        expect(IO.read('example.rb')).to eq(<<-RUBY.strip_indent)
+        expect(IO.read('example.rb')).to eq(<<~RUBY)
           # rubocop:disable Metrics/MethodLength
           # frozen_string_literal: true
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -589,7 +589,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       create_file('regexp.rb', 'x = 0')
       create_file('exclude_glob.rb', ['#!/usr/bin/env ruby', 'x = 0'])
       create_file('dir/thing.rb', 'x = 0')
-      create_file('.rubocop.yml', <<-'YAML'.strip_indent)
+      create_file('.rubocop.yml', <<~'YAML')
         Lint/UselessAssignment:
           Exclude:
             - example.rb
@@ -1466,7 +1466,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
        'with regexp' do
       create_file('example/example1.rb', '#' * 90)
 
-      create_file('rubocop.yml', <<-'YAML'.strip_indent)
+      create_file('rubocop.yml', <<~'YAML')
         AllCops:
           Exclude:
             - !ruby/regexp /example1\.rb$/

--- a/spec/rubocop/cop/layout/align_arguments_spec.rb
+++ b/spec/rubocop/cop/layout/align_arguments_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignArguments do
     end
 
     it 'can handle heredoc strings' do
-      expect_no_offenses(<<-'RUBY'.strip_indent)
+      expect_no_offenses(<<~'RUBY')
         class_eval(<<-EOS, __FILE__, __LINE__ + 1)
                     def run_#{name}_callbacks(*args)
                       a = 1
@@ -167,7 +167,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignArguments do
     end
 
     it 'can handle a call with a block inside another call' do
-      expect_no_offenses(<<-'RUBY'.strip_indent)
+      expect_no_offenses(<<~'RUBY')
         new(table_name,
             exec_query("info('#{row['name']}')").map { |col|
               col['name']
@@ -296,7 +296,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignArguments do
     end
 
     it 'does not crash in autocorrect on dynamic string in parameter value' do
-      src = <<-'RUBY'.strip_indent
+      src = <<~'RUBY'
         class MyModel < ActiveRecord::Base
           has_many :other_models,
             class_name: "legacy_name",
@@ -306,7 +306,7 @@ RSpec.describe RuboCop::Cop::Layout::AlignArguments do
       RUBY
       new_source = autocorrect_source(src)
       expect(new_source)
-        .to eq <<-'RUBY'.strip_indent
+        .to eq <<~'RUBY'
           class MyModel < ActiveRecord::Base
             has_many :other_models,
                      class_name: "legacy_name",

--- a/spec/rubocop/cop/layout/empty_lines_around_begin_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_begin_body_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
 
   shared_examples 'offense' do |name, message, code, correction|
     it "registers an offense for #{name} with a blank" do
-      inspect_source(code.strip_indent)
+      inspect_source(code)
       message = "Extra empty line detected at `begin` body #{message}."
       expect(cop.messages).to eq([message])
     end
 
     it "autocorrects for #{name} with a blank" do
-      corrected = autocorrect_source(code.strip_indent)
-      expect(corrected).to eq(correction.strip_indent)
+      corrected = autocorrect_source(code)
+      expect(corrected).to eq(correction)
     end
   end
 

--- a/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords d
 
   shared_examples 'offense' do |name, message, code, correction|
     it "registers an offense for #{name} with a blank" do
-      inspect_source(code.strip_indent)
+      inspect_source(code)
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(["Extra empty line detected #{message}."])
     end
 
     it "autocorrects for #{name} with a blank" do
-      corrected = autocorrect_source(code.strip_indent)
-      expect(corrected).to eq(correction.strip_indent)
+      corrected = autocorrect_source(code)
+      expect(corrected).to eq(correction)
     end
   end
 
@@ -104,7 +104,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords d
     end
   CORRECTION
 
-  include_examples 'accepts', 'no empty line', <<-RUBY
+  include_examples 'accepts', 'no empty line', <<~RUBY
     begin
       f1
     rescue
@@ -116,7 +116,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords d
     end
   RUBY
 
-  include_examples 'accepts', 'empty lines around begin body', <<-RUBY
+  include_examples 'accepts', 'empty lines around begin body', <<~RUBY
     begin
 
       f1
@@ -124,12 +124,12 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords d
     end
   RUBY
 
-  include_examples 'accepts', 'empty begin', <<-RUBY
+  include_examples 'accepts', 'empty begin', <<~RUBY
     begin
     end
   RUBY
 
-  include_examples 'accepts', 'empty method definition', <<-RUBY
+  include_examples 'accepts', 'empty method definition', <<~RUBY
     def foo
     end
   RUBY

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -334,7 +334,7 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
     end
 
     it 'does not register offenses for multiple complex nested assignments' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         def batch
           @areas   = params[:param].map {
                        var_1      = 123_456
@@ -386,7 +386,7 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
     end
 
     it 'does not register alignment errors on outdented lines' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         @areas = params[:param].map do |ca_params|
                    ca_params = ActionController::Parameters.new(stuff)
                  end
@@ -478,7 +478,7 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
     end
 
     it 'autocorrects complex nested assignments' do
-      new_source = autocorrect_source(<<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<~RUBY)
         def batch
           @areas = params[:param].map {
                        var_1 = 123_456
@@ -502,7 +502,7 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
         end
       RUBY
 
-      expect(new_source).to eq(<<-RUBY.strip_indent)
+      expect(new_source).to eq(<<~RUBY)
         def batch
           @areas   = params[:param].map {
                        var_1      = 123_456

--- a/spec/rubocop/cop/layout/indent_first_argument_spec.rb
+++ b/spec/rubocop/cop/layout/indent_first_argument_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentFirstArgument, :config do
       end
 
       it 'does not view chained call as an outer method call' do
-        expect_no_offenses(<<-'RUBY'.strip_indent)
+        expect_no_offenses(<<~'RUBY')
           A = Regexp.union(
             /[A-Za-z_][A-Za-z\d_]*[!?=]?/,
             *AST::Types::OPERATOR_METHODS.map(&:to_s)
@@ -340,7 +340,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentFirstArgument, :config do
         end
 
         it 'accepts a correctly indented first argument in interpolation' do
-          expect_no_offenses(<<-'RUBY'.strip_indent)
+          expect_no_offenses(<<~'RUBY')
             puts %(
               <p>
                 #{Array(
@@ -592,7 +592,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentFirstArgument, :config do
       end
 
       it 'does not view chained call as an outer method call' do
-        expect_no_offenses(<<-'RUBY'.strip_indent)
+        expect_no_offenses(<<~'RUBY')
           A = Regexp.union(
                 /[A-Za-z_][A-Za-z\d_]*[!?=]?/,
                 *AST::Types::OPERATOR_METHODS.map(&:to_s)

--- a/spec/rubocop/cop/layout/indent_first_hash_element_spec.rb
+++ b/spec/rubocop/cop/layout/indent_first_hash_element_spec.rb
@@ -297,7 +297,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentFirstHashElement do
         end
 
         it 'accepts special indentation for second argument' do
-          expect_no_offenses(<<-'RUBY'.strip_indent)
+          expect_no_offenses(<<~'RUBY')
             body.should have_tag("input", :attributes => {
                                    :name => /q\[(id_eq)\]/ })
           RUBY
@@ -348,7 +348,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentFirstHashElement do
         end
 
         it 'accepts normal indentation for second argument' do
-          expect_no_offenses(<<-'RUBY'.strip_indent)
+          expect_no_offenses(<<~'RUBY')
             body.should have_tag("input", :attributes => {
               :name => /q\[(id_eq)\]/ })
           RUBY

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
         end
 
         it 'does not indent heredoc strings' do
-          corrected = autocorrect_source(<<-'RUBY'.strip_indent)
+          corrected = autocorrect_source(<<~'RUBY')
             module Foo
             module Bar
               SOMETHING = <<GOO
@@ -290,7 +290,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
             end
             end
           RUBY
-          expect(corrected).to eq <<-'RUBY'.strip_indent
+          expect(corrected).to eq <<~'RUBY'
             module Foo
               module Bar
                 SOMETHING = <<GOO
@@ -774,7 +774,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
       end
 
       it 'accepts aligned values in when clause' do
-        expect_no_offenses(<<-'RUBY'.strip_indent)
+        expect_no_offenses(<<~'RUBY')
           case superclass
           when /\A(#{NAMESPACEMATCH})(?:\s|\Z)/,
                /\A(Struct|OStruct)\.new/,

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
   end
 
   it 'accepts the result of the ExtraSpacing Cop' do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       def batch
         @areas   = params[:param].map do
                      var_1      = 123_456

--- a/spec/rubocop/cop/layout/space_inside_string_interpolation_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_string_interpolation_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
 
     context 'for ill-formatted string interpolations' do
       it 'registers offenses and autocorrects' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           "#{ var}"
              ^ Space inside string interpolation detected.
           "#{var }"
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
                    ^^^^ Space inside string interpolation detected.
         RUBY
 
-        expect_correction(<<-'RUBY'.strip_indent)
+        expect_correction(<<~'RUBY')
           "#{var}"
           "#{var}"
           "#{var}"
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
       end
 
       it 'finds interpolations in string-like contexts' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           /regexp #{ var}/
                     ^ Space inside string interpolation detected.
           `backticks #{ var}`
@@ -49,7 +49,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
                      ^ Space inside string interpolation detected.
         RUBY
 
-        expect_correction(<<-'RUBY'.strip_indent)
+        expect_correction(<<~'RUBY')
           /regexp #{var}/
           `backticks #{var}`
           :"symbol #{var}"
@@ -59,33 +59,33 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
 
     context 'for "space" style formatted string interpolations' do
       it 'registers offenses and autocorrects' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           "#{ var }"
              ^ Space inside string interpolation detected.
                  ^ Space inside string interpolation detected.
         RUBY
 
-        expect_correction(<<-'RUBY'.strip_indent)
+        expect_correction(<<~'RUBY')
           "#{var}"
         RUBY
       end
     end
 
     it 'does not touch spaces inside the interpolated expression' do
-      expect_offense(<<-'RUBY'.strip_indent)
+      expect_offense(<<~'RUBY')
         "#{ a; b }"
            ^ Space inside string interpolation detected.
                 ^ Space inside string interpolation detected.
       RUBY
 
-      expect_correction(<<-'RUBY'.strip_indent)
+      expect_correction(<<~'RUBY')
         "#{a; b}"
       RUBY
     end
 
     context 'for well-formatted string interpolations' do
       let(:source) do
-        <<-'RUBY'.strip_indent
+        <<~'RUBY'
           "Variable is    #{var}      "
           "  Variable is  #{var}"
         RUBY
@@ -107,7 +107,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
 
     context 'when interpolation starts or ends with a line break' do
       it 'does not register an offense' do
-        expect_no_offenses(<<-'RUBY'.strip_indent)
+        expect_no_offenses(<<~'RUBY')
           "#{
             code
           }"
@@ -115,7 +115,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
       end
 
       it 'ignores comments and whitespace when looking for line breaks' do
-        expect_no_offenses(<<-'RUBY'.strip_indent)
+        expect_no_offenses(<<~'RUBY')
           def foo
             "#{ # comment
               code
@@ -131,7 +131,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
 
     context 'for ill-formatted string interpolations' do
       it 'registers offenses and autocorrects' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           "#{ var}"
                  ^ Missing space inside string interpolation detected.
           "#{var }"
@@ -146,7 +146,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
         RUBY
 
         # Extra space is handled by ExtraSpace cop.
-        expect_correction(<<-'RUBY'.strip_indent)
+        expect_correction(<<~'RUBY')
           "#{ var }"
           "#{ var }"
           "#{   var   }"
@@ -160,13 +160,13 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
 
     context 'for "no_space" style formatted string interpolations' do
       it 'registers offenses and autocorrects' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           "#{var}"
            ^^ Missing space inside string interpolation detected.
                 ^ Missing space inside string interpolation detected.
         RUBY
 
-        expect_correction(<<-'RUBY'.strip_indent)
+        expect_correction(<<~'RUBY')
           "#{ var }"
         RUBY
       end
@@ -174,7 +174,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
 
     context 'for well-formatted string interpolations' do
       let(:source) do
-        <<-'RUBY'.strip_indent
+        <<~'RUBY'
           "Variable is    #{ var }      "
           "  Variable is  #{ var }"
         RUBY

--- a/spec/rubocop/cop/layout/tab_spec.rb
+++ b/spec/rubocop/cop/layout/tab_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe RuboCop::Cop::Layout::Tab do
   end
 
   it 'registers an offense for a line indented with mixed whitespace' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<-'RUBY')
        	x = 0
        ^ Tab detected.
     RUBY

--- a/spec/rubocop/cop/lint/empty_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/empty_interpolation_spec.rb
@@ -4,29 +4,29 @@ RSpec.describe RuboCop::Cop::Lint::EmptyInterpolation do
   subject(:cop) { described_class.new }
 
   it 'registers an offense and corrects #{} in interpolation' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       "this is the #{}"
                    ^^^ Empty interpolation detected.
     RUBY
 
-    expect_correction(<<-'RUBY'.strip_indent)
+    expect_correction(<<~'RUBY')
       "this is the "
     RUBY
   end
 
   it 'registers an offense and corrects #{ } in interpolation' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       "this is the #{ }"
                    ^^^^ Empty interpolation detected.
     RUBY
 
-    expect_correction(<<-'RUBY'.strip_indent)
+    expect_correction(<<~'RUBY')
       "this is the "
     RUBY
   end
 
   it 'finds interpolations in string-like contexts' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       /regexp #{}/
               ^^^ Empty interpolation detected.
       `backticks #{}`

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -154,21 +154,21 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
   it_behaves_like('non-special string literal interpolation', %("foo"))
 
   it 'handles double quotes in single quotes when auto-correction' do
-    corrected = autocorrect_source(<<-'RUBY'.strip_indent)
+    corrected = autocorrect_source(<<~'RUBY')
       "this is #{'"'} silly"
     RUBY
-    expect(corrected).to eq(<<-'RUBY'.strip_indent)
+    expect(corrected).to eq(<<~'RUBY')
       "this is \" silly"
     RUBY
   end
 
   it 'handles backslach in single quotes when auto-correction' do
-    corrected = autocorrect_source(<<-'RUBY'.strip_indent)
+    corrected = autocorrect_source(<<~'RUBY')
       x = "ABC".gsub(/(A)(B)(C)/, "D#{'\2'}F")
       "this is #{'\n'} silly"
       "this is #{%q(\n)} silly"
     RUBY
-    expect(corrected).to eq(<<-'RUBY'.strip_indent)
+    expect(corrected).to eq(<<~'RUBY')
       x = "ABC".gsub(/(A)(B)(C)/, "D\\2F")
       "this is \\n silly"
       "this is \\n silly"
@@ -176,12 +176,12 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
   end
 
   it 'handles backslach in double quotes when auto-correction' do
-    corrected = autocorrect_source(<<-'RUBY'.strip_indent)
+    corrected = autocorrect_source(<<~'RUBY')
       "this is #{"\n"} silly"
       "this is #{%(\n)} silly"
       "this is #{%Q(\n)} silly"
     RUBY
-    expect(corrected).to eq(<<-'RUBY'.strip_indent)
+    expect(corrected).to eq(<<~'RUBY')
       "this is 
        silly"
       "this is 

--- a/spec/rubocop/cop/lint/string_conversion_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/string_conversion_in_interpolation_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::Lint::StringConversionInInterpolation do
   subject(:cop) { described_class.new }
 
   it 'registers an offense and corrects `to_s` in interpolation' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       "this is the #{result.to_s}"
                             ^^^^ Redundant use of `Object#to_s` in interpolation.
       /regexp #{result.to_s}/
@@ -15,7 +15,7 @@ RSpec.describe RuboCop::Cop::Lint::StringConversionInInterpolation do
                           ^^^^ Redundant use of `Object#to_s` in interpolation.
     RUBY
 
-    expect_correction(<<-'RUBY'.strip_indent)
+    expect_correction(<<~'RUBY')
       "this is the #{result}"
       /regexp #{result}/
       :"symbol #{result}"
@@ -25,12 +25,12 @@ RSpec.describe RuboCop::Cop::Lint::StringConversionInInterpolation do
 
   it 'registers an offense and corrects `to_s` in an interpolation ' \
     'with several expressions' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       "this is the #{top; result.to_s}"
                                  ^^^^ Redundant use of `Object#to_s` in interpolation.
     RUBY
 
-    expect_correction(<<-'RUBY'.strip_indent)
+    expect_correction(<<~'RUBY')
       "this is the #{top; result}"
     RUBY
   end
@@ -44,12 +44,12 @@ RSpec.describe RuboCop::Cop::Lint::StringConversionInInterpolation do
   end
 
   it 'registers an offense and corrects an implicit receiver' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       "#{to_s}"
          ^^^^ Use `self` instead of `Object#to_s` in interpolation.
     RUBY
 
-    expect_correction(<<-'RUBY'.strip_indent)
+    expect_correction(<<~'RUBY')
       "#{self}"
     RUBY
   end

--- a/spec/rubocop/cop/style/character_literal_spec.rb
+++ b/spec/rubocop/cop/style/character_literal_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::Style::CharacterLiteral do
   end
 
   it 'registers an offense for literals like \n' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       x = ?\n
           ^^^ Do not use the character literal - use string literal instead.
     RUBY

--- a/spec/rubocop/cop/style/command_literal_spec.rb
+++ b/spec/rubocop/cop/style/command_literal_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
       let(:source) { 'foo = `echo \`ls\``' }
 
       it 'registers an offense' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           foo = `echo \`ls\``
                 ^^^^^^^^^^^^^ Use `%x` around command string.
         RUBY
@@ -130,7 +130,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'registers an offense' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           foo = `
                 ^ Use `%x` around command string.
             echo \`ls\`
@@ -148,7 +148,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
         before { cop_config['AllowInnerBackticks'] = true }
 
         it 'is accepted' do
-          expect_no_offenses(<<-'RUBY'.strip_indent)
+          expect_no_offenses(<<~'RUBY')
             foo = `
               echo \`ls\`
               echo \`ls -l\`
@@ -292,7 +292,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
       let(:source) { 'foo = `echo \`ls\``' }
 
       it 'registers an offense' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           foo = `echo \`ls\``
                 ^^^^^^^^^^^^^ Use `%x` around command string.
         RUBY
@@ -315,7 +315,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'registers an offense' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           foo = `
                 ^ Use `%x` around command string.
             ls
@@ -337,7 +337,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
 
     describe 'a multi-line ` string with backticks' do
       let(:source) do
-        <<-'RUBY'.strip_indent
+        <<~'RUBY'
           foo = `
             echo \`ls\`
             echo \`ls -l\`
@@ -346,7 +346,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'registers an offense' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           foo = `
                 ^ Use `%x` around command string.
             echo \`ls\`
@@ -409,7 +409,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
       let(:source) { 'foo = `echo \`ls\``' }
 
       it 'registers an offense' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           foo = `echo \`ls\``
                 ^^^^^^^^^^^^^ Use `%x` around command string.
         RUBY
@@ -431,7 +431,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
 
     describe 'a multi-line ` string without backticks' do
       let(:source) do
-        <<-'RUBY'.strip_indent
+        <<~'RUBY'
           foo = `
             ls
             ls -l
@@ -462,7 +462,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
 
     describe 'a multi-line ` string with backticks' do
       let(:source) do
-        <<-'RUBY'.strip_indent
+        <<~'RUBY'
           foo = `
             echo \`ls\`
             echo \`ls -l\`
@@ -471,7 +471,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'registers an offense' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           foo = `
                 ^ Use `%x` around command string.
             echo \`ls\`

--- a/spec/rubocop/cop/style/format_string_spec.rb
+++ b/spec/rubocop/cop/style/format_string_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
     end
 
     it 'works if the first operand contains embedded expressions' do
-      expect_offense(<<-'RUBY'.strip_indent)
+      expect_offense(<<~'RUBY')
         puts "#{x * 5} %d #{@test}" % 10
                                     ^ Favor `sprintf` over `String#%`.
       RUBY
@@ -132,7 +132,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
     end
 
     it 'works if the first operand contains embedded expressions' do
-      expect_offense(<<-'RUBY'.strip_indent)
+      expect_offense(<<~'RUBY')
         puts "#{x * 5} %d #{@test}" % 10
                                     ^ Favor `format` over `String#%`.
       RUBY

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -374,7 +374,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'registers an offense when keys have special symbols in them' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           x = { :"\tab" => 1 }
                 ^^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
@@ -495,7 +495,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'registers an offense when keys have special symbols in them' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           x = { :"\tab" => 1 }
                 ^^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY

--- a/spec/rubocop/cop/style/line_end_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/line_end_concatenation_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
   end
 
   it 'registers an offense for dynamic string concat at line end' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       top = "test#{x}" +
                        ^ Use `\` instead of `+` or `<<` to concatenate those strings.
       "top"
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
   end
 
   it 'registers an offense for dynamic string concat with << at line end' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       top = "test#{x}" <<
                        ^^ Use `\` instead of `+` or `<<` to concatenate those strings.
       "top"
@@ -45,7 +45,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
   end
 
   it 'registers multiple offenses when there are chained << methods' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       top = "test#{x}" <<
                        ^^ Use `\` instead of `+` or `<<` to concatenate those strings.
       "top" <<
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
   end
 
   it 'registers multiple offenses when there are chained concatenations' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       top = "test#{x}" +
                        ^ Use `\` instead of `+` or `<<` to concatenate those strings.
       "top" +
@@ -66,7 +66,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
 
   it 'registers multiple offenses when there are chained concatenations' \
      'combined with << calls' do
-    inspect_source(<<-'RUBY'.strip_indent)
+    inspect_source(<<~'RUBY')
       top = "test#{x}" <<
       "top" +
       "foo" <<
@@ -131,7 +131,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
 
   it 'registers offenses only for the appropriate lines in chained concats' do
     # only the last concatenation is an offense
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       top = "test#{x}" + # comment
       "foo" +
       %(bar) +
@@ -178,14 +178,14 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
   end
 
   it 'autocorrects for chained concatenations and << calls' do
-    corrected = autocorrect_source(<<-'RUBY'.strip_indent)
+    corrected = autocorrect_source(<<~'RUBY')
       top = "test#{x}" <<
       "top" +
       "ubertop" <<
       "foo"
     RUBY
 
-    expect(corrected).to eq(<<-'RUBY'.strip_indent)
+    expect(corrected).to eq(<<~'RUBY')
       top = "test#{x}" \
       "top" \
       "ubertop" \
@@ -194,7 +194,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
   end
 
   it 'autocorrects only the lines that should be autocorrected' do
-    corrected = autocorrect_source(<<-'RUBY'.strip_indent)
+    corrected = autocorrect_source(<<~'RUBY')
       top = "test#{x}" <<
       "top" + # comment
       "foo" +
@@ -203,7 +203,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
       "qux"
     RUBY
 
-    expect(corrected).to eq(<<-'RUBY'.strip_indent)
+    expect(corrected).to eq(<<~'RUBY')
       top = "test#{x}" \
       "top" + # comment
       "foo" \

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
       let(:source) { 'foo = /home\//' }
 
       it 'registers an offense' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           foo = /home\//
                 ^^^^^^^^ Use `%r` around regular expression.
         RUBY
@@ -96,7 +96,7 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
       let(:source) { 'foo = /users\/#{user.id}\/forms/' }
 
       it 'registers an offense' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           foo = /users\/#{user.id}\/forms/
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `%r` around regular expression.
         RUBY
@@ -225,7 +225,7 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
 
     describe 'a multi-line %r regex without slashes' do
       let(:source) do
-        <<-'RUBY'.strip_indent.chomp
+        <<~'RUBY'.chomp
           foo = %r{
             foo
             bar
@@ -307,7 +307,7 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
       let(:source) { 'foo = /home\//' }
 
       it 'registers an offense' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           foo = /home\//
                 ^^^^^^^^ Use `%r` around regular expression.
         RUBY
@@ -321,7 +321,7 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
 
     describe 'a multi-line `//` regex without slashes' do
       let(:source) do
-        <<-'RUBY'.strip_indent.chomp
+        <<~'RUBY'.chomp
           foo = /
             foo
             bar
@@ -342,7 +342,7 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
 
     describe 'a multi-line `//` regex with slashes' do
       let(:source) do
-        <<-'RUBY'.strip_indent
+        <<~'RUBY'
           foo = /
             https?:\/\/
             example\.com
@@ -357,7 +357,7 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
 
       it 'auto-corrects' do
         new_source = autocorrect_source(source)
-        expect(new_source).to eq(<<-'RUBY'.strip_indent)
+        expect(new_source).to eq(<<~'RUBY')
           foo = %r{
             https?://
             example\.com
@@ -414,7 +414,7 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
       let(:source) { 'foo = /home\//' }
 
       it 'registers an offense' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           foo = /home\//
                 ^^^^^^^^ Use `%r` around regular expression.
         RUBY
@@ -436,7 +436,7 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
 
     describe 'a multi-line `//` regex without slashes' do
       let(:source) do
-        <<-'RUBY'.strip_indent.chomp
+        <<~'RUBY'.chomp
           foo = /
             foo
             bar
@@ -457,7 +457,7 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
 
     describe 'a multi-line `//` regex with slashes' do
       let(:source) do
-        <<-'RUBY'.strip_indent
+        <<~'RUBY'
           foo = /
             https?:\/\/
             example\.com
@@ -472,7 +472,7 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
 
       it 'auto-corrects' do
         new_source = autocorrect_source(source)
-        expect(new_source).to eq(<<-'RUBY'.strip_indent)
+        expect(new_source).to eq(<<~'RUBY')
           foo = %r{
             https?://
             example\.com

--- a/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'single_quotes' } }
 
     it 'registers an offense for double quotes within embedded expression' do
-      expect_offense(<<-'RUBY'.strip_indent)
+      expect_offense(<<~'RUBY')
         "#{"A"}"
            ^^^ Prefer single-quoted strings inside interpolations.
       RUBY
@@ -15,7 +15,7 @@ RSpec.describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
 
     it 'registers an offense for double quotes within embedded expression in ' \
        'a heredoc string' do
-      expect_offense(<<-'SOURCE'.strip_indent)
+      expect_offense(<<~'SOURCE')
         <<RUBY
         #{"A"}
           ^^^ Prefer single-quoted strings inside interpolations.
@@ -65,7 +65,7 @@ RSpec.describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'double_quotes' } }
 
     it 'registers an offense for single quotes within embedded expression' do
-      expect_offense(<<-'RUBY'.strip_indent)
+      expect_offense(<<~'RUBY')
         "#{'A'}"
            ^^^ Prefer double-quoted strings inside interpolations.
       RUBY
@@ -73,7 +73,7 @@ RSpec.describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
 
     it 'registers an offense for single quotes within embedded expression in ' \
        'a heredoc string' do
-      expect_offense(<<-'SOURCE'.strip_indent)
+      expect_offense(<<~'SOURCE')
         <<RUBY
         #{'A'}
           ^^^ Prefer double-quoted strings inside interpolations.

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'single_quotes' } }
 
     it 'registers offense for double quotes when single quotes suffice' do
-      expect_offense(<<-'RUBY'.strip_indent)
+      expect_offense(<<~'RUBY')
         s = "abc"
             ^^^^^ Prefer single-quoted strings when you don't need string interpolation or special symbols.
         x = "a\\b"
@@ -182,7 +182,7 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'registers offense for opposite + correct' do
-      expect_offense(<<-'RUBY'.strip_indent)
+      expect_offense(<<~'RUBY')
         s = "abc"
         x = 'abc'
             ^^^^^ Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
@@ -191,14 +191,14 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'registers offense for escaped single quote in single quotes' do
-      expect_offense(<<-'RUBY'.strip_indent)
+      expect_offense(<<~'RUBY')
         '\''
         ^^^^ Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
       RUBY
     end
 
     it 'does not accept multiple escaped single quotes in single quotes' do
-      expect_offense(<<-'RUBY'.strip_indent)
+      expect_offense(<<~'RUBY')
         'This \'string\' has \'multiple\' escaped quotes'
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
       RUBY

--- a/spec/rubocop/cop/style/unneeded_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_interpolation_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe RuboCop::Cop::Style::UnneededInterpolation do
   end
 
   it 'registers an offense for "#{var}"' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       var = 1; "#{var}"
                ^^^^^^^^ Prefer `to_s` over string interpolation.
     RUBY
@@ -169,12 +169,12 @@ RSpec.describe RuboCop::Cop::Style::UnneededInterpolation do
   end
 
   it 'registers an offense for ["#{@var}"]' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       ["#{@var}", 'foo']
        ^^^^^^^^^ Prefer `to_s` over string interpolation.
     RUBY
 
-    expect_correction(<<-'RUBY'.strip_indent)
+    expect_correction(<<~'RUBY')
       [@var.to_s, 'foo']
     RUBY
   end

--- a/spec/rubocop/cop/style/variable_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/variable_interpolation_spec.rb
@@ -4,56 +4,56 @@ RSpec.describe RuboCop::Cop::Style::VariableInterpolation do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for interpolated global variables in string' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       puts "this is a #$test"
                        ^^^^^ Replace interpolated variable `$test` with expression `#{$test}`.
     RUBY
   end
 
   it 'registers an offense for interpolated global variables in regexp' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       puts /this is a #$test/
                        ^^^^^ Replace interpolated variable `$test` with expression `#{$test}`.
     RUBY
   end
 
   it 'registers an offense for interpolated global variables in backticks' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       puts `this is a #$test`
                        ^^^^^ Replace interpolated variable `$test` with expression `#{$test}`.
     RUBY
   end
 
   it 'registers an offense for interpolated global variables in symbol' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       puts :"this is a #$test"
                         ^^^^^ Replace interpolated variable `$test` with expression `#{$test}`.
     RUBY
   end
 
   it 'registers an offense for interpolated regexp nth back references' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       puts "this is a #$1"
                        ^^ Replace interpolated variable `$1` with expression `#{$1}`.
     RUBY
   end
 
   it 'registers an offense for interpolated regexp back references' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       puts "this is a #$+"
                        ^^ Replace interpolated variable `$+` with expression `#{$+}`.
     RUBY
   end
 
   it 'registers an offense for interpolated instance variables' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       puts "this is a #@test"
                        ^^^^^ Replace interpolated variable `@test` with expression `#{@test}`.
     RUBY
   end
 
   it 'registers an offense for interpolated class variables' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       puts "this is a #@@t"
                        ^^^ Replace interpolated variable `@@t` with expression `#{@@t}`.
     RUBY

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::Team do
     let(:file_path) { 'example.rb' }
 
     it 'auto corrects without SyntaxError', :isolated_environment do
-      source = <<-'RUBY'.strip_indent
+      source = <<~'RUBY'
         foo.map{ |a| a.nil? }
 
         'foo' +
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::Cop::Team do
           self::b
         end
       RUBY
-      corrected = <<-'RUBY'.strip_indent
+      corrected = <<~'RUBY'
         # frozen_string_literal: true
 
         foo.map(&:nil?)


### PR DESCRIPTION
https://github.com/jruby/jruby/issues/4260 has been resolved and JRuby 9.2.8.0  is available on CircleCI.
https://hub.docker.com/r/circleci/jruby/tags

```console
% docker run --rm -it circleci/jruby:9.2
Unable to find image 'circleci/jruby:9.2' locally
9.2: Pulling from circleci/jruby
9cc2ad81d40d: Pull complete
e6cb98e32a52: Pull complete
ae1b8d879bad: Pull complete
2383fa4462e7: Pull complete
7ac3ce9f2067: Pull complete
ce9a16d8ddcb: Pull complete
b250e79d9c7f: Pull complete
ce3b7f0ecca6: Pull complete
2405779516de: Pull complete
902dc7b355a1: Pull complete
432a6994cb77: Pull complete
66a081bddadb: Pull complete
1576af617cb5: Pull complete
4233b310ce28: Pull complete
51c0ac4a73c0: Pull complete
c43fdb6f1fe8: Pull complete
909d5a0f7f69: Pull complete
940e076596c5: Pull complete
c6abd11f682b: Pull complete
678a31b2fb39: Pull complete
Digest:
sha256:ee43918172710e4871054ce450da6e5f6d66cdeb1fe8397d356742bf142f20a2
Status: Downloaded newer image for circleci/jruby:9.2
$ ruby -v
jruby 9.2.8.0 (2.5.3) 2019-08-12 a1ac7ff OpenJDK 64-Bit Server VM
25.222-b10 on 1.8.0_222-b10 +jit [linux-x86_64]
```

This PR aims to solve the following issues solved by JRuby.

- https://github.com/rubocop-hq/rubocop/pull/7026#issuecomment-490667498
- https://github.com/rubocop-hq/rubocop/pull/7173#issuecomment-505552299
- https://github.com/rubocop-hq/rubocop/pull/7229#discussion_r306578650
- https://github.com/rubocop-hq/rubocop/pull/7228#issuecomment-514424858

It also removes unnecessary `strip_indent`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
