### PR TITLE
Add a spec of beginless range for Ruby 2.7

### DIFF
--- a/spec/rubocop/ast/range_node_spec.rb
+++ b/spec/rubocop/ast/range_node_spec.rb
@@ -31,5 +31,15 @@ RSpec.describe RuboCop::AST::RangeNode do
       it { expect(range_node.is_a?(described_class)).to be(true) }
       it { expect(range_node.range_type?).to be(true) }
     end
+
+    context 'with a beiginless range' do
+      let(:ruby_version) { 2.7 }
+      let(:source) do
+        '..42'
+      end
+
+      it { expect(range_node.is_a?(described_class)).to be(true) }
+      it { expect(range_node.range_type?).to be(true) }
+    end
   end
 end


### PR DESCRIPTION
This PR adds a spec for beginless range for Ruby 2.7.

https://bugs.ruby-lang.org/issues/14799

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
