### PR TITLE
Handle assignment to shared object in Lint/UselessSetterCall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#7290](https://github.com/rubocop-hq/rubocop/issues/7290): Handle inner conditional inside `else` in `Style/ConditionalAssignment`. ([@jonas054][])
 * [#5788](https://github.com/rubocop-hq/rubocop/issues/5788): Allow block arguments on separate lines if line would be too long in `Layout/MultilineBlockLayout`. ([@jonas054][])
 * [#7305](https://github.com/rubocop-hq/rubocop/issues/7305): Register `Style/BlockDelimiters` offense when block result is assigned to an attribute. ([@mvz][])
+* [#6516](https://github.com/rubocop-hq/rubocop/pull/6516): Handle assignment to shared object in `Lint/UselessSetterCall`. ([@hmarr][], [@jonas054][])
 
 ### Changes
 
@@ -4178,3 +4179,4 @@
 [@buehmann]: https://github.com/buehmann
 [@halfwhole]: https://github.com/halfwhole
 [@riley-klingler]: https://github.com/riley-klingler
+[@hmarr]: https://github.com/hmarr

--- a/spec/rubocop/cop/lint/useless_setter_call_spec.rb
+++ b/spec/rubocop/cop/lint/useless_setter_call_spec.rb
@@ -187,16 +187,28 @@ RSpec.describe RuboCop::Cop::Lint::UselessSetterCall do
     end
   end
 
-  context 'when a lvar contains an object assgined to a non-local object' do
-    it 'accepts' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        def test
-          some_lvar = {}
-          Foo.shared_object = some_lvar
-          some_lvar[:attr] = 1
-        end
-      RUBY
+  context 'when a lvar contains an object assigned to a non-local object' do
+    shared_examples 'assignment to a non-local object' do |lhs|
+      it "accepts #{lhs} = ..." do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          def test
+            some_lvar = {}
+            #{lhs} = some_lvar
+            some_lvar[:attr] = 1
+          end
+        RUBY
+      end
     end
+
+    it_behaves_like 'assignment to a non-local object', 'Foo.shared_object'
+    it_behaves_like 'assignment to a non-local object', 'foo.shared_object'
+    it_behaves_like 'assignment to a non-local object', 'self.shared_object'
+    it_behaves_like 'assignment to a non-local object', '$foo.shared_object'
+    it_behaves_like 'assignment to a non-local object', '@foo.shared_object'
+    it_behaves_like 'assignment to a non-local object', '@@foo.shared_object'
+    it_behaves_like 'assignment to a non-local object', '$shared_object'
+    it_behaves_like 'assignment to a non-local object', '@shared_object'
+    it_behaves_like 'assignment to a non-local object', '@@shared_object'
   end
 
   it 'is not confused by operators ending with =' do

--- a/spec/rubocop/cop/lint/useless_setter_call_spec.rb
+++ b/spec/rubocop/cop/lint/useless_setter_call_spec.rb
@@ -175,6 +175,30 @@ RSpec.describe RuboCop::Cop::Lint::UselessSetterCall do
     end
   end
 
+  context 'when a lvar may contain a non-local object' do
+    it 'accepts' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def test
+          some_lvar = Foo.shared_object
+          some_lvar = {} if some_lvar.nil?
+          some_lvar.attr = 1
+        end
+      RUBY
+    end
+  end
+
+  context 'when a lvar contains an object assgined to a non-local object' do
+    it 'accepts' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def test
+          some_lvar = {}
+          Foo.shared_object = some_lvar
+          some_lvar[:attr] = 1
+        end
+      RUBY
+    end
+  end
+
   it 'is not confused by operators ending with =' do
     expect_no_offenses(<<~RUBY)
       def test


### PR DESCRIPTION
When a local variable is assigned to a shared object, the referenced object is effectively no longer local, so calling a setter method on it might very well be useful and should not be reported as an offense.