### PR TITLE
Fix false positive in Style/EvenOdd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,14 @@
 * [#7509](https://github.com/rubocop-hq/rubocop/issues/7509): Fix `Layout/SpaceInsideArrayLiteralBrackets` to correct empty lines. ([@ayacai115][])
 * [#7517](https://github.com/rubocop-hq/rubocop/issues/7517): `Style/SpaceAroundKeyword` allows `::` after `super`. ([@ozydingo][])
 * [#7515](https://github.com/rubocop-hq/rubocop/issues/7515): Fix a false negative for `Style/RedundantParentheses` when calling a method with safe navigation operator. ([@koic][])
+* [#7477](https://github.com/rubocop-hq/rubocop/issues/7477): Fix line length autocorrect for semicolons in string literals. ([@maxh][])
+* [#7522](https://github.com/rubocop-hq/rubocop/pull/7522): Fix a false-positive edge case (`n % 2 == 2`) for `Style/EvenOdd`. ([@buehmann][])
 
 ### Changes
 
 * [#7077](https://github.com/rubocop-hq/rubocop/issues/7077): **(Breaking)** Further standardisation of cop names. ([@scottmatthewman][])
 * [#7469](https://github.com/rubocop-hq/rubocop/pull/7469): **(Breaking)** Replace usages of the terms `Whitelist` and `Blacklist` with better alternatives. ([@koic][])
 * [#7502](https://github.com/rubocop-hq/rubocop/pull/7502): Remove `SafeMode` module. ([@koic][])
-
-### Bug fixes
-
-* [#7477](https://github.com/rubocop-hq/rubocop/issues/7477): Fix line length autocorrect for semicolons in string literals. ([@maxh][])
 
 ## 0.76.0 (2019-10-28)
 

--- a/lib/rubocop/cop/style/even_odd.rb
+++ b/lib/rubocop/cop/style/even_odd.rb
@@ -23,7 +23,7 @@ module RuboCop
             {(send $_ :% (int 2))
              (begin (send $_ :% (int 2)))}
             ${:== :!=}
-            (int ${0 1 2}))
+            (int ${0 1}))
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/style/even_odd_spec.rb
+++ b/spec/rubocop/cop/style/even_odd_spec.rb
@@ -73,6 +73,10 @@ RSpec.describe RuboCop::Cop::Style::EvenOdd do
     RUBY
   end
 
+  it 'accepts x % 2 == 2' do
+    expect_no_offenses('x % 2 == 2')
+  end
+
   it 'accepts x % 3 == 0' do
     expect_no_offenses('x % 3 == 0')
   end


### PR DESCRIPTION
```ruby
n % 2 == 2
```
is auto-corrected to
```
n.?
```
by `Style/EvenOdd`, which is clearly a mistake.

```
tmp-numbers.rb:1:1: C: [Corrected] Style/EvenOdd: Replace with Integer#?.
n % 2 == 2
^^^^^^^^^^
tmp-numbers.rb:1:3: E: Lint/Syntax: unexpected token tEH
(Using Ruby 2.3 parser; configure using TargetRubyVersion parameter, under AllCops)
n.?
  ^
```

I am not sure this unusual edge case warrants an entry in the changelog. Just let me know if I should add one.