### PR TITLE
[Fix #7539] Add `Style/RedundantReturn`'s `AllowedMethods` option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * [#7528](https://github.com/rubocop-hq/rubocop/pull/7528): Add new `Lint/NonDeterministicRequireOrder` cop. ([@mangara][])
 * [#7559](https://github.com/rubocop-hq/rubocop/pull/7559): Add `EnforcedStyleForExponentOperator` parameter to `Layout/SpaceAroundOperators` cop. ([@khiav223577][])
+* [#7587](https://github.com/rubocop-hq/rubocop/issues/7587): Add `Style/RedundantReturn`'s `AllowedMethods` option. ([@QWYNG][])
 
 ### Bug fixes
 
@@ -4297,3 +4298,5 @@
 [@movermeyer]: https://github.com/movermeyer
 [@jethroo]: https://github.com/jethroo
 [@mangara]: https://github.com/mangara
+[@QWYNG]: https://github.com/QWYNG
+

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -123,6 +123,8 @@ module RuboCop
           return if cop_config['AllowMultipleReturnValues'] &&
                     node.children.size > 1
 
+          return if allowed_methods.include?(method_name_before_of(node))
+
           add_offense(node, location: :keyword)
         end
 
@@ -164,6 +166,18 @@ module RuboCop
           else
             MSG
           end
+        end
+
+        def allowed_methods
+          cop_config['AllowedMethods']&.map(&:to_sym) || []
+        end
+
+        def method_name_before_of(node)
+          node_place_index = node.parent.children.find_index(node)
+          before_node = node.parent.children[node_place_index - 1]
+          return unless before_node.is_a?(RuboCop::AST::SendNode)
+
+          before_node.method_name
         end
       end
     end

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -475,4 +475,19 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
       RUBY
     end
   end
+
+  context 'with permitted methods' do
+    let(:cop_config) { { 'AllowedMethods' => %w[redirect_to] } }
+
+    it 'accepts method name which is in permitted list' do
+      expect_no_offenses(<<~RUBY)
+        def func
+          if cond
+            redirect_to some_path
+            return
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**
fix #7539 

Please comment on anything that needs to be changed

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
