### PR TITLE
[Fix #7595] Make `Style/NumericPredicate` aware of ignored methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#7590](https://github.com/rubocop-hq/rubocop/issues/7590): Fix an error for `Layout/SpaceBeforeBlockBraces` when using with `EnforcedStyle: line_count_based` of `Style/BlockDelimiters` cop. ([@koic][])
 * [#7569](https://github.com/rubocop-hq/rubocop/issues/7569): Make `Style/YodaCondition` accept `__FILE__ == $0`. ([@koic][])
 * [#7576](https://github.com/rubocop-hq/rubocop/issues/7576): Fix an error for `Gemspec/OrderedDependencies` when using a local variable in an argument of dependent gem. ([@koic][])
+* [#7595](https://github.com/rubocop-hq/rubocop/issues/7595): Make `Style/NumericPredicate` aware of ignored methods when specifying ignored methods. ([@koic][])
 
 ## 0.78.0 (2019-12-18)
 

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -54,9 +54,10 @@ module RuboCop
         }.freeze
 
         def on_send(node)
-          return if node.each_ancestor(:send, :block).any? do |ancestor|
-            ignored_method?(ancestor.method_name)
-          end
+          return if ignored_method?(node.method_name) ||
+                    node.each_ancestor(:send, :block).any? do |ancestor|
+                      ignored_method?(ancestor.method_name)
+                    end
 
           numeric, replacement = check(node)
 

--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -192,6 +192,42 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
       }
     end
 
+    context 'simple method call' do
+      context '`EnforcedStyle` is `predicate`' do
+        let(:cop_config) do
+          {
+            'EnforcedStyle' => 'predicate',
+            'IgnoredMethods' => %w[==]
+          }
+        end
+
+        context 'when checking if a number is zero' do
+          it_behaves_like 'code without offense', <<~RUBY
+            if number == 0
+              puts 'hello'
+            end
+          RUBY
+        end
+      end
+
+      context '`EnforcedStyle` is `comparison`' do
+        let(:cop_config) do
+          {
+            'EnforcedStyle' => 'comparison',
+            'IgnoredMethods' => %w[zero?]
+          }
+        end
+
+        context 'when checking if a number is zero' do
+          it_behaves_like 'code without offense', <<~RUBY
+            if number.zero?
+              puts 'hello'
+            end
+          RUBY
+        end
+      end
+    end
+
     context 'in argument' do
       context 'ignored method' do
         context 'when checking if a number is positive' do


### PR DESCRIPTION
Fixes #7595.

This PR makes `Style/NumericPredicate` aware of ignored methods when specifying ignored methods.

The following is a reproduction procedure.

```console
% cat .rubocop.yml
# .rubocop.yml
Style/NumericPredicate:
  EnforcedStyle: comparison
  IgnoredMethods: 'zero?'

% cat example.rb
if foo.zero?
  puts 'hello'
end

% bundle exec rubocop --only Style/NumericPredicate --cache false example.rb
Inspecting 1 file
C

Offenses:

example.rb:1:4: C: Style/NumericPredicate: Use foo == 0 instead of
foo.zero?.
if foo.zero?
   ^^^^^^^^^

1 file inspected, 1 offense detected
```

This PR resolves the issue caused by the callback node itself not being checked.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
