### PR TITLE
[Fix #4802] Detect all UnneededCopEnableDirective offenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#7290](https://github.com/rubocop-hq/rubocop/issues/7290): Handle inner conditional inside `else` in `Style/ConditionalAssignment`. ([@jonas054][])
 * [#5788](https://github.com/rubocop-hq/rubocop/issues/5788): Allow block arguments on separate lines if line would be too long in `Layout/MultilineBlockLayout`. ([@jonas054][])
 * [#7305](https://github.com/rubocop-hq/rubocop/issues/7305): Register `Style/BlockDelimiters` offense when block result is assigned to an attribute. ([@mvz][])
+* [#4802](https://github.com/rubocop-hq/rubocop/issues/4802): Don't leave any `Lint/UnneededCopEnableDirective` offenses undetected/uncorrected. ([@jonas054][])
 
 ### Changes
 

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -753,6 +753,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       class A
         # rubocop:disable Metrics/MethodLength
         def func
+          # rubocop:enable Metrics/MethodLength
           x = foo # rubocop:disable Lint/UselessAssignment,Style/For
           # rubocop:disable all
           # rubocop:disable Style/ClassVars
@@ -768,10 +769,13 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
       C:  3:  1: Style/Documentation: Missing top-level class documentation comment.
       W:  4:  3: [Corrected] Lint/UnneededCopDisableDirective: Unnecessary disabling of Metrics/MethodLength.
-      W:  6: 54: [Corrected] Lint/UnneededCopDisableDirective: Unnecessary disabling of Style/For.
-      W:  8:  5: [Corrected] Lint/UnneededCopDisableDirective: Unnecessary disabling of Style/ClassVars.
+      C:  5:  1: [Corrected] Layout/EmptyLinesAroundMethodBody: Extra empty line detected at method body beginning.
+      C:  5:  1: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
+      W:  5: 22: [Corrected] Lint/UnneededCopEnableDirective: Unnecessary enabling of Metrics/MethodLength.
+      W:  7: 54: [Corrected] Lint/UnneededCopDisableDirective: Unnecessary disabling of Style/For.
+      W:  9:  5: [Corrected] Lint/UnneededCopDisableDirective: Unnecessary disabling of Style/ClassVars.
 
-      1 file inspected, 6 offenses detected, 5 offenses corrected
+      1 file inspected, 9 offenses detected, 8 offenses corrected
     RESULT
     corrected = <<~RUBY
       # frozen_string_literal: true


### PR DESCRIPTION
After all other cops are finished we invoke the `Lint/UnneededCopDisableDirective` cop, since it depends on the results of the other cops. If it's an `--auto-correct` run, correcting `UnneededCopDisableDirective` offenses can introduce new `UnneededCopEnableDirective` offenses. For this reason we must do one more inspection after `UnneededCopDisableDirective` has corrected a file.