### PR TITLE
Restyle example formatting for `Style/MethodCallWithArgsParentheses`

### DIFF
--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -64,20 +64,6 @@ module RuboCop
       #   # okay with `^assert` listed in `IgnoredPatterns`
       #   assert_equal 'test', x
       #
-      #   # IgnoreMacros: true (default)
-      #
-      #   # good
-      #   class Foo
-      #     bar :baz
-      #   end
-      #
-      #   # IgnoreMacros: false
-      #
-      #   # bad
-      #   class Foo
-      #     bar :baz
-      #   end
-      #
       # @example EnforcedStyle: omit_parentheses
       #
       #   # bad
@@ -92,7 +78,21 @@ module RuboCop
       #   # good
       #   foo.enforce strict: true
       #
-      #   # AllowParenthesesInMultilineCall: false (default)
+      # @example IgnoreMacros: true (default)
+      #
+      #   # good
+      #   class Foo
+      #     bar :baz
+      #   end
+      #
+      # @example IgnoreMacros: false
+      #
+      #   # bad
+      #   class Foo
+      #     bar :baz
+      #   end
+      #
+      # @example AllowParenthesesInMultilineCall: false (default)
       #
       #   # bad
       #   foo.enforce(
@@ -103,7 +103,7 @@ module RuboCop
       #   foo.enforce \
       #     strict: true
       #
-      #   # AllowParenthesesInMultilineCall: true
+      # @example AllowParenthesesInMultilineCall: true
       #
       #   # good
       #   foo.enforce(
@@ -114,7 +114,7 @@ module RuboCop
       #   foo.enforce \
       #     strict: true
       #
-      #   # AllowParenthesesInChaining: false (default)
+      # @example AllowParenthesesInChaining: false (default)
       #
       #   # bad
       #   foo().bar(1)
@@ -122,7 +122,7 @@ module RuboCop
       #   # good
       #   foo().bar 1
       #
-      #   # AllowParenthesesInChaining: true
+      # @example AllowParenthesesInChaining: true
       #
       #   # good
       #   foo().bar(1)
@@ -130,7 +130,7 @@ module RuboCop
       #   # good
       #   foo().bar 1
       #
-      #   # AllowParenthesesInCamelCaseMethod: false (default)
+      # @example AllowParenthesesInCamelCaseMethod: false (default)
       #
       #   # bad
       #   Array(1)
@@ -138,7 +138,7 @@ module RuboCop
       #   # good
       #   Array 1
       #
-      #   # AllowParenthesesInCamelCaseMethod: true
+      # @example AllowParenthesesInCamelCaseMethod: true
       #
       #   # good
       #   Array(1)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3026,20 +3026,6 @@ puts 'test'
 
 # okay with `^assert` listed in `IgnoredPatterns`
 assert_equal 'test', x
-
-# IgnoreMacros: true (default)
-
-# good
-class Foo
-  bar :baz
-end
-
-# IgnoreMacros: false
-
-# bad
-class Foo
-  bar :baz
-end
 ```
 #### EnforcedStyle: omit_parentheses
 
@@ -3055,9 +3041,26 @@ foo.enforce(strict: true)
 
 # good
 foo.enforce strict: true
+```
+#### IgnoreMacros: true (default)
 
-# AllowParenthesesInMultilineCall: false (default)
+```ruby
+# good
+class Foo
+  bar :baz
+end
+```
+#### IgnoreMacros: false
 
+```ruby
+# bad
+class Foo
+  bar :baz
+end
+```
+#### AllowParenthesesInMultilineCall: false (default)
+
+```ruby
 # bad
 foo.enforce(
   strict: true
@@ -3066,9 +3069,10 @@ foo.enforce(
 # good
 foo.enforce \
   strict: true
+```
+#### AllowParenthesesInMultilineCall: true
 
-# AllowParenthesesInMultilineCall: true
-
+```ruby
 # good
 foo.enforce(
   strict: true
@@ -3077,33 +3081,37 @@ foo.enforce(
 # good
 foo.enforce \
   strict: true
+```
+#### AllowParenthesesInChaining: false (default)
 
-# AllowParenthesesInChaining: false (default)
-
+```ruby
 # bad
 foo().bar(1)
 
 # good
 foo().bar 1
+```
+#### AllowParenthesesInChaining: true
 
-# AllowParenthesesInChaining: true
-
+```ruby
 # good
 foo().bar(1)
 
 # good
 foo().bar 1
+```
+#### AllowParenthesesInCamelCaseMethod: false (default)
 
-# AllowParenthesesInCamelCaseMethod: false (default)
-
+```ruby
 # bad
 Array(1)
 
 # good
 Array 1
+```
+#### AllowParenthesesInCamelCaseMethod: true
 
-# AllowParenthesesInCamelCaseMethod: true
-
+```ruby
 # good
 Array(1)
 


### PR DESCRIPTION
Follow up of https://github.com/rubocop-hq/rubocop/pull/4880#issuecomment-338499947.

This PR is a change of document format for `Style/MethodCallWithArgsParentheses` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
