### PR TITLE
[Fix #7391] Use IO#winsize for Windows compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#7391](https://github.com/rubocop-hq/rubocop/issues/7391): Support pacman formatter on Windows. ([@laurenball][])
+
 ## 0.75.0 (2019-09-30)
 
 ### New features
@@ -17,6 +21,7 @@
 
 ### Bug fixes
 
+* [#7391](https://github.com/rubocop-hq/rubocop/issues/7391): Support pacman formatter on Windows. ([@laurenball][])
 * [#7256](https://github.com/rubocop-hq/rubocop/issues/7256): Fix an error of `Style/RedundantParentheses` on method calls where the first argument begins with a hash literal. ([@halfwhole][])
 * [#7263](https://github.com/rubocop-hq/rubocop/issues/7263): Make `Layout/SpaceInsideArrayLiteralBrackets` properly handle tab-indented arrays. ([@buehmann][])
 * [#7252](https://github.com/rubocop-hq/rubocop/issues/7252): Prevent infinite loops by making `Layout/SpaceInsideStringInterpolation` skip over interpolations that start or end with a line break. ([@buehmann][])
@@ -4208,3 +4213,4 @@
 [@raymondfallon]: https://github.com/raymondfallon
 [@crojasaragonez]: https://github.com/crojasaragonez
 [@desheikh]: https://github.com/desheikh
+[@laurenball]: https://github.com/laurenball

--- a/lib/rubocop/formatter/pacman_formatter.rb
+++ b/lib/rubocop/formatter/pacman_formatter.rb
@@ -49,7 +49,7 @@ module RuboCop
 
       def cols
         @cols ||= begin
-          width = `tput cols`.chomp.to_i
+          _height, width = $stdout.winsize
           width.nil? || width.zero? ? FALLBACK_TERMINAL_WIDTH : width
         end
       end


### PR DESCRIPTION
Removed `tput` from packman formatter and replaced with `IO#winsize` because `tput` is a *nix only command

Fixes #7391 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
