### PR TITLE
Require Parser 2.7.0.1 or higher

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('jaro_winkler', '~> 1.5.1')
   s.add_runtime_dependency('parallel', '~> 1.10')
-  s.add_runtime_dependency('parser', '>= 2.6')
+  s.add_runtime_dependency('parser', '>= 2.7.0.1')
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 1.7')


### PR DESCRIPTION
Follow up of https://github.com/rubocop-hq/rubocop/pull/7606#discussion_r361963001.

Parser 2.7.0.0 has the following issue.
https://github.com/rubocop-hq/rubocop/pull/7597

This PR changes to require Parser gem 2.7.0.1 or higher.
Parser 2.7 is compatible with Parser 2.6, so I think it's safe to upgrade.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
