### PR TITLE
Fix PercentLiteralCorrector with Ruby 2.7-dev

### DIFF
--- a/lib/rubocop/cop/correctors/percent_literal_corrector.rb
+++ b/lib/rubocop/cop/correctors/percent_literal_corrector.rb
@@ -98,7 +98,7 @@ module RuboCop
       end
 
       def fix_escaped_content(word_node, escape, delimiters)
-        content = word_node.children.first.to_s
+        content = +word_node.children.first.to_s
         content = escape_string(content) if escape
         substitute_escaped_delimiters(content, delimiters)
         content


### PR DESCRIPTION
Since https://github.com/ruby/ruby/pull/2437, `Symbol#to_s` returns frozen string.
PercentLiteralCorrector uses `Symbol#to_s` and `String#gsub!`. So the corrector raises an error for SymbolArray cop spec.

```
FrozenError:
can't modify frozen String: "bar"
# ./lib/rubocop/cop/correctors/percent_literal_corrector.rb:108:in `gsub!'
# ./lib/rubocop/cop/correctors/percent_literal_corrector.rb:108:in `block in substitute_escaped_delimiters'
# ./lib/rubocop/cop/correctors/percent_literal_corrector.rb:108:in `each'
# ./lib/rubocop/cop/correctors/percent_literal_corrector.rb:108:in `substitute_escaped_delimiters'
# ./lib/rubocop/cop/correctors/percent_literal_corrector.rb:103:in `fix_escaped_content'
# ./lib/rubocop/cop/correctors/percent_literal_corrector.rb:61:in `block in autocorrect_words'
# ./lib/rubocop/cop/correctors/percent_literal_corrector.rb:60:in `map'
# ./lib/rubocop/cop/correctors/percent_literal_corrector.rb:60:in `autocorrect_words'
# ./lib/rubocop/cop/correctors/percent_literal_corrector.rb:49:in `new_contents'
# ./lib/rubocop/cop/correctors/percent_literal_corrector.rb:20:in `correct'
# ./lib/rubocop/cop/style/symbol_array.rb:57:in `autocorrect'
# ./lib/rubocop/cop/cop.rb:159:in `correct'
# ./lib/rubocop/cop/cop.rb:137:in `add_offense'
# ./lib/rubocop/cop/mixin/percent_array.rb:48:in `check_bracketed_array'
# ./lib/rubocop/cop/style/symbol_array.rb:47:in `on_array'
# ./lib/rubocop/cop/commissioner.rb:57:in `block (2 levels) in trigger_responding_cops'
# ./lib/rubocop/cop/commissioner.rb:128:in `with_cop_error_handling'
# ./lib/rubocop/cop/commissioner.rb:56:in `block in trigger_responding_cops'
# ./lib/rubocop/cop/commissioner.rb:55:in `each'
# ./lib/rubocop/cop/commissioner.rb:55:in `trigger_responding_cops'
# ./lib/rubocop/cop/commissioner.rb:32:in `block (2 levels) in <class:Commissioner>'
# ./lib/rubocop/ast/traversal.rb:107:in `block in on_send'
# ./lib/rubocop/ast/traversal.rb:104:in `each'
# ./lib/rubocop/ast/traversal.rb:104:in `each_with_index'
# ./lib/rubocop/ast/traversal.rb:104:in `on_send'
# ./lib/rubocop/cop/commissioner.rb:33:in `block (2 levels) in <class:Commissioner>'
# ./lib/rubocop/ast/traversal.rb:160:in `on_block'
# ./lib/rubocop/cop/commissioner.rb:33:in `block (2 levels) in <class:Commissioner>'
# ./lib/rubocop/ast/traversal.rb:13:in `walk'
# ./lib/rubocop/cop/commissioner.rb:44:in `investigate'
# ./lib/rubocop/rspec/cop_helper.rb:75:in `_investigate'
# ./lib/rubocop/rspec/expect_offense.rb:95:in `expect_offense'
# ./spec/rubocop/cop/style/symbol_array_spec.rb:78:in `block (3 levels) in <top (required)>'
```

This pull request fixes the problem.



I'm not sure I should write a changelog entry, because this change is only for ruby 2.7-dev.
I think we can omit it. This change does not affect most people yet.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
