### PR TITLE
Fix new_cop task to avoid generating invalid YAML for the config file

### DIFF
--- a/lib/rubocop/cop/generator/configuration_injector.rb
+++ b/lib/rubocop/cop/generator/configuration_injector.rb
@@ -12,7 +12,6 @@ module RuboCop
             Description: 'TODO: Write a description of the cop.'
             Enabled: true
             VersionAdded: '%<version_added>s'
-
         YAML
 
         def initialize(configuration_file_path:, badge:, version_added:)
@@ -23,8 +22,13 @@ module RuboCop
         end
 
         def inject
-          configuration_entries.insert(find_target_line,
-                                       new_configuration_entry)
+          target_line = find_target_line
+          if target_line
+            configuration_entries.insert(find_target_line,
+                                         new_configuration_entry + "\n")
+          else
+            configuration_entries.push("\n" + new_configuration_entry)
+          end
 
           File.write(configuration_file_path, configuration_entries.join)
 
@@ -49,7 +53,8 @@ module RuboCop
 
             return index if badge.to_s < line
           end
-          configuration_entries.size - 1
+
+          nil
         end
 
         def cop_name_line?(yaml)

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -191,33 +191,93 @@ RSpec.describe RuboCop::Cop::Generator do
         Style/SpecialGlobalVars:
           Enabled: true
       YAML
+
+      stub_const('RuboCop::Version::STRING', '0.58.2')
     end
 
-    it 'inserts the cop in alphabetical order' do
-      stub_const('RuboCop::Version::STRING', '0.58.2')
+    context 'when it is the middle in alphabetical order' do
+      it 'inserts the cop' do
+        expect(File).to receive(:write).with(path, <<~YAML)
+          Style/Alias:
+            Enabled: true
 
-      expect(File).to receive(:write).with(path, <<~YAML)
-        Style/Alias:
-          Enabled: true
+          Style/FakeCop:
+            Description: 'TODO: Write a description of the cop.'
+            Enabled: true
+            VersionAdded: '0.59'
 
-        Style/FakeCop:
-          Description: 'TODO: Write a description of the cop.'
-          Enabled: true
-          VersionAdded: '0.59'
+          Style/Lambda:
+            Enabled: true
 
-        Style/Lambda:
-          Enabled: true
+          Style/SpecialGlobalVars:
+            Enabled: true
+        YAML
 
-        Style/SpecialGlobalVars:
-          Enabled: true
-      YAML
+        generator.inject_config(config_file_path: path)
 
-      generator.inject_config(config_file_path: path)
+        expect(stdout.string).to eq(<<~MESSAGE)
+          [modify] A configuration for the cop is added into #{path}.
+                   If you want to disable the cop by default, set `Enabled` option to false.
+        MESSAGE
+      end
+    end
 
-      expect(stdout.string).to eq(<<~MESSAGE)
-        [modify] A configuration for the cop is added into #{path}.
-                 If you want to disable the cop by default, set `Enabled` option to false.
-      MESSAGE
+    context 'when it is the first in alphabetical order' do
+      let(:cop_identifier) { 'Style/Aaa' }
+
+      it 'inserts the cop' do
+        expect(File).to receive(:write).with(path, <<~YAML)
+          Style/Aaa:
+            Description: 'TODO: Write a description of the cop.'
+            Enabled: true
+            VersionAdded: '0.59'
+
+          Style/Alias:
+            Enabled: true
+
+          Style/Lambda:
+            Enabled: true
+
+          Style/SpecialGlobalVars:
+            Enabled: true
+        YAML
+
+        generator.inject_config(config_file_path: path)
+
+        expect(stdout.string).to eq(<<~MESSAGE)
+          [modify] A configuration for the cop is added into #{path}.
+                   If you want to disable the cop by default, set `Enabled` option to false.
+        MESSAGE
+      end
+    end
+
+    context 'when it is the last in alphabetical order' do
+      let(:cop_identifier) { 'Style/Zzz' }
+
+      it 'inserts the cop' do
+        expect(File).to receive(:write).with(path, <<~YAML)
+          Style/Alias:
+            Enabled: true
+
+          Style/Lambda:
+            Enabled: true
+
+          Style/SpecialGlobalVars:
+            Enabled: true
+
+          Style/Zzz:
+            Description: 'TODO: Write a description of the cop.'
+            Enabled: true
+            VersionAdded: '0.59'
+        YAML
+
+        generator.inject_config(config_file_path: path)
+
+        expect(stdout.string).to eq(<<~MESSAGE)
+          [modify] A configuration for the cop is added into #{path}.
+                   If you want to disable the cop by default, set `Enabled` option to false.
+        MESSAGE
+      end
     end
   end
 


### PR DESCRIPTION
It generates invalid YAML if the new cop is named the last in alphabetical order.


```bash
$ bundle exec rake 'new_cop[Zzz/Zzz]'
(snip)

$ tail config/default.yml
  Description: 'Use #empty? when testing for objects of length 0.'
  Enabled: true
  Safe: false
  VersionAdded: '0.37'
Zzz/Zzz:
  Description: 'TODO: Write a description of the cop.'
  Enabled: true
  VersionAdded: '0.75'

  VersionChanged: '0.39'
```

`VersionChanged` on the last line is not for `Zzz/Zzz` cop, but it is put under `Zzz/Zzz` cop accidentally.

This pull request will fix the problem.

----------------- 

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
