### PR TITLE
[Fix #7439] Ignore percent escapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#7439](https://github.com/rubocop-hq/rubocop/issues/7439): Make `Style/FormatStringToken` ignore percent escapes (`%%`). ([@buehmann][])
+
 ## 0.75.1 (2019-10-14)
 
 ### Bug fixes

--- a/lib/rubocop/cop/style/format_string_token.rb
+++ b/lib/rubocop/cop/style/format_string_token.rb
@@ -104,6 +104,8 @@ module RuboCop
           format_string = RuboCop::Cop::Utils::FormatString.new(contents.source)
 
           format_string.format_sequences.each do |seq|
+            next if seq.percent?
+
             detected_style = seq.style
             token = contents.begin.adjust(
               begin_pos: seq.begin_pos,

--- a/spec/rubocop/cop/style/format_string_token_spec.rb
+++ b/spec/rubocop/cop/style/format_string_token_spec.rb
@@ -81,6 +81,10 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
     end
   end
 
+  it 'ignores percent escapes' do
+    expect_no_offenses("format('%<hit_rate>6.2f%%', hit_rate: 12.34)")
+  end
+
   it 'ignores xstr' do
     expect_no_offenses('`echo "%s %<annotated>s %{template}"`')
   end


### PR DESCRIPTION
`%%` is technically a format sequence in the `unannotated` style. But it
cannot be written in another style in a sensible way.

This closes #7439.