### PR TITLE
Deprecate departmentless cop names

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1854,6 +1854,14 @@ Metrics/PerceivedComplexity:
   VersionAdded: '0.25'
   Max: 7
 
+################## Migration #############################
+
+Migration/DepartmentName:
+  Description: >-
+                 Check that cop names in rubocop:disable (etc) comments are
+                 given with department name.
+  Enabled: false
+
 #################### Naming ##############################
 
 Naming/AccessorMethodName:

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -159,6 +159,8 @@ require_relative 'rubocop/cop/mixin/unused_argument'
 
 require_relative 'rubocop/cop/utils/format_string'
 
+require_relative 'rubocop/cop/migration/department_name'
+
 require_relative 'rubocop/cop/correctors/alignment_corrector'
 require_relative 'rubocop/cop/correctors/condition_corrector'
 require_relative 'rubocop/cop/correctors/each_to_for_corrector'

--- a/lib/rubocop/cop/layout/closing_parenthesis_indentation.rb
+++ b/lib/rubocop/cop/layout/closing_parenthesis_indentation.rb
@@ -191,7 +191,7 @@ module RuboCop
         end
 
         def indentation_width
-          @config.for_cop('IndentationWidth')['Width'] || 2
+          @config.for_cop('Layout/IndentationWidth')['Width'] || 2
         end
 
         def line_break_after_left_paren?(left_paren, elements)

--- a/lib/rubocop/cop/layout/indent_heredoc.rb
+++ b/lib/rubocop/cop/layout/indent_heredoc.rb
@@ -240,7 +240,7 @@ module RuboCop
         end
 
         def indentation_width
-          @config.for_cop('IndentationWidth')['Width'] || 2
+          @config.for_cop('Layout/IndentationWidth')['Width'] || 2
         end
 
         def heredoc_body(node)

