### PR TITLE
Remove workaround code for Parser 2.7.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,7 @@ gem 'bump', require: false
 # https://github.com/lsegal/yard/pull/1296
 gem 'e2mmap'
 gem 'irb', '1.0.0'
-# Workaround for Parser 2.7.0.0.
-# It specifies the upper version until Parser 2.7.0.1 release.
-gem 'parser', '>= 2.6', '< 2.7'
+gem 'parser', '>= 2.6'
 gem 'pry'
 gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.7'


### PR DESCRIPTION
Follow up of https://github.com/rubocop-hq/rubocop/pull/7597

https://github.com/whitequark/parser/pull/642 has been merged and Parser 2.7.0.1 has been released.
https://rubygems.org/gems/parser/versions/2.7.0.1

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
