### PR TITLE
Check begin-end blocks in Layout/EndAlignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [#7261](https://github.com/rubocop-hq/rubocop/issues/7261): `Style/FrozenStringLiteralComment` no longer inserts an empty line after the comment. This is left to `Layout/EmptyLineAfterMagicComment`. ([@buehmann][])
 * [#7091](https://github.com/rubocop-hq/rubocop/issues/7091): `Style/FormatStringToken` now detects format sequences with flags and modifiers. ([@buehmann][])
 * [#7319](https://github.com/rubocop-hq/rubocop/pull/7319): Rename `IgnoredMethodPatterns` option to `IgnoredPatterns` option for `Style/MethodCallWithArgsParentheses`. ([@koic][])
+* [#7337](https://github.com/rubocop-hq/rubocop/pull/7337): Check `begin`-`end` blocks in `Layout/EndAlignment`. ([@fphilipe][])
 
 ## 0.74.0 (2019-07-31)
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -236,14 +236,14 @@ module RuboCop
       # This must be done after the options have already been processed,
       # because they can affect how ConfigStore behaves
       @options[:formatters] ||= begin
-        if @options[:auto_gen_config]
-          formatter = 'autogenconf'
-        else
-          cfg = @config_store.for(Dir.pwd).for_all_cops
-          formatter = cfg['DefaultFormatter'] || 'progress'
-        end
-        [[formatter, @options[:output_path]]]
-      end
+                                  if @options[:auto_gen_config]
+                                    formatter = 'autogenconf'
+                                  else
+                                    cfg = @config_store.for(Dir.pwd).for_all_cops
+                                    formatter = cfg['DefaultFormatter'] || 'progress'
+                                  end
+                                  [[formatter, @options[:output_path]]]
+                                end
 
       return unless @options[:auto_gen_config]
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -235,15 +235,16 @@ module RuboCop
     def apply_default_formatter
       # This must be done after the options have already been processed,
       # because they can affect how ConfigStore behaves
-      @options[:formatters] ||= begin
-                                  if @options[:auto_gen_config]
-                                    formatter = 'autogenconf'
-                                  else
-                                    cfg = @config_store.for(Dir.pwd).for_all_cops
-                                    formatter = cfg['DefaultFormatter'] || 'progress'
-                                  end
-                                  [[formatter, @options[:output_path]]]
-                                end
+      @options[:formatters] ||=
+        begin
+          if @options[:auto_gen_config]
+            formatter = 'autogenconf'
+          else
+            cfg = @config_store.for(Dir.pwd).for_all_cops
+            formatter = cfg['DefaultFormatter'] || 'progress'
+          end
+          [[formatter, @options[:output_path]]]
+        end
 
       return unless @options[:auto_gen_config]
 

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -162,9 +162,9 @@ module RuboCop
 
     def non_comment_token_line_numbers
       @non_comment_token_line_numbers ||= begin
-        non_comment_tokens = processed_source.tokens.reject(&:comment?)
-        non_comment_tokens.map(&:line).uniq
-      end
+                                            non_comment_tokens = processed_source.tokens.reject(&:comment?)
+                                            non_comment_tokens.map(&:line).uniq
+                                          end
     end
 
     def enable_all?(comment)

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -161,10 +161,11 @@ module RuboCop
     end
 
     def non_comment_token_line_numbers
-      @non_comment_token_line_numbers ||= begin
-                                            non_comment_tokens = processed_source.tokens.reject(&:comment?)
-                                            non_comment_tokens.map(&:line).uniq
-                                          end
+      @non_comment_token_line_numbers ||=
+        begin
+          non_comment_tokens = processed_source.tokens.reject(&:comment?)
+          non_comment_tokens.map(&:line).uniq
+        end
     end
 
     def enable_all?(comment)

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -52,23 +52,24 @@ module RuboCop
     end
 
     def target_ruby_version
-      @target_ruby_version ||= begin
-                                 if for_all_cops['TargetRubyVersion']
-                                   @target_ruby_version_source = :rubocop_yml
+      @target_ruby_version ||=
+        begin
+          if for_all_cops['TargetRubyVersion']
+            @target_ruby_version_source = :rubocop_yml
 
-                                   for_all_cops['TargetRubyVersion'].to_f
-                                 elsif target_ruby_version_from_version_file
-                                   @target_ruby_version_source = :ruby_version_file
+            for_all_cops['TargetRubyVersion'].to_f
+          elsif target_ruby_version_from_version_file
+            @target_ruby_version_source = :ruby_version_file
 
-                                   target_ruby_version_from_version_file
-                                 elsif target_ruby_version_from_bundler_lock_file
-                                   @target_ruby_version_source = :bundler_lock_file
+            target_ruby_version_from_version_file
+          elsif target_ruby_version_from_bundler_lock_file
+            @target_ruby_version_source = :bundler_lock_file
 
-                                   target_ruby_version_from_bundler_lock_file
-                                 else
-                                   DEFAULT_RUBY_VERSION
-                                 end
-                               end
+            target_ruby_version_from_bundler_lock_file
+          else
+            DEFAULT_RUBY_VERSION
+          end
+        end
     end
 
     def validate_section_presence(name)

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -53,22 +53,22 @@ module RuboCop
 
     def target_ruby_version
       @target_ruby_version ||= begin
-        if for_all_cops['TargetRubyVersion']
-          @target_ruby_version_source = :rubocop_yml
+                                 if for_all_cops['TargetRubyVersion']
+                                   @target_ruby_version_source = :rubocop_yml
 
-          for_all_cops['TargetRubyVersion'].to_f
-        elsif target_ruby_version_from_version_file
-          @target_ruby_version_source = :ruby_version_file
+                                   for_all_cops['TargetRubyVersion'].to_f
+                                 elsif target_ruby_version_from_version_file
+                                   @target_ruby_version_source = :ruby_version_file
 
-          target_ruby_version_from_version_file
-        elsif target_ruby_version_from_bundler_lock_file
-          @target_ruby_version_source = :bundler_lock_file
+                                   target_ruby_version_from_version_file
+                                 elsif target_ruby_version_from_bundler_lock_file
+                                   @target_ruby_version_source = :bundler_lock_file
 
-          target_ruby_version_from_bundler_lock_file
-        else
-          DEFAULT_RUBY_VERSION
-        end
-      end
+                                   target_ruby_version_from_bundler_lock_file
+                                 else
+                                   DEFAULT_RUBY_VERSION
+                                 end
+                               end
     end
 
     def validate_section_presence(name)

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -51,7 +51,7 @@ module RuboCop
       reject_mutually_exclusive_defaults
     end
 
-    def target_ruby_version
+    def target_ruby_version # rubocop:disable Metrics/MethodLength
       @target_ruby_version ||=
         begin
           if for_all_cops['TargetRubyVersion']

--- a/lib/rubocop/cop/generator/require_file_injector.rb
+++ b/lib/rubocop/cop/generator/require_file_injector.rb
@@ -40,22 +40,24 @@ module RuboCop
         end
 
         def target_line
-          @target_line ||= begin
-                             in_the_same_department = false
-                             inject_parts = require_path_fragments(injectable_require_directive)
+          @target_line ||=
+            begin
+              in_the_same_department = false
+              inject_parts =
+                require_path_fragments(injectable_require_directive)
 
-                             require_entries.find.with_index do |entry, index|
-                               current_entry_parts = require_path_fragments(entry)
+              require_entries.find.with_index do |entry, index|
+                current_entry_parts = require_path_fragments(entry)
 
-                               if inject_parts[0..-2] == current_entry_parts[0..-2]
-                                 in_the_same_department = true
+                if inject_parts[0..-2] == current_entry_parts[0..-2]
+                  in_the_same_department = true
 
-                                 break index if inject_parts.last < current_entry_parts.last
-                               elsif in_the_same_department
-                                 break index
-                               end
-                             end
-                           end
+                  break index if inject_parts.last < current_entry_parts.last
+                elsif in_the_same_department
+                  break index
+                end
+              end
+            end
         end
 
         def require_path_fragments(require_directove)

--- a/lib/rubocop/cop/generator/require_file_injector.rb
+++ b/lib/rubocop/cop/generator/require_file_injector.rb
@@ -41,21 +41,21 @@ module RuboCop
 
         def target_line
           @target_line ||= begin
-            in_the_same_department = false
-            inject_parts = require_path_fragments(injectable_require_directive)
+                             in_the_same_department = false
+                             inject_parts = require_path_fragments(injectable_require_directive)
 
-            require_entries.find.with_index do |entry, index|
-              current_entry_parts = require_path_fragments(entry)
+                             require_entries.find.with_index do |entry, index|
+                               current_entry_parts = require_path_fragments(entry)
 
-              if inject_parts[0..-2] == current_entry_parts[0..-2]
-                in_the_same_department = true
+                               if inject_parts[0..-2] == current_entry_parts[0..-2]
+                                 in_the_same_department = true
 
-                break index if inject_parts.last < current_entry_parts.last
-              elsif in_the_same_department
-                break index
-              end
-            end
-          end
+                                 break index if inject_parts.last < current_entry_parts.last
+                               elsif in_the_same_department
+                                 break index
+                               end
+                             end
+                           end
         end
 
         def require_path_fragments(require_directove)

--- a/lib/rubocop/cop/generator/require_file_injector.rb
+++ b/lib/rubocop/cop/generator/require_file_injector.rb
@@ -39,7 +39,7 @@ module RuboCop
                                  injectable_require_directive).join
         end
 
-        def target_line
+        def target_line # rubocop:disable Metrics/MethodLength
           @target_line ||=
             begin
               in_the_same_department = false

--- a/lib/rubocop/cop/message_annotator.rb
+++ b/lib/rubocop/cop/message_annotator.rb
@@ -76,13 +76,13 @@ module RuboCop
         return nil if url.nil? || url.empty?
 
         self.class.style_guide_urls[url] ||= begin
-          base_url = style_guide_base_url
-          if base_url.nil? || base_url.empty?
-            url
-          else
-            URI.join(base_url, url).to_s
-          end
-        end
+                                               base_url = style_guide_base_url
+                                               if base_url.nil? || base_url.empty?
+                                                 url
+                                               else
+                                                 URI.join(base_url, url).to_s
+                                               end
+                                             end
       end
 
       def style_guide_base_url

--- a/lib/rubocop/cop/message_annotator.rb
+++ b/lib/rubocop/cop/message_annotator.rb
@@ -75,14 +75,15 @@ module RuboCop
         url = cop_config['StyleGuide']
         return nil if url.nil? || url.empty?
 
-        self.class.style_guide_urls[url] ||= begin
-                                               base_url = style_guide_base_url
-                                               if base_url.nil? || base_url.empty?
-                                                 url
-                                               else
-                                                 URI.join(base_url, url).to_s
-                                               end
-                                             end
+        self.class.style_guide_urls[url] ||=
+          begin
+            base_url = style_guide_base_url
+            if base_url.nil? || base_url.empty?
+              url
+            else
+              URI.join(base_url, url).to_s
+            end
+          end
       end
 
       def style_guide_base_url

--- a/lib/rubocop/cop/mixin/configurable_enforced_style.rb
+++ b/lib/rubocop/cop/mixin/configurable_enforced_style.rb
@@ -62,13 +62,13 @@ module RuboCop
 
       def style
         @style ||= begin
-          s = cop_config[style_parameter_name].to_sym
-          unless supported_styles.include?(s)
-            raise "Unknown style #{s} selected!"
-          end
+                     s = cop_config[style_parameter_name].to_sym
+                     unless supported_styles.include?(s)
+                       raise "Unknown style #{s} selected!"
+                     end
 
-          s
-        end
+                     s
+                   end
       end
 
       def alternative_style
@@ -85,9 +85,9 @@ module RuboCop
 
       def supported_styles
         @supported_styles ||= begin
-          supported_styles = Util.to_supported_styles(style_parameter_name)
-          cop_config[supported_styles].map(&:to_sym)
-        end
+                                supported_styles = Util.to_supported_styles(style_parameter_name)
+                                cop_config[supported_styles].map(&:to_sym)
+                              end
       end
 
       def style_parameter_name

--- a/lib/rubocop/cop/mixin/configurable_enforced_style.rb
+++ b/lib/rubocop/cop/mixin/configurable_enforced_style.rb
@@ -84,10 +84,11 @@ module RuboCop
       end
 
       def supported_styles
-        @supported_styles ||= begin
-                                supported_styles = Util.to_supported_styles(style_parameter_name)
-                                cop_config[supported_styles].map(&:to_sym)
-                              end
+        @supported_styles ||=
+          begin
+            supported_styles = Util.to_supported_styles(style_parameter_name)
+            cop_config[supported_styles].map(&:to_sym)
+          end
       end
 
       def style_parameter_name

--- a/lib/rubocop/cop/mixin/preceding_following_alignment.rb
+++ b/lib/rubocop/cop/mixin/preceding_following_alignment.rb
@@ -127,17 +127,18 @@ module RuboCop
       end
 
       def assignment_tokens
-        @assignment_tokens ||= begin
-                                 tokens = processed_source.tokens.select(&:equal_sign?)
+        @assignment_tokens ||=
+          begin
+            tokens = processed_source.tokens.select(&:equal_sign?)
 
-                                 # we don't want to operate on equals signs which are part of an
-                                 #   optarg in a method definition
-                                 # e.g.: def method(optarg = default_val); end
-                                 tokens = remove_optarg_equals(tokens, processed_source)
+            # we don't want to operate on equals signs which are part of an
+            #   optarg in a method definition
+            # e.g.: def method(optarg = default_val); end
+            tokens = remove_optarg_equals(tokens, processed_source)
 
-                                 # Only attempt to align the first = on each line
-                                 Set.new(tokens.uniq(&:line))
-                               end
+            # Only attempt to align the first = on each line
+            Set.new(tokens.uniq(&:line))
+          end
       end
 
       # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity

--- a/lib/rubocop/cop/mixin/preceding_following_alignment.rb
+++ b/lib/rubocop/cop/mixin/preceding_following_alignment.rb
@@ -128,16 +128,16 @@ module RuboCop
 
       def assignment_tokens
         @assignment_tokens ||= begin
-          tokens = processed_source.tokens.select(&:equal_sign?)
+                                 tokens = processed_source.tokens.select(&:equal_sign?)
 
-          # we don't want to operate on equals signs which are part of an
-          #   optarg in a method definition
-          # e.g.: def method(optarg = default_val); end
-          tokens = remove_optarg_equals(tokens, processed_source)
+                                 # we don't want to operate on equals signs which are part of an
+                                 #   optarg in a method definition
+                                 # e.g.: def method(optarg = default_val); end
+                                 tokens = remove_optarg_equals(tokens, processed_source)
 
-          # Only attempt to align the first = on each line
-          Set.new(tokens.uniq(&:line))
-        end
+                                 # Only attempt to align the first = on each line
+                                 Set.new(tokens.uniq(&:line))
+                               end
       end
 
       # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity

--- a/lib/rubocop/cop/mixin/surrounding_space.rb
+++ b/lib/rubocop/cop/mixin/surrounding_space.rb
@@ -46,13 +46,13 @@ module RuboCop
 
       def token_table
         @token_table ||= begin
-          table = {}
-          @processed_source.tokens.each_with_index do |t, ix|
-            table[t.line] ||= {}
-            table[t.line][t.column] = ix
-          end
-          table
-        end
+                           table = {}
+                           @processed_source.tokens.each_with_index do |t, ix|
+                             table[t.line] ||= {}
+                             table[t.line][t.column] = ix
+                           end
+                           table
+                         end
       end
 
       def no_space_offenses(node, # rubocop:disable Metrics/ParameterLists

--- a/lib/rubocop/cop/mixin/uncommunicative_name.rb
+++ b/lib/rubocop/cop/mixin/uncommunicative_name.rb
@@ -49,11 +49,11 @@ module RuboCop
 
       def name_type(node)
         @name_type ||= begin
-          case node.type
-          when :block then 'block parameter'
-          when :def, :defs then 'method parameter'
-          end
-        end
+                         case node.type
+                         when :block then 'block parameter'
+                         when :def, :defs then 'method parameter'
+                         end
+                       end
       end
 
       def num_offense(node, range)

--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -120,11 +120,12 @@ module RuboCop
         end
 
         def extra_right_space?(hash_node)
-          @extra_right_space ||= begin
-                                   bottom_line_number = hash_node.source_range.last_line
-                                   bottom_line = processed_source.lines[bottom_line_number - 1]
-                                   bottom_line.delete(' ') == '}'
-                                 end
+          @extra_right_space ||=
+            begin
+              bottom_line_number = hash_node.source_range.last_line
+              bottom_line = processed_source.lines[bottom_line_number - 1]
+              bottom_line.delete(' ') == '}'
+            end
         end
 
         def remove_braces_with_whitespace(corrector, node, space)

--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -114,17 +114,17 @@ module RuboCop
 
         def extra_left_space?(hash_node)
           @extra_left_space ||= begin
-            top_line = hash_node.source_range.source_line
-            top_line.delete(' ') == '{'
-          end
+                                  top_line = hash_node.source_range.source_line
+                                  top_line.delete(' ') == '{'
+                                end
         end
 
         def extra_right_space?(hash_node)
           @extra_right_space ||= begin
-            bottom_line_number = hash_node.source_range.last_line
-            bottom_line = processed_source.lines[bottom_line_number - 1]
-            bottom_line.delete(' ') == '}'
-          end
+                                   bottom_line_number = hash_node.source_range.last_line
+                                   bottom_line = processed_source.lines[bottom_line_number - 1]
+                                   bottom_line.delete(' ') == '}'
+                                 end
         end
 
         def remove_braces_with_whitespace(corrector, node, space)

--- a/lib/rubocop/formatter/colorizable.rb
+++ b/lib/rubocop/formatter/colorizable.rb
@@ -8,14 +8,14 @@ module RuboCop
     module Colorizable
       def rainbow
         @rainbow ||= begin
-          rainbow = Rainbow.new
-          if options[:color]
-            rainbow.enabled = true
-          elsif options[:color] == false || !output.tty?
-            rainbow.enabled = false
-          end
-          rainbow
-        end
+                       rainbow = Rainbow.new
+                       if options[:color]
+                         rainbow.enabled = true
+                       elsif options[:color] == false || !output.tty?
+                         rainbow.enabled = false
+                       end
+                       rainbow
+                     end
       end
 
       def colorize(string, *args)

--- a/lib/rubocop/formatter/pacman_formatter.rb
+++ b/lib/rubocop/formatter/pacman_formatter.rb
@@ -49,9 +49,9 @@ module RuboCop
 
       def cols
         @cols ||= begin
-          width = `tput cols`.chomp.to_i
-          width.nil? || width.zero? ? FALLBACK_TERMINAL_WIDTH : width
-        end
+                    width = `tput cols`.chomp.to_i
+                    width.nil? || width.zero? ? FALLBACK_TERMINAL_WIDTH : width
+                  end
       end
 
       def update_progress_line

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -54,16 +54,16 @@ module RuboCop
     # possible __END__ and everything that comes after.
     def lines
       @lines ||= begin
-        all_lines = @buffer.source_lines
-        last_token_line = tokens.any? ? tokens.last.line : all_lines.size
-        result = []
-        all_lines.each_with_index do |line, ix|
-          break if ix >= last_token_line && line == '__END__'
+                   all_lines = @buffer.source_lines
+                   last_token_line = tokens.any? ? tokens.last.line : all_lines.size
+                   result = []
+                   all_lines.each_with_index do |line, ix|
+                     break if ix >= last_token_line && line == '__END__'
 
-          result << line
-        end
-        result
-      end
+                     result << line
+                   end
+                   result
+                 end
     end
 
     def [](*args)

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -53,17 +53,18 @@ module RuboCop
     # Returns the source lines, line break characters removed, excluding a
     # possible __END__ and everything that comes after.
     def lines
-      @lines ||= begin
-                   all_lines = @buffer.source_lines
-                   last_token_line = tokens.any? ? tokens.last.line : all_lines.size
-                   result = []
-                   all_lines.each_with_index do |line, ix|
-                     break if ix >= last_token_line && line == '__END__'
+      @lines ||=
+        begin
+          all_lines = @buffer.source_lines
+          last_token_line = tokens.any? ? tokens.last.line : all_lines.size
+          result = []
+          all_lines.each_with_index do |line, ix|
+            break if ix >= last_token_line && line == '__END__'
 
-                     result << line
-                   end
-                   result
-                 end
+            result << line
+          end
+          result
+        end
     end
 
     def [](*args)

--- a/lib/rubocop/remote_config.rb
+++ b/lib/rubocop/remote_config.rb
@@ -92,9 +92,9 @@ module RuboCop
       return true unless cache_path_exists?
 
       @cache_path_expired ||= begin
-        file_age = (Time.now - File.stat(cache_path).mtime).to_f
-        (file_age / CACHE_LIFETIME) > 1
-      end
+                                file_age = (Time.now - File.stat(cache_path).mtime).to_f
+                                (file_age / CACHE_LIFETIME) > 1
+                              end
     end
 
     def cache_name_from_uri

--- a/lib/rubocop/remote_config.rb
+++ b/lib/rubocop/remote_config.rb
@@ -91,10 +91,11 @@ module RuboCop
     def cache_path_expired?
       return true unless cache_path_exists?
 
-      @cache_path_expired ||= begin
-                                file_age = (Time.now - File.stat(cache_path).mtime).to_f
-                                (file_age / CACHE_LIFETIME) > 1
-                              end
+      @cache_path_expired ||=
+        begin
+          file_age = (Time.now - File.stat(cache_path).mtime).to_f
+          (file_age / CACHE_LIFETIME) > 1
+        end
     end
 
     def cache_name_from_uri

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -289,22 +289,22 @@ module RuboCop
     def mobilized_cop_classes(config)
       @mobilized_cop_classes ||= {}
       @mobilized_cop_classes[config.object_id] ||= begin
-        cop_classes = Cop::Cop.all
+                                                     cop_classes = Cop::Cop.all
 
-        %i[only except].each do |opt|
-          OptionsValidator.validate_cop_list(@options[opt])
-        end
+                                                     %i[only except].each do |opt|
+                                                       OptionsValidator.validate_cop_list(@options[opt])
+                                                     end
 
-        if @options[:only]
-          cop_classes.select! { |c| c.match?(@options[:only]) }
-        else
-          filter_cop_classes(cop_classes, config)
-        end
+                                                     if @options[:only]
+                                                       cop_classes.select! { |c| c.match?(@options[:only]) }
+                                                     else
+                                                       filter_cop_classes(cop_classes, config)
+                                                     end
 
-        cop_classes.reject! { |c| c.match?(@options[:except]) }
+                                                     cop_classes.reject! { |c| c.match?(@options[:except]) }
 
-        Cop::Registry.new(cop_classes)
-      end
+                                                     Cop::Registry.new(cop_classes)
+                                                   end
     end
 
     def filter_cop_classes(cop_classes, config)
@@ -320,13 +320,13 @@ module RuboCop
 
     def formatter_set
       @formatter_set ||= begin
-        set = Formatter::FormatterSet.new(@options)
-        pairs = @options[:formatters] || [['progress']]
-        pairs.each do |formatter_key, output_path|
-          set.add_formatter(formatter_key, output_path)
-        end
-        set
-      end
+                           set = Formatter::FormatterSet.new(@options)
+                           pairs = @options[:formatters] || [['progress']]
+                           pairs.each do |formatter_key, output_path|
+                             set.add_formatter(formatter_key, output_path)
+                           end
+                           set
+                         end
     end
 
     def considered_failure?(offense)
@@ -340,9 +340,9 @@ module RuboCop
 
     def minimum_severity_to_fail
       @minimum_severity_to_fail ||= begin
-        name = @options[:fail_level] || :refactor
-        RuboCop::Cop::Severity.new(name)
-      end
+                                      name = @options[:fail_level] || :refactor
+                                      RuboCop::Cop::Severity.new(name)
+                                    end
     end
 
     def get_processed_source(file)

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -288,23 +288,24 @@ module RuboCop
 
     def mobilized_cop_classes(config)
       @mobilized_cop_classes ||= {}
-      @mobilized_cop_classes[config.object_id] ||= begin
-                                                     cop_classes = Cop::Cop.all
+      @mobilized_cop_classes[config.object_id] ||=
+        begin
+          cop_classes = Cop::Cop.all
 
-                                                     %i[only except].each do |opt|
-                                                       OptionsValidator.validate_cop_list(@options[opt])
-                                                     end
+          %i[only except].each do |opt|
+            OptionsValidator.validate_cop_list(@options[opt])
+          end
 
-                                                     if @options[:only]
-                                                       cop_classes.select! { |c| c.match?(@options[:only]) }
-                                                     else
-                                                       filter_cop_classes(cop_classes, config)
-                                                     end
+          if @options[:only]
+            cop_classes.select! { |c| c.match?(@options[:only]) }
+          else
+            filter_cop_classes(cop_classes, config)
+          end
 
-                                                     cop_classes.reject! { |c| c.match?(@options[:except]) }
+          cop_classes.reject! { |c| c.match?(@options[:except]) }
 
-                                                     Cop::Registry.new(cop_classes)
-                                                   end
+          Cop::Registry.new(cop_classes)
+        end
     end
 
     def filter_cop_classes(cop_classes, config)

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -286,7 +286,7 @@ module RuboCop
       [offenses, team.updated_source_file?]
     end
 
-    def mobilized_cop_classes(config)
+    def mobilized_cop_classes(config) # rubocop:disable Metrics/MethodLength
       @mobilized_cop_classes ||= {}
       @mobilized_cop_classes[config.object_id] ||=
         begin

--- a/spec/rubocop/cop/layout/end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/end_alignment_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
 
   include_examples 'aligned', 'class',  'Test',      'end'
   include_examples 'aligned', 'module', 'Test',      'end'
+  include_examples 'aligned', 'begin',  '',          'end'
   include_examples 'aligned', 'if',     'test',      'end'
   include_examples 'aligned', 'unless', 'test',      'end'
   include_examples 'aligned', 'while',  'test',      'end'
@@ -26,6 +27,10 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
       end
       ^^^ `end` at 2, 2 is not aligned with `module` at 1, 0.
 
+    begin
+      end
+      ^^^ `end` at 2, 2 is not aligned with `begin` at 1, 0.
+
     puts 1; class Test
       end
       ^^^ `end` at 2, 2 is not aligned with `class` at 1, 8.
@@ -33,6 +38,10 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
     module Test
       end
       ^^^ `end` at 2, 2 is not aligned with `module` at 1, 0.
+
+    begin
+      end
+      ^^^ `end` at 2, 2 is not aligned with `begin` at 1, 0.
 
     puts 1; if test
       end
@@ -77,6 +86,7 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
 
   include_examples 'aligned', 'puts 1; class',  'Test',     '        end'
   include_examples 'aligned', 'puts 1; module', 'Test',     '        end'
+  include_examples 'aligned', 'puts 1; begin',  '',         '        end'
   include_examples 'aligned', 'puts 1; if',     'Test',     '        end'
   include_examples 'aligned', 'puts 1; unless', 'Test',     '        end'
   include_examples 'aligned', 'puts 1; while',  'Test',     '        end'
@@ -98,6 +108,7 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
 
     include_examples 'aligned', 'puts 1; class',  'Test',     'end'
     include_examples 'aligned', 'puts 1; module', 'Test',     'end'
+    include_examples 'aligned', 'puts 1; begin',  '',         'end'
     include_examples 'aligned', 'puts 1; if',     'test',     'end'
     include_examples 'aligned', 'puts 1; unless', 'test',     'end'
     include_examples 'aligned', 'puts 1; while',  'test',     'end'
@@ -120,6 +131,14 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
       module Test
         end
         ^^^ `end` at 2, 2 is not aligned with `module Test` at 1, 0.
+
+      puts 1; begin
+        end
+        ^^^ `end` at 2, 2 is not aligned with `puts 1; begin` at 1, 0.
+
+      begin
+        end
+        ^^^ `end` at 2, 2 is not aligned with `begin` at 1, 0.
 
       puts 1; if test
         end
@@ -185,6 +204,10 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
              end
              ^^^ `end` at 2, 7 is not aligned with `module` at 1, 0.
 
+      begin
+             end
+             ^^^ `end` at 2, 7 is not aligned with `begin` at 1, 0.
+
       if test
         end
         ^^^ `end` at 2, 2 is not aligned with `if` at 1, 0.
@@ -208,6 +231,7 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
 
     include_examples 'aligned', 'class',  'Test',      'end'
     include_examples 'aligned', 'module', 'Test',      'end'
+    include_examples 'aligned', 'begin',  '',          'end'
     include_examples 'aligned', 'if',     'test',      'end'
     include_examples 'aligned', 'unless', 'test',      'end'
     include_examples 'aligned', 'while',  'test',      'end'
@@ -246,6 +270,7 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
 
     include_examples 'aligned', 'puts 1; class',  'Test',     '        end'
     include_examples 'aligned', 'puts 1; module', 'Test',     '        end'
+    include_examples 'aligned', 'puts 1; begin',  '',         '        end'
     include_examples 'aligned', 'puts 1; if',     'Test',     '        end'
     include_examples 'aligned', 'puts 1; unless', 'Test',     '        end'
     include_examples 'aligned', 'puts 1; while',  'Test',     '        end'
@@ -392,6 +417,7 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
         { 'EnforcedStyleAlignWith' => 'variable', 'AutoCorrect' => true }
       end
 
+      include_examples 'aligned', 'var = begin',  '',         'end'
       include_examples 'aligned', 'var << if',    'test',     'end'
       include_examples 'aligned', 'var = if',     'test',     'end'
       include_examples 'aligned', 'var = unless', 'test',     'end'


### PR DESCRIPTION
The `end` alignment in `begin`-`end` blocks was not implemented.

This is a follow-up to #7286. It serves as a first spike in exploring an option for handling `begin`-`end` blocks, which haven't been handled so far by RuboCop.

Thus, at this point this PR doesn't address the newly introduced style issues due to the new validation.

@jonas054, @bbatsov, as you see, introducing this reveals a bunch of offenses. How do you feel about the general direction of this? Should `Layout/EndAlignment` be in charge of `begin`-`end` blocks at all?

This partially addresses #6774.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/