### PR TITLE
[Fix #7517] Layout/WhitespaceAroundKeyword: allow `super::const`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#7493](https://github.com/rubocop-hq/rubocop/issues/7493): Fix `Style/RedundantReturn` to inspect conditional constructs that are preceded by other statements. ([@buehmann][])
 * [#7509](https://github.com/rubocop-hq/rubocop/issues/7509): Fix `Layout/SpaceInsideArrayLiteralBrackets` to correct empty lines. ([@ayacai115][])
+* [#7517](https://github.com/rubocop-hq/rubocop/issues/7517): `Style/SpaceAroundKeyword` allows `::` after `super`. ([@ozydingo][])
 
 ### Changes
 
@@ -4260,3 +4261,4 @@
 [@cstyles]: https://github.com/cstyles
 [@avmnu-sng]: https://github.com/avmnu-sng
 [@ayacai115]: https://github.com/ayacai115
+[@ozydingo]: https://github.com/ozydingo

--- a/lib/rubocop/cop/layout/space_around_keyword.rb
+++ b/lib/rubocop/cop/layout/space_around_keyword.rb
@@ -30,10 +30,12 @@ module RuboCop
 
         DO = 'do'
         SAFE_NAVIGATION = '&.'
+        NAMESPACE_OPERATOR = '::'
         ACCEPT_LEFT_PAREN =
           %w[break defined? next not rescue return super yield].freeze
         ACCEPT_LEFT_SQUARE_BRACKET =
           %w[super yield].freeze
+        ACCEPT_NAMESPACE_OPERATOR = 'super'
 
         def on_and(node)
           check(node, [:operator].freeze) if node.keyword?
@@ -193,6 +195,8 @@ module RuboCop
 
           return false if accepted_opening_delimiter?(range, char)
           return false if safe_navigation_call?(range, pos)
+          return false if accept_namespace_operator?(range) &&
+                          namespace_operator?(range, pos)
 
           char !~ /[\s;,#\\\)\}\]\.]/
         end
@@ -212,8 +216,16 @@ module RuboCop
           ACCEPT_LEFT_SQUARE_BRACKET.include?(range.source)
         end
 
+        def accept_namespace_operator?(range)
+          ACCEPT_NAMESPACE_OPERATOR == range.source
+        end
+
         def safe_navigation_call?(range, pos)
           range.source_buffer.source[pos, 2].start_with?(SAFE_NAVIGATION)
+        end
+
+        def namespace_operator?(range, pos)
+          range.source_buffer.source[pos, 2].start_with?(NAMESPACE_OPERATOR)
         end
 
         def preceded_by_operator?(node, _range)

--- a/spec/rubocop/cop/layout/space_around_keyword_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_keyword_spec.rb
@@ -158,6 +158,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword do
   it_behaves_like 'accept after', '.', 'yield.method'
   it_behaves_like 'accept before', '!', '!yield.method'
   it_behaves_like 'accept before', '!', '!super.method'
+  it_behaves_like 'accept after', '::', 'super::ModuleName'
 
   context '&.' do
     it_behaves_like 'accept after', '&.', 'super&.foo'


### PR DESCRIPTION
The `Layout/WhitespaceAroundKeyword` cop complains when `super::MyConst` is used. However, in Ruby, modules and classes are normal objects and can be returns by methods including by using `super`. Therefore, `super::MyConst` should be considered valid style.

This type of usage is distinct from the intention of this cop, which is to avoid missing space such as around `something = 123if test` and `while(something)`.

I considered adding a test that verifies that the cop complains when a keyword other than `super` is used in the same manner (it does). However, I believe this is a syntax error in every other case and so the behavior of this cop is perhaps best left undefined. The alternative would be to suggest that `yield ::` is the correct form of `yield::`, which is false; they're both wrong, and it's not the responsibility of this cop to know that.

-----------------

Before submitting the PR make sure the following are checked:

* [✓ ] Wrote [good commit messages][1].
* [✓ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [✓ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [✓ ] Squashed related commits together.
* [✓ ] Added tests.
* [✓ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [✓ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [✓ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
