### PR TITLE
update circleci.yml to use ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,29 @@ jobs:
     steps:
       *rubocop_steps
 
+  # Ruby 2.7
+  ruby-2.7-spec:
+    docker:
+      - image: circleci/ruby:2.7
+    environment:
+      <<: *common_env
+    steps:
+      *spec_steps
+  ruby-2.7-ascii_spec:
+    docker:
+      - image: circleci/ruby:2.7
+    environment:
+      <<: *common_env
+    steps:
+      *ascii_spec_steps
+  ruby-2.7-rubocop:
+    docker:
+      - image: circleci/ruby:2.7
+    environment:
+      <<: *common_env
+    steps:
+      *rubocop_steps
+
   # ruby-head (nightly snapshot build)
   ruby-head-spec:
     docker:
@@ -262,6 +285,11 @@ workflows:
             - cc-setup
       - ruby-2.6-ascii_spec
       - ruby-2.6-rubocop
+      - ruby-2.7-spec:
+          requires:
+            - cc-setup
+      - ruby-2.7-ascii_spec
+      - ruby-2.7-rubocop
       - ruby-head-spec:
           requires:
             - cc-setup
@@ -279,4 +307,5 @@ workflows:
             - ruby-2.4-spec
             - ruby-2.5-spec
             - ruby-2.6-spec
+            - ruby-2.7-spec
             - jruby-9.2-spec


### PR DESCRIPTION
Updates circleci config.yml to also use Ruby 2.7 now that it has been released.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
