### PR TITLE
[Fix #7212] Fix a false positive for `Layout/EmptyLinesAroundAccessModifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [#7369](https://github.com/rubocop-hq/rubocop/issues/7369): Fix an infinite loop error for `Layout/IndentAssignment` with `Layout/IndentFirstArgument` when using multiple assignment. ([@koic][])
 * [#7177](https://github.com/rubocop-hq/rubocop/issues/7177), [#7370](https://github.com/rubocop-hq/rubocop/issues/7370): When correcting alignment, do not insert spaces into string literals. ([@buehmann][])
 * [#7367](https://github.com/rubocop-hq/rubocop/issues/7367): Fix an error for `Style/OrAssignment` cop when `then` branch body is empty. ([@koic][])
+* [#7212](https://github.com/rubocop-hq/rubocop/issues/7212): Fix a false positive for `Layout/EmptyLinesAroundAccessModifier` and `UselessAccessModifier` when using method with the same name as access modifier around a method definition. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -222,21 +222,10 @@ module RuboCop
 
       def_node_matcher :macro_scope?, <<~PATTERN
         {^{({sclass class module block} ...) class_constructor?}
-         ^^#ascend_macro_scope?
+         ^^{({sclass class module block} ... ({begin if} ...)) class_constructor?}
          ^#macro_kwbegin_wrapper?
          #root_node?}
       PATTERN
-
-      def_node_matcher :wrapped_macro_scope?, <<~PATTERN
-        {({sclass class module block} ... ({begin if} ...)) class_constructor?}
-      PATTERN
-
-      def ascend_macro_scope?(ancestor)
-        return true if wrapped_macro_scope?(ancestor)
-        return false if root_node?(ancestor)
-
-        ascend_macro_scope?(ancestor.parent)
-      end
 
       # Check if a node's parent is a kwbegin wrapper within a macro scope
       #

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -58,6 +58,17 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
         RUBY
       end
 
+      it "ignores an accessor with the same name as #{access_modifier} " \
+         'above a method definition' do
+        expect_no_offenses(<<~RUBY)
+          class Test
+            attr_reader #{access_modifier}
+            def foo
+            end
+          end
+        RUBY
+      end
+
       it "ignores #{access_modifier} deep inside a method call" do
         expect_no_offenses(<<~RUBY)
           class Test

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -475,6 +475,21 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier do
     end
   end
 
+  shared_examples 'method named by access modifier name' do |keyword, modifier|
+    it "registers an offense for `#{modifier}`" do
+      expect_no_offenses(<<~RUBY)
+        #{keyword} A
+          def foo
+          end
+
+          do_something do
+            { #{modifier}: #{modifier} }
+          end
+        end
+      RUBY
+    end
+  end
+
   shared_examples 'unused visibility modifiers' do |keyword|
     it 'registers an error when visibility is immediately changed ' \
        'without any intervening defs' do
@@ -864,6 +879,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier do
       it_behaves_like('repeated visibility modifiers', keyword, modifier)
       it_behaves_like('at the end of the body', keyword, modifier)
       it_behaves_like('nested in a begin..end block', keyword, modifier)
+      it_behaves_like('method named by access modifier name', keyword, modifier)
 
       next if modifier == 'public'
 


### PR DESCRIPTION
Fixes #7212.
Fixes #7246.

This PR fixes a false positive for `Layout/EmptyLinesAroundAccessModifier` and `UselessAccessModifier` when using method with the same name as access modifier around a method definition.

The main changes are as follows.

- Added test for where #7194 change did not find a regression.
- The implementation needed to resolve #7186 will be moved to `Style/MixinUsage` cop. This solves false positives that occurred in other cops.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
