### PR TITLE
Add support for variable alignment to Layout/RescueEnsureAlignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#8164](https://github.com/rubocop-hq/rubocop/pull/8164): Support auto-correction for `Lint/InterpolationCheck`. ([@koic][])
 * [#8223](https://github.com/rubocop-hq/rubocop/pull/8223): Support auto-correction for `Style/IfUnlessModifierOfIfUnless`. ([@koic][])
 * [#8172](https://github.com/rubocop-hq/rubocop/pull/8172): Support auto-correction for `Lint/SafeNavigationWithEmpty`. ([@koic][])
+* [#7531](https://github.com/rubocop-hq/rubocop/pull/7531): Add support for variable alignment to Layout/RescueEnsureAlignment. ([@dylanahsmith][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1059,6 +1059,10 @@ Layout/ParameterAlignment:
 
 Layout/RescueEnsureAlignment:
   Description: 'Align rescues and ensures correctly.'
+  EnforcedStyleAlignWith: keyword
+  SupportedStylesAlignWith:
+    - keyword
+    - variable
   Enabled: true
   VersionAdded: '0.49'
 

--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -4757,24 +4757,64 @@ end
 This cop checks whether the rescue and ensure keywords are aligned
 properly.
 
+Two modes are supported through the `EnforcedStyleAlignWith`
+configuration parameter:
+
+If it's set to `keyword` (which is the default), the `rescue`
+shall be aligned with the start of the begin keyword.
+
+If it's set to `variable` the `rescue` shall be aligned with the
+left-hand-side of the variable assignment, if there is one.
+
 === Examples
+
+==== EnforcedStyleAlignWith: keyword (default)
 
 [source,ruby]
 ----
 # bad
-begin
+result = begin
+           something
+           rescue
+           puts 'error'
+         end
+
+# good
+result = begin
+           something
+         rescue
+           puts 'error'
+         end
+----
+
+==== EnforcedStyleAlignWith: variable
+
+[source,ruby]
+----
+# bad
+result = begin
   something
   rescue
   puts 'error'
 end
 
 # good
-begin
+result = begin
   something
 rescue
   puts 'error'
 end
 ----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| EnforcedStyleAlignWith
+| `keyword`
+| `keyword`, `variable`
+|===
 
 == Layout/SpaceAfterColon
 

--- a/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
@@ -6,22 +6,48 @@ module RuboCop
       # This cop checks whether the rescue and ensure keywords are aligned
       # properly.
       #
-      # @example
+      # Two modes are supported through the `EnforcedStyleAlignWith`
+      # configuration parameter:
+      #
+      # If it's set to `keyword` (which is the default), the `rescue`
+      # shall be aligned with the start of the begin keyword.
+      #
+      # If it's set to `variable` the `rescue` shall be aligned with the
+      # left-hand-side of the variable assignment, if there is one.
+      #
+      # @example EnforcedStyleAlignWith: keyword (default)
       #
       #   # bad
-      #   begin
+      #   result = begin
+      #              something
+      #              rescue
+      #              puts 'error'
+      #            end
+      #
+      #   # good
+      #   result = begin
+      #              something
+      #            rescue
+      #              puts 'error'
+      #            end
+      #
+      # @example EnforcedStyleAlignWith: variable
+      #
+      #   # bad
+      #   result = begin
       #     something
       #     rescue
       #     puts 'error'
       #   end
       #
       #   # good
-      #   begin
+      #   result = begin
       #     something
       #   rescue
       #     puts 'error'
       #   end
       class RescueEnsureAlignment < Cop
+        include ConfigurableEnforcedStyle
         include RangeHelp
 
         MSG = '`%<kw_loc>s` at %<kw_loc_line>d, %<kw_loc_column>d is not ' \
@@ -39,6 +65,10 @@ module RuboCop
 
         def on_ensure(node)
           check(node)
+        end
+
+        def style_parameter_name
+          'EnforcedStyleAlignWith'
         end
 
         def autocorrect(node)
@@ -122,8 +152,8 @@ module RuboCop
         def alignment_node(node)
           ancestor_node = ancestor_node(node)
 
-          return ancestor_node if ancestor_node.nil? ||
-                                  ancestor_node.kwbegin_type?
+          return ancestor_node if ancestor_node.nil?
+          return ancestor_node if style == :keyword && ancestor_node.kwbegin_type?
 
           assignment_node = assignment_node(ancestor_node)
           return assignment_node if same_line?(ancestor_node, assignment_node)


### PR DESCRIPTION
Fixes #6918

The Layout/RescueEnsureAlignment cop was always enforcing alignment of the `rescue` keyword with the `begin` keyword, even when the `begin` block was being assigned to a variable.  For example, it would expect code like

```ruby
result = begin
           something
         rescue
           puts 'error'
         end
```

but reject code aligning `rescue` with a variable like

```ruby
result = begin
  something
rescue
  puts 'error'
end
```

even though a variable style is supported for similar cops, such as Layout/EndAlignment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
