### PR TITLE
Add migration department to ToC of manual

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ pages:
     - Layout Cops: cops_layout.md
     - Linting Cops: cops_lint.md
     - Metrics Cops: cops_metrics.md
+    - Migration Cops: cops_migration.md
     - Naming Cops: cops_naming.md
     - Security Cops: cops_security.md
     - Style Cops: cops_style.md


### PR DESCRIPTION
Migration department is introduced by https://github.com/rubocop-hq/rubocop/pull/7385, but the ToC of the manual does not contain the department.

![191115130103](https://user-images.githubusercontent.com/4361134/68916149-0e0f3800-07a8-11ea-956c-0cc5f414f94c.png)

This pull request adds Migration department to the ToC.


note: I've noticed this problem with an article (Japanese) :heart:  https://qiita.com/sakuraya/items/e8089c6c824716c156d9#migrationdepartmentname