### PR TITLE
Change warning location of `SafeMode`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -86,6 +86,10 @@ Metrics/BlockLength:
     - 'spec/**/*.rb'
     - '**/*.gemspec'
 
+Metrics/ClassLength:
+  Exclude:
+    - lib/rubocop/config_obsoletion.rb
+
 Metrics/ModuleLength:
   Exclude:
     - 'spec/**/*.rb'

--- a/lib/rubocop/config_obsoletion.rb
+++ b/lib/rubocop/config_obsoletion.rb
@@ -125,6 +125,12 @@ module RuboCop
         parameters: 'IgnoredMethodPatterns',
         alternative: '`IgnoredMethodPatterns` has been renamed to ' \
                      '`IgnoredPatterns`'
+      },
+      {
+        cops: %w[Performance/Count Performance/Detect],
+        parameters: 'SafeMode',
+        alternative: '`SafeMode` has been removed. ' \
+                     'Use `SafeAutoCorrect` instead.'
       }
     ].freeze
 

--- a/lib/rubocop/cop/mixin/safe_mode.rb
+++ b/lib/rubocop/cop/mixin/safe_mode.rb
@@ -3,10 +3,9 @@
 module RuboCop
   module Cop
     # Common functionality for Rails safe mode.
+    #
+    # This module can be removed from RuboCop 0.76.
     module SafeMode
-      warn 'The `SafeMode` option will be removed in `RuboCop` 0.76. ' \
-        'Please update `rubocop-performance` to 1.5.0 or higher.'
-
       private
 
       def rails_safe_mode?


### PR DESCRIPTION
### Summary

Related https://github.com/rubocop-hq/rubocop/pull/7249.

In #7249, the following deprecation  warning is displayed for all operations of `rubocop` command.

```console
% bundle exec rubocop -v
The `SafeMode` option will be removed in `RuboCop` 0.76. Please update
`rubocop-performance` to 1.5.0 or higher.
0.74.0
```

I noticed that with the `ConfigObsolete` module, RuboCop can only show the warning when using `SafeMode`.

```console
% cat .rubocop.yml
require: rubocop-performance

Performance/Count:
  SafeMode: false

% bundle exec rubocop
Error: obsolete parameter SafeMode (for Performance/Count) found in .rubocop.yml
`SafeMode` has been removed. Use `SafeAutoCorrect` instead.
```

OTOH, RuboCop Performance happens the following error when `SafeMode` module will removed:

```console
NameError:
 uninitialized constant RuboCop::Cop::Performance::Count::SafeMode
```

Therefore, the following milestones were planned. This plan does not remove `SafeMode` module immediately.

- RuboCop 0.75 ... Presents an alternative API via `ConfigObsolete` module
- RuboCop 0.76 ... Remove SafeMode

This is probably a better way, as it is best to offer an alternative API in the 3rd party module.

### Other Information

`Metrics/ClassLength` cop excludes config_obsoletion.rb by .rubocop.yaml because most of the code in `ConfigObsoletion` module are configuration codes.

```console
% bundle exec rake internal_investigation

(snip)

Offenses:

lib/rubocop/config_obsoletion.rb:5:3: C: Metrics/ClassLength: Class has
too many lines. [185/182]
  class ConfigObsoletion ...
    ^^^^^^^^^^^^^^^^^^^^^^

1101 files inspected, 1 offense detected
RuboCop failed!
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
