### PR TITLE
[Fix #7628] Include trailing comma for single arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#7602](https://github.com/rubocop-hq/rubocop/pull/7602): Ensure proper handling of Ruby 2.7 syntax. ([@drenmi][])
 * [#7620](https://github.com/rubocop-hq/rubocop/issues/7620): Fix a false positive for `Migration/DepartmentName` when a disable comment contains a plain comment. ([@koic][])
 * [#7616](https://github.com/rubocop-hq/rubocop/issues/7616): Fix an incorrect autocorrect for `Style/MultilineWhenThen` for when statement with then is an array or a hash. ([@koic][])
+* [#7628](https://github.com/rubocop-hq/rubocop/issues/7628): Fix an incorrect autocorrect for `Layout/MultilineBlockLayout` removing trailing comma with single argument. ([@pawptart][])
 
 ### Changes
 
@@ -4315,3 +4316,4 @@
 [@jethroo]: https://github.com/jethroo
 [@mangara]: https://github.com/mangara
 [@pirj]: https://github.com/pirj
+[@pawptart]: https://github.com/pawptart

--- a/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
@@ -259,4 +259,39 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
       end
     RUBY
   end
+
+  it 'does not auto-correct a trailing comma when only one argument ' \
+     'is present' do
+    new_source = autocorrect_source(<<~RUBY)
+      def f
+        X.map do |
+          a,
+        |
+        end
+      end
+    RUBY
+    expect(new_source).to eq(<<~RUBY)
+      def f
+        X.map do |a,|
+        end
+      end
+    RUBY
+  end
+
+  it 'auto-corrects nested parens correctly' do
+    new_source = autocorrect_source(<<~RUBY)
+      def f
+        X.map do |
+          (((a), b), c)
+        |
+        end
+      end
+    RUBY
+    expect(new_source).to eq(<<~RUBY)
+      def f
+        X.map do |(((a), b), c)|
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #7628.

Autocorrect for `Layout/MultilineBlockLayout` removed a trailing comma for single arguments that could potentially change semantics. 

Introduced `include_trailing_comma?` method to determine whether this trailing comma is both present and required in order to include it where necessary.

Tests added for this case and also to make sure it functioned correctly with nested parentheses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
