### PR TITLE
Revert "Remove unused code"

### DIFF
--- a/lib/rubocop/ast/node/mixin/conditional_node.rb
+++ b/lib/rubocop/ast/node/mixin/conditional_node.rb
@@ -14,6 +14,14 @@ module RuboCop
         loc.keyword.line == condition.source_range.line
       end
 
+      # Checks whether the condition of the node is written on more than
+      # one line.
+      #
+      # @return [Boolean] whether the condition is on more than one line
+      def multiline_condition?
+        !single_line_condition?
+      end
+
       # Returns the condition of the node. This works together with each node's
       # custom destructuring method to select the correct part of the node.
       #

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -8,6 +8,7 @@ module RuboCop
       extend NodePattern::Macros
       include MethodIdentifierPredicates
 
+      ARITHMETIC_OPERATORS = %i[+ - * / % **].freeze
       SPECIAL_MODIFIERS = %w[private protected].freeze
 
       # The receiving node of the method dispatch.
@@ -150,6 +151,14 @@ module RuboCop
       # @return [Boolean] whether the dispatched method has a block
       def block_literal?
         parent&.block_type? && eql?(parent.send_node)
+      end
+
+      # Checks whether this node is an arithmetic operation
+      #
+      # @return [Boolean] whether the dispatched method is an arithmetic
+      #                   operation
+      def arithmetic_operation?
+        ARITHMETIC_OPERATORS.include?(method_name)
       end
 
       # Checks if this node is part of a chain of `def` modifiers.

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -184,6 +184,10 @@ module RuboCop
           cop_config['Max']
         end
 
+        def allow_heredoc?
+          allowed_heredoc
+        end
+
         def allowed_heredoc
           cop_config['AllowHeredoc']
         end
@@ -204,6 +208,12 @@ module RuboCop
           heredocs.any? do |range, delimiter|
             range.cover?(line_number) &&
               (allowed_heredoc == true || allowed_heredoc.include?(delimiter))
+          end
+        end
+
+        def line_in_heredoc?(line_number)
+          heredocs.any? do |range, _delimiter|
+            range.cover?(line_number)
           end
         end
 

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -996,6 +996,26 @@ RSpec.describe RuboCop::AST::SendNode do
     end
   end
 
+  describe '#arithmetic_operation?' do
+    context 'with a binary arithmetic operation' do
+      let(:source) { 'foo + bar' }
+
+      it { expect(send_node.arithmetic_operation?).to be_truthy }
+    end
+
+    context 'with a unary numeric operation' do
+      let(:source) { '+foo' }
+
+      it { expect(send_node.arithmetic_operation?).to be_falsey }
+    end
+
+    context 'with a regular method call' do
+      let(:source) { 'foo.bar' }
+
+      it { expect(send_node.arithmetic_operation?).to be_falsey }
+    end
+  end
+
   describe '#block_node' do
     context 'with a block literal' do
       let(:send_node) { parse_source(source).ast.children[0] }


### PR DESCRIPTION
Reverts rubocop-hq/rubocop#7600

As pointed out by @bbatsov the removed code consists of public API methods and we can be breaking some unknown extension. 