### PR TITLE
Fix a typo in default.yml

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -196,7 +196,7 @@ Gemspec/RequiredRubyVersion:
   VersionAdded: '0.52'
   Include:
     - '**/*.gemspec'
-    -
+
 Gemspec/RubyVersionGlobalsUsage:
   Description: Checks usage of RUBY_VERSION in gemspec.
   Enabled: true

--- a/manual/cops_gemspec.md
+++ b/manual/cops_gemspec.md
@@ -157,7 +157,7 @@ end
 
 Name | Default value | Configurable values
 --- | --- | ---
-Include | `**/*.gemspec`, `<none>` | Array
+Include | `**/*.gemspec` | Array
 
 ## Gemspec/RubyVersionGlobalsUsage
 


### PR DESCRIPTION
This PR fixes a typo in config/default.yml.

The typo included in the following commit.
https://github.com/rubocop-hq/rubocop/commit/248e921

There is only one similar typo.

```console
% git grep '^ *-$'
config/default.yml:    -
```

This fix removes unnecessary default value `none` from manual/cops_gemspec.md.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
