### PR TITLE
[Fix #7353] Fix a false positive for `Style/RedundantSelf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [#7161](https://github.com/rubocop-hq/rubocop/issues/7161): Fix `Style/SafeNavigation` cop for preserve comments inside if expression. ([@tejasbubane][])
 * [#5212](https://github.com/rubocop-hq/rubocop/issues/5212): Avoid false positive for braces that are needed to preserve semantics in `Style/BracesAroundHashParameters`. ([@jonas054][])
 * [#7353](https://github.com/rubocop-hq/rubocop/issues/7353): Fix a false positive for `Style/RedundantSelf` when receiver and multiple assigned lvalue have the same name. ([@koic][])
+* [#7353](https://github.com/rubocop-hq/rubocop/issues/7353): Fix a false positive for `Style/RedundantSelf` when a self receiver is used as a method argument. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -86,13 +86,13 @@ module RuboCop
         def on_masgn(node)
           lhs, rhs = *node
           lhs.children.each do |child|
-            @local_variables_scopes[rhs] << child.to_a.first
+            add_lhs_to_local_variables_scopes(rhs, child.to_a.first)
           end
         end
 
         def on_lvasgn(node)
           lhs, rhs = *node
-          @local_variables_scopes[rhs] << lhs
+          add_lhs_to_local_variables_scopes(rhs, lhs)
         end
 
         def on_send(node)
@@ -154,6 +154,16 @@ module RuboCop
           return unless node.send_type? && node.self_receiver?
 
           @allowed_send_nodes << node
+        end
+
+        def add_lhs_to_local_variables_scopes(rhs, lhs)
+          if rhs&.send_type? && !rhs.arguments.empty?
+            rhs.arguments.each do |argument|
+              @local_variables_scopes[argument] << lhs
+            end
+          else
+            @local_variables_scopes[rhs] << lhs
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -19,6 +19,16 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf do
     expect_no_offenses('a, b = self.a')
   end
 
+  it 'does not report an offense when self receiver in a method argument and ' \
+     'lvalue have the same name' do
+    expect_no_offenses('a = do_something(self.a)')
+  end
+
+  it 'does not report an offense when self receiver in a method argument and ' \
+     'multiple assigned lvalue have the same name' do
+    expect_no_offenses('a, b = do_something(self.a)')
+  end
+
   it 'accepts a self receiver on an lvalue of an assignment' do
     expect_no_offenses('self.a = b')
   end


### PR DESCRIPTION
This PR fixes a false positive for `Style/RedundantSelf` when a self receiver is used as a method argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
