### PR TITLE
Fix an error for `rake internal_investigation:auto_correct` task

### DIFF
--- a/lib/rubocop/rake_task.rb
+++ b/lib/rubocop/rake_task.rb
@@ -70,6 +70,7 @@ module RuboCop
           RakeFileUtils.verbose(verbose) do
             yield(*[self, task_args].slice(0, task_block.arity)) if block_given?
             options = full_options.unshift('--auto-correct')
+            options.delete('--parallel')
             run_cli(verbose, options)
           end
         end


### PR DESCRIPTION
This PR fixes the following error when using `rake internal_investigation:auto_correct` task.

```console
% bundle exec rake internal_investigation:auto_correct
Running RuboCop...
-P/--parallel can not be combined with --auto-correct.
RuboCop failed!
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
