### PR TITLE
[Fix #7193] Prevent PercentLiteralDelimiters from breaking certain %i literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#7193](https://github.com/rubocop-hq/rubocop/issues/7193): Prevent `Style/PercentLiteralDelimiters` from changing `%i` literals that contain escaped delimiters. ([@buehmann][])
+
 ## 0.78.0 (2019-12-18)
 
 ### New features

--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -88,27 +88,27 @@ module RuboCop
         end
 
         def contains_preferred_delimiter?(node, type)
-          preferred_delimiters = preferred_delimiters_for(type)
-          node
-            .children.map { |n| string_source(n) }.compact
-            .any? { |s| preferred_delimiters.any? { |d| s.include?(d) } }
+          contains_delimiter?(node, preferred_delimiters_for(type))
         end
 
         def include_same_character_as_used_for_delimiter?(node, type)
           return false unless %w[%w %i].include?(type)
 
           used_delimiters = matchpairs(begin_source(node)[-1])
-          escaped_delimiters = used_delimiters.map { |d| "\\#{d}" }.join('|')
+          contains_delimiter?(node, used_delimiters)
+        end
 
+        def contains_delimiter?(node, delimiters)
+          delimiters_regexp = Regexp.union(delimiters)
           node
             .children.map { |n| string_source(n) }.compact
-            .any? { |s| Regexp.new(escaped_delimiters) =~ s }
+            .any? { |s| delimiters_regexp =~ s }
         end
 
         def string_source(node)
           if node.is_a?(String)
             node
-          elsif node.respond_to?(:type) && node.str_type?
+          elsif node.respond_to?(:type) && (node.str_type? || node.sym_type?)
             node.source
           end
         end

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -200,6 +200,11 @@ RSpec.describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
       expect_no_offenses('%i[some symbols]')
     end
 
+    it 'does not register an offense for non-preferred delimiters ' \
+       'enclosing escaped delimiters' do
+      expect_no_offenses('%i(\(\) each)')
+    end
+
     it 'registers an offense for other delimiters' do
       expect_offense(<<~RUBY)
         %i(some symbols)


### PR DESCRIPTION
This fixes #7193 and actually follows up on https://github.com/rubocop-hq/rubocop/pull/5020, which claimed to fix the situation where escaped delimiters are contained in a percent literal but only did so for `%w` literals.