### PR TITLE
[Fix #7493] Detect redundant returns at end of longer methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#7493](https://github.com/rubocop-hq/rubocop/issues/7493): Fix `Style/RedundantReturn` to inspect conditional constructs that are preceded by other statements. ([@buehmann][])
+
 ### Changes
 
 * [#7077](https://github.com/rubocop-hq/rubocop/issues/7077): **(Breaking)** Further standardisation of cop names. ([@scottmatthewman][])

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -54,8 +54,6 @@ module RuboCop
         MULTI_RETURN_MSG = 'To return multiple values, use an array.'
 
         def on_def(node)
-          return unless node.body
-
           check_branch(node.body)
         end
         alias on_defs on_def
@@ -152,12 +150,8 @@ module RuboCop
         end
 
         def check_begin_node(node)
-          expressions = *node
-          last_expr = expressions.last
-
-          return unless last_expr&.return_type?
-
-          check_return_node(last_expr)
+          last_expr = node.children.last
+          check_branch(last_expr)
         end
 
         def allow_multiple_return_values?

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -28,8 +28,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
   it 'reports an offense for def ending with return' do
     expect_offense(<<~RUBY)
       def func
-        one
-        two
+        some_preceding_statements
         return something
         ^^^^^^ Redundant `return` detected.
       end
@@ -39,8 +38,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
   it 'reports an offense for defs ending with return' do
     expect_offense(<<~RUBY)
       def self.func
-        one
-        two
+        some_preceding_statements
         return something
         ^^^^^^ Redundant `return` detected.
       end
@@ -271,6 +269,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
     let(:src) do
       <<~RUBY
         def func
+          some_preceding_statements
           begin
             return 1
           end
@@ -281,6 +280,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         def func
+          some_preceding_statements
           begin
             return 1
             ^^^^^^ Redundant `return` detected.
@@ -293,6 +293,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
       corrected = autocorrect_source(src)
       expect(corrected).to eq <<~RUBY
         def func
+          some_preceding_statements
           begin
             1
           end
@@ -362,6 +363,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
     let(:src) do
       <<~RUBY
         def func
+          some_preceding_statements
           if x
             return 1
           elsif y
@@ -376,6 +378,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         def func
+          some_preceding_statements
           if x
             return 1
             ^^^^^^ Redundant `return` detected.
@@ -394,6 +397,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
       corrected = autocorrect_source(src)
       expect(corrected).to eq <<~RUBY
         def func
+          some_preceding_statements
           if x
             1
           elsif y
@@ -410,6 +414,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
     let(:src) do
       <<~RUBY
         def func
+          some_preceding_statements
           case x
           when y then return 1
           when z then return 2
@@ -424,6 +429,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         def func
+          some_preceding_statements
           case x
           when y then return 1
                       ^^^^^^ Redundant `return` detected.
@@ -442,6 +448,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
       corrected = autocorrect_source(src)
       expect(corrected).to eq <<~RUBY
         def func
+          some_preceding_statements
           case x
           when y then 1
           when z then 2


### PR DESCRIPTION
This fixes #7493.