### PR TITLE
[Fix #7361] Fix a false positive for `Style/TernaryParentheses`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [#7353](https://github.com/rubocop-hq/rubocop/issues/7353): Fix a false positive for `Style/RedundantSelf` when receiver and multiple assigned lvalue have the same name. ([@koic][])
 * [#7353](https://github.com/rubocop-hq/rubocop/issues/7353): Fix a false positive for `Style/RedundantSelf` when a self receiver is used as a method argument. ([@koic][])
 * [#7358](https://github.com/rubocop-hq/rubocop/issues/7358): Fix an incorrect autocorrect for `Style/NestedModifier` when parentheses are required in method arguments. ([@koic][])
+* [#7361](https://github.com/rubocop-hq/rubocop/issues/7361): Fix a false positive for `Style/TernaryParentheses` when only the closing parenthesis is used in the last line of condition. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -67,9 +67,14 @@ module RuboCop
           ' complex conditions.'
 
         def on_if(node)
+          return if only_closing_parenthesis_is_last_line?(node.condition)
           return unless node.ternary? && !infinite_loop? && offense?(node)
 
           add_offense(node, location: node.source_range)
+        end
+
+        def only_closing_parenthesis_is_last_line?(condition)
+          condition.source.split("\n").last == ')'
         end
 
         def autocorrect(node)

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -155,6 +155,20 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
       it_behaves_like 'code with offense',
                       'foo = (bar[:baz]) ? a : b',
                       'foo = bar[:baz] ? a : b'
+
+      it_behaves_like 'code with offense', <<~RUBY, <<~CORRECTION
+        (foo ||
+          bar) ? a : b
+      RUBY
+        foo ||
+          bar ? a : b
+      CORRECTION
+
+      it_behaves_like 'code without offense', <<~RUBY
+        (
+          foo || bar
+        ) ? a : b
+      RUBY
     end
 
     context 'with a complex condition' do


### PR DESCRIPTION
Fixes #7361.

This PR fixes a false positive for `Style/TernaryParentheses` when only the closing parenthesis is used in the last line of condition.

It prevents the following syntax errors caused by auto-correction:

```ruby
(
  foo || bar
) ? a : b
```

```console
% rubocop --only Style/TernaryParentheses -a
```

The following autocorrected code has a syntax error.

```ruby

  foo || bar
 ? a : b
```

```console
% ruby -c example.rb
example.rb:3: warning: invalid character syntax; use ?\s
example.rb:3: syntax error, unexpected '?', expecting end-of-input
 ? a : b
```

For example, it accepts parentheses to be used when a conditional is a long line.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
