### PR TITLE
CI against Ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,29 @@ jobs:
     steps:
       *rubocop_steps
 
+  # Ruby 2.7
+  ruby-2.7-spec:
+    docker:
+      - image: circleci/ruby:2.7
+    environment:
+      <<: *common_env
+    steps:
+      *spec_steps
+  ruby-2.7-ascii_spec:
+    docker:
+      - image: circleci/ruby:2.7
+    environment:
+      <<: *common_env
+    steps:
+      *ascii_spec_steps
+  ruby-2.7-rubocop:
+    docker:
+      - image: circleci/ruby:2.7
+    environment:
+      <<: *common_env
+    steps:
+      *rubocop_steps
+
   # ruby-head (nightly snapshot build)
   ruby-head-spec:
     docker:
@@ -217,7 +240,7 @@ jobs:
       - run:
           name: Upload coverage results to Code Climate
           command: |
-            ./tmp/cc-test-reporter sum-coverage tmp/codeclimate.*.json --parts 5 --output tmp/codeclimate.total.json
+            ./tmp/cc-test-reporter sum-coverage tmp/codeclimate.*.json --parts 6 --output tmp/codeclimate.total.json
             ./tmp/cc-test-reporter upload-coverage --input tmp/codeclimate.total.json
 
   # Miscellaneous tasks
@@ -262,6 +285,11 @@ workflows:
             - cc-setup
       - ruby-2.6-ascii_spec
       - ruby-2.6-rubocop
+      - ruby-2.7-spec:
+          requires:
+            - cc-setup
+      - ruby-2.7-ascii_spec
+      - ruby-2.7-rubocop
       - ruby-head-spec:
           requires:
             - cc-setup
@@ -279,4 +307,5 @@ workflows:
             - ruby-2.4-spec
             - ruby-2.5-spec
             - ruby-2.6-spec
+            - ruby-2.7-spec
             - jruby-9.2-spec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ rubocop_steps: &rubocop_steps
       name: Check requiring libraries successfully
       # See https://github.com/rubocop-hq/rubocop/pull/4523#issuecomment-309136113
       command: |
-        ruby -I lib -r rubocop -e 'exit 0'
+        ruby -I lib -r bundler/setup -r rubocop -e 'exit 0'
 
 jobs:
 


### PR DESCRIPTION
Ruby 2.7.0 has been released and this Ruby version is available on `circleci/ruby:2.7` image.

- https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/
- https://hub.docker.com/r/circleci/ruby/tags/

```console
% docker pull circleci/ruby:2.7
2.7: Pulling from circleci/ruby

(snip)

Status: Downloaded newer image for circleci/ruby:2.7
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
