### PR TITLE
[Fix #5212] Allow braces around block with do..end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [#7326](https://github.com/rubocop-hq/rubocop/issues/7326): Fix a false positive for `Style/AccessModifierDeclarations` when access modifier name is used for hash literal value. ([@koic][])
 * [#3591](https://github.com/rubocop-hq/rubocop/issues/3591): Handle modifier `if`/`unless` correctly in `Lint/UselessAssignment`. ([@jonas054][])
 * [#7161](https://github.com/rubocop-hq/rubocop/issues/7161): Fix `Style/SafeNavigation` cop for preserve comments inside if expression. ([@tejasbubane][])
+* [#5212](https://github.com/rubocop-hq/rubocop/issues/5212): Avoid false positive for braces that are needed to preserve semantics in `Style/BracesAroundHashParameters`. ([@jonas054][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       expect_no_offenses(['where(  {     ',
                           " }\t   )  "].join("\n"))
     end
+
+    it 'accepts braces that are needed to make a block bind to an inner ' \
+       'method call' do
+      expect_no_offenses('f 1, { k: proc do h end }')
+    end
   end
 
   shared_examples 'no_braces and context_dependent non-offenses' do


### PR DESCRIPTION
Users are getting false positives saying that hash braces should be removed although doing so would change semantics for a block with `do`..`end`. We fix the false positive by allowing the braces in this particular case.