### PR TITLE
[Fix #7509] Layout/SpaceInsideArrayLiteralBrackets to correct empty lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#7493](https://github.com/rubocop-hq/rubocop/issues/7493): Fix `Style/RedundantReturn` to inspect conditional constructs that are preceded by other statements. ([@buehmann][])
+* [#7509](https://github.com/rubocop-hq/rubocop/issues/7509): Fix `Layout/SpaceInsideArrayLiteralBrackets` to correct empty lines. ([@ayacai115][])
 
 ### Changes
 
@@ -4258,3 +4259,4 @@
 [@jdkaplan]: https://github.com/jdkaplan
 [@cstyles]: https://github.com/cstyles
 [@avmnu-sng]: https://github.com/avmnu-sng
+[@ayacai115]: https://github.com/ayacai115

--- a/lib/rubocop/cop/correctors/space_corrector.rb
+++ b/lib/rubocop/cop/correctors/space_corrector.rb
@@ -12,12 +12,11 @@ module RuboCop
         def empty_corrections(processed_source, corrector, empty_config,
                               left_token, right_token)
           @processed_source = processed_source
+          range = range_between(left_token.end_pos, right_token.begin_pos)
           if offending_empty_space?(empty_config, left_token, right_token)
-            range = side_space_range(range: left_token.pos, side: :right)
             corrector.remove(range)
             corrector.insert_after(left_token.pos, ' ')
           elsif offending_empty_no_space?(empty_config, left_token, right_token)
-            range = side_space_range(range: left_token.pos, side: :right)
             corrector.remove(range)
           end
         end

--- a/spec/rubocop/cop/layout/space_inside_array_literal_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_array_literal_brackets_spec.rb
@@ -42,6 +42,11 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       new_source = autocorrect_source('a = [           ]')
       expect(new_source).to eq('a = []')
     end
+
+    it 'auto-corrects multiline spaces' do
+      new_source = autocorrect_source("a = [\n]")
+      expect(new_source).to eq('a = []')
+    end
   end
 
   context 'with space inside empty braces allowed' do


### PR DESCRIPTION
Fixed Layout/SpaceInsideArrayLiteralBrackets to correct empty lines.
See https://github.com/rubocop-hq/rubocop/issues/7509 for details.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
