### PR TITLE
Workaround for broke docs with YARD 0.9.20 when using Ruby 2.7.0-dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,10 @@ gem 'rubocop-performance', '~> 1.5.0'
 gem 'rubocop-rspec', '~> 1.33.0'
 gem 'simplecov', '~> 0.10'
 gem 'test-queue'
-gem 'yard', '~> 0.9'
+# Workaround for YARD 0.9.20 or lower.
+# It specifies `github` until the release that includes the following changes:
+# https://github.com/lsegal/yard/pull/1290
+gem 'yard', github: 'lsegal/yard', ref: '10a2e5b'
 
 group :test do
   gem 'safe_yaml', require: false


### PR DESCRIPTION
This PR solves a broken document as follows:

```console
% ruby -v
ruby 2.7.0dev (2019-12-08T15:13:07Z master 0e71fbc18e) [x86_64-darwin17]

% bundle exec rake generate_cops_documentation
Files:         473
Modules:        83 (   76 undocumented)
Classes:       437 (  411 undocumented)
Constants:     628 (  620 undocumented)
Attributes:     31 (    0 undocumented)
Methods:      1080 (  961 undocumented)
 8.46% documented
* generated /Users/koic/src/github.com/rubocop-hq/rubocop/manual/cops_bundler.md
* generated /Users/koic/src/github.com/rubocop-hq/rubocop/manual/cops_gemspec.md
* generated /Users/koic/src/github.com/rubocop-hq/rubocop/manual/cops_layout.md
* generated /Users/koic/src/github.com/rubocop-hq/rubocop/manual/cops_lint.md
* generated /Users/koic/src/github.com/rubocop-hq/rubocop/manual/cops_metrics.md
* generated /Users/koic/src/github.com/rubocop-hq/rubocop/manual/cops_migration.md
* generated /Users/koic/src/github.com/rubocop-hq/rubocop/manual/cops_naming.md
* generated /Users/koic/src/github.com/rubocop-hq/rubocop/manual/cops_security.md
* generated /Users/koic/src/github.com/rubocop-hq/rubocop/manual/cops_style.md
```

The document will be empty as follows:

```diff
% git diff
diff --git a/manual/cops_bundler.md b/manual/cops_bundler.md
index b36941383..3dc102845 100644
--- a/manual/cops_bundler.md
+++ b/manual/cops_bundler.md
@@ -6,32 +6,7 @@ Enabled by default | Safe | Supports autocorrection |
VersionAdded | VersionChan
 --- | --- | --- | --- | ---
 Enabled | Yes | No | 0.46 | -

-A Gem's requirements should be listed only once in a Gemfile.
-
-### Examples
-
-```ruby
-# bad
-gem 'rubocop'
-gem 'rubocop'
-
-# bad
-group :development do
-  gem 'rubocop'
-end
-
-group :test do
-  gem 'rubocop'
-end
-
-# good
-group :development, :test do
-  gem 'rubocop'
-end
-
-# good
-gem 'rubocop', groups: [:development, :test]
-```
+No documentation

(snip)
```

This issue will be resolved with the release of YARD 0.9.21 or higher, which includes the following changes:
https://github.com/lsegal/yard/pull/1290

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