--- a/lib/rubocop/cop/migration/department_name.rb
+++ b/lib/rubocop/cop/migration/department_name.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Migration
+      # Check that cop names in rubocop:disable comments are given with
+      # department name.
+      class DepartmentName < Cop
+        include RangeHelp
+
+        MSG = 'Department name is missing.'
+
+        def investigate(processed_source)
+          processed_source.each_comment do |comment|
+            next if comment.text !~ /\A(# *rubocop:((dis|en)able|todo) +)(.*)/
+
+            offset = Regexp.last_match(1).length
+            Regexp.last_match(4).scan(%r{[\w/]+|\W+}) do |name|
+              check_cop_name(name, comment, offset)
+              offset += name.length
+            end
+          end
+        end
+
+        def autocorrect(range)
+          shall_warn = false
+          qualified_cop_name = Cop.registry.qualified_cop_name(range.source,
+                                                               nil, shall_warn)
+          ->(corrector) { corrector.replace(range, qualified_cop_name) }
+        end
+
+        private
+
+        def check_cop_name(name, comment, offset)
+          return if name !~ /^[A-Z]/ || name =~ %r{/}
+
+          start = comment.location.expression.begin_pos + offset
+          range = range_between(start, start + name.length)
+          add_offense(range, location: range)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/mixin/alignment.rb
+++ b/lib/rubocop/cop/mixin/alignment.rb
@@ -13,7 +13,7 @@ module RuboCop
 
       def configured_indentation_width
         cop_config['IndentationWidth'] ||
-          config.for_cop('IndentationWidth')['Width']
+          config.for_cop('Layout/IndentationWidth')['Width']
       end
 
       def indentation(node)

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -93,6 +93,9 @@ module RuboCop
       # @return [String] Qualified cop name
       def qualified_cop_name(name, path)
         badge = Badge.parse(name)
+        if !badge.qualified? && unqualified_cop_names.include?(name)
+          warn "#{path}: Warning: no department given for #{name}."
+        end
         return name if registered?(badge)
 
         potential_badges = qualify_badge(badge)
@@ -102,6 +105,12 @@ module RuboCop
         when 1 then resolve_badge(badge, potential_badges.first, path)
         else raise AmbiguousCopName.new(badge, path, potential_badges)
         end
+      end
+
+      def unqualified_cop_names
+        @unqualified_cop_names ||=
+          Set.new(@cops_by_cop_name.keys.map { |qn| File.basename(qn) }) <<
+          'UnneededCopDisableDirective'
       end
 
       # @return [Hash{String => Array<Class>}]

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -91,10 +91,10 @@ module RuboCop
       # @note Emits a warning if the provided name has an incorrect namespace
       #
       # @return [String] Qualified cop name
-      def qualified_cop_name(name, path)
+      def qualified_cop_name(name, path, shall_warn = true)
         badge = Badge.parse(name)
-        if !badge.qualified? && unqualified_cop_names.include?(name)
-          warn "#{path}: Warning: no department given for #{name}."
+        if shall_warn && department_missing?(badge, name)
+          print_warning(name, path)
         end
         return name if registered?(badge)
 
@@ -105,6 +105,18 @@ module RuboCop
         when 1 then resolve_badge(badge, potential_badges.first, path)
         else raise AmbiguousCopName.new(badge, path, potential_badges)
         end
+      end
+
+      def department_missing?(badge, name)
+        !badge.qualified? && unqualified_cop_names.include?(name)
+      end
+
+      def print_warning(name, path)
+        message = "#{path}: Warning: no department given for #{name}."
+        if path.end_with?('.rb')
+          message += ' Run `rubocop -a --only Migration/DepartmentName` to fix.'
+        end
+        warn message
       end
 
       def unqualified_cop_names

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -115,7 +115,7 @@ module RuboCop
         end
 
         def indent_width
-          @config.for_cop('IndentationWidth')['Width'] || 2
+          @config.for_cop('Layout/IndentationWidth')['Width'] || 2
         end
 
         def check_style(node, body)

--- a/lib/rubocop/cop/style/infinite_loop.rb
+++ b/lib/rubocop/cop/style/infinite_loop.rb
@@ -119,7 +119,7 @@ module RuboCop
         end
 
         def configured_indent
-          ' ' * config.for_cop('IndentationWidth')['Width']
+          ' ' * config.for_cop('Layout/IndentationWidth')['Width']
         end
       end
     end

--- a/lib/rubocop/cop/style/multiline_memoization.rb
+++ b/lib/rubocop/cop/style/multiline_memoization.rb
@@ -73,7 +73,7 @@ module RuboCop
         end
 
         def keyword_begin_str(node, node_buf)
-          indent = config.for_cop('IndentationWidth')['Width'] || 2
+          indent = config.for_cop('Layout/IndentationWidth')['Width'] || 2
           if node_buf.source[node.loc.begin.end_pos] == "\n"
             'begin'
           else

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -270,6 +270,10 @@ In the following section you find all available cops:
 * [Metrics/ParameterLists](cops_metrics.md#metricsparameterlists)
 * [Metrics/PerceivedComplexity](cops_metrics.md#metricsperceivedcomplexity)
 
+#### Department [Migration](cops_migration.md)
+
+* [Migration/DepartmentName](cops_migration.md#migrationdepartmentname)
+
 #### Department [Naming](cops_naming.md)
 
 * [Naming/AccessorMethodName](cops_naming.md#namingaccessormethodname)

--- a/manual/cops_migration.md
+++ b/manual/cops_migration.md
@@ -1,0 +1,10 @@
+# Migration
+
+## Migration/DepartmentName
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Disabled | Yes | Yes  | - | -
+
+Check that cop names in rubocop:disable comments are given with
+department name.

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1343,8 +1343,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                  '  ',
                  '  def f; end',
                  'end'])
-    expect(cli.run(%w[--auto-correct --only
-                      TrailingWhitespace,EmptyLinesAroundClassBody])).to eq(0)
+    expect(cli.run(['--auto-correct', '--only',
+                    'Layout/TrailingWhitespace,' \
+                    'Layout/EmptyLinesAroundClassBody'])).to eq(0)
     expect(IO.read('example.rb'))
       .to eq(<<~RUBY)
         # Example class.
@@ -1373,7 +1374,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
     RUBY
     expect(cli.run(%w[-D --auto-correct
-                      --only MethodDefParentheses,SymbolProc])).to eq(0)
+                      --only Style/MethodDefParentheses,Style/SymbolProc]))
+      .to eq(0)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq(<<~RUBY)
       def primes(limit)
@@ -1482,7 +1484,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     create_file('example.rb', 'Hash.new()')
     exit_status = cli.run(
       %w[--auto-correct --format emacs
-         --only MethodCallWithoutArgsParentheses,EmptyLiteral]
+         --only Style/MethodCallWithoutArgsParentheses,Style/EmptyLiteral]
     )
     expect(exit_status).to eq(0)
     expect($stderr.string).to eq('')
