### PR TITLE
Workaround for a build error when using Ruby 2.7.0 with YARD

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,12 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'bump', require: false
+# Workaround for YARD 0.9.20 or lower.
+# Depends on `e2mmap` and `irb` until the release that includes
+# the following changes:
+# https://github.com/lsegal/yard/pull/1296
+gem 'e2mmap'
+gem 'irb', '1.0.0'
 # Workaround for Parser 2.7.0.0.
 # It specifies the upper version until Parser 2.7.0.1 release.
 gem 'parser', '>= 2.6', '< 2.7'


### PR DESCRIPTION
This PR fixes a build error when using Ruby 2.7.0 with YARD.

```console
% cd path/to/repo/rubocop
% ruby -v
ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin17]

% bundle exec rake
rake aborted!
LoadError: cannot load such file -- e2mmap
/Users/koic/.rbenv/versions/2.7.0/bin/bundle:23:in `load'
/Users/koic/.rbenv/versions/2.7.0/bin/bundle:23:in `<main>'
Tasks: TOP => default => documentation_syntax_check =>
yard_for_generate_documentation
(See full trace by running task with --trace)
```

After adding `e2mmap` gem, the following error occurs.

```console
% bundle exec rake
rake aborted!
LoadError: cannot load such file -- irb/slex
/Users/koic/.rbenv/versions/2.7.0/bin/bundle:23:in `load'
/Users/koic/.rbenv/versions/2.7.0/bin/bundle:23:in `<main>'
Tasks: TOP => default => documentation_syntax_check =>
yard_for_generate_documentation
(See full trace by running task with --trace)
```

The following PR has been opened to resolve these errors.
https://github.com/lsegal/yard/pull/1296

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
