### PR TITLE
Restyle example formatting for `Lint/Void`

### DIFF
--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -6,54 +6,35 @@ module RuboCop
       # This cop checks for operators, variables, literals, and nonmutating
       # methods used in void context.
       #
-      # @example
-      #
+      # @example CheckForMethodsWithNoSideEffects: false (default)
       #   # bad
-      #
       #   def some_method
       #     some_num * 10
       #     do_something
       #   end
-      #
-      # @example
-      #
-      #   # bad
       #
       #   def some_method(some_var)
       #     some_var
       #     do_something
       #   end
       #
-      # @example
-      #
-      #   # bad, when CheckForMethodsWithNoSideEffects is set true
-      #
+      # @example CheckForMethodsWithNoSideEffects: true
+      #   # bad
       #   def some_method(some_array)
       #     some_array.sort
       #     do_something(some_array)
       #   end
       #
-      # @example
-      #
       #   # good
-      #
       #   def some_method
       #     do_something
       #     some_num * 10
       #   end
       #
-      # @example
-      #
-      #   # good
-      #
       #   def some_method(some_var)
       #     do_something
       #     some_var
       #   end
-      #
-      # @example
-      #
-      #   # good, when CheckForMethodsWithNoSideEffects is set true
       #
       #   def some_method(some_array)
       #     some_array.sort!

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -2851,48 +2851,39 @@ methods used in void context.
 
 ### Examples
 
+#### CheckForMethodsWithNoSideEffects: false (default)
+
 ```ruby
 # bad
-
 def some_method
   some_num * 10
   do_something
 end
-```
-```ruby
-# bad
 
 def some_method(some_var)
   some_var
   do_something
 end
 ```
-```ruby
-# bad, when CheckForMethodsWithNoSideEffects is set true
+#### CheckForMethodsWithNoSideEffects: true
 
+```ruby
+# bad
 def some_method(some_array)
   some_array.sort
   do_something(some_array)
 end
-```
-```ruby
-# good
 
+# good
 def some_method
   do_something
   some_num * 10
 end
-```
-```ruby
-# good
 
 def some_method(some_var)
   do_something
   some_var
 end
-```
-```ruby
-# good, when CheckForMethodsWithNoSideEffects is set true
 
 def some_method(some_array)
   some_array.sort!


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This PR is a change of document format for `Lint/Void` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
