### PR TITLE
[Fix #7287] Auto-correction of FrozenStringLiteralComment is unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 * [#7595](https://github.com/rubocop-hq/rubocop/issues/7595): Make `Style/NumericPredicate` aware of ignored methods when specifying ignored methods. ([@koic][])
 * [#7607](https://github.com/rubocop-hq/rubocop/issues/7607): Fix `Style/FrozenStringLiteralComment` infinite loop when magic comments are newline-separated. ([@pirj][])
 
+### Changes
+
+* [#7287](https://github.com/rubocop-hq/rubocop/issues/7287): `Style/FrozenStringLiteralComment` is now considered unsafe. ([@buehmann][])
+
 ## 0.78.0 (2019-12-18)
 
 ### New features

--- a/config/default.yml
+++ b/config/default.yml
@@ -2758,7 +2758,7 @@ Style/FrozenStringLiteralComment:
                  to help transition to frozen string literals by default.
   Enabled: true
   VersionAdded: '0.36'
-  VersionChanged: '0.69'
+  VersionChanged: '0.79'
   EnforcedStyle: always
   SupportedStyles:
     # `always` will always add the frozen string literal comment to a file
@@ -2769,6 +2769,7 @@ Style/FrozenStringLiteralComment:
     # `never` will enforce that the frozen string literal comment does not
     # exist in a file.
     - never
+  Safe: false
 
 Style/GlobalVars:
   Description: 'Do not introduce global variables.'

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2271,7 +2271,7 @@ EnforcedStyle | `annotated` | `annotated`, `template`, `unannotated`
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.36 | 0.69
+Enabled | No | Yes  | 0.36 | 0.79
 
 This cop is designed to help you transition from mutable string literals
 to frozen string literals.


### PR DESCRIPTION
Auto-correction of `Style/FrozenStringLiteralComment` changes the state of
string objects in a program and may thus break it.

This closes #7287.