### PR TITLE
Suppress a deprecation warning when using Ruby 2.7.0-dev

### DIFF
--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -9,9 +9,11 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
 
   shared_examples(
     'code with offense'
-  ) do |code, expected:, use: expected, instead_of: code|
+  ) do |code, options|
     context "when checking #{code}" do
       let(:source) { code }
+      let(:use) { options[:use] || options[:expected] }
+      let(:instead_of) { options[:instead_of] || code }
 
       let(:message) { "Use `#{use}` instead of `#{instead_of}`." }
 
@@ -20,7 +22,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
         expect(cop.messages).to eq([message])
       end
 
-      if expected
+      if (expected = options[:expected])
         it 'auto-corrects' do
           expect(autocorrect_source(code)).to eq(expected)
         end


### PR DESCRIPTION
This PR suppresses the following deprecation warning when using Ruby 2.7.0-dev.

```console
% ruby -v
ruby 2.7.0dev (2019-12-23T02:48:54Z master 048f797bf0) [x86_64-darwin17]

% bundle exec rake

(snip)

/Users/koic/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/rspec-core-3.9.0/lib/rspec/core/shared_example_group.rb:36:
warning: The last argument is used as keyword parameters; maybe **
should be added to the call
/Users/koic/src/github.com/rubocop-hq/rubocop/spec/rubocop/cop/style/numeric_predicate_spec.rb:12:
warning: The called method is defined here
```

https://bugs.ruby-lang.org/issues/14183

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
