### PR TITLE
Add the Style Guide URL for `Gemspec/RubyVersionGlobalsUsage`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -200,6 +200,7 @@ Gemspec/RequiredRubyVersion:
 
 Gemspec/RubyVersionGlobalsUsage:
   Description: Checks usage of RUBY_VERSION in gemspec.
+  StyleGuide: '#no-ruby-version-in-the-gemspec'
   Enabled: true
   VersionAdded: '0.72'
   Include:

--- a/manual/cops_gemspec.md
+++ b/manual/cops_gemspec.md
@@ -194,3 +194,7 @@ end
 Name | Default value | Configurable values
 --- | --- | ---
 Include | `**/*.gemspec` | Array
+
+### References
+
+* [https://rubystyle.guide#no-ruby-version-in-the-gemspec](https://rubystyle.guide#no-ruby-version-in-the-gemspec)


### PR DESCRIPTION
Follow up of https://github.com/rubocop-hq/ruby-style-guide/pull/782 and https://github.com/rubocop-hq/ruby-style-guide/pull/784.

This PR adds the Style Guide URL for `Gemspec/RubyVersionGlobalsUsage`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
