### PR TITLE
Allow YAML aliases In Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#7272](https://github.com/rubocop-hq/rubocop/pull/7272): Show warning message if passed string to `Enabled`, `Safe`, `SafeAutocorrect`, and `AutoCorrect` keys in .rubocop.yml. ([@unasuke][])
 * [#7295](https://github.com/rubocop-hq/rubocop/pull/7295): Make it possible to set `StyleGuideBaseURL` per department. ([@koic][])
 * [#7301](https://github.com/rubocop-hq/rubocop/pull/7301): Add check for calls to `remote_byebug` to `Lint/Debugger` cop. ([@riley-klingler][])
+* [#7321](https://github.com/rubocop-hq/rubocop/issues/7321): Allow YAML aliases in `.rubocop.yml`. ([@raymondfallon][])
 
 ### Bug fixes
 
@@ -4183,3 +4184,4 @@
 [@halfwhole]: https://github.com/halfwhole
 [@riley-klingler]: https://github.com/riley-klingler
 [@prathamesh-sonpatki]: https://github.com/prathamesh-sonpatki
+[@raymondfallon]: https://github.com/raymondfallon

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -258,11 +258,11 @@ module RuboCop
             yaml_code,
             permitted_classes: [Regexp, Symbol],
             permitted_symbols: [],
-            aliases: false,
+            aliases: true,
             filename: filename
           )
         else
-          YAML.safe_load(yaml_code, [Regexp, Symbol], [], false, filename)
+          YAML.safe_load(yaml_code, [Regexp, Symbol], [], true, filename)
         end
       end
     end


### PR DESCRIPTION
# Allow YAML aliases In Configuration

[Fix #7321]

As described in detail in the above issue, disallowing YAML aliasing can force unnecessary repetition in the `.rubocop.yml` file. This PR sets `aliases: true` in the `YAML.safe_load` call, so that users can use YAML aliases in their `.rubocop.yml`. 