### PR TITLE
Fix heredoc edge cases in Layout/EmptyLineAfterGuardClause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * [#7367](https://github.com/rubocop-hq/rubocop/issues/7367): Fix an error for `Style/OrAssignment` cop when `then` branch body is empty. ([@koic][])
 * [#7363](https://github.com/rubocop-hq/rubocop/issues/7363): Fix an incorrect autocorrect for `Layout/SpaceInsideBlockBraces` and `Style/BlockDelimiters` when using multiline empty braces. ([@koic][])
 * [#7212](https://github.com/rubocop-hq/rubocop/issues/7212): Fix a false positive for `Layout/EmptyLinesAroundAccessModifier` and `UselessAccessModifier` when using method with the same name as access modifier around a method definition. ([@koic][])
+* [#7378](https://github.com/rubocop-hq/rubocop/pull/7378): Fix heredoc edge cases in `Layout/EmptyLineAfterGuardClause`. ([@gsamokovarov][])
 
 ### Changes
 

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -274,6 +274,34 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
+  it 'does not register offense when guard clause is after multiline heredoc ' \
+     'with chained calls' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        raise ArgumentError, <<~END.squish.it.good unless guard
+          A multiline message
+          that will be squished.
+        END
+
+        return_value
+      end
+    RUBY
+  end
+
+  it 'does not register offense when guard clause is after multiline heredoc ' \
+     'nested argument call' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        raise ArgumentError, call(<<~END.squish) unless guard
+          A multiline message
+          that will be squished.
+        END
+
+        return_value
+      end
+    RUBY
+  end
+
   it 'registers an offense when guard clause is a ternary operator' do
     expect_offense(<<~RUBY)
       def foo


### PR DESCRIPTION
If you'd call a method on a heredoc string the cop couldn't
recognize that a heredoc is passed. The same happened if the heredoc was
given to a method, the result of which is passed as a value in another
call.

Here are the two examples:

```ruby
def foo
  raise ArgumentError, <<~END.squish.it.good unless guard
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
    A multiline message
    that will be squished.
  END

  return_value
end
```

```ruby
def foo
  raise ArgumentError, call(<<~END.squish) unless guard
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
    A multiline message
    that will be squished.
  END

  return_value
end
```