@@ -1543,7 +1545,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     YAML
     create_file('example.rb', src)
     exit_status = cli.run(
-      %w[-a -f simple --only BlockDelimiters,Semicolon,UnusedMethodArgument]
+      %w[-a -f simple
+         --only Style/BlockDelimiters,Style/Semicolon,Lint/UnusedMethodArgument]
     )
     expect(exit_status).to eq(1)
     expect($stderr.string).to eq('')

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -348,8 +348,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                      'y("123") # rubocop:disable StringLiterals'])
         expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)
         expect($stderr.string).to eq(<<~OUTPUT)
-          #{abs('example.rb')}: Warning: no department given for LineLength.
-          #{abs('example.rb')}: Warning: no department given for StringLiterals.
+          #{abs('example.rb')}: Warning: no department given for LineLength. Run `rubocop -a --only Migration/DepartmentName` to fix.
+          #{abs('example.rb')}: Warning: no department given for StringLiterals. Run `rubocop -a --only Migration/DepartmentName` to fix.
         OUTPUT
         expect($stdout.string)
           .to eq(<<~RESULT)
@@ -399,8 +399,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             create_file('.rubocop.yml', config)
             expect(cli.run(['--format', 'emacs'])).to eq(1)
             expect($stderr.string).to eq(<<~OUTPUT)
-              #{abs('example.rb')}: Warning: no department given for LineLength.
-              #{abs('example.rb')}: Warning: no department given for ClassLength.
+              #{abs('example.rb')}: Warning: no department given for LineLength. Run `rubocop -a --only Migration/DepartmentName` to fix.
+              #{abs('example.rb')}: Warning: no department given for ClassLength. Run `rubocop -a --only Migration/DepartmentName` to fix.
             OUTPUT
             expect($stdout.string)
               .to eq(<<~RESULT)

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -50,9 +50,9 @@ RSpec.describe RuboCop::CommentConfig do
         '# rubocop:disable Layout/BlockAlignment some comment why',
         '# rubocop:enable Style/Send, Layout/BlockAlignment but why?',
         '# rubocop:enable Lint/RandOne foo bar!',            # 43
-        '# rubocop:disable EmptyInterpolation',
+        '# rubocop:disable Lint/EmptyInterpolation',
         '"result is #{}"',
-        '# rubocop:enable EmptyInterpolation',
+        '# rubocop:enable Lint/EmptyInterpolation',
         '# rubocop:disable RSpec/Example',
         '# rubocop:disable Custom2/Number9'                  # 48
       ].join("\n")

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe RuboCop::Cop::Generator do
     described_class.new(cop_identifier, 'your_id', output: stdout)
   end
 
+  HOME_DIR = Dir.pwd
+
   let(:stdout) { StringIO.new }
   let(:cop_identifier) { 'Style/FakeCop' }
 
@@ -318,12 +320,22 @@ RSpec.describe RuboCop::Cop::Generator do
 
     it 'generates a cop file that has no offense' do
       generator.write_source
-      expect(runner.run([])).to be true
+      result = nil
+      expect { result = runner.run([]) }.to output(<<~OUTPUT).to_stderr
+        Warning: unrecognized cop InternalAffairs/NodeDestructuring found in #{HOME_DIR}/.rubocop_todo.yml
+        Warning: unrecognized cop InternalAffairs/NodeDestructuring found in #{HOME_DIR}/.rubocop.yml
+      OUTPUT
+      expect(result).to be true
     end
 
     it 'generates a spec file that has no offense' do
       generator.write_spec
-      expect(runner.run([])).to be true
+      result = nil
+      expect { result = runner.run([]) }.to output(<<~OUTPUT).to_stderr
+        Warning: unrecognized cop InternalAffairs/NodeDestructuring found in #{HOME_DIR}/.rubocop_todo.yml
+        Warning: unrecognized cop InternalAffairs/NodeDestructuring found in #{HOME_DIR}/.rubocop.yml
+      OUTPUT
+      expect(result).to be true
     end
   end
 end

--- a/spec/rubocop/cop/metrics/line_length_spec.rb
+++ b/spec/rubocop/cop/metrics/line_length_spec.rb
@@ -325,7 +325,7 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
 
       context 'and the source contains non-directive #s as non-comment' do
         let(:source) { <<-RUBY }
