### PR TITLE
[Fix #7515] Fix a false negative for `Style/RedundantParentheses`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#7493](https://github.com/rubocop-hq/rubocop/issues/7493): Fix `Style/RedundantReturn` to inspect conditional constructs that are preceded by other statements. ([@buehmann][])
 * [#7509](https://github.com/rubocop-hq/rubocop/issues/7509): Fix `Layout/SpaceInsideArrayLiteralBrackets` to correct empty lines. ([@ayacai115][])
 * [#7517](https://github.com/rubocop-hq/rubocop/issues/7517): `Style/SpaceAroundKeyword` allows `::` after `super`. ([@ozydingo][])
+* [#7515](https://github.com/rubocop-hq/rubocop/issues/7515): Fix a false negative for `Style/RedundantParentheses` when calling a method with safe navigation operator. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/redundant_splat_expansion.rb
+++ b/lib/rubocop/cop/lint/redundant_splat_expansion.rb
@@ -146,7 +146,7 @@ module RuboCop
           grandparent = node.parent.parent
 
           parent.when_type? || parent.send_type? || part_of_an_array?(node) ||
-            (grandparent&.resbody_type?)
+            grandparent&.resbody_type?
         end
 
         def remove_brackets(array)

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -19,7 +19,7 @@ module RuboCop
         def_node_matcher :square_brackets?,
                          '(send {(send _recv _msg) str array hash} :[] ...)'
         def_node_matcher :range_end?, '^^{irange erange}'
-        def_node_matcher :method_node_and_args, '$(send _recv _msg $...)'
+        def_node_matcher :method_node_and_args, '$(call _recv _msg $...)'
         def_node_matcher :rescue?, '{^resbody ^^resbody}'
         def_node_matcher :arg_in_call_with_block?,
                          '^^(block (send _ _ equal?(%0) ...) ...)'
@@ -102,7 +102,7 @@ module RuboCop
           return offense(begin_node, 'a variable') if node.variable?
           return offense(begin_node, 'a constant') if node.const_type?
 
-          check_send(begin_node, node) if node.send_type?
+          check_send(begin_node, node) if node.call_type?
         end
 
         def check_send(begin_node, node)
@@ -195,7 +195,7 @@ module RuboCop
         end
 
         def method_call_with_redundant_parentheses?(node)
-          return false unless node.send_type?
+          return false unless node.call_type?
           return false if node.prefix_not?
           return false if range_end?(node)
 

--- a/lib/rubocop/cop/style/redundant_sort.rb
+++ b/lib/rubocop/cop/style/redundant_sort.rb
@@ -127,7 +127,7 @@ module RuboCop
         end
 
         def base(accessor, arg)
-          if accessor == :first || (arg&.zero?)
+          if accessor == :first || arg&.zero?
             'min'
           elsif accessor == :last || arg == -1
             'max'

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses do
   it_behaves_like 'redundant', '(x)', 'x', 'a method call'
   it_behaves_like 'redundant', '(x(1, 2))', 'x(1, 2)', 'a method call'
   it_behaves_like 'redundant', '("x".to_sym)', '"x".to_sym', 'a method call'
+  it_behaves_like 'redundant', '("x"&.to_sym)', '"x"&.to_sym', 'a method call'
   it_behaves_like 'redundant', '(x[:y])', 'x[:y]', 'a method call'
   it_behaves_like 'redundant', '("foo"[0])', '"foo"[0]', 'a method call'
   it_behaves_like 'redundant', '(["foo"][0])', '["foo"][0]', 'a method call'


### PR DESCRIPTION
Fixes #7515.

This PR fixes a false negative for `Style/RedundantParentheses` when calling a method with safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
