### PR TITLE
[Fix #7434] Fix an incorrect autocorrect for `Style/MultilineWhenThen`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changes
 
 * [#7446](https://github.com/rubocop-hq/rubocop/issues/7446): Add `merge` to list of non-mutating methods. ([@cstyles][])
+* [#7434](https://github.com/rubocop-hq/rubocop/issues/7434): Fix an incorrect autocorrect for `Style/MultilineWhenThen` when the body of `when` branch starts with `then`. ([@koic][])
 
 ## 0.75.1 (2019-10-14)
 

--- a/lib/rubocop/cop/style/multiline_when_then.rb
+++ b/lib/rubocop/cop/style/multiline_when_then.rb
@@ -44,7 +44,7 @@ module RuboCop
           lambda do |corrector|
             corrector.remove(
               range_with_surrounding_space(
-                range: node.loc.begin, side: :left
+                range: node.loc.begin, side: :left, newlines: false
               )
             )
           end

--- a/spec/rubocop/cop/style/multiline_when_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_when_then_spec.rb
@@ -84,4 +84,21 @@ RSpec.describe RuboCop::Cop::Style::MultilineWhenThen do
       end
     RUBY
   end
+
+  it 'autocorrects when the body of `when` branch starts ' \
+     'with `then`' do
+    new_source = autocorrect_source(<<~RUBY)
+      case foo
+      when bar
+        then do_something
+      end
+    RUBY
+
+    expect(new_source).to eq(<<~RUBY)
+      case foo
+      when bar
+       do_something
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #7434.

This PR fixes an incorrect autocorrect for `Style/MultilineWhenThen` when the body of `when` branch starts with `then`.

The following is a reproduction procedure.

```console
% cat example.rb
# frozen_string_literal: true

case foo
when bar
  then do_something
end
```

```
% ruby -c example.rb
Syntax OK
```

## Before

```console
% rubocop example.rb
Inspecting 1 file
C

Offenses:

example.rb:5:3: C: Style/MultilineWhenThen: Do not use then for
multiline when statement.
  then do_something
  ^^^^
```

It is changed to the code with syntax error as follows.

```ruby
# frozen_string_literal: true

case foo
when bar do_something
end
```

```console
% ruby -c example.rb
example.rb:4: syntax error, unexpected tIDENTIFIER, expecting do or '{'
or '('
when bar do_something
```

## After

```console
% rubocop example.rb -a
Inspecting 1 file
C

Offenses:

example.rb:5:1: C: [Corrected] Layout/IndentationWidth: Use 2 (not 1)
spaces for indentation.
 do_something
^
example.rb:5:3: C: [Corrected] Style/MultilineWhenThen: Do not use then
for multiline when statement.
  then do_something
  ^^^^

1 file inspected, 2 offenses detected, 2 offenses corrected
```

It will be changed to valid Ruby code as follows.

```ruby
# frozen_string_literal: true

case foo
when bar
  do_something
end
```

There is a slight difference in indentation using only this cop. That indentation is corrected using `Layout/IndentationWidth` cop.

```diff
 case foo
 when bar
- do_something
+  do_something
 end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
