### PR TITLE
Fix the warning message about which version of rubocop-performance to upgrade to

### DIFF
--- a/lib/rubocop/cop/mixin/safe_mode.rb
+++ b/lib/rubocop/cop/mixin/safe_mode.rb
@@ -5,7 +5,7 @@ module RuboCop
     # Common functionality for Rails safe mode.
     module SafeMode
       warn 'The `SafeMode` option will be removed in `RuboCop` 0.76. ' \
-        'Please update `rubocop-performance` to 1.15.0 or higher.'
+        'Please update `rubocop-performance` to 1.5.0 or higher.'
 
       private
 


### PR DESCRIPTION
We have received a couple of questions about this in https://github.com/rubocop-hq/rubocop/pull/7249. If there is a plan to release a minor or revision update, we may want to include this.

`rubocop-performance` hasn't created their 1.5.0 release yet. Maybe it would be easier for that version to jump to 1.15.0 🤣 