### PR TITLE
Register BlockDelimiters offense with attribute assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#7241](https://github.com/rubocop-hq/rubocop/issues/7241): Make `Style/FrozenStringLiteralComment` match only true & false. ([@tejasbubane][])
 * [#7290](https://github.com/rubocop-hq/rubocop/issues/7290): Handle inner conditional inside `else` in `Style/ConditionalAssignment`. ([@jonas054][])
 * [#5788](https://github.com/rubocop-hq/rubocop/issues/5788): Allow block arguments on separate lines if line would be too long in `Layout/MultilineBlockLayout`. ([@jonas054][])
+* [#7305](https://github.com/rubocop-hq/rubocop/issues/7305): Register `Style/BlockDelimiters` offense when block result is assigned to an attribute. ([@mvz][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -114,7 +114,8 @@ module RuboCop
 
         def on_send(node)
           return unless node.arguments?
-          return if node.parenthesized? || node.operator_method?
+          return if node.parenthesized?
+          return if node.operator_method? || node.assignment_method?
 
           node.arguments.each do |arg|
             get_blocks(arg) do |block|

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -116,6 +116,16 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       RUBY
     end
 
+    it 'registers an offense for a multi-line block with do-end if the ' \
+       'return value is attribute-assigned' do
+      expect_offense(<<~RUBY)
+        foo.bar = map do |x|
+                      ^^ Prefer `{...}` over `do...end` for functional blocks.
+          x
+        end
+      RUBY
+    end
+
     it 'accepts a multi-line block with do-end if it is the return value ' \
        'of its scope' do
       expect_no_offenses(<<~RUBY)
@@ -351,6 +361,14 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
         RUBY
       end
 
+      it 'registers an offense when combined with attribute assignment' do
+        expect_offense(<<~RUBY)
+          foo.bar = baz.map { |x|
+                            ^ Avoid using `{...}` for multi-line blocks.
+          }
+        RUBY
+      end
+
       it 'accepts braces if do-end would change the meaning' do
         expect_no_offenses(<<~RUBY)
           scope :foo, lambda { |f|
@@ -535,9 +553,24 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
         RUBY
       end
 
+      it 'registers an offense when combined with attribute assignment' do
+        expect_offense(<<~RUBY)
+          foo.bar = baz.map { |x|
+                            ^ Prefer `do...end` for multi-line blocks without chaining.
+          }
+        RUBY
+      end
+
       it 'allows when the block is being chained' do
         expect_no_offenses(<<~RUBY)
           each { |x|
+          }.map(&:to_sym)
+        RUBY
+      end
+
+      it 'allows when the block is being chained with attribute assignment' do
+        expect_no_offenses(<<~RUBY)
+          foo.bar = baz.map { |x|
           }.map(&:to_sym)
         RUBY
       end
@@ -617,6 +650,15 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       RUBY
     end
 
+    it 'registers an offense for multi-lined do-end blocks when combined ' \
+       'with attribute assignment' do
+      expect_offense(<<~RUBY)
+        foo.bar = baz.map do |x|
+                          ^^ Prefer `{...}` over `do...end` for blocks.
+        end
+      RUBY
+    end
+
     it 'accepts a multi-line functional block with do-end if it is ' \
        'an ignored method' do
       expect_no_offenses(<<~RUBY)
@@ -627,11 +669,17 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
     end
 
     context 'when there are braces around a multi-line block' do
-      it 'registers an offense in the simple case' do
-        expect_offense(<<~RUBY)
-          each do |x|
-               ^^ Prefer `{...}` over `do...end` for blocks.
-          end
+      it 'allows in the simple case' do
+        expect_no_offenses(<<~RUBY)
+          each { |x|
+          }
+        RUBY
+      end
+
+      it 'allows when combined with attribute assignment' do
+        expect_no_offenses(<<~RUBY)
+          foo.bar = baz.map { |x|
+          }
         RUBY
       end
 


### PR DESCRIPTION
Update Style/BlockDelimiters to handle attribute assignment.

Fixes #7305 by recognizing that blocks as arguments of assignment methods can safely be mutated from one block delimiter style to the other.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
