### PR TITLE
Revert workaround for YARD

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'bump', require: false
-# Workaround for YARD 0.9.20 or lower.
-# Depends on `e2mmap` and `irb` until the release that includes
-# the following changes:
-# https://github.com/lsegal/yard/pull/1296
-gem 'e2mmap'
-gem 'irb', '1.0.0'
 gem 'pry'
 gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.7'
@@ -18,10 +12,7 @@ gem 'rubocop-performance', '~> 1.5.0'
 gem 'rubocop-rspec', '~> 1.33.0'
 gem 'simplecov', '~> 0.10'
 gem 'test-queue'
-# Workaround for YARD 0.9.20 or lower.
-# It specifies `github` until the release that includes the following changes:
-# https://github.com/lsegal/yard/pull/1290
-gem 'yard', github: 'lsegal/yard', ref: '10a2e5b'
+gem 'yard', '~> 0.9'
 
 group :test do
   gem 'safe_yaml', require: false


### PR DESCRIPTION
YARD 0.9.21 has been released.
https://rubygems.org/gems/yard/versions/0.9.21

This PR reverts the following workaround code for YARD.

- https://github.com/rubocop-hq/rubocop/pull/7598
- https://github.com/rubocop-hq/rubocop/pull/7558

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
