### PR TITLE
[Fix #7501] Make `Lint/RescueException` not flag offense if exception is re-raised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#7534](https://github.com/rubocop-hq/rubocop/issues/7534): Fix an incorrect autocorrect for `Style/BlockDelimiters` cop and `Layout/SpaceBeforeBlockBraces` cop with `EnforcedStyle: no_space` when using multiline braces. ([@koic][])
 * [#7231](https://github.com/rubocop-hq/rubocop/issues/7231): Fix the exit code to be `2` rather when `0` when the config file contains an unknown cop. ([@jethroo][])
 * [#7513](https://github.com/rubocop-hq/rubocop/issues/7513): Fix abrupt error on autocorrecting with `--disable-uncorrectable`. ([@tejasbubane][])
+* [#7501](https://github.com/rubocop-hq/rubocop/issues/7501): Make `Lint/RescueException` not flag offense if exception is re-raised. ([@tejasbubane][])
 
 ## 0.77.0 (2019-11-27)
 

--- a/lib/rubocop/cop/lint/rescue_exception.rb
+++ b/lib/rubocop/cop/lint/rescue_exception.rb
@@ -28,13 +28,26 @@ module RuboCop
         MSG = 'Avoid rescuing the `Exception` class. ' \
               'Perhaps you meant to rescue `StandardError`?'
 
+        def_node_matcher :raise?, <<~PATTERN
+          (send nil? :raise)
+        PATTERN
+
         def on_resbody(node)
           return unless node.children.first
+
+          begin_body = node.children.last
+          return if begin_body && re_raised?(begin_body.children)
 
           rescue_args = node.children.first.children
           return unless rescue_args.any? { |a| targets_exception?(a) }
 
           add_offense(node)
+        end
+
+        private
+
+        def re_raised?(children)
+          children.reverse.any? { |a| raise?(a) }
         end
 
         def targets_exception?(rescue_arg_node)

--- a/spec/rubocop/cop/lint/rescue_exception_spec.rb
+++ b/spec/rubocop/cop/lint/rescue_exception_spec.rb
@@ -122,4 +122,41 @@ RSpec.describe RuboCop::Cop::Lint::RescueException do
       end
     RUBY
   end
+
+  it 'does not register an offense if exception is re-raised' do
+    expect_no_offenses(<<~RUBY)
+      begin
+        do_something
+      rescue Exception => error
+        do_something_with_error
+        raise
+      end
+    RUBY
+  end
+
+  it 'registers an offense if different exception is re-raised' do
+    expect_offense(<<~RUBY)
+      begin
+        do_something
+      rescue Exception => error
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid rescuing the `Exception` class. Perhaps you meant to rescue `StandardError`?
+        do_something_with_error
+        raise 'New Exception'
+      end
+    RUBY
+  end
+
+  it 'does not register an offense if exception is re-raised, but raise ' \
+     'is not the last expression' do
+    expect_no_offenses(<<~RUBY)
+      begin
+        do_something
+      rescue Exception => error
+        do_something_with_error
+        raise
+        # some comments
+        dead_code
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Closes #7501 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/