### PR TITLE
Workaround to skip some tests when using JRuby

### DIFF
--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -89,11 +89,20 @@ RSpec.describe RuboCop::Cop::Style::ParallelAssignment, :config do
   RUBY
   it_behaves_like('allowed', 'a, b = Float::INFINITY')
   it_behaves_like('allowed', 'a[0], a[1] = a[1], a[0]')
-  it_behaves_like('allowed', 'obj.attr1, obj.attr2 = obj.attr2, obj.attr1')
-  it_behaves_like('allowed', 'obj.attr1, ary[0] = ary[0], obj.attr1')
   it_behaves_like('allowed', 'ary[0], ary[1], ary[2] = ary[1], ary[2], ary[0]')
-  it_behaves_like('allowed', 'self.a, self.b = self.b, self.a')
-  it_behaves_like('allowed', 'self.a, self.b = b, a')
+
+  # FIXME: Remove `RUBY_ENGINE` condition, which works around
+  # a JRuby 9.2.9.0 regression:
+  # https://github.com/jruby/jruby/issues/5968
+  # Originally, both MRI and JRuby are successful tests.
+  # The tests fail as follows:
+  # https://circleci.com/gh/rubocop-hq/rubocop/74069
+  unless RUBY_ENGINE == 'jruby'
+    it_behaves_like('allowed', 'obj.attr1, obj.attr2 = obj.attr2, obj.attr1')
+    it_behaves_like('allowed', 'obj.attr1, ary[0] = ary[0], obj.attr1')
+    it_behaves_like('allowed', 'self.a, self.b = self.b, self.a')
+    it_behaves_like('allowed', 'self.a, self.b = b, a')
+  end
 
   it 'highlights the entire expression' do
     expect_offense(<<~RUBY)


### PR DESCRIPTION
This PR adds a workaround that skips some tests when using JRuby to stabilize CI.

### JRuby 9.2.8.0

All tests are successful.

```console
% ruby -v
jruby 9.2.8.0 (2.5.3) 2019-08-12 a1ac7ff Java HotSpot(TM) 64-Bit Server
VM 25.5-b02 on 1.8.0_05-b13 +jit [darwin-x86_64]

% bundle exec rspec ./spec/rubocop/cop/style/parallel_assignment_spec.rb

(snip)

Finished in 2.19 seconds (files took 7.43 seconds to load)
89 examples, 0 failures

Randomized with seed 46036
```

### JRuby 9.2.9.0

Four tests fail. The following fails with JRuby 9.2.9.0.

