### PR TITLE
[Fix #7454] Skip cache on read-only filesystems

### DIFF
--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -100,7 +100,7 @@ module RuboCop
 
       begin
         FileUtils.mkdir_p(dir)
-      rescue Errno::EACCES => e
+      rescue Errno::EACCES, Errno::EROFS => e
         warn "Couldn't create cache directory. Continuing without cache."\
              "\n  #{e.message}"
         return

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -231,12 +231,19 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
       end
     end
 
+    shared_examples 'invalid cache location' do |error|
+      it 'doesn\'t raise an exception' do
+        expect(FileUtils).to receive(:mkdir_p).with(start_with(cache_root))
+                                              .and_raise(error)
+        expect { cache.save([]) }.not_to raise_error
+      end
+    end
+
     context 'when the @path is not writable' do
       let(:cache_root) { '/permission_denied_dir' }
 
-      it 'doesn\'t raise an exception' do
-        expect { cache.save([]) }.not_to raise_error
-      end
+      it_behaves_like 'invalid cache location', Errno::EACCES
+      it_behaves_like 'invalid cache location', Errno::EROFS
     end
   end
 


### PR DESCRIPTION
This closes #7454. I was able to reproduce this without Catalina by mounting a
filesystem image read-only -- before stubbing the filesystem in the specs.