### PR TITLE
[Fix #7616] Fix an incorrect autocorrect for `Style/MultilineWhenThen`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#7607](https://github.com/rubocop-hq/rubocop/issues/7607): Fix `Style/FrozenStringLiteralComment` infinite loop when magic comments are newline-separated. ([@pirj][])
 * [#7602](https://github.com/rubocop-hq/rubocop/pull/7602): Ensure proper handling of Ruby 2.7 syntax. ([@drenmi][])
 * [#7620](https://github.com/rubocop-hq/rubocop/issues/7620): Fix a false positive for `Migration/DepartmentName` when a disable comment contains a plain comment. ([@koic][])
+* [#7616](https://github.com/rubocop-hq/rubocop/issues/7616): Fix an incorrect autocorrect for `Style/MultilineWhenThen` for when statement with then is an array or a hash. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/multiline_when_then.rb
+++ b/lib/rubocop/cop/style/multiline_when_then.rb
@@ -35,7 +35,7 @@ module RuboCop
           return if !node.children.last.nil? && !node.multiline? && node.then?
 
           # With more than one statements after then, there's not offense
-          return if node.children.last&.begin_type?
+          return if accept_node_type?(node.body)
 
           add_offense(node, location: :begin)
         end
@@ -48,6 +48,10 @@ module RuboCop
               )
             )
           end
+        end
+
+        def accept_node_type?(node)
+          node&.begin_type? || node&.array_type? || node&.hash_type?
         end
       end
     end

--- a/spec/rubocop/cop/style/multiline_when_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_when_then_spec.rb
@@ -57,6 +57,26 @@ RSpec.describe RuboCop::Cop::Style::MultilineWhenThen do
     RUBY
   end
 
+  it 'does not register an offense for hash when statement with then' do
+    expect_no_offenses(<<~RUBY)
+      case condition
+      when foo then {
+          key: 'value'
+        }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for array when statement with then' do
+    expect_no_offenses(<<~RUBY)
+      case condition
+      when foo then [
+          'element'
+        ]
+      end
+    RUBY
+  end
+
   it 'autocorrects then in empty when' do
     new_source = autocorrect_source(<<~RUBY)
       case foo


### PR DESCRIPTION
Fixes #7616.

This PR fixes an incorrect autocorrect for `Style/MultilineWhenThen` for when statement with then is an array or a hash.

The following is a reproduction procedure.

```console
% cat example.rb
case condition
when foo then {
    key: 'value'
  }
end

% ruby -c example.rb
Syntax OK
```

It is changed to the code with syntax error as follows.

```console
% bundle exec rubocop -a --only Style/MultilineWhenThen
(snip)

% cat example.rb
case condition
when foo {
    key: 'value'
  }
end

% ruby -c example.rb
example.rb:3: syntax error, unexpected ':', expecting '}'
    key: 'value'
example.rb:4: syntax error, unexpected '}', expecting end-of-input
```

The same is true when replacing a hash with an array.
The PR will accept these cases without offense.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
