### PR TITLE
Fix  edge case in `omit_parentheses` style of `Style/MethodCallWithArgsParentheses`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#7639](https://github.com/rubocop-hq/rubocop/pull/7639): Fix logical operator edge case in `omit_parentheses` style of `Style/MethodCallWithArgsParentheses`. ([@gsamokovarov][])
+
 ### Changes
 
 * [#7636](https://github.com/rubocop-hq/rubocop/issues/7636): Remove `console` from `Lint/Debugger` to prevent false positives. ([@gsamokovarov][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -74,10 +74,11 @@ module RuboCop
           end
 
           def call_in_logical_operators?(node)
-            node.parent &&
-              (logical_operator?(node.parent) ||
-              node.parent.send_type? &&
-              node.parent.arguments.any?(&method(:logical_operator?)))
+            parent = node.parent&.block_type? ? node.parent.parent : node.parent
+            parent &&
+              (logical_operator?(parent) ||
+              parent.send_type? &&
+              parent.arguments.any?(&method(:logical_operator?)))
           end
 
           def call_in_optional_arguments?(node)

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -471,6 +471,11 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
     it 'accepts parens in calls with logical operators' do
       expect_no_offenses('foo(a) && bar(b)')
       expect_no_offenses('foo(a) || bar(b)')
+      expect_no_offenses(<<~RUBY)
+        foo(a) || bar(b) do
+          pass
+        end
+      RUBY
     end
 
     it 'accepts parens in calls with args with logical operators' do


### PR DESCRIPTION
Before this change:

```ruby
foo(a) || bar(b) do
             ^^^ Omit parentheses for method calls with arguments.
  pass
end
```

This resulted in a `SyntaxError` if corrected. The check for a call
with a logical operator did not take into account that the parent of a
send node with a block is the block node itself.

After this change, the code below is lawful:

```ruby
foo(a) || bar(b) do
  pass
end
```