### PR TITLE
[Fix #7332] Update doc for `Style/FrozenStringLiteralComment`

### DIFF
--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -3,11 +3,13 @@
 module RuboCop
   module Cop
     module Style
-      # This cop is designed to help upgrade to after Ruby 3.0. It will add the
-      # comment `# frozen_string_literal: true` to the top of files to
-      # enable frozen string literals. Frozen string literals may be default
-      # after Ruby 3.0. The comment will be added below a shebang and encoding
-      # comment. The frozen string literal comment is only valid in Ruby 2.3+.
+      # This cop is designed to help you transition from mutable string literals
+      # to frozen string literals.
+      # It will add the comment `# frozen_string_literal: true` to the top of
+      # files to enable frozen string literals. Frozen string literals may be
+      # default in future Ruby. The comment will be added below a shebang and
+      # encoding comment. The frozen string literal comment is only valid in
+      # Ruby 2.3+.
       #
       # @example EnforcedStyle: always (default)
       #   # The `always` style will always add the frozen string literal comment

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2225,11 +2225,13 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 --- | --- | --- | --- | ---
 Enabled | Yes | Yes  | 0.36 | 0.69
 
-This cop is designed to help upgrade to after Ruby 3.0. It will add the
-comment `# frozen_string_literal: true` to the top of files to
-enable frozen string literals. Frozen string literals may be default
-after Ruby 3.0. The comment will be added below a shebang and encoding
-comment. The frozen string literal comment is only valid in Ruby 2.3+.
+This cop is designed to help you transition from mutable string literals
+to frozen string literals.
+It will add the comment `# frozen_string_literal: true` to the top of
+files to enable frozen string literals. Frozen string literals may be
+default in future Ruby. The comment will be added below a shebang and
+encoding comment. The frozen string literal comment is only valid in
+Ruby 2.3+.
 
 ### Examples
 


### PR DESCRIPTION
Closes #7332.

This PR updates a description to Ruby version where frozen string literals will be introduced.

AFAIK, matz has not given up the possibility of defaulting to a frozen string in the future. In Ruby 3.0, matz was abandant for changing it because there were not enough tools to prevent destructive changes (I heard that at RubyKaigi 2019 and RubyConf Taiwan 2019).

Frozen string literals are being introduced around Ruby.

- https://github.com/ruby/ruby/blob/master/lib/erb.rb
- https://github.com/ruby/psych
- https://github.com/ruby/csv
- https://github.com/rubygems/rubygems
- https://github.com/bundler/bundler
- others

So this cop remains enabled by default.

cf. https://bugs.ruby-lang.org/issues/11473#note-53

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
