### PR TITLE
[Fix #7345] Mark unsafe for `Style/YodaCondition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [#7261](https://github.com/rubocop-hq/rubocop/issues/7261): `Style/FrozenStringLiteralComment` no longer inserts an empty line after the comment. This is left to `Layout/EmptyLineAfterMagicComment`. ([@buehmann][])
 * [#7091](https://github.com/rubocop-hq/rubocop/issues/7091): `Style/FormatStringToken` now detects format sequences with flags and modifiers. ([@buehmann][])
 * [#7319](https://github.com/rubocop-hq/rubocop/pull/7319): Rename `IgnoredMethodPatterns` option to `IgnoredPatterns` option for `Style/MethodCallWithArgsParentheses`. ([@koic][])
+* [#7345](https://github.com/rubocop-hq/rubocop/issues/7345): Mark unsafe for `Style/YodaCondition`. ([@koic][])
 
 ## 0.74.0 (2019-07-31)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -3919,8 +3919,9 @@ Style/YodaCondition:
     - require_for_all_comparison_operators
     # enforce yoda only for equality operators: `!=` and `==`
     - require_for_equality_operators_only
+  Safe: false
   VersionAdded: '0.49'
-  VersionChanged: '0.63'
+  VersionChanged: '0.75'
 
 Style/ZeroLengthPredicate:
   Description: 'Use #empty? when testing for objects of length 0.'

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -7291,7 +7291,7 @@ WordRegex | `(?-mix:\A(?:\p{Word}|\p{Word}-\p{Word}|\n|\t)+\z)` |
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.49 | 0.63
+Enabled | No | Yes  | 0.49 | 0.75
 
 This cop can either enforce or forbid Yoda conditions,
 i.e. comparison operations where the order of expression is reversed.


### PR DESCRIPTION
Resolves #7345.

This PR marks unsafe for `Style/YodaCondition`.

A Ruby committer @knu says "Reversing operands is an unsafe modification in Ruby and can easily break existing code that is written for a reason". Thank you.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
