### PR TITLE
[Fix #7576] Fix an error for `Gemspec/OrderedDependencies`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#7193](https://github.com/rubocop-hq/rubocop/issues/7193): Prevent `Style/PercentLiteralDelimiters` from changing `%i` literals that contain escaped delimiters. ([@buehmann][])
 * [#7590](https://github.com/rubocop-hq/rubocop/issues/7590): Fix an error for `Layout/SpaceBeforeBlockBraces` when using with `EnforcedStyle: line_count_based` of `Style/BlockDelimiters` cop. ([@koic][])
 * [#7569](https://github.com/rubocop-hq/rubocop/issues/7569): Make `Style/YodaCondition` accept `__FILE__ == $0`. ([@koic][])
+* [#7576](https://github.com/rubocop-hq/rubocop/issues/7576): Fix an error for `Gemspec/OrderedDependencies` when using a local variable in an argument of dependent gem. ([@koic][])
 
 ## 0.78.0 (2019-12-18)
 

--- a/lib/rubocop/cop/gemspec/ordered_dependencies.rb
+++ b/lib/rubocop/cop/gemspec/ordered_dependencies.rb
@@ -98,7 +98,7 @@ module RuboCop
         end
 
         def_node_search :dependency_declarations, <<~PATTERN
-          (send (lvar _) {:add_dependency :add_runtime_dependency :add_development_dependency} ...)
+          (send (lvar _) {:add_dependency :add_runtime_dependency :add_development_dependency} (str _) ...)
         PATTERN
       end
     end

--- a/spec/rubocop/cop/gemspec/ordered_dependencies_spec.rb
+++ b/spec/rubocop/cop/gemspec/ordered_dependencies_spec.rb
@@ -198,4 +198,15 @@ RSpec.describe RuboCop::Cop::Gemspec::OrderedDependencies, :config do
       RUBY
     end
   end
+
+  context 'When using a local variable in an argument of dependent gem' do
+    it 'does not register any offenses' do
+      expect_no_offenses(<<~RUBY)
+        Gem::Specification.new do |spec|
+          %w(rubocop-performance rubocop-rails).each { |dep| spec.add_dependency dep }
+          spec.add_dependency 'parser'
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #7576.

This PR fixes the following error for `Gemspec/OrderedDependencies` when using a local variable in an argument of dependent gem.

```console
% cat example.gemspec
Gem::Specification.new do |s|
  %w[foo bar].each { |dep| s.add_dependency dep }
  s.add_dependency 'baz'
end

% rubocop --only Gemspec/OrderedDependencies example.gemspec -d
(nsip)

An error occurred while Gemspec/OrderedDependencies cop was inspecting
/Users/koic/src/github.com/koic/rubocop-issues/7576/example.gemspec.
undefined method `str_type?' for nil:NilClass
```

Since it is difficult to trace variables and list gem names, this PR will skip them.

And `add_dependency`, `add_runtime_dependency`, and `add_development_dependency` accept a symbol.

e.g. `add_dependency(:foo)`

The original implementation raises the same error if a symbol is passed as an argument. This PR also solves that problem.

The issue for `add_dependency` and` abc` to accept symbols will open as separate a PR.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
