### PR TITLE
Fix a typo for `Layout/EmptyLinesAroundClassBody`

### DIFF
--- a/lib/rubocop/cop/layout/empty_lines_around_class_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_class_body.rb
@@ -36,7 +36,7 @@ module RuboCop
       #
       #   end
       #
-      # @example Enforcedstyle: beginning_only
+      # @example EnforcedStyle: beginning_only
       #   # good
       #
       #   class Foo
@@ -46,7 +46,7 @@ module RuboCop
       #     end
       #   end
       #
-      # @example Enforcedstyle: ending_only
+      # @example EnforcedStyle: ending_only
       #   # good
       #
       #   class Foo

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -1560,7 +1560,7 @@ class Foo
 
 end
 ```
-#### Enforcedstyle: beginning_only
+#### EnforcedStyle: beginning_only
 
 ```ruby
 # good
@@ -1572,7 +1572,7 @@ class Foo
   end
 end
 ```
-#### Enforcedstyle: ending_only
+#### EnforcedStyle: ending_only
 
 ```ruby
 # good


### PR DESCRIPTION
This PR fixes a typo for `Layout/EmptyLinesAroundClassBody`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
