### PR TITLE
[Fix #7389] Fixing `-fp` exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#7389](https://github.com/rubocop-hq/rubocop/issues/7389): Fix error when using `-fp` so we now use `progress` when using `-fp`. ([@zmaupin][])
+
 ## 0.75.0 (2019-09-30)
 
 ### New features
@@ -4208,3 +4210,4 @@
 [@raymondfallon]: https://github.com/raymondfallon
 [@crojasaragonez]: https://github.com/crojasaragonez
 [@desheikh]: https://github.com/desheikh
+[@zmaupin]: https://github.com/zmaupin

--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -82,12 +82,14 @@ module RuboCop
 
       def builtin_formatter_class(specified_key)
         matching_keys = BUILTIN_FORMATTERS_FOR_KEYS.keys.select do |key|
-          key.start_with?(specified_key)
+          key =~ /^#{specified_key}.*/
         end
 
         raise %(No formatter for "#{specified_key}") if matching_keys.empty?
 
-        if matching_keys.size > 1
+        if matching_keys.size > 1 && matching_keys.first.start_with?('p')
+          matching_keys = ['progress']
+        elsif matching_keys.size > 1
           raise %(Cannot determine formatter for "#{specified_key}")
         end
 

--- a/spec/rubocop/formatter/formatter_set_spec.rb
+++ b/spec/rubocop/formatter/formatter_set_spec.rb
@@ -42,6 +42,22 @@ RSpec.describe RuboCop::Formatter::FormatterSet do
         .to eq(RuboCop::Formatter::EmacsStyleFormatter)
     end
 
+    context 'when formatter p(rogress) is specified' do
+      it 'adds a formatter with specified type progress' do
+        formatter_set.add_formatter('p')
+        expect(formatter_set[0].class)
+          .to eq(RuboCop::Formatter::ProgressFormatter)
+      end
+    end
+
+    context 'when formatter pa(cman) is specified' do
+      it 'adds a formatter with specified type pacman' do
+        formatter_set.add_formatter('pa')
+        expect(formatter_set[0].class)
+          .to eq(RuboCop::Formatter::PacmanFormatter)
+      end
+    end
+
     context 'when output path is omitted' do
       it 'adds a formatter outputs to $stdout' do
         formatter_set.add_formatter('simple')


### PR DESCRIPTION
When using `-fp` an error is raised because it matches two keys ('progress' and 'pacman'). Now when using `-fp` we default to progress and don't raise an exception.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
