### PR TITLE
Bump RuboCop Performance to 1.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'bump', require: false
 gem 'pry'
 gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.7'
-gem 'rubocop-performance', '~> 1.4.0'
+gem 'rubocop-performance', '~> 1.5.0'
 gem 'rubocop-rspec', '~> 1.33.0'
 gem 'simplecov', '~> 0.10'
 gem 'test-queue'

--- a/lib/rubocop/cop/layout/empty_line_after_magic_comment.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_magic_comment.rb
@@ -55,8 +55,8 @@ module RuboCop
           source
             .comments
             .take_while { |comment| comment.loc.line < source.ast.loc.line }
-            .select     { |comment| MagicComment.parse(comment.text).any?  }
-            .last
+            .reverse
+            .find { |comment| MagicComment.parse(comment.text).any? }
         end
       end
     end

--- a/lib/rubocop/cop/style/expand_path_arguments.rb
+++ b/lib/rubocop/cop/style/expand_path_arguments.rb
@@ -160,7 +160,7 @@ module RuboCop
         def depth(current_path)
           paths = current_path.split(File::SEPARATOR)
 
-          paths.reject { |path| path == '.' }.count
+          paths.count { |path| path != '.' }
         end
 
         def parent_path(current_path)


### PR DESCRIPTION
RuboCop Performance 1.5.0 has been released.
https://github.com/rubocop-hq/rubocop-performance/releases/tag/v1.5.0

This PR bumps RuboCop Performance to 1.5.0 and suppresses the following new offenses.

```console
% bundle exec rake
(snip)

lib/rubocop/cop/layout/empty_line_after_magic_comment.rb:58:14: C:
Performance/Detect: Use reverse.find instead of select.last.
          .select     { |comment| MagicComment.parse(comment.text).any?  }
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/style/expand_path_arguments.rb:163:17: C:
Performance/Count: Use count instead of reject...count.
          paths.reject { |path| path == '.' }.count
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
