### PR TITLE
Restyle example formatting for `Style/NumericLiterals`

### DIFF
--- a/lib/rubocop/cop/style/numeric_literals.rb
+++ b/lib/rubocop/cop/style/numeric_literals.rb
@@ -9,18 +9,22 @@ module RuboCop
       # @example
       #
       #   # bad
-      #
       #   1000000
       #   1_00_000
       #   1_0000
       #
       #   # good
-      #
       #   1_000_000
       #   1000
       #
-      #   # good unless Strict is set
+      # @example Strict: false (default)
       #
+      #   # good
+      #   10_000_00 # typical representation of $10,000 in cents
+      #
+      # @example Strict: true
+      #
+      #   # bad
       #   10_000_00 # typical representation of $10,000 in cents
       #
       class NumericLiterals < Cop

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4549,18 +4549,24 @@ of digits in them.
 
 ```ruby
 # bad
-
 1000000
 1_00_000
 1_0000
 
 # good
-
 1_000_000
 1000
+```
+#### Strict: false (default)
 
-# good unless Strict is set
+```ruby
+# good
+10_000_00 # typical representation of $10,000 in cents
+```
+#### Strict: true
 
+```ruby
+# bad
 10_000_00 # typical representation of $10,000 in cents
 ```
 


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This PR is a change of document format for `Style/NumericLiterals` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
