### PR TITLE
Remove `console` from `Lint/Debugger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#7636](https://github.com/rubocop-hq/rubocop/issues/7636): Remove `console` from `Lint/Debugger` to prevent false positives. ([@gsamokovarov][])
+
 ## 0.79.0 (2020-01-06)
 
 ### New features

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -43,7 +43,7 @@ module RuboCop
         PATTERN
 
         def_node_matcher :debugger_call?, <<~PATTERN
-          {(send {nil? #kernel?} {:debugger :byebug :remote_byebug :console} ...)
+          {(send {nil? #kernel?} {:debugger :byebug :remote_byebug} ...)
            (send (send {#kernel? nil?} :binding)
              {:pry :remote_pry :pry_remote :console} ...)
            (send (const {nil? (cbase)} :Pry) :rescue ...)

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
                    'save_screenshot foo'
 
   include_examples 'debugger', 'remote_byebug', 'remote_byebug'
-  include_examples 'debugger', 'web console', 'console'
   include_examples 'debugger', 'web console binding', 'binding.console'
 
   it 'does not report an offense for a non-pry binding' do
@@ -62,7 +61,6 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
   include_examples 'debugger', 'debugger with Kernel', 'Kernel.debugger'
   include_examples 'debugger', 'debugger with ::Kernel', '::Kernel.debugger'
   include_examples 'debugger', 'binding.pry with Kernel', 'Kernel.binding.pry'
-  include_examples 'debugger', 'web console with Kernel', 'Kernel.console'
 
   it 'does not report an offense for save_and_open_page with Kernel' do
     expect_no_offenses('Kernel.save_and_open_page')


### PR DESCRIPTION
It's ambiguous and we can play games and try not to recognize:

```ruby
console(with, arguments_or) do
  with_a_block
end
```

But, other use cases will come up. Web Console supports
`binding.console`, which is safe to recognize, so let's drop
the ambiguous `console` one.