### PR TITLE
[Fix #7513] Fix abrupt error on autocorrecting with `--disable-uncorrectable`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ InternalAffairs/NodeDestructuring:
 # Offense count: 49
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 182
+  Max: 183
 
 # Offense count: 209
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#7532](https://github.com/rubocop-hq/rubocop/issues/7532): Fix an error for `Style/TrailingCommaInArguments` when using an anonymous function with multiple line arguments with `EnforcedStyleForMultiline: consistent_comma`. ([@koic][])
 * [#7534](https://github.com/rubocop-hq/rubocop/issues/7534): Fix an incorrect autocorrect for `Style/BlockDelimiters` cop and `Layout/SpaceBeforeBlockBraces` cop with `EnforcedStyle: no_space` when using multiline braces. ([@koic][])
 * [#7231](https://github.com/rubocop-hq/rubocop/issues/7231): Fix the exit code to be `2` rather when `0` when the config file contains an unknown cop. ([@jethroo][])
+* [#7513](https://github.com/rubocop-hq/rubocop/issues/7513): Fix abrupt error on autocorrecting with `--disable-uncorrectable`. ([@tejasbubane][])
 
 ## 0.77.0 (2019-11-27)
 

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -172,6 +172,8 @@ module RuboCop
       end
 
       def disable_uncorrectable(node)
+        return unless node
+
         @disabled_lines ||= {}
         line = node.location.line
         return if @disabled_lines.key?(line)

--- a/spec/rubocop/cop/lint/syntax_spec.rb
+++ b/spec/rubocop/cop/lint/syntax_spec.rb
@@ -42,6 +42,21 @@ RSpec.describe RuboCop::Cop::Lint::Syntax do
           expect(offense.severity).to eq(:error)
         end
       end
+
+      context 'with --auto-correct --disable-uncorrectable options' do
+        let(:options) { { auto_correct: true, disable_uncorrectable: true } }
+
+        it 'returns an offense' do
+          expect(offenses.size).to eq(1)
+          message = <<~MESSAGE.chomp
+            unexpected token $end
+            (Using Ruby 2.4 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)
+          MESSAGE
+          offense = offenses.first
+          expect(offense.message).to eq(message)
+          expect(offense.severity).to eq(:error)
+        end
+      end
     end
 
     context 'with a parser error' do


### PR DESCRIPTION
Closes #7513

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/