### PR TITLE
[Fix #7091] Extract FormatString parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 * [#7275](https://github.com/rubocop-hq/rubocop/issues/7275): Make `Style/VariableName` aware argument names when invoking a method. ([@koic][])
 * [#3534](https://github.com/rubocop-hq/rubocop/issues/3534): Make `Style/IfUnlessModifier` report and auto-correct modifier lines that are too long. ([@jonas054][])
+* [#7091](https://github.com/rubocop-hq/rubocop/issues/7091): `Style/FormatStringToken` now detects format sequences with flags and modifiers. ([@buehmann][])
 
 ## 0.74.0 (2019-07-31)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -2711,7 +2711,7 @@ Style/FormatStringToken:
     - template
     - unannotated
   VersionAdded: '0.49'
-  VersionChanged: '0.52'
+  VersionChanged: '0.75'
 
 Style/FrozenStringLiteralComment:
   Description: >-

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -158,6 +158,8 @@ require_relative 'rubocop/cop/mixin/trailing_comma'
 require_relative 'rubocop/cop/mixin/uncommunicative_name'
 require_relative 'rubocop/cop/mixin/unused_argument'
 
+require_relative 'rubocop/cop/utils/format_string'
+
 require_relative 'rubocop/cop/correctors/alignment_corrector'
 require_relative 'rubocop/cop/correctors/condition_corrector'
 require_relative 'rubocop/cop/correctors/each_to_for_corrector'

--- a/lib/rubocop/cop/utils/format_string.rb
+++ b/lib/rubocop/cop/utils/format_string.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Utils
+      # Parses {Kernel#sprintf} format strings.
+      class FormatString
+        DIGIT_DOLLAR  = /(\d+)\$/.freeze
+        FLAG          = /[ #0+-]|#{DIGIT_DOLLAR}/.freeze
+        NUMBER_ARG    = /\*#{DIGIT_DOLLAR}?/.freeze
+        NUMBER        = /\d+|#{NUMBER_ARG}/.freeze
+        WIDTH         = /(?<width>#{NUMBER})/.freeze
+        PRECISION     = /\.(?<precision>#{NUMBER})/.freeze
+        TYPE          = /(?<type>[bBdiouxXeEfgGaAcps])/.freeze
+        NAME          = /<(?<name>\w+)>/.freeze
+        TEMPLATE_NAME = /\{(?<name>\w+)\}/.freeze
+
+        SEQUENCE = /
+            % (?<type>%)
+          | % (?<flags>#{FLAG}*)
+            (?:
+              (?: #{WIDTH}? #{PRECISION}? #{NAME}?
+                | #{WIDTH}? #{NAME} #{PRECISION}?
+                | #{NAME} (?<more_flags>#{FLAG}*) #{WIDTH}? #{PRECISION}?
+              ) #{TYPE}
+              | #{WIDTH}? #{PRECISION}? #{TEMPLATE_NAME}
+            )
+        /x.freeze
+
+        # The syntax of a format sequence is as follows.
+        #
+        # ```
+        # %[flags][width][.precision]type
+        # ```
+        #
+        # A format sequence consists of a percent sign, followed by optional
+        # flags, width, and precision indicators, then terminated with a field
+        # type character.
+        #
+        # For more complex formatting, Ruby supports a reference by name.
+        #
+        # @see https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-format
+        class FormatSequence
+          attr_reader :begin_pos, :end_pos
+          attr_reader :flags, :width, :precision, :name, :type
+
+          def initialize(string, **opts)
+            @source = string
+            @begin_pos = opts[:begin_pos]
+            @end_pos = opts[:end_pos]
+            @flags = opts[:flags]
+            @width = opts[:width]
+            @precision = opts[:precision]
+            @name = opts[:name]
+            @type = opts[:type]
+          end
+
+          def percent?
+            type == '%'
+          end
+
+          def annotated?
+            name && @source.include?('<')
+          end
+
+          def template?
+            name && @source.include?('{')
+          end
+
+          # Number of arguments required for the format sequence
+          def arity
+            @source.scan('*').count + 1
+          end
+
+          def max_digit_dollar_num
+            @source.scan(DIGIT_DOLLAR).map do |(digit_dollar_num)|
+              digit_dollar_num.to_i
+            end.max
+          end
+
+          def style
+            if annotated?
+              :annotated
+            elsif template?
+              :template
+            else
+              :unannotated
+            end
+          end
+        end
+
+        def initialize(string)
+          @source = string
+        end
+
+        def format_sequences
+          @format_sequences ||= parse
+        end
+
+        def named_interpolation?
+          format_sequences.any?(&:name)
+        end
+
+        def max_digit_dollar_num
+          format_sequences.map(&:max_digit_dollar_num).max
+        end
+
+        private
+
+        def parse
+          @source.to_enum(:scan, SEQUENCE).map do
+            match = Regexp.last_match
+            FormatSequence.new(
+              match[0],
+              begin_pos: match.begin(0),
+              end_pos: match.end(0),
+              flags: match[:flags].to_s + match[:more_flags].to_s,
+              width: match[:width],
+              precision: match[:precision],
+              name: match[:name],
+              type: match[:type]
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2169,7 +2169,7 @@ EnforcedStyle | `format` | `format`, `sprintf`, `percent`
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.49 | 0.52
+Enabled | Yes | No | 0.49 | 0.75
 
 Use a consistent style for named format string tokens.
 

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -197,10 +197,6 @@ RSpec.describe RuboCop::Cop::Lint::FormatParameterMismatch do
     expect_no_offenses('format("%0*x", max_width, id)')
   end
 
-  it 'accepts an extra arg for dynamic width with other following flags' do
-    expect_no_offenses('format("%*0x", max_width, id)')
-  end
-
   it 'does not register an offense argument is the result of a message send' do
     expect_no_offenses('format("%s", "a b c".gsub(" ", "_"))')
   end
@@ -288,76 +284,4 @@ RSpec.describe RuboCop::Cop::Lint::FormatParameterMismatch do
       expect_no_offenses('format("%*.*f %*.*f", 10, 2, 20.19, 5, 1, 11.22)')
     end
   end
-
-  it 'finds the correct number of fields' do
-    expect(''.scan(described_class::FIELD_REGEX).size)
-      .to eq(0)
-    expect('%s'.scan(described_class::FIELD_REGEX).size)
-      .to eq(1)
-    expect('%s %s'.scan(described_class::FIELD_REGEX).size)
-      .to eq(2)
-    expect('%s %s %%'.scan(described_class::FIELD_REGEX).size)
-      .to eq(3)
-    expect('%s %s %%'.scan(described_class::FIELD_REGEX).size)
-      .to eq(3)
-    expect('% d'.scan(described_class::FIELD_REGEX).size)
-      .to eq(1)
-    expect('%+d'.scan(described_class::FIELD_REGEX).size)
-      .to eq(1)
-    expect('%d'.scan(described_class::FIELD_REGEX).size)
-      .to eq(1)
-    expect('%+o'.scan(described_class::FIELD_REGEX).size)
-      .to eq(1)
-    expect('%#o'.scan(described_class::FIELD_REGEX).size)
-      .to eq(1)
-    expect('%.0e'.scan(described_class::FIELD_REGEX).size)
-      .to eq(1)
-    expect('%#.0e'.scan(described_class::FIELD_REGEX).size)
-      .to eq(1)
-    expect('% 020d'.scan(described_class::FIELD_REGEX).size)
-      .to eq(1)
-    expect('%20d'.scan(described_class::FIELD_REGEX).size)
-      .to eq(1)
-    expect('%+20d'.scan(described_class::FIELD_REGEX).size)
-      .to eq(1)
-    expect('%020d'.scan(described_class::FIELD_REGEX).size)
-      .to eq(1)
-    expect('%+020d'.scan(described_class::FIELD_REGEX).size)
-      .to eq(1)
-    expect('% 020d'.scan(described_class::FIELD_REGEX).size)
-      .to eq(1)
-    expect('%-20d'.scan(described_class::FIELD_REGEX).size)
-      .to eq(1)
-    expect('%-+20d'.scan(described_class::FIELD_REGEX).size)
-      .to eq(1)
-    expect('%- 20d'.scan(described_class::FIELD_REGEX).size)
-      .to eq(1)
-    expect('%020x'.scan(described_class::FIELD_REGEX).size)
-      .to eq(1)
-    expect('%#20.8x'.scan(described_class::FIELD_REGEX).size)
-      .to eq(1)
-    expect('%+g:% g:%-g'.scan(described_class::FIELD_REGEX).size)
-      .to eq(3)
-    expect('%+-d'.scan(described_class::FIELD_REGEX).size) # multiple flags
-      .to eq(1)
-  end
-
-  shared_examples 'named format sequence' do |format_string|
-    it 'detects named format sequence' do
-      expect(described_class::NAMED_INTERPOLATION).to match(format_string)
-    end
-
-    it 'does not detect escaped named format sequence' do
-      escaped = format_string.gsub(/%/, '%%')
-      regexp = described_class::NAMED_INTERPOLATION
-
-      expect(regexp).not_to match(escaped)
-      expect(regexp).not_to match('prefix:' + escaped)
-    end
-  end
-
-  it_behaves_like 'named format sequence', '%<greeting>2s'
-  it_behaves_like 'named format sequence', '%2<greeting>s'
-  it_behaves_like 'named format sequence', '%+0<num>8.2f'
-  it_behaves_like 'named format sequence', '%+08<num>.2f'
 end

--- a/spec/rubocop/cop/style/format_string_token_spec.rb
+++ b/spec/rubocop/cop/style/format_string_token_spec.rb
@@ -138,6 +138,14 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
     RUBY
   end
 
+  it 'supports flags and modifiers' do
+    expect_offense(<<~RUBY)
+      format('%-20s %-30s', 'foo', 'bar')
+              ^^^^^ Prefer annotated tokens (like `%<foo>s`) over unannotated tokens (like `%s`).
+                    ^^^^^ Prefer annotated tokens (like `%<foo>s`) over unannotated tokens (like `%s`).
+    RUBY
+  end
+
   it 'handles __FILE__' do
     expect_no_offenses('__FILE__')
   end

--- a/spec/rubocop/cop/utils/format_string_spec.rb
+++ b/spec/rubocop/cop/utils/format_string_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Utils::FormatString do
+  def format_sequences(string)
+    described_class.new(string).format_sequences
+  end
+
+  it 'finds the correct number of fields' do
+    expect(format_sequences('').size)
+      .to eq(0)
+    expect(format_sequences('%s').size)
+      .to eq(1)
+    expect(format_sequences('%s %s').size)
+      .to eq(2)
+    expect(format_sequences('%s %s %%').size)
+      .to eq(3)
+    expect(format_sequences('%s %s %%').size)
+      .to eq(3)
+    expect(format_sequences('% d').size)
+      .to eq(1)
+    expect(format_sequences('%+d').size)
+      .to eq(1)
+    expect(format_sequences('%d').size)
+      .to eq(1)
+    expect(format_sequences('%+o').size)
+      .to eq(1)
+    expect(format_sequences('%#o').size)
+      .to eq(1)
+    expect(format_sequences('%.0e').size)
+      .to eq(1)
+    expect(format_sequences('%#.0e').size)
+      .to eq(1)
+    expect(format_sequences('% 020d').size)
+      .to eq(1)
+    expect(format_sequences('%20d').size)
+      .to eq(1)
+    expect(format_sequences('%+20d').size)
+      .to eq(1)
+    expect(format_sequences('%020d').size)
+      .to eq(1)
+    expect(format_sequences('%+020d').size)
+      .to eq(1)
+    expect(format_sequences('% 020d').size)
+      .to eq(1)
+    expect(format_sequences('%-20d').size)
+      .to eq(1)
+    expect(format_sequences('%-+20d').size)
+      .to eq(1)
+    expect(format_sequences('%- 20d').size)
+      .to eq(1)
+    expect(format_sequences('%020x').size)
+      .to eq(1)
+    expect(format_sequences('%#20.8x').size)
+      .to eq(1)
+    expect(format_sequences('%+g:% g:%-g').size)
+      .to eq(3)
+    expect(format_sequences('%+-d').size) # multiple flags
+      .to eq(1)
+  end
+
+  describe '#named_interpolation?' do
+    shared_examples 'named format sequence' do |format_string|
+      it 'detects named format sequence' do
+        expect(described_class.new(format_string).named_interpolation?)
+          .to be_truthy
+      end
+
+      it 'does not detect escaped named format sequence' do
+        escaped = format_string.gsub(/%/, '%%')
+
+        expect(described_class.new(escaped).named_interpolation?)
+          .to be_falsey
+        expect(described_class.new('prefix:' + escaped).named_interpolation?)
+          .to be_falsey
+      end
+    end
+
+    it_behaves_like 'named format sequence', '%<greeting>2s'
+    it_behaves_like 'named format sequence', '%2<greeting>s'
+    it_behaves_like 'named format sequence', '%+0<num>8.2f'
+    it_behaves_like 'named format sequence', '%+08<num>.2f'
+  end
+end


### PR DESCRIPTION
This extracts and unifies the format string parsing from two different cops. As a consequence, `Style/FormatStringToken` is now able to inspect more variants of format sequences.

I didn't really know where to best put the `FormatString` class, so I am open for suggestions. Maybe there is a place for such auxiliary classes that I overlooked.