### PR TITLE
Add rubocop-rake to the extension list

### DIFF
--- a/manual/extensions.md
+++ b/manual/extensions.md
@@ -46,8 +46,10 @@ See [development](development.md).
   i18n wrapper function analysis (gettext and rails-i18n)
 * [rubocop-sequel](https://github.com/rubocop-hq/rubocop-sequel) -
   Code style checking for Sequel gem
-* [cookstyle](https://github.com/chef/cookstyle) - 
+* [cookstyle](https://github.com/chef/cookstyle) -
   Custom cops and config defaults for Chef Infra Cookbooks
+* [rubocop-rake](https://github.com/rubocop-hq/rubocop-rake) -
+  Rake-specific analysis
 
 Any extensions missing? Send us a Pull Request!
 


### PR DESCRIPTION
This pull request adds [rubocop-rake](https://github.com/rubocop-hq/rubocop-rake) to the extension list.


I'd like to get more cop ideas and contributions to rubocop-rake by adding it to the list.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
