### PR TITLE
Add exmaple of `AllowIfMethodIsEmpty` option

### DIFF
--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -13,9 +13,16 @@ module RuboCop
       #   def @table.columns; super; end
       #
       #   # good
-      #   def no_op; end
       #   def self.resource_class=(klass); end
       #   def @table.columns; end
+      #
+      # @example AllowIfMethodIsEmpty: true (default)
+      #   # good
+      #   def no_op; end
+      #
+      # @example AllowIfMethodIsEmpty: false
+      #   # bad
+      #   def no_op; end
       #
       class SingleLineMethods < Cop
         include Alignment

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -6006,9 +6006,20 @@ def link_to(url); {:name => url}; end
 def @table.columns; super; end
 
 # good
-def no_op; end
 def self.resource_class=(klass); end
 def @table.columns; end
+```
+#### AllowIfMethodIsEmpty: true (default)
+
+```ruby
+# good
+def no_op; end
+```
+#### AllowIfMethodIsEmpty: false
+
+```ruby
+# bad
+def no_op; end
 ```
 
 ### Configurable attributes


### PR DESCRIPTION
This PR adds exmaple of `AllowIfMethodIsEmpty` option for `Style/SingleLineMethods`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
