### PR TITLE
[Fix #7389] Ambiguous formatter matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Bug fixes
 
+* [#7389](https://github.com/rubocop-hq/rubocop/issues/7389): Fix an issue where passing a formatter might result in an error depending on what character it started with. ([@jfhinchcliffe][])
 * [#7256](https://github.com/rubocop-hq/rubocop/issues/7256): Fix an error of `Style/RedundantParentheses` on method calls where the first argument begins with a hash literal. ([@halfwhole][])
 * [#7263](https://github.com/rubocop-hq/rubocop/issues/7263): Make `Layout/SpaceInsideArrayLiteralBrackets` properly handle tab-indented arrays. ([@buehmann][])
 * [#7252](https://github.com/rubocop-hq/rubocop/issues/7252): Prevent infinite loops by making `Layout/SpaceInsideStringInterpolation` skip over interpolations that start or end with a line break. ([@buehmann][])
@@ -4208,3 +4209,4 @@
 [@raymondfallon]: https://github.com/raymondfallon
 [@crojasaragonez]: https://github.com/crojasaragonez
 [@desheikh]: https://github.com/desheikh
+[@jfhinchcliffe]: https://github.com/jfhinchcliffe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#7389](https://github.com/rubocop-hq/rubocop/issues/7389): Fix an issue where passing a formatter might result in an error depending on what character it started with. ([@jfhinchcliffe][])
+
 ## 0.75.0 (2019-09-30)
 
 ### New features
@@ -17,7 +19,6 @@
 
 ### Bug fixes
 
-* [#7389](https://github.com/rubocop-hq/rubocop/issues/7389): Fix an issue where passing a formatter might result in an error depending on what character it started with. ([@jfhinchcliffe][])
 * [#7256](https://github.com/rubocop-hq/rubocop/issues/7256): Fix an error of `Style/RedundantParentheses` on method calls where the first argument begins with a hash literal. ([@halfwhole][])
 * [#7263](https://github.com/rubocop-hq/rubocop/issues/7263): Make `Layout/SpaceInsideArrayLiteralBrackets` properly handle tab-indented arrays. ([@buehmann][])
 * [#7252](https://github.com/rubocop-hq/rubocop/issues/7252): Prevent infinite loops by making `Layout/SpaceInsideStringInterpolation` skip over interpolations that start or end with a line break. ([@buehmann][])

--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -9,21 +9,21 @@ module RuboCop
     # which invoke same method of each formatters.
     class FormatterSet < Array
       BUILTIN_FORMATTERS_FOR_KEYS = {
-        'progress'    => ProgressFormatter,
-        'simple'      => SimpleTextFormatter,
-        'clang'       => ClangStyleFormatter,
-        'fuubar'      => FuubarStyleFormatter,
-        'emacs'       => EmacsStyleFormatter,
-        'json'        => JSONFormatter,
-        'html'        => HTMLFormatter,
-        'files'       => FileListFormatter,
-        'offenses'    => OffenseCountFormatter,
-        'disabled'    => DisabledLinesFormatter,
-        'worst'       => WorstOffendersFormatter,
-        'tap'         => TapFormatter,
-        'quiet'       => QuietFormatter,
-        'autogenconf' => AutoGenConfigFormatter,
-        'pacman'      => PacmanFormatter
+        '[p]rogress'    => ProgressFormatter,
+        '[s]imple'      => SimpleTextFormatter,
+        '[c]lang'       => ClangStyleFormatter,
+        '[fu]ubar'      => FuubarStyleFormatter,
+        '[e]macs'       => EmacsStyleFormatter,
+        '[j]son'        => JSONFormatter,
+        '[h]tml'        => HTMLFormatter,
+        '[fi]les'       => FileListFormatter,
+        '[o]ffenses'    => OffenseCountFormatter,
+        '[d]isabled'    => DisabledLinesFormatter,
+        '[w]orst'       => WorstOffendersFormatter,
+        '[t]ap'         => TapFormatter,
+        '[q]uiet'       => QuietFormatter,
+        '[a]utogenconf' => AutoGenConfigFormatter,
+        '[pa]cman'      => PacmanFormatter
       }.freeze
 
       FORMATTER_APIS = %i[started finished].freeze
@@ -82,7 +82,7 @@ module RuboCop
 
       def builtin_formatter_class(specified_key)
         matching_keys = BUILTIN_FORMATTERS_FOR_KEYS.keys.select do |key|
-          key.start_with?(specified_key)
+          key =~ /^\[#{specified_key}\]/ || specified_key == key.delete('[]')
         end
 
         raise %(No formatter for "#{specified_key}") if matching_keys.empty?

--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -9,21 +9,21 @@ module RuboCop
     # which invoke same method of each formatters.
     class FormatterSet < Array
       BUILTIN_FORMATTERS_FOR_KEYS = {
-        '[p]rogress'    => ProgressFormatter,
-        '[s]imple'      => SimpleTextFormatter,
-        '[c]lang'       => ClangStyleFormatter,
-        '[fu]ubar'      => FuubarStyleFormatter,
-        '[e]macs'       => EmacsStyleFormatter,
-        '[j]son'        => JSONFormatter,
-        '[h]tml'        => HTMLFormatter,
-        '[fi]les'       => FileListFormatter,
-        '[o]ffenses'    => OffenseCountFormatter,
-        '[d]isabled'    => DisabledLinesFormatter,
-        '[w]orst'       => WorstOffendersFormatter,
-        '[t]ap'         => TapFormatter,
-        '[q]uiet'       => QuietFormatter,
         '[a]utogenconf' => AutoGenConfigFormatter,
-        '[pa]cman'      => PacmanFormatter
+        '[c]lang'       => ClangStyleFormatter,
+        '[d]isabled'    => DisabledLinesFormatter,
+        '[e]macs'       => EmacsStyleFormatter,
+        '[fi]les'       => FileListFormatter,
+        '[fu]ubar'      => FuubarStyleFormatter,
+        '[h]tml'        => HTMLFormatter,
+        '[j]son'        => JSONFormatter,
+        '[o]ffenses'    => OffenseCountFormatter,
+        '[pa]cman'      => PacmanFormatter,
+        '[p]rogress'    => ProgressFormatter,
+        '[q]uiet'       => QuietFormatter,
+        '[s]imple'      => SimpleTextFormatter,
+        '[t]ap'         => TapFormatter,
+        '[w]orst'       => WorstOffendersFormatter
       }.freeze
 
       FORMATTER_APIS = %i[started finished].freeze

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -367,8 +367,9 @@ module RuboCop
   # This module contains help texts for command line options.
   module OptionsHelp
     MAX_EXCL = RuboCop::Options::DEFAULT_MAXIMUM_EXCLUSION_ITEMS.to_s
-
     # rubocop:disable Metrics/LineLength
+    FORMATTER_OPTION_LIST = RuboCop::Formatter::FormatterSet::BUILTIN_FORMATTERS_FOR_KEYS.keys
+
     TEXT = {
       only:                             'Run only the given cop(s).',
       only_guide_cops:                  ['Run only cops for rules that link to a',
@@ -407,21 +408,8 @@ module RuboCop
       format:                           ['Choose an output formatter. This option',
                                          'can be specified multiple times to enable',
                                          'multiple formatters at the same time.',
-                                         '  [p]rogress (default)',
-                                         '  [s]imple',
-                                         '  [c]lang',
-                                         '  [d]isabled cops via inline comments',
-                                         '  [fu]ubar',
-                                         '  [pa]cman',
-                                         '  [e]macs',
-                                         '  [j]son',
-                                         '  [h]tml',
-                                         '  [fi]les',
-                                         '  [o]ffenses',
-                                         '  [w]orst',
-                                         '  [t]ap',
-                                         '  [q]uiet',
-                                         '  [a]utogenconf',
+                                         '[p]rogress is used by default',
+                                         *FORMATTER_OPTION_LIST.map { |item| "  #{item}" },
                                          '  custom formatter class name'],
       out:                              ['Write output to a file instead of STDOUT.',
                                          'This option applies to the previously',

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -994,15 +994,6 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             .to include('No formatter for "unknown"')
         end
       end
-
-      context 'when ambiguous format name is specified' do
-        it 'aborts with error message' do
-          # Both 'files' and 'fuubar' start with an 'f'.
-          expect(cli.run(['--format', 'f', 'example.rb'])).to eq(2)
-          expect($stderr.string)
-            .to include('Cannot determine formatter for "f"')
-        end
-      end
     end
 
     describe 'custom formatter' do

--- a/spec/rubocop/formatter/formatter_set_spec.rb
+++ b/spec/rubocop/formatter/formatter_set_spec.rb
@@ -112,10 +112,14 @@ RSpec.describe RuboCop::Formatter::FormatterSet do
         .to eq(RuboCop::Formatter::SimpleTextFormatter)
     end
 
-    it 'returns class whose first letter of alias name ' \
-       'matches passed letter' do
-      expect(builtin_formatter_class('s'))
-        .to eq(RuboCop::Formatter::SimpleTextFormatter)
+    it 'returns class which matches double character alias name' do
+      expect(builtin_formatter_class('pa'))
+        .to eq(RuboCop::Formatter::PacmanFormatter)
+    end
+
+    it 'returns class which matches single character alias name' do
+      expect(builtin_formatter_class('p'))
+        .to eq(RuboCop::Formatter::ProgressFormatter)
     end
   end
 

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -68,21 +68,22 @@ RSpec.describe RuboCop::Options, :isolated_environment do
               -f, --format FORMATTER           Choose an output formatter. This option
                                                can be specified multiple times to enable
                                                multiple formatters at the same time.
-                                                 [p]rogress (default)
-                                                 [s]imple
-                                                 [c]lang
-                                                 [d]isabled cops via inline comments
-                                                 [fu]ubar
-                                                 [pa]cman
-                                                 [e]macs
-                                                 [j]son
-                                                 [h]tml
-                                                 [fi]les
-                                                 [o]ffenses
-                                                 [w]orst
-                                                 [t]ap
-                                                 [q]uiet
+                                               [p]rogress is used by default
                                                  [a]utogenconf
+                                                 [c]lang
+                                                 [d]isabled
+                                                 [e]macs
+                                                 [fi]les
+                                                 [fu]ubar
+                                                 [h]tml
+                                                 [j]son
+                                                 [o]ffenses
+                                                 [pa]cman
+                                                 [p]rogress
+                                                 [q]uiet
+                                                 [s]imple
+                                                 [t]ap
+                                                 [w]orst
                                                  custom formatter class name
               -o, --out FILE                   Write output to a file instead of STDOUT.
                                                This option applies to the previously

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
           match = line.match(/^[ ]{39}(\[[a-z\]]+)/)
           next keys unless match
 
-          keys << match.captures.first.gsub(/\[|\]/, '')
+          keys << match.captures.first
         end.sort
 
         expected_formatter_keys =


### PR DESCRIPTION
Fixed an issue where passing a formatter alias which started with the
same character as another caused an error.

Specifically, passing in `-f p` caused an error as this matched
both 'pacman' and 'progress' in
Rubocop:: Formatter::FormatterSet::BUILTIN_FORMATTERS_FOR_KEYS


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
