### PR TITLE
[Fix #7366] Mark unsafe for `Style/UnneededSort`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [#7091](https://github.com/rubocop-hq/rubocop/issues/7091): `Style/FormatStringToken` now detects format sequences with flags and modifiers. ([@buehmann][])
 * [#7319](https://github.com/rubocop-hq/rubocop/pull/7319): Rename `IgnoredMethodPatterns` option to `IgnoredPatterns` option for `Style/MethodCallWithArgsParentheses`. ([@koic][])
 * [#7345](https://github.com/rubocop-hq/rubocop/issues/7345): Mark unsafe for `Style/YodaCondition`. ([@koic][])
+* [#7366](https://github.com/rubocop-hq/rubocop/issues/7366): Mark unsafe for `Style/UnneededSort`. ([@koic][])
 
 ## 0.74.0 (2019-07-31)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -3847,7 +3847,9 @@ Style/UnneededSort:
                   Use `min` instead of `sort.first`,
                   `max_by` instead of `sort_by...last`, etc.
   Enabled: true
+  Safe: false
   VersionAdded: '0.55'
+  VersionChanged: '0.75'
 
 Style/UnpackFirst:
   Description: >-

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -7038,7 +7038,7 @@ question = '"What did you say?"'
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.55 | -
+Enabled | No | Yes  | 0.55 | 0.75
 
 This cop is used to identify instances of sorting and then
 taking only the first or last element. The same behavior can


### PR DESCRIPTION
Fixes #7366.

This PR marks unsafe for `Style/UnneededSort`.

As shown in #7366, the replacement of bad and good methods has the potential to behave differently.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
