### PR TITLE
[Fix #7586] Fix infinite loop in Style/FrozenStringLiteralComment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#7569](https://github.com/rubocop-hq/rubocop/issues/7569): Make `Style/YodaCondition` accept `__FILE__ == $0`. ([@koic][])
 * [#7576](https://github.com/rubocop-hq/rubocop/issues/7576): Fix an error for `Gemspec/OrderedDependencies` when using a local variable in an argument of dependent gem. ([@koic][])
 * [#7595](https://github.com/rubocop-hq/rubocop/issues/7595): Make `Style/NumericPredicate` aware of ignored methods when specifying ignored methods. ([@koic][])
+* [#7607](https://github.com/rubocop-hq/rubocop/issues/7607): Fix `Style/FrozenStringLiteralComment` infinite loop when magic comments are newline-separated. ([@pirj][])
 
 ## 0.78.0 (2019-12-18)
 

--- a/lib/rubocop/cop/mixin/frozen_string_literal.rb
+++ b/lib/rubocop/cop/mixin/frozen_string_literal.rb
@@ -40,13 +40,7 @@ module RuboCop
       end
 
       def leading_comment_lines
-        comments = processed_source.comments
-
-        comments.each_with_object([]) do |comment, leading_comments|
-          next if comment.loc.line > 3
-
-          leading_comments << comment.text
-        end
+        processed_source.comments.first(3).map(&:text)
       end
     end
   end

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
       RUBY
     end
 
-    it 'accepts a dsabled frozen string literal below an encoding comment' do
+    it 'accepts a disabled frozen string literal below an encoding comment' do
       expect_no_offenses(<<~RUBY)
         # encoding: utf-8
         # frozen_string_literal: false
@@ -375,7 +375,7 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
       RUBY
     end
 
-    it 'registers an offense for a dsabled frozen string literal below ' \
+    it 'registers an offense for a disabled frozen string literal below ' \
       'an encoding comment' do
       expect_offense(<<~RUBY)
         # encoding: utf-8
@@ -500,7 +500,7 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         RUBY
       end
 
-      it 'removes a dsabled frozen string literal below an encoding comment' do
+      it 'removes a disabled frozen string literal below an encoding comment' do
         new_source = autocorrect_source(<<~RUBY)
           # encoding: utf-8
           # frozen_string_literal: false

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -45,6 +45,11 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         puts 1
         ^ Missing magic comment `# frozen_string_literal: true`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        # frozen_string_literal: true
+        puts 1
+      RUBY
     end
 
     it 'registers an offense for not having a frozen string literal comment ' \
@@ -53,6 +58,25 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         #!/usr/bin/env ruby
         ^ Missing magic comment `# frozen_string_literal: true`.
         puts 1
+      RUBY
+
+      expect_correction(<<~RUBY)
+        #!/usr/bin/env ruby
+        # frozen_string_literal: true
+        puts 1
+      RUBY
+    end
+
+    it 'registers an offense for not having a frozen string literal comment ' \
+       'when there is only a shebang' do
+      expect_offense(<<~RUBY)
+        #!/usr/bin/env ruby
+        ^ Missing magic comment `# frozen_string_literal: true`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        #!/usr/bin/env ruby
+        # frozen_string_literal: true
       RUBY
     end
 
@@ -79,6 +103,29 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         ^ Missing magic comment `# frozen_string_literal: true`.
         puts 1
       RUBY
+
+      expect_correction(<<~RUBY)
+        # encoding: utf-8
+        # frozen_string_literal: true
+        puts 1
+      RUBY
+    end
+
+    it 'registers an offense for not having a frozen string literal comment ' \
+       'under an encoding comment separated by a newline' do
+      expect_offense(<<~RUBY)
+        # encoding: utf-8
+        ^ Missing magic comment `# frozen_string_literal: true`.
+
+        puts 1
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # encoding: utf-8
+        # frozen_string_literal: true
+
+        puts 1
+      RUBY
     end
 
     it 'accepts a frozen string literal below an encoding comment' do
@@ -103,6 +150,32 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         #!/usr/bin/env ruby
         ^ Missing magic comment `# frozen_string_literal: true`.
         # encoding: utf-8
+        puts 1
+      RUBY
+
+      expect_correction(<<~RUBY)
+        #!/usr/bin/env ruby
+        # encoding: utf-8
+        # frozen_string_literal: true
+        puts 1
+      RUBY
+    end
+
+    it 'registers an offense with an empty line between magic comments ' \
+       'and the code' do
+      expect_offense(<<~RUBY)
+        #!/usr/bin/env ruby
+        ^ Missing magic comment `# frozen_string_literal: true`.
+        # encoding: utf-8
+
+        puts 1
+      RUBY
+
+      expect_correction(<<~RUBY)
+        #!/usr/bin/env ruby
+        # encoding: utf-8
+        # frozen_string_literal: true
+
         puts 1
       RUBY
     end
@@ -176,120 +249,21 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
       RUBY
     end
 
-    context 'auto-correct' do
-      it 'adds a frozen string literal comment to the first line if one is ' \
-         'missing' do
-        new_source = autocorrect_source(<<~RUBY)
-          puts 1
-        RUBY
+    it 'registers an offence for an extra first empty line' do
+      pending 'There is a flaw that skips adding caret symbol in this case' \
+              'making it impossible to use `expect_offense` matcher'
 
-        expect(new_source).to eq(<<~RUBY)
-          # frozen_string_literal: true
-          puts 1
-        RUBY
-      end
+      expect_offense(<<~RUBY)
 
-      it 'adds a frozen string literal comment to the first line if one is ' \
-         'missing and handles extra spacing' do
-        new_source = autocorrect_source(<<~RUBY)
+        ^ Missing magic comment `# frozen_string_literal: true`.
+        puts 1
+      RUBY
 
-          puts 1
-        RUBY
+      expect(new_source).to eq(<<~RUBY)
+        # frozen_string_literal: true
 
-        expect(new_source).to eq(<<~RUBY)
-          # frozen_string_literal: true
-
-          puts 1
-        RUBY
-      end
-
-      it 'adds a frozen string literal comment after a shebang' do
-        new_source = autocorrect_source(<<~RUBY)
-          #!/usr/bin/env ruby
-          puts 1
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          #!/usr/bin/env ruby
-          # frozen_string_literal: true
-          puts 1
-        RUBY
-      end
-
-      it 'adds a frozen string literal comment after an encoding comment' do
-        new_source = autocorrect_source(<<~RUBY)
-          # encoding: utf-8
-          puts 1
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          # encoding: utf-8
-          # frozen_string_literal: true
-          puts 1
-        RUBY
-      end
-
-      it 'adds a frozen string literal comment after a shebang and encoding ' \
-         'comment' do
-        new_source = autocorrect_source(<<~RUBY)
-          #!/usr/bin/env ruby
-          # encoding: utf-8
-          puts 1
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          #!/usr/bin/env ruby
-          # encoding: utf-8
-          # frozen_string_literal: true
-          puts 1
-        RUBY
-      end
-
-      it 'adds a frozen string literal comment after a shebang and encoding ' \
-         'comment when there is an empty line before the code' do
-        new_source = autocorrect_source(<<~RUBY)
-          #!/usr/bin/env ruby
-          # encoding: utf-8
-
-          puts 1
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          #!/usr/bin/env ruby
-          # encoding: utf-8
-          # frozen_string_literal: true
-
-          puts 1
-        RUBY
-      end
-
-      it 'adds a frozen string literal comment after an encoding comment ' \
-         'when there is an empty line before the code' do
-        new_source = autocorrect_source(<<~RUBY)
-          # encoding: utf-8
-
-          puts 1
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          # encoding: utf-8
-          # frozen_string_literal: true
-
-          puts 1
-        RUBY
-      end
-
-      it 'adds a frozen string literal comment after a shebang when there is ' \
-         'only a shebang' do
-        new_source = autocorrect_source(<<~RUBY)
-          #!/usr/bin/env ruby
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          #!/usr/bin/env ruby
-          # frozen_string_literal: true
-        RUBY
-      end
+        puts 1
+      RUBY
     end
   end
 
@@ -314,6 +288,10 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary frozen string literal comment.
         puts 1
       RUBY
+
+      expect_correction(<<~RUBY)
+        puts 1
+      RUBY
     end
 
     it 'registers an offense for a disabled frozen string literal comment ' \
@@ -321,6 +299,10 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
       expect_offense(<<~RUBY)
         # frozen_string_literal: false
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary frozen string literal comment.
+        puts 1
+      RUBY
+
+      expect_correction(<<~RUBY)
         puts 1
       RUBY
     end
@@ -345,6 +327,11 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary frozen string literal comment.
         puts 1
       RUBY
+
+      expect_correction(<<~RUBY)
+        #!/usr/bin/env ruby
+        puts 1
+      RUBY
     end
 
     it 'registers an offense for a disabled frozen string literal ' \
@@ -353,6 +340,11 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         #!/usr/bin/env ruby
         # frozen_string_literal: false
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary frozen string literal comment.
+        puts 1
+      RUBY
+
+      expect_correction(<<~RUBY)
+        #!/usr/bin/env ruby
         puts 1
       RUBY
     end
@@ -373,6 +365,11 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary frozen string literal comment.
         puts 1
       RUBY
+
+      expect_correction(<<~RUBY)
+        # encoding: utf-8
+        puts 1
+      RUBY
     end
 
     it 'registers an offense for a disabled frozen string literal below ' \
@@ -381,6 +378,11 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         # encoding: utf-8
         # frozen_string_literal: false
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary frozen string literal comment.
+        puts 1
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # encoding: utf-8
         puts 1
       RUBY
     end
@@ -403,6 +405,12 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary frozen string literal comment.
         puts 1
       RUBY
+
+      expect_correction(<<~RUBY)
+        #!/usr/bin/env ruby
+        # encoding: utf-8
+        puts 1
+      RUBY
     end
 
     it 'registers an offense for a disabled frozen string literal comment ' \
@@ -412,6 +420,12 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         # encoding: utf-8
         # frozen_string_literal: false
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary frozen string literal comment.
+        puts 1
+      RUBY
+
+      expect_correction(<<~RUBY)
+        #!/usr/bin/env ruby
+        # encoding: utf-8
         puts 1
       RUBY
     end
@@ -425,6 +439,12 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         # encoding: utf-8
         puts 1
       RUBY
+
+      expect_correction(<<~RUBY)
+        #!/usr/bin/env ruby
+        # encoding: utf-8
+        puts 1
+      RUBY
     end
 
     it 'registers an offense for a disabled frozen string literal comment ' \
@@ -436,146 +456,12 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         # encoding: utf-8
         puts 1
       RUBY
-    end
 
-    context 'auto-correct' do
-      it 'removes the frozen string literal comment from the top line' do
-        new_source = autocorrect_source(<<~RUBY)
-          # frozen_string_literal: true
-          puts 1
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          puts 1
-        RUBY
-      end
-
-      it 'removes a disabled frozen string literal comment on the top line' do
-        new_source = autocorrect_source(<<~RUBY)
-          # frozen_string_literal: false
-          puts 1
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          puts 1
-        RUBY
-      end
-
-      it 'removes a frozen string literal comment below a shebang comment' do
-        new_source = autocorrect_source(<<~RUBY)
-          #!/usr/bin/env ruby
-          # frozen_string_literal: true
-          puts 1
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          #!/usr/bin/env ruby
-          puts 1
-        RUBY
-      end
-
-      it 'removes a disabled frozen string literal below a shebang comment' do
-        new_source = autocorrect_source(<<~RUBY)
-          #!/usr/bin/env ruby
-          # frozen_string_literal: false
-          puts 1
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          #!/usr/bin/env ruby
-          puts 1
-        RUBY
-      end
-
-      it 'removes a frozen string literal comment below an encoding comment' do
-        new_source = autocorrect_source(<<~RUBY)
-          # encoding: utf-8
-          # frozen_string_literal: true
-          puts 1
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          # encoding: utf-8
-          puts 1
-        RUBY
-      end
-
-      it 'removes a disabled frozen string literal below an encoding comment' do
-        new_source = autocorrect_source(<<~RUBY)
-          # encoding: utf-8
-          # frozen_string_literal: false
-          puts 1
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          # encoding: utf-8
-          puts 1
-        RUBY
-      end
-
-      it 'removes a frozen string literal comment ' \
-        'below shebang and encoding comments' do
-        new_source = autocorrect_source(<<~RUBY)
-          #!/usr/bin/env ruby
-          # encoding: utf-8
-          # frozen_string_literal: true
-          puts 1
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          #!/usr/bin/env ruby
-          # encoding: utf-8
-          puts 1
-        RUBY
-      end
-
-      it 'removes a disabled frozen string literal comment from ' \
-        'below shebang and encoding comments' do
-        new_source = autocorrect_source(<<~RUBY)
-          #!/usr/bin/env ruby
-          # encoding: utf-8
-          # frozen_string_literal: false
-          puts 1
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          #!/usr/bin/env ruby
-          # encoding: utf-8
-          puts 1
-        RUBY
-      end
-
-      it 'removes a frozen string literal comment ' \
-        'below shebang above an encoding comments' do
-        new_source = autocorrect_source(<<~RUBY)
-          #!/usr/bin/env ruby
-          # frozen_string_literal: true
-          # encoding: utf-8
-          puts 1
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          #!/usr/bin/env ruby
-          # encoding: utf-8
-          puts 1
-        RUBY
-      end
-
-      it 'removes a disabled frozen string literal comment ' \
-        'below shebang above an encoding comments' do
-        new_source = autocorrect_source(<<~RUBY)
-          #!/usr/bin/env ruby
-          # frozen_string_literal: false
-          # encoding: utf-8
-          puts 1
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          #!/usr/bin/env ruby
-          # encoding: utf-8
-          puts 1
-        RUBY
-      end
+      expect_correction(<<~RUBY)
+        #!/usr/bin/env ruby
+        # encoding: utf-8
+        puts 1
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -117,6 +117,18 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
       RUBY
     end
 
+    it 'accepts a frozen string literal comment below newline-separated ' \
+       'magic comments' do
+      expect_no_offenses(<<~RUBY)
+        #!/usr/bin/env ruby
+
+        # encoding: utf-8
+
+        # frozen_string_literal: true
+        puts 1
+      RUBY
+    end
+
     it 'accepts a disabled frozen string literal comment below shebang and ' \
        'encoding comments' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #7586

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/