### PR TITLE
[Fix #5979] Introduce cops with special status

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,10 +10,10 @@
 InternalAffairs/NodeDestructuring:
   Enabled: false
 
-# Offense count: 49
+# Offense count: 50
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 183
+  Max: 197
 
 # Offense count: 209
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 * [#7528](https://github.com/rubocop-hq/rubocop/pull/7528): Add new `Lint/NonDeterministicRequireOrder` cop. ([@mangara][])
 * [#7559](https://github.com/rubocop-hq/rubocop/pull/7559): Add `EnforcedStyleForExponentOperator` parameter to `Layout/SpaceAroundOperators` cop. ([@khiav223577][])
-* [#7184](https://github.com/rubocop-hq/rubocop/pull/7184): Introduce new `pending` status for new cops. ([@Darhazer][])
+* [#7567](https://github.com/rubocop-hq/rubocop/pull/7567): Introduce new `pending` status for new cops. ([@Darhazer][], [@pirj][])
 
 ### Bug fixes
 
@@ -4294,3 +4294,4 @@
 [@movermeyer]: https://github.com/movermeyer
 [@jethroo]: https://github.com/jethroo
 [@mangara]: https://github.com/mangara
+[@pirj]: https://github.com/pirj

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * [#7528](https://github.com/rubocop-hq/rubocop/pull/7528): Add new `Lint/NonDeterministicRequireOrder` cop. ([@mangara][])
 * [#7559](https://github.com/rubocop-hq/rubocop/pull/7559): Add `EnforcedStyleForExponentOperator` parameter to `Layout/SpaceAroundOperators` cop. ([@khiav223577][])
+* [#7184](https://github.com/rubocop-hq/rubocop/pull/7184): Introduce new `pending` status for new cops. ([@Darhazer][])
 
 ### Bug fixes
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -124,8 +124,8 @@ module RuboCop
         return if pending_cops.none?
 
         warn Rainbow('The following cops were added to RuboCop, but are not ' \
-        'configured. Please set Enabled to either `true` or `false` in your ' \
-        '`.rubocop.yml` file:').yellow
+                     'configured. Please set Enabled to either `true` or ' \
+                     '`false` in your `.rubocop.yml` file:').yellow
 
         pending_cops.each do |cop|
           warn Rainbow(" - #{cop}").yellow

--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -104,10 +104,9 @@ module RuboCop
         end
       SPEC
 
-      CONFIGURATION_ADDED_MESSAGE = <<~MESSAGE
-        [modify] A configuration for the cop is added into %<configuration_file_path>s.
-                 If you want to disable the cop by default, set `Enabled` option to false.
-      MESSAGE
+      CONFIGURATION_ADDED_MESSAGE =
+        '[modify] A configuration for the cop is added into ' \
+          '%<configuration_file_path>s.'
 
       def initialize(name, github_user, output: $stdout)
         @badge = Badge.parse(name)

--- a/lib/rubocop/cop/generator/configuration_injector.rb
+++ b/lib/rubocop/cop/generator/configuration_injector.rb
@@ -10,7 +10,7 @@ module RuboCop
         TEMPLATE = <<~YAML
           %<badge>s:
             Description: 'TODO: Write a description of the cop.'
-            Enabled: true
+            Enabled: pending
             VersionAdded: '%<version_added>s'
         YAML
 

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -146,10 +146,15 @@ module RuboCop
 
       def enabled?(cop, config, only_safe)
         cfg = config.for_cop(cop)
+
+        # cfg['Enabled'] might be a string `pending`, which is considered
+        # disabled
+        cop_enabled = cfg.fetch('Enabled') == true
+
         if only_safe
-          cfg.fetch('Enabled') && cfg.fetch('Safe', true)
+          cop_enabled && cfg.fetch('Safe', true)
         else
-          cfg.fetch('Enabled')
+          cop_enabled
         end
       end
 

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
 module RuboCop
   module Cop
     module Style
@@ -385,4 +384,3 @@ module RuboCop
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -52,6 +52,7 @@ RSpec.shared_context 'config', :config do
       cop_name = described_class.cop_name
       hash[cop_name] = RuboCop::ConfigLoader
                        .default_configuration[cop_name]
+                       .merge('Enabled' => true) # in case it is 'pending'
                        .merge(cop_config)
     end
 

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -408,7 +408,7 @@ Layout/LineLength:
 
 Most cops are enabled by default. Cops, introduced or significantly updated
 between major versions, are in a special pending status (read more in
-["Versioning"](versioning.md). Some cops, configured the above `Enabled: false`
+["Versioning"](versioning.md)). Some cops, configured the above `Enabled: false`
 in [config/default.yml](https://github.com/rubocop-hq/rubocop/blob/master/config/default.yml),
 are disabled by default. The cop enabling process can be altered by
 setting `DisabledByDefault` or `EnabledByDefault` (but not both) to `true`.

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -406,7 +406,9 @@ Layout/LineLength:
   Enabled: false
 ```
 
-Most cops are enabled by default. Some cops, configured the above `Enabled: false`
+Most cops are enabled by default. Cops, introduced or significantly updated
+between major versions, are in a special pending status (read more in
+["Versioning"](versioning.md). Some cops, configured the above `Enabled: false`
 in [config/default.yml](https://github.com/rubocop-hq/rubocop/blob/master/config/default.yml),
 are disabled by default. The cop enabling process can be altered by
 setting `DisabledByDefault` or `EnabledByDefault` (but not both) to `true`.

--- a/manual/development.md
+++ b/manual/development.md
@@ -10,7 +10,6 @@ Files created:
 File modified:
   - `require_relative 'rubocop/cop/department/name'` added into lib/rubocop.rb
   - A configuration for the cop is added into config/default.yml
-    - If you want to disable the cop by default, set `Enabled` option to false.
 
 Do 3 steps:
   1. Add an entry to the "New features" section in CHANGELOG.md,

--- a/manual/index.md
+++ b/manual/index.md
@@ -7,14 +7,16 @@
 
 **RuboCop** is a Ruby static code analyzer (a.k.a. linter) and code
 formatter. Out of the box it will enforce many of the guidelines
-outlined in the community [Ruby Style
-Guide](https://rubystyle.guide).
+outlined in the community [Ruby Style Guide](https://rubystyle.guide).
 
 Apart from reporting problems in your code, RuboCop can also
 automatically fix some of the problems for you.
 
 See ["Basic Usage"](basic_usage.md) to get yourself familiar with RuboCop's
 capabilities.
+
+See ["Versioning"](versioning.md) for information about RuboCop versioning,
+updates, and introduction of new cops.
 
 RuboCop is an extremely flexible tool and most aspects of its behavior
 can be tweaked via various [configuration

--- a/manual/versioning.md
+++ b/manual/versioning.md
@@ -1,0 +1,9 @@
+## Versioning
+
+RuboCop is stable between major versions, both in terms of API and cops.
+
+New cops introduced between major versions are set to a special pending
+status and are not enabled by default. A warning is emitted if such cops
+and are not explicitly enabled or disabled in the user configuration.
+
+On major version updates, pending cops are enabled in bulk.

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -915,7 +915,8 @@ RSpec.describe RuboCop::ConfigLoader do
 
       before do
         stub_const('RuboCop::ConfigLoader::RUBOCOP_HOME', 'rubocop')
-        stub_const('RuboCop::ConfigLoader::DEFAULT_FILE', File.join('rubocop', 'config', 'default.yml'))
+        stub_const('RuboCop::ConfigLoader::DEFAULT_FILE',
+                   File.join('rubocop', 'config', 'default.yml'))
         create_file('rubocop/config/default.yml',
                     <<~YAML)
                       AllCops:

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -914,8 +914,12 @@ RSpec.describe RuboCop::ConfigLoader do
       let(:cop_class) { RuboCop::Cop::Metrics::MethodLength }
 
       before do
-        create_file('~/.rubocop.yml',
+        stub_const('RuboCop::ConfigLoader::RUBOCOP_HOME', 'rubocop')
+        stub_const('RuboCop::ConfigLoader::DEFAULT_FILE', File.join('rubocop', 'config', 'default.yml'))
+        create_file('rubocop/config/default.yml',
                     <<~YAML)
+                      AllCops:
+                        AnythingGoes: banana
                       Metrics/MethodLength:
                         Enabled: pending
                     YAML
@@ -923,7 +927,7 @@ RSpec.describe RuboCop::ConfigLoader do
       end
 
       context 'when not configured explicitly' do
-        let(:config) { ['inherit_from: ~/.rubocop.yml'] }
+        let(:config) { '' }
 
         it 'is disabled' do
           expect(cop_enabled?(cop_class)).to eq 'pending'
@@ -933,7 +937,6 @@ RSpec.describe RuboCop::ConfigLoader do
       context 'when enabled explicitly in config' do
         let(:config) do
           <<~YAML
-            inherit_from: ~/.rubocop.yml
             Metrics/MethodLength:
               Enabled: true
           YAML
@@ -947,7 +950,6 @@ RSpec.describe RuboCop::ConfigLoader do
       context 'when disabled explicitly in config' do
         let(:config) do
           <<~YAML
-            inherit_from: ~/.rubocop.yml
             Metrics/MethodLength:
               Enabled: false
           YAML
@@ -961,14 +963,12 @@ RSpec.describe RuboCop::ConfigLoader do
       context 'when DisabledByDefault is true' do
         let(:config) do
           <<~YAML
-            inherit_from: ~/.rubocop.yml
             AllCops:
               DisabledByDefault: true
           YAML
         end
 
         it 'is disabled' do
-          pending
           expect(cop_enabled?(cop_class)).to be false
         end
       end
@@ -976,14 +976,12 @@ RSpec.describe RuboCop::ConfigLoader do
       context 'when EnabledByDefault is true' do
         let(:config) do
           <<~YAML
-            inherit_from: ~/.rubocop.yml
             AllCops:
               EnabledByDefault: true
           YAML
         end
 
         it 'is enabled' do
-          pending
           expect(cop_enabled?(cop_class)).to be true
         end
       end

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -904,6 +904,90 @@ RSpec.describe RuboCop::ConfigLoader do
         end
       end
     end
+
+    context 'when a new cop is introduced' do
+      def cop_enabled?(cop_class)
+        configuration_from_file.for_cop(cop_class).fetch('Enabled')
+      end
+
+      let(:file_path) { '.rubocop.yml' }
+      let(:cop_class) { RuboCop::Cop::Metrics::MethodLength }
+
+      before do
+        create_file('~/.rubocop.yml',
+                    <<~YAML)
+                      Metrics/MethodLength:
+                        Enabled: pending
+                    YAML
+        create_file(file_path, config)
+      end
+
+      context 'when not configured explicitly' do
+        let(:config) { ['inherit_from: ~/.rubocop.yml'] }
+
+        it 'is disabled' do
+          expect(cop_enabled?(cop_class)).to eq 'pending'
+        end
+      end
+
+      context 'when enabled explicitly in config' do
+        let(:config) do
+          <<~YAML
+            inherit_from: ~/.rubocop.yml
+            Metrics/MethodLength:
+              Enabled: true
+          YAML
+        end
+
+        it 'is enabled' do
+          expect(cop_enabled?(cop_class)).to be true
+        end
+      end
+
+      context 'when disabled explicitly in config' do
+        let(:config) do
+          <<~YAML
+            inherit_from: ~/.rubocop.yml
+            Metrics/MethodLength:
+              Enabled: false
+          YAML
+        end
+
+        it 'is disabled' do
+          expect(cop_enabled?(cop_class)).to be false
+        end
+      end
+
+      context 'when DisabledByDefault is true' do
+        let(:config) do
+          <<~YAML
+            inherit_from: ~/.rubocop.yml
+            AllCops:
+              DisabledByDefault: true
+          YAML
+        end
+
+        it 'is disabled' do
+          pending
+          expect(cop_enabled?(cop_class)).to be false
+        end
+      end
+
+      context 'when EnabledByDefault is true' do
+        let(:config) do
+          <<~YAML
+            inherit_from: ~/.rubocop.yml
+            AllCops:
+              EnabledByDefault: true
+          YAML
+        end
+
+        it 'is enabled' do
+          pending
+          expect(cop_enabled?(cop_class)).to be true
+        end
+      end
+    end
   end
 
   describe '.load_file', :isolated_environment do

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe RuboCop::Cop::Generator do
 
           Style/FakeCop:
             Description: 'TODO: Write a description of the cop.'
-            Enabled: true
+            Enabled: pending
             VersionAdded: '0.59'
 
           Style/Lambda:
@@ -217,10 +217,9 @@ RSpec.describe RuboCop::Cop::Generator do
 
         generator.inject_config(config_file_path: path)
 
-        expect(stdout.string).to eq(<<~MESSAGE)
-          [modify] A configuration for the cop is added into #{path}.
-                   If you want to disable the cop by default, set `Enabled` option to false.
-        MESSAGE
+        expect(stdout.string)
+          .to eq('[modify] A configuration for the cop is added into ' \
+                 "#{path}.\n")
       end
     end
 
@@ -231,7 +230,7 @@ RSpec.describe RuboCop::Cop::Generator do
         expect(File).to receive(:write).with(path, <<~YAML)
           Style/Aaa:
             Description: 'TODO: Write a description of the cop.'
-            Enabled: true
+            Enabled: pending
             VersionAdded: '0.59'
 
           Style/Alias:
@@ -246,10 +245,9 @@ RSpec.describe RuboCop::Cop::Generator do
 
         generator.inject_config(config_file_path: path)
 
-        expect(stdout.string).to eq(<<~MESSAGE)
-          [modify] A configuration for the cop is added into #{path}.
-                   If you want to disable the cop by default, set `Enabled` option to false.
-        MESSAGE
+        expect(stdout.string)
+          .to eq('[modify] A configuration for the cop is added into ' \
+                 "#{path}.\n")
       end
     end
 
@@ -269,16 +267,15 @@ RSpec.describe RuboCop::Cop::Generator do
 
           Style/Zzz:
             Description: 'TODO: Write a description of the cop.'
-            Enabled: true
+            Enabled: pending
             VersionAdded: '0.59'
         YAML
 
         generator.inject_config(config_file_path: path)
 
-        expect(stdout.string).to eq(<<~MESSAGE)
-          [modify] A configuration for the cop is added into #{path}.
-                   If you want to disable the cop by default, set `Enabled` option to false.
-        MESSAGE
+        expect(stdout.string)
+          .to eq('[modify] A configuration for the cop is added into ' \
+                 "#{path}.\n")
       end
     end
   end

--- a/spec/rubocop/cop/registry_spec.rb
+++ b/spec/rubocop/cop/registry_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe RuboCop::Cop::Registry do
       .to eq(described_class.new(cops.drop(2)))
   end
 
-  context '#contains_cop_matching?' do
+  describe '#contains_cop_matching?' do
     it 'can find cops matching a given name' do
       result = registry.contains_cop_matching?(
         ['Test/FirstArrayElementIndentation']
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::Cop::Registry do
     end
   end
 
-  context '#qualified_cop_name' do
+  describe '#qualified_cop_name' do
     let(:origin) { '/app/.rubocop.yml' }
 
     it 'gives back already properly qualified names' do
@@ -155,7 +155,7 @@ RSpec.describe RuboCop::Cop::Registry do
     )
   end
 
-  context '#cops' do
+  describe '#cops' do
     it 'exposes a list of cops' do
       expect(registry.cops).to eql(cops)
     end
@@ -165,7 +165,7 @@ RSpec.describe RuboCop::Cop::Registry do
     expect(registry.length).to be(6)
   end
 
-  context '#enabled' do
+  describe '#enabled' do
     let(:config) do
       RuboCop::Config.new(
         'Test/FirstArrayElementIndentation' => { 'Enabled' => false },
@@ -185,6 +185,24 @@ RSpec.describe RuboCop::Cop::Registry do
     it 'selects only safe cops if :safe passed' do
       enabled_cops = registry.enabled(config, [], true)
       expect(enabled_cops).not_to include(RuboCop::Cop::RSpec::Foo)
+    end
+
+    context 'when new cops are introduced' do
+      let(:config) do
+        RuboCop::Config.new(
+          'Lint/BooleanSymbol' => { 'Enabled' => 'pending' }
+        )
+      end
+
+      it 'does not include them' do
+        result = registry.enabled(config, [])
+        expect(result).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
+      end
+
+      it 'overrides config if :only includes the cop' do
+        result = registry.enabled(config, ['Lint/BooleanSymbol'])
+        expect(result).to eql(cops)
+      end
     end
   end
 


### PR DESCRIPTION
New cops, introduced or significantly changed between major versions, are introduced with `pending` status. This is done to avoid frustration over numerous offences during updates between minor versions. RuboCop will emit a warning that new cops were introduced, and suggest to explicitly enable or disable them in the user configuration file.

Based on https://github.com/rubocop-hq/rubocop/pull/7184

Fixes #5979

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/