### PR TITLE
[Fix #7291] Add better message for layout/HashAlignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 * [#7193](https://github.com/rubocop-hq/rubocop/issues/7193): Prevent `Style/PercentLiteralDelimiters` from changing `%i` literals that contain escaped delimiters. ([@buehmann][])
 * [#7590](https://github.com/rubocop-hq/rubocop/issues/7590): Fix an error for `Layout/SpaceBeforeBlockBraces` when using with `EnforcedStyle: line_count_based` of `Style/BlockDelimiters` cop. ([@koic][])
 * [#7569](https://github.com/rubocop-hq/rubocop/issues/7569): Make `Style/YodaCondition` accept `__FILE__ == $0`. ([@koic][])
-* [#7291](https://github.com/rubocop-hq/rubocop/issues/7291): Fix misleading error messages in `Layout/AlignHash` cop to specify how to align the hash. ([@jsartin513][])
 
 ## 0.78.0 (2019-12-18)
 
@@ -4305,4 +4304,3 @@
 [@jethroo]: https://github.com/jethroo
 [@mangara]: https://github.com/mangara
 [@pirj]: https://github.com/pirj
-[@jsartin513]: https://github.com/jsartin513

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#7193](https://github.com/rubocop-hq/rubocop/issues/7193): Prevent `Style/PercentLiteralDelimiters` from changing `%i` literals that contain escaped delimiters. ([@buehmann][])
 * [#7590](https://github.com/rubocop-hq/rubocop/issues/7590): Fix an error for `Layout/SpaceBeforeBlockBraces` when using with `EnforcedStyle: line_count_based` of `Style/BlockDelimiters` cop. ([@koic][])
 * [#7569](https://github.com/rubocop-hq/rubocop/issues/7569): Make `Style/YodaCondition` accept `__FILE__ == $0`. ([@koic][])
+* [#7291](https://github.com/rubocop-hq/rubocop/issues/7291): Fix misleading error messages in `Layout/AlignHash` cop to specify how to align the hash. ([@jsartin513][])
 
 ## 0.78.0 (2019-12-18)
 
@@ -4304,3 +4305,4 @@
 [@jethroo]: https://github.com/jethroo
 [@mangara]: https://github.com/mangara
 [@pirj]: https://github.com/pirj
+[@jsartin513]: https://github.com/jsartin513

--- a/lib/rubocop/cop/layout/hash_alignment.rb
+++ b/lib/rubocop/cop/layout/hash_alignment.rb
@@ -179,8 +179,12 @@ module RuboCop
         include HashAlignmentStyles
         include RangeHelp
 
-        MSG = 'Align the elements of a hash literal if they span more than ' \
-              'one line.'
+        MESSAGES = { KeyAlignment => 'Align the keys of a hash literal if ' \
+                      'they span more than one line.',
+                     SeparatorAlignment => 'Align the separators of a hash ' \
+                       'literal if they span more than one line.',
+                     TableAlignment => 'Align the keys and values of a hash ' \
+                       'literal if they span more than one line.' }.freeze
 
         def on_send(node)
           return if double_splat?(node)
@@ -249,9 +253,9 @@ module RuboCop
         end
 
         def add_offences
-          _format, offences = offences_by.min_by { |_, v| v.length }
+          format, offences = offences_by.min_by { |_, v| v.length }
           (offences || []).each do |offence|
-            add_offense offence
+            add_offense(offence, message: MESSAGES[format])
           end
         end
 

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_offense(<<~RUBY)
         func(a: 0,
           b: 1)
-          ^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^ Align the keys of a hash literal if they span more than one line.
       RUBY
     end
 
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_offense(<<~RUBY)
         func({a: 0,
           b: 1})
-          ^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^ Align the keys of a hash literal if they span more than one line.
       RUBY
     end
 
@@ -66,7 +66,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_offense(<<~RUBY)
         super(a: 0,
           b: 1)
-          ^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^ Align the keys of a hash literal if they span more than one line.
       RUBY
     end
 
@@ -74,7 +74,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_offense(<<~RUBY)
         super({a: 0,
           b: 1})
-          ^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^ Align the keys of a hash literal if they span more than one line.
       RUBY
     end
 
@@ -82,7 +82,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_offense(<<~RUBY)
         yield(a: 0,
           b: 1)
-          ^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^ Align the keys of a hash literal if they span more than one line.
       RUBY
     end
 
@@ -90,7 +90,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_offense(<<~RUBY)
         yield({a: 0,
           b: 1})
-          ^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^ Align the keys of a hash literal if they span more than one line.
       RUBY
     end
   end
@@ -163,7 +163,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_offense(<<~RUBY)
         func({a: 0,
           b: 1})
-          ^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^ Align the keys of a hash literal if they span more than one line.
       RUBY
     end
 
@@ -178,7 +178,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_offense(<<~RUBY)
         super({a: 0,
           b: 1})
-          ^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^ Align the keys of a hash literal if they span more than one line.
       RUBY
     end
 
@@ -193,7 +193,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_offense(<<~RUBY)
         yield({a: 0,
           b: 1})
-          ^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^ Align the keys of a hash literal if they span more than one line.
       RUBY
     end
   end
@@ -209,7 +209,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_offense(<<~RUBY)
         func(a: 0,
           b: 1)
-          ^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^ Align the keys of a hash literal if they span more than one line.
       RUBY
     end
 
@@ -224,7 +224,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_offense(<<~RUBY)
         super(a: 0,
           b: 1)
-          ^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^ Align the keys of a hash literal if they span more than one line.
       RUBY
     end
 
@@ -239,7 +239,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_offense(<<~RUBY)
         yield(a: 0,
           b: 1)
-          ^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^ Align the keys of a hash literal if they span more than one line.
       RUBY
     end
 
@@ -257,12 +257,12 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
         hash1 = {
           a: 0,
            bb: 1
-           ^^^^^ Align the elements of a hash literal if they span more than one line.
+           ^^^^^ Align the keys of a hash literal if they span more than one line.
         }
         hash2 = {
           'ccc' => 2,
          'dddd'  =>  2
-         ^^^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+         ^^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
         }
       RUBY
     end
@@ -271,7 +271,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_offense(<<~RUBY)
         hash = { a: 1, b: 2,
                 c: 3 }
-                ^^^^ Align the elements of a hash literal if they span more than one line.
+                ^^^^ Align the keys of a hash literal if they span more than one line.
       RUBY
     end
 
@@ -296,15 +296,15 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_offense(<<~RUBY)
         hash1 = {
           a:   0,
-          ^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^ Align the keys of a hash literal if they span more than one line.
           bb:1,
-          ^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^ Align the keys of a hash literal if they span more than one line.
         }
         hash2 = {
           'ccc'=> 2,
-          ^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
           'dddd' =>  3
-          ^^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
         }
       RUBY
     end
@@ -314,7 +314,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
         hash = {
             'a' => 0,
           'bbb' => 1
-          ^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
         }
       RUBY
     end
@@ -323,7 +323,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_offense(<<~RUBY)
         hash = {
           'a'   => 0,
-          ^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
           'bbb' => 1
         }
       RUBY
@@ -333,7 +333,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_offense(<<~RUBY)
         hash = {
           'a' =>  (
-          ^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
             ),
           'bbb' => 1
         }
@@ -355,7 +355,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
         expect_offense(<<~RUBY)
           func(a: 0,
             b: 1)
-            ^^^^ Align the elements of a hash literal if they span more than one line.
+            ^^^^ Align the keys of a hash literal if they span more than one line.
         RUBY
       end
 
@@ -363,7 +363,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
         expect_offense(<<~RUBY)
           func(a: 0,
              bbb: 1)
-             ^^^^^^ Align the elements of a hash literal if they span more than one line.
+             ^^^^^^ Align the keys of a hash literal if they span more than one line.
         RUBY
       end
 
@@ -528,13 +528,13 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_offense(<<~RUBY)
         hash1 = {
           'a'   =>  0,
-          ^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^^^^^^ Align the keys and values of a hash literal if they span more than one line.
           'bbb' => 1
         }
         hash2 = {
           a:   0,
           bbb:1
-          ^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^ Align the keys and values of a hash literal if they span more than one line.
         }
       RUBY
     end
@@ -543,15 +543,15 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_offense(<<~RUBY)
         hash1 = {
           'a'   =>  0,
-          ^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^^^^^^ Align the keys and values of a hash literal if they span more than one line.
          'bbb'  =>  1
-         ^^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+         ^^^^^^^^^^^^ Align the keys and values of a hash literal if they span more than one line.
         }
         hash2 = {
            a:  0,
-           ^^^^^ Align the elements of a hash literal if they span more than one line.
+           ^^^^^ Align the keys and values of a hash literal if they span more than one line.
           bbb: 1
-          ^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^ Align the keys and values of a hash literal if they span more than one line.
         }
       RUBY
     end
@@ -561,7 +561,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
         hash = {
           'a'   => 0,
           'bbb'  => 1
-          ^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^^^^^^ Align the keys and values of a hash literal if they span more than one line.
         }
       RUBY
     end
@@ -648,7 +648,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
         hash = {
             'a' =>  0,
           'bbb' => 1
-          ^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^^^^^ Align the separators of a hash literal if they span more than one line.
         }
       RUBY
     end
@@ -658,7 +658,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
         hash = {
             'a'  => 0,
           'bbb' =>  1
-          ^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^^^^^^ Align the separators of a hash literal if they span more than one line.
         }
       RUBY
     end
@@ -783,9 +783,9 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
         expect_offense(<<~RUBY)
           hash = {
               'a' =>  0,
-              ^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+              ^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
             'bbb' => 1
-            ^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+            ^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
           }
         RUBY
       end
@@ -798,9 +798,9 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
             'gijk'    => 0,
             'a'       => 0,
             'b' => 1,
-            ^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+            ^^^^^^^^ Align the keys and values of a hash literal if they span more than one line.
                   'c' => 1
-                  ^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+                  ^^^^^^^^ Align the keys and values of a hash literal if they span more than one line.
           }
         RUBY
       end
@@ -810,12 +810,12 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
           hash = {
             'abcdefg' => 0,
             'abcdef'  => 0,
-            ^^^^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+            ^^^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
             'gijk' => 0,
             'a' => 0,
             'b' => 1,
                   'c' => 1
-                  ^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+                  ^^^^^^^^ Align the keys of a hash literal if they span more than one line.
           }
         RUBY
       end
@@ -825,7 +825,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
           headers = {
             "Content-Type" => 0,
              Authorization: 1
-             ^^^^^^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+             ^^^^^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
           }
         RUBY
       end
@@ -835,14 +835,14 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
           hash = {
             'abcdefg' => 0,
             'abcdef'  => 0,
-            ^^^^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+            ^^^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
             'gijk' => 0
           }
 
           hash = {
             'abcdefg' => 0,
             'abcdef'       => 0,
-            ^^^^^^^^^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+            ^^^^^^^^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
             'gijk' => 0
           }
         RUBY
@@ -940,12 +940,12 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
         hash1 = {
           a:   0,
           bbb: 1
-          ^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^ Align the separators of a hash literal if they span more than one line.
         }
         hash2 = {
             'a' => 0,
           'bbb' => 1
-          ^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
+          ^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
         }
       RUBY
     end


### PR DESCRIPTION
Fixes [#7291](https://github.com/rubocop-hq/rubocop/issues/7291)

Before this change, the Layout/HashAlignment cop always gave the same error message: "Align the elements of a hash literal if they span more than one line."
This was confusing in situations where a hash appeared to be aligned, but was not according to the configured alignment settings.

This PR changes the error message to reflect which part(s) of a hash must be aligned to pass the cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
