### PR TITLE
[Fix #3534] Report long modifier lines in IfUnlessModifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Changes
 
 * [#7275](https://github.com/rubocop-hq/rubocop/issues/7275): Make `Style/VariableName` aware argument names when invoking a method. ([@koic][])
+* [#3534](https://github.com/rubocop-hq/rubocop/issues/3534): Make `Style/IfUnlessModifier` report and auto-correct modifier lines that are too long. ([@jonas054][])
 
 ## 0.74.0 (2019-07-31)
 

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -3,10 +3,13 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for if and unless statements that would fit on one line
-      # if written as a modifier if/unless. The maximum line length is
-      # configured in the `Metrics/LineLength` cop. The tab size is configured
-      # in the `IndentationWidth` of the `Layout/Tab` cop.
+      # Checks for `if` and `unless` statements that would fit on one line if
+      # written as modifier `if`/`unless`. The cop also checks for modifier
+      # `if`/`unless` lines that exceed the maximum line length.
+      #
+      # The maximum line length is configured in the `Metrics/LineLength`
+      # cop. The tab size is configured in the `IndentationWidth` of the
+      # `Layout/Tab` cop.
       #
       # @example
       #   # bad
@@ -18,34 +21,58 @@ module RuboCop
       #     Foo.do_something
       #   end
       #
+      #   do_something_in_a_method_with_a_long_name(arg) if long_condition
+      #
       #   # good
       #   do_stuff(bar) if condition
       #   Foo.do_something unless qux.empty?
+      #
+      #   if long_condition
+      #     do_something_in_a_method_with_a_long_name(arg)
+      #   end
       class IfUnlessModifier < Cop
         include StatementModifier
 
-        MSG = 'Favor modifier `%<keyword>s` usage when having a single-line ' \
-              'body. Another good alternative is the usage of control flow ' \
-              '`&&`/`||`.'
+        MSG_USE_MODIFIER = 'Favor modifier `%<keyword>s` usage when having a ' \
+                           'single-line body. Another good alternative is ' \
+                           'the usage of control flow `&&`/`||`.'
+        MSG_USE_NORMAL =
+          'Modifier form of `%<keyword>s` makes the line too long.'
 
         ASSIGNMENT_TYPES = %i[lvasgn casgn cvasgn
                               gvasgn ivasgn masgn].freeze
 
         def on_if(node)
-          return unless eligible_node?(node)
-          return if named_capture_in_condition?(node)
+          msg = if eligible_node?(node)
+                  MSG_USE_MODIFIER unless named_capture_in_condition?(node)
+                elsif node.modifier_form? && too_long_single_line?(node)
+                  MSG_USE_NORMAL
+                end
+          return unless msg
 
-          add_offense(node, location: :keyword,
-                            message: format(MSG, keyword: node.keyword))
+          add_offense(node,
+                      location: :keyword,
+                      message: format(msg, keyword: node.keyword))
         end
 
         def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.source_range, to_modifier_form(node))
-          end
+          replacement = if node.modifier_form?
+                          to_normal_form(node)
+                        else
+                          to_modifier_form(node)
+                        end
+          ->(corrector) { corrector.replace(node.source_range, replacement) }
         end
 
         private
+
+        def too_long_single_line?(node)
+          return false unless max_line_length
+
+          range = node.source_range
+          range.first_line == range.last_line &&
+            range.last_column > max_line_length
+        end
 
         def named_capture_in_condition?(node)
           node.condition.match_with_lvasgn_type?
@@ -77,6 +104,15 @@ module RuboCop
                         first_line_comment(node)].compact.join(' ')
 
           parenthesize?(node) ? "(#{expression})" : expression
+        end
+
+        def to_normal_form(node)
+          indentation = ' ' * node.source_range.column
+          <<~RUBY.chomp
+            #{node.keyword} #{node.condition.source}
+            #{indentation}  #{node.body.source}
+            #{indentation}end
+          RUBY
         end
 
         def first_line_comment(node)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2594,10 +2594,13 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 --- | --- | --- | --- | ---
 Enabled | Yes | Yes  | 0.9 | 0.30
 
-Checks for if and unless statements that would fit on one line
-if written as a modifier if/unless. The maximum line length is
-configured in the `Metrics/LineLength` cop. The tab size is configured
-in the `IndentationWidth` of the `Layout/Tab` cop.
+Checks for `if` and `unless` statements that would fit on one line if
+written as modifier `if`/`unless`. The cop also checks for modifier
+`if`/`unless` lines that exceed the maximum line length.
+
+The maximum line length is configured in the `Metrics/LineLength`
+cop. The tab size is configured in the `IndentationWidth` of the
+`Layout/Tab` cop.
 
 ### Examples
 
@@ -2611,9 +2614,15 @@ unless qux.empty?
   Foo.do_something
 end
 
+do_something_in_a_method_with_a_long_name(arg) if long_condition
+
 # good
 do_stuff(bar) if condition
 Foo.do_something unless qux.empty?
+
+if long_condition
+  do_something_in_a_method_with_a_long_name(arg)
+end
 ```
 
 ### References


### PR DESCRIPTION
Make `Style/IfUnlessModifier` work in two directions. Apart from the already existing reporting of `if`/`unless` expressions on normal form that could be changed to modifier form, we add reporting and correcting of modifier form `if`/`unless` expressions that make the line too long and should be written on normal form.

It could be argued that `Metrics/LineLength` should be responsible for reporting and correcting lines that are too long, but I think it's easier to put this logic in `Style/IfUnlessModifier`.