```console
% ruby -v
jruby 9.2.9.0 (2.5.7) 2019-10-30 458ad3e Java HotSpot(TM) 64-Bit Server
VM 25.5-b02 on 1.8.0_05-b13 +jit [darwin-x86_64]

% bundle exec rspec ./spec/rubocop/cop/style/parallel_assignment_spec.rb

(snip)

Failures:

  1) RuboCop::Cop::Style::ParallelAssignment behaves like allowed allows
  assignment of: self.a, self.b = b, a
     Failure/Error: expect(actual_annotations.to_s).to eq(source)

       expected: "self.a, self.b = b, a"
            got: "self.a, self.b = b, a^^^^^^^^^^^^^^^^^^^^^ Do not use
            parallel assignment.\n"

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -self.a, self.b = b, a
       +self.a, self.b = b, a^^^^^^^^^^^^^^^^^^^^^ Do not use parallel
       assignment.

     Shared Example Group: "allowed" called from
     ./spec/rubocop/cop/style/parallel_assignment_spec.rb:96
     # ./lib/rubocop/rspec/expect_offense.rb:138:in `expect_no_offenses'
     # ./spec/rubocop/cop/style/parallel_assignment_spec.rb:54:in `block
     in <main>'

  2) RuboCop::Cop::Style::ParallelAssignment behaves like allowed allows
  assignment of: self.a, self.b = self.b, self.a
     Failure/Error: expect(actual_annotations.to_s).to eq(source)

       expected: "self.a, self.b = self.b, self.a"
            got: "self.a, self.b = self.b,
            self.a^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use parallel
            assignment.\n"

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -self.a, self.b = self.b, self.a
       +self.a, self.b = self.b, self.a^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       Do not use parallel assignment.

     Shared Example Group: "allowed" called from
     ./spec/rubocop/cop/style/parallel_assignment_spec.rb:95
     # ./lib/rubocop/rspec/expect_offense.rb:138:in `expect_no_offenses'
     # ./spec/rubocop/cop/style/parallel_assignment_spec.rb:54:in `block
     in <main>'

  3) RuboCop::Cop::Style::ParallelAssignment behaves like allowed allows
  assignment of: obj.attr1, ary[0] = ary[0], obj.attr1
     Failure/Error: expect(actual_annotations.to_s).to eq(source)

       expected: "obj.attr1, ary[0] = ary[0], obj.attr1"
            got: "obj.attr1, ary[0] = ary[0],
            obj.attr1^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use
            parallel assignment.\n"

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -obj.attr1, ary[0] = ary[0], obj.attr1
       +obj.attr1, ary[0] = ary[0],
       obj.attr1^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use
       parallel assignment.

     Shared Example Group: "allowed" called from
     ./spec/rubocop/cop/style/parallel_assignment_spec.rb:93
     # ./lib/rubocop/rspec/expect_offense.rb:138:in `expect_no_offenses'
     # ./spec/rubocop/cop/style/parallel_assignment_spec.rb:54:in `block
     in <main>'

  4) RuboCop::Cop::Style::ParallelAssignment behaves like allowed allows
  assignment of: obj.attr1, obj.attr2 = obj.attr2, obj.attr1
     Failure/Error: expect(actual_annotations.to_s).to eq(source)

       expected: "obj.attr1, obj.attr2 = obj.attr2, obj.attr1"
            got: "obj.attr1, obj.attr2 = obj.attr2,
            obj.attr1^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not
            use parallel assignment.\n"

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -obj.attr1, obj.attr2 = obj.attr2, obj.attr1
       +obj.attr1, obj.attr2 = obj.attr2,
       obj.attr1^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use
       parallel assignment.

     Shared Example Group: "allowed" called from
     ./spec/rubocop/cop/style/parallel_assignment_spec.rb:92
     # ./lib/rubocop/rspec/expect_offense.rb:138:in `expect_no_offenses'
     # ./spec/rubocop/cop/style/parallel_assignment_spec.rb:54:in `block
     in <main>'

Finished in 3.54 seconds (files took 7.74 seconds to load)
89 examples, 4 failures

Failed examples:

rspec './spec/rubocop/cop/style/parallel_assignment_spec.rb[1:52:1]' #
RuboCop::Cop::Style::ParallelAssignment behaves like allowed allows
assignment of: obj.attr1, ary[0] = ary[0], obj.attr1
rspec './spec/rubocop/cop/style/parallel_assignment_spec.rb[1:55:1]' #
RuboCop::Cop::Style::ParallelAssignment behaves like allowed allows
assignment of: self.a, self.b = b, a
rspec './spec/rubocop/cop/style/parallel_assignment_spec.rb[1:54:1]' #
RuboCop::Cop::Style::ParallelAssignment behaves like allowed allows
assignment of: self.a, self.b = self.b, self.a
rspec './spec/rubocop/cop/style/parallel_assignment_spec.rb[1:51:1]' #
RuboCop::Cop::Style::ParallelAssignment behaves like allowed allows
assignment of: obj.attr1, obj.attr2 = obj.attr2, obj.attr1

Randomized with seed 40690
```

Originally, both MRI and JRuby are successful tests.
The cause needs to be investigated and feedback to JRuby.

The tests fail as follows:
https://circleci.com/gh/rubocop-hq/rubocop/74069

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
