### PR TITLE
[Fix #7261] Do not insert empty lines in FrozenStringLiteralComment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 * [#7275](https://github.com/rubocop-hq/rubocop/issues/7275): Make `Style/VariableName` aware argument names when invoking a method. ([@koic][])
 * [#3534](https://github.com/rubocop-hq/rubocop/issues/3534): Make `Style/IfUnlessModifier` report and auto-correct modifier lines that are too long. ([@jonas054][])
+* [#7261](https://github.com/rubocop-hq/rubocop/issues/7261): `Style/FrozenStringLiteralComment` no longer inserts an empty line after the comment. This is left to `Layout/EmptyLineAfterMagicComment`. ([@buehmann][])
 
 ## 0.74.0 (2019-07-31)
 

--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -121,42 +121,25 @@ module RuboCop
         end
 
         def insert_comment(corrector)
-          last_special_comment = last_special_comment(processed_source)
-          if last_special_comment.nil?
-            corrector.insert_before(correction_range, preceding_comment)
+          comment = last_special_comment(processed_source)
+
+          if comment
+            corrector.insert_after(line_range(comment.line), following_comment)
           else
-            corrector.insert_after(correction_range, proceeding_comment)
+            corrector.insert_before(line_range(1), preceding_comment)
           end
+        end
+
+        def line_range(line)
+          processed_source.buffer.line_range(line)
         end
 
         def preceding_comment
-          if processed_source.tokens[0].space_before?
-            "#{FROZEN_STRING_LITERAL_ENABLED}\n"
-          else
-            "#{FROZEN_STRING_LITERAL_ENABLED}\n\n"
-          end
+          "#{FROZEN_STRING_LITERAL_ENABLED}\n"
         end
 
-        def proceeding_comment
-          last_special_comment = last_special_comment(processed_source)
-          following_line = processed_source.following_line(last_special_comment)
-
-          if following_line&.empty?
-            "\n#{FROZEN_STRING_LITERAL_ENABLED}"
-          else
-            "\n#{FROZEN_STRING_LITERAL_ENABLED}\n"
-          end
-        end
-
-        def correction_range
-          last_special_comment = last_special_comment(processed_source)
-
-          if last_special_comment.nil?
-            range_with_surrounding_space(range: processed_source.tokens[0],
-                                         side: :left)
-          else
-            last_special_comment.pos
-          end
+        def following_comment
+          "\n#{FROZEN_STRING_LITERAL_ENABLED}"
         end
       end
     end

--- a/spec/rubocop/cli/cli_disable_uncorrectable_spec.rb
+++ b/spec/rubocop/cli/cli_disable_uncorrectable_spec.rb
@@ -18,8 +18,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         == example.rb ==
         C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
         C:  1:  7: [Corrected] Layout/SpaceAroundOperators: Surrounding space missing for operator ==.
+        C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
 
-        1 file inspected, 2 offenses detected, 2 offenses corrected
+        1 file inspected, 3 offenses detected, 3 offenses corrected
       OUTPUT
       expect(IO.read('example.rb')).to eq(<<~RUBY)
         # frozen_string_literal: true
@@ -41,8 +42,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           == example.rb ==
           C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
           C:  1:  5: [Corrected] Naming/PredicateName: Rename is_example to example?.
+          C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
 
-          1 file inspected, 2 offenses detected, 2 offenses corrected
+          1 file inspected, 3 offenses detected, 3 offenses corrected
         OUTPUT
         expect(IO.read('example.rb')).to eq(<<~RUBY)
           # frozen_string_literal: true
@@ -69,8 +71,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
             C:  1:  4: [Corrected] Style/IpAddresses: Do not hardcode IP addresses.
             C:  1: 15: [Corrected] Style/IpAddresses: Do not hardcode IP addresses.
+            C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
 
-            1 file inspected, 3 offenses detected, 3 offenses corrected
+            1 file inspected, 4 offenses detected, 4 offenses corrected
           OUTPUT
           expect(IO.read('example.rb')).to eq(<<~RUBY)
             # frozen_string_literal: true
@@ -109,14 +112,15 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           expect($stdout.string).to eq(<<~OUTPUT)
             == example.rb ==
             C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
+            C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
             C:  3:  3: [Corrected] Metrics/AbcSize: Assignment Branch Condition size for choose_move is too high. [15.62/15]
             C:  3:  3: [Corrected] Metrics/CyclomaticComplexity: Cyclomatic complexity for choose_move is too high. [7/6]
             C:  3:  3: [Corrected] Metrics/MethodLength: Method has too many lines. [11/10]
-            C:  5:  3: [Corrected] Metrics/AbcSize: Assignment Branch Condition size for choose_move is too high. [15.62/15]
-            C:  5:  3: [Corrected] Metrics/MethodLength: Method has too many lines. [11/10]
-            C:  5: 32: [Corrected] Style/DoubleCopDisableDirective: More than one disable comment on one line.
+            C:  4:  3: [Corrected] Metrics/AbcSize: Assignment Branch Condition size for choose_move is too high. [15.62/15]
+            C:  4:  3: [Corrected] Metrics/MethodLength: Method has too many lines. [11/10]
+            C:  4: 32: [Corrected] Style/DoubleCopDisableDirective: More than one disable comment on one line.
 
-            1 file inspected, 7 offenses detected, 7 offenses corrected
+            1 file inspected, 8 offenses detected, 8 offenses corrected
           OUTPUT
           expect(IO.read('example.rb')).to eq(<<~RUBY)
             # frozen_string_literal: true
@@ -167,8 +171,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           == example.rb ==
           C:  1:  1: [Corrected] Metrics/MethodLength: Method has too many lines. [2/1]
           C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
+          C:  3:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
 
-          1 file inspected, 2 offenses detected, 2 offenses corrected
+          1 file inspected, 3 offenses detected, 3 offenses corrected
         OUTPUT
         expect(IO.read('example.rb')).to eq(<<~RUBY)
           # rubocop:disable Metrics/MethodLength

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -1102,23 +1102,29 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     def expect_offense_detected
       expect($stderr.string).to eq('')
       expect($stdout.string)
-        .to include('1 file inspected, 2 offenses detected')
+        .to include('1 file inspected, 1 offense detected')
       expect($stdout.string).to include 'Layout/IndentationWidth'
     end
 
     it 'fails when option is less than the severity level' do
-      expect(cli.run(['--fail-level', 'refactor', target_file])).to eq(1)
+      expect(cli.run(['--fail-level', 'refactor',
+                      '--only', 'Layout/IndentationWidth',
+                      target_file])).to eq(1)
       expect(cli.run(['--fail-level', 'autocorrect', target_file])).to eq(1)
       expect_offense_detected
     end
 
     it 'fails when option is equal to the severity level' do
-      expect(cli.run(['--fail-level', 'convention', target_file])).to eq(1)
+      expect(cli.run(['--fail-level', 'convention',
+                      '--only', 'Layout/IndentationWidth',
+                      target_file])).to eq(1)
       expect_offense_detected
     end
 
     it 'succeeds when option is greater than the severity level' do
-      expect(cli.run(['--fail-level', 'warning', target_file])).to eq(0)
+      expect(cli.run(['--fail-level', 'warning',
+                      '--only', 'Layout/IndentationWidth',
+                      target_file])).to eq(0)
       expect_offense_detected
     end
 
@@ -1126,6 +1132,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       it 'outputs offense message when fail-level is less than the severity' do
         expect(cli.run(['--fail-level', 'refactor',
                         '--display-only-fail-level-offenses',
+                        '--only', 'Layout/IndentationWidth',
                         target_file])).to eq(1)
         expect(cli.run(['--fail-level', 'autocorrect',
                         '--display-only-fail-level-offenses',
@@ -1136,6 +1143,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       it 'outputs offense message when fail-level is equal to the severity' do
         expect(cli.run(['--fail-level', 'convention',
                         '--display-only-fail-level-offenses',
+                        '--only', 'Layout/IndentationWidth',
                         target_file])).to eq(1)
         expect_offense_detected
       end
@@ -1143,6 +1151,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       it "doesn't output offense message when less than the fail-level" do
         expect(cli.run(['--fail-level', 'warning',
                         '--display-only-fail-level-offenses',
+                        '--only', 'Layout/IndentationWidth',
                         target_file])).to eq 0
         expect($stderr.string).to eq('')
         expect($stdout.string)
@@ -1191,14 +1200,15 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       def expect_auto_corrected
         expect_offense_detected
         expect($stdout.string.lines.to_a.last)
-          .to eq('1 file inspected, 2 offenses detected, ' \
-                 "2 offenses corrected\n")
+          .to eq('1 file inspected, 1 offense detected, ' \
+                 "1 offense corrected\n")
       end
 
       it 'fails when option is autocorrect and all offenses are ' \
          'autocorrected' do
         expect(cli.run(['--auto-correct', '--format', 'simple',
                         '--fail-level', 'autocorrect',
+                        '--only', 'Layout/IndentationWidth',
                         target_file])).to eq(1)
         expect_auto_corrected
       end
@@ -1206,6 +1216,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       it 'fails when option is A and all offenses are autocorrected' do
         expect(cli.run(['--auto-correct', '--format', 'simple',
                         '--fail-level', 'A',
+                        '--only', 'Layout/IndentationWidth',
                         target_file])).to eq(1)
         expect_auto_corrected
       end
@@ -1213,6 +1224,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       it 'succeeds when option is not given and all offenses are ' \
          'autocorrected' do
         expect(cli.run(['--auto-correct', '--format', 'simple',
+                        '--only', 'Layout/IndentationWidth',
                         target_file])).to eq(0)
         expect_auto_corrected
       end
@@ -1221,6 +1233,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
          'autocorrected' do
         expect(cli.run(['--auto-correct', '--format', 'simple',
                         '--fail-level', 'refactor',
+                        '--only', 'Layout/IndentationWidth',
                         target_file])).to eq(0)
         expect_auto_corrected
       end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -264,6 +264,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           Style/FrozenStringLiteralComment:
             Enabled: true
             EnforcedStyle: always
+          Layout/EmptyLineAfterMagicComment:
+            Enabled: false
         YAML
         expect(cli.run(['--format', 'offenses', '-a', 'example.rb'])).to eq(0)
         expect($stdout.string).to eq(<<~RESULT)
@@ -276,7 +278,6 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect(IO.read('example.rb'))
           .to eq(<<~RUBY)
             # frozen_string_literal: true
-
             a = 1 # rubocop:disable Lint/UselessAssignment
         RUBY
       end

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -173,7 +173,6 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
         expect(new_source).to eq(<<~RUBY)
           # frozen_string_literal: true
-
           puts 1
         RUBY
       end
@@ -201,7 +200,6 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         expect(new_source).to eq(<<~RUBY)
           #!/usr/bin/env ruby
           # frozen_string_literal: true
-
           puts 1
         RUBY
       end
@@ -215,7 +213,6 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         expect(new_source).to eq(<<~RUBY)
           # encoding: utf-8
           # frozen_string_literal: true
-
           puts 1
         RUBY
       end
@@ -232,7 +229,6 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
           #!/usr/bin/env ruby
           # encoding: utf-8
           # frozen_string_literal: true
-
           puts 1
         RUBY
       end

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -137,7 +137,6 @@ RSpec.describe RuboCop::Cop::Team do
         corrected_source = File.read(file_path)
         expect(corrected_source).to eq(<<~RUBY)
           # frozen_string_literal: true
-
           puts 'string'
         RUBY
       end


### PR DESCRIPTION
`FrozenStringLiteralComment` should only be concerned about inserting/removing the magic comment as necessary but not about its spacing. So it should never insert empty lines.

The spacing is the responsibility of `EmptyLineAfterMagicComment`.

This closes #7261.

The change itself was pretty straightforward but I was surprised how much impact it had on other specs, especially on `cli_autocorrect_spec.rb` although the examples there mostly did not care at all about how `FrozenStringLiteralComment` works. By adding a lot of `--only`s I tried to restrict these examples to the cops they really need (if possible) such that they will not be affected by similar changes in the future.
