### PR TITLE
Add comments explaining external dependency checksum caching

### DIFF
--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -186,6 +186,8 @@ module RuboCop
       options.to_s.gsub(/[^a-z]+/i, '_')
     end
 
+    # The external dependency checksums are cached per RuboCop team so that
+    # the checksums don't need to be recomputed for each file.
     def team_checksum(team)
       @checksum_by_team ||= {}
       @checksum_by_team[team.object_id] ||= team.external_dependency_checksum

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -366,6 +366,10 @@ module RuboCop
       end
     end
 
+    # A Cop::Team instance is stateful and may change when inspecting.
+    # The "standby" team for a given config is an initialized but
+    # otherwise dormant team that can be used for config- and option-
+    # level caching in ResultCache.
     def standby_team(config)
       @team_by_config ||= {}
       @team_by_config[config.object_id] ||=


### PR DESCRIPTION
This PR aims to answer https://github.com/rubocop-hq/rubocop/pull/7496#discussion_r350462926 by @exterm on https://github.com/rubocop-hq/rubocop/pull/7496 "Allow cops to invalidate results cache" with code comments.

An alternative (more invasive) implementation I considered was to pull the cop mobilization logic out of `Runner` into a new helper module `RuboCop::Cop::Mobilizer`. Then the runner could just pass the `config` and `options` to the `ResultCache`, which could then create its own "standby" teams internally. This would more cleanly contain the team-level external dependency checksum caching logic within the `ResultCache`, but it would require more refactoring.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
