### PR TITLE
[Fix #7587] Add `Style/RedundantReturn`'s `AllowedMethods` option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * [#7528](https://github.com/rubocop-hq/rubocop/pull/7528): Add new `Lint/NonDeterministicRequireOrder` cop. ([@mangara][])
 * [#7559](https://github.com/rubocop-hq/rubocop/pull/7559): Add `EnforcedStyleForExponentOperator` parameter to `Layout/SpaceAroundOperators` cop. ([@khiav223577][])
+* [#7587](https://github.com/rubocop-hq/rubocop/issues/7587): Add `Style/RedundantReturn`'s `AllowedMethods` option. ([@QWYNG][])
 
 ### Bug fixes
 
@@ -4297,3 +4298,5 @@
 [@movermeyer]: https://github.com/movermeyer
 [@jethroo]: https://github.com/jethroo
 [@mangara]: https://github.com/mangara
+[@QWYNG]: https://github.com/QWYNG
+

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -475,4 +475,29 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
       RUBY
     end
   end
+
+  context 'with permitted methods' do
+    let(:cop_config) { { 'AllowedMethods' => %w[redirect_to] } }
+
+    it 'accepts before method name which is in permitted list' do
+      expect_no_offenses(<<~RUBY)
+        def func
+          if cond?
+            redirect_to some_path
+            return
+          end
+        end
+      RUBY
+    end
+
+    it 'accepts after method name which is in permitted list' do
+      expect_no_offenses(<<~RUBY)
+        def func
+          if cond?
+            return redirect_to some_path
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
fix #7587 
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
