### PR TITLE
[Fix #6075] Support `IgnoredPatterns` option for `Naming/MethodName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#7295](https://github.com/rubocop-hq/rubocop/pull/7295): Make it possible to set `StyleGuideBaseURL` per department. ([@koic][])
 * [#7301](https://github.com/rubocop-hq/rubocop/pull/7301): Add check for calls to `remote_byebug` to `Lint/Debugger` cop. ([@riley-klingler][])
 * [#7321](https://github.com/rubocop-hq/rubocop/issues/7321): Allow YAML aliases in `.rubocop.yml`. ([@raymondfallon][])
+* [#6075](https://github.com/rubocop-hq/rubocop/issues/6075): Support `IgnoredPatterns` option for `Naming/MethodName` cop. ([@koic][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1989,6 +1989,13 @@ Naming/MethodName:
   SupportedStyles:
     - snake_case
     - camelCase
+  # Method names matching patterns are always allowed.
+  #
+  #   IgnoredPatterns:
+  #     - '\A\s*onSelectionBulkChange\s*'
+  #     - '\A\s*onSelectionCleared\s*'
+  #
+  IgnoredPatterns: []
 
 Naming/PredicateName:
   Description: 'Check the names of predicate methods.'

--- a/lib/rubocop/cop/naming/method_name.rb
+++ b/lib/rubocop/cop/naming/method_name.rb
@@ -6,6 +6,15 @@ module RuboCop
       # This cop makes sure that all methods use the configured style,
       # snake_case or camelCase, for their names.
       #
+      # This cop has `IgnoredPatterns` configuration option.
+      #
+      #   Naming/MethodName:
+      #     IgnoredPatterns:
+      #       - '\A\s*onSelectionBulkChange\s*'
+      #       - '\A\s*onSelectionCleared\s*'
+      #
+      # Method names matching patterns are always allowed.
+      #
       # @example EnforcedStyle: snake_case (default)
       #   # bad
       #   def fooBar; end
@@ -21,11 +30,13 @@ module RuboCop
       #   def fooBar; end
       class MethodName < Cop
         include ConfigurableNaming
+        include IgnoredPattern
 
         MSG = 'Use %<style>s for method names.'
 
         def on_def(node)
-          return if node.operator_method?
+          return if node.operator_method? ||
+                    matches_ignored_pattern?(node.method_name)
 
           check_name(node, node.method_name, node.loc.name)
         end

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -398,6 +398,15 @@ Enabled | Yes | No | 0.50 | -
 This cop makes sure that all methods use the configured style,
 snake_case or camelCase, for their names.
 
+This cop has `IgnoredPatterns` configuration option.
+
+  Naming/MethodName:
+    IgnoredPatterns:
+      - '\A\s*onSelectionBulkChange\s*'
+      - '\A\s*onSelectionCleared\s*'
+
+Method names matching patterns are always allowed.
+
 ### Examples
 
 #### EnforcedStyle: snake_case (default)
@@ -424,6 +433,7 @@ def fooBar; end
 Name | Default value | Configurable values
 --- | --- | ---
 EnforcedStyle | `snake_case` | `snake_case`, `camelCase`
+IgnoredPatterns | `[]` | Array
 
 ### References
 

--- a/spec/rubocop/cop/naming/method_name_spec.rb
+++ b/spec/rubocop/cop/naming/method_name_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
     end
   end
 
-  shared_examples 'always accepted' do
+  shared_examples 'always accepted' do |enforced_style|
     it 'accepts one line methods' do
       expect_no_offenses("def body; '' end")
     end
@@ -84,6 +84,34 @@ RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
                 end
               end
             end
+          end
+        RUBY
+      end
+    end
+
+    context 'when specifying `IgnoredPatterns`' do
+      let(:cop_config) do
+        {
+          'EnforcedStyle' => enforced_style,
+          'IgnoredPatterns' => [
+            '\A\s*onSelectionBulkChange\s*',
+            '\A\s*on_selection_cleared\s*'
+          ]
+        }
+      end
+
+      it 'does not register an offense for camel case method name ' \
+         ' matching `IgnoredPatterns`' do
+        expect_no_offenses(<<~RUBY)
+          def onSelectionBulkChange(arg)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for snake case method name ' \
+         ' matching `IgnoredPatterns`' do
+        expect_no_offenses(<<~RUBY)
+          def on_selection_cleared(arg)
           end
         RUBY
       end


### PR DESCRIPTION
Resolves #6075.

This PR supports `IgnoredPatterns` option for `Naming/MethodName`.

```yaml
Naming/MethodName:
  IgnoredPatterns:
    - '\A\s*onSelectionBulkChange\s*'
    - '\A\s*onSelectionCleared\s*'
```

Method names matching patterns are always allowed, both `EnforcedStyle: snake_case` and `EnforcedStyle: camelCase`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
