### PR TITLE
[Fix #7353] Fix a false positive for `Style/RedundantSelf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [#3591](https://github.com/rubocop-hq/rubocop/issues/3591): Handle modifier `if`/`unless` correctly in `Lint/UselessAssignment`. ([@jonas054][])
 * [#7161](https://github.com/rubocop-hq/rubocop/issues/7161): Fix `Style/SafeNavigation` cop for preserve comments inside if expression. ([@tejasbubane][])
 * [#5212](https://github.com/rubocop-hq/rubocop/issues/5212): Avoid false positive for braces that are needed to preserve semantics in `Style/BracesAroundHashParameters`. ([@jonas054][])
+* [#7353](https://github.com/rubocop-hq/rubocop/issues/7353): Fix a false positive for `Style/RedundantSelf` when receiver and multiple assigned lvalue have the same name. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -83,6 +83,13 @@ module RuboCop
           on_argument(node)
         end
 
+        def on_masgn(node)
+          lhs, rhs = *node
+          lhs.children.each do |child|
+            @local_variables_scopes[rhs] << child.to_a.first
+          end
+        end
+
         def on_lvasgn(node)
           lhs, rhs = *node
           @local_variables_scopes[rhs] << lhs

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf do
     expect_no_offenses('a = self.a')
   end
 
+  it 'does not report an offense when receiver and multiple assigned lvalue ' \
+     'have the same name' do
+    expect_no_offenses('a, b = self.a')
+  end
+
   it 'accepts a self receiver on an lvalue of an assignment' do
     expect_no_offenses('self.a = b')
   end


### PR DESCRIPTION
Fixes #7353.

This PR fixes a false positive for `Style/RedundantSelf` when receiver and multiple assigned lvalue have the same name.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
