### PR TITLE
[Fix #7569] Make `Style/YodaCondition` accept `__FILE__ == $0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#7193](https://github.com/rubocop-hq/rubocop/issues/7193): Prevent `Style/PercentLiteralDelimiters` from changing `%i` literals that contain escaped delimiters. ([@buehmann][])
 * [#7590](https://github.com/rubocop-hq/rubocop/issues/7590): Fix an error for `Layout/SpaceBeforeBlockBraces` when using with `EnforcedStyle: line_count_based` of `Style/BlockDelimiters` cop. ([@koic][])
+* [#7569](https://github.com/rubocop-hq/rubocop/issues/7569): Make `Style/YodaCondition` accept `__FILE__ == $0`. ([@koic][])
 
 ## 0.78.0 (2019-12-18)
 

--- a/spec/rubocop/cop/style/yoda_condition_spec.rb
+++ b/spec/rubocop/cop/style/yoda_condition_spec.rb
@@ -55,6 +55,10 @@ RSpec.describe RuboCop::Cop::Style::YodaCondition, :config do
     it_behaves_like 'accepts', 'not true'
     it_behaves_like 'accepts', '0 <=> val'
     it_behaves_like 'accepts', '"foo" === bar'
+    it_behaves_like 'accepts', '__FILE__ == $0'
+    it_behaves_like 'accepts', '__FILE__ != $0'
+    it_behaves_like 'accepts', '__FILE__ == $PROGRAM_NAME'
+    it_behaves_like 'accepts', '__FILE__ != $PROGRAM_NAME'
 
     it_behaves_like 'offense', '"foo" == bar'
     it_behaves_like 'offense', 'nil == bar'


### PR DESCRIPTION
Fixes #7569.

This PR makes `Style/YodaCondition` cop accept `__FILE__ == $0`

I think that both operands `__FILE__ == $0` can be assumed to be read-only, as mentioned in #7569. If users try to assign `__FILE__`, an error will occur. Also, it is not usually assigned to `$0` by users.

Therefore, this PR will make `Style/YodaCondition` cop accept both `__FILE__` and `$0` on the left side.

Also, this PR will change only an idiom `__FILE__ == $0`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
