### PR TITLE
Defer tests where frozen string by default

### DIFF
--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -137,9 +137,12 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
     end
 
     context 'when the constant is a frozen string literal' do
-      if RuboCop::TargetRuby.supported_versions.include?(3.0)
-        context 'when the target ruby version >= 3.0' do
-          let(:ruby_version) { 3.0 }
+      # TODO : It is not yet decided when frozen string will be the default.
+      # It has been abandoned in the Ruby 3.0 period, but may default in
+      # the long run. So these tests are left with a provisional value of 4.0.
+      if RuboCop::TargetRuby.supported_versions.include?(4.0)
+        context 'when the target ruby version >= 4.0' do
+          let(:ruby_version) { 4.0 }
 
           context 'when the frozen string literal comment is missing' do
             it_behaves_like 'immutable objects', '"#{a}"'

--- a/spec/rubocop/cop/style/redundant_freeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_freeze_spec.rb
@@ -54,9 +54,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze do
   end
 
   context 'when the receiver is a frozen string literal' do
-    if RuboCop::TargetRuby.supported_versions.include?(3.0)
-      context 'when the target ruby version >= 3.0' do
-        let(:ruby_version) { 3.0 }
+    # TODO : It is not yet decided when frozen string will be the default.
+    # It has been abandoned in the Ruby 3.0 period, but may default in
+    # the long run. So these tests are left with a provisional value of 4.0.
+    if RuboCop::TargetRuby.supported_versions.include?(4.0)
+      context 'when the target ruby version >= 4.0' do
+        let(:ruby_version) { 4.0 }
 
         context 'when the frozen string literal comment is missing' do
           it_behaves_like 'immutable objects', '"#{a}"'


### PR DESCRIPTION
It has been abandoned in the Ruby 3.0 period, but may default in the long run. So these tests are left with a provisional value of 4.0.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
