### PR TITLE
Added description for RescueModifier cop explaining reasons for not to use modifier form rescue

### DIFF
--- a/lib/rubocop/cop/style/rescue_modifier.rb
+++ b/lib/rubocop/cop/style/rescue_modifier.rb
@@ -5,14 +5,38 @@ module RuboCop
     module Style
       # This cop checks for uses of rescue in its modifier form.
       #
+      # The cop to check `rescue` in its modifier form is added for following
+      # reasons:
+      #
+      # * The syntax of modifier form `rescue` can be misleading because it
+      #   might led us to believe that `rescue` handles the given exception
+      #   but it acutally rescue all exceptions to return the given rescue
+      #   block. In this case, value returned by handle_error or
+      #   SomeException.
+      #
+      # * Modifier form `rescue` would rescue all the exceptions. It would
+      #   silently skip all exception or errors and handle the error.
+      #   Example: If `NoMethodError` is raised, modifier form rescue would
+      #   handle the exception.
+      #
       # @example
       #   # bad
       #   some_method rescue handle_error
+      #
+      #   # bad
+      #   some_method rescue SomeException
       #
       #   # good
       #   begin
       #     some_method
       #   rescue
+      #     handle_error
+      #   end
+      #
+      #   # good
+      #   begin
+      #     some_method
+      #   rescue SomeException
       #     handle_error
       #   end
       class RescueModifier < Cop

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -5426,16 +5426,40 @@ Enabled | Yes | Yes  | 0.9 | 0.34
 
 This cop checks for uses of rescue in its modifier form.
 
+The cop to check `rescue` in its modifier form is added for following
+reasons:
+
+* The syntax of modifier form `rescue` can be misleading because it
+  might led us to believe that `rescue` handles the given exception
+  but it acutally rescue all exceptions to return the given rescue
+  block. In this case, value returned by handle_error or
+  SomeException.
+
+* Modifier form `rescue` would rescue all the exceptions. It would
+  silently skip all exception or errors and handle the error.
+  Example: If `NoMethodError` is raised, modifier form rescue would
+  handle the exception.
+
 ### Examples
 
 ```ruby
 # bad
 some_method rescue handle_error
 
+# bad
+some_method rescue SomeException
+
 # good
 begin
   some_method
 rescue
+  handle_error
+end
+
+# good
+begin
+  some_method
+rescue SomeException
   handle_error
 end
 ```


### PR DESCRIPTION
fixes #7289 

Adds a description to the cop specifying the reason for not using modifier form rescue. The reasons are similar to the ones mentioned in the https://thoughtbot.com/blog/don-t-inline-rescue-in-ruby blog.