### PR TITLE
EndAlignment: add support for kwbegin

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,6 +10,41 @@
 InternalAffairs/NodeDestructuring:
   Enabled: false
 
+# It is not intended that the following exclusions be merged. These exclusions
+# are temporary pending a maintainer decision re: the current discrepancy
+# between eg:
+#
+#     x = begin
+#       foo
+#     end
+#
+# and
+#
+#     x = if y
+#           foo
+#         end
+#
+# EndAlignment recently began to care about the former (`begin`) thus making
+# these temporary exclusions necessary.
+Layout/EndAlignment:
+  Exclude:
+    - lib/rubocop/cli.rb
+    - lib/rubocop/comment_config.rb
+    - lib/rubocop/config_validator.rb
+    - lib/rubocop/cop/generator/require_file_injector.rb
+    - lib/rubocop/cop/message_annotator.rb
+    - lib/rubocop/cop/mixin/configurable_enforced_style.rb
+    - lib/rubocop/cop/mixin/configurable_enforced_style.rb
+    - lib/rubocop/cop/mixin/preceding_following_alignment.rb
+    - lib/rubocop/cop/mixin/surrounding_space.rb
+    - lib/rubocop/cop/mixin/uncommunicative_name.rb
+    - lib/rubocop/cop/style/braces_around_hash_parameters.rb
+    - lib/rubocop/formatter/colorizable.rb
+    - lib/rubocop/formatter/pacman_formatter.rb
+    - lib/rubocop/processed_source.rb
+    - lib/rubocop/remote_config.rb
+    - lib/rubocop/runner.rb
+
 # Offense count: 49
 # Configuration parameters: CountComments.
 Metrics/ClassLength:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#7528](https://github.com/rubocop-hq/rubocop/pull/7528): Add new `Lint/NonDeterministicRequireOrder` cop. ([@mangara][])
 * [#7559](https://github.com/rubocop-hq/rubocop/pull/7559): Add `EnforcedStyleForExponentOperator` parameter to `Layout/SpaceAroundOperators` cop. ([@khiav223577][])
+* [#7565](https://github.com/rubocop-hq/rubocop/pull/7565): Add support for `begin` to `Layout/EndAlignment` cop. ([@jaredbeck][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/layout/end_alignment.rb
+++ b/lib/rubocop/cop/layout/end_alignment.rb
@@ -72,6 +72,15 @@ module RuboCop
         include EndKeywordAlignment
         include RangeHelp
 
+        def on_kwbegin(node)
+          align_with = {
+            keyword: node.loc.begin,
+            variable: node.loc.begin,
+            start_of_line: start_line_range(node)
+          }
+          check_end_kw_alignment(node, align_with)
+        end
+
         def on_class(node)
           check_other_alignment(node)
         end

--- a/spec/rubocop/cop/layout/end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/end_alignment_spec.rb
@@ -16,6 +16,15 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
   include_examples 'aligned', 'while',  'test',      'end'
   include_examples 'aligned', 'until',  'test',      'end'
   include_examples 'aligned', 'case',   'a when b',  'end'
+  include_examples 'aligned', 'begin',  'test',      'end'
+
+  it 'can handle block assignment' do
+    expect_no_offenses <<~RUBY
+      x = begin
+            :foo
+          end
+    RUBY
+  end
 
   include_examples 'misaligned', <<~RUBY, false
     puts 1; class Test
@@ -73,6 +82,11 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
     case a when b
       end
       ^^^ `end` at 2, 2 is not aligned with `case` at 1, 0.
+
+    begin
+      # foo
+      end
+      ^^^ `end` at 3, 2 is not aligned with `begin` at 1, 0.
   RUBY
 
   include_examples 'aligned', 'puts 1; class',  'Test',     '        end'
@@ -103,6 +117,15 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
     include_examples 'aligned', 'puts 1; while',  'test',     'end'
     include_examples 'aligned', 'puts 1; until',  'test',     'end'
     include_examples 'aligned', 'puts 1; case',   'a when b', 'end'
+    include_examples 'aligned', 'puts 1; begin',  'test',     'end'
+
+    it 'can handle block assignment' do
+      expect_no_offenses <<~RUBY
+        x = begin
+          :foo
+        end
+      RUBY
+    end
 
     include_examples 'misaligned', <<~RUBY, false
       puts 1; class Test


### PR DESCRIPTION
`EndAlignment` currently supports `if`, `class`, `module`, `while`, etc. This PR attempts to add support for `begin`. For example, the following misalignment is generally considered bad.

```
begin
    # foo
  end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [N/A] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
