### PR TITLE
Add check for calls to remote_byebug to Lint/Debugger Cop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#7274](https://github.com/rubocop-hq/rubocop/issues/7274): Add new `Lint/SendWithMixinArgument` cop. ([@koic][])
 * [#7272](https://github.com/rubocop-hq/rubocop/pull/7272): Show warning message if passed string to `Enabled`, `Safe`, `SafeAutocorrect`, and `AutoCorrect` keys in .rubocop.yml. ([@unasuke][])
 * [#7295](https://github.com/rubocop-hq/rubocop/pull/7295): Make it possible to set `StyleGuideBaseURL` per department. ([@koic][])
+* [#7301](https://github.com/rubocop-hq/rubocop/pull/7301): Add check for calls to `remote_byebug` to `Lint/Debugger` cop. ([@riley-klingler][])
 
 ### Bug fixes
 
@@ -4174,3 +4175,4 @@
 [@okuramasafumi]: https://github.com/okuramasafumi
 [@buehmann]: https://github.com/buehmann
 [@halfwhole]: https://github.com/halfwhole
+[@riley-klingler]: https://github.com/riley-klingler

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -43,7 +43,7 @@ module RuboCop
         PATTERN
 
         def_node_matcher :debugger_call?, <<~PATTERN
-          {(send {nil? #kernel?} {:debugger :byebug} ...)
+          {(send {nil? #kernel?} {:debugger :byebug :remote_byebug} ...)
            (send (send {#kernel? nil?} :binding)
              {:pry :remote_pry :pry_remote} ...)
            (send (const {nil? (cbase)} :Pry) :rescue ...)

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
   include_examples 'debugger',
                    'capybara debug method with an argument',
                    'save_screenshot foo'
+  include_examples 'debugger', 'remote_byebug', 'remote_byebug'
 
   it 'does not report an offense for a non-pry binding' do
     expect_no_offenses('binding.pirate')
@@ -65,7 +66,7 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
 
   ALL_COMMANDS = %w[debugger byebug pry remote_pry pry_remote irb
                     save_and_open_page save_and_open_screenshot
-                    save_screenshot].freeze
+                    save_screenshot remote_byebug].freeze
 
   ALL_COMMANDS.each do |src|
     it "does not report an offense for a #{src} in comments" do


### PR DESCRIPTION
The `byebug` gem [added a method](https://github.com/deivid-rodriguez/byebug/releases/tag/v10.0.0)  called `remote_byebug` for triggering breakpoints in ruby code running remotely. This PR makes the `Debugger` cop fail if it finds a call to `remote_byebug`. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists). (N/A)
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
