### PR TITLE
[Fix #7326] Fix a false positive for `Style/AccessModifierDeclarations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#5788](https://github.com/rubocop-hq/rubocop/issues/5788): Allow block arguments on separate lines if line would be too long in `Layout/MultilineBlockLayout`. ([@jonas054][])
 * [#7305](https://github.com/rubocop-hq/rubocop/issues/7305): Register `Style/BlockDelimiters` offense when block result is assigned to an attribute. ([@mvz][])
 * [#4802](https://github.com/rubocop-hq/rubocop/issues/4802): Don't leave any `Lint/UnneededCopEnableDirective` offenses undetected/uncorrected. ([@jonas054][])
+* [#7326](https://github.com/rubocop-hq/rubocop/issues/7326): Fix a false positive for `Style/AccessModifierDeclarations` when access modifier name is used for hash literal value. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -63,6 +63,7 @@ module RuboCop
 
         def on_send(node)
           return unless node.access_modifier?
+          return if node.parent.pair_type?
 
           if offense?(node)
             add_offense(node, location: :selector) do

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -3,6 +3,17 @@
 RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
   subject(:cop) { described_class.new(config) }
 
+  shared_examples 'always accepted' do |access_modifier|
+    it 'accepts when #{access_modifier} is a hash literal value' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          foo
+          bar(key: #{access_modifier})
+        end
+      RUBY
+    end
+  end
+
   context 'when `group` is configured' do
     let(:cop_config) do
       {
@@ -47,6 +58,8 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
           end
         RUBY
       end
+
+      include_examples 'always accepted', access_modifier
     end
   end
 
@@ -93,6 +106,8 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
           end
         RUBY
       end
+
+      include_examples 'always accepted', access_modifier
     end
   end
 end


### PR DESCRIPTION
Fixes #7326.

This PR fixes a false positive for `Style/AccessModifierDeclarations` when access modifier name is used for hash literal value.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
