### PR TITLE
Add forward slash to LITERAL_REGEX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#7449](https://github.com/rubocop-hq/rubocop/pull/7449): Make `Style/IfUnlessModifier` respect `rubocop:disable` comments for `Metrics/LineLength`. ([@jonas054][])
 * [#7442](https://github.com/rubocop-hq/rubocop/issues/7442): Fix an incorrect autocorrect for `Style/SafeNavigation` when an object check followed by a method call with a comment at EOL. ([@koic][])
 * [#7434](https://github.com/rubocop-hq/rubocop/issues/7434): Fix an incorrect autocorrect for `Style/MultilineWhenThen` when the body of `when` branch starts with `then`. ([@koic][])
+* [#7464](https://github.com/rubocop-hq/rubocop/pull/7464): Let `Performance/StartWith` and `Performance/EndWith` correct regexes that contain forward slashes. ([@eugeneius][])
 
 ### Changes
 

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -9,7 +9,7 @@ module RuboCop
       # Match literal regex characters, not including anchors, character
       # classes, alternatives, groups, repetitions, references, etc
       LITERAL_REGEX =
-        /[\w\s\-,"'!#%&<>=;:`~]|\\[^AbBdDgGhHkpPRwWXsSzZ0-9]/.freeze
+        %r{[\w\s\-,"'!#%&<>=;:`~/]|\\[^AbBdDgGhHkpPRwWXsSzZ0-9]}.freeze
 
       module_function
 


### PR DESCRIPTION
The forward slash character has no special meaning when it appears in a regex. This will let `Performance/StartWith` and `Performance/EndWith` correct code like the following:

```ruby
path =~ %r{/\z}
```

To:

```ruby
path.end_with?('/')
```

I noticed this problem thanks to @eregon's comment here: https://github.com/rails/rails/pull/37504#discussion_r339314567

`LITERAL_REGEX` is only used in RuboCop Performance, so I couldn't add a test to demonstrate the new behaviour. Arguably the constant should be defined there instead, but removing it from RuboCop would introduce an incompatibility with all existing versions of RuboCop Performance. I opted to update the constant in-place; let me know if another approach is preferable.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/