### PR TITLE
remove alias to corrected methods

### DIFF
--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -67,26 +67,32 @@ module RuboCop
 
       # @api public
       #
-      # @!attribute [r] corrected
+      # @!attribute [r] corrected?
       #
       # @return [Boolean]
-      #   whether this offense is automatically corrected.
-      def corrected
+      #   whether this offense is automatically corrected via
+      #   autocorrect or a todo.
+      def corrected?
         @status == :corrected || @status == :corrected_with_todo
       end
-      alias corrected? corrected
 
-      def corrected_with_todo
+      # @api public
+      #
+      # @!attribute [r] corrected_with_todo?
+      #
+      # @return [Boolean]
+      #   whether this offense is automatically disabled via a todo.
+      def corrected_with_todo?
         @status == :corrected_with_todo
       end
-      alias corrected_with_todo? corrected_with_todo
 
       # @api public
       #
       # @!attribute [r] disabled?
       #
       # @return [Boolean]
-      #   whether this offense was locally disabled where it occurred
+      #   whether this offense was locally disabled with a
+      #   disable or todo where it occurred.
       def disabled?
         @status == :disabled || @status == :todo
       end


### PR DESCRIPTION
Remove redundant aliasing of the corrected? and corrected_with_todo? method.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
