### PR TITLE
Remove unnecessary use of regexp

### DIFF
--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -213,7 +213,7 @@ module RuboCop
         end
 
         def matching_range(haystack, needle)
-          offset = (haystack.source =~ Regexp.new(Regexp.escape(needle)))
+          offset = haystack.source.index(needle)
           return unless offset
 
           offset += haystack.begin_pos


### PR DESCRIPTION
This is just a line I stumbled across. There is no need to use the
regexp machinery just to match a fixed substring.