### PR TITLE
[Fix #7407] Better detect typical format string contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#7407](https://github.com/rubocop-hq/rubocop/issues/7407): Make `Style/FormatStringToken` work inside hashes. ([@buehmann][])
+
 ## 0.75.0 (2019-09-30)
 
 ### New features

--- a/lib/rubocop/cop/style/format_string_token.rb
+++ b/lib/rubocop/cop/style/format_string_token.rb
@@ -95,11 +95,7 @@ module RuboCop
           if source_map.is_a?(Parser::Source::Map::Heredoc)
             source_map.heredoc_body
           elsif source_map.begin
-            slice_source(
-              source_map.expression,
-              source_map.expression.begin_pos + 1,
-              source_map.expression.end_pos - 1
-            )
+            source_map.expression.adjust(begin_pos: +1, end_pos: -1)
           else
             source_map.expression
           end
@@ -110,22 +106,13 @@ module RuboCop
 
           format_string.format_sequences.each do |seq|
             detected_style = seq.style
-            token = slice_source(
-              contents,
-              contents.begin_pos + seq.begin_pos,
-              contents.begin_pos + seq.end_pos
+            token = contents.begin.adjust(
+              begin_pos: seq.begin_pos,
+              end_pos:   seq.end_pos
             )
 
             yield(detected_style, token)
           end
-        end
-
-        def slice_source(source_range, new_begin, new_end)
-          Parser::Source::Range.new(
-            source_range.source_buffer,
-            new_begin,
-            new_end
-          )
         end
 
         def placeholder_argument?(node)

--- a/spec/rubocop/cop/style/format_string_token_spec.rb
+++ b/spec/rubocop/cop/style/format_string_token_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
     RUBY
   end
 
-  it 'ignores placeholder argumetns' do
+  it 'ignores placeholder arguments' do
     expect_no_offenses(<<~RUBY)
       format(
         '%<day>s %<start>s-%<end>s',
@@ -135,6 +135,13 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
         start: open_house.starts_at.strftime('%l'),
         end: open_house.ends_at.strftime('%l %p').strip
       )
+    RUBY
+  end
+
+  it 'works inside hashes' do
+    expect_offense(<<~RUBY)
+      { bar: format('%{foo}', foo: 'foo') }
+                     ^^^^^^ Prefer annotated tokens (like `%<foo>s`) over template tokens (like `%{foo}`).
     RUBY
   end
 


### PR DESCRIPTION
This fixes #7407 by improving upon earlier attempts at avoiding false
positives: Strings that look like format strings in the `unannotated`
style (with simple format sequences such as `%a`) can as well be
something else depending on the context (e.g. date/time formats, encoded
URLs).

The documentation of the cop has long had a note about in which typical
contexts such strings are considered format strings. This is now
reflected in a node matcher in the code.