### PR TITLE
[Fix #7477] Fix semicolon line length autocorrection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 * [#7469](https://github.com/rubocop-hq/rubocop/pull/7469): **(Breaking)** Replace usages of the terms `Whitelist` and `Blacklist` with better alternatives. ([@koic][])
 * [#7502](https://github.com/rubocop-hq/rubocop/pull/7502): Remove `SafeMode` module. ([@koic][])
 
+### Bug fixes
+
+* [#7477](https://github.com/rubocop-hq/rubocop/issues/7477): Fix line length autocorrect for semicolons in string literals. ([@maxh][])
+
 ## 0.76.0 (2019-10-28)
 
 ### Bug fixes

--- a/spec/rubocop/cop/metrics/line_length_spec.rb
+++ b/spec/rubocop/cop/metrics/line_length_spec.rb
@@ -735,7 +735,7 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
       end
 
       context 'when over limit' do
-        it 'adds offense and autocorrects it by breaking the semicolon ' \
+        it 'adds offense and autocorrects it by breaking the semicolon' \
           'before the hash' do
           expect_offense(<<~RUBY)
             {foo: 1, bar: "2"}; a = 400000000000 + 500000000000000
@@ -748,6 +748,106 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
           RUBY
         end
       end
+
+      context 'when over limit and semicolon at end of line' do
+        it 'adds offense and autocorrects it by breaking the first semicolon' \
+          'before the hash' do
+          expect_offense(<<~RUBY)
+            {foo: 1, bar: "2"}; a = 400000000000 + 500000000000000;
+                                                    ^^^^^^^^^^^^^^^ Line is too long. [55/40]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            {foo: 1, bar: "2"};
+             a = 400000000000 + 500000000000000;
+          RUBY
+        end
+      end
+
+      context 'when over limit and many spaces around semicolon' do
+        it 'adds offense and autocorrects it by breaking the semicolon' \
+          'before the hash' do
+          expect_offense(<<~RUBY)
+            {foo: 1, bar: "2"}  ;   a = 400000000000 + 500000000000000
+                                                    ^^^^^^^^^^^^^^^^^^ Line is too long. [58/40]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            {foo: 1, bar: "2"}  ;
+               a = 400000000000 + 500000000000000
+          RUBY
+        end
+      end
+
+      context 'when over limit and many semicolons' do
+        it 'adds offense and autocorrects it by breaking the semicolon' \
+          'before the hash' do
+          expect_offense(<<~RUBY)
+            {foo: 1, bar: "2"}  ;;; a = 400000000000 + 500000000000000
+                                                    ^^^^^^^^^^^^^^^^^^ Line is too long. [58/40]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            {foo: 1, bar: "2"}  ;;;
+             a = 400000000000 + 500000000000000
+          RUBY
+        end
+      end
+
+      context 'when over limit and one semicolon at the end' do
+        it 'adds offense and does not autocorrect' \
+          'before the hash' do
+          expect_offense(<<~RUBY)
+            a = 400000000000 + 500000000000000000000;
+                                                    ^ Line is too long. [41/40]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            a = 400000000000 + 500000000000000000000;
+          RUBY
+        end
+      end
+
+      context 'when over limit and many semicolons at the end' do
+        it 'adds offense and does not autocorrect' \
+          'before the hash' do
+          expect_offense(<<~RUBY)
+            a = 400000000000 + 500000000000000000000;;;;;;;
+                                                    ^^^^^^^ Line is too long. [47/40]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            a = 400000000000 + 500000000000000000000;;;;;;;
+          RUBY
+        end
+      end
+
+      context 'semicolon inside string literal' do
+        it 'adds offense and autocorrects elsewhere' do
+          expect_offense(<<~RUBY)
+            FooBar.new(baz: 30, bat: 'publisher_group:123;publisher:456;s:123')
+                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [67/40]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            FooBar.new(baz: 30,\s
+            bat: 'publisher_group:123;publisher:456;s:123')
+          RUBY
+        end
+      end
+
+      context 'semicolons  inside string literal' do
+        it 'adds offense and autocorrects elsewhere' do
+          expect_offense(<<~RUBY)
+            "00000000000000000;0000000000000000000'000000;00000'0000;0000;000"
+                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [66/40]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            "00000000000000000;0000000000000000000'000000;00000'0000;0000;000"
+          RUBY
+        end
+      end
     end
 
     context 'HEREDOC' do
@@ -755,7 +855,7 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
         { 'Max' => 40, 'AllowURI' => false, 'AllowHeredoc' => false }
       end
 
-      context 'when over limit with semi-colon' do
+      context 'when over limit with semicolon' do
         it 'adds offense and does not autocorrect' do
           expect_offense(<<~RUBY)
             foo = <<-SQL
@@ -774,7 +874,7 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
     end
 
     context 'comments' do
-      context 'when over limit with semi-colon' do
+      context 'when over limit with semicolon' do
         it 'adds offense and does not autocorrect' do
           expect_offense(<<~RUBY)
             # a b c d a b c d a b c d ; a b c d a b c d a b c d a


### PR DESCRIPTION
Fixes https://github.com/rubocop-hq/rubocop/issues/7477. Previously the cop naively checked for the character `;` anywhere in the source code, which would match semicolons within string literals and cause correctness issues.

Now the cop instead uses the tokenizer output to find semicolons.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
