### PR TITLE
Add `VersionRemoved` to internal params

### DIFF
--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -10,8 +10,9 @@ module RuboCop
 
     COMMON_PARAMS = %w[Exclude Include Severity inherit_mode
                        AutoCorrect StyleGuide Details].freeze
-    INTERNAL_PARAMS = %w[Description StyleGuide VersionAdded
-                         VersionChanged Reference Safe SafeAutoCorrect].freeze
+    INTERNAL_PARAMS = %w[Description StyleGuide
+                         VersionAdded VersionChanged VersionRemoved
+                         Reference Safe SafeAutoCorrect].freeze
 
     # 2.3 is the oldest officially supported Ruby version.
     DEFAULT_RUBY_VERSION = 2.3


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/6601

`VersionRemoved` is an unused parameter, but it is the same kind of parameter as `VersionAdded` and `VersionChanged`.

This PR adds `VersionRemoved` to these internal params.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
