### PR TITLE
[Fix #7590] Fix an error for `Layout/SpaceBeforeBlockBraces`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#7193](https://github.com/rubocop-hq/rubocop/issues/7193): Prevent `Style/PercentLiteralDelimiters` from changing `%i` literals that contain escaped delimiters. ([@buehmann][])
+* [#7590](https://github.com/rubocop-hq/rubocop/issues/7590): Fix an error for `Layout/SpaceBeforeBlockBraces` when using with `EnforcedStyle: line_count_based` of `Style/BlockDelimiters` cop. ([@koic][])
 
 ## 0.78.0 (2019-12-18)
 

--- a/lib/rubocop/cop/layout/space_before_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_before_block_braces.rb
@@ -47,7 +47,7 @@ module RuboCop
           # That means preventing auto-correction to incorrect auto-corrected
           # code.
           # See: https://github.com/rubocop-hq/rubocop/issues/7534
-          return if conflict_with_block_delimiters?
+          return if conflict_with_block_delimiters?(node)
 
           left_brace = node.loc.begin
           space_plus_brace = range_with_surrounding_space(range: left_brace)
@@ -118,7 +118,7 @@ module RuboCop
           end
         end
 
-        def conflict_with_block_delimiters?
+        def conflict_with_block_delimiters?(node)
           block_delimiters_style == 'line_count_based' &&
             style == :no_space && node.multiline?
         end

--- a/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
@@ -62,6 +62,25 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
     it 'accepts left brace without outer space' do
       expect_no_offenses('each{ puts }')
     end
+
+    context 'with `EnforcedStyle` of `Style/BlockDelimiters`' do
+      let(:config) do
+        merged_config = RuboCop::ConfigLoader.default_configuration[
+          'Layout/SpaceBeforeBlockBraces'
+        ].merge(cop_config)
+
+        RuboCop::Config.new(
+          'Layout/SpaceBeforeBlockBraces' => merged_config,
+          'Style/BlockDelimiters' => { 'EnforcedStyle' => 'line_count_based' }
+        )
+      end
+
+      it 'accepts left brace without outer space' do
+        expect_no_offenses(<<~RUBY)
+          let(:foo){{foo: 1, bar: 2}}
+        RUBY
+      end
+    end
   end
 
   context 'with space before empty braces not allowed' do


### PR DESCRIPTION
Fixes #7590.

This PR fixes an error for `Layout/SpaceBeforeBlockBraces` when using with `EnforcedStyle: line_count_based` of `Style/BlockDelimiters` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
