### PR TITLE
Add new `InternalAffairs/MethodNameEqual` cop

### DIFF
--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -624,7 +624,7 @@ module RuboCop
       end
 
       def parent_module_name_for_block(ancestor)
-        if ancestor.method_name == :class_eval
+        if ancestor.method?(:class_eval)
           # `class_eval` with no receiver applies to whatever module or class
           # we are currently in
           return unless (receiver = ancestor.receiver)

--- a/lib/rubocop/ast/node/block_node.rb
+++ b/lib/rubocop/ast/node/block_node.rb
@@ -9,6 +9,8 @@ module RuboCop
     # A `block` node is essentially a method send with a block. Parser nests
     # the `send` node inside the `block` node.
     class BlockNode < Node
+      include MethodIdentifierPredicates
+
       VOID_CONTEXT_METHODS = %i[each tap].freeze
 
       # The `send` node associated with this block.

--- a/lib/rubocop/cop/internal_affairs.rb
+++ b/lib/rubocop/cop/internal_affairs.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'internal_affairs/method_name_equal'
 require_relative 'internal_affairs/node_destructuring'
 require_relative 'internal_affairs/node_type_predicate'
 require_relative 'internal_affairs/offense_location_keyword'

--- a/lib/rubocop/cop/internal_affairs/method_name_equal.rb
+++ b/lib/rubocop/cop/internal_affairs/method_name_equal.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module InternalAffairs
+      # Checks that method names are checked using `method?` method.
+      #
+      # @example
+      #   # bad
+      #   node.method_name == :do_something
+      #
+      #   # good
+      #   node.method?(:do_something)
+      #
+      class MethodNameEqual < Cop
+        include RangeHelp
+
+        MSG = 'Use `method?(%<method_name>s)` instead of ' \
+              '`method_name == %<method_name>s`.'
+
+        def_node_matcher :method_name?, <<~PATTERN
+          (send
+            $(send
+              (...) :method_name) :==
+            $...)
+        PATTERN
+
+        def on_send(node)
+          method_name?(node) do |method_name_node, method_name_arg|
+            message = format(MSG, method_name: method_name_arg.first.source)
+
+            range = range(method_name_node, node)
+
+            add_offense(node, location: range, message: message)
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            method_name?(node) do |method_name_node, method_name_arg|
+              corrector.replace(
+                range(method_name_node, node),
+                "method?(#{method_name_arg.first.source})"
+              )
+            end
+          end
+        end
+
+        private
+
+        def range(method_name_node, node)
+          range_between(
+            method_name_node.loc.selector.begin_pos, node.source_range.end_pos
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/layout/multiline_method_argument_line_breaks.rb
+++ b/lib/rubocop/cop/layout/multiline_method_argument_line_breaks.rb
@@ -26,7 +26,7 @@ module RuboCop
           'on a separate line.'
 
         def on_send(node)
-          return if node.method_name == :[]=
+          return if node.method?(:[]=)
 
           args = node.arguments
 

--- a/lib/rubocop/cop/lint/disjunctive_assignment_in_constructor.rb
+++ b/lib/rubocop/cop/lint/disjunctive_assignment_in_constructor.rb
@@ -33,7 +33,7 @@ module RuboCop
 
         # @param [DefNode] node a constructor definition
         def check(node)
-          return unless node.method_name == :initialize
+          return unless node.method?(:initialize)
 
           check_body(node.body)
         end

--- a/lib/rubocop/cop/lint/ineffective_access_modifier.rb
+++ b/lib/rubocop/cop/lint/ineffective_access_modifier.rb
@@ -117,7 +117,7 @@ module RuboCop
         end
 
         def correct_visibility?(node, modifier, ignored_methods)
-          return true if modifier.nil? || modifier.method_name == :public
+          return true if modifier.nil? || modifier.method?(:public)
 
           ignored_methods.include?(node.method_name)
         end

--- a/lib/rubocop/cop/lint/redundant_with_index.rb
+++ b/lib/rubocop/cop/lint/redundant_with_index.rb
@@ -50,7 +50,7 @@ module RuboCop
         def autocorrect(node)
           lambda do |corrector|
             redundant_with_index?(node) do |send|
-              if send.method_name == :each_with_index
+              if send.method?(:each_with_index)
                 corrector.replace(send.loc.selector, 'each')
               else
                 corrector.remove(with_index_range(send))
@@ -63,7 +63,7 @@ module RuboCop
         private
 
         def message(node)
-          if node.method_name == :each_with_index
+          if node.method?(:each_with_index)
             MSG_EACH_WITH_INDEX
           else
             MSG_WITH_INDEX

--- a/lib/rubocop/cop/lint/redundant_with_object.rb
+++ b/lib/rubocop/cop/lint/redundant_with_object.rb
@@ -51,7 +51,7 @@ module RuboCop
         def autocorrect(node)
           lambda do |corrector|
             redundant_with_object?(node) do |send|
-              if send.method_name == :each_with_object
+              if send.method?(:each_with_object)
                 corrector.replace(with_object_range(send), 'each')
               else
                 corrector.remove(with_object_range(send))
@@ -64,7 +64,7 @@ module RuboCop
         private
 
         def message(node)
-          if node.method_name == :each_with_object
+          if node.method?(:each_with_object)
             MSG_EACH_WITH_OBJECT
           else
             MSG_WITH_OBJECT

--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -175,7 +175,7 @@ module RuboCop
 
         def access_modifier?(node)
           node.bare_access_modifier? ||
-            node.method_name == :private_class_method
+            node.method?(:private_class_method)
         end
 
         def check_scope(node)
@@ -203,7 +203,7 @@ module RuboCop
         def check_send_node(node, cur_vis, unused)
           if node.bare_access_modifier?
             check_new_visibility(node, unused, node.method_name, cur_vis)
-          elsif node.method_name == :private_class_method && !node.arguments?
+          elsif node.method?(:private_class_method) && !node.arguments?
             add_offense(node, message: format(MSG, current: node.method_name))
             [cur_vis, unused]
           end

--- a/lib/rubocop/cop/lint/useless_setter_call.rb
+++ b/lib/rubocop/cop/lint/useless_setter_call.rb
@@ -155,7 +155,7 @@ module RuboCop
             return true if node.literal?
             return false unless node.send_type?
 
-            node.method_name == :new
+            node.method?(:new)
           end
         end
       end

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -20,7 +20,7 @@ module RuboCop
         alias on_defs on_def
 
         def on_block(node)
-          return unless node.send_node.method_name == :define_method
+          return unless node.send_node.method?(:define_method)
 
           check_code_length(node)
         end

--- a/lib/rubocop/cop/style/alias.rb
+++ b/lib/rubocop/cop/style/alias.rb
@@ -91,7 +91,7 @@ module RuboCop
             when :def, :defs
               return :dynamic
             when :block
-              return :instance_eval if parent.method_name == :instance_eval
+              return :instance_eval if parent.method?(:instance_eval)
 
               return :dynamic
             end

--- a/lib/rubocop/cop/style/eval_with_location.rb
+++ b/lib/rubocop/cop/style/eval_with_location.rb
@@ -85,7 +85,7 @@ module RuboCop
         # FIXME: It's a Style/ConditionalAssignment's false positive.
         # rubocop:disable Style/ConditionalAssignment
         def with_lineno?(node)
-          if node.method_name == :eval
+          if node.method?(:eval)
             node.arguments.size == 4
           else
             node.arguments.size == 3

--- a/lib/rubocop/cop/style/mixin_grouping.rb
+++ b/lib/rubocop/cop/style/mixin_grouping.rb
@@ -103,7 +103,7 @@ module RuboCop
                               .select(&:macro?)
 
           siblings.select do |sibling_node|
-            sibling_node.method_name == send_node.method_name
+            sibling_node.method?(send_node.method_name)
           end
         end
 

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -60,7 +60,7 @@ module RuboCop
             when :module
               return true
             else
-              return true if pnode.method_name == :instance_eval
+              return true if pnode.method?(:instance_eval)
             end
           end
           false

--- a/spec/rubocop/cop/internal_affairs/method_name_equal_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/method_name_equal_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::InternalAffairs::MethodNameEqual do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers an offense when using `#method == :do_something`' do
+    expect_offense(<<~RUBY)
+      node.method_name == :do_something
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `method?(:do_something)` instead of `method_name == :do_something`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node.method?(:do_something)
+    RUBY
+  end
+
+  it 'registers an offense when using `#method == other_node.do_something`' do
+    expect_offense(<<~RUBY)
+      node.method_name == other_node.do_something
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `method?(other_node.do_something)` instead of `method_name == other_node.do_something`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node.method?(other_node.do_something)
+    RUBY
+  end
+
+  it 'does not register an offense when using `#method?`' do
+    expect_no_offenses(<<~RUBY)
+      node.method?(:do_something)
+    RUBY
+  end
+end


### PR DESCRIPTION
This PR adds new `InternalAffairs/MethodNameEqual` cop.

```ruby
# bad
node.method_name == :do_something

# good
node.method?(:do_something)
```

This cop is an internal cop and will not be added to a changelog entry.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
