### PR TITLE
Autofix for Style/StructInheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#7786](https://github.com/rubocop-hq/rubocop/pull/7786): Support Ruby 2.7's pattern match for `Layout/ElseAlignment` cop. ([@koic][])
 * [#7784](https://github.com/rubocop-hq/rubocop/pull/7784): Support Ruby 2.7's numbered parameter for `Lint/SafeNavigationChain`. ([@koic][])
 * [#7331](https://github.com/rubocop-hq/rubocop/issues/7331): Add `forbidden` option to `Style/ModuleFunction` cop. ([@weh][])
+* [#7499](https://github.com/rubocop-hq/rubocop/pull/7499): Autocorrection for `Style/StructInheritance`. ([@bubaflub][])
 
 ### Bug fixes
 
@@ -4411,3 +4412,4 @@
 [@nikitasakov]: https://github.com/nikitasakov
 [@dmolesUC]: https://github.com/dmolesUC
 [@yuritomanek]: https://github.com/yuritomanek
+[@bubaflub]: https://github.com/bubaflub

--- a/config/default.yml
+++ b/config/default.yml
@@ -3758,7 +3758,9 @@ Style/StructInheritance:
   Description: 'Checks for inheritance from Struct.new.'
   StyleGuide: '#no-extend-struct-new'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.29'
+  VersionChanged: '0.81'
 
 Style/SymbolArray:
   Description: 'Use %i or %I for arrays of symbols.'

--- a/lib/rubocop/ast/node/class_node.rb
+++ b/lib/rubocop/ast/node/class_node.rb
@@ -6,9 +6,9 @@ module RuboCop
     # node when the builder constructs the AST, making its methods available
     # to all `class` nodes within RuboCop.
     class ClassNode < Node
-      # The identifer for this `class` node.
+      # The identifier for this `class` node.
       #
-      # @return [Node] the identifer of the class
+      # @return [Node] the identifier of the class
       def identifier
         node_parts[0]
       end

--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -20,6 +20,8 @@ module RuboCop
       #     end
       #   end
       class StructInheritance < Cop
+        include RangeHelp
+
         MSG = "Don't extend an instance initialized by `Struct.new`. " \
               'Use a block to customize the struct.'
 
@@ -33,6 +35,48 @@ module RuboCop
           {(send (const nil? :Struct) :new ...)
            (block (send (const nil? :Struct) :new ...) ...)}
         PATTERN
+
+        def autocorrect(class_node)
+          lambda do |corrector|
+            return nil if struct_definition_has_block?(class_node)
+
+            remove_class_keyword(class_node, corrector)
+
+            corrector.replace(class_node.loc.operator, '=')
+
+            transform_class_body(class_node, corrector)
+          end
+        end
+
+        private
+
+        def struct_definition_has_block?(class_node)
+          class_node.parent_class.is_a?(RuboCop::AST::BlockNode)
+        end
+
+        def remove_class_keyword(class_node, corrector)
+          corrector.remove(
+            range_with_surrounding_space(
+              range: class_node.loc.keyword,
+              side: :right
+            )
+          )
+        end
+
+        def transform_class_body(class_node, corrector)
+          body = class_node.body
+
+          if body
+            corrector.insert_after(class_node.parent_class.source_range, ' do')
+          else
+            corrector.remove(
+              range_with_surrounding_space(
+                range: class_node.loc.end,
+                side: :right
+              )
+            )
+          end
+        end
       end
     end
   end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -6747,7 +6747,7 @@ This cop identifies places where `lstrip.rstrip` can be replaced by
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.29 | -
+Enabled | Yes | Yes (Unsafe) | 0.29 | 0.81
 
 This cop checks for inheritance from Struct.new.
 

--- a/spec/rubocop/cop/style/struct_inheritance_spec.rb
+++ b/spec/rubocop/cop/style/struct_inheritance_spec.rb
@@ -46,4 +46,66 @@ RSpec.describe RuboCop::Cop::Style::StructInheritance do
       end
     RUBY
   end
+
+  it 'autocorrects simple inline class with no block' do
+    new_source = autocorrect_source(<<~RUBY)
+      class Person < Struct.new(:first_name, :last_name)
+      end
+    RUBY
+
+    expect(new_source).to eq(<<~RUBY)
+      Person = Struct.new(:first_name, :last_name)
+    RUBY
+  end
+
+  it 'autocorrects a class with a body' do
+    new_source = autocorrect_source(<<~RUBY)
+      class Person < Struct.new(:first_name, :last_name)
+        def age
+          42
+        end
+      end
+    RUBY
+
+    expect(new_source).to eq(<<~RUBY)
+      Person = Struct.new(:first_name, :last_name) do
+        def age
+          42
+        end
+      end
+    RUBY
+  end
+
+  it 'ignores a class with an empty block and empty body' do
+    original_source = <<~RUBY
+      class Person < Struct.new(:first_name, :last_name) do end
+      end
+    RUBY
+
+    expect(autocorrect_source(original_source)).to eq(original_source)
+  end
+
+  it 'ignores a class with a body and an empty block' do
+    original_source = <<~RUBY
+      class Person < Struct.new(:first_name, :last_name) do end
+        def age
+          42
+        end
+      end
+    RUBY
+
+    expect(autocorrect_source(original_source)).to eq(original_source)
+  end
+
+  it 'ignores a class with a body and a block' do
+    original_source = <<~RUBY
+      class Person < Struct.new(:first_name, :last_name) do def baz; end end
+        def age
+          42
+        end
+      end
+    RUBY
+
+    expect(autocorrect_source(original_source)).to eq(original_source)
+  end
 end


### PR DESCRIPTION
Adds an autofix for `Style/StructInheritance`.

This is my first attempt at writing developing on Rubocop so I'm open to any suggestions.  In particular I know that the autofix method is currently violating `Metrics/AbcSize` and `Metrics/MethodLength` but I'm unsure of the best way to fix this.  Should I pull out some of the fixes in to private methods in the checker?  I think that would address at least some of those violations.

I'm also sure there's a better way to do the autofix itself.  Removing the `class` keyword and changing the `<` operator to an `=` is simple enough, but I seem to sometimes be losing the `do` of a block that is passed in.  Maybe there's a different part of the AST I should be operating on.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
