### PR TITLE
[Fix #7367] Fix an error for `Style/OrAssignment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [#7361](https://github.com/rubocop-hq/rubocop/issues/7361): Fix a false positive for `Style/TernaryParentheses` when only the closing parenthesis is used in the last line of condition. ([@koic][])
 * [#7369](https://github.com/rubocop-hq/rubocop/issues/7369): Fix an infinite loop error for `Layout/IndentAssignment` with `Layout/IndentFirstArgument` when using multiple assignment. ([@koic][])
 * [#7177](https://github.com/rubocop-hq/rubocop/issues/7177), [#7370](https://github.com/rubocop-hq/rubocop/issues/7370): When correcting alignment, do not insert spaces into string literals. ([@buehmann][])
+* [#7367](https://github.com/rubocop-hq/rubocop/issues/7367): Fix an error for `Style/OrAssignment` cop when `then` branch body is empty. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/or_assignment.rb
+++ b/lib/rubocop/cop/style/or_assignment.rb
@@ -81,7 +81,12 @@ module RuboCop
         end
 
         def take_variable_and_default_from_unless(node)
-          variable, default = *node.if_branch
+          if node.if_branch
+            variable, default = *node.if_branch
+          else
+            variable, default = *node.else_branch
+          end
+
           [variable, default]
         end
       end

--- a/spec/rubocop/cop/style/or_assignment_spec.rb
+++ b/spec/rubocop/cop/style/or_assignment_spec.rb
@@ -303,4 +303,22 @@ RSpec.describe RuboCop::Cop::Style::OrAssignment do
       RUBY
     end
   end
+
+  context 'when `then` branch body is empty' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        foo = nil
+        if foo
+        ^^^^^^ Use the double pipe equals operator `||=` instead.
+        else
+          foo = 2
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo = nil
+        foo ||= 2
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #7367.

This PR fixes an error for `Style/OrAssignment` cop when `then` branch body is empty.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
