### PR TITLE
Exclude .git from internal investigation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'
     - 'tmp/**/*'
+    - '.git/**/*'
   TargetRubyVersion: 2.3
 
 Naming/PredicateName:


### PR DESCRIPTION
In the project's `.rubocop.yml` we overwrite the default
`AllCops/Exclude` and do not exclude `.git`.

On my machine fixing this saves 1 of 3 seconds for a simple `rubocop
--list-target-files`.