### PR TITLE
[Fix #7404] Fix a false negative for `Layout/IndentAssignment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#7389](https://github.com/rubocop-hq/rubocop/issues/7389): Fix an issue where passing a formatter might result in an error depending on what character it started with. ([@jfhinchcliffe][])
 * [#7397](https://github.com/rubocop-hq/rubocop/issues/7397): Fix extra comments being added to the correction of `Style/SafeNavigation`. ([@rrosenblum][])
 * [#7378](https://github.com/rubocop-hq/rubocop/pull/7378): Fix heredoc edge cases in `Layout/EmptyLineAfterGuardClause`. ([@gsamokovarov][])
+* [#7404](https://github.com/rubocop-hq/rubocop/issues/7404): Fix a false negative for `Layout/IndentAssignment` when multiple assignment with line breaks on each line. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/indent_assignment.rb
+++ b/lib/rubocop/cop/layout/indent_assignment.rb
@@ -42,7 +42,8 @@ module RuboCop
         end
 
         def leftmost_multiple_assignment(node)
-          return node unless node.parent&.assignment?
+          return node unless same_line?(node, node.parent) &&
+                             node.parent.assignment?
 
           leftmost_multiple_assignment(node.parent)
 

--- a/spec/rubocop/cop/layout/indent_assignment_spec.rb
+++ b/spec/rubocop/cop/layout/indent_assignment_spec.rb
@@ -105,4 +105,20 @@ RSpec.describe RuboCop::Cop::Layout::IndentAssignment, :config do
         baz = ''
     RUBY
   end
+
+  it 'registers an offense for incorrectly indented rhs when' \
+     'multiple assignment with line breaks on each line' do
+    expect_offense(<<~RUBY)
+      foo =
+        bar =
+        baz = 42
+        ^^^^^^^^ Indent the first line of the right-hand-side of a multi-line assignment.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo =
+        bar =
+          baz = 42
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #7404.

This PR fixes a false negative for `Layout/IndentAssignment` when multiple assignment with line breaks on each line.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
