### PR TITLE
In default.yml, Exclude tmp

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -59,6 +59,7 @@ AllCops:
     - '**/Vagrantfile'
   Exclude:
     - 'node_modules/**/*'
+    - 'tmp/**/*'
     - 'vendor/**/*'
     - '.git/**/*'
   # Default formatter will be used if no `-f/--format` option is given.


### PR DESCRIPTION
In certain rails projects, `tmp` can contain hundreds of thousands of files.

Excluding `tmp` in my project seems to decrease `time bin/rubocop` from 90s to 20s, though that's just an anecdote and not a scientific benchmark.

Does anyone put code in `tmp` that they actually want to lint? That'd be rare, right?

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [N/A] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [N/A] Added tests.
* [N/A] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [N/A?] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/

-----

Do I need to run `rake` after editing `default.yml`?