### PR TITLE
Restyle example formatting for `Style/NonNilCheck`

### DIFF
--- a/lib/rubocop/cop/style/non_nil_check.rb
+++ b/lib/rubocop/cop/style/non_nil_check.rb
@@ -5,27 +5,39 @@ module RuboCop
     module Style
       # This cop checks for non-nil checks, which are usually redundant.
       #
-      # @example
+      # With `IncludeSemanticChanges` set to `false` by default, this cop
+      # does not report offenses for `!x.nil?` and does no changes that might
+      # change behavior.
       #
+      # With `IncludeSemanticChanges` set to `true`, this cop reports offenses
+      # for `!x.nil?` and autocorrects that and `x != nil` to solely `x`, which
+      # is **usually** OK, but might change behavior.
+      #
+      # @example
       #   # bad
       #   if x != nil
       #   end
       #
-      #   # good (when not allowing semantic changes)
-      #   # bad (when allowing semantic changes)
-      #   if !x.nil?
-      #   end
-      #
-      #   # good (when allowing semantic changes)
+      #   # good
       #   if x
       #   end
       #
-      # Non-nil checks are allowed if they are the final nodes of predicate.
-      #
+      #   # Non-nil checks are allowed if they are the final nodes of predicate.
       #   # good
       #   def signed_in?
       #     !current_user.nil?
       #   end
+      #
+      # @example IncludeSemanticChanges: false (default)
+      #   # good
+      #   if !x.nil?
+      #   end
+      #
+      # @example IncludeSemanticChanges: true
+      #   # bad
+      #   if !x.nil?
+      #   end
+      #
       class NonNilCheck < Cop
         def_node_matcher :not_equal_to_nil?, '(send _ :!= nil)'
         def_node_matcher :unless_check?, '(if (send _ :nil?) ...)'

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4410,12 +4410,13 @@ Enabled | Yes | Yes  | 0.20 | 0.22
 
 This cop checks for non-nil checks, which are usually redundant.
 
-Non-nil checks are allowed if they are the final nodes of predicate.
+With `IncludeSemanticChanges` set to `false` by default, this cop
+does not report offenses for `!x.nil?` and does no changes that might
+change behavior.
 
-  # good
-  def signed_in?
-    !current_user.nil?
-  end
+With `IncludeSemanticChanges` set to `true`, this cop reports offenses
+for `!x.nil?` and autocorrects that and `x != nil` to solely `x`, which
+is **usually** OK, but might change behavior.
 
 ### Examples
 
@@ -4424,13 +4425,28 @@ Non-nil checks are allowed if they are the final nodes of predicate.
 if x != nil
 end
 
-# good (when not allowing semantic changes)
-# bad (when allowing semantic changes)
-if !x.nil?
+# good
+if x
 end
 
-# good (when allowing semantic changes)
-if x
+# Non-nil checks are allowed if they are the final nodes of predicate.
+# good
+def signed_in?
+  !current_user.nil?
+end
+```
+#### IncludeSemanticChanges: false (default)
+
+```ruby
+# good
+if !x.nil?
+end
+```
+#### IncludeSemanticChanges: true
+
+```ruby
+# bad
+if !x.nil?
 end
 ```
 


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This PR is a change of document format for `Style/NonNilCheck` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
