### PR TITLE
Fix typo in Layout/FirstArrayElementIndentation

### DIFF
--- a/lib/rubocop/cop/layout/first_array_element_indentation.rb
+++ b/lib/rubocop/cop/layout/first_array_element_indentation.rb
@@ -22,7 +22,7 @@ module RuboCop
       # @example EnforcedStyle: special_inside_parentheses (default)
       #   # The `special_inside_parentheses` style enforces that the first
       #   # element in an array literal where the opening bracket and first
-      #   # element are on seprate lines is indented one step (two spaces) more
+      #   # element are on separate lines is indented one step (two spaces) more
       #   # than the position inside the opening parenthesis.
       #
       #   #bad
@@ -44,7 +44,7 @@ module RuboCop
       # @example EnforcedStyle: consistent
       #   # The `consistent` style enforces that the first element in an array
       #   # literal where the opening bracket and the first element are on
-      #   # seprate lines is indented the same as an array literal which is not
+      #   # separate lines is indented the same as an array literal which is not
       #   # defined inside a method call.
       #
       #   #bad

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -1887,7 +1887,7 @@ styles are 'consistent' and 'align_brackets'. Here are examples:
 ```ruby
 # The `special_inside_parentheses` style enforces that the first
 # element in an array literal where the opening bracket and first
-# element are on seprate lines is indented one step (two spaces) more
+# element are on separate lines is indented one step (two spaces) more
 # than the position inside the opening parenthesis.
 
 #bad
@@ -1911,7 +1911,7 @@ but_in_a_method_call([
 ```ruby
 # The `consistent` style enforces that the first element in an array
 # literal where the opening bracket and the first element are on
-# seprate lines is indented the same as an array literal which is not
+# separate lines is indented the same as an array literal which is not
 # defined inside a method call.
 
 #bad


### PR DESCRIPTION
Little fix for a typo I found while reading the docs. 🎈

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
