### PR TITLE
Add examples of `AllowSafeAssignment` option

### DIFF
--- a/lib/rubocop/cop/lint/assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/assignment_in_condition.rb
@@ -6,21 +6,34 @@ module RuboCop
       # This cop checks for assignments in the conditions of
       # if/while/until.
       #
+      # `AllowSafeAssignment` option for safe assignment.
+      # By safe assignment we mean putting parentheses around
+      # an assignment to indicate "I know I'm using an assignment
+      # as a condition. It's not a mistake."
+      #
       # @example
-      #
       #   # bad
-      #
       #   if some_var = true
       #     do_something
       #   end
       #
-      # @example
-      #
       #   # good
-      #
       #   if some_var == true
       #     do_something
       #   end
+      #
+      # @example AllowSafeAssignment: true (default)
+      #   # good
+      #   if (some_var = true)
+      #     do_something
+      #   end
+      #
+      # @example AllowSafeAssignment: false
+      #   # bad
+      #   if (some_var = true)
+      #     do_something
+      #   end
+      #
       class AssignmentInCondition < Cop
         include SafeAssignment
 

--- a/lib/rubocop/cop/style/parentheses_around_condition.rb
+++ b/lib/rubocop/cop/style/parentheses_around_condition.rb
@@ -6,6 +6,11 @@ module RuboCop
       # This cop checks for the presence of superfluous parentheses around the
       # condition of if/unless/while/until.
       #
+      # `AllowSafeAssignment` option for safe assignment.
+      # By safe assignment we mean putting parentheses around
+      # an assignment to indicate "I know I'm using an assignment
+      # as a condition. It's not a mistake."
+      #
       # @example
       #   # bad
       #   x += 1 while (x < 10)
@@ -23,6 +28,14 @@ module RuboCop
       #   elsif x < 3
       #   end
       #
+      # @example AllowSafeAssignment: true (default)
+      #   # good
+      #   foo unless (bar = baz)
+      #
+      # @example AllowSafeAssignment: false
+      #   # bad
+      #   foo unless (bar = baz)
+      #
       # @example AllowInMultilineConditions: false (default)
       #   # bad
       #   if (x > 10 &&
@@ -39,6 +52,7 @@ module RuboCop
       #   if (x > 10 &&
       #      y > 10)
       #   end
+      #
       class ParenthesesAroundCondition < Cop
         include SafeAssignment
         include Parentheses

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -8,6 +8,11 @@ module RuboCop
       # parentheses using `EnforcedStyle`. Omission is only enforced when
       # removing the parentheses won't cause a different behavior.
       #
+      # `AllowSafeAssignment` option for safe assignment.
+      # By safe assignment we mean putting parentheses around
+      # an assignment to indicate "I know I'm using an assignment
+      # as a condition. It's not a mistake."
+      #
       # @example EnforcedStyle: require_no_parentheses (default)
       #   # bad
       #   foo = (bar?) ? a : b
@@ -40,6 +45,15 @@ module RuboCop
       #   foo = bar? ? a : b
       #   foo = bar.baz? ? a : b
       #   foo = (bar && baz) ? a : b
+      #
+      # @example AllowSafeAssignment: true (default)
+      #   # good
+      #   foo = (bar = baz) ? a : b
+      #
+      # @example AllowSafeAssignment: false
+      #   # bad
+      #   foo = (bar = baz) ? a : b
+      #
       class TernaryParentheses < Cop
         include SafeAssignment
         include ConfigurableEnforcedStyle

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -97,19 +97,37 @@ Enabled | Yes | No | 0.9 | -
 This cop checks for assignments in the conditions of
 if/while/until.
 
+`AllowSafeAssignment` option for safe assignment.
+By safe assignment we mean putting parentheses around
+an assignment to indicate "I know I'm using an assignment
+as a condition. It's not a mistake."
+
 ### Examples
 
 ```ruby
 # bad
-
 if some_var = true
   do_something
 end
+
+# good
+if some_var == true
+  do_something
+end
 ```
+#### AllowSafeAssignment: true (default)
+
 ```ruby
 # good
+if (some_var = true)
+  do_something
+end
+```
+#### AllowSafeAssignment: false
 
-if some_var == true
+```ruby
+# bad
+if (some_var = true)
   do_something
 end
 ```

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4727,6 +4727,11 @@ Enabled | Yes | Yes  | 0.9 | 0.56
 This cop checks for the presence of superfluous parentheses around the
 condition of if/unless/while/until.
 
+`AllowSafeAssignment` option for safe assignment.
+By safe assignment we mean putting parentheses around
+an assignment to indicate "I know I'm using an assignment
+as a condition. It's not a mistake."
+
 ### Examples
 
 ```ruby
@@ -4745,6 +4750,18 @@ foo unless bar || baz
 if x > 10
 elsif x < 3
 end
+```
+#### AllowSafeAssignment: true (default)
+
+```ruby
+# good
+foo unless (bar = baz)
+```
+#### AllowSafeAssignment: false
+
+```ruby
+# bad
+foo unless (bar = baz)
 ```
 #### AllowInMultilineConditions: false (default)
 
@@ -6429,6 +6446,11 @@ conditions. It is configurable to enforce inclusion or omission of
 parentheses using `EnforcedStyle`. Omission is only enforced when
 removing the parentheses won't cause a different behavior.
 
+`AllowSafeAssignment` option for safe assignment.
+By safe assignment we mean putting parentheses around
+an assignment to indicate "I know I'm using an assignment
+as a condition. It's not a mistake."
+
 ### Examples
 
 #### EnforcedStyle: require_no_parentheses (default)
@@ -6469,6 +6491,18 @@ foo = bar && baz ? a : b
 foo = bar? ? a : b
 foo = bar.baz? ? a : b
 foo = (bar && baz) ? a : b
+```
+#### AllowSafeAssignment: true (default)
+
+```ruby
+# good
+foo = (bar = baz) ? a : b
+```
+#### AllowSafeAssignment: false
+
+```ruby
+# bad
+foo = (bar = baz) ? a : b
 ```
 
 ### Configurable attributes


### PR DESCRIPTION
This is only document change.

This commit adds examples of `AllowSafeAssignment` option for `Lint/AssignmentInCondition` cop, `Style/ParenthesesAroundCondition` cop, and `Style/TernaryParentheses` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
