### PR TITLE
[Fix #6964] Set default `IgnoreCopDirectives` to `true` for `Metrics/LineLength`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changes
 
 * [#7410](https://github.com/rubocop-hq/rubocop/issues/7410): `Style/FormatStringToken` now finds unannotated format sequences in `printf` arguments. ([@buehmann][])
+* [#6964](https://github.com/rubocop-hq/rubocop/issues/6964): Set default `IgnoreCopDirectives` to `true` for `Metrics/LineLength`. ([@jdkaplan][])
 
 ## 0.75.0 (2019-09-30)
 
@@ -4222,3 +4223,4 @@
 [@desheikh]: https://github.com/desheikh
 [@laurenball]: https://github.com/laurenball
 [@jfhinchcliffe]: https://github.com/jfhinchcliffe
+[@jdkaplan]: https://github.com/jdkaplan

--- a/config/default.yml
+++ b/config/default.yml
@@ -1815,7 +1815,7 @@ Metrics/LineLength:
     - https
   # The IgnoreCopDirectives option causes the LineLength rule to ignore cop
   # directives like '# rubocop: enable ...' when calculating a line's length.
-  IgnoreCopDirectives: false
+  IgnoreCopDirectives: true
   # The IgnoredPatterns option is a list of !ruby/regexp and/or string
   # elements. Strings will be converted to Regexp objects. A line that matches
   # any regular expression listed in this option will be ignored by LineLength.

--- a/manual/cops_metrics.md
+++ b/manual/cops_metrics.md
@@ -173,7 +173,7 @@ Max | `80` | Integer
 AllowHeredoc | `true` | Boolean
 AllowURI | `true` | Boolean
 URISchemes | `http`, `https` | Array
-IgnoreCopDirectives | `false` | Boolean
+IgnoreCopDirectives | `true` | Boolean
 IgnoredPatterns | `[]` | Array
 
 ### References

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -537,7 +537,7 @@ RSpec.describe RuboCop::ConfigLoader do
               'AllowHeredoc' => true,
               'AllowURI' => true,
               'URISchemes' => %w[http https],
-              'IgnoreCopDirectives' => false,
+              'IgnoreCopDirectives' => true,
               'IgnoredPatterns' => []
             },
             'Metrics/MethodLength' => {
@@ -641,7 +641,7 @@ RSpec.describe RuboCop::ConfigLoader do
               'AllowHeredoc' => false,  # overridden in rubocop.yml
               'AllowURI' => true,
               'URISchemes' => %w[http https],
-              'IgnoreCopDirectives' => false,
+              'IgnoreCopDirectives' => true,
               'IgnoredPatterns' => []
             }
           )


### PR DESCRIPTION
As described in #6964, including cop directives in the line length calculation causes long comments to push otherwise good code in an awkward direction. This PR changes the default value of `IgnoreCopDirectives` to `true` for `Metrics/LineLength`, which should remove some noisy warnings. In particular, this will prevent rubocop from discouraging single-line cop directives where they make sense.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
