### PR TITLE
Fix an obsoletion misconfig that inadvertently blocks use of `Layout/FirstParameterIndentation`

### DIFF
--- a/lib/rubocop/config_obsoletion.rb
+++ b/lib/rubocop/config_obsoletion.rb
@@ -8,7 +8,6 @@ module RuboCop
       'Layout/AlignArray' => 'Layout/ArrayAlignment',
       'Layout/AlignHash' => 'Layout/HashAlignment',
       'Layout/AlignParameters' => 'Layout/ParameterAlignment',
-      'Layout/FirstParameterIndentation' => 'Layout/FirstArgumentIndentation',
       'Layout/IndentArray' => 'Layout/FirstArrayElementIndentation',
       'Layout/IndentAssignment' => 'Layout/AssignmentIndentation',
       'Layout/IndentFirstArgument' => 'Layout/FirstArgumentIndentation',

--- a/spec/rubocop/config_obsoletion_spec.rb
+++ b/spec/rubocop/config_obsoletion_spec.rb
@@ -90,8 +90,6 @@ RSpec.describe RuboCop::ConfigObsoletion do
           (obsolete configuration found in example/.rubocop.yml, please update it)
           The `Layout/AlignParameters` cop has been renamed to `Layout/ParameterAlignment`.
           (obsolete configuration found in example/.rubocop.yml, please update it)
-          The `Layout/FirstParameterIndentation` cop has been renamed to `Layout/FirstArgumentIndentation`.
-          (obsolete configuration found in example/.rubocop.yml, please update it)
           The `Layout/IndentArray` cop has been renamed to `Layout/FirstArrayElementIndentation`.
           (obsolete configuration found in example/.rubocop.yml, please update it)
           The `Layout/IndentAssignment` cop has been renamed to `Layout/AssignmentIndentation`.


### PR DESCRIPTION
In April 2019, "Add IndentFirstArgument and IndentFirstParameter" https://github.com/rubocop-hq/rubocop/pull/6982 forked the existing `FirstParameterIndentation` cop into two and added new argument-related functionality.

A few weeks ago, these two cops were renamed as part of broad renaming effort (https://github.com/rubocop-hq/rubocop/issues/7077), and it just so happened `IndentFirstParameter` now has the name of the old pre-forked cop.

https://github.com/rubocop-hq/rubocop/pull/7468/files#diff-a19f978b95beb4caeb1831d6bef7e443R11

The obsoletion config now thinks the two forked cops are the same, but they are not. When I try to run RuboCop locally from master against our codebase, I get this spurious warning:

```
Error: The `Layout/FirstParameterIndentation` cop has been renamed to `Layout/FirstArgumentIndentation`.
(obsolete configuration found in .rubocop.yml, please update it)
```

This PR should fix that.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
