### PR TITLE
Accept braces for hashes with kwsplat in `Style/BracesAroundHashParamerers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#7439](https://github.com/rubocop-hq/rubocop/issues/7439): Make `Style/FormatStringToken` ignore percent escapes (`%%`). ([@buehmann][])
 * [#7438](https://github.com/rubocop-hq/rubocop/issues/7438): Fix assignment edge-cases in `Layout/MultilineAssignmentLayout`. ([@gsamokovarov][])
+* [#7443](https://github.com/rubocop-hq/rubocop/issues/7443): Accept braces for hashes with kwsplat in `Style/BracesAroundHashParamerers`. ([@gsamokovarov][])
 
 ## 0.75.1 (2019-10-14)
 

--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -109,11 +109,14 @@ module RuboCop
         # and that block uses do..end. The reason for wanting to check this is
         # that the do..end could bind to a different method invocation if the
         # hash braces were removed.
+        #
+        # Another case for true return value is when you splat extra keyword
+        # arguments into the last argument like: `f({val: 1, **extra})`.
         def braces_needed_for_semantics?(arg)
           arg.each_pair do |_key, value|
             return true if value.block_type? && !value.braces?
           end
-          false
+          arg.children.any?(&:kwsplat_type?)
         end
 
         def add_arg_offense(arg, type)

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
        'method call' do
       expect_no_offenses('f 1, { k: proc do h end }')
     end
+
+    it 'accepts braces that are needed for inner keyword splat' do
+      expect_no_offenses('f 1, { foo: :bar, **extra }')
+    end
   end
 
   shared_examples 'no_braces and context_dependent non-offenses' do
@@ -36,8 +40,16 @@ RSpec.describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       expect_no_offenses('where(x: "y", foo: "bar")')
     end
 
+    it 'accepts braces that are needed for inner keyword splat' do
+    end
+
     it 'accepts one hash parameter without braces and with one hash value' do
       expect_no_offenses('where(x: { "y" => "z" })')
+    end
+
+    it 'accepts one hash parameter without braces and with one hash value' \
+       'with kwsplat' do
+      expect_no_offenses('where(x: { "y" => "z", **extra })')
     end
 
     it 'accepts property assignment with braces' do


### PR DESCRIPTION
I was writing metrics code recently and wanted to splat extra data into
the last argument call of a method and rubocop wouldn't let me do that.

I run rubocop on save and my code got it autocorrected from:

```ruby
metrics_for(event, {data: values, **extra})
```

to:

```ruby
metrics_for(event, data: values, **extra)
```

The code above ☝️  has different semantics than the one I need, though,
so the braces are actually needed.