### PR TITLE
[Fix #3591] Handle modifier if in Variable#reference!()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#7305](https://github.com/rubocop-hq/rubocop/issues/7305): Register `Style/BlockDelimiters` offense when block result is assigned to an attribute. ([@mvz][])
 * [#4802](https://github.com/rubocop-hq/rubocop/issues/4802): Don't leave any `Lint/UnneededCopEnableDirective` offenses undetected/uncorrected. ([@jonas054][])
 * [#7326](https://github.com/rubocop-hq/rubocop/issues/7326): Fix a false positive for `Style/AccessModifierDeclarations` when access modifier name is used for hash literal value. ([@koic][])
+* [#3591](https://github.com/rubocop-hq/rubocop/issues/3591): Handle modifier `if`/`unless` correctly in `Lint/UselessAssignment`. ([@jonas054][])
 
 ### Changes
 

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -3,6 +3,23 @@
 RSpec.describe RuboCop::Cop::Lint::UselessAssignment do
   subject(:cop) { described_class.new }
 
+  context 'when a variable is assigned and assigned again in a modifier ' \
+          'condition' do
+    it 'accepts with parentheses' do
+      expect_no_offenses(<<~RUBY)
+        a = nil
+        puts a if (a = 123)
+      RUBY
+    end
+
+    it 'accepts without parentheses' do
+      expect_no_offenses(<<~RUBY)
+        a = nil
+        puts a unless a = 123
+      RUBY
+    end
+  end
+
   context 'when a variable is assigned and unreferenced in a method' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Assignments in modifier if/unless conditions are special. The following program
exits with the error "undefined local variable or method `a' for main:Object"
when executed.

```
puts a if (a = @x)
```

A preceding assignment to `a` is needed to put it in scope. So there are no
useless assignments in

```
a = nil
puts a if (a = @x)
```