### PR TITLE
Workaround for a build error when using Ruby 2.8.0-dev with crack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,11 @@ gem 'test-queue'
 gem 'yard', '~> 0.9'
 
 group :test do
+  # Workaround for crack 0.4.3 or lower.
+  # Depends on `rexml` until the release that includes
+  # the following changes:
+  # https://github.com/jnunemaker/crack/pull/62
+  gem 'rexml'
   gem 'safe_yaml', require: false
   gem 'webmock', require: false
 end


### PR DESCRIPTION
REXML gem has been unbundled since Ruby 2.8.0-dev (Ruby 3.0).
https://github.com/ruby/ruby/commit/c3ccf23d5807f2ff20127bf5e42df0977bf672fb

This PR fixes a build error when using Ruby 2.8.0-dev with crack.

```console
% cd path/to/repo/rubocop
% ruby -v
ruby 2.8.0dev (2020-01-14T00:46:52Z master 440013b2fa) [x86_64-darwin17]
% bundle exec rake
(snip)

An error occurred while loading spec_helper. - Did you mean?
                    rspec ./spec/spec_helper.rb

Failure/Error: require 'webmock/rspec'

LoadError:
  cannot load such file -- rexml/parsers/streamparser
# ./spec/spec_helper.rb:10:in `require'
# ./spec/spec_helper.rb:10:in `<top (required)>'
# tasks/spec_runner.rake:102:in `all_suite_files'
# tasks/spec_runner.rake:60:in `initialize'
# tasks/spec_runner.rake:27:in `new'
# tasks/spec_runner.rake:27:in `block in run_specs'
# tasks/spec_runner.rake:41:in `with_encoding'
# tasks/spec_runner.rake:25:in `run_specs'
# tasks/spec_runner.rake:112:in `block in <top (required)>'
Starting test-queue master (/tmp/test_queue_74588_13980.sock)
```

https://circleci.com/gh/rubocop-hq/rubocop/81817

The following PR has been opened to resolve the error.
https://github.com/jnunemaker/crack/pull/62

This patch is a workaround until a new version of crack will be released.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
