### PR TITLE
[Fix #7442] Fix an incorrect autocorrect for `Style/SafeNavigation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#7439](https://github.com/rubocop-hq/rubocop/issues/7439): Make `Style/FormatStringToken` ignore percent escapes (`%%`). ([@buehmann][])
 * [#7438](https://github.com/rubocop-hq/rubocop/issues/7438): Fix assignment edge-cases in `Layout/MultilineAssignmentLayout`. ([@gsamokovarov][])
 * [#7449](https://github.com/rubocop-hq/rubocop/pull/7449): Make `Style/IfUnlessModifier` respect `rubocop:disable` comments for `Metrics/LineLength`. ([@jonas054][])
+* [#7442](https://github.com/rubocop-hq/rubocop/issues/7442): Fix an incorrect autocorrect for `Style/SafeNavigation` when an object check followed by a method call with a comment at EOL. ([@koic][])
 
 ## 0.75.1 (2019-10-14)
 

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -129,19 +129,18 @@ module RuboCop
         private
 
         def handle_comments(corrector, node, method_call)
-          return if processed_source.comments.empty?
+          comments = comments(node)
+          return if comments.empty?
 
           corrector.insert_before(method_call.loc.expression,
-                                  "#{comments(node).join("\n")}\n")
+                                  "#{comments.map(&:text).join("\n")}\n")
         end
 
         def comments(node)
-          comments = processed_source.comments.select do |comment|
-            comment.loc.first_line >= node.loc.first_line &&
-              comment.loc.last_line <= node.loc.last_line
+          processed_source.comments.select do |comment|
+            comment.loc.first_line > node.loc.first_line &&
+              comment.loc.last_line < node.loc.last_line
           end
-
-          comments.map(&:text)
         end
 
         def allowed_if_condition?(node)

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -674,6 +674,15 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
           expect(new_source).to eq("#{variable}&.bar(baz)")
         end
 
+        it 'corrects an object check followed by a method call ' \
+           'with a comment at EOL' do
+          source = "foo if #{variable} && #{variable}.bar # comment"
+
+          new_source = autocorrect_source(source)
+
+          expect(new_source).to eq("foo if #{variable}&.bar # comment")
+        end
+
         it 'corrects a method call with a block safeguarded with a check ' \
            'for the object' do
           source = "#{variable}.bar { |e| e.qux } if #{variable}"


### PR DESCRIPTION
Fixes #7442.

This PR fixes an incorrect autocorrect for `Style/SafeNavigation` when an object check followed by a method call with a comment at EOL.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
