### PR TITLE
Remove redundant Parser gem dependency from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem 'bump', require: false
 # https://github.com/lsegal/yard/pull/1296
 gem 'e2mmap'
 gem 'irb', '1.0.0'
-gem 'parser', '>= 2.6'
 gem 'pry'
 gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.7'


### PR DESCRIPTION
Follow up of https://github.com/rubocop-hq/rubocop/pull/7606#discussion_r361956264.

This PR removes redundant Parser gem dependency from Gemfile.
It is redundant with the specification in gemspec.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
