### PR TITLE
[Fix #7410] Add printf as a typical format string context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#7407](https://github.com/rubocop-hq/rubocop/issues/7407): Make `Style/FormatStringToken` work inside hashes. ([@buehmann][])
 
+### Changes
+
+* [#7410](https://github.com/rubocop-hq/rubocop/issues/7410): `Style/FormatStringToken` now finds unannotated format sequences in `printf` arguments. ([@buehmann][])
+
 ## 0.75.0 (2019-09-30)
 
 ### New features

--- a/lib/rubocop/cop/style/format_string_token.rb
+++ b/lib/rubocop/cop/style/format_string_token.rb
@@ -8,7 +8,7 @@ module RuboCop
       # **Note:**
       # `unannotated` style cop only works for strings
       # which are passed as arguments to those methods:
-      # `sprintf`, `format`, `%`.
+      # `printf`, `sprintf`, `format`, `%`.
       # The reason is that *unannotated* format is very similar
       # to encoded URLs or Date/Time formatting strings.
       #
@@ -60,7 +60,7 @@ module RuboCop
 
         def_node_matcher :format_string_in_typical_context?, <<~PATTERN
           {
-            ^(send _ {:format :sprintf} %0 ...)
+            ^(send _ {:format :sprintf :printf} %0 ...)
             ^(send %0 :% _)
           }
         PATTERN

--- a/lib/rubocop/formatter/clang_style_formatter.rb
+++ b/lib/rubocop/formatter/clang_style_formatter.rb
@@ -15,9 +15,14 @@ module RuboCop
       private
 
       def report_offense(file, offense)
-        output.printf("%s:%d:%d: %s: %s\n",
-                      cyan(smart_path(file)), offense.line, offense.real_column,
-                      colored_severity_code(offense), message(offense))
+        output.printf(
+          "%<path>s:%<line>d:%<column>d: %<severity>s: %<message>s\n",
+          path: cyan(smart_path(file)),
+          line: offense.line,
+          column: offense.real_column,
+          severity: colored_severity_code(offense),
+          message: message(offense)
+        )
 
         # rubocop:disable Lint/HandleExceptions
         begin

--- a/lib/rubocop/formatter/emacs_style_formatter.rb
+++ b/lib/rubocop/formatter/emacs_style_formatter.rb
@@ -8,19 +8,29 @@ module RuboCop
     class EmacsStyleFormatter < BaseFormatter
       def file_finished(file, offenses)
         offenses.each do |o|
-          message =
-            if o.corrected_with_todo?
-              "[Todo] #{o.message}"
-            elsif o.corrected?
-              "[Corrected] #{o.message}"
-            else
-              o.message
-            end
-
-          output.printf("%s:%d:%d: %s: %s\n",
-                        file, o.line, o.real_column, o.severity.code,
-                        message.tr("\n", ' '))
+          output.printf(
+            "%<path>s:%<line>d:%<column>d: %<severity>s: %<message>s\n",
+            path: file,
+            line: o.line,
+            column: o.real_column,
+            severity: o.severity.code,
+            message: message(o)
+          )
         end
+      end
+
+      private
+
+      def message(offense)
+        message =
+          if offense.corrected_with_todo?
+            "[Todo] #{offense.message}"
+          elsif offense.corrected?
+            "[Corrected] #{offense.message}"
+          else
+            offense.message
+          end
+        message.tr("\n", ' ')
       end
     end
   end

--- a/lib/rubocop/formatter/file_list_formatter.rb
+++ b/lib/rubocop/formatter/file_list_formatter.rb
@@ -13,7 +13,7 @@ module RuboCop
       def file_finished(file, offenses)
         return if offenses.empty?
 
-        output.printf("%s\n", file)
+        output.printf("%<path>s\n", path: file)
       end
     end
   end

--- a/lib/rubocop/formatter/pacman_formatter.rb
+++ b/lib/rubocop/formatter/pacman_formatter.rb
@@ -68,7 +68,7 @@ module RuboCop
       def step(character)
         regex = /#{Regexp.quote(PACMAN)}|#{Regexp.quote(PACDOT)}/
         @progress_line = @progress_line.sub(regex, character)
-        output.printf("%s\r", @progress_line)
+        output.printf("%<line>s\r", line: @progress_line)
         return unless @progress_line[-1] =~ /ᗣ|\./
 
         @repetitions += 1

--- a/lib/rubocop/formatter/simple_text_formatter.rb
+++ b/lib/rubocop/formatter/simple_text_formatter.rb
@@ -42,9 +42,13 @@ module RuboCop
         output.puts yellow("== #{smart_path(file)} ==")
 
         offenses.each do |o|
-          output.printf("%s:%3d:%3d: %s\n",
-                        colored_severity_code(o),
-                        o.line, o.real_column, message(o))
+          output.printf(
+            "%<severity>s:%3<line>d:%3<column>d: %<message>s\n",
+            severity: colored_severity_code(o),
+            line: o.line,
+            column: o.real_column,
+            message: message(o)
+          )
         end
       end
 

--- a/lib/rubocop/formatter/tap_formatter.rb
+++ b/lib/rubocop/formatter/tap_formatter.rb
@@ -42,9 +42,14 @@ module RuboCop
       end
 
       def report_offense(file, offense)
-        output.printf("# %s:%d:%d: %s: %s\n",
-                      cyan(smart_path(file)), offense.line, offense.real_column,
-                      colored_severity_code(offense), message(offense))
+        output.printf(
+          "# %<path>s:%<line>d:%<column>d: %<severity>s: %<message>s\n",
+          path: cyan(smart_path(file)),
+          line: offense.line,
+          column: offense.real_column,
+          severity: colored_severity_code(offense),
+          message: message(offense)
+        )
 
         # rubocop:disable Lint/HandleExceptions
         begin

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2177,7 +2177,7 @@ Use a consistent style for named format string tokens.
 **Note:**
 `unannotated` style cop only works for strings
 which are passed as arguments to those methods:
-`sprintf`, `format`, `%`.
+`printf`, `sprintf`, `format`, `%`.
 The reason is that *unannotated* format is very similar
 to encoded URLs or Date/Time formatting strings.
 


### PR DESCRIPTION
The cop `Style/FormatStringToken` used to treat `sprintf`, `format`, and `%` methods as typical use cases of `printf`-style format strings, but ironically not the `printf` method itself.

This fixes #7410.