### PR TITLE
Add `EnforcedStyleForExponentOperator` parameter to `Layout/SpaceAroundOperators`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#7559](https://github.com/rubocop-hq/rubocop/pull/7559): Add `EnforcedStyleForExponentOperator` parameter to `Layout/SpaceAroundOperators` cop. ([@khiav223577][])
+
 ### Bug fixes
 
 * [#7530](https://github.com/rubocop-hq/rubocop/issues/7530): Typo in `Style/TrivialAccessors`'s `AllowedMethods`. ([@movermeyer][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1066,6 +1066,10 @@ Layout/SpaceAroundOperators:
   # with an operator on the previous or next line, not counting empty lines
   # or comment lines.
   AllowForAlignment: true
+  EnforcedStyleForExponentOperator: no_space
+  SupportedStylesForExponentOperator:
+    - space
+    - no_space
 
 Layout/SpaceBeforeBlockBraces:
   Description: >-

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -3,21 +3,33 @@
 module RuboCop
   module Cop
     module Layout
-      # Checks that operators have space around them, except for **
-      # which should not have surrounding space.
+      # Checks that operators have space around them, except for ** which
+      # should or shouldn't have surrounding space depending on configuration.
       #
       # @example
       #   # bad
       #   total = 3*4
       #   "apple"+"juice"
       #   my_number = 38/4
-      #   a ** b
       #
       #   # good
       #   total = 3 * 4
       #   "apple" + "juice"
       #   my_number = 38 / 4
+      #
+      # @example EnforcedStyleForExponentOperator: no_space (default)
+      #   # bad
+      #   a ** b
+      #
+      #   # good
       #   a**b
+      #
+      # @example EnforcedStyleForExponentOperator: space
+      #   # bad
+      #   a**b
+      #
+      #   # good
+      #   a ** b
       class SpaceAroundOperators < Cop
         include PrecedingFollowingAlignment
         include RangeHelp
@@ -104,7 +116,7 @@ module RuboCop
 
         def autocorrect(range)
           lambda do |corrector|
-            if range.source =~ /\*\*/
+            if range.source =~ /\*\*/ && !space_around_exponent_operator?
               corrector.replace(range, '**')
             elsif range.source.end_with?("\n")
               corrector.replace(range, " #{range.source.strip}\n")
@@ -141,8 +153,10 @@ module RuboCop
         end
 
         def offense_message(type, operator, with_space, right_operand)
-          if operator.is?('**')
-            'Space around operator `**` detected.' unless with_space.is?('**')
+          if should_not_have_surrounding_space?(operator)
+            return if with_space.is?(operator.source)
+
+            "Space around operator `#{operator.source}` detected."
           elsif with_space.source !~ /^\s.*\s$/
             "Surrounding space missing for operator `#{operator.source}`."
           elsif excess_leading_space?(type, operator, with_space) ||
@@ -178,6 +192,14 @@ module RuboCop
         def hash_table_style?
           align_hash_cop_config &&
             align_hash_cop_config['EnforcedHashRocketStyle'] == 'table'
+        end
+
+        def space_around_exponent_operator?
+          cop_config['EnforcedStyleForExponentOperator'] == 'space'
+        end
+
+        def should_not_have_surrounding_space?(operator)
+          operator.is?('**') ? !space_around_exponent_operator? : false
         end
       end
     end

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -4034,8 +4034,8 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 --- | --- | --- | --- | ---
 Enabled | Yes | Yes  | 0.49 | -
 
-Checks that operators have space around them, except for **
-which should not have surrounding space.
+Checks that operators have space around them, except for ** which
+should or shouldn't have surrounding space depending on configuration.
 
 ### Examples
 
@@ -4044,13 +4044,29 @@ which should not have surrounding space.
 total = 3*4
 "apple"+"juice"
 my_number = 38/4
-a ** b
 
 # good
 total = 3 * 4
 "apple" + "juice"
 my_number = 38 / 4
+```
+#### EnforcedStyleForExponentOperator: no_space (default)
+
+```ruby
+# bad
+a ** b
+
+# good
 a**b
+```
+#### EnforcedStyleForExponentOperator: space
+
+```ruby
+# bad
+a**b
+
+# good
+a ** b
 ```
 
 ### Configurable attributes
@@ -4058,6 +4074,7 @@ a**b
 Name | Default value | Configurable values
 --- | --- | ---
 AllowForAlignment | `true` | Boolean
+EnforcedStyleForExponentOperator | `no_space` | `space`, `no_space`
 
 ### References
 

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -321,7 +321,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       expect(IO.readlines('.rubocop_todo.yml')[8..-1].map(&:chomp))
         .to eq(['# Offense count: 1',
                 '# Cop supports --auto-correct.',
-                '# Configuration parameters: AllowForAlignment.',
+                '# Configuration parameters: AllowForAlignment, ' \
+                'EnforcedStyleForExponentOperator.',
+                '# SupportedStylesForExponentOperator: space, no_space',
                 'Layout/SpaceAroundOperators:',
                 '  Exclude:',
                 "    - 'example1.rb'",
@@ -589,7 +591,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
          '',
          '# Offense count: 1',
          '# Cop supports --auto-correct.',
-         '# Configuration parameters: AllowForAlignment.',
+         '# Configuration parameters: AllowForAlignment, ' \
+         'EnforcedStyleForExponentOperator.',
+         '# SupportedStylesForExponentOperator: space, no_space',
          'Layout/SpaceAroundOperators:',
          '  Exclude:',
          "    - 'example1.rb'",
@@ -686,7 +690,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
          '',
          '# Offense count: 1',
          '# Cop supports --auto-correct.',
-         '# Configuration parameters: AllowForAlignment.',
+         '# Configuration parameters: AllowForAlignment, ' \
+         'EnforcedStyleForExponentOperator.',
+         '# SupportedStylesForExponentOperator: space, no_space',
          'Layout/SpaceAroundOperators:',
          '  Exclude:',
          "    - 'example1.rb'",
@@ -889,7 +895,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
          "    - 'example2.rb'",
          '',
          '# Cop supports --auto-correct.',
-         '# Configuration parameters: AllowForAlignment.',
+         '# Configuration parameters: AllowForAlignment, ' \
+         'EnforcedStyleForExponentOperator.',
+         '# SupportedStylesForExponentOperator: space, no_space',
          'Layout/SpaceAroundOperators:',
          '  Exclude:',
          "    - 'example1.rb'",

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -9,12 +9,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
         'Layout/ExtraSpacing' => { 'ForceEqualSignAlignment' => true },
         'Layout/HashAlignment' => { 'EnforcedHashRocketStyle' => hash_style },
         'Layout/SpaceAroundOperators' => {
-          'AllowForAlignment' => allow_for_alignment
+          'AllowForAlignment' => allow_for_alignment,
+          'EnforcedStyleForExponentOperator' => exponent_operator_style
         }
       )
   end
   let(:hash_style) { 'key' }
   let(:allow_for_alignment) { true }
+  let(:exponent_operator_style) { nil }
 
   it 'accepts operator surrounded by tabs' do
     expect_no_offenses("a\t+\tb")
@@ -186,6 +188,28 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
 
   it 'accepts exponent operator without spaces' do
     expect_no_offenses('x = a * b**2')
+  end
+
+  context 'when EnforcedStyleForExponentOperator is space' do
+    let(:exponent_operator_style) { 'space' }
+
+    it 'registers an offenses for exponent operator without spaces' do
+      expect_offense(<<~RUBY)
+        x = a * b**2
+                 ^^ Surrounding space missing for operator `**`.
+      RUBY
+    end
+
+    it 'auto-corrects a exponent operator without space' do
+      new_source = autocorrect_source(<<~RUBY)
+        x = a * b ** 2
+        y = a * b** 2
+      RUBY
+      expect(new_source).to eq(<<~RUBY)
+        x = a * b ** 2
+        y = a * b ** 2
+      RUBY
+    end
   end
 
   it 'accepts unary operators without space' do


### PR DESCRIPTION
This PR add `EnforcedStyleForExponentOperator` parameter to `Layout/SpaceAroundOperators` cop in order to allow spaces around `**`.

There are some old discussion in #2972.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
