### PR TITLE
Add custom cop generator to the manual

### DIFF
--- a/manual/extensions.md
+++ b/manual/extensions.md
@@ -28,7 +28,9 @@ other cop.
 
 #### Writing your own Cops
 
-See [development](development.md).
+If you'd like to create an extension gem, you can use [rubocop-extension-generator](https://github.com/rubocop-hq/rubocop-extension-generator).
+
+See [development](development.md) to learn how to implement a cop.
 
 #### Known Custom Cops
 


### PR DESCRIPTION
Recently I created a custom cop generator.
https://github.com/pocke/custom_cops_generator


It generates a boilerplate of custom cop extension gem.
I think it is helpful for creators for a custom cop.



And I'd like to move the repository to under the rubocop-hq organization. What do you think, @rubocop-hq/rubocop-core ?
If it is ok, I'll move the repository and update this pull request to refer the moved repository.


Thanks!
