### PR TITLE
Fix #7231 unknown cop in config file will exit with code 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#7530](https://github.com/rubocop-hq/rubocop/issues/7530): Typo in `Style/TrivialAccessors`'s `AllowedMethods`. ([@movermeyer][])
 * [#7532](https://github.com/rubocop-hq/rubocop/issues/7532): Fix an error for `Style/TrailingCommaInArguments` when using an anonymous function with multiple line arguments with `EnforcedStyleForMultiline: consistent_comma`. ([@koic][])
 * [#7534](https://github.com/rubocop-hq/rubocop/issues/7534): Fix an incorrect autocorrect for `Style/BlockDelimiters` cop and `Layout/SpaceBeforeBlockBraces` cop with `EnforcedStyle: no_space` when using multiline braces. ([@koic][])
+* [#7231](https://github.com/rubocop-hq/rubocop/issues/7231): Fix the exit code to be `2` rather when `0` when the config file contains an unknown cop. ([@jethroo][])
 
 ## 0.77.0 (2019-11-27)
 
@@ -4274,3 +4275,4 @@
 [@ayacai115]: https://github.com/ayacai115
 [@ozydingo]: https://github.com/ozydingo
 [@movermeyer]: https://github.com/movermeyer
+[@jethroo]: https://github.com/jethroo

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -41,7 +41,7 @@ module RuboCop
 
       @config_obsoletion.reject_obsolete_cops_and_parameters
 
-      warn_about_unrecognized_cops(invalid_cop_names)
+      alert_about_unrecognized_cops(invalid_cop_names)
       check_target_ruby
       validate_parameter_names(valid_cop_names)
       validate_enforced_styles(valid_cop_names)
@@ -96,7 +96,8 @@ module RuboCop
       raise ValidationError, msg
     end
 
-    def warn_about_unrecognized_cops(invalid_cop_names)
+    def alert_about_unrecognized_cops(invalid_cop_names)
+      unknown_cops = []
       invalid_cop_names.each do |name|
         # There could be a custom cop with this name. If so, don't warn
         next if Cop::Cop.registry.contains_cop_matching?([name])
@@ -106,9 +107,10 @@ module RuboCop
         # to do so than to pass the value around to various methods.
         next if name == 'inherit_mode'
 
-        warn Rainbow("Warning: unrecognized cop #{name} found in " \
-                     "#{smart_loaded_path}").yellow
+        unknown_cops << "unrecognized cop #{name} found in " \
+          "#{smart_loaded_path}"
       end
+      raise ValidationError, unknown_cops.join(', ') if unknown_cops.any?
     end
 
     def validate_syntax_cop

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1415,7 +1415,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                 ''].join("\n"))
     end
 
-    it 'prints a warning for an unrecognized cop name in .rubocop.yml' do
+    it 'prints an error for an unrecognized cop name in .rubocop.yml' do
       create_file('example/example1.rb', '#' * 90)
 
       create_file('example/.rubocop.yml', <<~YAML)
@@ -1424,9 +1424,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           Max: 100
       YAML
 
-      expect(cli.run(%w[--format simple example])).to eq(1)
+      expect(cli.run(%w[--format simple example])).to eq(2)
       expect($stderr.string)
-        .to eq(['Warning: unrecognized cop Style/LyneLenth found in ' \
+        .to eq(['Error: unrecognized cop Style/LyneLenth found in ' \
                 'example/.rubocop.yml',
                 ''].join("\n"))
     end
@@ -1695,6 +1695,22 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
            '`Style/TrailingCommaInHashLiteral` instead.',
            '(obsolete configuration found in .rubocop.yml, ' \
            'please update it)'].join("\n")
+        )
+      end
+    end
+  end
+
+  describe 'unknown cop' do
+    context 'in configuration file is given' do
+      it 'prints the error and exists with code 2' do
+        create_file('example1.rb', "puts 'no offenses here'")
+        create_file('.rubocop.yml', <<~YAML)
+          Syntax/Whatever:
+            Enabled: true
+        YAML
+        expect(cli.run(['example1.rb'])).to eq(2)
+        expect($stderr.string.strip).to eq(
+          'Error: unrecognized cop Syntax/Whatever found in .rubocop.yml'
         )
       end
     end

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe RuboCop::Config do
 
   describe '#validate', :isolated_environment do
     subject(:configuration) do
+      # ConfigLoader.load_file will validate config
       RuboCop::ConfigLoader.load_file(configuration_path)
     end
 
@@ -29,9 +30,11 @@ RSpec.describe RuboCop::Config do
         $stderr = STDERR
       end
 
-      it 'prints a warning message' do
-        configuration # ConfigLoader.load_file will validate config
-        expect($stderr.string).to match(/unrecognized cop LyneLenth/)
+      it 'raises an validation error' do
+        expect { configuration }.to raise_error(
+          RuboCop::ValidationError,
+          'unrecognized cop LyneLenth found in .rubocop.yml'
+        )
       end
     end
 

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -302,8 +302,12 @@ RSpec.describe RuboCop::Cop::Generator do
 
     around do |example|
       orig_registry = RuboCop::Cop::Cop.registry
-      RuboCop::Cop::Cop.instance_variable_set(:@registry,
-                                              RuboCop::Cop::Registry.new)
+      RuboCop::Cop::Cop.instance_variable_set(
+        :@registry,
+        RuboCop::Cop::Registry.new(
+          [RuboCop::Cop::InternalAffairs::NodeDestructuring]
+        )
+      )
       example.run
       RuboCop::Cop::Cop.instance_variable_set(:@registry, orig_registry)
     end
@@ -320,22 +324,12 @@ RSpec.describe RuboCop::Cop::Generator do
 
     it 'generates a cop file that has no offense' do
       generator.write_source
-      result = nil
-      expect { result = runner.run([]) }.to output(<<~OUTPUT).to_stderr
-        Warning: unrecognized cop InternalAffairs/NodeDestructuring found in #{HOME_DIR}/.rubocop_todo.yml
-        Warning: unrecognized cop InternalAffairs/NodeDestructuring found in #{HOME_DIR}/.rubocop.yml
-      OUTPUT
-      expect(result).to be true
+      expect(runner.run([])).to be true
     end
 
     it 'generates a spec file that has no offense' do
       generator.write_spec
-      result = nil
-      expect { result = runner.run([]) }.to output(<<~OUTPUT).to_stderr
-        Warning: unrecognized cop InternalAffairs/NodeDestructuring found in #{HOME_DIR}/.rubocop_todo.yml
-        Warning: unrecognized cop InternalAffairs/NodeDestructuring found in #{HOME_DIR}/.rubocop.yml
-      OUTPUT
-      expect(result).to be true
+      expect(runner.run([])).to be true
     end
   end
 end

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -106,6 +106,10 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
       formatter.file_finished('test_a.rb', offenses)
       formatter.file_started('test_b.rb', {})
       formatter.file_finished('test_b.rb', [offenses.first])
+
+      # Cop1 and Cop2 are unknown cops and would raise an validation error
+      allow(RuboCop::Cop::Cop.registry).to receive(:contains_cop_matching?)
+        .and_return(true)
       formatter.finished(['test_a.rb', 'test_b.rb'])
     end
 


### PR DESCRIPTION
This PR addresses the issue raised in #7231. Loading the config file will now memorize the warning for unknown cops and will exit with status `1` if the run would otherwise exit with `0` (STATUS_SUCCESS).
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
