### PR TITLE
[Fix #7620] Fix a false positive for `Migration/DepartmentName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#7595](https://github.com/rubocop-hq/rubocop/issues/7595): Make `Style/NumericPredicate` aware of ignored methods when specifying ignored methods. ([@koic][])
 * [#7607](https://github.com/rubocop-hq/rubocop/issues/7607): Fix `Style/FrozenStringLiteralComment` infinite loop when magic comments are newline-separated. ([@pirj][])
 * [#7602](https://github.com/rubocop-hq/rubocop/pull/7602): Ensure proper handling of Ruby 2.7 syntax. ([@drenmi][])
+* [#7620](https://github.com/rubocop-hq/rubocop/issues/7620): Fix a false positive for `Migration/DepartmentName` when a disable comment contains a plain comment. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/migration/department_name.rb
+++ b/lib/rubocop/cop/migration/department_name.rb
@@ -10,13 +10,21 @@ module RuboCop
 
         MSG = 'Department name is missing.'
 
+        # The token that makes up a disable comment.
+        # The token used after `# rubocop: disable` are `A-z`, `/`, and `,`.
+        # Also `A-z` includes `all`.
+        DISABLING_COPS_CONTENT_TOKEN = %r{[A-z/,]+}.freeze
+
         def investigate(processed_source)
           processed_source.each_comment do |comment|
             next if comment.text !~ /\A(# *rubocop:((dis|en)able|todo) +)(.*)/
 
             offset = Regexp.last_match(1).length
             Regexp.last_match(4).scan(%r{[\w/]+|\W+}) do |name|
+              break unless valid_content_token?(name.strip)
+
               check_cop_name(name, comment, offset)
+
               offset += name.length
             end
           end
@@ -37,6 +45,10 @@ module RuboCop
           start = comment.location.expression.begin_pos + offset
           range = range_between(start, start + name.length)
           add_offense(range, location: range)
+        end
+
+        def valid_content_token?(content_token)
+          !DISABLING_COPS_CONTENT_TOKEN.match(content_token).nil?
         end
       end
     end

--- a/spec/rubocop/cop/migration/department_name_spec.rb
+++ b/spec/rubocop/cop/migration/department_name_spec.rb
@@ -43,4 +43,13 @@ RSpec.describe RuboCop::Cop::Migration::DepartmentName do
       RUBY
     end
   end
+
+  context 'when a disable comment contains a plain comment' do
+    it 'accepts' do
+      expect_no_offenses(<<~RUBY)
+        # rubocop:disable Style/Alias # Plain code comment
+        alias :ala :bala
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #7620.

This PR fixes the following false positive for `Migration/DepartmentName` when a disable comment contains a plain comment.

```console
% cat example.rb
# rubocop:disable Style/SafeNavigation # support Ruby < 2.3.0

% rubocop --only Migration/DepartmentName
Inspecting 1 file
C

Offenses:

example.rb:1:50: C: Migration/DepartmentName: Department name is missing.
# rubocop:disable Style/SafeNavigation # support Ruby < 2.3.0
                                                 ^^^^

1 file inspected, 1 offense detected
```

The following is an example disable comment.

```ruby
# rubocop:disable Style/FrozenStringLiteralComment, Style/StringLiterals
```

The token used after `# rubocop: disable` are `A-z`, `/`, `,`.
And `A-z` includes `all`.

```ruby
# rubocop:disable all
```

This PR will change the processing of `Migration/DepartmentName` cop to finish when an invalid token is used.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
