### PR TITLE
[Fix #7593] Do not Kernel#abort on validation errors

### DIFF
--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -217,8 +217,6 @@ module RuboCop
           raise(TypeError, "Malformed configuration in #{absolute_path}")
         end
 
-        check_cop_config_value(hash)
-
         hash
       end
 
@@ -237,24 +235,6 @@ module RuboCop
                         "`#{value}` is concealed by duplicate"
                     end
           warn Rainbow(message).yellow
-        end
-      end
-
-      def check_cop_config_value(hash, parent = nil)
-        hash.each do |key, value|
-          check_cop_config_value(value, key) if value.is_a?(Hash)
-
-          next unless %w[Enabled
-                         Safe
-                         SafeAutoCorrect
-                         AutoCorrect].include?(key) && value.is_a?(String)
-
-          next if key == 'Enabled' && value == 'pending'
-
-          abort(
-            "Property #{Rainbow(key).yellow} of cop #{Rainbow(parent).yellow}" \
-            " is supposed to be a boolean and #{Rainbow(value).yellow} is not."
-          )
         end
       end
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1087,7 +1087,7 @@ RSpec.describe RuboCop::ConfigLoader do
         expect do
           load_file
         end.to raise_error(
-          SystemExit,
+          RuboCop::ValidationError,
           /supposed to be a boolean and disable is not/
         )
       end


### PR DESCRIPTION
This fixes #7593. There is no changelog entry because this is not a
user-facing bug: From a user's perspective RuboCop exits immediately in
any case.

Merry Christmas :christmas_tree: