### PR TITLE
[Fix #7369] Fix an infinite loop error for `Layout/IndentAssignment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [#7353](https://github.com/rubocop-hq/rubocop/issues/7353): Fix a false positive for `Style/RedundantSelf` when a self receiver is used as a method argument. ([@koic][])
 * [#7358](https://github.com/rubocop-hq/rubocop/issues/7358): Fix an incorrect autocorrect for `Style/NestedModifier` when parentheses are required in method arguments. ([@koic][])
 * [#7361](https://github.com/rubocop-hq/rubocop/issues/7361): Fix a false positive for `Style/TernaryParentheses` when only the closing parenthesis is used in the last line of condition. ([@koic][])
+* [#7369](https://github.com/rubocop-hq/rubocop/issues/7369): Fix an infinite loop error for `Layout/IndentAssignment` with `Layout/IndentFirstArgument` when using multiple assignment. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/indent_assignment.rb
+++ b/lib/rubocop/cop/layout/indent_assignment.rb
@@ -33,12 +33,20 @@ module RuboCop
           return unless node.loc.operator
           return if node.loc.operator.line == rhs.first_line
 
-          base = display_column(node.source_range)
+          base = display_column(leftmost_multiple_assignment(node).source_range)
           check_alignment([rhs], base + configured_indentation_width)
         end
 
         def autocorrect(node)
           AlignmentCorrector.correct(processed_source, node, column_delta)
+        end
+
+        def leftmost_multiple_assignment(node)
+          return node unless node.parent&.assignment?
+
+          leftmost_multiple_assignment(node.parent)
+
+          node.parent
         end
       end
     end

--- a/spec/rubocop/cop/layout/indent_assignment_spec.rb
+++ b/spec/rubocop/cop/layout/indent_assignment_spec.rb
@@ -91,4 +91,18 @@ RSpec.describe RuboCop::Cop::Layout::IndentAssignment, :config do
       RUBY
     end
   end
+
+  it 'registers an offense for incorrectly indented rhs ' \
+     'when multiple assignment' do
+    expect_offense(<<~RUBY)
+      foo = bar =
+      baz = ''
+      ^^^^^^^^ Indent the first line of the right-hand-side of a multi-line assignment.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo = bar =
+        baz = ''
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #7369.

This PR fixes an infinite loop error for `Layout/IndentAssignment` with `Layout/IndentFirstArgument` when using multiple assignment.

```console
% cat example.rb
a.b = a.c =
  e = ''
```

```console
% rubocop --auto-correct --only Layout/IndentAssignment,Layout/IndentFirstArgument
Inspecting 1 file
C

Offenses:

example.rb:2:3: C: [Corrected] Layout/IndentAssignment: Indent the first
line of the right-hand-side of a multi-line assignment.
  e = ''
  ^^^^^^
example.rb:2:9: C: [Corrected] Layout/IndentFirstArgument: Indent
the first argument one step more than the start of the previous line.
        e = ''
        ^^^^^^

0 files inspected, 2 offenses detected, 2 offenses corrected
Infinite loop detected in
/Users/koic/src/github.com/koic/rubocop-issues/7369/example.rb.
/Users/koic/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/rubocop-0.74.0/lib/rubocop/runner.rb:274:in
`check_for_infinite_loop'
/Users/koic/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/rubocop-0.74.0/lib/rubocop/runner.rb:257:in
`block in iterate_until_no_changes'
/Users/koic/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/rubocop-0.74.0/lib/rubocop/runner.rb:256:in `loop'
```

That caused the infinite loop in `Layout/IndentAssignment` and `Layout/IndentFirstArgument`.

First, auto-corrected by `Layout/IndentAssignment`.

```diff
% git diff
@@ -1,2 +1,2 @@
 a.b = a.c =
-  e = ''
+        e = ''
```

Next, auto-corrected by `Layout/IndentFirstArgument`.

```diff
% git diff
@@ -1,2 +1,2 @@
 a.b = a.c =
-        e = ''
+  e = ''
```

This will return to the original code.

With this PR, `Layout/IndentAssignment` cop makes aware of multiple assignment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
