### PR TITLE
Make IfUnlessModifier respect rubocop:disable comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#7439](https://github.com/rubocop-hq/rubocop/issues/7439): Make `Style/FormatStringToken` ignore percent escapes (`%%`). ([@buehmann][])
 * [#7438](https://github.com/rubocop-hq/rubocop/issues/7438): Fix assignment edge-cases in `Layout/MultilineAssignmentLayout`. ([@gsamokovarov][])
+* [#7449](https://github.com/rubocop-hq/rubocop/pull/7449): Make `Style/IfUnlessModifier` respect `rubocop:disable` comments for `Metrics/LineLength`. ([@jonas054][])
 
 ## 0.75.1 (2019-10-14)
 

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -70,8 +70,15 @@ module RuboCop
           return false unless max_line_length
 
           range = node.source_range
-          range.first_line == range.last_line &&
-            range.last_column > max_line_length
+          return false unless range.first_line == range.last_line
+          return false unless line_length_enabled_at_line?(range.first_line)
+
+          range.last_column > max_line_length
+        end
+
+        def line_length_enabled_at_line?(line)
+          processed_source.comment_config
+                          .cop_enabled_at_line?('Metrics/LineLength', line)
         end
 
         def named_capture_in_condition?(node)

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -36,13 +36,25 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier do
       end
     end
 
-    context 'when Metrics/LineLength is disabled' do
+    context 'when Metrics/LineLength is disabled in configuration' do
       let(:line_length_config) { { 'Enabled' => false, 'Max' => 80 } }
 
       it 'accepts' do
         expect_no_offenses(<<~RUBY)
           def f
             #{source}
+          end
+        RUBY
+      end
+    end
+
+    context 'when Metrics/LineLength is disabled with a comment' do
+      it 'accepts' do
+        expect_no_offenses(<<~RUBY)
+          def f
+            # rubocop:disable Metrics/LineLength
+            #{source}
+            # rubocop:enable Metrics/LineLength
           end
         RUBY
       end


### PR DESCRIPTION
A bug was discovered in https://github.com/rubocop-hq/rubocop/pull/7308#issuecomment-544236793

When `Style/IfUnlessModifier` decides that a line on modifier form is too long and that it should be written on normal form, it must respect comments that disable the `Metrics/LineLength` cop for the line in question. If that cop is disabled, then there can be no offense.