### PR TITLE
Use Ruby 2.7 parser for `rake documentation_syntax_check`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -91,6 +91,7 @@ desc 'Syntax check for the documentation comments'
 task documentation_syntax_check: :yard_for_generate_documentation do
   require 'parser/ruby25'
   require 'parser/ruby26'
+  require 'parser/ruby27'
 
   ok = true
   YARD::Registry.load!
@@ -113,8 +114,12 @@ task documentation_syntax_check: :yard_for_generate_documentation do
         # `Lint/UselessElseWithoutRescue` cop's example.
         parser = if cop == RuboCop::Cop::Lint::UselessElseWithoutRescue
                    Parser::Ruby25.new(RuboCop::AST::Builder.new)
-                 else
+                 # Ruby 2.7 raises an syntax error in
+                 # `Lint/CircularArgumentReference` cop's example.
+                 elsif cop == RuboCop::Cop::Lint::CircularArgumentReference
                    Parser::Ruby26.new(RuboCop::AST::Builder.new)
+                 else
+                   Parser::Ruby27.new(RuboCop::AST::Builder.new)
                  end
         parser.diagnostics.all_errors_are_fatal = true
         parser.parse(buffer)


### PR DESCRIPTION
## Summary

This PR uses Ruby 2.7 parser for `rake documentation_syntax_check`.
With this change, example code written using Ruby 2.7 syntax can be analyzed.

## Other infromation

The following error occurs in `Lint/CircularArgumentReference` example code when Ruby 2.7 parser is used.

```consle
% bundle exec rake documentation_syntax_check
Files:         474
Modules:        83 (   11 undocumented)
Classes:       438 (    3 undocumented)
Constants:     631 (  621 undocumented)
Attributes:     31 (    0 undocumented)
Methods:      1081 (  960 undocumented)
 29.55% documented
 lib/rubocop/cop/lint/circular_argument_reference.rb: Syntax Error in an
 example. circular argument reference pie
 lib/rubocop/cop/lint/circular_argument_reference.rb: Syntax Error in an
 example. circular argument reference dry_ingredients
```

The error is avoided by using Ruby 2.6 parser for `Lint/CircularArgumentReference` example code as a workaround.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
