### PR TITLE
[Fix #7627] Fix a false negative for `Migration/DepartmentName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#7602](https://github.com/rubocop-hq/rubocop/pull/7602): Ensure proper handling of Ruby 2.7 syntax. ([@drenmi][])
 * [#7620](https://github.com/rubocop-hq/rubocop/issues/7620): Fix a false positive for `Migration/DepartmentName` when a disable comment contains a plain comment. ([@koic][])
 * [#7616](https://github.com/rubocop-hq/rubocop/issues/7616): Fix an incorrect autocorrect for `Style/MultilineWhenThen` for when statement with then is an array or a hash. ([@koic][])
+* [#7627](https://github.com/rubocop-hq/rubocop/issues/7627): Fix a false negative for `Migration/DepartmentName` when there is space around `:` (e.g. `# rubocop : disable`). ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/migration/department_name.rb
+++ b/lib/rubocop/cop/migration/department_name.rb
@@ -10,6 +10,9 @@ module RuboCop
 
         MSG = 'Department name is missing.'
 
+        DISABLE_COMMENT_FORMAT =
+          /\A(# *rubocop *: *((dis|en)able|todo) +)(.*)/.freeze
+
         # The token that makes up a disable comment.
         # The token used after `# rubocop: disable` are `A-z`, `/`, and `,`.
         # Also `A-z` includes `all`.
@@ -17,7 +20,7 @@ module RuboCop
 
         def investigate(processed_source)
           processed_source.each_comment do |comment|
-            next if comment.text !~ /\A(# *rubocop:((dis|en)able|todo) +)(.*)/
+            next if comment.text !~ DISABLE_COMMENT_FORMAT
 
             offset = Regexp.last_match(1).length
             Regexp.last_match(4).scan(%r{[\w/]+|\W+}) do |name|

--- a/spec/rubocop/cop/migration/department_name_spec.rb
+++ b/spec/rubocop/cop/migration/department_name_spec.rb
@@ -33,6 +33,26 @@ RSpec.describe RuboCop::Cop::Migration::DepartmentName do
         # rubocop:enable Style/Alias, Layout/LineLength
       RUBY
     end
+
+    it 'registers offenses and corrects when there is space around `:`' do
+      expect do
+        expect_offense(<<~RUBY, 'file.rb')
+          # rubocop : todo Alias, LineLength
+                                  ^^^^^^^^^^ Department name is missing.
+                           ^^^^^ Department name is missing.
+          alias :ala :bala
+          # rubocop : enable Alias, LineLength
+                                    ^^^^^^^^^^ Department name is missing.
+                             ^^^^^ Department name is missing.
+        RUBY
+      end.to output(warning).to_stderr
+
+      expect_correction(<<~RUBY)
+        # rubocop : todo Style/Alias, Layout/LineLength
+        alias :ala :bala
+        # rubocop : enable Style/Alias, Layout/LineLength
+      RUBY
+    end
   end
 
   context 'when a disable comment has cop names with departments' do


### PR DESCRIPTION
Fixes #7627.

This PR fixes a false negative for `Migration/DepartmentName` when there is space around `:`.

For example, `# rubocop : disable` is a valid syntax for a disable comment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
