### PR TITLE
Add Extensions Cops Documentation references in the official docs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
 * [#7091](https://github.com/rubocop-hq/rubocop/issues/7091): `Style/FormatStringToken` now detects format sequences with flags and modifiers. ([@buehmann][])
 * [#7319](https://github.com/rubocop-hq/rubocop/pull/7319): Rename `IgnoredMethodPatterns` option to `IgnoredPatterns` option for `Style/MethodCallWithArgsParentheses`. ([@koic][])
 * [#7345](https://github.com/rubocop-hq/rubocop/issues/7345): Mark unsafe for `Style/YodaCondition`. ([@koic][])
-
+* [#7400](https://github.com/rubocop-hq/rubocop/pull/7400): Add extensions cops documentations links in the official docs. ([@Bhacaz][])
 ## 0.74.0 (2019-07-31)
 
 ### New features

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,10 @@ pages:
     - Style Cops: cops_style.md
     - Bundler Cops: cops_bundler.md
     - Gemspec Cops: cops_gemspec.md
+- Extensions Cops Documentation:
+    - Rails Cops: https://docs.rubocop.org/projects/rails/en/stable/
+    - Minitest Cops: https://docs.rubocop.org/projects/minitest/en/stable/
+    - Performance Cops: https://docs.rubocop.org/projects/performance/en/stable/
 extra_css:
   - css/extra.css
 markdown_extensions:


### PR DESCRIPTION
The official documentation of Rubocop only list the known extensions in the [Extensions 
 section of the documentation](http://docs.rubocop.org/en/stable/extensions/#known-custom-cops). I know by experience that it can be difficult to find the cops documentation of those extensions since there is not mention of the manual folder in the `README.md` of the extension  (maybe we can just do this) or in the official documentation.

So I started this PR by basically putting a link to the cops documentation file of each _rubocop-hq_ extensions.

**I pretty sure there is a more elegant way to do this and I'll be pleased to hear any suggestions and the preferences of others**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
