### PR TITLE
[Fix #6759] Reference configuration in Basic Usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#6759](https://github.com/rubocop-hq/rubocop/issues/6759): Mention configuration in Basic Usage documentation. ([@scottmatthewman][])
+
 ## 0.75.0 (2019-09-30)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## master (unreleased)
 
-### New features
-
-* [#6759](https://github.com/rubocop-hq/rubocop/issues/6759): Mention configuration in Basic Usage documentation. ([@scottmatthewman][])
-
 ## 0.75.0 (2019-09-30)
 
 ### New features

--- a/manual/basic_usage.md
+++ b/manual/basic_usage.md
@@ -71,6 +71,16 @@ $ rubocop -a
 
 See [Auto-correct](auto_correct.md).
 
+#### Changing what RuboCop considers to be offenses
+
+RuboCop comes with a preconfigured set of rules for each of its cops. Depending on your project, you may wish to
+reconfigure a cop, tell to ignore certain files, or disable it altogether.
+
+The most common way to change RuboCop's behaviour is to create a configuration file named `.rubocop.yml` in the
+project's root directory.
+
+For more information, see [Configuration](configuration.md).
+
 ### 2. RuboCop as a replacement for `ruby -w`
 
 RuboCop natively implements almost all `ruby -w` lint warning checks, and then some. If you want you can use RuboCop

--- a/manual/basic_usage.md
+++ b/manual/basic_usage.md
@@ -73,8 +73,8 @@ See [Auto-correct](auto_correct.md).
 
 #### Changing what RuboCop considers to be offenses
 
-RuboCop comes with a preconfigured set of rules for each of its cops. Depending on your project, you may wish to
-reconfigure a cop, tell to ignore certain files, or disable it altogether.
+RuboCop comes with a preconfigured set of rules for each of its cops, based on the [Ruby Style Guide](https://rubystyle.guide).
+Depending on your project, you may wish to reconfigure a cop, tell to ignore certain files, or disable it altogether.
 
 The most common way to change RuboCop's behaviour is to create a configuration file named `.rubocop.yml` in the
 project's root directory.


### PR DESCRIPTION
Within the Basic Usage page, make a brief mention of the use of `.rubocop.yml` to change RuboCop's behaviour. The additional content links to the **Configuration** page to go into more detail.

Fixes #6759.