### PR TITLE
[Fix #7532] Fix an error for `Style/TrailingCommaInArguments`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#7530](https://github.com/rubocop-hq/rubocop/issues/7530): Typo in `Style/TrivialAccessors`'s `AllowedMethods`. ([@movermeyer][])
+* [#7532](https://github.com/rubocop-hq/rubocop/issues/7532): Fix an error for `Style/TrailingCommaInArguments` when using an anonymous function with multiple line arguments with `EnforcedStyleForMultiline: consistent_comma`. ([@koic][])
 
 ## 0.77.0 (2019-11-27)
 

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -93,9 +93,12 @@ module RuboCop
       end
 
       def method_name_and_arguments_on_same_line?(node)
-        %i[send csend].include?(node.type) &&
-          node.loc.selector.line == node.arguments.last.last_line &&
-          node.last_line == node.arguments.last.last_line
+        return false unless node.call_type?
+
+        line = node.loc.selector.nil? ? node.loc.line : node.loc.selector.line
+
+        line == node.last_argument.last_line &&
+          node.last_line == node.last_argument.last_line
       end
 
       # A single argument with the closing bracket on the same line as the end

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -142,6 +142,23 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
     end
   end
 
+  context 'with a single argument of anonymous function ' \
+          'spanning multiple lines' do
+    context 'when EnforcedStyleForMultiline is consistent_comma' do
+      let(:cop_config) { { 'EnforcedStyleForMultiline' => 'consistent_comma' } }
+
+      it 'accepts a single argument with no trailing comma' do
+        expect_no_offenses(<<~RUBY)
+          func.(
+            'foo',
+            'bar',
+            'baz',
+          )
+        RUBY
+      end
+    end
+  end
+
   context 'with multi-line list of values' do
     context 'when EnforcedStyleForMultiline is no_comma' do
       let(:cop_config) { { 'EnforcedStyleForMultiline' => 'no_comma' } }


### PR DESCRIPTION
Fixes #7532.

This PR fixes an error for `Style/TrailingCommaInArguments` when using an anonymous function with multiple line arguments with `EnforcedStyleForMultiline: consistent_comma`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