-          LARGE_DATA_STRING_PATTERN = %r{\A([A-Za-z0-9\+\/#]*\={0,2})#([A-Za-z0-9\+\/#]*\={0,2})#([A-Za-z0-9\+\/#]*\={0,2})\z} # rubocop:disable LineLength
+          LARGE_DATA_STRING_PATTERN = %r{\A([A-Za-z0-9\+\/#]*\={0,2})#([A-Za-z0-9\+\/#]*\={0,2})#([A-Za-z0-9\+\/#]*\={0,2})\z} # rubocop:disable Metrics/LineLength
         RUBY
 
         it 'registers an offense for the line' do

--- a/spec/rubocop/cop/migration/department_name_spec.rb
+++ b/spec/rubocop/cop/migration/department_name_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Migration::DepartmentName do
+  subject(:cop) { described_class.new }
+
+  context 'when todo/enable comments have cop names without departments' do
+    let(:tip) { 'Run `rubocop -a --only Migration/DepartmentName` to fix.' }
+    let(:warning) do
+      <<~OUTPUT
+        file.rb: Warning: no department given for Alias. #{tip}
+        file.rb: Warning: no department given for LineLength. #{tip}
+        file.rb: Warning: no department given for Alias. #{tip}
+        file.rb: Warning: no department given for LineLength. #{tip}
+      OUTPUT
+    end
+
+    it 'registers offenses and corrects' do
+      expect do
+        expect_offense(<<~RUBY, 'file.rb')
+          # rubocop:todo Alias, LineLength
+                                ^^^^^^^^^^ Department name is missing.
+                         ^^^^^ Department name is missing.
+          alias :ala :bala
+          # rubocop:enable Alias, LineLength
+                                  ^^^^^^^^^^ Department name is missing.
+                           ^^^^^ Department name is missing.
+        RUBY
+      end.to output(warning).to_stderr
+
+      expect_correction(<<~RUBY)
+        # rubocop:todo Style/Alias, Metrics/LineLength
+        alias :ala :bala
+        # rubocop:enable Style/Alias, Metrics/LineLength
+      RUBY
+    end
+  end
+
+  context 'when a disable comment has cop names with departments' do
+    it 'accepts' do
+      expect_no_offenses(<<~RUBY)
+        alias :ala :bala # rubocop:disable all
+        # rubocop:disable Style/Alias
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/registry_spec.rb
+++ b/spec/rubocop/cop/registry_spec.rb
@@ -85,12 +85,26 @@ RSpec.describe RuboCop::Cop::Registry do
     end
 
     it 'qualifies names without a namespace' do
-      expect(registry.qualified_cop_name('MethodLength', origin))
-        .to eql('Metrics/MethodLength')
+      warning =
+        "/app/.rubocop.yml: Warning: no department given for MethodLength.\n"
+      qualified = nil
+
+      expect do
+        qualified = registry.qualified_cop_name('MethodLength', origin)
+      end.to output(warning).to_stderr
+
+      expect(qualified).to eql('Metrics/MethodLength')
     end
 
     it 'qualifies names with the correct namespace' do
-      expect(registry.qualified_cop_name('Foo', origin)).to eql('RSpec/Foo')
+      warning = "/app/.rubocop.yml: Warning: no department given for Foo.\n"
+      qualified = nil
+
+      expect do
+        qualified = registry.qualified_cop_name('Foo', origin)
+      end.to output(warning).to_stderr
+
+      expect(qualified).to eql('RSpec/Foo')
     end
 
     it 'emits a warning when namespace is incorrect' do
@@ -107,11 +121,14 @@ RSpec.describe RuboCop::Cop::Registry do
 
     it 'raises an error when a cop name is ambiguous' do
       expect { registry.qualified_cop_name('IndentFirstArrayElement', origin) }
-        .to raise_error(RuboCop::Cop::AmbiguousCopName).with_message(
+        .to raise_error(RuboCop::Cop::AmbiguousCopName)
+        .with_message(
           'Ambiguous cop name `IndentFirstArrayElement` used in ' \
           '/app/.rubocop.yml needs department qualifier. Did you mean ' \
           'Layout/IndentFirstArrayElement or Test/IndentFirstArrayElement?'
         )
+        .and output('/app/.rubocop.yml: Warning: no department given for ' \
+                    "IndentFirstArrayElement.\n").to_stderr
     end
 
     it 'returns the provided name if no namespace is found' do


### PR DESCRIPTION
Ever since departments (namespaces) were introduced, or almost since then, it's been possible to give cop names on the command line, in configuration and in `rubocop:disable` comments without a preceding department name. RuboCop deduces what the department should be and errors out only if it doesn't find exactly one matching department.

The optional department functionality was added as a way to stay backwards compatible with configuration that was created before departments existed. But the grace period is coming to an end. We start now by issuing warnings whenever cop names without departments are encountered. Later on, in a future version, we will remove the department deduction functionality and require that departments always be given for cop names.

**Note:** Warnings about `rubocop:disable` comments are not printed when inspection results are taken from the cache, so there's a chance this warning goes unnoticed in some cases.