### PR TITLE
[Fix #7177] Do not insert spaces into string literals when aligning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [#7358](https://github.com/rubocop-hq/rubocop/issues/7358): Fix an incorrect autocorrect for `Style/NestedModifier` when parentheses are required in method arguments. ([@koic][])
 * [#7361](https://github.com/rubocop-hq/rubocop/issues/7361): Fix a false positive for `Style/TernaryParentheses` when only the closing parenthesis is used in the last line of condition. ([@koic][])
 * [#7369](https://github.com/rubocop-hq/rubocop/issues/7369): Fix an infinite loop error for `Layout/IndentAssignment` with `Layout/IndentFirstArgument` when using multiple assignment. ([@koic][])
+* [#7177](https://github.com/rubocop-hq/rubocop/issues/7177), [#7370](https://github.com/rubocop-hq/rubocop/issues/7370): When correcting alignment, do not insert spaces into string literals. ([@buehmann][])
 
 ### Changes
 

--- a/lib/rubocop/cop/correctors/alignment_corrector.rb
+++ b/lib/rubocop/cop/correctors/alignment_corrector.rb
@@ -56,7 +56,7 @@ module RuboCop
         def heredoc_ranges(node)
           return [] unless node.is_a?(Parser::AST::Node)
 
-          node.each_node(:dstr, :xstr)
+          node.each_node(:str, :dstr, :xstr)
               .select(&:heredoc?)
               .map { |n| n.loc.heredoc_body.join(n.loc.heredoc_end) }
         end

--- a/lib/rubocop/cop/correctors/alignment_corrector.rb
+++ b/lib/rubocop/cop/correctors/alignment_corrector.rb
@@ -45,9 +45,8 @@ module RuboCop
           return if heredoc_ranges.any? { |h| within?(range, h) }
 
           if column_delta.positive?
-            unless range.source == "\n"
-              # TODO: Fix ranges instead of using `begin`
-              corrector.insert_before(range.begin, ' ' * column_delta)
+            unless range.resize(1).source == "\n"
+              corrector.insert_before(range, ' ' * column_delta)
             end
           elsif range.source =~ /\A[ \t]+\z/
             remove(range, corrector)
@@ -69,6 +68,10 @@ module RuboCop
         end
 
         def calculate_range(expr, line_begin_pos, column_delta)
+          if column_delta.positive?
+            return range_between(line_begin_pos, line_begin_pos)
+          end
+
           starts_with_space =
             expr.source_buffer.source[line_begin_pos].start_with?(' ')
           pos_to_remove = if column_delta.positive? || starts_with_space

--- a/lib/rubocop/cop/correctors/alignment_corrector.rb
+++ b/lib/rubocop/cop/correctors/alignment_corrector.rb
@@ -56,7 +56,7 @@ module RuboCop
         def heredoc_ranges(node)
           return [] unless node.is_a?(Parser::AST::Node)
 
-          node.each_node(:dstr)
+          node.each_node(:dstr, :xstr)
               .select(&:heredoc?)
               .map { |n| n.loc.heredoc_body.join(n.loc.heredoc_end) }
         end

--- a/lib/rubocop/cop/correctors/alignment_corrector.rb
+++ b/lib/rubocop/cop/correctors/alignment_corrector.rb
@@ -19,10 +19,12 @@ module RuboCop
           expr = node.respond_to?(:loc) ? node.loc.expression : node
           return if block_comment_within?(expr)
 
+          heredoc_ranges = heredoc_ranges(node)
+
           lambda do |corrector|
             each_line(expr) do |line_begin_pos|
               autocorrect_line(corrector, line_begin_pos, expr, column_delta,
-                               heredoc_ranges(node))
+                               heredoc_ranges)
             end
           end
         end
@@ -74,13 +76,12 @@ module RuboCop
 
           starts_with_space =
             expr.source_buffer.source[line_begin_pos].start_with?(' ')
-          pos_to_remove = if column_delta.positive? || starts_with_space
-                            line_begin_pos
-                          else
-                            line_begin_pos - column_delta.abs
-                          end
 
-          range_between(pos_to_remove, pos_to_remove + column_delta.abs)
+          if starts_with_space
+            range_between(line_begin_pos, line_begin_pos + column_delta.abs)
+          else
+            range_between(line_begin_pos - column_delta.abs, line_begin_pos)
+          end
         end
 
         def remove(range, corrector)

--- a/spec/rubocop/cop/alignment_corrector_spec.rb
+++ b/spec/rubocop/cop/alignment_corrector_spec.rb
@@ -85,5 +85,35 @@ RSpec.describe RuboCop::Cop::AlignmentCorrector do
         OUTPUT
       end
     end
+
+    context 'within string literals' do
+      it 'does not insert whitespace' do
+        expect(autocorrect_source(<<~INPUT)).to eq(<<~OUTPUT)
+          # >> 2
+          begin
+            dstr =
+          'a
+          b
+          c'
+            xstr =
+          `a
+          b
+          c`
+          end
+        INPUT
+          # >> 2
+            begin
+              dstr =
+            'a
+          b
+          c'
+              xstr =
+            `a
+          b
+          c`
+            end
+        OUTPUT
+      end
+    end
   end
 end

--- a/spec/rubocop/cop/alignment_corrector_spec.rb
+++ b/spec/rubocop/cop/alignment_corrector_spec.rb
@@ -64,5 +64,26 @@ RSpec.describe RuboCop::Cop::AlignmentCorrector do
         it_behaves_like 'heredoc indenter', '<<`DOC`', 20
       end
     end
+
+    context 'with single-line here docs' do
+      it 'does not indent body and end marker' do
+        indentation = '  '
+        expect(autocorrect_source(<<~INPUT)).to eq(<<~OUTPUT)
+          # >> 2
+          begin
+            <<DOC
+          single line
+          DOC
+          end
+        INPUT
+          # >> 2
+          #{indentation}begin
+          #{indentation}  <<DOC
+          single line
+          DOC
+          #{indentation}end
+        OUTPUT
+      end
+    end
   end
 end

--- a/spec/rubocop/cop/alignment_corrector_spec.rb
+++ b/spec/rubocop/cop/alignment_corrector_spec.rb
@@ -29,5 +29,36 @@ RSpec.describe RuboCop::Cop::AlignmentCorrector do
         end
       end
     end
+
+    shared_examples 'heredoc indenter' do |start_heredoc, column_delta|
+      let(:indentation) { ' ' * column_delta }
+      let(:end_heredoc) { /\w+/.match(start_heredoc)[0] }
+
+      it 'does not change indentation of here doc bodies and end markers' do
+        expect(autocorrect_source(<<~INPUT)).to eq(<<~OUTPUT)
+          # >> #{column_delta}
+          begin
+            #{start_heredoc}
+          a
+          b
+          #{end_heredoc}
+          end
+        INPUT
+          # >> #{column_delta}
+          #{indentation}begin
+          #{indentation}  #{start_heredoc}
+          a
+          b
+          #{end_heredoc}
+          #{indentation}end
+        OUTPUT
+      end
+    end
+
+    context 'with large column deltas' do
+      context 'with plain heredoc (<<)' do
+        it_behaves_like 'heredoc indenter', '<<DOC', 20
+      end
+    end
   end
 end

--- a/spec/rubocop/cop/alignment_corrector_spec.rb
+++ b/spec/rubocop/cop/alignment_corrector_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::AlignmentCorrector do
+  let(:cop) { RuboCop::Cop::Test::AlignmentDirective.new }
+
+  describe '#correct' do
+    context 'simple indentation' do
+      context 'with a positive column delta' do
+        it 'indents' do
+          expect(autocorrect_source(<<~INPUT)).to eq(<<~OUTPUT)
+            # >> 2
+              42
+          INPUT
+            # >> 2
+                42
+          OUTPUT
+        end
+      end
+
+      context 'with a negative column delta' do
+        it 'outdents' do
+          expect(autocorrect_source(<<~INPUT)).to eq(<<~OUTPUT)
+            # << 3
+                42
+          INPUT
+            # << 3
+             42
+          OUTPUT
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/alignment_corrector_spec.rb
+++ b/spec/rubocop/cop/alignment_corrector_spec.rb
@@ -59,6 +59,10 @@ RSpec.describe RuboCop::Cop::AlignmentCorrector do
       context 'with plain heredoc (<<)' do
         it_behaves_like 'heredoc indenter', '<<DOC', 20
       end
+
+      context 'with heredoc in backticks (<<``)' do
+        it_behaves_like 'heredoc indenter', '<<`DOC`', 20
+      end
     end
   end
 end

--- a/spec/support/cops/alignment_directive.rb
+++ b/spec/support/cops/alignment_directive.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Test
+      # This cop allows us to test the {AlignmentCorrector}. A node that is
+      # annotated with a comment of the form `# << delta` or `# >> delta` where
+      # `delta` is an integer will be shifted by `delta` columns in the
+      # indicated direction.
+      class AlignmentDirective < RuboCop::Cop::Cop
+        MSG = 'Indent this node'
+
+        def investigate(processed_source)
+          processed_source.ast_with_comments.each do |node, comments|
+            add_offense(node) if comments.find { |c| @column_delta = delta(c) }
+          end
+        end
+
+        def autocorrect(node)
+          AlignmentCorrector.correct(processed_source, node, @column_delta)
+        end
+
+        private
+
+        def delta(comment)
+          /\A#\s*(<<|>>)\s*(\d+)\s*\z/.match(comment.text) do |m|
+            (m[1] == '<<' ? -1 : 1) * m[2].to_i
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This fixes #7177 and fixes #7370.

There was a bug in the `AlignmentCorrector` used by many cops to shift pieces of code to the left or right: The corrector already knew not to touch the contents of some heredocs, but was not aware that the contents of other string literals must not be changed either. So it happily inserted or removed leading spaces inside string literals.

I started by writing some specs for the `AlignmentCorrector` because there were none and that class was only implicitly covered by specs in the cops that use the corrector.

While doing that I stumbled across a few bugs/shortcomings in the heredoc handling and fixed them straight away. Finally it felt safe enough to teach the corrector to recognize and avoid regular string literals.

In order to exercise the `AlignmentCorrector` in the specs in a concise way independent of actual cops, I added a little cop `Test/AlignmentDirective` that reacts to comments such as `# << 4` in the code and shifts the code into the indicated direction. I am not 100% convinced of this approach, but it is the best one I have come up with so far.