### PR TITLE
Added new cop - Naming/AsciiConstants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+### New features
+* "Add new `Naming/AsciiConstants` cop. ([@pjskennedy][])
+
 ### Bug fixes
 
 * [#7439](https://github.com/rubocop-hq/rubocop/issues/7439): Make `Style/FormatStringToken` ignore percent escapes (`%%`). ([@buehmann][])
@@ -4241,3 +4244,4 @@
 [@jfhinchcliffe]: https://github.com/jfhinchcliffe
 [@jdkaplan]: https://github.com/jdkaplan
 [@cstyles]: https://github.com/cstyles
+[@pjskennedy]: https://github.com/pjskennedy

--- a/config/default.yml
+++ b/config/default.yml
@@ -1870,6 +1870,12 @@ Naming/AccessorMethodName:
   Enabled: true
   VersionAdded: '0.50'
 
+Naming/AsciiConstants:
+  Description: 'Use only ascii symbols in constants.'
+  StyleGuide: '#english-identifiers'
+  Enabled: true
+  VersionAdded: '0.76'
+
 Naming/AsciiIdentifiers:
   Description: 'Use only ascii symbols in identifiers.'
   StyleGuide: '#english-identifiers'

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -372,6 +372,7 @@ require_relative 'rubocop/cop/metrics/parameter_lists'
 require_relative 'rubocop/cop/metrics/perceived_complexity'
 
 require_relative 'rubocop/cop/naming/accessor_method_name'
+require_relative 'rubocop/cop/naming/ascii_constants'
 require_relative 'rubocop/cop/naming/ascii_identifiers'
 require_relative 'rubocop/cop/naming/class_and_module_camel_case'
 require_relative 'rubocop/cop/naming/constant_name'

--- a/lib/rubocop/cop/naming/ascii_constants.rb
+++ b/lib/rubocop/cop/naming/ascii_constants.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# rubocop:disable Style/AsciiComments
+
+module RuboCop
+  module Cop
+    module Naming
+      # This cop checks for non-ascii characters in constant declarations.
+      #
+      # @example
+      #   # bad
+      #   class Foõ
+      #   end
+      #
+      #   # bad
+      #   module Foõ
+      #   end
+      #
+      #   # bad
+      #   FOÕ = "bar"
+      #
+      #   # good
+      #   class Foo
+      #   end
+      #
+      #   # good
+      #   module Foo
+      #   end
+      #
+      #   # good
+      #   FOO = "bar"
+      #
+      class AsciiConstants < Cop
+        include RangeHelp
+
+        MSG = 'Use only ascii symbols in constants.'
+
+        def investigate(processed_source)
+          processed_source.each_token do |token|
+            next unless token.type == :tCONSTANT && !token.text.ascii_only?
+
+            add_offense(token, location: first_offense_range(token))
+          end
+        end
+
+        private
+
+        def first_offense_range(identifier)
+          expression    = identifier.pos
+          first_offense = first_non_ascii_chars(identifier.text)
+
+          start_position = expression.begin_pos +
+                           identifier.text.index(first_offense)
+          end_position   = start_position + first_offense.length
+
+          range_between(start_position, end_position)
+        end
+
+        def first_non_ascii_chars(string)
+          string.match(/[^[:ascii:]]+/).to_s
+        end
+      end
+    end
+  end
+end
+# rubocop:enable Style/AsciiComments

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -277,6 +277,7 @@ In the following section you find all available cops:
 #### Department [Naming](cops_naming.md)
 
 * [Naming/AccessorMethodName](cops_naming.md#namingaccessormethodname)
+* [Naming/AsciiConstants](cops_naming.md#namingasciiconstants)
 * [Naming/AsciiIdentifiers](cops_naming.md#namingasciiidentifiers)
 * [Naming/BinaryOperatorParameterName](cops_naming.md#namingbinaryoperatorparametername)
 * [Naming/ClassAndModuleCamelCase](cops_naming.md#namingclassandmodulecamelcase)

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -32,6 +32,44 @@ end
 
 * [https://rubystyle.guide#accessor_mutator_method_names](https://rubystyle.guide#accessor_mutator_method_names)
 
+## Naming/AsciiConstants
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.76 | -
+
+This cop checks for non-ascii characters in constant declarations.
+
+### Examples
+
+```ruby
+# bad
+class Foõ
+end
+
+# bad
+module Foõ
+end
+
+# bad
+FOÕ = "bar"
+
+# good
+class Foo
+end
+
+# good
+module Foo
+end
+
+# good
+FOO = "bar"
+```
+
+### References
+
+* [https://rubystyle.guide#english-identifiers](https://rubystyle.guide#english-identifiers)
+
 ## Naming/AsciiIdentifiers
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/spec/rubocop/cop/naming/ascii_constants_spec.rb
+++ b/spec/rubocop/cop/naming/ascii_constants_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Naming::AsciiConstants do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers an offense for a class name with non-ascii chars' do
+    expect_offense(<<~RUBY)
+      class Foõ; end
+              ^ Use only ascii symbols in constants.
+    RUBY
+  end
+
+  it 'registers an offense for a module name with non-ascii chars' do
+    expect_offense(<<~RUBY)
+      module Foõ; end
+               ^ Use only ascii symbols in constants.
+    RUBY
+  end
+
+  it 'registers an offense for a constant name with non-ascii chars' do
+    expect_offense(<<~RUBY)
+      FOÕ = "bar"
+        ^ Use only ascii symbols in constants.
+    RUBY
+  end
+
+  it 'accepts identifiers with only ascii chars' do
+    expect_no_offenses('FOO = "bar"')
+  end
+
+  it 'does not get confused by a byte order mark' do
+    expect_no_offenses(<<~RUBY)
+      ﻿
+      puts 'foo'
+    RUBY
+  end
+
+  it 'does not get confused by an empty file' do
+    expect_no_offenses('')
+  end
+end


### PR DESCRIPTION
This adds a new cop: `Naming/AsciiConstants`

This is an attempt to implement https://github.com/rubocop-hq/rubocop/issues/7458

Rubocop currently has [Naming/AsciiIdentifiers](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/AsciiIdentifiers) which correctly adds offenses to ruby identifiers (`tIDENTIFIER`) containing non-ascii characters. I find that the same rigor should be applied to constants (`tCONSTANT`) as the following are currently not offenses:
```rb
class Foö
end
```
```rb
module Foö
end
```
```rb
FOÖ = "foo"
```



-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
