### PR TITLE
[Fix #7397] Fix issue where Style/SafeNavigation adds extra comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#7391](https://github.com/rubocop-hq/rubocop/issues/7391): Support pacman formatter on Windows. ([@laurenball][])
 * [#7407](https://github.com/rubocop-hq/rubocop/issues/7407): Make `Style/FormatStringToken` work inside hashes. ([@buehmann][])
 * [#7389](https://github.com/rubocop-hq/rubocop/issues/7389): Fix an issue where passing a formatter might result in an error depending on what character it started with. ([@jfhinchcliffe][])
+* [#7397](https://github.com/rubocop-hq/rubocop/issues/7397): Fix extra comments being added to the correction of `Style/SafeNavigation`. ([@rrosenblum][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -120,7 +120,7 @@ module RuboCop
             corrector.remove(begin_range(node, body))
             corrector.remove(end_range(node, body))
             corrector.insert_before(method_call.loc.dot, '&')
-            handle_comments(corrector, method_call)
+            handle_comments(corrector, node, method_call)
 
             add_safe_nav_to_all_methods_in_chain(corrector, method_call, body)
           end
@@ -128,12 +128,20 @@ module RuboCop
 
         private
 
-        def handle_comments(corrector, method_call)
+        def handle_comments(corrector, node, method_call)
           return if processed_source.comments.empty?
 
-          comments = processed_source.comments.map(&:text).join("\n")
           corrector.insert_before(method_call.loc.expression,
-                                  comments + "\n")
+                                  "#{comments(node).join("\n")}\n")
+        end
+
+        def comments(node)
+          comments = processed_source.comments.select do |comment|
+            comment.loc.first_line >= node.loc.first_line &&
+              comment.loc.last_line <= node.loc.last_line
+          end
+
+          comments.map(&:text)
         end
 
         def allowed_if_condition?(node)

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -950,6 +950,26 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
           expect(new_source).to eq(expected_source)
         end
 
+        it 'only moves comments that fall within the expression' do
+          new_source = autocorrect_source(<<~RUBY)
+            # comment one
+            def foobar
+              if #{variable}
+                # comment 2
+                #{variable}.bar
+              end
+            end
+          RUBY
+
+          expect(new_source).to eq(<<~RUBY)
+            # comment one
+            def foobar
+              # comment 2
+            #{variable}&.bar
+            end
+          RUBY
+        end
+
         it 'corrects a single method call inside of an unless nil check ' \
            'for the object' do
           new_source = autocorrect_source(<<~RUBY)


### PR DESCRIPTION
This fixes #7397 

When moving comments around, the original implementation failed to limit the comments to the section of code being analyzed. It was pulling the comments for the entire file.