### PR TITLE
[Fix #7363] Fix an incorrect autocorrect when multiline empty braces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [#7369](https://github.com/rubocop-hq/rubocop/issues/7369): Fix an infinite loop error for `Layout/IndentAssignment` with `Layout/IndentFirstArgument` when using multiple assignment. ([@koic][])
 * [#7177](https://github.com/rubocop-hq/rubocop/issues/7177), [#7370](https://github.com/rubocop-hq/rubocop/issues/7370): When correcting alignment, do not insert spaces into string literals. ([@buehmann][])
 * [#7367](https://github.com/rubocop-hq/rubocop/issues/7367): Fix an error for `Style/OrAssignment` cop when `then` branch body is empty. ([@koic][])
+* [#7363](https://github.com/rubocop-hq/rubocop/issues/7363): Fix an incorrect autocorrect for `Layout/SpaceInsideBlockBraces` and `Style/BlockDelimiters` when using multiline empty braces. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/space_inside_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_block_braces.rb
@@ -84,6 +84,13 @@ module RuboCop
         def on_block(node)
           return if node.keywords?
 
+          # Do not register an offense for multi-line empty braces. That means
+          # preventing auto-correction to single-line empty braces. It will
+          # conflict with auto-correction by `Layout/SpaceInsideBlockBraces` cop
+          # if auto-corrected to a single-line empty braces.
+          # See: https://github.com/rubocop-hq/rubocop/issues/7363
+          return if node.body.nil? && node.multiline?
+
           left_brace = node.loc.begin
           right_brace = node.loc.end
 

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1629,6 +1629,30 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     RUBY
   end
 
+  it 'corrects Style/BlockDelimiters offenses when specifing' \
+     'Layout/SpaceInsideBlockBraces together' do
+    create_file('example.rb', <<~RUBY)
+      each {
+      }
+    RUBY
+
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/SpaceInsideBlockBraces:
+        EnforcedStyle: space
+      Style/BlockDelimiters:
+        EnforcedStyle: line_count_based
+    YAML
+
+    expect(cli.run(%w[--auto-correct])).to eq(0)
+    expect($stderr.string).to eq('')
+    expect(IO.read('example.rb')).to eq(<<~RUBY)
+      # frozen_string_literal: true
+
+      each do
+      end
+    RUBY
+  end
+
   it 'corrects BracesAroundHashParameters offenses leaving the ' \
      'MultilineHashBraceLayout offense unchanged' do
     create_file('example.rb', <<~RUBY)

--- a/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
@@ -38,13 +38,11 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
       RUBY
     end
 
-    it 'registers an offense for empty braces with line break inside' do
-      inspect_source(<<-RUBY.strip_margin('|'))
+    it 'accepts empty braces with line break inside' do
+      expect_no_offenses(<<-RUBY.strip_margin('|'))
         |  each {
         |  }
       RUBY
-      expect(cop.messages).to eq(['Space inside empty braces detected.'])
-      expect(cop.highlights).to eq(["\n  "])
     end
 
     it 'registers an offense for empty braces with space inside' do


### PR DESCRIPTION
Fixes #7363.

This PR fixes an incorrect autocorrect for `Layout/SpaceInsideBlockBraces` and `Style/BlockDelimiters` when using multiline empty braces.

As a result of applying the two auto-corrections, the code is converted to have the following syntax error code:

```console
% cat example.rb
do_something {
}

% rubocop --auto-correct --only Style/BlockDelimiters,Layout/SpaceInsideBlockBraces

% cat example.rb
do_something doend
```

`doend` is because `Layout/SpaceInsideBlockBraces` cop auto-corrects to single-line empty braces:

```console
% rubocop --auto-correct --only Layout/SpaceInsideBlockBraces

% cat example.rb
do_something {}
```

and `Style/BlockDelimiters` auto-corrects to `do` ... `end`.

```console
% rubocop --auto-correct --only Style/BlockDelimiters

% cat example.rb
do_something do
end
```

This PR prevents auto-correction to syntax error code by keeping multiline empty braces.

```console
% rubocop --auto-correct --only Layout/SpaceInsideBlockBraces
Inspecting 1 file
.

1 file inspected, no offenses detected

% cat example.rb
do_something {
}
```

This is the same intent as not converting multiline empty `do` ... `end` to single line empty `do` ... `end`.

As a result, it is auto-corrected to the following valid syntax code.

```console
% rubocop --auto-correct --only Style/BlockDelimiters,Layout/SpaceInsideBlockBraces

% cat example.rb
do_something do
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
