### PR TITLE
Added single quotes around new cop examples.

### DIFF
--- a/manual/development.md
+++ b/manual/development.md
@@ -3,7 +3,7 @@
 Use a rake task to generate a cop template.
 
 ```sh
-$ bundle exec rake new_cop[Department/Name]
+$ bundle exec rake 'new_cop[Department/Name]'
 Files created:
   - lib/rubocop/cop/department/name.rb
   - spec/rubocop/cop/department/name_spec.rb
@@ -150,7 +150,7 @@ In other words, it says: "Match code calling `!<expression>.empty?`".
 Great! Now, lets implement our cop to simplify such statements:
 
 ```sh
-$ rake new_cop[Style/SimplifyNotEmptyWithAny]
+$ rake 'new_cop[Style/SimplifyNotEmptyWithAny]'
 ```
 
 After the cop scaffold is generated, change the node matcher to match with


### PR DESCRIPTION
Added single quotes around new cop examples in the development readme.

Zshell requires the quotes and bash still understands them correctly. So this makes the examples a bit more universal.


-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
