### PR TITLE
Fix an error when using Parser 2.7.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'bump', require: false
+# Workaround for Parser 2.7.0.0.
+# It specifies the upper version until Parser 2.7.0.1 release.
+gem 'parser', '>= 2.6', '< 2.7'
 gem 'pry'
 gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.7'


### PR DESCRIPTION
This PR fixes the following error when using Parser 2.7.0.0.

https://circleci.com/gh/rubocop-hq/rubocop/78846

```console
% cd path/to/repo/rubocop
% bundle exec rake internal_investigation
Running RuboCop...
invalid byte sequence in UTF-8
/Users/koic/src/github.com/whitequark/parser/lib/parser/lexer/dedenter.rb:40:in `split'
/Users/koic/src/github.com/whitequark/parser/lib/parser/lexer/dedenter.rb:40:in `dedent'
/Users/koic/src/github.com/whitequark/parser/lib/parser/builders/default.rb:288:in `block in dedent_string'
/Users/koic/src/github.com/whitequark/parser/lib/parser/builders/default.rb:285:in `each'
/Users/koic/src/github.com/whitequark/parser/lib/parser/builders/default.rb:285:in `dedent_string'
/Users/koic/src/github.com/whitequark/parser/lib/parser/ruby23.rb:5713:in `_reduce_435'
/Users/koic/.rbenv/versions/2.6.5/lib/ruby/2.6.0/racc/parser.rb:259:in `_racc_do_parse_c'
/Users/koic/.rbenv/versions/2.6.5/lib/ruby/2.6.0/racc/parser.rb:259:in `do_parse'
/Users/koic/src/github.com/whitequark/parser/lib/parser/base.rb:189:in `parse'
/Users/koic/src/github.com/whitequark/parser/lib/parser/base.rb:236:in `tokenize'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/processed_source.rb:163:in tokenize'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/processed_source.rb:158:in `parse'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/processed_source.rb:36:in `initialize'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/processed_source.rb:17:in `new'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/processed_source.rb:17:in `from_file'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:365:in `get_processed_source'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:118:in `block in file_offenses'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:143:in `file_offense_cache'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:117:in `file_offenses'
```

The percent_string_array_spec.rb file contains a test case for binary encoded source, but the default file encoding is UTF-8.

```ruby
%W[\xC0 "foo"]
```

https://github.com/rubocop-hq/rubocop/blob/v0.78.0/spec/rubocop/cop/lint/percent_string_array_spec.rb#L95

This error is affected by the following Parser gem changes:
https://github.com/whitequark/parser/pull/641

I'm not confident about the solution, anyway I opened the following patch as PR to the whitequark/parser reposity.
https://github.com/whitequark/parser/pull/642

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
