### PR TITLE
Allow cops to invalidate results cache

### DIFF
--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -217,6 +217,25 @@ module RuboCop
         !relevant_file?(file)
       end
 
+      # This method should be overriden when a cop's behavior depends
+      # on state that lives outside of these locations:
+      #
+      #   (1) the file under inspection
+      #   (2) the cop's source code
+      #   (3) the config (eg a .rubocop.yml file)
+      #
+      # For example, some cops may want to look at other parts of
+      # the codebase being inspected to find violations. A cop may
+      # use the presence or absence of file `foo.rb` to determine
+      # whether a certain violation exists in `bar.rb`.
+      #
+      # Overriding this method allows the cop to indicate to RuboCop's
+      # ResultCache system when those external dependencies change,
+      # ie when the ResultCache should be invalidated.
+      def external_dependency_checksum
+        nil
+      end
+
       private
 
       def find_message(node, message)

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -86,6 +86,11 @@ module RuboCop
         raise e.cause
       end
 
+      def external_dependency_checksum
+        keys = cops.map(&:external_dependency_checksum).compact
+        Digest::SHA1.hexdigest(keys.join)
+      end
+
       private
 
       def offenses(processed_source)

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -4,7 +4,17 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
   include FileHelper
 
   subject(:cache) do
-    described_class.new(file, options, config_store, cache_root)
+    described_class.new(file, team, options, config_store, cache_root)
+  end
+
+  let(:cops) { RuboCop::Cop::Cop.all }
+  let(:registry) { RuboCop::Cop::Cop.registry }
+  let(:team) do
+    RuboCop::Cop::Team.new(
+      registry,
+      RuboCop::ConfigLoader.default_configuration,
+      options
+    )
   end
 
   let(:file) { 'example.rb' }
@@ -34,13 +44,16 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
     RUBY
     allow(config_store).to receive(:for).with('example.rb')
                                         .and_return(RuboCop::Config.new)
+    allow(team).to receive(:external_dependency_checksum).and_return('foo')
   end
 
   describe 'cached result that was saved with no command line option' do
     shared_examples 'valid' do
       it 'is valid and can be loaded' do
         cache.save(offenses)
-        cache2 = described_class.new(file, options2, config_store, cache_root)
+        cache2 = described_class.new(
+          file, team, options2, config_store, cache_root
+        )
         expect(cache2.valid?).to eq(true)
         saved_offenses = cache2.load
         expect(saved_offenses).to eq(offenses)
@@ -79,7 +92,9 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
         it 'is invalid' do
           cache.save(offenses)
           create_file('example.rb', ['x = 2'])
-          cache2 = described_class.new(file, options, config_store, cache_root)
+          cache2 = described_class.new(
+            file, team, options, config_store, cache_root
+          )
           expect(cache2.valid?).to eq(false)
         end
       end
@@ -89,7 +104,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
           it 'is invalid' do
             cache.save(offenses)
             FileUtils.chmod('+x', file)
