### PR TITLE
Fix assignment edge-cases in Layout/MultilineAssignmentLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#7439](https://github.com/rubocop-hq/rubocop/issues/7439): Make `Style/FormatStringToken` ignore percent escapes (`%%`). ([@buehmann][])
+* [#7438](https://github.com/rubocop-hq/rubocop/issues/7438): Fix assignment edge-cases in `Layout/MultilineAssignmentLayout`. ([@gsamokovarov][])
 
 ## 0.75.1 (2019-10-14)
 

--- a/lib/rubocop/cop/layout/multiline_assignment_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_assignment_layout.rb
@@ -43,7 +43,7 @@ module RuboCop
           'on the same line as the assignment operator `=`.'
 
         def check_assignment(node, rhs)
-          return if node.send_type?
+          return if node.send_type? && node.loc.operator&.source != '='
           return unless rhs
           return unless supported_types.include?(rhs.type)
           return if rhs.first_line == rhs.last_line

--- a/spec/rubocop/cop/layout/multiline_assignment_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_assignment_layout_spec.rb
@@ -21,16 +21,37 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
         ^^^^^^^^^^^^^^^ Right hand side of multi-line assignment is on the same line as the assignment operator `=`.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        blarg =
+         if true
+        end
+      RUBY
     end
 
-    it 'auto-corrects offenses' do
-      new_source = autocorrect_source(<<~RUBY)
-        blarg = if true
+    it 'registers an offense when the rhs is on the same line in []=' do
+      expect_offense(<<~RUBY)
+        hash[:foo] = if true
+        ^^^^^^^^^^^^^^^^^^^^ Right hand side of multi-line assignment is on the same line as the assignment operator `=`.
         end
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
-        blarg =
+      expect_correction(<<~RUBY)
+        hash[:foo] =
+         if true
+        end
+      RUBY
+    end
+
+    it 'registers an offense when the rhs is on the same line in setters' do
+      expect_offense(<<~RUBY)
+        foo.bar = if true
+        ^^^^^^^^^^^^^^^^^ Right hand side of multi-line assignment is on the same line as the assignment operator `=`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo.bar =
          if true
         end
       RUBY
@@ -123,17 +144,37 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
         if true
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        blarg = if true
+        end
+      RUBY
     end
 
-    it 'auto-corrects offenses' do
-      new_source = autocorrect_source(<<~RUBY)
-        blarg =
+    it 'registers an offense when the rhs is a different line in []=' do
+      expect_offense(<<~RUBY)
+        hash[:foo] =
+        ^^^^^^^^^^^^ Right hand side of multi-line assignment is not on the same line as the assignment operator `=`.
         if true
         end
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
-        blarg = if true
+      expect_correction(<<~RUBY)
+        hash[:foo] = if true
+        end
+      RUBY
+    end
+
+    it 'registers an offense when the rhs is a different line in setters' do
+      expect_offense(<<~RUBY)
+        foo.bar =
+        ^^^^^^^^^ Right hand side of multi-line assignment is not on the same line as the assignment operator `=`.
+        if true
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo.bar = if true
         end
       RUBY
     end


### PR DESCRIPTION
Assignments from `:[]=` or setter methods (`foo.bar=(value)`) like the ones below did not produce cop reports and were not autocorrected. Now, they are!

```ruby
hash[:foo] = if true
^^^^^^^^^^^^^^^^^^^^ Right hand side of multi-line assignment is on the same line as the assignment operator `=`.
end
```

```ruby
foo.bar = if true
^^^^^^^^^^^^^^^^^^^^ Right hand side of multi-line assignment is on the same line as the assignment operator `=`.
end
```