### PR TITLE
Typo fix in Style/ArrayJoin docs

### DIFF
--- a/lib/rubocop/cop/style/array_join.rb
+++ b/lib/rubocop/cop/style/array_join.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for uses of "*" as a substitute for *join*.
+      # This cop checks for uses of "\*" as a substitute for *join*.
       #
       # Not all cases can reliably checked, due to Ruby's dynamic
       # types, so we consider only cases when the first argument is an

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -170,7 +170,7 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 --- | --- | --- | --- | ---
 Enabled | Yes | Yes  | 0.20 | 0.31
 
-This cop checks for uses of "*" as a substitute for *join*.
+This cop checks for uses of "\*" as a substitute for *join*.
 
 Not all cases can reliably checked, due to Ruby's dynamic
 types, so we consider only cases when the first argument is an


### PR DESCRIPTION
Just a markdown syntax fix

I'm not totally sure if I should add a changelog entry given that this is one character in docs, but if you want I am happy to.

-----------------

Before submitting the PR make sure the following are checked:

* [*] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [*] Feature branch is up-to-date with `master` (if not - rebase it).
* [*] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [*] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [*] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