-            cache2 = described_class.new(file, options,
+            cache2 = described_class.new(file, team, options,
                                          config_store, cache_root)
             expect(cache2.valid?).to eq(false)
           end
@@ -107,15 +122,41 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
               f.write(contents.gsub(/\n/, "\r\n"))
             end
           end
-          cache2 = described_class.new(file, options,
+          cache2 = described_class.new(file, team, options,
                                        config_store, cache_root)
           expect(cache2.valid?).to eq(false)
         end
       end
 
+      context 'when team external_dependency_checksum changes' do
+        it 'is invalid' do
+          cache.save(offenses)
+          expect(team).to(
+            receive(:external_dependency_checksum).and_return('bar')
+          )
+          cache2 = described_class.new(
+            file, team, options, config_store, cache_root
+          )
+          expect(cache2.valid?).to eq(false)
+        end
+      end
+
+      context 'when team external_dependency_checksum is the same' do
+        it 'is valid' do
+          cache.save(offenses)
+          expect(team).to(
+            receive(:external_dependency_checksum).and_return('foo')
+          )
+          cache2 = described_class.new(
+            file, team, options, config_store, cache_root
+          )
+          expect(cache2.valid?).to eq(true)
+        end
+      end
+
       context 'when a symlink is present in the cache location' do
         let(:cache2) do
-          described_class.new(file, options, config_store, cache_root)
+          described_class.new(file, team, options, config_store, cache_root)
         end
 
         let(:attack_target_dir) { Dir.mktmpdir }
@@ -128,12 +169,10 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
           end
 
           cache.save(offenses)
-          Find.find(cache_root) do |path|
-            next unless File.basename(path) == '_'
-
-            FileUtils.rm_rf(path)
-            FileUtils.ln_s(attack_target_dir, path)
-          end
+          result = Dir["#{cache_root}/*/*"]
+          path = result.first
+          FileUtils.rm_rf(path)
+          FileUtils.ln_s(attack_target_dir, path)
           $stderr = StringIO.new
         end
 
@@ -184,7 +223,8 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
     context 'when --only is given' do
       it 'is invalid' do
         cache.save(offenses)
-        cache2 = described_class.new(file, { only: ['Metrics/LineLength'] },
+        cache2 = described_class.new(file, team,
+                                     { only: ['Metrics/LineLength'] },
                                      config_store, cache_root)
         expect(cache2.valid?).to eq(false)
       end
@@ -193,7 +233,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
     context 'when --display-cop-names is given' do
       it 'is invalid' do
         cache.save(offenses)
-        cache2 = described_class.new(file, { display_cop_names: true },
+        cache2 = described_class.new(file, team, { display_cop_names: true },
                                      config_store, cache_root)
         expect(cache2.valid?).to eq(false)
       end
@@ -262,14 +302,14 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
 
     it 'removes the oldest files in the cache if needed' do
       cache.save(offenses)
-      cache2 = described_class.new('other.rb', options, config_store,
+      cache2 = described_class.new('other.rb', team, options, config_store,
                                    cache_root)
-      expect(Dir["#{cache_root}/*/_/*"].size).to eq(1)
+      expect(Dir["#{cache_root}/*/*/*"].size).to eq(1)
       cache.class.cleanup(config_store, :verbose, cache_root)
       expect($stdout.string).to eq('')
 
       cache2.save(offenses)
-      underscore_dir = Dir["#{cache_root}/*/_"].first
+      underscore_dir = Dir["#{cache_root}/*/*"].first
       expect(Dir["#{underscore_dir}/*"].size).to eq(2)
       cache.class.cleanup(config_store, :verbose, cache_root)
       expect(File.exist?(underscore_dir)).to be_falsey


### PR DESCRIPTION
Internally at Flexport, we've written a few cops to enforce Rails Engine isolation. They've helped us incrementally modularize our system, and we think they might be valuable to others too. I'm working to open source them now.

For example, `GlobalModelAccessFromEngine` (https://github.com/flexport/rubocop-flexport/pull/5) forbids code within Rails Engines from directly accessing global models in the main `app/` directory. Another example is `EngineApiBoundary` (https://github.com/flexport/rubocop-flexport/pull/6).

(Note: we considered upstream these to `rubocop-rails`, and @koic suggested we create our gem instead: https://github.com/rubocop-hq/rubocop-rails/pull/152#issuecomment-554839724)

These cops read from the filesystem, taking a holistic view of our codebase while they inspect. Unfortunately, this approach does not play nice with the RuboCop results cache. As a workaround, we created a custom `lint.rb` that wraps `rubocop` and busts the cache when needed using the `--cache` param. It works ok.

But it's not ideal, especially for broader use. This PR aims to fix the issue at its source by allowing cops themselves to invalidate the cache.

## Example

Consider the following example:

(1) A filesystem contains these files:

```
app/models/my_model.rb
engines/my_engine/app/services/my_engine/my_service.rb
```

(2) We run `rubocop engines/my_engine/app/services/my_engine/my_service.rb` and find a violation -- `service.rb` contains `MyModel.find(123)`. 

(2b) During that run, a cached result is stored, keyed by: the inspected source code, the RuboCop config, command-line options, and executable version.

(3) We run the same command again. Cache is hit, same violation shown. All good.

(4) We move the model file into the engine. So now `app/models/my_model.rb` no longer exists and we have `engines/my_engine/app/models/my_engine/my_model.rb`.

(5) We run the same RuboCop command again. Because none of the cache key inputs changed, _the same violation is shown again_. This is incorrect.

(6) We run the same command again with `--cache false` and see that the violation no longer exists. This is correct.

## Implementation overview

This PR allows cops to define an `external_dependency_checksum` method that busts the cache when their external dependencies change. Cops are responsible for computing their own checksum however they deem appropriate.

Among existing cops, I believe there are no use cases for this method. For the cops we've written, there are two types of external dependencies: (1) the presence or absence of certain files and/or (2) the contents of certain files.

## Discussion

I recognize that this is perhaps an unusual use case for RuboCop. As an alternative, we could create our own repo with these cache-unfriendly cops and package them with a custom runner script that does cache busting inside the script. But that seems suboptimal. And I suspect other cops may make use of this feature in the future as well.

Feedback welcome! Thanks!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
