### PR TITLE
Update JRuby version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can read a lot more about RuboCop in its [official docs](https://docs.ruboco
 RuboCop supports the following Ruby implementations:
 
 * MRI 2.3+
-* JRuby 9.1+
+* JRuby 9.2+
 
 ## Team
 


### PR DESCRIPTION
The JRuby version 9.1+ is listed as a supported Ruby implementation in the README. However, Rubocop's CircleCI configuration is only testing against JRuby 9.2. This PR updates the README to list JRuby 9.2+ as the supported JRuby implementation.

Alternatively, if we want to continue to support JRuby 9.1.x, we can update the CircleCI configuration to include testing against JRuby 9.1.

With regards to unchecked items on the checklist below, there's no related issue, there's only one commit so there's no need to squash. We also don't need to add tests, update the Changelog, or generate docs for this change if I understand correctly. Let me know if that's not the case or if I missed anything.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
