### PR TITLE
[Fix #7446] Add `merge` to `NONMUTATING_METHODS`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * [#7439](https://github.com/rubocop-hq/rubocop/issues/7439): Make `Style/FormatStringToken` ignore percent escapes (`%%`). ([@buehmann][])
 * [#7438](https://github.com/rubocop-hq/rubocop/issues/7438): Fix assignment edge-cases in `Layout/MultilineAssignmentLayout`. ([@gsamokovarov][])
 
+### Changes
+
+* [#7446](https://github.com/rubocop-hq/rubocop/issues/7446): Add `merge` to list of non-mutating methods. ([@cstyles][])
+
 ## 0.75.1 (2019-10-14)
 
 ### Bug fixes
@@ -4233,3 +4237,4 @@
 [@laurenball]: https://github.com/laurenball
 [@jfhinchcliffe]: https://github.com/jfhinchcliffe
 [@jdkaplan]: https://github.com/jdkaplan
+[@cstyles]: https://github.com/cstyles

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -55,10 +55,10 @@ module RuboCop
         VOID_CONTEXT_TYPES = %i[def for block].freeze
         NONMUTATING_METHODS = %i[capitalize chomp chop collect compact
                                  delete_prefix delete_suffix downcase
-                                 encode flatten gsub lstrip map next reject
-                                 reverse rotate rstrip scrub select shuffle
-                                 slice sort sort_by squeeze strip sub succ
-                                 swapcase tr tr_s transform_values
+                                 encode flatten gsub lstrip map merge next
+                                 reject reverse rotate rstrip scrub select
+                                 shuffle slice sort sort_by squeeze strip sub
+                                 succ swapcase tr tr_s transform_values
                                  unicode_normalize uniq upcase].freeze
 
         def on_block(node)


### PR DESCRIPTION
Fixes #7446

Now, if `merge` is used in a void context, the `Lint/Void` cop will
register an offense and the mutating `merge!` method will be suggested.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
