### PR TITLE
[Fix #7358] Fix an incorrect autocorrect for `Style/NestedModifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#5212](https://github.com/rubocop-hq/rubocop/issues/5212): Avoid false positive for braces that are needed to preserve semantics in `Style/BracesAroundHashParameters`. ([@jonas054][])
 * [#7353](https://github.com/rubocop-hq/rubocop/issues/7353): Fix a false positive for `Style/RedundantSelf` when receiver and multiple assigned lvalue have the same name. ([@koic][])
 * [#7353](https://github.com/rubocop-hq/rubocop/issues/7353): Fix a false positive for `Style/RedundantSelf` when a self receiver is used as a method argument. ([@koic][])
+* [#7358](https://github.com/rubocop-hq/rubocop/issues/7358): Fix an incorrect autocorrect for `Style/NestedModifier` when parentheses are required in method arguments. ([@koic][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/nested_modifier_spec.rb
+++ b/spec/rubocop/cop/style/nested_modifier_spec.rb
@@ -65,6 +65,12 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier do
     expect(corrected).to eq 'something if (c || d) && (a || b)'
   end
 
+  it 'adds parentheses to method arguments when needed ' \
+     'in auto-correction' do
+    corrected = autocorrect_source('a unless [1, 2].include? a if a')
+    expect(corrected).to eq 'a if a && ![1, 2].include?(a)'
+  end
+
   it 'does not add redundant parentheses in auto-correction' do
     corrected = autocorrect_source('something if a unless c || d')
     expect(corrected).to eq 'something unless c || d || !a'


### PR DESCRIPTION
Fixes #7358.

This PR fix an incorrect autocorrect for `Style/NestedModifier` when parentheses are required in method arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
