### PR TITLE
Convert tests to use expect_correction

### DIFF
--- a/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
   context 'when EnforcedStyle is set to indent' do
     let(:cop_config) { { 'EnforcedStyle' => 'indent' } }
 
-    it 'registers an offense for misaligned private' do
+    it 'registers an offense and corrects misaligned private' do
       expect_offense(<<~RUBY)
         class Test
 
@@ -24,9 +24,18 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
           def test; end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        class Test
+
+          private
+
+          def test; end
+        end
+      RUBY
     end
 
-    it 'registers an offense for misaligned private in module' do
+    it 'registers an offense and corrects misaligned private in module' do
       expect_offense(<<~RUBY)
         module Test
 
@@ -36,9 +45,19 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
           def test; end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        module Test
+
+          private
+
+          def test; end
+        end
+      RUBY
     end
 
-    it 'registers an offense for misaligned module_function in module' do
+    it 'registers an offense and corrects misaligned module_function ' \
+      'in module' do
       expect_offense(<<~RUBY)
         module Test
 
@@ -48,9 +67,18 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
           def test; end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        module Test
+
+          module_function
+
+          def test; end
+        end
+      RUBY
     end
 
-    it 'registers an offense for correct + opposite alignment' do
+    it 'registers an offense and corrects correct + opposite alignment' do
       expect_offense(<<~RUBY)
         module Test
 
@@ -62,9 +90,20 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
           def test; end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        module Test
+
+          public
+
+          private
+
+          def test; end
+        end
+      RUBY
     end
 
-    it 'registers an offense for opposite + correct alignment' do
+    it 'registers an offense and corrects opposite + correct alignment' do
       expect_offense(<<~RUBY)
         module Test
 
@@ -76,9 +115,21 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
           def test; end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        module Test
+
+          public
+
+          private
+
+          def test; end
+        end
+      RUBY
     end
 
-    it 'registers an offense for misaligned private in singleton class' do
+    it 'registers an offense and corrects misaligned private ' \
+      'in a singleton class' do
       expect_offense(<<~RUBY)
         class << self
 
@@ -88,9 +139,18 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
           def test; end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        class << self
+
+          private
+
+          def test; end
+        end
+      RUBY
     end
 
-    it 'registers an offense for misaligned private in class ' \
+    it 'registers an offense and corrects misaligned private in class ' \
        'defined with Class.new' do
       expect_offense(<<~RUBY)
         Test = Class.new do
@@ -101,9 +161,19 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
           def test; end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        Test = Class.new do
+
+          private
+
+          def test; end
+        end
+      RUBY
     end
 
-    it 'registers an offense for access modifiers in arbitrary blocks' do
+    it 'registers an offense and corrects access modifiers ' \
+      'in arbitrary blocks' do
       expect_offense(<<~RUBY)
         Test = func do
 
@@ -113,9 +183,18 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
           def test; end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        Test = func do
+
+          private
+
+          def test; end
+        end
+      RUBY
     end
 
-    it 'registers an offense for misaligned private in module ' \
+    it 'registers an offense and corrects misaligned private in module ' \
        'defined with Module.new' do
       expect_offense(<<~RUBY)
         Test = Module.new do
@@ -126,14 +205,32 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
           def test; end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        Test = Module.new do
+
+          private
+
+          def test; end
+        end
+      RUBY
     end
 
-    it 'registers an offense for misaligned protected' do
+    it 'registers an offense and corrects misaligned protected' do
       expect_offense(<<~RUBY)
         class Test
 
         protected
         ^^^^^^^^^ Indent access modifiers like `protected`.
+
+          def test; end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Test
+
+          protected
 
           def test; end
         end
@@ -190,7 +287,8 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
       RUBY
     end
 
-    it 'handles properly nested classes' do
+    it 'registers an offense and corrects misaligned access modifiers ' \
+      'in nested classes' do
       expect_offense(<<~RUBY)
         class Test
 
@@ -198,6 +296,22 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
 
           private
           ^^^^^^^ Indent access modifiers like `private`.
+
+            def a; end
+          end
+
+          protected
+
+          def test; end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Test
+
+          class Nested
+
+            private
 
             def a; end
           end
@@ -231,29 +345,6 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
           class << self
             private :test
           end
-        end
-      RUBY
-    end
-
-    it 'auto-corrects incorrectly indented access modifiers' do
-      corrected = autocorrect_source(<<~RUBY)
-        class Test
-
-        public
-         private
-           protected
-
-          def test; end
-        end
-      RUBY
-      expect(corrected).to eq(<<~RUBY)
-        class Test
-
-          public
-          private
-          protected
-
-          def test; end
         end
       RUBY
     end
@@ -294,12 +385,22 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
   context 'when EnforcedStyle is set to outdent' do
     let(:cop_config) { { 'EnforcedStyle' => 'outdent' } }
 
-    it 'registers offense for private indented to method depth in a class' do
+    it 'registers offense and corrects private indented ' \
+      'to method depth in a class' do
       expect_offense(<<~RUBY)
         class Test
 
           private
           ^^^^^^^ Outdent access modifiers like `private`.
+
+          def test; end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Test
+
+        private
 
           def test; end
         end
@@ -325,12 +426,22 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
       RUBY
     end
 
-    it 'registers offense for private indented to method depth in a module' do
+    it 'registers an offense and corrects private indented ' \
+      'to method depth in a module' do
       expect_offense(<<~RUBY)
         module Test
 
           private
           ^^^^^^^ Outdent access modifiers like `private`.
+
+          def test; end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module Test
+
+        private
 
           def test; end
         end
@@ -356,12 +467,22 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
       RUBY
     end
 
-    it 'registers offense for module fn indented to method depth in a module' do
+    it 'registers an offense and corrects module_function indented ' \
+      'to method depth in a module' do
       expect_offense(<<~RUBY)
         module Test
 
           module_function
           ^^^^^^^^^^^^^^^ Outdent access modifiers like `module_function`.
+
+          def test; end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module Test
+
+        module_function
 
           def test; end
         end
@@ -388,13 +509,22 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
       RUBY
     end
 
-    it 'registers offense for private indented to method depth in singleton ' \
-       'class' do
+    it 'registers an offense and corrects private indented ' \
+      'to method depth in singleton class' do
       expect_offense(<<~RUBY)
         class << self
 
           private
           ^^^^^^^ Outdent access modifiers like `private`.
+
+          def test; end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class << self
+
+        private
 
           def test; end
         end
@@ -421,13 +551,22 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
       RUBY
     end
 
-    it 'registers offense for private indented to method depth in class ' \
-       'defined with Class.new' do
+    it 'registers an offense and corrects private indented to method depth ' \
+      'in class defined with Class.new' do
       expect_offense(<<~RUBY)
         Test = Class.new do
 
           private
           ^^^^^^^ Outdent access modifiers like `private`.
+
+          def test; end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Test = Class.new do
+
+        private
 
           def test; end
         end
@@ -455,13 +594,22 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
       RUBY
     end
 
-    it 'registers offense for private indented to method depth in module ' \
-       'defined with Module.new' do
+    it 'registers an offense and corrects private indented to method depth ' \
+      'in module defined with Module.new' do
       expect_offense(<<~RUBY)
         Test = Module.new do
 
           private
           ^^^^^^^ Outdent access modifiers like `private`.
+
+          def test; end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Test = Module.new do
+
+        private
 
           def test; end
         end
@@ -511,7 +659,8 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
       RUBY
     end
 
-    it 'handles properly nested classes' do
+    it 'registers an offense and corrects misaligned access modifiers ' \
+      'in nested classes' do
       expect_offense(<<~RUBY)
         class Test
 
@@ -528,70 +677,20 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
           def test; end
         end
       RUBY
-    end
 
-    it 'auto-corrects incorrectly indented access modifiers' do
-      corrected = autocorrect_source(<<~RUBY)
-        module M
-          class Test
+      expect_correction(<<~RUBY)
+        class Test
 
-        public
-         private
-             protected
+          class Nested
 
-            def test; end
-          end
-        end
-      RUBY
-      expect(corrected).to eq(<<~RUBY)
-        module M
-          class Test
-
-          public
           private
-          protected
 
-            def test; end
-          end
-        end
-      RUBY
-    end
-
-    it 'auto-corrects private in complicated case' do
-      corrected = autocorrect_source(<<~RUBY)
-        class Hello
-          def foo
-            'hi'
+            def a; end
           end
 
-          def bar
-            Module.new do
+        protected
 
-             private
-
-              def hi
-                'bye'
-              end
-            end
-          end
-        end
-      RUBY
-      expect(corrected).to eq(<<~RUBY)
-        class Hello
-          def foo
-            'hi'
-          end
-
-          def bar
-            Module.new do
-
-            private
-
-              def hi
-                'bye'
-              end
-            end
-          end
+          def test; end
         end
       RUBY
     end

--- a/spec/rubocop/cop/layout/array_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/array_alignment_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::Layout::ArrayAlignment do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for misaligned array elements' do
+  it 'registers an offense and corrects misaligned array elements' do
     expect_offense(<<~RUBY)
       array = [
         a,
@@ -12,6 +12,15 @@ RSpec.describe RuboCop::Cop::Layout::ArrayAlignment do
         c,
          d
          ^ Align the elements of an array literal if they span more than one line.
+      ]
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array = [
+        a,
+        b,
+        c,
+        d
       ]
     RUBY
   end
@@ -45,35 +54,18 @@ RSpec.describe RuboCop::Cop::Layout::ArrayAlignment do
     RUBY
   end
 
-  it 'auto-corrects alignment' do
-    new_source = autocorrect_source(<<~RUBY)
-      array = [
-        a,
-         b,
-        c,
-       d
-      ]
-    RUBY
-    expect(new_source).to eq(<<~RUBY)
-      array = [
-        a,
-        b,
-        c,
-        d
-      ]
-    RUBY
-  end
-
   it 'does not auto-correct array within array with too much indentation' do
-    original_source = <<~RUBY
+    expect_offense(<<~RUBY)
       [:l1,
         [:l2,
+        ^^^^^ Align the elements of an array literal if they span more than one line.
 
           [:l3,
+          ^^^^^ Align the elements of an array literal if they span more than one line.
            [:l4]]]]
     RUBY
-    new_source = autocorrect_source(original_source)
-    expect(new_source).to eq(<<~RUBY)
+
+    expect_correction(<<~RUBY)
       [:l1,
        [:l2,
 
@@ -83,15 +75,17 @@ RSpec.describe RuboCop::Cop::Layout::ArrayAlignment do
   end
 
   it 'does not auto-correct array within array with too little indentation' do
-    original_source = <<~RUBY
+    expect_offense(<<~RUBY)
       [:l1,
       [:l2,
+      ^^^^^ Align the elements of an array literal if they span more than one line.
 
         [:l3,
+        ^^^^^ Align the elements of an array literal if they span more than one line.
          [:l4]]]]
     RUBY
-    new_source = autocorrect_source(original_source)
-    expect(new_source).to eq(<<~RUBY)
+
+    expect_correction(<<~RUBY)
       [:l1,
        [:l2,
 
@@ -100,17 +94,8 @@ RSpec.describe RuboCop::Cop::Layout::ArrayAlignment do
     RUBY
   end
 
-  it 'auto-corrects only elements that begin a line' do
-    original_source = <<~RUBY
-      array = [:bar, {
-               whiz: 2, bang: 3 }, option: 3]
-    RUBY
-    new_source = autocorrect_source(original_source)
-    expect(new_source).to eq(original_source)
-  end
-
   it 'does not indent heredoc strings in autocorrect' do
-    original_source = <<~RUBY
+    expect_offense(<<~RUBY)
       var = [
              { :type => 'something',
                :sql => <<EOF
@@ -119,6 +104,7 @@ RSpec.describe RuboCop::Cop::Layout::ArrayAlignment do
       EOF
              },
             { :type => 'something',
+            ^^^^^^^^^^^^^^^^^^^^^^^ Align the elements of an array literal if they span more than one line.
               :sql => <<EOF
       Select something
       from atable
@@ -126,8 +112,8 @@ RSpec.describe RuboCop::Cop::Layout::ArrayAlignment do
             }
       ]
     RUBY
-    new_source = autocorrect_source(original_source)
-    expect(new_source).to eq(<<~RUBY)
+
+    expect_correction(<<~RUBY)
       var = [
              { :type => 'something',
                :sql => <<EOF

--- a/spec/rubocop/cop/layout/block_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/block_alignment_spec.rb
@@ -495,24 +495,23 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
       RUBY
     end
 
-    it 'autocorrects' do
-      source = <<~RUBY
+    it 'registers an offense and corrects misaligned end braces' do
+      expect_offense(<<~RUBY)
         def get_gems_by_name
           @gems ||= Hash[*get_latest_gems.map { |gem|
                            [gem.name, gem, gem.full_name, gem]
                       }.flatten]
+                      ^ `}` at 4, 14 is not aligned with `*get_latest_gems.map { |gem|` at 2, 17 or `@gems ||= Hash[*get_latest_gems.map { |gem|` at 2, 2.
         end
       RUBY
-      corrected = <<~RUBY
+
+      expect_correction(<<~RUBY)
         def get_gems_by_name
           @gems ||= Hash[*get_latest_gems.map { |gem|
                            [gem.name, gem, gem.full_name, gem]
                          }.flatten]
         end
       RUBY
-
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(corrected)
     end
   end
 
@@ -527,24 +526,23 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
       RUBY
     end
 
-    it 'autocorrects' do
-      source = <<~RUBY
+    it 'registers an offense and corrects misaligned end brace' do
+      expect_offense(<<~RUBY)
         def abc
           @abc ||= A[~xyz { |x|
                        x
                                 }.flatten]
+                                ^ `}` at 4, 24 is not aligned with `~xyz { |x|` at 2, 13 or `@abc ||= A[~xyz { |x|` at 2, 2.
         end
       RUBY
-      corrected = <<~RUBY
+
+      expect_correction(<<~RUBY)
         def abc
           @abc ||= A[~xyz { |x|
                        x
                      }.flatten]
         end
       RUBY
-
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(corrected)
     end
   end
 
@@ -559,24 +557,23 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
       RUBY
     end
 
-    it 'autocorrects' do
-      source = <<~RUBY
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
         def abc
           @abc ||= A[!xyz { |x|
                        x
         }.flatten]
+        ^ `}` at 4, 0 is not aligned with `!xyz { |x|` at 2, 13 or `@abc ||= A[!xyz { |x|` at 2, 2.
         end
       RUBY
-      corrected = <<~RUBY
+
+      expect_correction(<<~RUBY)
         def abc
           @abc ||= A[!xyz { |x|
                        x
                      }.flatten]
         end
       RUBY
-
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(corrected)
     end
   end
 
@@ -591,24 +588,23 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
       RUBY
     end
 
-    it 'autocorrects' do
-      source = <<~RUBY
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
         def abc
           @abc ||= A[-xyz { |x|
                        x
                           }.flatten]
+                          ^ `}` at 4, 18 is not aligned with `-xyz { |x|` at 2, 13 or `@abc ||= A[-xyz { |x|` at 2, 2.
         end
       RUBY
-      corrected = <<~RUBY
+
+      expect_correction(<<~RUBY)
         def abc
           @abc ||= A[-xyz { |x|
                        x
                      }.flatten]
         end
       RUBY
-
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(corrected)
     end
   end
 
@@ -618,6 +614,11 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
         test {
           }
           ^ `}` at 2, 2 is not aligned with `test {` at 1, 0.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        test {
+        }
       RUBY
     end
   end

--- a/spec/rubocop/cop/layout/block_end_newline_spec.rb
+++ b/spec/rubocop/cop/layout/block_end_newline_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe RuboCop::Cop::Layout::BlockEndNewline do
     RUBY
   end
 
-  it 'registers an offense when multiline block end is not on its own line' do
+  it 'registers an offense and corrects when multiline block end ' \
+    'is not on its own line' do
     expect_offense(<<~RUBY)
       test do
         foo end
@@ -29,7 +30,8 @@ RSpec.describe RuboCop::Cop::Layout::BlockEndNewline do
     RUBY
   end
 
-  it 'registers an offense when multiline block } is not on its own line' do
+  it 'registers an offense and corrects when multiline block } ' \
+    'is not on its own line' do
     expect_offense(<<~RUBY)
       test {
         foo }
@@ -39,26 +41,6 @@ RSpec.describe RuboCop::Cop::Layout::BlockEndNewline do
     expect_correction(<<~RUBY)
       test {
         foo
-      }
-    RUBY
-  end
-
-  it 'autocorrects a {} block where the } is top level code ' \
-    'outside of a class' do
-    new_source = autocorrect_source(<<~RUBY)
-      # frozen_string_literal: true
-
-      test {[
-        foo
-      ]}
-    RUBY
-
-    expect(new_source).to eq(<<~RUBY)
-      # frozen_string_literal: true
-
-      test {[
-        foo
-      ]
       }
     RUBY
   end

--- a/spec/rubocop/cop/layout/case_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/case_indentation_spec.rb
@@ -23,17 +23,6 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation do
       end
 
       context 'regarding assignment where the right hand side is a case' do
-        let(:correct_source) do
-          <<~RUBY
-            output = case variable
-                     when 'value1'
-              'output1'
-            else
-              'output2'
-            end
-          RUBY
-        end
-
         it 'accepts a correctly indented assignment' do
           expect_no_offenses(<<~RUBY)
             output = case variable
@@ -45,153 +34,106 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation do
           RUBY
         end
 
-        context 'an assignment indented as end' do
-          let(:source) do
-            <<~RUBY
-              output = case variable
-              when 'value1'
-                'output1'
-              else
-                'output2'
-              end
-            RUBY
-          end
+        it 'registers an offense and corrects assignment indented as end' do
+          expect_offense(<<~RUBY)
+            output = case variable
+            when 'value1'
+            ^^^^ Indent `when` as deep as `case`.
+              'output1'
+            else
+              'output2'
+            end
+          RUBY
 
-          it 'registers an offense' do
-            inspect_source(source)
-            expect(cop.messages).to eq(['Indent `when` as deep as `case`.'])
-            expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
-                                                       'end')
-          end
-
-          it 'does auto-correction' do
-            corrected = autocorrect_source(source)
-            expect(corrected).to eq correct_source
-          end
+          expect_correction(<<~RUBY)
+            output = case variable
+                     when 'value1'
+              'output1'
+            else
+              'output2'
+            end
+          RUBY
         end
 
-        context 'an assignment indented some other way' do
-          let(:source) do
-            <<~RUBY
-              output = case variable
-                when 'value1'
-                  'output1'
-                else
-                  'output2'
-              end
-            RUBY
-          end
+        it 'registers an offense and corrects assignment indented ' \
+          'some other way' do
+          expect_offense(<<~RUBY)
+            output = case variable
+              when 'value1'
+              ^^^^ Indent `when` as deep as `case`.
+                'output1'
+              else
+                'output2'
+            end
+          RUBY
 
-          let(:correct_source) do
-            <<~RUBY
-              output = case variable
-                       when 'value1'
-                  'output1'
-                else
-                  'output2'
-              end
-            RUBY
-          end
-
-          it 'registers an offense' do
-            inspect_source(source)
-            expect(cop.messages).to eq(['Indent `when` as deep as `case`.'])
-            expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-          end
-
-          it 'does auto-correction' do
-            corrected = autocorrect_source(source)
-            expect(corrected).to eq correct_source
-          end
+          expect_correction(<<~RUBY)
+            output = case variable
+                     when 'value1'
+                'output1'
+              else
+                'output2'
+            end
+          RUBY
         end
 
-        context 'correct + opposite' do
-          let(:source) do
-            <<~RUBY
-              output = case variable
-                       when 'value1'
-                         'output1'
-                       else
-                         'output2'
-                       end
-              output = case variable
-              when 'value1'
-                'output1'
-              else
-                'output2'
-              end
-            RUBY
-          end
+        it 'registers an offense and corrects correct + opposite style' do
+          expect_offense(<<~RUBY)
+            output = case variable
+                     when 'value1'
+                       'output1'
+                     else
+                       'output2'
+                     end
+            output = case variable
+            when 'value1'
+            ^^^^ Indent `when` as deep as `case`.
+              'output1'
+            else
+              'output2'
+            end
+          RUBY
 
-          let(:correct_source) do
-            <<~RUBY
-              output = case variable
-                       when 'value1'
-                         'output1'
-                       else
-                         'output2'
-                       end
-              output = case variable
-                       when 'value1'
-                'output1'
-              else
-                'output2'
-              end
-            RUBY
-          end
-
-          it 'registers an offense' do
-            inspect_source(source)
-            expect(cop.messages).to eq(['Indent `when` as deep as `case`.'])
-            expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-          end
-
-          it 'does auto-correction' do
-            corrected = autocorrect_source(source)
-            expect(corrected).to eq(correct_source)
-          end
+          expect_correction(<<~RUBY)
+            output = case variable
+                     when 'value1'
+                       'output1'
+                     else
+                       'output2'
+                     end
+            output = case variable
+                     when 'value1'
+              'output1'
+            else
+              'output2'
+            end
+          RUBY
         end
       end
 
-      context "a when clause that's deeper than case" do
-        let(:source) do
-          <<~RUBY
-            case a
-                when 0 then return
-                else
-                    case b
-                     when 1 then return
-                    end
-            end
-          RUBY
-        end
+      it 'registers an offense and corrects a when clause ' \
+        'that is indented deeper than case' do
+        expect_offense(<<~RUBY)
+          case a
+              when 0 then return
+              ^^^^ Indent `when` as deep as `case`.
+              else
+                  case b
+                   when 1 then return
+                   ^^^^ Indent `when` as deep as `case`.
+                  end
+          end
+        RUBY
 
-        it 'registers an offense' do
-          expect_offense(<<~RUBY)
-            case a
-                when 0 then return
-                ^^^^ Indent `when` as deep as `case`.
-                else
-                    case b
-                     when 1 then return
-                     ^^^^ Indent `when` as deep as `case`.
-                    end
-            end
-          RUBY
-        end
-
-        it 'does auto-correction' do
-          corrected = autocorrect_source(source)
-          expect(corrected).to eq(<<~RUBY)
-            case a
-            when 0 then return
-                else
-                    case b
-                    when 1 then return
-                    end
-            end
-          RUBY
-        end
+        expect_correction(<<~RUBY)
+          case a
+          when 0 then return
+              else
+                  case b
+                  when 1 then return
+                  end
+          end
+        RUBY
       end
 
       it "accepts a when clause that's equally indented with case" do
@@ -278,45 +220,26 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation do
           RUBY
         end
 
-        context 'an assignment indented some other way' do
-          let(:source) do
-            <<~RUBY
-              output = case variable
+        it 'registers an offense and corrects an assignment ' \
+          'indented some other way' do
+          expect_offense(<<~RUBY)
+            output = case variable
+                     when 'value1'
+                     ^^^^ Indent `when` one step more than `case`.
+                       'output1'
+                     else
+                       'output2'
+                     end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            output = case variable
                        when 'value1'
-                         'output1'
-                       else
-                         'output2'
-                       end
-            RUBY
-          end
-
-          let(:correct_source) do
-            <<~RUBY
-              output = case variable
-                         when 'value1'
-                         'output1'
-                       else
-                         'output2'
-                       end
-            RUBY
-          end
-
-          it 'registers an offense' do
-            expect_offense(<<~RUBY)
-              output = case variable
-                       when 'value1'
-                       ^^^^ Indent `when` one step more than `case`.
-                         'output1'
-                       else
-                         'output2'
-                       end
-            RUBY
-          end
-
-          it 'does auto-correction' do
-            corrected = autocorrect_source(source)
-            expect(corrected).to eq correct_source
-          end
+                       'output1'
+                     else
+                       'output2'
+                     end
+          RUBY
         end
       end
 
@@ -332,60 +255,40 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation do
         RUBY
       end
 
-      context "a when clause that's equally indented with case" do
-        let(:source) do
-          <<~RUBY
-            y = case a
+      it 'registers an offense and corrects a when clause that is ' \
+        'equally indented with case' do
+        expect_offense(<<~RUBY)
+          y = case a
+              when 0 then break
+              ^^^^ Indent `when` one step more than `case`.
+              when 0 then return
+              ^^^^ Indent `when` one step more than `case`.
+                z = case b
+                    when 1 then return
+                    ^^^^ Indent `when` one step more than `case`.
+                    when 1 then break
+                    ^^^^ Indent `when` one step more than `case`.
+                    end
+              end
+          case c
+          when 2 then encoding
+          ^^^^ Indent `when` one step more than `case`.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          y = case a
                 when 0 then break
                 when 0 then return
-                  z = case b
+                z = case b
                       when 1 then return
                       when 1 then break
-                      end
-                end
-            case c
+                    end
+              end
+          case c
             when 2 then encoding
-            end
-          RUBY
-        end
-
-        it 'registers an offense' do
-          expect_offense(<<~RUBY)
-            y = case a
-                when 0 then break
-                ^^^^ Indent `when` one step more than `case`.
-                when 0 then return
-                ^^^^ Indent `when` one step more than `case`.
-                  z = case b
-                      when 1 then return
-                      ^^^^ Indent `when` one step more than `case`.
-                      when 1 then break
-                      ^^^^ Indent `when` one step more than `case`.
-                      end
-                end
-            case c
-            when 2 then encoding
-            ^^^^ Indent `when` one step more than `case`.
-            end
-          RUBY
-        end
-
-        it 'does auto-correction' do
-          corrected = autocorrect_source(source)
-          expect(corrected).to eq(<<~RUBY)
-            y = case a
-                  when 0 then break
-                  when 0 then return
-                  z = case b
-                        when 1 then return
-                        when 1 then break
-                      end
-                end
-            case c
-              when 2 then encoding
-            end
-          RUBY
-        end
+          end
+        RUBY
       end
 
       context 'when indentation width is overridden for this cop only' do
@@ -435,45 +338,26 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation do
           RUBY
         end
 
-        context 'an assignment indented some other way' do
-          let(:source) do
-            <<~RUBY
-              output = case variable
-                when 'value1'
-                  'output1'
-                else
-                  'output2'
-              end
-            RUBY
-          end
-
-          let(:correct_source) do
-            <<~RUBY
-              output = case variable
+        it 'registers an offense and corrects an assignment indented ' \
+          'some other way' do
+          expect_offense(<<~RUBY)
+            output = case variable
               when 'value1'
-                  'output1'
-                else
-                  'output2'
-              end
-            RUBY
-          end
+              ^^^^ Indent `when` as deep as `end`.
+                'output1'
+              else
+                'output2'
+            end
+          RUBY
 
-          it 'registers an offense' do
-            expect_offense(<<~RUBY)
-              output = case variable
-                when 'value1'
-                ^^^^ Indent `when` as deep as `end`.
-                  'output1'
-                else
-                  'output2'
-              end
-            RUBY
-          end
-
-          it 'does auto-correction' do
-            corrected = autocorrect_source(source)
-            expect(corrected).to eq correct_source
-          end
+          expect_correction(<<~RUBY)
+            output = case variable
+            when 'value1'
+                'output1'
+              else
+                'output2'
+            end
+          RUBY
         end
       end
     end
@@ -501,77 +385,47 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation do
           RUBY
         end
 
-        context 'an assignment indented as case' do
-          let(:source) do
-            <<~RUBY
-              output = case variable
+        it 'registers an offense and corrects an assignment indented as case' do
+          expect_offense(<<~RUBY)
+            output = case variable
+                     when 'value1'
+                     ^^^^ Indent `when` one step more than `end`.
+                       'output1'
+                     else
+                       'output2'
+                     end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            output = case variable
                        when 'value1'
-                         'output1'
-                       else
-                         'output2'
-                       end
-            RUBY
-          end
-
-          let(:correct_source) do
-            <<~RUBY
-              output = case variable
-                         when 'value1'
-                         'output1'
-                       else
-                         'output2'
-                       end
-            RUBY
-          end
-
-          it 'registers an offense' do
-            inspect_source(source)
-            expect(cop.messages)
-              .to eq(['Indent `when` one step more than `end`.'])
-            expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
-                                                       'case')
-          end
-
-          it 'does auto-correction' do
-            corrected = autocorrect_source(source)
-            expect(corrected).to eq correct_source
-          end
+                       'output1'
+                     else
+                       'output2'
+                     end
+          RUBY
         end
 
-        context 'an assignment indented some other way' do
-          let(:source) do
-            <<~RUBY
-              output = case variable
+        it 'registers an offense and corrects an assignment indented ' \
+          'some other way' do
+          expect_offense(<<~RUBY)
+            output = case variable
+                   when 'value1'
+                   ^^^^ Indent `when` one step more than `end`.
+                     'output1'
+                   else
+                     'output2'
+                   end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            output = case variable
                      when 'value1'
-                       'output1'
-                     else
-                       'output2'
-                     end
-            RUBY
-          end
-
-          let(:correct_source) do
-            <<~RUBY
-              output = case variable
-                       when 'value1'
-                       'output1'
-                     else
-                       'output2'
-                     end
-            RUBY
-          end
-
-          it 'registers an offense' do
-            inspect_source(source)
-            expect(cop.messages)
-              .to eq(['Indent `when` one step more than `end`.'])
-            expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-          end
-
-          it 'does auto-correction' do
-            corrected = autocorrect_source(source)
-            expect(corrected).to eq correct_source
-          end
+                     'output1'
+                   else
+                     'output2'
+                   end
+          RUBY
         end
       end
     end
@@ -579,23 +433,18 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation do
 
   context 'when case is preceded by something else than whitespace' do
     let(:cop_config) { {} }
-    let(:source) do
-      <<~RUBY
-        case test when something
-        end
-      RUBY
-    end
 
-    it 'registers an offense' do
+    it 'registers an offense and does not correct' do
       expect_offense(<<~RUBY)
         case test when something
                   ^^^^ Indent `when` as deep as `case`.
         end
       RUBY
-    end
 
-    it "doesn't auto-correct" do
-      expect(autocorrect_source(source)).to eq(source)
+      expect_correction(<<~RUBY)
+        case test when something
+        end
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
@@ -76,17 +76,21 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
         RUBY
       end
 
-      it 'autocorrects misindented )' do
-        corrected = autocorrect_source(<<~RUBY)
+      it 'registers an offense and corrects misindented ) ' \
+        'when ) is aligned with the params' do
+        expect_offense(<<~RUBY)
           some_method(a,
             x: 1,
             y: 2
                       )
+                      ^ Indent `)` to column 0 (not 12)
           b =
             some_method(a,
                         )
+                        ^ Align `)` with `(`.
         RUBY
-        expect(corrected).to eq <<~RUBY
+
+        expect_correction(<<~RUBY)
           some_method(a,
             x: 1,
             y: 2
@@ -172,11 +176,20 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
           foo = some_method(a
           )
           ^ Align `)` with `(`.
+          some_method(a,
+                      x: 1,
+                      y: 2
+                      )
+                      ^ Align `)` with `(`.
         RUBY
 
         expect_correction(<<~RUBY)
           foo = some_method(a
                            )
+          some_method(a,
+                      x: 1,
+                      y: 2
+                     )
         RUBY
       end
 
@@ -229,27 +242,6 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
                             x: 1,
                             y: 2
                            )
-          b =
-            some_method(a,
-                       )
-        RUBY
-      end
-
-      it 'autocorrects misindented )' do
-        corrected = autocorrect_source(<<~RUBY)
-          some_method(a,
-                      x: 1,
-                      y: 2
-                      )
-          b =
-            some_method(a,
-                        )
-        RUBY
-        expect(corrected).to eq <<~RUBY
-          some_method(a,
-                      x: 1,
-                      y: 2
-                     )
           b =
             some_method(a,
                        )
@@ -321,13 +313,14 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
       RUBY
     end
 
-    it 'can autocorrect method chains' do
-      corrected = autocorrect_source(<<~RUBY)
+    it 'registers an offense and corrects method chains' do
+      expect_offense(<<~RUBY)
         good = foo.methA(:arg1, :arg2, options: :hash)
                  .methB(
                    :arg1,
                    :arg2,
              )
+             ^ Indent `)` to column 9 (not 5)
                  .methC
 
         good = foo.methA(
@@ -335,14 +328,16 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
                    :arg2,
                    options: :hash,
             )
+            ^ Indent `)` to column 9 (not 4)
                  .methB(
                    :arg1,
                    :arg2,
                )
+               ^ Indent `)` to column 9 (not 7)
                  .methC
       RUBY
 
-      expect(corrected).to eq <<~RUBY
+      expect_correction(<<~RUBY)
         good = foo.methA(:arg1, :arg2, options: :hash)
                  .methB(
                    :arg1,
@@ -364,12 +359,18 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
     end
 
     context 'when using safe navigation operator' do
-      it 'registers an offense for misaligned )' do
+      it 'registers an offense and corrects misaligned )' do
         expect_offense(<<~RUBY)
           receiver&.some_method(
             a
             )
             ^ Indent `)` to column 0 (not 2)
+        RUBY
+
+        expect_correction(<<~RUBY)
+          receiver&.some_method(
+            a
+          )
         RUBY
       end
     end

--- a/spec/rubocop/cop/layout/comment_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/comment_indentation_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::Layout::CommentIndentation do
       expect_no_offenses('hello # comment')
     end
 
-    it 'accepts a documentation comment' do
+    it 'registers an offense and corrects a documentation comment' do
       expect_offense(<<~RUBY)
         =begin
         Doc comment
@@ -28,19 +28,38 @@ RSpec.describe RuboCop::Cop::Layout::CommentIndentation do
          ^ Incorrect indentation detected (column 1 instead of 0).
         hi
       RUBY
+
+      expect_correction(<<~RUBY)
+        =begin
+        Doc comment
+        =end
+          hello
+        #
+        hi
+      RUBY
     end
 
-    it 'registers an offense for an incorrectly indented (1) comment' do
+    it 'registers an offense and corrects an incorrectly ' \
+      'indented (1) comment' do
       expect_offense(<<-RUBY.strip_margin('|'))
         | # comment
         | ^^^^^^^^^ Incorrect indentation detected (column 1 instead of 0).
       RUBY
+
+      expect_correction(<<-RUBY.strip_margin('|'))
+        |# comment
+      RUBY
     end
 
-    it 'registers an offense for an incorrectly indented (2) comment' do
+    it 'registers an offense and corrects an incorrectly ' \
+      'indented (2) comment' do
       expect_offense(<<-RUBY.strip_margin('|'))
         |  # comment
         |  ^^^^^^^^^ Incorrect indentation detected (column 2 instead of 0).
+      RUBY
+
+      expect_correction(<<-RUBY.strip_margin('|'))
+        |# comment
       RUBY
     end
 
@@ -58,10 +77,16 @@ RSpec.describe RuboCop::Cop::Layout::CommentIndentation do
     end
   end
 
-  it 'registers offenses before __END__ but not after' do
+  it 'registers offenses and corrects before __END__ but not after' do
     expect_offense(<<~RUBY)
        #
        ^ Incorrect indentation detected (column 1 instead of 0).
+      __END__
+        #
+    RUBY
+
+    expect_correction(<<~RUBY)
+      #
       __END__
         #
     RUBY
@@ -169,6 +194,7 @@ RSpec.describe RuboCop::Cop::Layout::CommentIndentation do
           b
         end
     RUBY
+
     expect(new_source).to eq(<<~RUBY)
       # comment
       # comment

--- a/spec/rubocop/cop/layout/empty_comment_spec.rb
+++ b/spec/rubocop/cop/layout/empty_comment_spec.rb
@@ -7,26 +7,38 @@ RSpec.describe RuboCop::Cop::Layout::EmptyComment, :config do
     { 'AllowBorderComment' => true, 'AllowMarginComment' => true }
   end
 
-  it 'registers an offense when using single line empty comment' do
+  it 'registers an offense and corrects using single line empty comment' do
     expect_offense(<<~RUBY)
       #
       ^ Source code comment is empty.
     RUBY
+
+    expect_correction(<<~RUBY)
+    RUBY
   end
 
-  it 'registers an offense when using multiline empty comments' do
+  it 'registers an offense and corrects using multiline empty comments' do
     expect_offense(<<~RUBY)
       #
       ^ Source code comment is empty.
       #
       ^ Source code comment is empty.
     RUBY
+
+    expect_correction(<<~RUBY)
+    RUBY
   end
 
-  it 'registers an offense when using an empty comment next to code' do
+  it 'registers an offense and corrects using an empty comment next to code' do
     expect_offense(<<~RUBY)
       def foo #
               ^ Source code comment is empty.
+        something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
         something
       end
     RUBY
@@ -70,17 +82,23 @@ RSpec.describe RuboCop::Cop::Layout::EmptyComment, :config do
   context 'disallow border comment' do
     let(:cop_config) { { 'AllowBorderComment' => false } }
 
-    it 'registers an offense when using single line empty comment' do
+    it 'registers an offense and corrects using single line empty comment' do
       expect_offense(<<~RUBY)
         #
         ^ Source code comment is empty.
       RUBY
+
+      expect_correction(<<~RUBY)
+      RUBY
     end
 
-    it 'registers an offense when using border comment' do
+    it 'registers an offense and corrects using border comment' do
       expect_offense(<<~RUBY)
         #################################
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Source code comment is empty.
+      RUBY
+
+      expect_correction(<<~RUBY)
       RUBY
     end
   end
@@ -100,7 +118,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyComment, :config do
   context 'disallow margin comment' do
     let(:cop_config) { { 'AllowMarginComment' => false } }
 
-    it 'registers an offense when using margin comment' do
+    it 'registers an offense and corrects using margin comment' do
       expect_offense(<<~RUBY)
         #
         ^ Source code comment is empty.
@@ -110,77 +128,58 @@ RSpec.describe RuboCop::Cop::Layout::EmptyComment, :config do
         def hello
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        # Description of `hello` method.
+        def hello
+        end
+      RUBY
     end
   end
 
-  it 'autocorrects empty comment' do
-    new_source = autocorrect_source(<<~RUBY)
-      #
-      class Foo
-        #
-        def hello
-        end
-      end
-    RUBY
-
-    expect(new_source).to eq <<~RUBY
-      class Foo
-        def hello
-        end
-      end
-    RUBY
-  end
-
-  it 'autocorrects an empty comment next to code' do
-    new_source = autocorrect_source(<<~RUBY)
-      def foo #
-        something
-      end
-    RUBY
-
-    expect(new_source).to eq(<<~RUBY)
-      def foo
-        something
-      end
-    RUBY
-  end
-
-  it 'autocorrects an empty comment without space next to code' do
-    new_source = autocorrect_source(<<~RUBY)
+  it 'registers an offense and corrects an empty comment without space ' \
+    'next to code' do
+    expect_offense(<<~RUBY)
       def foo#
+             ^ Source code comment is empty.
         something
       end
     RUBY
 
-    expect(new_source).to eq(<<~RUBY)
+    expect_correction(<<~RUBY)
       def foo
         something
       end
     RUBY
   end
 
-  it 'autocorrects multiple empty comments next to code' do
-    new_source = autocorrect_source(<<~RUBY)
+  it 'register offenses and correct multiple empty comments next to code' do
+    expect_offense(<<~RUBY)
       def foo #
+              ^ Source code comment is empty.
         something #
+                  ^ Source code comment is empty.
       end
     RUBY
 
-    expect(new_source).to eq(<<~RUBY)
+    expect_correction(<<~RUBY)
       def foo
         something
       end
     RUBY
   end
 
-  it 'autocorrects multiple aligned empty comments next to code' do
-    new_source = autocorrect_source(<<~RUBY)
+  it 'register offenses and correct multiple aligned empty comments ' \
+    'next to code' do
+    expect_offense(<<~RUBY)
       def foo     #
+                  ^ Source code comment is empty.
         something #
+                  ^ Source code comment is empty.
       end
     RUBY
 
-    expect(new_source).to eq(<<~RUBY)
+    expect_correction(<<~RUBY)
       def foo
         something
       end

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -3,7 +3,8 @@
 RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for guard clause not followed by empty line' do
+  it 'registers an offense and corrects a guard clause ' \
+    'not followed by empty line' do
     expect_offense(<<~RUBY)
       def foo
         return if need_return?
@@ -11,20 +12,36 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
         foobar
       end
     RUBY
-  end
 
-  it 'registers an offense for `next` guard clause not followed by ' \
-     'empty line' do
-    expect_offense(<<~RUBY)
+    expect_correction(<<~RUBY)
       def foo
-        next unless need_next?
-        ^^^^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
+        return if need_return?
+
         foobar
       end
     RUBY
   end
 
-  it 'registers offense when guard clause is before `begin`' do
+  it 'registers an offense and corrects `next` guard clause not followed by ' \
+     'empty line' do
+    expect_offense(<<~RUBY)
+      def foo
+        next unless need_next? # comment
+        ^^^^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
+        foobar
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        next unless need_next? # comment
+
+        foobar
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects a guard clause is before `begin`' do
     expect_offense(<<~RUBY)
       def foo
         return another_object if something_different?
@@ -36,10 +53,22 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
         end
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        return another_object if something_different?
+
+        begin
+          bar
+        rescue SomeException
+          baz
+        end
+      end
+    RUBY
   end
 
-  it 'registers an offense for `raise` guard clause not followed by ' \
-     'empty line when `unless` condition is after heredoc' do
+  it 'registers an offense and corrects a `raise` guard clause not followed ' \
+    'by empty line when `unless` condition is after heredoc' do
     expect_offense(<<~RUBY)
       def foo
         raise ArgumentError, <<-MSG unless path
@@ -49,9 +78,19 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
         bar
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        raise ArgumentError, <<-MSG unless path
+          Must be called with mount point
+        MSG
+
+        bar
+      end
+    RUBY
   end
 
-  it 'registers an offense for `raise` guard clause not followed ' \
+  it 'registers an offense and corrects a `raise` guard clause not followed ' \
      'by empty line when `if` condition is after heredoc' do
     expect_offense(<<~RUBY)
       def foo
@@ -62,10 +101,21 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
         bar
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        raise ArgumentError, <<-MSG if path
+          Must be called with mount point
+        MSG
+
+        bar
+      end
+    RUBY
   end
 
-  it 'registers an offense for next guard clause not followed by empty line ' \
-     'when guard clause is after heredoc including string interpolation' do
+  it 'registers an offense and corrects a next guard clause not followed by ' \
+    'empty line when guard clause is after heredoc ' \
+    'including string interpolation' do
     expect_offense(<<~'RUBY')
       raise(<<-FAIL) unless true
         #{1 + 1}
@@ -73,10 +123,18 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
       ^^^^ Add empty line after guard clause.
       1
     RUBY
+
+    expect_correction(<<~'RUBY')
+      raise(<<-FAIL) unless true
+        #{1 + 1}
+      FAIL
+
+      1
+    RUBY
   end
 
-  it 'registers an offense for `raise` guard clause not followed by empty ' \
-     'line when guard clause is after condition without method invocation' do
+  it 'accepts a `raise` guard clause not followed by empty line when guard ' \
+    'clause is after condition without method invocation' do
     expect_no_offenses(<<~'RUBY')
       def foo
         raise unless $1 == o
@@ -86,8 +144,8 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'registers an offense for `raise` guard clause not followed by ' \
-     'empty line when guard clause is after method call with argument' do
+  it 'registers an offense and corrects a `raise` guard clause not followed ' \
+    'by empty line when guard clause is after method call with argument' do
     expect_offense(<<~'RUBY')
       def foo
         raise SerializationError.new("Unsupported argument type: #{argument.class.name}") unless serializer
@@ -95,9 +153,17 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
         serializer.serialize(argument)
       end
     RUBY
+
+    expect_correction(<<~'RUBY')
+      def foo
+        raise SerializationError.new("Unsupported argument type: #{argument.class.name}") unless serializer
+
+        serializer.serialize(argument)
+      end
+    RUBY
   end
 
-  it 'does not register offense for modifier if' do
+  it 'accepts modifier if' do
     expect_no_offenses(<<~RUBY)
       def foo
         foo += 1 if need_add?
@@ -106,8 +172,8 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'registers an offense for guard clause followed by empty line' \
-     'when guard clause including heredoc' do
+  it 'accepts a guard clause followed by empty line when guard clause ' \
+    'including heredoc' do
     expect_no_offenses(<<~RUBY)
       def method
         if truthy
@@ -121,8 +187,8 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'registers an offense for guard clause not followed by empty line' \
-     'when guard clause including heredoc' do
+  it 'registers an offense and corrects a guard clause not followed by ' \
+    'empty line when guard clause including heredoc' do
     expect_offense(<<~RUBY)
       def method
         if truthy
@@ -134,9 +200,21 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
         value
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def method
+        if truthy
+          raise <<-MSG
+            This is an error.
+          MSG
+        end
+
+        value
+      end
+    RUBY
   end
 
-  it 'does not register offense for guard clause followed by end' do
+  it 'accepts a guard clause followed by end' do
     expect_no_offenses(<<~RUBY)
       def foo
         if something?
@@ -146,7 +224,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offense when using guard clause is after `raise`' do
+  it 'accepts using guard clause is after `raise`' do
     expect_no_offenses(<<~RUBY)
       def foo
         raise ArgumentError, 'HTTP redirect too deep' if limit.zero?
@@ -156,7 +234,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offense for guard clause inside oneliner block' do
+  it 'accepts a guard clause inside oneliner block' do
     expect_no_offenses(<<~RUBY)
       def foo
         object.tap { |obj| return another_object if something? }
@@ -165,7 +243,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offense for multiple guard clauses' do
+  it 'accepts multiple guard clauses' do
     expect_no_offenses(<<~RUBY)
       def foo
         return another_object if something?
@@ -177,7 +255,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offense if next line is end' do
+  it 'accepts a modifier if when the next line is `end`' do
     expect_no_offenses(<<~RUBY)
       def foo
         return another_object if something_different?
@@ -185,7 +263,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offense when guard clause is before `rescue`' do
+  it 'accepts a guard clause when the next line is `rescue`' do
     expect_no_offenses(<<~RUBY)
       def foo
         begin
@@ -197,7 +275,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offense when guard clause is before `ensure`' do
+  it 'accpets a guard clause when the next line is `ensure`' do
     expect_no_offenses(<<~RUBY)
       def foo
         begin
@@ -209,7 +287,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offense when guard clause is before `rescue`-`else`' do
+  it 'accpets a guard clause when the next line is `rescue`-`else`' do
     expect_no_offenses(<<~RUBY)
       def foo
         begin
@@ -223,7 +301,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offense when guard clause is before `else`' do
+  it 'accepts a guard clause when the next line is `else`' do
     expect_no_offenses(<<~RUBY)
       def foo
         if cond
@@ -235,7 +313,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offense when guard clause is before `elsif`' do
+  it 'accpets a guard clause when the next line is `elsif`' do
     expect_no_offenses(<<~RUBY)
       def foo
         if cond
@@ -247,8 +325,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offense when guard clause is after single line ' \
-     'heredoc' do
+  it 'accepta a guard clause after a single line heredoc' do
     expect_no_offenses(<<~RUBY)
       def foo
         raise ArgumentError, <<-MSG unless path
@@ -260,7 +337,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offense when guard clause is after multiline heredoc' do
+  it 'accepta a guard clause that is after multiline heredoc' do
     expect_no_offenses(<<~RUBY)
       def foo
         raise ArgumentError, <<-MSG unless path
@@ -274,7 +351,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offense when guard clause is after multiline heredoc ' \
+  it 'accpets a guard clause that is after a multiline heredoc ' \
      'with chained calls' do
     expect_no_offenses(<<~RUBY)
       def foo
@@ -288,7 +365,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offense when guard clause is after multiline heredoc ' \
+  it 'accpets a guard clause that is after a multiline heredoc ' \
      'nested argument call' do
     expect_no_offenses(<<~RUBY)
       def foo
@@ -302,7 +379,8 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'registers an offense when guard clause is a ternary operator' do
+  it 'registers an offense and corrects a guard clause that is ' \
+    'a ternary operator' do
     expect_offense(<<~RUBY)
       def foo
         puts 'some action happens here'
@@ -324,7 +402,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'registers an offense for methods starting with end_' do
+  it 'registers an offense and corrects a method starting with end_' do
     expect_offense(<<~RUBY)
       def foo
         next unless need_next?
@@ -332,61 +410,32 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
         end_this!
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        next unless need_next?
+
+        end_this!
+      end
+    RUBY
   end
 
-  it 'autocorrects offense' do
-    new_source = autocorrect_source(<<~RUBY)
+  it 'registers an offense and corrects only the last guard clause' do
+    expect_offense(<<~RUBY)
       def foo
         next if foo?
         next if bar?
+        ^^^^^^^^^^^^ Add empty line after guard clause.
         foobar
       end
     RUBY
 
-    expect(new_source).to eq(<<~RUBY)
+    expect_correction(<<~RUBY)
       def foo
         next if foo?
         next if bar?
 
         foobar
-      end
-    RUBY
-  end
-
-  it 'correctly autocorrects offense with comment on same line' do
-    new_source = autocorrect_source(<<~RUBY)
-      def foo
-        next if foo? # This is foo
-        foobar
-      end
-    RUBY
-
-    expect(new_source).to eq(<<~RUBY)
-      def foo
-        next if foo? # This is foo
-
-        foobar
-      end
-    RUBY
-  end
-
-  it 'correctly autocorrects offense when guard clause is after heredoc' do
-    new_source = autocorrect_source(<<~RUBY)
-      def foo
-        raise(<<-FAIL) if true
-          boop
-        FAIL
-        1
-      end
-    RUBY
-
-    expect(new_source).to eq(<<~RUBY)
-      def foo
-        raise(<<-FAIL) if true
-          boop
-        FAIL
-
-        1
       end
     RUBY
   end

--- a/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
@@ -226,14 +226,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
   end
 
   it 'auto-corrects when there are too many new lines' do
-    corrected = autocorrect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       def a; end
 
 
 
       def b; end
+      ^^^ Use empty lines between method definitions.
     RUBY
-    expect(corrected).to eq(<<~RUBY)
+
+    expect_correction(<<~RUBY)
       def a; end
 
       def b; end
@@ -264,6 +266,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
         end
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      class A
+        def n
+        end
+
+        def o
+        end
+      end
+    RUBY
   end
 
   context 'when AllowAdjacentOneLineDefs is enabled' do
@@ -285,6 +297,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
         end
         def d; end # Also an offense since previous was multi-line:
         ^^^ Use empty lines between method definitions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def a; end
+        def b; end
+
+        def c # Not a one-liner, so this is an offense.
+        end
+
+        def d; end # Also an offense since previous was multi-line:
       RUBY
     end
   end
@@ -355,8 +377,8 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
       RUBY
     end
 
-    it 'auto-corrects when there are too many new lines' do
-      corrected = autocorrect_source(<<~RUBY)
+    it 'registers an offense and corrects when there are too many new lines' do
+      expect_offense(<<~RUBY)
         def n
         end
 
@@ -364,10 +386,11 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
 
 
         def o
+        ^^^ Use empty lines between method definitions.
         end
       RUBY
 
-      expect(corrected).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         def n
         end
 

--- a/spec/rubocop/cop/layout/empty_lines_around_begin_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_begin_body_spec.rb
@@ -8,12 +8,13 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
   shared_examples 'offense' do |name, message, code, correction|
     it "registers an offense for #{name} with a blank" do
       inspect_source(code)
-      message = "Extra empty line detected at `begin` body #{message}."
-      expect(cop.messages).to eq([message])
+      expect(cop.messages)
+        .to eq(["Extra empty line detected at `begin` body #{message}."])
     end
 
     it "autocorrects for #{name} with a blank" do
       corrected = autocorrect_source(code)
+
       expect(corrected).to eq(correction)
     end
   end
@@ -35,6 +36,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
       foo
     end
   CORRECTION
+
   include_examples 'offense', 'begin body ending', 'end', <<-CODE, <<-CORRECTION
     begin
       foo
@@ -45,6 +47,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
       foo
     end
   CORRECTION
+
   include_examples 'offense',
                    'begin body starting in method', 'beginning',
                    <<-CODE, <<-CORRECTION
@@ -61,6 +64,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
       end
     end
   CORRECTION
+
   include_examples 'offense',
                    'begin body ending in method', 'end', <<-CODE, <<-CORRECTION
     def bar
@@ -93,6 +97,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
       bar
     end
   CORRECTION
+
   include_examples 'offense',
                    'rescue body ending', 'end',
                    <<-CODE, <<-CORRECTION
@@ -128,6 +133,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
       baz
     end
   CORRECTION
+
   include_examples 'offense',
                    'ensure body ending', 'end',
                    <<-CODE, <<-CORRECTION
@@ -163,6 +169,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
 
       end
     RUBY
+
     let(:correction) { <<~RUBY }
       begin
         do_something1
@@ -195,6 +202,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
       foo
     end
   RUBY
+
   include_examples 'accepts',
                    'begin block without empty line in a method', <<-RUBY
     def foo

--- a/spec/rubocop/cop/layout/empty_lines_around_module_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_module_body_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
           do_something
         end
       RUBY
-      expect(cop.messages)
-        .to eq(['Extra empty line detected at module body beginning.'])
+
+      expect(cop.messages).to eq([extra_begin])
     end
 
     it 'registers an offense for module body ending with a blank' do
@@ -31,8 +31,8 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
 
         end
       RUBY
-      expect(cop.messages)
-        .to eq(['Extra empty line detected at module body end.'])
+
+      expect(cop.messages).to eq([extra_end])
     end
 
     it 'autocorrects beginning and end' do
@@ -43,6 +43,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
 
         end
       RUBY
+
       expect(new_source).to eq(<<~RUBY)
         module SomeModule
           do_something
@@ -61,9 +62,8 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
           do_something
         end
       RUBY
-      expect(cop.messages)
-        .to eq(['Empty line missing at module body beginning.',
-                'Empty line missing at module body end.'])
+
+      expect(cop.messages).to eq([missing_begin, missing_end])
     end
 
     it 'registers an offense for module body not ending with a blank' do
@@ -82,6 +82,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
           do_something
         end
       RUBY
+
       expect(new_source).to eq(<<~RUBY)
         module SomeModule
 
@@ -91,10 +92,11 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
       RUBY
     end
 
-    it 'ignores modules with an empty body' do
-      source = "module A\nend"
-      corrected = autocorrect_source(source)
-      expect(corrected).to eq(source)
+    it 'accepts modules with an empty body' do
+      expect_no_offenses(<<~RUBY)
+        module A
+        end
+      RUBY
     end
   end
 
@@ -125,6 +127,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
             end
           end
         RUBY
+
         expect(cop.messages).to eq([extra_begin])
       end
 
@@ -139,6 +142,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
 
           end
         RUBY
+
         expect(cop.messages).to eq([extra_end])
       end
 
@@ -152,6 +156,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
             end
           end
         RUBY
+
         expect(cop.messages).to eq([missing_begin])
       end
 
@@ -165,6 +170,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
             end
           end
         RUBY
+
         expect(cop.messages).to eq([missing_end])
       end
 
@@ -178,6 +184,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
 
           end
         RUBY
+
         expect(new_source).to eq(<<~RUBY)
           module Parent
             module Child
@@ -210,6 +217,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
             end
           end
         RUBY
+
         expect(cop.messages).to eq([extra_begin])
       end
 
@@ -222,6 +230,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
 
           end
         RUBY
+
         expect(cop.messages).to eq([extra_end])
       end
     end
@@ -258,6 +267,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
             end
           end
         RUBY
+
         expect(cop.messages).to eq([missing_begin, missing_end])
       end
     end

--- a/spec/rubocop/cop/layout/end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/end_alignment_spec.rb
@@ -254,29 +254,18 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
   end
 
   context 'correct + opposite' do
-    let(:source) do
-      <<~RUBY
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
         x = if a
               a1
             end
         y = if b
           b1
         end
+        ^^^ `end` at 6, 0 is not aligned with `if` at 4, 4.
       RUBY
-    end
 
-    it 'registers an offense' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages.first)
-        .to eq('`end` at 6, 0 is not aligned with `if` at 4, 4.')
-      expect(cop.highlights.first).to eq('end')
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-    end
-
-    it 'does auto-correction' do
-      corrected = autocorrect_source(source)
-      expect(corrected).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         x = if a
               a1
             end
@@ -288,25 +277,17 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
   end
 
   context 'when end is preceded by something else than whitespace' do
-    let(:source) do
-      <<~RUBY
+    it 'registers an offense and does not correct' do
+      expect_offense(<<~RUBY)
+        module A
+        puts a end
+               ^^^ `end` at 2, 7 is not aligned with `module` at 1, 0.
+      RUBY
+
+      expect_correction(<<~RUBY)
         module A
         puts a end
       RUBY
-    end
-
-    it 'registers an offense' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages.first)
-        .to eq('`end` at 2, 7 is not aligned with `module` at 1, 0.')
-      expect(cop.highlights.first).to eq('end')
-    end
-
-    it "doesn't auto-correct" do
-      expect(autocorrect_source(source))
-        .to eq(source)
-      expect(cop.offenses.map(&:corrected?)).to eq [false]
     end
   end
 

--- a/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
     context 'when IndentationWidth:Width is 2' do
       let(:indentation_width) { 2 }
 
-      it 'registers an offense for an over-indented first argument' do
+      it 'registers an offense and corrects an over-indented first argument' do
         expect_offense(<<~RUBY)
           run(
               :foo,
@@ -27,9 +27,16 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
               bar: 3
           )
         RUBY
+
+        expect_correction(<<~RUBY)
+          run(
+            :foo,
+              bar: 3
+          )
+        RUBY
       end
 
-      it 'registers an offense for an under-indented first argument' do
+      it 'registers an offense and corrects an under-indented first argument' do
         expect_offense(<<~RUBY)
           run(
            :foo,
@@ -37,9 +44,17 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
               bar: 3
           )
         RUBY
+
+        expect_correction(<<~RUBY)
+          run(
+            :foo,
+              bar: 3
+          )
+        RUBY
       end
 
-      it 'registers an offense on lines affected by another offense' do
+      it 'registers an offense and corrects lines ' \
+        'affected by another offense' do
         expect_offense(<<~RUBY)
           foo(
            bar(
@@ -49,10 +64,19 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
           )
           )
         RUBY
+
+        # The first `)` Will be corrected by IndentationConsistency.
+        expect_correction(<<~RUBY)
+          foo(
+            bar(
+             7
+           )
+          )
+        RUBY
       end
 
       context 'when using safe navigation operator' do
-        it 'registers an offense for an under-indented first argument' do
+        it 'registers an offense and corrects an under-indented 1st argument' do
           expect_offense(<<~RUBY)
             receiver&.run(
              :foo,
@@ -60,26 +84,14 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
                 bar: 3
             )
           RUBY
+
+          expect_correction(<<~RUBY)
+            receiver&.run(
+              :foo,
+                bar: 3
+            )
+          RUBY
         end
-      end
-
-      it 'auto-corrects nested offenses' do
-        new_source = autocorrect_source(<<~RUBY)
-          foo(
-           bar(
-            7
-          )
-          )
-        RUBY
-
-        # The first `)` Will be corrected by IndentationConsistency.
-        expect(new_source).to eq(<<~RUBY)
-          foo(
-            bar(
-             7
-           )
-          )
-        RUBY
       end
 
       context 'for assignment' do
@@ -102,12 +114,19 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
             RUBY
           end
 
-          it 'registers an offense for an under-indented first argument' do
+          it 'registers an offense and corrects ' \
+            'an under-indented first argument' do
             expect_offense(<<~RUBY)
               @x =
                 run(
                 :foo)
                 ^^^^ Indent the first argument one step more than the start of the previous line.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              @x =
+                run(
+                  :foo)
             RUBY
           end
         end
@@ -130,12 +149,20 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
           RUBY
         end
 
-        it 'registers an offense for an over-indented first argument' do
+        it 'registers an offense and corrects ' \
+          'an over-indented first argument' do
           expect_offense(<<~RUBY)
             puts x.
               merge(
                   b: 2
                   ^^^^ Indent the first argument one step more than the start of the previous line.
+              )
+          RUBY
+
+          expect_correction(<<~RUBY)
+            puts x.
+              merge(
+                b: 2
               )
           RUBY
         end
@@ -162,13 +189,22 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
             RUBY
           end
 
-          it 'registers an offense for an under-indented first argument' do
+          it 'registers an offense and corrects ' \
+            'an under-indented first argument' do
             expect_offense(<<~RUBY)
               puts x.
                 merge(
                 # comment
                 b: 2
                 ^^^^ Indent the first argument one step more than the start of the previous line (not counting the comment).
+                )
+            RUBY
+
+            expect_correction(<<~RUBY)
+              puts x.
+                merge(
+                # comment
+                  b: 2
                 )
             RUBY
           end
@@ -206,35 +242,20 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
           ).freeze
         RUBY
       end
-
-      it 'auto-corrects an under-indented first argument' do
-        new_source = autocorrect_source(<<~RUBY)
-          x =
-            run(
-            :foo,
-              bar: 3
-          )
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          x =
-            run(
-              :foo,
-              bar: 3
-          )
-        RUBY
-      end
     end
 
     context 'when IndentationWidth:Width is 4' do
       let(:indentation_width) { 4 }
 
-      it 'auto-corrects an over-indented first argument' do
-        new_source = autocorrect_source(<<~RUBY)
+      it 'registers an offense and corrects an over-indented first argument' do
+        expect_offense(<<~RUBY)
           run(
                   :foo,
+                  ^^^^ Indent the first argument one step more than the start of the previous line.
               bar: 3)
         RUBY
-        expect(new_source).to eq(<<~RUBY)
+
+        expect_correction(<<~RUBY)
           run(
               :foo,
               bar: 3)
@@ -259,13 +280,15 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
         RUBY
       end
 
-      it 'auto-corrects an over-indented first argument' do
-        new_source = autocorrect_source(<<~RUBY)
+      it 'registers an offense and corrects an over-indented first argument' do
+        expect_offense(<<~RUBY)
           run(
                   :foo,
+                  ^^^^ Indent the first argument one step more than the start of the previous line.
               bar: 3)
         RUBY
-        expect(new_source).to eq(<<~RUBY)
+
+        expect_correction(<<~RUBY)
           run(
               :foo,
               bar: 3)
@@ -282,11 +305,17 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
 
     context 'for method calls within method calls' do
       context 'with outer parentheses' do
-        it 'registers an offense for an over-indented first argument' do
+        it 'registers an offense and corrects ' \
+          'an over-indented first argument' do
           expect_offense(<<~RUBY)
             run(:foo, defaults.merge(
                                     bar: 3))
                                     ^^^^^^ Indent the first argument one step more than `defaults.merge(`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            run(:foo, defaults.merge(
+                        bar: 3))
           RUBY
         end
       end
@@ -298,17 +327,6 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
                         bar: 3)
           RUBY
         end
-      end
-
-      it 'auto-corrects an over-indented first argument' do
-        new_source = autocorrect_source(<<~RUBY)
-          run(:foo, defaults.merge(
-                                  bar: 3))
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          run(:foo, defaults.merge(
-                      bar: 3))
-        RUBY
       end
     end
   end
@@ -322,20 +340,33 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
 
     context 'for method calls within method calls' do
       context 'with outer parentheses' do
-        it 'registers an offense for an over-indented first argument' do
+        it 'registers an offense and corrects ' \
+          'an over-indented first argument' do
           expect_offense(<<~RUBY)
             run(:foo, defaults.merge(
                                     bar: 3))
                                     ^^^^^^ Indent the first argument one step more than `defaults.merge(`.
           RUBY
+
+          expect_correction(<<~RUBY)
+            run(:foo, defaults.merge(
+                        bar: 3))
+          RUBY
         end
 
-        it 'registers an offense for an under-indented first argument' do
+        it 'registers an offense and corrects ' \
+          'an under-indented first argument' do
           expect_offense(<<~RUBY)
             run(:foo, defaults.
                       merge(
               bar: 3))
               ^^^^^^ Indent the first argument one step more than the start of the previous line.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            run(:foo, defaults.
+                      merge(
+                        bar: 3))
           RUBY
         end
 
@@ -368,17 +399,6 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
           RUBY
         end
       end
-
-      it 'auto-corrects an over-indented first argument' do
-        new_source = autocorrect_source(<<~RUBY)
-          run(:foo, defaults.merge(
-                                  bar: 3))
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          run(:foo, defaults.merge(
-                      bar: 3))
-        RUBY
-      end
     end
   end
 
@@ -389,11 +409,16 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
     include_examples 'common behavior'
 
     context 'for method calls within method calls' do
-      it 'registers an offense for an over-indented first argument' do
+      it 'registers an offense and corrects an over-indented first argument' do
         expect_offense(<<~RUBY)
           run(:foo, defaults.merge(
                       bar: 3))
                       ^^^^^^ Indent the first argument one step more than the start of the previous line.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          run(:foo, defaults.merge(
+            bar: 3))
         RUBY
       end
 
@@ -401,17 +426,6 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
         expect_no_offenses(<<~RUBY)
           @diagnostics.process(Diagnostic.new(
             :error, :token, { :token => name }, location))
-        RUBY
-      end
-
-      it 'auto-corrects an over-indented first argument' do
-        new_source = autocorrect_source(<<~RUBY)
-          run(:foo, defaults.merge(
-                                  bar: 3))
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          run(:foo, defaults.merge(
-            bar: 3))
         RUBY
       end
     end
@@ -423,7 +437,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
     context 'when IndentationWidth:Width is 2' do
       let(:indentation_width) { 2 }
 
-      it 'registers an offense for an over-indented first argument' do
+      it 'registers an offense and corrects an over-indented first argument' do
         expect_offense(<<~RUBY)
           run(
               :foo,
@@ -431,9 +445,16 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
               bar: 3
           )
         RUBY
+
+        expect_correction(<<~RUBY)
+          run(
+            :foo,
+              bar: 3
+          )
+        RUBY
       end
 
-      it 'registers an offense for an under-indented first argument' do
+      it 'registers an offense and corrects an under-indented first argument' do
         expect_offense(<<~RUBY)
           run(
            :foo,
@@ -441,9 +462,16 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
               bar: 3
           )
         RUBY
+
+        expect_correction(<<~RUBY)
+          run(
+            :foo,
+              bar: 3
+          )
+        RUBY
       end
 
-      it 'registers an offense on lines affected by another offense' do
+      it 'registers an offense and corrects lines affected by other offenses' do
         expect_offense(<<~RUBY)
           foo(
            bar(
@@ -453,19 +481,9 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
           )
           )
         RUBY
-      end
-
-      it 'auto-corrects nested offenses' do
-        new_source = autocorrect_source(<<~RUBY)
-          foo(
-           bar(
-            7
-          )
-          )
-        RUBY
 
         # The first `)` Will be corrected by IndentationConsistency.
-        expect(new_source).to eq(<<~RUBY)
+        expect_correction(<<~RUBY)
           foo(
             bar(
              7
@@ -475,12 +493,19 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
       end
 
       context 'for assignment' do
-        it 'accepts a correctly indented first argument and does not care ' \
-           'about the second argument' do
+        it 'register an offense and corrects a correctly indented first ' \
+          'argument and does not care about the second argument' do
           expect_offense(<<~RUBY)
             x = run(
               :foo,
               ^^^^ Indent the first argument one step more than `run(`.
+                bar: 3
+            )
+          RUBY
+
+          expect_correction(<<~RUBY)
+            x = run(
+                  :foo,
                 bar: 3
             )
           RUBY
@@ -495,12 +520,19 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
             RUBY
           end
 
-          it 'registers an offense for an under-indented first argument' do
+          it 'registers an offense and corrects ' \
+            'an under-indented first argument' do
             expect_offense(<<~RUBY)
               @x =
                 run(
                 :foo)
                 ^^^^ Indent the first argument one step more than `run(`.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              @x =
+                run(
+                  :foo)
             RUBY
           end
         end
@@ -523,12 +555,19 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
           RUBY
         end
 
-        it 'registers an offense for an over-indented first argument' do
+        it 'registers an offense and corrects an over-indented 1st argument' do
           expect_offense(<<~RUBY)
             puts x.
               merge(
                   b: 2
                   ^^^^ Indent the first argument one step more than the start of the previous line.
+              )
+          RUBY
+
+          expect_correction(<<~RUBY)
+            puts x.
+              merge(
+                b: 2
               )
           RUBY
         end
@@ -555,13 +594,22 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
             RUBY
           end
 
-          it 'registers an offense for an under-indented first argument' do
+          it 'registers an offense and corrects ' \
+            'an under-indented first argument' do
             expect_offense(<<~RUBY)
               puts x.
                 merge(
                 # comment
                 b: 2
                 ^^^^ Indent the first argument one step more than the start of the previous line (not counting the comment).
+                )
+            RUBY
+
+            expect_correction(<<~RUBY)
+              puts x.
+                merge(
+                # comment
+                  b: 2
                 )
             RUBY
           end
@@ -599,35 +647,20 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
               ).freeze
         RUBY
       end
-
-      it 'auto-corrects an under-indented first argument' do
-        new_source = autocorrect_source(<<~RUBY)
-          x =
-            run(
-            :foo,
-              bar: 3
-          )
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          x =
-            run(
-              :foo,
-              bar: 3
-          )
-        RUBY
-      end
     end
 
     context 'when IndentationWidth:Width is 4' do
       let(:indentation_width) { 4 }
 
-      it 'auto-corrects an over-indented first argument' do
-        new_source = autocorrect_source(<<~RUBY)
+      it 'registers an offense and corrects an over-indented first argument' do
+        expect_offense(<<~RUBY)
           run(
                   :foo,
+                  ^^^^ Indent the first argument one step more than `run(`.
               bar: 3)
         RUBY
-        expect(new_source).to eq(<<~RUBY)
+
+        expect_correction(<<~RUBY)
           run(
               :foo,
               bar: 3)
@@ -653,13 +686,15 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
         RUBY
       end
 
-      it 'auto-corrects an over-indented first argument' do
-        new_source = autocorrect_source(<<~RUBY)
+      it 'registers an offense and corrects an over-indented first argument' do
+        expect_offense(<<~RUBY)
           run(
                   :foo,
+                  ^^^^ Indent the first argument one step more than `run(`.
               bar: 3)
         RUBY
-        expect(new_source).to eq(<<~RUBY)
+
+        expect_correction(<<~RUBY)
           run(
               :foo,
               bar: 3)
@@ -671,11 +706,16 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
       let(:indentation_width) { 2 }
 
       context 'with outer parentheses' do
-        it 'registers an offense for an over-indented first argument' do
+        it 'registers an offense and corrects an over-indented 1st argument' do
           expect_offense(<<~RUBY)
             run(:foo, defaults.merge(
                                     bar: 3))
                                     ^^^^^^ Indent the first argument one step more than `defaults.merge(`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            run(:foo, defaults.merge(
+                        bar: 3))
           RUBY
         end
 
@@ -724,22 +764,6 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
                                   bar: 3))
           RUBY
         end
-      end
-
-      it 'auto-corrects an over-indented first argument' do
-        new_source = autocorrect_source(
-          autocorrect_source(<<~RUBY)
-            run(
-                  :foo, defaults.merge(
-                                        bar: 3))
-          RUBY
-        )
-
-        expect(new_source).to eq(<<~RUBY)
-          run(
-            :foo, defaults.merge(
-                    bar: 3))
-        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/layout/first_array_element_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_array_element_indentation_spec.rb
@@ -26,33 +26,31 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementIndentation do
       RUBY
     end
 
-    it 'registers an offense for incorrectly indented first element' do
+    it 'registers an offense and corrects incorrectly indented first element' do
       expect_offense(<<~RUBY)
         a << [
          1
          ^ Use 2 spaces for indentation in an array, relative to the start of the line where the left square bracket is.
         ]
       RUBY
-    end
 
-    it 'auto-corrects incorrectly indented first element' do
-      corrected = autocorrect_source(<<~RUBY)
-        a << [
-         1
-        ]
-      RUBY
-      expect(corrected).to eq <<~RUBY
+      expect_correction(<<~RUBY)
         a << [
           1
         ]
       RUBY
     end
 
-    it 'registers an offense for incorrectly indented ]' do
+    it 'registers an offense and corrects incorrectly indented ]' do
       expect_offense(<<~RUBY)
         a << [
           ]
           ^ Indent the right bracket the same as the start of the line where the left bracket is.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a << [
+        ]
       RUBY
     end
 
@@ -67,11 +65,17 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementIndentation do
         RUBY
       end
 
-      it 'registers an offense for incorrectly indented first element' do
+      it 'registers an offense and corrects incorrectly indented 1st element' do
         expect_offense(<<~RUBY)
           a << [
             1
             ^ Use 4 spaces for indentation in an array, relative to the start of the line where the left square bracket is.
+          ]
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a << [
+              1
           ]
         RUBY
       end
@@ -89,7 +93,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementIndentation do
       RUBY
     end
 
-    it 'registers an offense for incorrectly indented first element' do
+    it 'registers an offense and corrects incorrectly indented first element' do
       expect_offense(<<~RUBY)
         config.rack_cache = [
         "rails:/",
@@ -98,11 +102,19 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementIndentation do
         false
         ]
       RUBY
+
+      expect_correction(<<~RUBY)
+        config.rack_cache = [
+          "rails:/",
+        "rails:/",
+        false
+        ]
+      RUBY
     end
   end
 
   context 'when array is right hand side in assignment' do
-    it 'registers an offense for incorrectly indented first element' do
+    it 'registers an offense and corrects incorrectly indented first element' do
       expect_offense(<<~RUBY)
         a = [
             1,
@@ -111,17 +123,8 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementIndentation do
          3
         ]
       RUBY
-    end
 
-    it 'auto-corrects incorrectly indented first element' do
-      corrected = autocorrect_source(<<~RUBY)
-        a = [
-            1,
-          2,
-         3
-        ]
-      RUBY
-      expect(corrected).to eq <<~RUBY
+      expect_correction(<<~RUBY)
         a = [
           1,
           2,
@@ -193,7 +196,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementIndentation do
           RUBY
         end
 
-        it "registers an offense for 'consistent' indentation" do
+        it "registers an offense and corrects 'consistent' indentation" do
           expect_offense(<<~RUBY)
             func([
               1
@@ -201,10 +204,16 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementIndentation do
             ])
             ^ Indent the right bracket the same as the first position after the preceding left parenthesis.
           RUBY
+
+          expect_correction(<<~RUBY)
+            func([
+                   1
+                 ])
+          RUBY
         end
 
         context 'when using safe navigation operator' do
-          it "registers an offense for 'consistent' indentation" do
+          it "registers an offense and corrects 'consistent' indentation" do
             expect_offense(<<~RUBY)
               receiver&.func([
                 1
@@ -212,10 +221,16 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementIndentation do
               ])
               ^ Indent the right bracket the same as the first position after the preceding left parenthesis.
             RUBY
+
+            expect_correction(<<~RUBY)
+              receiver&.func([
+                               1
+                             ])
+            RUBY
           end
         end
 
-        it "registers an offense for 'align_brackets' indentation" do
+        it "registers an offense and corrects 'align_brackets' indentation" do
           expect_offense(<<~RUBY)
             var = [
                     1
@@ -223,18 +238,11 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementIndentation do
                   ]
                   ^ Indent the right bracket the same as the start of the line where the left bracket is.
           RUBY
-        end
 
-        it 'auto-corrects incorrectly indented first element' do
-          corrected = autocorrect_source(<<~RUBY)
-            func([
+          expect_correction(<<~RUBY)
+            var = [
               1
-            ])
-          RUBY
-          expect(corrected).to eq <<~RUBY
-            func([
-                   1
-                 ])
+            ]
           RUBY
         end
 
@@ -279,13 +287,19 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementIndentation do
           RUBY
         end
 
-        it 'registers an offense for incorrect indentation' do
+        it 'registers an offense and corrects incorrect indentation' do
           expect_offense(<<~RUBY)
             func([
                    1
                    ^ Use 2 spaces for indentation in an array, relative to the start of the line where the left square bracket is.
                  ])
                  ^ Indent the right bracket the same as the start of the line where the left bracket is.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            func([
+              1
+            ])
           RUBY
         end
 
@@ -314,12 +328,17 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementIndentation do
         RUBY
       end
 
-      it 'registers an offense for incorrectly indented multi-line array ' \
-         'with brackets' do
+      it 'registers an offense and corrects incorrectly indented multi-line ' \
+        'array with brackets' do
         expect_offense(<<~RUBY)
           func x, [
                  1, 2]
                  ^ Use 2 spaces for indentation in an array, relative to the start of the line where the left square bracket is.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          func x, [
+            1, 2]
         RUBY
       end
     end
@@ -368,7 +387,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementIndentation do
     end
 
     context "when 'consistent' style is used" do
-      it 'registers an offense for incorrect indentation' do
+      it 'registers an offense and corrects incorrect indentation' do
         expect_offense(<<~RUBY)
           func([
             1
@@ -376,17 +395,24 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementIndentation do
           ])
           ^ Indent the right bracket the same as the left bracket.
         RUBY
-        expect(cop.config_to_allow_offenses)
-          .to eq('EnforcedStyle' => 'consistent')
+
+        expect_correction(<<~RUBY)
+          func([
+                 1
+               ])
+        RUBY
       end
 
-      it 'auto-corrects incorrectly indented first element' do
-        corrected = autocorrect_source(<<~RUBY)
+      it 'registers an offense and corrects incorrectly indented 1st element' do
+        expect_offense(<<~RUBY)
           var = [
             1
+            ^ Use 2 spaces for indentation in an array, relative to the position of the opening bracket.
           ]
+          ^ Indent the right bracket the same as the left bracket.
         RUBY
-        expect(corrected).to eq <<~RUBY
+
+        expect_correction(<<~RUBY)
           var = [
                   1
                 ]
@@ -395,7 +421,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementIndentation do
     end
 
     context "when 'special_inside_parentheses' style is used" do
-      it 'registers an offense for incorrect indentation' do
+      it 'registers an offense and corrects incorrect indentation' do
         expect_offense(<<~RUBY)
           var = [
             1
@@ -406,14 +432,28 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementIndentation do
                  1
                ])
         RUBY
+
+        expect_correction(<<~RUBY)
+          var = [
+                  1
+                ]
+          func([
+                 1
+               ])
+        RUBY
       end
     end
 
-    it 'registers an offense for incorrectly indented ]' do
+    it 'registers an offense and corrects incorrectly indented ]' do
       expect_offense(<<~RUBY)
         a << [
           ]
           ^ Indent the right bracket the same as the left bracket.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a << [
+             ]
       RUBY
     end
 
@@ -428,13 +468,16 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementIndentation do
         RUBY
       end
 
-      it 'autocorrects indentation which does not match IndentationWidth' do
-        new_source = autocorrect_source(<<~RUBY)
+      it 'registers an offense and corrects indentation ' \
+        'that does not match IndentationWidth' do
+        expect_offense(<<~RUBY)
           a = [
                 1
+                ^ Use 4 spaces for indentation in an array, relative to the position of the opening bracket.
               ]
         RUBY
-        expect(new_source).to eq(<<~RUBY)
+
+        expect_correction(<<~RUBY)
           a = [
                   1
               ]

--- a/spec/rubocop/cop/layout/first_hash_element_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_hash_element_indentation_spec.rb
@@ -26,11 +26,16 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation do
   let(:cop_indent) { nil } # use indentation width from Layout/IndentationWidth
 
   shared_examples 'right brace' do
-    it 'registers an offense for incorrectly indented }' do
+    it 'registers an offense and corrects incorrectly indented }' do
       expect_offense(<<~RUBY)
         a << {
           }
           ^ Indent the right brace the same as the start of the line where the left brace is.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a << {
+        }
       RUBY
     end
   end
@@ -53,11 +58,19 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation do
       RUBY
     end
 
-    it 'registers an offense for incorrectly indented first pair with :' do
+    it 'registers an offense and corrects incorrectly indented ' \
+      'first pair with :' do
       expect_offense(<<~RUBY)
         a << {
                a: 1,
                ^^^^ Use 2 spaces for indentation in a hash, relative to the start of the line where the left curly brace is.
+             aaa: 222
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a << {
+            a: 1,
              aaa: 222
         }
       RUBY
@@ -84,11 +97,19 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation do
       RUBY
     end
 
-    it 'registers an offense for incorrectly indented first pair with =>' do
+    it 'registers an offense and corrects incorrectly indented ' \
+      'first pair with =>' do
       expect_offense(<<~RUBY)
         a << {
            'a' => 1,
            ^^^^^^^^ Use 2 spaces for indentation in a hash, relative to the start of the line where the left curly brace is.
+         'aaa' => 222
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a << {
+            'a' => 1,
          'aaa' => 222
         }
       RUBY
@@ -106,7 +127,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation do
       RUBY
     end
 
-    it 'registers an offense for incorrectly indented first pair' do
+    it 'registers an offense and corrects incorrectly indented first pair' do
       expect_offense(<<~RUBY)
         a << {
          a: 1
@@ -135,7 +156,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation do
       RUBY
     end
 
-    it 'registers an offense for incorrectly indented first pair' do
+    it 'registers an offense and corrects incorrectly indented first pair' do
       expect_offense(<<~RUBY)
         config.rack_cache = {
         :metastore => "rails:/",
@@ -144,11 +165,19 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation do
         :verbose => false
         }
       RUBY
+
+      expect_correction(<<~RUBY)
+        config.rack_cache = {
+          :metastore => "rails:/",
+        :entitystore => "rails:/",
+        :verbose => false
+        }
+      RUBY
     end
   end
 
   context 'when hash is right hand side in assignment' do
-    it 'registers an offense for incorrectly indented first pair' do
+    it 'registers an offense and corrects incorrectly indented first pair' do
       expect_offense(<<~RUBY)
         a = {
             a: 1,
@@ -201,15 +230,17 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation do
     context 'when indentation width is overridden for this cop' do
       let(:cop_indent) { 3 }
 
-      it 'auto-corrects incorrectly indented first pair' do
-        corrected = autocorrect_source(<<~RUBY)
+      it 'registers an offense and corrects incorrectly indented first pair' do
+        expect_offense(<<~RUBY)
           a = {
               a: 1,
+              ^^^^ Use 3 spaces for indentation in a hash, relative to the start of the line where the left curly brace is.
             b: 2,
            c: 3
           }
         RUBY
-        expect(corrected).to eq <<~RUBY
+
+        expect_correction(<<~RUBY)
           a = {
              a: 1,
             b: 2,
@@ -251,7 +282,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation do
           RUBY
         end
 
-        it "registers an offense for 'consistent' indentation" do
+        it "registers an offense and corrects 'consistent' indentation" do
           expect_offense(<<~RUBY)
             func({
               a: 1
@@ -259,10 +290,16 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation do
             })
             ^ Indent the right brace the same as the first position after the preceding left parenthesis.
           RUBY
+
+          expect_correction(<<~RUBY)
+            func({
+                   a: 1
+                 })
+          RUBY
         end
 
         context 'when using safe navigation operator' do
-          it "registers an offense for 'consistent' indentation" do
+          it "registers an offense and corrects 'consistent' indentation" do
             expect_offense(<<~RUBY)
               receiver&.func({
                 a: 1
@@ -270,10 +307,16 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation do
               })
               ^ Indent the right brace the same as the first position after the preceding left parenthesis.
             RUBY
+
+            expect_correction(<<~RUBY)
+              receiver&.func({
+                               a: 1
+                             })
+            RUBY
           end
         end
 
-        it "registers an offense for 'align_braces' indentation" do
+        it "registers an offense and corrects 'align_braces' indentation" do
           expect_offense(<<~RUBY)
             var = {
                     a: 1
@@ -281,18 +324,11 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation do
                   }
                   ^ Indent the right brace the same as the start of the line where the left brace is.
           RUBY
-        end
 
-        it 'auto-corrects incorrectly indented first pair' do
-          corrected = autocorrect_source(<<~RUBY)
-            func({
+          expect_correction(<<~RUBY)
+            var = {
               a: 1
-            })
-          RUBY
-          expect(corrected).to eq <<~RUBY
-            func({
-                   a: 1
-                 })
+            }
           RUBY
         end
 
@@ -337,13 +373,19 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation do
           RUBY
         end
 
-        it 'registers an offense for incorrect indentation' do
+        it 'registers an offense and corrects incorrect indentation' do
           expect_offense(<<~RUBY)
             func({
                    a: 1
                    ^^^^ Use 2 spaces for indentation in a hash, relative to the start of the line where the left curly brace is.
                  })
                  ^ Indent the right brace the same as the start of the line where the left brace is.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            func({
+              a: 1
+            })
           RUBY
         end
 
@@ -378,6 +420,11 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation do
           func x, {
                  a: 1, b: 2 }
                  ^^^^ Use 2 spaces for indentation in a hash, relative to the start of the line where the left curly brace is.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          func x, {
+            a: 1, b: 2 }
         RUBY
       end
     end
@@ -418,7 +465,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation do
     end
 
     context "when 'consistent' style is used" do
-      it 'registers an offense for incorrect indentation' do
+      it 'registers an offense and correcs incorrect indentation' do
         expect_offense(<<~RUBY)
           func({
             a: 1
@@ -426,24 +473,17 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation do
           })
           ^ Indent the right brace the same as the left brace.
         RUBY
-      end
 
-      it 'auto-corrects incorrectly indented first pair' do
-        corrected = autocorrect_source(<<~RUBY)
-          var = {
-            a: 1
-          }
-        RUBY
-        expect(corrected).to eq <<~RUBY
-          var = {
-                  a: 1
-                }
+        expect_correction(<<~RUBY)
+          func({
+                 a: 1
+               })
         RUBY
       end
     end
 
     context "when 'special_inside_parentheses' style is used" do
-      it 'registers an offense for incorrect indentation' do
+      it 'registers an offense and corrects incorrect indentation' do
         expect_offense(<<~RUBY)
           var = {
             a: 1
@@ -454,14 +494,28 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation do
                  a: 1
                })
         RUBY
+
+        expect_correction(<<~RUBY)
+          var = {
+                  a: 1
+                }
+          func({
+                 a: 1
+               })
+        RUBY
       end
     end
 
-    it 'registers an offense for incorrectly indented }' do
+    it 'registers an offense and corrects incorrectly indented }' do
       expect_offense(<<~RUBY)
         a << {
           }
           ^ Indent the right brace the same as the left brace.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a << {
+             }
       RUBY
     end
   end

--- a/spec/rubocop/cop/layout/first_hash_element_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_hash_element_line_break_spec.rb
@@ -3,50 +3,32 @@
 RSpec.describe RuboCop::Cop::Layout::FirstHashElementLineBreak do
   subject(:cop) { described_class.new }
 
-  context 'elements listed on the first line' do
-    it 'detects the offense' do
-      expect_offense(<<~RUBY)
-        a = { a: 1,
-              ^^^^ Add a line break before the first element of a multi-line hash.
-              b: 2 }
-      RUBY
-    end
+  it 'registers an offense and corrects elements listed on the first line' do
+    expect_offense(<<~RUBY)
+      a = { a: 1,
+            ^^^^ Add a line break before the first element of a multi-line hash.
+            b: 2 }
+    RUBY
 
-    it 'autocorrects the offense' do
-      new_source = autocorrect_source(<<~RUBY)
-        a = { a: 1,
-              b: 2 }
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        a = { 
-        a: 1,
-              b: 2 }
-      RUBY
-    end
+    expect_correction(<<~RUBY)
+      a = { 
+      a: 1,
+            b: 2 }
+    RUBY
   end
 
-  context 'hash nested in a method call' do
-    it 'detects the offense' do
-      expect_offense(<<~RUBY)
-        method({ foo: 1,
-                 ^^^^^^ Add a line break before the first element of a multi-line hash.
-                 bar: 2 })
-      RUBY
-    end
+  it 'registers an offense and corrects hash nested in a method call' do
+    expect_offense(<<~RUBY)
+      method({ foo: 1,
+               ^^^^^^ Add a line break before the first element of a multi-line hash.
+               bar: 2 })
+    RUBY
 
-    it 'autocorrects the offense' do
-      new_source = autocorrect_source(<<~RUBY)
-        method({ foo: 1,
-                 bar: 2 })
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        method({ 
-        foo: 1,
-                 bar: 2 })
-      RUBY
-    end
+    expect_correction(<<~RUBY)
+      method({ 
+      foo: 1,
+               bar: 2 })
+    RUBY
   end
 
   it 'ignores implicit hashes in method calls with parens' do

--- a/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
@@ -4,28 +4,21 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak do
   subject(:cop) { described_class.new }
 
   context 'args listed on the first line' do
-    it 'detects the offense' do
+    it 'registers an offense and corrects' do
       expect_offense(<<~RUBY)
         foo(bar,
             ^^^ Add a line break before the first argument of a multi-line method argument list.
           baz)
       RUBY
-    end
 
-    it 'autocorrects the offense' do
-      new_source = autocorrect_source(<<~RUBY)
-        foo(bar,
-          baz)
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         foo(
         bar,
           baz)
       RUBY
     end
 
-    it 'detects the offense when using `super`' do
+    it 'registers an offense and corrects using `super`' do
       expect_offense(<<~RUBY)
         super(bar,
               ^^^ Add a line break before the first argument of a multi-line method argument list.
@@ -39,74 +32,48 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak do
       RUBY
     end
 
-    context 'when using safe navigation operator' do
-      it 'detects the offense' do
-        expect_offense(<<~RUBY)
-          receiver&.foo(bar,
-                        ^^^ Add a line break before the first argument of a multi-line method argument list.
-            baz)
-        RUBY
-      end
-
-      it 'autocorrects the offense' do
-        new_source = autocorrect_source(<<~RUBY)
-          receiver&.foo(bar,
-            baz)
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          receiver&.foo(
-          bar,
-            baz)
-        RUBY
-      end
-    end
-  end
-
-  context 'hash arg spanning multiple lines' do
-    it 'detects the offense' do
+    it 'registers an offense and corrects using safe navigation operator' do
       expect_offense(<<~RUBY)
-        something(3, bar: 1,
-                  ^ Add a line break before the first argument of a multi-line method argument list.
-        baz: 2)
-      RUBY
-    end
-
-    it 'autocorrects the offense' do
-      new_source = autocorrect_source(<<~RUBY)
-        something(3, bar: 1,
-        baz: 2)
+        receiver&.foo(bar,
+                      ^^^ Add a line break before the first argument of a multi-line method argument list.
+          baz)
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
-        something(
-        3, bar: 1,
-        baz: 2)
+      expect_correction(<<~RUBY)
+        receiver&.foo(
+        bar,
+          baz)
       RUBY
     end
   end
 
-  context 'hash arg without a line break before the first pair' do
-    it 'detects the offense' do
-      expect_offense(<<~RUBY)
-        something(bar: 1,
-                  ^^^^^^ Add a line break before the first argument of a multi-line method argument list.
-        baz: 2)
-      RUBY
-    end
+  it 'registers an offense and corrects hash arg spanning multiple lines' do
+    expect_offense(<<~RUBY)
+      something(3, bar: 1,
+                ^ Add a line break before the first argument of a multi-line method argument list.
+      baz: 2)
+    RUBY
 
-    it 'autocorrects the offense' do
-      new_source = autocorrect_source(<<~RUBY)
-        something(bar: 1,
-        baz: 2)
-      RUBY
+    expect_correction(<<~RUBY)
+      something(
+      3, bar: 1,
+      baz: 2)
+    RUBY
+  end
 
-      expect(new_source).to eq(<<~RUBY)
-        something(
-        bar: 1,
-        baz: 2)
-      RUBY
-    end
+  it 'registers an offense and corrects hash arg ' \
+    'without a line break before the first pair' do
+    expect_offense(<<~RUBY)
+      something(bar: 1,
+                ^^^^^^ Add a line break before the first argument of a multi-line method argument list.
+      baz: 2)
+    RUBY
+
+    expect_correction(<<~RUBY)
+      something(
+      bar: 1,
+      baz: 2)
+    RUBY
   end
 
   it 'ignores arguments listed on a single line' do

--- a/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
@@ -3,65 +3,44 @@
 RSpec.describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
   subject(:cop) { described_class.new }
 
-  context 'params listed on the first line' do
-    it 'detects the offense' do
-      expect_offense(<<~RUBY)
-        def foo(bar,
-                ^^^ Add a line break before the first parameter of a multi-line method parameter list.
-          baz)
-          do_something
-        end
-      RUBY
-    end
+  it 'registers an offense and corrects params listed on the first line' do
+    expect_offense(<<~RUBY)
+      def foo(bar,
+              ^^^ Add a line break before the first parameter of a multi-line method parameter list.
+        baz)
+        do_something
+      end
+    RUBY
 
-    it 'autocorrects the offense' do
-      new_source = autocorrect_source(<<~RUBY)
-        def foo(bar,
-          baz)
-          do_something
-        end
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        def foo(
-        bar,
-          baz)
-          do_something
-        end
-      RUBY
-    end
+    expect_correction(<<~RUBY)
+      def foo(
+      bar,
+        baz)
+        do_something
+      end
+    RUBY
   end
 
-  context 'params on first line of singleton method' do
-    it 'detects the offense' do
-      expect_offense(<<~RUBY)
-        def self.foo(bar,
-                     ^^^ Add a line break before the first parameter of a multi-line method parameter list.
-          baz)
-          do_something
-        end
-      RUBY
-    end
+  it 'registers an offense and corrects params on first line ' \
+    'of singleton method' do
+    expect_offense(<<~RUBY)
+      def self.foo(bar,
+                   ^^^ Add a line break before the first parameter of a multi-line method parameter list.
+        baz)
+        do_something
+      end
+    RUBY
 
-    it 'autocorrects the offense' do
-      new_source = autocorrect_source(<<~RUBY)
-        def self.foo(bar,
-          baz)
-          do_something
-        end
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        def self.foo(
-        bar,
-          baz)
-          do_something
-        end
-      RUBY
-    end
+    expect_correction(<<~RUBY)
+      def self.foo(
+      bar,
+        baz)
+        do_something
+      end
+    RUBY
   end
 
-  it 'ignores params listed on a single line' do
+  it 'accepts params listed on a single line' do
     expect_no_offenses(<<~RUBY)
       def foo(bar, baz, bing)
         do_something
@@ -69,7 +48,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
     RUBY
   end
 
-  it 'ignores params without parens' do
+  it 'accepts params without parens' do
     expect_no_offenses(<<~RUBY)
       def foo bar,
         baz
@@ -78,11 +57,11 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
     RUBY
   end
 
-  it 'ignores single-line methods' do
+  it 'accepts single-line methods' do
     expect_no_offenses('def foo(bar, baz) ; bing ; end')
   end
 
-  it 'ignores methods without params' do
+  it 'accepts methods without params' do
     expect_no_offenses(<<~RUBY)
       def foo
         bing
@@ -90,32 +69,21 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
     RUBY
   end
 
-  context 'params with default values' do
-    it 'detects the offense' do
-      expect_offense(<<~RUBY)
-        def foo(bar = [],
-                ^^^^^^^^ Add a line break before the first parameter of a multi-line method parameter list.
-          baz = 2)
-          do_something
-        end
-      RUBY
-    end
+  it 'registers an offense and corrects params with default values' do
+    expect_offense(<<~RUBY)
+      def foo(bar = [],
+              ^^^^^^^^ Add a line break before the first parameter of a multi-line method parameter list.
+        baz = 2)
+        do_something
+      end
+    RUBY
 
-    it 'autocorrects the offense' do
-      new_source = autocorrect_source(<<~RUBY)
-        def foo(bar = [],
-          baz = 2)
-          do_something
-        end
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        def foo(
-        bar = [],
-          baz = 2)
-          do_something
-        end
-      RUBY
-    end
+    expect_correction(<<~RUBY)
+      def foo(
+      bar = [],
+        baz = 2)
+        do_something
+      end
+    RUBY
   end
 end

--- a/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
@@ -108,7 +108,8 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
 
     context 'invalid indentation on multi-line defs' do
       context 'normal arguments' do
-        it 'detects incorrectly indented first element' do
+        it 'registers an offense and corrects incorrectly indented ' \
+          'first element' do
           expect_offense(<<~RUBY)
             def abc(
                         foo,
@@ -119,19 +120,8 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
               foo
             end
           RUBY
-        end
 
-        it 'auto-corrects incorrectly indented first element' do
-          corrected = autocorrect_source(<<~RUBY)
-            def abc(
-                        foo,
-                        bar,
-                        baz
-            )
-              foo
-            end
-          RUBY
-          expect(corrected).to eq <<~RUBY
+          expect_correction(<<~RUBY)
             def abc(
               foo,
                         bar,
@@ -144,7 +134,8 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
       end
 
       context 'hash arguments' do
-        it 'detects incorrectly indented first element' do
+        it 'registers an offense and corrects incorrectly indented ' \
+          'first element' do
           expect_offense(<<~RUBY)
             def abc(
                       foo: 1,
@@ -155,22 +146,12 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
               foo
             end
           RUBY
-        end
-        it 'auto-corrects incorrectly indented first element' do
-          corrected = autocorrect_source(<<~RUBY)
-            def abc(
-                        foo: 1,
-                        bar: 3,
-                        baz: 3
-            )
-              foo
-            end
-          RUBY
-          expect(corrected).to eq <<~RUBY
+
+          expect_correction(<<~RUBY)
             def abc(
               foo: 1,
-                        bar: 3,
-                        baz: 3
+                      bar: 3,
+                      baz: 3
             )
               foo
             end
@@ -179,7 +160,8 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
       end
 
       context 'hash arguments static method def' do
-        it 'detects incorrectly indented first element' do
+        it 'registers an offense and corrects incorrectly indented ' \
+          'first element' do
           expect_offense(<<~RUBY)
             def self.abc(
                       foo: 1,
@@ -190,22 +172,12 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
               foo
             end
           RUBY
-        end
-        it 'auto-corrects incorrectly indented first element' do
-          corrected = autocorrect_source(<<~RUBY)
-            def self.abc(
-                        foo: 1,
-                        bar: 3,
-                        baz: 3
-            )
-              foo
-            end
-          RUBY
-          expect(corrected).to eq <<~RUBY
+
+          expect_correction(<<~RUBY)
             def self.abc(
               foo: 1,
-                        bar: 3,
-                        baz: 3
+                      bar: 3,
+                      baz: 3
             )
               foo
             end
@@ -282,7 +254,8 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
 
     context 'invalid indentation on multi-line defs' do
       context 'normal arguments' do
-        it 'detects incorrectly indented first element' do
+        it 'registers an offense and corrects incorrectly indented ' \
+          'first element' do
           expect_offense(<<~RUBY)
             def abc(
                         foo,
@@ -293,19 +266,8 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
               foo
             end
           RUBY
-        end
 
-        it 'auto-corrects incorrectly indented first element' do
-          corrected = autocorrect_source(<<~RUBY)
-            def abc(
-                        foo,
-                        bar,
-                        baz
-            )
-              foo
-            end
-          RUBY
-          expect(corrected).to eq <<~RUBY
+          expect_correction(<<~RUBY)
             def abc(
                      foo,
                         bar,
@@ -318,7 +280,8 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
       end
 
       context 'hash arguments' do
-        it 'detects incorrectly indented first element' do
+        it 'registers an offense and corrects incorrectly indented ' \
+          'first element' do
           expect_offense(<<~RUBY)
             def abc(
                       foo: 1,
@@ -329,22 +292,12 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
               foo
             end
           RUBY
-        end
-        it 'auto-corrects incorrectly indented first element' do
-          corrected = autocorrect_source(<<~RUBY)
-            def abc(
-                        foo: 1,
-                        bar: 3,
-                        baz: 3
-            )
-              foo
-            end
-          RUBY
-          expect(corrected).to eq <<~RUBY
+
+          expect_correction(<<~RUBY)
             def abc(
                      foo: 1,
-                        bar: 3,
-                        baz: 3
+                      bar: 3,
+                      baz: 3
             )
               foo
             end
@@ -353,7 +306,8 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
       end
 
       context 'hash arguments static def' do
-        it 'detects incorrectly indented first element' do
+        it 'registers an offense and corrects incorrectly indented ' \
+          'first element' do
           expect_offense(<<~RUBY)
             def self.abc(
                       foo: 1,
@@ -364,22 +318,12 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
               foo
             end
           RUBY
-        end
-        it 'auto-corrects incorrectly indented first element' do
-          corrected = autocorrect_source(<<~RUBY)
-            def self.abc(
-                        foo: 1,
-                        bar: 3,
-                        baz: 3
-            )
-              foo
-            end
-          RUBY
-          expect(corrected).to eq <<~RUBY
+
+          expect_correction(<<~RUBY)
             def self.abc(
                           foo: 1,
-                        bar: 3,
-                        baz: 3
+                      bar: 3,
+                      baz: 3
             )
               foo
             end

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       RUBY
     end
 
-    it "does not auto-correct pairs that don't start a line" do
-      source = <<~RUBY
+    it "accepts pairs that don't start a line" do
+      expect_no_offenses(<<~RUBY)
         render :json => {:a => messages,
                          :b => :json}, :status => 404
         def example
@@ -34,8 +34,6 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
             ), h: :i)
         end
       RUBY
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(source)
     end
   end
 
@@ -46,51 +44,85 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       }
     end
 
-    it 'registers offense for misaligned keys in implicit hash' do
+    it 'registers offense and corrects misaligned keys in implicit hash' do
       expect_offense(<<~RUBY)
         func(a: 0,
           b: 1)
           ^^^^ Align the keys of a hash literal if they span more than one line.
       RUBY
+
+      expect_correction(<<~RUBY)
+        func(a: 0,
+             b: 1)
+      RUBY
     end
 
-    it 'registers offense for misaligned keys in explicit hash' do
+    it 'registers offense and corrects misaligned keys in explicit hash' do
       expect_offense(<<~RUBY)
         func({a: 0,
           b: 1})
           ^^^^ Align the keys of a hash literal if they span more than one line.
       RUBY
+
+      expect_correction(<<~RUBY)
+        func({a: 0,
+              b: 1})
+      RUBY
     end
 
-    it 'registers offense for misaligned keys in implicit hash for super' do
+    it 'registers an offense and corrects misaligned keys in implicit ' \
+      'hash for super' do
       expect_offense(<<~RUBY)
         super(a: 0,
           b: 1)
           ^^^^ Align the keys of a hash literal if they span more than one line.
       RUBY
+
+      expect_correction(<<~RUBY)
+        super(a: 0,
+              b: 1)
+      RUBY
     end
 
-    it 'registers offense for misaligned keys in explicit hash for super' do
+    it 'registers an offense and corrects misaligned keys in explicit ' \
+      'hash for super' do
       expect_offense(<<~RUBY)
         super({a: 0,
           b: 1})
           ^^^^ Align the keys of a hash literal if they span more than one line.
       RUBY
+
+      expect_correction(<<~RUBY)
+        super({a: 0,
+               b: 1})
+      RUBY
     end
 
-    it 'registers offense for misaligned keys in implicit hash for yield' do
+    it 'registers an offense and corrects misaligned keys in implicit ' \
+      'hash for yield' do
       expect_offense(<<~RUBY)
         yield(a: 0,
           b: 1)
           ^^^^ Align the keys of a hash literal if they span more than one line.
       RUBY
+
+      expect_correction(<<~RUBY)
+        yield(a: 0,
+              b: 1)
+      RUBY
     end
 
-    it 'registers offense for misaligned keys in explicit hash for yield' do
+    it 'registers an offense and corrects misaligned keys in explicit ' \
+      'hash for yield' do
       expect_offense(<<~RUBY)
         yield({a: 0,
           b: 1})
           ^^^^ Align the keys of a hash literal if they span more than one line.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        yield({a: 0,
+               b: 1})
       RUBY
     end
   end
@@ -159,11 +191,16 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       RUBY
     end
 
-    it 'registers offense for misaligned keys in explicit hash' do
+    it 'registers an offense and corrects misaligned keys in explicit hash' do
       expect_offense(<<~RUBY)
         func({a: 0,
           b: 1})
           ^^^^ Align the keys of a hash literal if they span more than one line.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        func({a: 0,
+              b: 1})
       RUBY
     end
 
@@ -174,11 +211,17 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       RUBY
     end
 
-    it 'registers offense for misaligned keys in explicit hash for super' do
+    it 'registers an offense and corrects misaligned keys in explicit ' \
+      'hash for super' do
       expect_offense(<<~RUBY)
         super({a: 0,
           b: 1})
           ^^^^ Align the keys of a hash literal if they span more than one line.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        super({a: 0,
+               b: 1})
       RUBY
     end
 
@@ -189,11 +232,17 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       RUBY
     end
 
-    it 'registers offense for misaligned keys in explicit hash for yield' do
+    it 'registers an offense and corrects misaligned keys in explicit ' \
+      'hash for yield' do
       expect_offense(<<~RUBY)
         yield({a: 0,
           b: 1})
           ^^^^ Align the keys of a hash literal if they span more than one line.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        yield({a: 0,
+               b: 1})
       RUBY
     end
   end
@@ -205,11 +254,16 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       }
     end
 
-    it 'registers offense for misaligned keys in implicit hash' do
+    it 'registers an offense and corrects misaligned keys in implicit hash' do
       expect_offense(<<~RUBY)
         func(a: 0,
           b: 1)
           ^^^^ Align the keys of a hash literal if they span more than one line.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        func(a: 0,
+             b: 1)
       RUBY
     end
 
@@ -220,11 +274,17 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       RUBY
     end
 
-    it 'registers offense for misaligned keys in implicit hash for super' do
+    it 'registers an offense and corrects misaligned keys in implicit ' \
+      'hash for super' do
       expect_offense(<<~RUBY)
         super(a: 0,
           b: 1)
           ^^^^ Align the keys of a hash literal if they span more than one line.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        super(a: 0,
+              b: 1)
       RUBY
     end
 
@@ -235,11 +295,17 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       RUBY
     end
 
-    it 'registers offense for misaligned keys in implicit hash for yield' do
+    it 'registers an offense and corrects misaligned keys in implicit ' \
+      'hash for yield' do
       expect_offense(<<~RUBY)
         yield(a: 0,
           b: 1)
           ^^^^ Align the keys of a hash literal if they span more than one line.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        yield(a: 0,
+              b: 1)
       RUBY
     end
 
@@ -252,7 +318,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
   end
 
   context 'with default configuration' do
-    it 'registers an offense for misaligned hash keys' do
+    it 'registers an offense and corrects misaligned hash keys' do
       expect_offense(<<~RUBY)
         hash1 = {
           a: 0,
@@ -265,13 +331,30 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
          ^^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
         }
       RUBY
+
+      expect_correction(<<~RUBY)
+        hash1 = {
+          a: 0,
+          bb: 1
+        }
+        hash2 = {
+          'ccc' => 2,
+          'dddd' => 2
+        }
+      RUBY
     end
 
-    it 'registers an offense for misaligned mixed multiline hash keys' do
+    it 'registers an offense and corrects misaligned mixed multiline ' \
+      'hash keys' do
       expect_offense(<<~RUBY)
         hash = { a: 1, b: 2,
                 c: 3 }
                 ^^^^ Align the keys of a hash literal if they span more than one line.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        hash = { a: 1, b: 2,
+                 c: 3 }
       RUBY
     end
 
@@ -292,7 +375,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       RUBY
     end
 
-    it 'registers an offense for zero or multiple spaces' do
+    it 'registers an offense and corrects zero or multiple spaces' do
       expect_offense(<<~RUBY)
         hash1 = {
           a:   0,
@@ -307,9 +390,20 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
           ^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
         }
       RUBY
+
+      expect_correction(<<~RUBY)
+        hash1 = {
+          a: 0,
+          bb: 1,
+        }
+        hash2 = {
+          'ccc' => 2,
+          'dddd' => 3
+        }
+      RUBY
     end
 
-    it 'registers an offense for separator alignment' do
+    it 'registers an offense and corrects separator alignment' do
       expect_offense(<<~RUBY)
         hash = {
             'a' => 0,
@@ -317,9 +411,16 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
           ^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
         }
       RUBY
+
+      expect_correction(<<~RUBY)
+        hash = {
+            'a' => 0,
+            'bbb' => 1
+        }
+      RUBY
     end
 
-    it 'registers an offense for table alignment' do
+    it 'registers an offense and corrects table alignment' do
       expect_offense(<<~RUBY)
         hash = {
           'a'   => 0,
@@ -327,13 +428,29 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
           'bbb' => 1
         }
       RUBY
+
+      expect_correction(<<~RUBY)
+        hash = {
+          'a' => 0,
+          'bbb' => 1
+        }
+      RUBY
     end
 
-    it 'registers an offense when multiline value starts in wrong place' do
+    it 'registers an offense and corrects multiline value starts ' \
+      'in wrong place' do
       expect_offense(<<~RUBY)
         hash = {
           'a' =>  (
           ^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
+            ),
+          'bbb' => 1
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        hash = {
+          'a' => (
             ),
           'bbb' => 1
         }
@@ -351,19 +468,29 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
     end
 
     context 'with implicit hash as last argument' do
-      it 'registers an offense for misaligned hash keys' do
+      it 'registers an offense and corrects misaligned hash keys' do
         expect_offense(<<~RUBY)
           func(a: 0,
             b: 1)
             ^^^^ Align the keys of a hash literal if they span more than one line.
         RUBY
+
+        expect_correction(<<~RUBY)
+          func(a: 0,
+               b: 1)
+        RUBY
       end
 
-      it 'registers an offense for right alignment of keys' do
+      it 'registers an offense and corrects right alignment of keys' do
         expect_offense(<<~RUBY)
           func(a: 0,
              bbb: 1)
              ^^^^^^ Align the keys of a hash literal if they span more than one line.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          func(a: 0,
+               bbb: 1)
         RUBY
       end
 
@@ -379,20 +506,28 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       end
     end
 
-    it 'auto-corrects alignment' do
-      new_source = autocorrect_source(<<~RUBY)
+    it 'registers an offense and corrects mixed hash styles' do
+      expect_offense(<<~RUBY)
         hash1 = { a: 0,
              bb: 1,
+             ^^^^^ Align the keys of a hash literal if they span more than one line.
                    ccc: 2 }
+                   ^^^^^^ Align the keys of a hash literal if they span more than one line.
         hash2 = { :a   => 0,
+                  ^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
           :bb  => 1,
+          ^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
                     :ccc  =>2 }
+                    ^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
         hash3 = { 'a'   =>   0,
+                  ^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
                        'bb'  => 1,
+                       ^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
             'ccc'  =>2 }
+            ^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         hash1 = { a: 0,
                   bb: 1,
                   ccc: 2 }
@@ -405,40 +540,32 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       RUBY
     end
 
-    it 'auto-corrects alignment for mixed multiline hash keys' do
-      new_sources = autocorrect_source(<<~RUBY)
-        hash = { a: 1, b: 2,
-                c:   3 }
-      RUBY
-      expect(new_sources).to eq(<<~RUBY)
-        hash = { a: 1, b: 2,
-                 c: 3 }
-      RUBY
-    end
-
-    it 'auto-corrects alignment when using double splat ' \
+    it 'registers an offense and corrects alignment when using double splat ' \
        'in an explicit hash' do
-      new_source = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         Hash(foo: 'bar',
                **extra_params
+               ^^^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
         )
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         Hash(foo: 'bar',
              **extra_params
         )
       RUBY
     end
 
-    it 'auto-corrects alignment when using double splat in braces' do
-      new_source = autocorrect_source(<<~RUBY)
+    it 'registers an offense and corrects alignment when using double splat ' \
+      'in braces' do
+      expect_offense(<<~RUBY)
         {foo: 'bar',
                **extra_params
+               ^^^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
         }
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         {foo: 'bar',
          **extra_params
         }
@@ -539,7 +666,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       RUBY
     end
 
-    it 'registers an offense for misaligned hash keys' do
+    it 'registers an offense and corrects for misaligned hash keys' do
       expect_offense(<<~RUBY)
         hash1 = {
           'a'   =>  0,
@@ -554,9 +681,20 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
           ^^^^^^ Align the keys and values of a hash literal if they span more than one line.
         }
       RUBY
+
+      expect_correction(<<~RUBY)
+        hash1 = {
+          'a'   => 0,
+          'bbb' => 1
+        }
+        hash2 = {
+           a:   0,
+           bbb: 1
+        }
+      RUBY
     end
 
-    it 'registers an offense for misaligned hash rockets' do
+    it 'registers an offense and corrects misaligned hash rockets' do
       expect_offense(<<~RUBY)
         hash = {
           'a'   => 0,
@@ -564,24 +702,12 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
           ^^^^^^^^^^^ Align the keys and values of a hash literal if they span more than one line.
         }
       RUBY
-    end
 
-    it 'auto-corrects alignment' do
-      new_source = autocorrect_source(<<~RUBY)
-        hash1 = { a: 0,
-             bb:   1,
-                   ccc: 2 }
-        hash2 = { 'a' => 0,
-             'bb' =>   1,
-                   'ccc'  =>2 }
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
-        hash1 = { a:   0,
-                  bb:  1,
-                  ccc: 2 }
-        hash2 = { 'a'   => 0,
-                  'bb'  => 1,
-                  'ccc' => 2 }
+      expect_correction(<<~RUBY)
+        hash = {
+          'a'   => 0,
+          'bbb' => 1
+        }
       RUBY
     end
   end
@@ -643,7 +769,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_no_offenses('h = {}')
     end
 
-    it 'registers an offense for misaligned hash values' do
+    it 'registers an offense and corrects misaligned hash values' do
       expect_offense(<<~RUBY)
         hash = {
             'a' =>  0,
@@ -651,14 +777,28 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
           ^^^^^^^^^^ Align the separators of a hash literal if they span more than one line.
         }
       RUBY
+
+      expect_correction(<<~RUBY)
+        hash = {
+            'a' =>  0,
+          'bbb' =>  1
+        }
+      RUBY
     end
 
-    it 'registers an offense for misaligned hash rockets' do
+    it 'registers an offense and corrects misaligned hash rockets' do
       expect_offense(<<~RUBY)
         hash = {
             'a'  => 0,
           'bbb' =>  1
           ^^^^^^^^^^^ Align the separators of a hash literal if they span more than one line.
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        hash = {
+            'a'  => 0,
+          'bbb'  => 1
         }
       RUBY
     end
@@ -673,16 +813,21 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
 
     include_examples 'not on separate lines'
 
-    it 'auto-corrects alignment' do
-      new_source = autocorrect_source(<<~RUBY)
+    it 'registers an offense and corrects mixed indentation and spacing' do
+      expect_offense(<<~RUBY)
         hash1 = { a: 0,
              bb:    1,
+             ^^^^^^^^ Align the separators of a hash literal if they span more than one line.
                    ccc: 2 }
+                   ^^^^^^ Align the separators of a hash literal if they span more than one line.
         hash2 = { a => 0,
              bb =>    1,
+             ^^^^^^^^^^ Align the separators of a hash literal if they span more than one line.
                    ccc  =>2 }
+                   ^^^^^^^^ Align the separators of a hash literal if they span more than one line.
       RUBY
-      expect(new_source).to eq(<<~RUBY)
+
+      expect_correction(<<~RUBY)
         hash1 = { a: 0,
                  bb: 1,
                 ccc: 2 }
@@ -694,13 +839,15 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
 
     it "doesn't break code by moving long keys too far left" do
       # regression test; see GH issue 2582
-      new_source = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         {
           sjtjo: sjtjo,
           too_ono_ilitjion_tofotono_o: too_ono_ilitjion_tofotono_o,
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Align the separators of a hash literal if they span more than one line.
         }
       RUBY
-      expect(new_source).to eq(<<~RUBY)
+
+      expect_correction(<<~RUBY)
         {
           sjtjo: sjtjo,
         too_ono_ilitjion_tofotono_o: too_ono_ilitjion_tofotono_o,
@@ -778,19 +925,139 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_no_offenses('h = {}')
     end
 
-    describe 'registers an offense' do
-      it 'for misaligned hash values' do
-        expect_offense(<<~RUBY)
-          hash = {
-              'a' =>  0,
-              ^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
+    it 'registers an offense and corrects misaligned hash values' do
+      expect_offense(<<~RUBY)
+        hash = {
+            'a' =>  0,
+            ^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
+          'bbb' => 1
+          ^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        hash = {
+            'a' => 0,
             'bbb' => 1
-            ^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
-          }
-        RUBY
+        }
+      RUBY
+    end
+
+    it 'registers an offense and corrects misaligned hash values, ' \
+      'prefer table when least offenses' do
+      expect_offense(<<~RUBY)
+        hash = {
+          'abcdefg' => 0,
+          'abcdef'  => 0,
+          'gijk'    => 0,
+          'a'       => 0,
+          'b' => 1,
+          ^^^^^^^^ Align the keys and values of a hash literal if they span more than one line.
+                'c' => 1
+                ^^^^^^^^ Align the keys and values of a hash literal if they span more than one line.
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        hash = {
+          'abcdefg' => 0,
+          'abcdef'  => 0,
+          'gijk'    => 0,
+          'a'       => 0,
+          'b' => 1,
+          'c' => 1
+        }
+      RUBY
+    end
+
+    it 'registers an offense and corrects misaligned hash values, ' \
+      'prefer key when least offenses' do
+      expect_offense(<<~RUBY)
+        hash = {
+          'abcdefg' => 0,
+          'abcdef'  => 0,
+          ^^^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
+          'gijk' => 0,
+          'a' => 0,
+          'b' => 1,
+                'c' => 1
+                ^^^^^^^^ Align the keys of a hash literal if they span more than one line.
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        hash = {
+          'abcdefg' => 0,
+          'abcdef' => 0,
+          'gijk' => 0,
+          'a' => 0,
+          'b' => 1,
+          'c' => 1
+        }
+      RUBY
+    end
+
+    it 'registers an offense and corrects misaligned hash keys ' \
+      'with mixed hash style' do
+      expect_offense(<<~RUBY)
+        headers = {
+          "Content-Type" => 0,
+           Authorization: 1
+           ^^^^^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        headers = {
+          "Content-Type" => 0,
+          Authorization: 1
+        }
+      RUBY
+    end
+
+    it 'registers an offense and corrects misaligned hash values, ' \
+      'works separate for each hash' do
+      expect_offense(<<~RUBY)
+        hash = {
+          'abcdefg' => 0,
+          'abcdef'  => 0,
+          ^^^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
+          'gijk' => 0
+        }
+
+        hash = {
+          'abcdefg' => 0,
+          'abcdef'       => 0,
+          ^^^^^^^^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
+          'gijk' => 0
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        hash = {
+          'abcdefg' => 0,
+          'abcdef' => 0,
+          'gijk' => 0
+        }
+
+        hash = {
+          'abcdefg' => 0,
+          'abcdef' => 0,
+          'gijk' => 0
+        }
+      RUBY
+    end
+
+    describe 'table and key config' do
+      let(:cop_config) do
+        {
+          'EnforcedHashRocketStyle' => %w[table key],
+          'EnforcedColonStyle' => %w[table key]
+        }
       end
 
-      it 'for misaligned hash values, prefer table when least offenses' do
+      it 'registers an offense and corrects misaligned hash values, '\
+         'prefer table because it is specified first' do
         expect_offense(<<~RUBY)
           hash = {
             'abcdefg' => 0,
@@ -803,126 +1070,17 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
                   ^^^^^^^^ Align the keys and values of a hash literal if they span more than one line.
           }
         RUBY
-      end
 
-      it 'for misaligned hash values, prefer key when least offenses' do
-        expect_offense(<<~RUBY)
+        expect_correction(<<~RUBY)
           hash = {
             'abcdefg' => 0,
             'abcdef'  => 0,
-            ^^^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
-            'gijk' => 0,
-            'a' => 0,
-            'b' => 1,
-                  'c' => 1
-                  ^^^^^^^^ Align the keys of a hash literal if they span more than one line.
+            'gijk'    => 0,
+            'a'       => 0,
+            'b'       => 1,
+            'c'       => 1
           }
         RUBY
-      end
-
-      it 'for misaligned hash keys with mixed hash style' do
-        expect_offense(<<~RUBY)
-          headers = {
-            "Content-Type" => 0,
-             Authorization: 1
-             ^^^^^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
-          }
-        RUBY
-      end
-
-      it 'for misaligned hash values, works separate for each hash' do
-        expect_offense(<<~RUBY)
-          hash = {
-            'abcdefg' => 0,
-            'abcdef'  => 0,
-            ^^^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
-            'gijk' => 0
-          }
-
-          hash = {
-            'abcdefg' => 0,
-            'abcdef'       => 0,
-            ^^^^^^^^^^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
-            'gijk' => 0
-          }
-        RUBY
-      end
-
-      describe 'auto-corrects an offense' do
-        it 'for misaligned hash values' do
-          new_source = autocorrect_source(<<~RUBY)
-            hash = {
-                'a' =>  0,
-              'bbb' => 1
-            }
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
-            hash = {
-                'a' => 0,
-                'bbb' => 1
-            }
-          RUBY
-        end
-
-        describe 'table and key config' do
-          let(:cop_config) do
-            {
-              'EnforcedHashRocketStyle' => %w[table key],
-              'EnforcedColonStyle' => %w[table key]
-            }
-          end
-
-          it 'for misaligned hash values, '\
-             'prefer table because it is specified first' do
-            new_source = autocorrect_source(<<~RUBY)
-              hash = {
-                'abcdefg' => 0,
-                'abcdef'  => 0,
-                'gijk'    => 0,
-                'a'       => 0,
-                'b' => 1,
-                      'c' => 1
-              }
-            RUBY
-
-            expect(new_source).to eq(<<~RUBY)
-              hash = {
-                'abcdefg' => 0,
-                'abcdef'  => 0,
-                'gijk'    => 0,
-                'a'       => 0,
-                'b'       => 1,
-                'c'       => 1
-              }
-            RUBY
-          end
-        end
-
-        it 'for misaligned hash values, '\
-           'prefer key because it is specified first' do
-          new_source = autocorrect_source(<<~RUBY)
-            hash = {
-              'abcdefg' => 0,
-              'abcdef'  => 0,
-              'gijk' => 0,
-              'a' => 0,
-              'b' => 1,
-                    'c' => 1
-            }
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
-            hash = {
-              'abcdefg' => 0,
-              'abcdef' => 0,
-              'gijk' => 0,
-              'a' => 0,
-              'b' => 1,
-              'c' => 1
-            }
-          RUBY
-        end
       end
     end
   end
@@ -935,7 +1093,7 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       }
     end
 
-    it 'registers offenses for misaligned entries' do
+    it 'registers offenses and correct misaligned entries' do
       expect_offense(<<~RUBY)
         hash1 = {
           a:   0,
@@ -946,6 +1104,17 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
             'a' => 0,
           'bbb' => 1
           ^^^^^^^^^^ Align the keys of a hash literal if they span more than one line.
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        hash1 = {
+          a:   0,
+        bbb:   1
+        }
+        hash2 = {
+            'a' => 0,
+            'bbb' => 1
         }
       RUBY
     end

--- a/spec/rubocop/cop/layout/indentation_consistency_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_consistency_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
   end
 
   context 'with if statement' do
-    it 'registers an offense for bad indentation in an if body' do
+    it 'registers an offense and corrects bad indentation in an if body' do
       expect_offense(<<~RUBY)
         if cond
          func
@@ -22,9 +22,16 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
           ^^^^ Inconsistent indentation detected.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        if cond
+         func
+         func
+        end
+      RUBY
     end
 
-    it 'registers an offense for bad indentation in an else body' do
+    it 'registers an offense and corrects bad indentation in an else body' do
       expect_offense(<<~RUBY)
         if cond
           func1
@@ -34,9 +41,18 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
           ^^^^^ Inconsistent indentation detected.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        if cond
+          func1
+        else
+         func2
+         func2
+        end
+      RUBY
     end
 
-    it 'registers an offense for bad indentation in an elsif body' do
+    it 'registers an offense and corrects bad indentation in an elsif body' do
       expect_offense(<<~RUBY)
         if a1
           b1
@@ -48,27 +64,15 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
           c
         end
       RUBY
-    end
 
-    it 'autocorrects bad indentation' do
-      corrected = autocorrect_source(<<~RUBY)
+      expect_correction(<<~RUBY)
         if a1
-           b1
-        elsif a2
-         b2
-          b3
-        else
-            c
-        end
-      RUBY
-      expect(corrected).to eq <<~RUBY
-        if a1
-           b1
+          b1
         elsif a2
          b2
          b3
         else
-            c
+          c
         end
       RUBY
     end
@@ -226,12 +230,19 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
   end
 
   context 'with unless' do
-    it 'registers an offense for bad indentation in an unless body' do
+    it 'registers an offense and corrects bad indentation in an unless body' do
       expect_offense(<<~RUBY)
         unless cond
          func
           func
           ^^^^ Inconsistent indentation detected.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        unless cond
+         func
+         func
         end
       RUBY
     end
@@ -246,7 +257,8 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
   end
 
   context 'with case' do
-    it 'registers an offense for bad indentation in a case/when body' do
+    it 'registers an offense and corrects bad indentation ' \
+      'in a case/when body' do
       expect_offense(<<~RUBY)
         case a
         when b
@@ -255,9 +267,18 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
             ^ Inconsistent indentation detected.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        case a
+        when b
+         c
+         d
+        end
+      RUBY
     end
 
-    it 'registers an offense for bad indentation in a case/else body' do
+    it 'registers an offense and corrects bad indentation ' \
+      'in a case/else body' do
       expect_offense(<<~RUBY)
         case a
         when b
@@ -268,6 +289,18 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
            f
           g
           ^ Inconsistent indentation detected.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        case a
+        when b
+          c
+        when d
+          e
+        else
+           f
+           g
         end
       RUBY
     end
@@ -322,7 +355,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
   end
 
   context 'with while/until' do
-    it 'registers an offense for bad indentation in a while body' do
+    it 'registers an offense and corrects bad indentation in a while body' do
       expect_offense(<<~RUBY)
         while cond
          func
@@ -330,9 +363,16 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
           ^^^^ Inconsistent indentation detected.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        while cond
+         func
+         func
+        end
+      RUBY
     end
 
-    it 'registers an offense for bad indentation in begin/end/while' do
+    it 'registers an offense and corrects bad indentation in begin/end/while' do
       expect_offense(<<~RUBY)
         something = begin
          func1
@@ -340,14 +380,28 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
            ^^^^^ Inconsistent indentation detected.
         end while cond
       RUBY
+
+      expect_correction(<<~RUBY)
+        something = begin
+         func1
+         func2
+        end while cond
+      RUBY
     end
 
-    it 'registers an offense for bad indentation in an until body' do
+    it 'registers an offense and corrects bad indentation in an until body' do
       expect_offense(<<~RUBY)
         until cond
          func
           func
           ^^^^ Inconsistent indentation detected.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        until cond
+         func
+         func
         end
       RUBY
     end
@@ -361,12 +415,19 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
   end
 
   context 'with for' do
-    it 'registers an offense for bad indentation in a for body' do
+    it 'registers an offense and corrects bad indentation in a for body' do
       expect_offense(<<~RUBY)
         for var in 1..10
          func
         func
         ^^^^ Inconsistent indentation detected.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        for var in 1..10
+         func
+         func
         end
       RUBY
     end
@@ -380,7 +441,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
   end
 
   context 'with def/defs' do
-    it 'registers an offense for bad indentation in a def body' do
+    it 'registers an offense and corrects bad indentation in a def body' do
       expect_offense(<<~RUBY)
         def test
             func1
@@ -388,14 +449,28 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
              ^^^^^ Inconsistent indentation detected.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def test
+            func1
+            func2
+        end
+      RUBY
     end
 
-    it 'registers an offense for bad indentation in a defs body' do
+    it 'registers an offense and corrects bad indentation in a defs body' do
       expect_offense(<<~RUBY)
         def self.test
            func
             func
             ^^^^ Inconsistent indentation detected.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def self.test
+           func
+           func
         end
       RUBY
     end
@@ -457,7 +532,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
     end
 
     context 'with normal style configured' do
-      it 'registers an offense for bad indentation in a class body' do
+      it 'registers an offense and corrects bad indentation in a class body' do
         expect_offense(<<~RUBY)
           class Test
               def func1
@@ -465,6 +540,15 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
             def func2
             ^^^^^^^^^ Inconsistent indentation detected.
             end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class Test
+              def func1
+              end
+              def func2
+              end
           end
         RUBY
       end
@@ -497,8 +581,8 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
         RUBY
       end
 
-      it 'registers an offense for bad indentation in def but not for ' \
-         'outdented public, protected, and private' do
+      it 'registers an offense and corrects bad indentation ' \
+        'in def but not for outdented public, protected, and private' do
         expect_offense(<<~RUBY)
           class Test
           public
@@ -518,12 +602,31 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
            end
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          class Test
+          public
+
+            def e
+            end
+
+          protected
+
+            def f
+            end
+
+          private
+
+            def g
+            end
+          end
+        RUBY
       end
     end
   end
 
   context 'with module' do
-    it 'registers an offense for bad indentation in a module body' do
+    it 'registers an offense and corrects bad indentation in a module body' do
       expect_offense(<<~RUBY)
         module Test
             def func1
@@ -531,6 +634,15 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
              def func2
              ^^^^^^^^^ Inconsistent indentation detected.
              end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module Test
+            def func1
+            end
+            def func2
+            end
         end
       RUBY
     end
@@ -542,7 +654,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
       RUBY
     end
 
-    it 'registers an offense for bad indentation of private methods' do
+    it 'registers an offense and corrects bad indentation of private methods' do
       expect_offense(<<~RUBY)
         module Test
           def pub
@@ -553,10 +665,21 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
             end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        module Test
+          def pub
+          end
+          private
+          def priv
+          end
+        end
+      RUBY
     end
 
     context 'even when there are no public methods' do
-      it 'still registers an offense for bad indentation of private methods' do
+      it 'registers an offense and corrects bad indentation ' \
+        'of private methods' do
         expect_offense(<<~RUBY)
           module Test
             private
@@ -565,12 +688,20 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
               end
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          module Test
+            private
+            def priv
+            end
+          end
+        RUBY
       end
     end
   end
 
   context 'with block' do
-    it 'registers an offense for bad indentation in a do/end body' do
+    it 'registers an offense and correct bad indentation in a do/end body' do
       expect_offense(<<~RUBY)
         a = func do
          b
@@ -578,14 +709,28 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
           ^ Inconsistent indentation detected.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        a = func do
+         b
+         c
+        end
+      RUBY
     end
 
-    it 'registers an offense for bad indentation in a {} body' do
+    it 'registers an offense and corrects bad indentation in a {} body' do
       expect_offense(<<~RUBY)
         func {
            b
           c
           ^ Inconsistent indentation detected.
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        func {
+           b
+           c
         }
       RUBY
     end
@@ -607,28 +752,29 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
     end
 
     it 'does not auto-correct an offense within another offense' do
-      corrected = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         require 'spec_helper'
         describe ArticlesController do
           render_views
-            describe "GET \'index\'" do
+            describe "GET 'index'" do
+            ^^^^^^^^^^^^^^^^^^^^^^^^^ Inconsistent indentation detected.
                     it "returns success" do
                     end
                 describe "admin user" do
+                ^^^^^^^^^^^^^^^^^^^^^^^^ Inconsistent indentation detected.
                      before(:each) do
                     end
                 end
             end
         end
       RUBY
-      expect(cop.offenses.map(&:line)).to eq [4, 7] # Two offenses are found.
 
       # The offense on line 4 is corrected, affecting lines 4 to 11.
-      expect(corrected).to eq <<~RUBY
+      expect_correction(<<~RUBY)
         require 'spec_helper'
         describe ArticlesController do
           render_views
-          describe \"GET 'index'\" do
+          describe "GET 'index'" do
                   it "returns success" do
                   end
               describe "admin user" do

--- a/spec/rubocop/cop/layout/initial_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/initial_indentation_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe RuboCop::Cop::Layout::InitialIndentation do
     |  ^^^ Indentation of first line in file detected.
     |  end
     RUBY
+
+    expect_correction(<<-RUBY.strip_margin('|'))
+    |def f
+    |  end
+    RUBY
   end
 
   it 'accepts unindented method definition' do
@@ -23,18 +28,27 @@ RSpec.describe RuboCop::Cop::Layout::InitialIndentation do
       expect_no_offenses('﻿puts 1')
     end
 
-    it 'registers an offense for indented method call' do
+    it 'registers an offense and corrects indented method call' do
       expect_offense(<<~RUBY)
         ﻿  puts 1
            ^^^^ Indentation of first line in file detected.
       RUBY
+
+      expect_correction(<<~RUBY)
+        ﻿puts 1
+      RUBY
     end
 
-    it 'registers an offense for indented method call after comment' do
+    it 'registers an offense and corrects indented method call after comment' do
       expect_offense(<<~RUBY)
         ﻿# comment
           puts 1
           ^^^^ Indentation of first line in file detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ﻿# comment
+        puts 1
       RUBY
     end
   end
@@ -43,39 +57,23 @@ RSpec.describe RuboCop::Cop::Layout::InitialIndentation do
     expect_no_offenses('')
   end
 
-  it 'registers an offense for indented assignment disregarding comment' do
-    expect_offense(<<-RUBY)
-       # comment
-       x = 1
-       ^ Indentation of first line in file detected.
+  it 'registers an offense and corrects indented assignment ' \
+    'disregarding comment' do
+    expect_offense(<<-RUBY.strip_margin('|'))
+    |   # comment
+    |   x = 1
+    |   ^ Indentation of first line in file detected.
+    RUBY
+
+    expect_correction(<<-RUBY.strip_margin('|'))
+    |   # comment
+    |x = 1
     RUBY
   end
 
   it 'accepts unindented comment + assignment' do
     expect_no_offenses(<<~RUBY)
       # comment
-      x = 1
-    RUBY
-  end
-
-  it 'auto-corrects indented method definition' do
-    corrected = autocorrect_source(<<-RUBY)
-      def f
-      end
-    RUBY
-    expect(corrected).to eq(<<~RUBY)
-      def f
-            end
-    RUBY
-  end
-
-  it 'auto-corrects indented assignment but not comment' do
-    corrected = autocorrect_source(<<-RUBY)
-      # comment
-      x = 1
-    RUBY
-    expect(corrected).to eq(<<~RUBY)
-            # comment
       x = 1
     RUBY
   end

--- a/spec/rubocop/cop/layout/leading_comment_space_spec.rb
+++ b/spec/rubocop/cop/layout/leading_comment_space_spec.rb
@@ -3,10 +3,14 @@
 RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense for comment without leading space' do
+  it 'registers an offense and corrects comment without leading space' do
     expect_offense(<<~RUBY)
       #missing space
       ^^^^^^^^^^^^^^ Missing space after `#`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # missing space
     RUBY
   end
 
@@ -33,11 +37,16 @@ RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace, :config do
     RUBY
   end
 
-  it 'registers an offense for #! after the first line' do
+  it 'registers an offense and corrects #! after the first line' do
     expect_offense(<<~RUBY)
       test
       #!/usr/bin/ruby
       ^^^^^^^^^^^^^^^ Missing space after `#`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      test
+      # !/usr/bin/ruby
     RUBY
   end
 
@@ -49,29 +58,44 @@ RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace, :config do
       RUBY
     end
 
-    it 'registers an offense for #\ after the first line' do
-      expect_offense(<<~'RUBY', 'config.ru')
+    it 'registers an offense and corrects for #\ after the first line' do
+      expect_offense(<<~'RUBY')
         test
         #\ -w -p 8765
         ^^^^^^^^^^^^^ Missing space after `#`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        test
+        # \ -w -p 8765
       RUBY
     end
   end
 
   context 'file not named config.ru' do
-    it 'registers an offense for #\ on first line' do
-      expect_offense(<<~'RUBY', 'test/test_case.rb')
+    it 'registers an offense and corrects #\ on first line' do
+      expect_offense(<<~'RUBY')
         #\ -w -p 8765
         ^^^^^^^^^^^^^ Missing space after `#`.
         test
       RUBY
+
+      expect_correction(<<~'RUBY')
+        # \ -w -p 8765
+        test
+      RUBY
     end
 
-    it 'registers an offense for #\ after the first line' do
-      expect_offense(<<~'RUBY', 'test/test_case.rb')
+    it 'registers an offense and corrects #\ after the first line' do
+      expect_offense(<<~'RUBY')
         test
         #\ -w -p 8765
         ^^^^^^^^^^^^^ Missing space after `#`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        test
+        # \ -w -p 8765
       RUBY
     end
   end
@@ -80,7 +104,7 @@ RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace, :config do
     context 'when config option is disabled' do
       let(:cop_config) { { 'AllowDoxygenCommentStyle' => false } }
 
-      it 'registers an offense when using Doxygen style' do
+      it 'registers an offense and corrects using Doxygen style' do
         expect_offense(<<~RUBY)
           #**
           ^^^ Missing space after `#`.
@@ -88,6 +112,13 @@ RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace, :config do
           # Another comment on a second line
           #*
           ^^ Missing space after `#`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # **
+          # Some comment
+          # Another comment on a second line
+          # *
         RUBY
       end
     end
@@ -116,11 +147,6 @@ RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace, :config do
 
   it 'accepts sprockets directives' do
     expect_no_offenses('#= require_tree .')
-  end
-
-  it 'auto-corrects missing space' do
-    new_source = autocorrect_source('#comment')
-    expect(new_source).to eq('# comment')
   end
 
   it 'accepts =begin/=end comments' do

--- a/spec/rubocop/cop/layout/leading_empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/leading_empty_lines_spec.rb
@@ -30,81 +30,60 @@ RSpec.describe RuboCop::Cop::Layout::LeadingEmptyLines, :config do
     RUBY
   end
 
-  it 'registers an offense when there is a new line before a class' do
+  it 'registers an offense and corrects a new line before a class' do
     expect_offense(<<~RUBY)
 
       class Foo
       ^^^^^ Unnecessary blank line at the beginning of the source.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo
+      end
+    RUBY
   end
 
-  it 'registers an offense when there is a new line before code' do
+  it 'registers an offense and corrects a new line before code' do
     expect_offense(<<~RUBY)
 
       puts 1
       ^^^^ Unnecessary blank line at the beginning of the source.
     RUBY
+
+    expect_correction(<<~RUBY)
+      puts 1
+    RUBY
   end
 
-  it 'registers an offense when there is a new line before a comment' do
+  it 'registers an offense and corrects a new line before a comment' do
     expect_offense(<<~RUBY)
 
       # something
       ^^^^^^^^^^^ Unnecessary blank line at the beginning of the source.
     RUBY
+
+    expect_correction(<<~RUBY)
+      # something
+    RUBY
+  end
+
+  it 'registers an offense and corrects multiple new lines before a class' do
+    expect_offense(<<~RUBY)
+
+
+      class Foo
+      ^^^^^ Unnecessary blank line at the beginning of the source.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo
+      end
+    RUBY
   end
 
   context 'auto-correct' do
-    it 'removes new lines before a class' do
-      new_source = autocorrect_source(<<~RUBY)
-
-        class Foo
-        end
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        class Foo
-        end
-      RUBY
-    end
-
-    it 'removes new lines before code' do
-      new_source = autocorrect_source(<<~RUBY)
-
-        puts 1
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        puts 1
-      RUBY
-    end
-
-    it 'removes new lines before a comment' do
-      new_source = autocorrect_source(<<~RUBY)
-
-        # something
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        # something
-      RUBY
-    end
-
-    it 'removes multiple new lines' do
-      new_source = autocorrect_source(<<~RUBY)
-
-
-        class Foo
-        end
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        class Foo
-        end
-      RUBY
-    end
-
     context 'in collaboration' do
       let(:config) do
         RuboCop::Config.new('Layout/SpaceAroundEqualsInParameterDefault' => {

--- a/spec/rubocop/cop/layout/multiline_array_line_breaks_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_array_line_breaks_spec.rb
@@ -5,44 +5,31 @@ RSpec.describe RuboCop::Cop::Layout::MultilineArrayLineBreaks do
 
   context 'when on same line' do
     it 'does not add any offenses' do
-      expect_no_offenses(
-        <<-RUBY
-          [1,2,3]
-        RUBY
-      )
+      expect_no_offenses(<<~RUBY)
+        [1,2,3]
+      RUBY
     end
   end
 
   context 'when on same line, separate line from brackets' do
     it 'does not add any offenses' do
-      expect_no_offenses(
-        <<-RUBY
-          [
-            1,2,3,
-          ]
-        RUBY
-      )
+      expect_no_offenses(<<~RUBY)
+        [
+          1,2,3,
+        ]
+      RUBY
     end
   end
 
   context 'when two elements on same line' do
-    it 'adds an offense' do
-      expect_offense(
-        <<-RUBY
-          [1,
-            2, 4]
-               ^ Each item in a multi-line array must start on a separate line.
-        RUBY
-      )
-    end
-
-    it 'autocorrects the offense' do
-      new_source = autocorrect_source(<<~RUBY)
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
         [1,
           2, 4]
+             ^ Each item in a multi-line array must start on a separate line.
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         [1,
           2,\s
         4]
@@ -51,23 +38,14 @@ RSpec.describe RuboCop::Cop::Layout::MultilineArrayLineBreaks do
   end
 
   context 'when nested arrays' do
-    it 'adds an offense' do
-      expect_offense(
-        <<-RUBY
-          [1,
-            [2, 3], 4]
-                    ^ Each item in a multi-line array must start on a separate line.
-        RUBY
-      )
-    end
-
-    it 'autocorrects the offense' do
-      new_source = autocorrect_source(<<~RUBY)
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
         [1,
           [2, 3], 4]
+                  ^ Each item in a multi-line array must start on a separate line.
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         [1,
           [2, 3],\s
         4]

--- a/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
@@ -9,28 +9,55 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
               ^^^ Block body expression is on the same line as the block start.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      test do 
+        foo
+      end
+    RUBY
   end
 
-  it 'registers an offense for missing newline in {} block w/o params' do
+  it 'registers an offense and corrects for missing newline ' \
+    'in {} block w/o params' do
     expect_offense(<<~RUBY)
       test { foo
              ^^^ Block body expression is on the same line as the block start.
       }
     RUBY
+
+    expect_correction(<<~RUBY)
+      test { 
+        foo
+      }
+    RUBY
   end
 
-  it 'registers an offense for missing newline in do/end block with params' do
+  it 'registers an offense and corrects for missing newline ' \
+    'in do/end block with params' do
     expect_offense(<<~RUBY)
       test do |x| foo
                   ^^^ Block body expression is on the same line as the block start.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      test do |x| 
+        foo
+      end
+    RUBY
   end
 
-  it 'registers an offense for missing newline in {} block with params' do
+  it 'registers an offense and corrects for missing newline ' \
+    'in {} block with params' do
     expect_offense(<<~RUBY)
       test { |x| foo
                  ^^^ Block body expression is on the same line as the block start.
+      }
+    RUBY
+
+    expect_correction(<<~RUBY)
+      test { |x| 
+        foo
       }
     RUBY
   end
@@ -80,109 +107,108 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
     RUBY
   end
 
-  it 'registers offenses for lambdas as expected' do
+  it 'registers offenses and corrects for lambdas' do
     expect_offense(<<~RUBY)
       -> (x) do foo
                 ^^^ Block body expression is on the same line as the block start.
         bar
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      -> (x) do 
+        foo
+        bar
+      end
+    RUBY
   end
 
-  it 'registers offenses for new lambda literal syntax as expected' do
+  it 'registers offenses and corrrects for new lambda literal syntax' do
     expect_offense(<<~RUBY)
       -> x do foo
               ^^^ Block body expression is on the same line as the block start.
         bar
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      -> x do 
+        foo
+        bar
+      end
+    RUBY
   end
 
-  it 'registers an offense for line-break before arguments' do
+  it 'registers an offense and corrects line-break before arguments' do
     expect_offense(<<~RUBY)
       test do
         |x| play_with(x)
         ^^^ Block argument expression is not on the same line as the block start.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      test do |x|
+        play_with(x)
+      end
+    RUBY
   end
 
-  it 'registers an offense for line-break before arguments with empty block' do
+  it 'registers an offense and corrects line-break ' \
+    'before arguments with empty block' do
     expect_offense(<<~RUBY)
       test do
         |x|
         ^^^ Block argument expression is not on the same line as the block start.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      test do |x|
+      end
+    RUBY
   end
 
-  it 'registers an offense for line-break within arguments' do
+  it 'registers an offense and corrects line-break within arguments' do
     expect_offense(<<~RUBY)
       test do |x,
               ^^^ Block argument expression is not on the same line as the block start.
         y|
       end
     RUBY
-  end
 
-  it 'auto-corrects a do/end block with params that is missing newlines' do
-    src = <<~RUBY
-      test do |foo| bar
-      end
-    RUBY
-
-    new_source = autocorrect_source(src)
-
-    expect(new_source).to eq(<<~RUBY)
-      test do |foo| 
-        bar
+    expect_correction(<<~RUBY)
+      test do |x, y|
       end
     RUBY
   end
 
-  it 'auto-corrects a do/end block with a mult-line body' do
-    src = <<~RUBY
+  it 'registers an offense and corrects a do/end block with a mult-line body' do
+    expect_offense(<<~RUBY)
       test do |foo| bar
+                    ^^^ Block body expression is on the same line as the block start.
         test
       end
     RUBY
 
-    new_source = autocorrect_source(src)
-
-    expect(new_source).to eq(<<~RUBY)
+    expect_correction(<<~RUBY)
       test do |foo| 
         bar
         test
       end
-    RUBY
-  end
-
-  it 'auto-corrects a {} block with params that is missing newlines' do
-    src = <<~RUBY
-      test { |foo| bar
-      }
-    RUBY
-
-    new_source = autocorrect_source(src)
-
-    expect(new_source).to eq(<<~RUBY)
-      test { |foo| 
-        bar
-      }
     RUBY
   end
 
   it 'autocorrects in more complex case with lambda and assignment, and '\
      'aligns the next line two spaces out from the start of the block' do
-    src = <<~RUBY
+    expect_offense(<<~RUBY)
       x = -> (y) { foo
+                   ^^^ Block body expression is on the same line as the block start.
         bar
       }
     RUBY
 
-    new_source = autocorrect_source(src)
-
-    expect(new_source).to eq(<<~RUBY)
+    expect_correction(<<~RUBY)
       x = -> (y) { 
             foo
         bar
@@ -190,53 +216,31 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
     RUBY
   end
 
-  it 'auto-corrects a line-break before arguments' do
-    new_source = autocorrect_source(<<~RUBY)
-      test do
-        |x| play_with(x)
-      end
-    RUBY
-
-    expect(new_source).to eq(<<~RUBY)
-      test do |x|
-        play_with(x)
-      end
-    RUBY
-  end
-
-  it 'auto-corrects a line-break before arguments with empty block' do
-    new_source = autocorrect_source(<<~RUBY)
-      test do
-        |x|
-      end
-    RUBY
-
-    expect(new_source).to eq(<<~RUBY)
-      test do |x|
-      end
-    RUBY
-  end
-
-  it 'auto-corrects a line-break within arguments' do
-    new_source = autocorrect_source(<<~RUBY)
+  it 'registers an offense and corrects a line-break within arguments' do
+    expect_offense(<<~RUBY)
       test do |x,
+              ^^^ Block argument expression is not on the same line as the block start.
         y| play_with(x, y)
       end
     RUBY
-    expect(new_source).to eq(<<~RUBY)
+
+    expect_correction(<<~RUBY)
       test do |x, y|
         play_with(x, y)
       end
     RUBY
   end
 
-  it 'auto-corrects a line break within destructured arguments' do
-    new_source = autocorrect_source(<<~RUBY)
+  it 'registers an offense and corrects a line break ' \
+    'within destructured arguments' do
+    expect_offense(<<~RUBY)
       test do |(x,
+              ^^^^ Block argument expression is not on the same line as the block start.
         y)| play_with(x, y)
       end
     RUBY
-    expect(new_source).to eq(<<~RUBY)
+
+    expect_correction(<<~RUBY)
       test do |(x, y)|
         play_with(x, y)
       end
@@ -245,14 +249,16 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
 
   it "doesn't move end keyword in a way which causes infinite loop " \
      'in combination with Style/BlockEndNewLine' do
-    new_source = autocorrect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       def f
         X.map do |(a,
+                 ^^^^ Block argument expression is not on the same line as the block start.
         b)|
         end
       end
     RUBY
-    expect(new_source).to eq(<<~RUBY)
+
+    expect_correction(<<~RUBY)
       def f
         X.map do |(a, b)|
         end
@@ -262,15 +268,17 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
 
   it 'does not auto-correct a trailing comma when only one argument ' \
      'is present' do
-    new_source = autocorrect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       def f
         X.map do |
+                 ^ Block argument expression is not on the same line as the block start.
           a,
         |
         end
       end
     RUBY
-    expect(new_source).to eq(<<~RUBY)
+
+    expect_correction(<<~RUBY)
       def f
         X.map do |a,|
         end
@@ -279,15 +287,17 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
   end
 
   it 'auto-corrects nested parens correctly' do
-    new_source = autocorrect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       def f
         X.map do |
+                 ^ Block argument expression is not on the same line as the block start.
           (((a), b), c)
         |
         end
       end
     RUBY
-    expect(new_source).to eq(<<~RUBY)
+
+    expect_correction(<<~RUBY)
       def f
         X.map do |(((a), b), c)|
         end

--- a/spec/rubocop/cop/layout/multiline_hash_key_line_breaks_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_hash_key_line_breaks_spec.rb
@@ -31,30 +31,21 @@ RSpec.describe RuboCop::Cop::Layout::MultilineHashKeyLineBreaks do
     end
   end
 
-  context 'when key starts on same line as another' do
-    it 'adds an offense' do
-      expect_offense(<<~RUBY)
-        {
-          foo: 1,
-          baz: 3, bar: "2"}
-                  ^^^^^^^^ Each key in a multi-line hash must start on a separate line.
-      RUBY
-    end
+  it 'registers an offense and corrects when key starts ' \
+    'on same line as another' do
+    expect_offense(<<~RUBY)
+      {
+        foo: 1,
+        baz: 3, bar: "2"}
+                ^^^^^^^^ Each key in a multi-line hash must start on a separate line.
+    RUBY
 
-    it 'autocorrects the offense' do
-      new_source = autocorrect_source(<<~RUBY)
-        {
-          foo: 1,
-          baz: 3, bar: "2"}
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        {
-          foo: 1,
-          baz: 3,\s
-        bar: "2"}
-      RUBY
-    end
+    expect_correction(<<~RUBY)
+      {
+        foo: 1,
+        baz: 3,\s
+      bar: "2"}
+    RUBY
   end
 
   context 'when key starts on same line as another with rockets' do
@@ -65,77 +56,46 @@ RSpec.describe RuboCop::Cop::Layout::MultilineHashKeyLineBreaks do
           baz => 3, bar: "2"}
                     ^^^^^^^^ Each key in a multi-line hash must start on a separate line.
       RUBY
-    end
 
-    it 'autocorrects the offense' do
-      new_source = autocorrect_source(<<~RUBY)
-        {
-          foo => 1,
-          baz => 3, bar => "2"}
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         {
           foo => 1,
           baz => 3,\s
-        bar => "2"}
-      RUBY
-    end
-  end
-
-  context 'when key starts on same line as another' do
-    it 'adds an offense' do
-      expect_offense(
-        <<-RUBY
-          {foo: 1,
-            baz: 3, bar: "2"}
-                    ^^^^^^^^ Each key in a multi-line hash must start on a separate line.
-        RUBY
-      )
-    end
-
-    it 'autocorrects the offense' do
-      new_source = autocorrect_source(<<~RUBY)
-        {foo: 1,
-          baz: 3, bar: "2"}
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        {foo: 1,
-          baz: 3,\s
         bar: "2"}
       RUBY
     end
   end
 
-  context 'when nested hashes' do
-    it 'adds an offense' do
-      expect_offense(
-        <<-RUBY
-          {foo: 1,
-            baz: {
-              as: 12,
-            }, bar: "2"}
-               ^^^^^^^^ Each key in a multi-line hash must start on a separate line.
-        RUBY
-      )
-    end
+  it 'registers an offense and corrects when key starts ' \
+    'on same line as another' do
+    expect_offense(<<~RUBY)
+      {foo: 1,
+        baz: 3, bar: "2"}
+                ^^^^^^^^ Each key in a multi-line hash must start on a separate line.
+    RUBY
 
-    it 'autocorrects the offense' do
-      new_source = autocorrect_source(<<~RUBY)
-        {foo: 1,
-          baz: {
-            as: 12,
-          }, bar: "2"}
-      RUBY
+    expect_correction(<<~RUBY)
+      {foo: 1,
+        baz: 3,\s
+      bar: "2"}
+    RUBY
+  end
 
-      expect(new_source).to eq(<<~RUBY)
-        {foo: 1,
-          baz: {
-            as: 12,
-          },\s
-        bar: "2"}
-      RUBY
-    end
+  it 'registers an offense and corrects nested hashes' do
+    expect_offense(<<~RUBY)
+      {foo: 1,
+        baz: {
+          as: 12,
+        }, bar: "2"}
+           ^^^^^^^^ Each key in a multi-line hash must start on a separate line.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      {foo: 1,
+        baz: {
+          as: 12,
+        },\s
+      bar: "2"}
+    RUBY
   end
 end

--- a/spec/rubocop/cop/layout/multiline_method_argument_line_breaks_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_argument_line_breaks_spec.rb
@@ -5,75 +5,56 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodArgumentLineBreaks do
 
   context 'when one argument on same line' do
     it 'does not add any offenses' do
-      expect_no_offenses(
-        <<-RUBY
-          taz("abc")
-        RUBY
-      )
+      expect_no_offenses(<<~RUBY)
+        taz("abc")
+      RUBY
     end
   end
 
   context 'when bracket hash assignment on multiple lines' do
     it 'does not add any offenses' do
-      expect_no_offenses(
-        <<-RUBY
-          class Thing
-            def call
-              bar['foo'] = ::Time.zone.at(
-                             huh['foo'],
-                           )
-            end
+      expect_no_offenses(<<~RUBY)
+        class Thing
+          def call
+            bar['foo'] = ::Time.zone.at(
+                           huh['foo'],
+                         )
           end
-        RUBY
-      )
+        end
+      RUBY
     end
   end
 
   context 'when bracket hash assignment key on multiple lines' do
     it 'does not add any offenses' do
-      expect_no_offenses(
-        <<-RUBY
-          a['b',
-              'c', 'd'] = e
-        RUBY
-      )
+      expect_no_offenses(<<~RUBY)
+        a['b',
+            'c', 'd'] = e
+      RUBY
     end
   end
 
   context 'when two arguments are on next line' do
     it 'does not add any offenses' do
-      expect_no_offenses(
-        <<-RUBY
-          taz(
-            "abc", "foo"
-          )
-        RUBY
-      )
+      expect_no_offenses(<<~RUBY)
+        taz(
+          "abc", "foo"
+        )
+      RUBY
     end
   end
 
   context 'when many arguments are on multiple lines, two on same line' do
-    it 'adds an offense' do
-      expect_offense(
-        <<-RUBY
-          taz("abc",
-          "foo", "bar",
-                 ^^^^^ Each argument in a multi-line method call must start on a separate line.
-          "baz"
-          )
-        RUBY
-      )
-    end
-
-    it 'autocorrects the offense' do
-      new_source = autocorrect_source(<<~RUBY)
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
         taz("abc",
         "foo", "bar",
+               ^^^^^ Each argument in a multi-line method call must start on a separate line.
         "baz"
         )
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         taz("abc",
         "foo",\s
         "bar",
@@ -84,28 +65,17 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodArgumentLineBreaks do
   end
 
   context 'when many arguments are on multiple lines, three on same line' do
-    it 'adds an offense' do
-      expect_offense(
-        <<-RUBY
-          taz("abc",
-          "foo", "bar", "barz",
-                        ^^^^^^ Each argument in a multi-line method call must start on a separate line.
-                 ^^^^^ Each argument in a multi-line method call must start on a separate line.
-          "baz"
-          )
-        RUBY
-      )
-    end
-
-    it 'autocorrects the offense' do
-      new_source = autocorrect_source(<<~RUBY)
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
         taz("abc",
         "foo", "bar", "barz",
+                      ^^^^^^ Each argument in a multi-line method call must start on a separate line.
+               ^^^^^ Each argument in a multi-line method call must start on a separate line.
         "baz"
         )
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         taz("abc",
         "foo",\s
         "bar",\s
@@ -117,28 +87,17 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodArgumentLineBreaks do
   end
 
   context 'when many arguments are on multiple lines, three on same line' do
-    it 'adds an offense' do
-      expect_offense(
-        <<-RUBY
-          taz("abc",
-          "foo", "bar", z: "barz",
-                        ^^^^^^^^^ Each argument in a multi-line method call must start on a separate line.
-                 ^^^^^ Each argument in a multi-line method call must start on a separate line.
-          x: "baz"
-          )
-        RUBY
-      )
-    end
-
-    it 'autocorrects the offense' do
-      new_source = autocorrect_source(<<~RUBY)
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
         taz("abc",
         "foo", "bar", z: "barz",
+                      ^^^^^^^^^ Each argument in a multi-line method call must start on a separate line.
+               ^^^^^ Each argument in a multi-line method call must start on a separate line.
         x: "baz"
         )
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         taz("abc",
         "foo",\s
         "bar",\s
@@ -150,25 +109,15 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodArgumentLineBreaks do
   end
 
   context 'when argument starts on same line but ends on different line' do
-    it 'adds an offense' do
-      expect_offense(
-        <<-RUBY
-          taz("abc", {
-                     ^ Each argument in a multi-line method call must start on a separate line.
-            foo: "edf",
-          })
-        RUBY
-      )
-    end
-
-    it 'autocorrects the offense' do
-      new_source = autocorrect_source(<<~RUBY)
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
         taz("abc", {
+                   ^ Each argument in a multi-line method call must start on a separate line.
           foo: "edf",
         })
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         taz("abc",\s
         {
           foo: "edf",
@@ -178,25 +127,15 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodArgumentLineBreaks do
   end
 
   context 'when second argument starts on same line as end of first' do
-    it 'adds an offense' do
-      expect_offense(
-        <<-RUBY
-          taz({
-            foo: "edf",
-          }, "abc")
-             ^^^^^ Each argument in a multi-line method call must start on a separate line.
-        RUBY
-      )
-    end
-
-    it 'autocorrects the offense' do
-      new_source = autocorrect_source(<<~RUBY)
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
         taz({
           foo: "edf",
         }, "abc")
+           ^^^^^ Each argument in a multi-line method call must start on a separate line.
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         taz({
           foo: "edf",
         },\s

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -117,15 +117,20 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       RUBY
     end
 
-    it 'registers an offense for no indentation of second line' do
+    it 'registers an offense and corrects no indentation of second line' do
       expect_offense(<<~RUBY)
         a.
         b
         ^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a.
+          b
+      RUBY
     end
 
-    it 'registers an offense for 3 spaces indentation of second line' do
+    it 'registers an offense and corrects 3 spaces indentation of 2nd line' do
       expect_offense(<<~RUBY)
         a.
            b
@@ -134,19 +139,32 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
            d
            ^ Use 2 (not 3) spaces for indenting an expression spanning multiple lines.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a.
+          b
+        c.
+          d
+      RUBY
     end
 
-    it 'registers an offense for extra indentation of third line' do
+    it 'registers an offense and corrects extra indentation of third line' do
       expect_offense(<<~RUBY)
         a.
           b.
             c
             ^ Use 2 (not 4) spaces for indenting an expression spanning multiple lines.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a.
+          b.
+          c
+      RUBY
     end
 
-    it 'registers an offense for the emacs ruby-mode 1.1 indentation of an ' \
-       'expression in an array' do
+    it 'registers an offense and corrects the emacs ruby-mode 1.1 ' \
+      'indentation of an expression in an array' do
       expect_offense(<<~RUBY)
         [
          a.
@@ -154,31 +172,54 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
          ^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
         ]
       RUBY
+
+      expect_correction(<<~RUBY)
+        [
+         a.
+           b
+        ]
+      RUBY
     end
 
-    it 'registers an offense for extra indentation of 3rd line in typical ' \
-       'RSpec code' do
+    it 'registers an offense and corrects extra indentation of 3rd line ' \
+      'in typical RSpec code' do
       expect_offense(<<~RUBY)
         expect { Foo.new }.
           to change { Bar.count }.
               from(1).to(2)
               ^^^^ Use 2 (not 6) spaces for indenting an expression spanning multiple lines.
       RUBY
+
+      expect_correction(<<~RUBY)
+        expect { Foo.new }.
+          to change { Bar.count }.
+          from(1).to(2)
+      RUBY
     end
 
-    it 'registers an offense for proc call without a selector' do
+    it 'registers an offense and corrects proc call without a selector' do
       expect_offense(<<~RUBY)
         a
          .(args)
          ^^ Use 2 (not 1) spaces for indenting an expression spanning multiple lines.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a
+          .(args)
+      RUBY
     end
 
-    it 'registers an offense for one space indentation of second line' do
+    it 'registers an offense and corrects one space indentation of 2nd line' do
       expect_offense(<<~RUBY)
         a
          .b
          ^^ Use 2 (not 1) spaces for indenting an expression spanning multiple lines.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a
+          .b
       RUBY
     end
   end
@@ -260,7 +301,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
         RUBY
       end
 
-      it 'registers an offense for unaligned methods' do
+      it 'registers an offense and corrects unaligned methods' do
         expect_offense(<<~RUBY)
           User.a
             .b
@@ -268,9 +309,15 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
            .c
            ^^ Align `.c` with `.a` on line 1.
         RUBY
+
+        expect_correction(<<~RUBY)
+          User.a
+              .b
+              .c
+        RUBY
       end
 
-      it 'registers an offense for unaligned method in block body' do
+      it 'registers an offense and corrects unaligned method in block body' do
         expect_offense(<<~RUBY)
           a do
             b.c
@@ -278,16 +325,12 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
               ^^ Align `.d` with `.c` on line 2.
           end
         RUBY
-      end
 
-      it 'auto-corrects' do
-        new_source = autocorrect_source(<<~RUBY)
-          User.all.first
-            .age.to_s
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          User.all.first
-              .age.to_s
+        expect_correction(<<~RUBY)
+          a do
+            b.c
+             .d
+          end
         RUBY
       end
     end
@@ -334,12 +377,18 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       RUBY
     end
 
-    it 'registers an offense for one space indentation of third line' do
+    it 'registers an offense and corrects one space indentation of 3rd line' do
       expect_offense(<<~RUBY)
         a
           .b
          .c
          ^^ Use 2 (not 1) spaces for indenting an expression spanning multiple lines.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a
+          .b
+          .c
       RUBY
     end
 
@@ -372,11 +421,18 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       RUBY
     end
 
-    it 'registers an offense for misaligned methods in if condition' do
+    it 'registers an offense and corrects misaligned methods in if condition' do
       expect_offense(<<~RUBY)
         if a.
             b
             ^ Align `b` with `a.` on line 1.
+          something
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if a.
+           b
           something
         end
       RUBY
@@ -398,16 +454,23 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       RUBY
     end
 
-    it 'registers an offense for misaligned method in []= call' do
+    it 'registers an offense and corrects misaligned method in []= call' do
       expect_offense(<<~RUBY)
         flash[:error] = here_is_a_string.
                         that_spans.
            multiple_lines
            ^^^^^^^^^^^^^^ Align `multiple_lines` with `here_is_a_string.` on line 1.
       RUBY
+
+      expect_correction(<<~RUBY)
+        flash[:error] = here_is_a_string.
+                        that_spans.
+                        multiple_lines
+      RUBY
     end
 
-    it 'registers an offense for misaligned methods in unless condition' do
+    it 'registers an offense and corrects misaligned methods ' \
+      'in unless condition' do
       expect_offense(<<~RUBY)
         unless a
         .b
@@ -415,9 +478,17 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
           something
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        unless a
+               .b
+          something
+        end
+      RUBY
     end
 
-    it 'registers an offense for misaligned methods in while condition' do
+    it 'registers an offense and corrects misaligned methods ' \
+      'in while condition' do
       expect_offense(<<~RUBY)
         while a.
             b
@@ -425,13 +496,28 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
           something
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        while a.
+              b
+          something
+        end
+      RUBY
     end
 
-    it 'registers an offense for misaligned methods in until condition' do
+    it 'registers an offense and corrects misaligned methods ' \
+      'in until condition' do
       expect_offense(<<~RUBY)
         until a.
             b
             ^ Align `b` with `a.` on line 1.
+          something
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        until a.
+              b
           something
         end
       RUBY
@@ -464,12 +550,17 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       RUBY
     end
 
-    it 'registers an offense for misaligned methods in local variable ' \
-       'assignment' do
+    it 'registers an offense and corrects misaligned methods ' \
+      'in local variable assignment' do
       expect_offense(<<~RUBY)
         a = b.c.
          d
          ^ Align `d` with `b.c.` on line 1.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a = b.c.
+            d
       RUBY
     end
 
@@ -488,27 +579,18 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       RUBY
     end
 
-    it 'registers an offense for unaligned methods in assignment' do
+    it 'registers an offense and corrects unaligned methods in assignment' do
       expect_offense(<<~RUBY)
         bar = Foo
           .a
           ^^ Align `.a` with `Foo` on line 1.
               .b(c)
       RUBY
-    end
 
-    it 'auto-corrects' do
-      new_source = autocorrect_source(<<~RUBY)
-        until a.
-            b
-          something
-        end
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
-        until a.
-              b
-          something
-        end
+      expect_correction(<<~RUBY)
+        bar = Foo
+              .a
+              .b(c)
       RUBY
     end
   end
@@ -549,41 +631,63 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       RUBY
     end
 
-    it 'registers an offense for no indentation of second line' do
+    it 'registers an offense and corrects no indentation of second line' do
       expect_offense(<<~RUBY)
         a.
         b
         ^ Indent `b` 2 spaces more than `a` on line 1.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a.
+          b
+      RUBY
     end
 
-    it 'registers an offense for extra indentation of 3rd line in typical ' \
-       'RSpec code' do
+    it 'registers an offense and corrects extra indentation of 3rd line ' \
+      'in typical RSpec code' do
       expect_offense(<<~RUBY)
         expect { Foo.new }.
           to change { Bar.count }.
               from(1).to(2)
               ^^^^ Indent `from` 2 spaces more than `change { Bar.count }` on line 2.
       RUBY
+
+      expect_correction(<<~RUBY)
+        expect { Foo.new }.
+          to change { Bar.count }.
+               from(1).to(2)
+      RUBY
     end
 
-    it 'registers an offense for proc call without a selector' do
+    it 'registers an offense and corrects proc call without a selector' do
       expect_offense(<<~RUBY)
         a
          .(args)
          ^^ Indent `.(` 2 spaces more than `a` on line 1.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a
+          .(args)
+      RUBY
     end
 
-    it 'registers an offense for one space indentation of second line' do
+    it 'registers an offense and corrects one space indentation of 2nd line' do
       expect_offense(<<~RUBY)
         a
          .b
          ^^ Indent `.b` 2 spaces more than `a` on line 1.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a
+          .b
+      RUBY
     end
 
-    it 'registers an offense for 3 spaces indentation of second line' do
+    it 'registers an offense and corrects 3 spaces indentation ' \
+      'of second line' do
       expect_offense(<<~RUBY)
         a.
            b
@@ -592,19 +696,32 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
            d
            ^ Indent `d` 2 spaces more than `c` on line 3.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a.
+          b
+        c.
+          d
+      RUBY
     end
 
-    it 'registers an offense for extra indentation of third line' do
+    it 'registers an offense and corrects extra indentation of 3rd line' do
       expect_offense(<<~RUBY)
         a.
           b.
             c
             ^ Indent `c` 2 spaces more than `a` on line 1.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a.
+          b.
+          c
+      RUBY
     end
 
-    it 'registers an offense for the emacs ruby-mode 1.1 indentation of an ' \
-       'expression in an array' do
+    it 'registers an offense and corrects the emacs ruby-mode 1.1 ' \
+      'indentation of an expression in an array' do
       expect_offense(<<~RUBY)
         [
          a.
@@ -612,20 +729,12 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
          ^ Indent `b` 2 spaces more than `a` on line 2.
         ]
       RUBY
-    end
 
-    it 'auto-corrects' do
-      new_source = autocorrect_source(<<~RUBY)
-        until a.
-              b
-          something
-        end
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
-        until a.
-                b
-          something
-        end
+      expect_correction(<<~RUBY)
+        [
+         a.
+           b
+        ]
       RUBY
     end
   end
@@ -645,12 +754,18 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       RUBY
     end
 
-    it 'registers an offense for one space indentation of third line' do
+    it 'registers an offense and corrects 1 space indentation of 3rd line' do
       expect_offense(<<~RUBY)
         a
           .b
          .c
          ^^ Use 2 (not 1) spaces for indenting an expression spanning multiple lines.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a
+          .b
+          .c
       RUBY
     end
 
@@ -663,11 +778,18 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       RUBY
     end
 
-    it 'registers an offense for aligned methods in if condition' do
+    it 'registers an offense and corrects aligned methods in if condition' do
       expect_offense(<<~RUBY)
         if a.
            b
            ^ Use 4 (not 3) spaces for indenting a condition in an `if` statement spanning multiple lines.
+          something
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if a.
+            b
           something
         end
       RUBY
@@ -744,11 +866,18 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       end
     end
 
-    it 'registers an offense for wrong indentation of for expression' do
+    it 'registers an offense and corrects wrong indentation ' \
+      'of for expression' do
       expect_offense(<<~RUBY)
         for n in a.
           b
           ^ Use 4 (not 2) spaces for indenting a collection in a `for` statement spanning multiple lines.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        for n in a.
+            b
         end
       RUBY
     end
@@ -772,7 +901,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       RUBY
     end
 
-    it 'registers an offense for correct + unrecognized style' do
+    it 'registers an offense and corrects correct + unrecognized style' do
       expect_offense(<<~RUBY)
         a.
           b
@@ -780,33 +909,28 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
             d
             ^ Use 2 (not 4) spaces for indenting an expression spanning multiple lines.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a.
+          b
+        c.
+          d
+      RUBY
     end
 
-    it 'registers an offense for aligned operators in assignment' do
-      msg = 'Use %d (not %d) spaces for indenting an expression ' \
-              'in an assignment spanning multiple lines.'
-
+    it 'registers an offense and corrects aligned operators in assignment' do
       expect_offense(<<~RUBY)
         formatted_int = int_part
                         .abs
-                        ^^^^ #{format(msg, 2, 16)}
+                        ^^^^ Use 2 (not 16) spaces for indenting an expression in an assignment spanning multiple lines.
                         .reverse
-                        ^^^^^^^^ #{format(msg, 2, 16)}
+                        ^^^^^^^^ Use 2 (not 16) spaces for indenting an expression in an assignment spanning multiple lines.
       RUBY
-    end
 
-    it 'auto-corrects' do
-      new_source = autocorrect_source(<<~RUBY)
-        until a.
-              b
-          something
-        end
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
-        until a.
-            b
-          something
-        end
+      expect_correction(<<~RUBY)
+        formatted_int = int_part
+          .abs
+          .reverse
       RUBY
     end
 

--- a/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
@@ -43,19 +43,30 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
       RUBY
     end
 
-    it 'registers an offense for no indentation of second line' do
+    it 'registers an offense and corrects no indentation of second line' do
       expect_offense(<<~RUBY)
         a +
         b
         ^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a +
+          b
+      RUBY
     end
 
-    it 'registers an offense for one space indentation of second line' do
+    it 'registers an offense and corrects one space indentation ' \
+      'of second line' do
       expect_offense(<<~RUBY)
         a +
          b
          ^ Use 2 (not 1) spaces for indenting an expression spanning multiple lines.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a +
+          b
       RUBY
     end
 
@@ -78,7 +89,8 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
       RUBY
     end
 
-    it 'registers an offense for three spaces indentation of second line' do
+    it 'registers an offense and corrects three space indentation ' \
+      'of second line' do
       expect_offense(<<~RUBY)
         a ||
            b
@@ -87,24 +99,44 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
            d
            ^ Use 2 (not 3) spaces for indenting an expression spanning multiple lines.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a ||
+          b
+        c and
+          d
+      RUBY
     end
 
-    it 'registers an offense for extra indentation of third line' do
+    it 'registers an offense and corrects extra indentation of third line' do
       expect_offense(<<~RUBY)
         a ||
           b ||
             c
             ^ Use 2 (not 4) spaces for indenting an expression spanning multiple lines.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a ||
+          b ||
+          c
+      RUBY
     end
 
-    it 'registers an offense for the emacs ruby-mode 1.1 indentation of an ' \
-       'expression in an array' do
+    it 'registers an offense and corrects emacs ruby-mode 1.1 indentation of ' \
+    'an expression in an array' do
       expect_offense(<<~RUBY)
         [
          a +
          b
          ^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
+        ]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [
+         a +
+           b
         ]
       RUBY
     end
@@ -183,12 +215,17 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
       RUBY
     end
 
-    it 'registers an offense for an unindented multiline operation that is ' \
-       'the left operand in another operation' do
+    it 'registers an offense and corrects an unindented multiline operation ' \
+      'that is the left operand in another operation' do
       expect_offense(<<~RUBY)
         a +
         b < 3
         ^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a +
+          b < 3
       RUBY
     end
   end
@@ -207,11 +244,18 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
       RUBY
     end
 
-    it 'registers an offense for indented operands in if condition' do
+    it 'registers an offense and corrects indented operands in if condition' do
       expect_offense(<<~RUBY)
         if a +
             b
             ^ Align the operands of a condition in an `if` statement spanning multiple lines.
+          something
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if a +
+           b
           something
         end
       RUBY
@@ -247,7 +291,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
       RUBY
     end
 
-    it 'registers an offense for indented second part of string' do
+    it 'registers an offense and corrects indented second part of string' do
       expect_offense(<<~RUBY)
         it "should convert " +
           "a to " +
@@ -256,18 +300,31 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
           ^^^ Align the operands of an expression spanning multiple lines.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        it "should convert " +
+           "a to " +
+           "b" do
+        end
+      RUBY
     end
 
-    it 'registers an offense for indented operand in second argument' do
+    it 'registers an offense and corrects indented operand ' \
+      'in second argument' do
       expect_offense(<<~RUBY)
         puts a, 1 +
           2
           ^ Align the operands of an expression spanning multiple lines.
       RUBY
+
+      expect_correction(<<~RUBY)
+        puts a, 1 +
+                2
+      RUBY
     end
 
-    it 'registers an offense for misaligned string operand when the first ' \
-       'operand has backslash continuation' do
+    it 'registers an offense and corrects misaligned string operand ' \
+      'when the first operand has backslash continuation' do
       expect_offense(<<~RUBY)
         def f
           flash[:error] = 'Here is a string ' \
@@ -276,22 +333,45 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
               ^^^^^^^^^^^^^^^^ Align the operands of an expression in an assignment spanning multiple lines.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def f
+          flash[:error] = 'Here is a string ' \
+                          'That spans' <<
+                          'multiple lines'
+        end
+      RUBY
     end
 
-    it 'registers an offense for misaligned string operand when plus is used' do
+    it 'registers an offense and corrects misaligned string operand ' \
+      'when plus is used' do
       expect_offense(<<~RUBY)
         Error = 'Here is a string ' +
                 'That spans' <<
           'multiple lines'
           ^^^^^^^^^^^^^^^^ Align the operands of an expression in an assignment spanning multiple lines.
       RUBY
+
+      expect_correction(<<~RUBY)
+        Error = 'Here is a string ' +
+                'That spans' <<
+                'multiple lines'
+      RUBY
     end
 
-    it 'registers an offense for misaligned operands in unless condition' do
+    it 'registers an offense and corrects misaligned operands ' \
+      'in unless condition' do
       expect_offense(<<~RUBY)
         unless a +
           b
           ^ Align the operands of a condition in an `unless` statement spanning multiple lines.
+          something
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        unless a +
+               b
           something
         end
       RUBY
@@ -330,27 +410,19 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
       RUBY
     end
 
-    it 'registers an offense for unaligned operands in op-assignment' do
+    it 'registers an offense and corrects unaligned operands ' \
+      'in op-assignment' do
       expect_offense(<<~RUBY)
         bar *= Foo +
           a +
           ^ Align the operands of an expression in an assignment spanning multiple lines.
                b(c)
       RUBY
-    end
 
-    it 'auto-corrects' do
-      new_source = autocorrect_source(<<~RUBY)
-        until a +
-            b
-          something
-        end
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
-        until a +
-              b
-          something
-        end
+      expect_correction(<<~RUBY)
+        bar *= Foo +
+               a +
+               b(c)
       RUBY
     end
   end
@@ -369,11 +441,18 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
       RUBY
     end
 
-    it 'registers an offense for aligned operands in if condition' do
+    it 'registers an offense and corrects aligned operands in if conditions' do
       expect_offense(<<~RUBY)
         if a +
            b
            ^ Use 4 (not 3) spaces for indenting a condition in an `if` statement spanning multiple lines.
+          something
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if a +
+            b
           something
         end
       RUBY
@@ -411,12 +490,20 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
       RUBY
     end
 
-    it 'registers an offense for aligned code on LHS of equality operator' do
+    it 'registers an offense and corrects aligned code on LHS ' \
+      'of equality operator' do
       expect_offense(<<~RUBY)
         def config_to_allow_offenses
           a +
           b == c
           ^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def config_to_allow_offenses
+          a +
+            b == c
         end
       RUBY
     end
@@ -478,11 +565,18 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
       end
     end
 
-    it 'registers an offense for wrong indentation of for expression' do
+    it 'registers an offense and corrects wrong indentation ' \
+      'of for expression' do
       expect_offense(<<~RUBY)
         for n in a +
           b
           ^ Use 4 (not 2) spaces for indenting a collection in a `for` statement spanning multiple lines.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        for n in a +
+            b
         end
       RUBY
     end
@@ -503,7 +597,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
       RUBY
     end
 
-    it 'registers an offense for correct + unrecognized style' do
+    it 'registers an offense and corrects correct + unrecognized style' do
       expect_offense(<<~RUBY)
         a ||
           b
@@ -511,32 +605,28 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
             d
             ^ Use 2 (not 4) spaces for indenting an expression spanning multiple lines.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a ||
+          b
+        c and
+          d
+      RUBY
     end
 
-    it 'registers an offense for aligned operators in assignment' do
-      msg = 'Use %d (not %d) spaces for indenting an expression in ' \
-              'an assignment spanning multiple lines.'
+    it 'registers an offense and corrects aligned operators in assignment' do
       expect_offense(<<~RUBY)
         a = b +
             c +
-            ^ #{format(msg, 2, 4)}
+            ^ Use 2 (not 4) spaces for indenting an expression in an assignment spanning multiple lines.
             d
-            ^ #{format(msg, 2, 4)}
+            ^ Use 2 (not 4) spaces for indenting an expression in an assignment spanning multiple lines.
       RUBY
-    end
 
-    it 'auto-corrects' do
-      new_source = autocorrect_source(<<~RUBY)
-        until a +
-              b
-          something
-        end
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
-        until a +
-            b
-          something
-        end
+      expect_correction(<<~RUBY)
+        a = b +
+          c +
+          d
       RUBY
     end
 
@@ -596,14 +686,16 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
         end
       end
 
-      it 'auto-corrects' do
-        new_source = autocorrect_source(<<~RUBY)
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
           until a +
                 b
+                ^ Use 8 (not 6) spaces for indenting a condition in an `until` statement spanning multiple lines.
             something
           end
         RUBY
-        expect(new_source).to eq(<<~RUBY)
+
+        expect_correction(<<~RUBY)
           until a +
                   b
             something

--- a/spec/rubocop/cop/layout/parameter_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/parameter_alignment_spec.rb
@@ -18,20 +18,32 @@ RSpec.describe RuboCop::Cop::Layout::ParameterAlignment do
       }
     end
 
-    it 'registers an offense for parameters with single indent' do
+    it 'registers an offense and corrects parameters with single indent' do
       expect_offense(<<~RUBY)
         def method(a,
           b)
           ^ Align the parameters of a method definition if they span more than one line.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def method(a,
+                   b)
+        end
+      RUBY
     end
 
-    it 'registers an offense for parameters with double indent' do
+    it 'registers an offense and corrects parameters with double indent' do
       expect_offense(<<~RUBY)
         def method(a,
             b)
             ^ Align the parameters of a method definition if they span more than one line.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def method(a,
+                   b)
         end
       RUBY
     end
@@ -75,27 +87,27 @@ RSpec.describe RuboCop::Cop::Layout::ParameterAlignment do
                   c)
         end
       RUBY
-    end
 
-    it 'auto-corrects alignment' do
-      new_source = autocorrect_source(<<~RUBY)
-        def method(a,
-            b)
-        end
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
-        def method(a,
-                   b)
+      expect_correction(<<~RUBY)
+        def func2(a,
+                  *b,
+                  c)
         end
       RUBY
     end
 
     context 'defining self.method' do
-      it 'registers an offense for parameters with single indent' do
+      it 'registers an offense and corrects parameters with single indent' do
         expect_offense(<<~RUBY)
           def self.method(a,
             b)
             ^ Align the parameters of a method definition if they span more than one line.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def self.method(a,
+                          b)
           end
         RUBY
       end
@@ -107,30 +119,20 @@ RSpec.describe RuboCop::Cop::Layout::ParameterAlignment do
           end
         RUBY
       end
-
-      it 'auto-corrects alignment' do
-        new_source = autocorrect_source(<<~RUBY)
-          def self.method(a,
-              b)
-          end
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          def self.method(a,
-                          b)
-          end
-        RUBY
-      end
     end
 
-    it 'auto-corrects alignment in simple case' do
-      new_source = autocorrect_source(<<~RUBY)
+    it 'registers an offense and corrects alignment in simple case' do
+      expect_offense(<<~RUBY)
         def func(a,
                b,
+               ^ Align the parameters of a method definition if they span more than one line.
         c)
+        ^ Align the parameters of a method definition if they span more than one line.
           123
         end
       RUBY
-      expect(new_source).to eq(<<~RUBY)
+
+      expect_correction(<<~RUBY)
         def func(a,
                  b,
                  c)
@@ -147,20 +149,32 @@ RSpec.describe RuboCop::Cop::Layout::ParameterAlignment do
       }
     end
 
-    it 'registers an offense for parameters aligned to first param' do
+    it 'registers an offense and corrects parameters aligned to first param' do
       expect_offense(<<~RUBY)
         def method(a,
                    b)
                    ^ Use one level of indentation for parameters following the first line of a multi-line method definition.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def method(a,
+          b)
+        end
+      RUBY
     end
 
-    it 'registers an offense for parameters with double indent' do
+    it 'registers an offense and corrects parameters with double indent' do
       expect_offense(<<~RUBY)
         def method(a,
             b)
             ^ Use one level of indentation for parameters following the first line of a multi-line method definition.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def method(a,
+          b)
         end
       RUBY
     end
@@ -205,46 +219,34 @@ RSpec.describe RuboCop::Cop::Layout::ParameterAlignment do
                   ^ Use one level of indentation for parameters following the first line of a multi-line method definition.
         end
       RUBY
-    end
 
-    it 'auto-corrects alignment' do
-      new_source = autocorrect_source(<<~RUBY)
-        def method(a,
-            b)
-        end
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
-        def method(a,
-          b)
+      expect_correction(<<~RUBY)
+        def func2(a,
+          *b,
+          c)
         end
       RUBY
     end
 
     context 'defining self.method' do
-      it 'registers an offense for parameters aligned to first param' do
+      it 'registers an offense and corrects parameters ' \
+        'aligned to first param' do
         expect_offense(<<~RUBY)
           def self.method(a,
                           b)
                           ^ Use one level of indentation for parameters following the first line of a multi-line method definition.
           end
         RUBY
-      end
 
-      it 'accepts proper indentation' do
-        expect_no_offenses(<<~RUBY)
+        expect_correction(<<~RUBY)
           def self.method(a,
             b)
           end
         RUBY
       end
 
-      it 'auto-corrects alignment' do
-        new_source = autocorrect_source(<<~RUBY)
-          def self.method(a,
-              b)
-          end
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
+      it 'accepts proper indentation' do
+        expect_no_offenses(<<~RUBY)
           def self.method(a,
             b)
           end

--- a/spec/rubocop/cop/layout/space_after_colon_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_colon_spec.rb
@@ -3,10 +3,14 @@
 RSpec.describe RuboCop::Cop::Layout::SpaceAfterColon do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for colon without space after it' do
+  it 'registers an offense and corrects colon without space after it' do
     expect_offense(<<~RUBY)
       {a:3}
         ^ Space missing after colon.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      {a: 3}
     RUBY
   end
 
@@ -52,16 +56,17 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAfterColon do
     RUBY
   end
 
-  it 'registers an offense if an keyword optional argument has no space' do
+  it 'registers an offense and corrects a keyword optional ' \
+    'argument without a space' do
     expect_offense(<<~RUBY)
       def m(var:1, other_var: 2)
                ^ Space missing after colon.
       end
     RUBY
-  end
 
-  it 'auto-corrects missing space' do
-    new_source = autocorrect_source('def f(a:, b:2); {a:3}; end')
-    expect(new_source).to eq('def f(a:, b: 2); {a: 3}; end')
+    expect_correction(<<~RUBY)
+      def m(var: 1, other_var: 2)
+      end
+    RUBY
   end
 end

--- a/spec/rubocop/cop/layout/space_after_method_name_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_method_name_spec.rb
@@ -3,28 +3,48 @@
 RSpec.describe RuboCop::Cop::Layout::SpaceAfterMethodName do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for def with space before the parenthesis' do
+  it 'registers an offense and corrects def with space ' \
+    'before the parenthesis' do
     expect_offense(<<~RUBY)
       def func (x)
               ^ Do not put a space between a method name and the opening parenthesis.
         a
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def func(x)
+        a
+      end
+    RUBY
   end
 
-  it 'registers offense for class def with space before parenthesis' do
+  it 'registers offense and corrects class def with space before parenthesis' do
     expect_offense(<<~RUBY)
       def self.func (x)
                    ^ Do not put a space between a method name and the opening parenthesis.
         a
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def self.func(x)
+        a
+      end
+    RUBY
   end
 
-  it 'registers offense for assignment def with space before parenthesis' do
+  it 'registers offense and corrects assignment def with space ' \
+    'before parenthesis' do
     expect_offense(<<~RUBY)
       def func= (x)
                ^ Do not put a space between a method name and the opening parenthesis.
+        a
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def func=(x)
         a
       end
     RUBY
@@ -65,31 +85,6 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAfterMethodName do
   it 'accepts an assignment def with arguments but no parentheses' do
     expect_no_offenses(<<~RUBY)
       def func= x
-        a
-      end
-    RUBY
-  end
-
-  it 'auto-corrects unwanted space' do
-    new_source = autocorrect_source(<<~RUBY)
-      def func (x)
-        a
-      end
-      def self.func (x)
-        a
-      end
-      def func= (x)
-        a
-      end
-    RUBY
-    expect(new_source).to eq(<<~RUBY)
-      def func(x)
-        a
-      end
-      def self.func(x)
-        a
-      end
-      def func=(x)
         a
       end
     RUBY

--- a/spec/rubocop/cop/layout/space_after_not_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_not_spec.rb
@@ -3,10 +3,25 @@
 RSpec.describe RuboCop::Cop::Layout::SpaceAfterNot do
   subject(:cop) { described_class.new }
 
-  it 'reports an offense for space after !' do
+  it 'registers an offense and corrects a single space after !' do
     expect_offense(<<~RUBY)
       ! something
       ^^^^^^^^^^^ Do not leave space between `!` and its argument.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      !something
+    RUBY
+  end
+
+  it 'registers an offense and corrects multiple spaces after !' do
+    expect_offense(<<~RUBY)
+      !   something
+      ^^^^^^^^^^^^^ Do not leave space between `!` and its argument.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      !something
     RUBY
   end
 
@@ -18,31 +33,15 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAfterNot do
     expect_no_offenses('not something')
   end
 
-  it 'reports an offense for space after ! with the negated receiver ' \
-     'wrapped in parentheses' do
+  it 'registers an offense and corrects space after ! with ' \
+    'the negated receiver wrapped in parentheses' do
     expect_offense(<<~RUBY)
       ! (model)
       ^^^^^^^^^ Do not leave space between `!` and its argument.
     RUBY
-  end
 
-  context 'auto-correct' do
-    it 'removes redundant space' do
-      new_source = autocorrect_source('!  something')
-
-      expect(new_source).to eq('!something')
-    end
-
-    it 'keeps space after not keyword' do
-      new_source = autocorrect_source('not something')
-
-      expect(new_source).to eq('not something')
-    end
-
-    it 'removes redundant space when there is a parentheses' do
-      new_source = autocorrect_source('!  (model)')
-
-      expect(new_source).to eq('!(model)')
-    end
+    expect_correction(<<~RUBY)
+      !(model)
+    RUBY
   end
 end

--- a/spec/rubocop/cop/layout/space_after_semicolon_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_semicolon_spec.rb
@@ -8,20 +8,19 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAfterSemicolon do
   end
   let(:brace_config) { {} }
 
-  it 'registers an offense for semicolon without space after it' do
+  it 'registers an offense and corrects semicolon without space after it' do
     expect_offense(<<~RUBY)
       x = 1;y = 2
            ^ Space missing after semicolon.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x = 1; y = 2
     RUBY
   end
 
   it 'does not crash if semicolon is the last character of the file' do
     expect_no_offenses('x = 1;')
-  end
-
-  it 'auto-corrects missing space' do
-    new_source = autocorrect_source('x = 1;y = 2')
-    expect(new_source).to eq('x = 1; y = 2')
   end
 
   context 'inside block braces' do
@@ -38,11 +37,15 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAfterSemicolon do
 
       it_behaves_like 'common behavior'
 
-      it 'registers an offense for no space between a semicolon and a ' \
-         'closing brace' do
+      it 'registers an offense and corrects no space between a semicolon ' \
+        'and a closing brace' do
         expect_offense(<<~RUBY)
           test { ;}
                  ^ Space missing after semicolon.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          test { ; }
         RUBY
       end
     end

--- a/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
@@ -55,38 +55,60 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
       expect_no_offenses('->(x, y) { puts x }')
     end
 
-    it 'registers an offense for space before first parameter' do
+    it 'registers an offense and corrects space before first parameter' do
       expect_offense(<<~RUBY)
         {}.each { | x| puts x }
                    ^ Space before first block parameter detected.
       RUBY
+
+      expect_correction(<<~RUBY)
+        {}.each { |x| puts x }
+      RUBY
     end
 
-    it 'registers an offense for space after last parameter' do
+    it 'registers an offense and corrects space after last parameter' do
       expect_offense(<<~RUBY)
         {}.each { |x, y  | puts x }
                        ^^ Space after last block parameter detected.
       RUBY
+
+      expect_correction(<<~RUBY)
+        {}.each { |x, y| puts x }
+      RUBY
     end
 
-    it 'registers an offense for no space after closing pipe' do
+    it 'registers an offense and corrects no space after closing pipe' do
       expect_offense(<<~RUBY)
         {}.each { |x, y|puts x }
                        ^ Space after closing `|` missing.
       RUBY
+
+      expect_correction(<<~RUBY)
+        {}.each { |x, y| puts x }
+      RUBY
     end
 
-    it 'registers an offense to a lambda for space before first parameter' do
+    it 'registers an offense and corrects a lambda for space before ' \
+      'first parameter' do
       expect_offense(<<~RUBY)
         ->( x, y) { puts x }
            ^ Space before first block parameter detected.
       RUBY
+
+      expect_correction(<<~RUBY)
+        ->(x, y) { puts x }
+      RUBY
     end
 
-    it 'registers an offense to a lambda for space after last parameter' do
+    it 'registers an offense and corrects a lambda for space after ' \
+      'the last parameter' do
       expect_offense(<<~RUBY)
         ->(x, y  ) { puts x }
                ^^ Space after last block parameter detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ->(x, y) { puts x }
       RUBY
     end
 
@@ -98,19 +120,27 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
       RUBY
     end
 
-    it 'registers an offense for multiple spaces before parameter' do
+    it 'registers an offense and corrects multiple spaces before parameter' do
       expect_offense(<<~RUBY)
         {}.each { |x,   y| puts x }
                      ^^ Extra space before block parameter detected.
       RUBY
+
+      expect_correction(<<~RUBY)
+        {}.each { |x, y| puts x }
+      RUBY
     end
 
-    it 'registers an offense for space with parens' do
+    it 'registers an offense and corrects for space with parens' do
       expect_offense(<<~RUBY)
         {}.each { |a,  (x,  y),  z| puts x }
                      ^ Extra space before block parameter detected.
                           ^ Extra space before block parameter detected.
                                ^ Extra space before block parameter detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        {}.each { |a, (x, y), z| puts x }
       RUBY
     end
 
@@ -120,6 +150,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
           {}.each { |x, | puts x }
                        ^ Space after last block parameter detected.
         RUBY
+
+        expect_correction(<<~RUBY)
+          {}.each { |x,| puts x }
+        RUBY
       end
 
       it 'accepts no space after the last comma' do
@@ -127,14 +161,33 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
       end
     end
 
-    it 'auto-corrects offenses' do
-      new_source = autocorrect_source('{}.each { |  x=5,  (y,*z) |puts x }')
-      expect(new_source).to eq('{}.each { |x=5, (y,*z)| puts x }')
+    it 'registers an offense and corrects all types of spacing issues' do
+      expect_offense(<<~RUBY)
+        {}.each { |  x=5,  (y,*z) |puts x }
+                                  ^ Space after closing `|` missing.
+                                 ^ Space after last block parameter detected.
+                         ^ Extra space before block parameter detected.
+                   ^ Extra space before block parameter detected.
+                   ^^ Space before first block parameter detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        {}.each { |x=5, (y,*z)| puts x }
+      RUBY
     end
 
-    it 'auto-corrects offenses for a lambda' do
-      new_source = autocorrect_source('->(  a,  b, c) { puts a }')
-      expect(new_source).to eq('->(a, b, c) { puts a }')
+    it 'registers an offense and corrects all types of spacing issues ' \
+      'for a lambda' do
+      expect_offense(<<~RUBY)
+        ->(  a,  b, c) { puts a }
+               ^ Extra space before block parameter detected.
+           ^ Extra space before block parameter detected.
+           ^^ Space before first block parameter detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ->(a, b, c) { puts a }
+      RUBY
     end
   end
 
@@ -165,63 +218,102 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
         {}.each { |x | puts x }
                    ^ Space before first block parameter missing.
       RUBY
+
+      expect_correction(<<~RUBY)
+        {}.each { | x | puts x }
+      RUBY
     end
 
-    it 'registers an offense for no space after last parameter' do
+    it 'registers an offense and corrects no space after last parameter' do
       expect_offense(<<~RUBY)
         {}.each { | x, y| puts x }
                        ^ Space after last block parameter missing.
       RUBY
+
+      expect_correction(<<~RUBY)
+        {}.each { | x, y | puts x }
+      RUBY
     end
 
-    it 'registers an offense for extra space before first parameter' do
+    it 'registers an offense and corrects extra space before first parameter' do
       expect_offense(<<~RUBY)
         {}.each { |  x | puts x }
                    ^ Extra space before first block parameter detected.
       RUBY
+
+      expect_correction(<<~RUBY)
+        {}.each { | x | puts x }
+      RUBY
     end
 
-    it 'registers an offense for multiple spaces after last parameter' do
+    it 'registers an offense and corrects multiple spaces ' \
+      'after last parameter' do
       expect_offense(<<~RUBY)
         {}.each { | x, y   | puts x }
                          ^^ Extra space after last block parameter detected.
       RUBY
+
+      expect_correction(<<~RUBY)
+        {}.each { | x, y | puts x }
+      RUBY
     end
 
-    it 'registers an offense for no space after closing pipe' do
+    it 'registers an offense and corrects no space after closing pipe' do
       expect_offense(<<~RUBY)
         {}.each { | x, y |puts x }
                          ^ Space after closing `|` missing.
       RUBY
+
+      expect_correction(<<~RUBY)
+        {}.each { | x, y | puts x }
+      RUBY
     end
 
-    it 'registers an offense to a lambda for no space before first parameter' do
+    it 'registers an offense and corrects a lambda for no space ' \
+      'before first parameter' do
       expect_offense(<<~RUBY)
         ->(x ) { puts x }
            ^ Space before first block parameter missing.
       RUBY
+
+      expect_correction(<<~RUBY)
+        ->( x ) { puts x }
+      RUBY
     end
 
-    it 'registers an offense to a lambda for no space after last parameter' do
+    it 'registers an offense and corrects a lambda for ' \
+      'no space after last parameter' do
       expect_offense(<<~RUBY)
         ->( x, y) { puts x }
                ^ Space after last block parameter missing.
       RUBY
+
+      expect_correction(<<~RUBY)
+        ->( x, y ) { puts x }
+      RUBY
     end
 
-    it 'registers an offense to a lambda for extra space' \
+    it 'registers an offense and corrects a lambda for extra space' \
        'before first parameter' do
       expect_offense(<<~RUBY)
         ->(  x ) { puts x }
            ^ Extra space before first block parameter detected.
       RUBY
+
+      expect_correction(<<~RUBY)
+        ->( x ) { puts x }
+      RUBY
     end
 
-    it 'registers an offense to a lambda for multiple spaces' \
+    it 'registers an offense and corrects a lambda for multiple spaces' \
        'after last parameter' do
       expect_offense(<<~RUBY)
         ->( x, y   ) { puts x }
                  ^^ Extra space after last block parameter detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ->( x, y ) { puts x }
       RUBY
     end
 
@@ -233,20 +325,28 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
       RUBY
     end
 
-    it 'registers an offense for multiple spaces before parameter' do
+    it 'registers an offense and corrects multiple spaces before parameter' do
       expect_offense(<<~RUBY)
         {}.each { | x,   y | puts x }
                       ^^ Extra space before block parameter detected.
       RUBY
+
+      expect_correction(<<~RUBY)
+        {}.each { | x, y | puts x }
+      RUBY
     end
 
-    it 'registers an offense for space with parens at middle' do
+    it 'registers an offense and corrects space with parens at middle' do
       expect_offense(<<~RUBY)
         {}.each { |(x,  y),  z| puts x }
                    ^^^^^^^ Space before first block parameter missing.
                       ^ Extra space before block parameter detected.
                            ^ Extra space before block parameter detected.
                              ^ Space after last block parameter missing.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        {}.each { | (x, y), z | puts x }
       RUBY
     end
 
@@ -255,27 +355,56 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
         expect_no_offenses('{}.each { | x, | puts x }')
       end
 
-      it 'registers an offense for no space after the last comma' do
+      it 'registers an offense and corrects no space after the last comma' do
         expect_offense(<<~RUBY)
           {}.each { | x,| puts x }
                       ^ Space after last block parameter missing.
         RUBY
+
+        expect_correction(<<~RUBY)
+          {}.each { | x ,| puts x }
+        RUBY
       end
     end
 
-    it 'auto-corrects block arguments inside Hash#each' do
-      new_source = autocorrect_source('{}.each { |  x=5,  (y,*z)|puts x }')
-      expect(new_source).to eq('{}.each { | x=5, (y,*z) | puts x }')
+    it 'registers an offense and corrects block arguments inside Hash#each' do
+      expect_offense(<<~RUBY)
+        {}.each { |  x=5,  (y,*z)|puts x }
+                                 ^ Space after closing `|` missing.
+                           ^^^^^^ Space after last block parameter missing.
+                         ^ Extra space before block parameter detected.
+                   ^ Extra space before first block parameter detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        {}.each { | x=5, (y,*z) | puts x }
+      RUBY
     end
 
-    it 'auto-corrects missing space before first argument' do
-      new_source = autocorrect_source_with_loop('{}.each { |x, z| puts x }')
-      expect(new_source).to eq('{}.each { | x, z | puts x }')
+    it 'registers an offense and corrects missing space ' \
+      'before first argument and after last argument' do
+      expect_offense(<<~RUBY)
+        {}.each { |x, z| puts x }
+                      ^ Space after last block parameter missing.
+                   ^ Space before first block parameter missing.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        {}.each { | x, z | puts x }
+      RUBY
     end
 
-    it 'auto-corrects lambda args' do
-      new_source = autocorrect_source('->(  x,  y) { puts x }')
-      expect(new_source).to eq('->( x, y ) { puts x }')
+    it 'registers an offense and corrects spacing in lambda args' do
+      expect_offense(<<~RUBY)
+        ->(  x,  y) { puts x }
+                 ^ Space after last block parameter missing.
+               ^ Extra space before block parameter detected.
+           ^ Extra space before first block parameter detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ->( x, y ) { puts x }
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/layout/space_around_equals_in_parameter_default_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_equals_in_parameter_default_spec.rb
@@ -6,27 +6,45 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :confi
   context 'when EnforcedStyle is space' do
     let(:cop_config) { { 'EnforcedStyle' => 'space' } }
 
-    it 'registers an offense for default value assignment without space' do
+    it 'registers an offense and corrects default value assignment ' \
+      'without space' do
       expect_offense(<<~RUBY)
         def f(x, y=0, z= 1)
                   ^ Surrounding space missing in default value assignment.
                        ^^ Surrounding space missing in default value assignment.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def f(x, y = 0, z = 1)
+        end
+      RUBY
     end
 
-    it 'registers an offense for assignment empty string without space' do
+    it 'registers an offense and corrects assigning empty string ' \
+      'without space' do
       expect_offense(<<~RUBY)
         def f(x, y="")
                   ^ Surrounding space missing in default value assignment.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def f(x, y = "")
+        end
+      RUBY
     end
 
-    it 'registers an offense for assignment of empty list without space' do
+    it 'registers an offense and corrects assignment of empty list ' \
+      'without space' do
       expect_offense(<<~RUBY)
         def f(x, y=[])
                   ^ Surrounding space missing in default value assignment.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def f(x, y = [])
         end
       RUBY
     end
@@ -38,18 +56,6 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :confi
       RUBY
     end
 
-    it 'auto-corrects missing space' do
-      new_source = autocorrect_source(<<~RUBY)
-        def f(x, y=0, z=1)
-        end
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        def f(x, y = 0, z = 1)
-        end
-      RUBY
-    end
-
     it 'accepts default value assignment with spaces and unary + operator' do
       expect_no_offenses(<<~RUBY)
         def f(x, y = +1, z = {})
@@ -57,12 +63,17 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :confi
       RUBY
     end
 
-    it 'auto-corrects missing space for arguments with unary operators' do
-      new_source = autocorrect_source(<<~RUBY)
+    it 'registers an offense and corrects missing space for arguments ' \
+      'with unary operators' do
+      expect_offense(<<~RUBY)
         def f(x=-1, y= 0, z =+1)
+                           ^^ Surrounding space missing in default value assignment.
+                     ^^ Surrounding space missing in default value assignment.
+               ^ Surrounding space missing in default value assignment.
         end
       RUBY
-      expect(new_source).to eq(<<~RUBY)
+
+      expect_correction(<<~RUBY)
         def f(x = -1, y = 0, z = +1)
         end
       RUBY
@@ -72,7 +83,8 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :confi
   context 'when EnforcedStyle is no_space' do
     let(:cop_config) { { 'EnforcedStyle' => 'no_space' } }
 
-    it 'registers an offense for default value assignment with space' do
+    it 'registers an offense and corrects default value assignment ' \
+      'with space' do
       expect_offense(<<~RUBY)
         def f(x, y = 0, z =1, w= 2)
                   ^^^ Surrounding space detected in default value assignment.
@@ -80,20 +92,37 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :confi
                                ^^ Surrounding space detected in default value assignment.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def f(x, y=0, z=1, w=2)
+        end
+      RUBY
     end
 
-    it 'registers an offense for assignment empty string with space' do
+    it 'registers an offense and corrects assignment of empty string ' \
+      'with space' do
       expect_offense(<<~RUBY)
         def f(x, y = "")
                   ^^^ Surrounding space detected in default value assignment.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def f(x, y="")
+        end
+      RUBY
     end
 
-    it 'registers an offense for assignment of empty list with space' do
+    it 'registers an offense and corrects assignment ' \
+      'of empty list with space' do
       expect_offense(<<~RUBY)
         def f(x, y = [])
                   ^^^ Surrounding space detected in default value assignment.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def f(x, y=[])
         end
       RUBY
     end
@@ -101,17 +130,6 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :confi
     it 'accepts default value assignment without space' do
       expect_no_offenses(<<~RUBY)
         def f(x, y=0, z={})
-        end
-      RUBY
-    end
-
-    it 'auto-corrects unwanted space' do
-      new_source = autocorrect_source(<<~RUBY)
-        def f(x, y = 0, z= 1, w= 2)
-        end
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
-        def f(x, y=0, z=1, w=2)
         end
       RUBY
     end

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -42,10 +42,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
     expect_no_offenses('::Kernel::raise IllegalBlockError.new')
   end
 
-  it 'accepts exclamation point negation' do
+  it 'registers an offense and corrects exclamation point negation' do
     expect_offense(<<~RUBY)
       x = !a&&!b
             ^^ Surrounding space missing for operator `&&`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x = !a && !b
     RUBY
   end
 
@@ -172,15 +176,11 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
     expect_offense(<<~RUBY)
       x = a * b ** 2
                 ^^ Space around operator `**` detected.
-    RUBY
-  end
-
-  it 'auto-corrects unwanted space around **' do
-    new_source = autocorrect_source(<<~RUBY)
-      x = a * b ** 2
       y = a * b** 2
+               ^^ Space around operator `**` detected.
     RUBY
-    expect(new_source).to eq(<<~RUBY)
+
+    expect_correction(<<~RUBY)
       x = a * b**2
       y = a * b**2
     RUBY
@@ -198,16 +198,9 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
         x = a * b**2
                  ^^ Surrounding space missing for operator `**`.
       RUBY
-    end
 
-    it 'auto-corrects a exponent operator without space' do
-      new_source = autocorrect_source(<<~RUBY)
+      expect_correction(<<~RUBY)
         x = a * b ** 2
-        y = a * b** 2
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
-        x = a * b ** 2
-        y = a * b ** 2
       RUBY
     end
   end
@@ -280,50 +273,51 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
         z[0] =0
              ^ Surrounding space missing for operator `=`.
       RUBY
-    end
 
-    it 'auto-corrects assignment without space on both sides' do
-      new_source = autocorrect_source(<<~RUBY)
-        x=0
-        y= 0
-        z =0
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         x = 0
-        y = 0
-        z = 0
+        y += 0
+        z[0] = 0
       RUBY
     end
 
     context 'ternary operators' do
-      it 'registers an offense for operators with no spaces' do
+      it 'registers an offense and corrects operators with no spaces' do
         expect_offense(<<~RUBY)
           x == 0?1:2
                   ^ Surrounding space missing for operator `:`.
                 ^ Surrounding space missing for operator `?`.
         RUBY
+
+        expect_correction(<<~RUBY)
+          x == 0 ? 1 : 2
+        RUBY
       end
 
-      it 'registers an offense for operators with just a trailing space' do
+      it 'registers an offense and corrects operators with ' \
+        'just a trailing space' do
         expect_offense(<<~RUBY)
           x == 0? 1: 2
                    ^ Surrounding space missing for operator `:`.
                 ^ Surrounding space missing for operator `?`.
         RUBY
+
+        expect_correction(<<~RUBY)
+          x == 0 ? 1 : 2
+        RUBY
       end
 
-      it 'registers an offense for operators with just a leading space' do
+      it 'registers an offense and corrects operators with ' \
+        'just a leading space' do
         expect_offense(<<~RUBY)
           x == 0 ?1 :2
                     ^ Surrounding space missing for operator `:`.
                  ^ Surrounding space missing for operator `?`.
         RUBY
-      end
 
-      it 'auto-corrects a ternary operator without space' do
-        new_source = autocorrect_source('x == 0?1:2')
-        expect(new_source).to eq('x == 0 ? 1 : 2')
+        expect_correction(<<~RUBY)
+          x == 0 ? 1 : 2
+        RUBY
       end
     end
 
@@ -341,32 +335,23 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
         z+0
          ^ Surrounding space missing for operator `+`.
       RUBY
-    end
 
-    it 'auto-corrects missing space in binary operators that could be unary' do
-      new_source = autocorrect_source(<<~RUBY)
-        a-3
-        x&0xff
-        z+0
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         a - 3
         x & 0xff
         z + 0
       RUBY
     end
 
-    it 'registers an offense for arguments to a method' do
+    it 'registers an offense and corrects arguments to a method' do
       expect_offense(<<~RUBY)
         puts 1+2
               ^ Surrounding space missing for operator `+`.
       RUBY
-    end
 
-    it 'auto-corrects missing space in arguments to a method' do
-      new_source = autocorrect_source('puts 1+2')
-      expect(new_source).to eq('puts 1 + 2')
+      expect_correction(<<~RUBY)
+        puts 1 + 2
+      RUBY
     end
 
     it 'registers an offense for operators without spaces' do
@@ -386,23 +371,21 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
           ^^ Surrounding space missing for operator `-=`.
              ^^ Surrounding space missing for operator `&&`.
       RUBY
-    end
 
-    it 'auto-corrects missing space' do
-      new_source = autocorrect_source(<<~RUBY)
-        x+= a+b-c*d/e%f^g|h&i||j
-        y -=k&&l
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         x += a + b - c * d / e % f ^ g | h & i || j
         y -= k && l
       RUBY
     end
 
-    it 'registers an offense for a setter call without spaces' do
+    it 'registers an offense and corrects a setter call without spaces' do
       expect_offense(<<~RUBY)
         x.y=2
            ^ Surrounding space missing for operator `=`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.y = 2
       RUBY
     end
 
@@ -410,10 +393,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
       context 'and Layout/HashAlignment:EnforcedHashRocketStyle is key' do
         let(:hash_style) { 'key' }
 
-        it 'registers an offense for a hash rocket without spaces' do
+        it 'registers an offense and corrects a hash rocket without spaces' do
           expect_offense(<<~RUBY)
             { 1=>2, a: b }
                ^^ Surrounding space missing for operator `=>`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            { 1 => 2, a: b }
           RUBY
         end
       end
@@ -421,10 +408,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
       context 'and Layout/HashAlignment:EnforcedHashRocketStyle is table' do
         let(:hash_style) { 'table' }
 
-        it 'registers an offense for a hash rocket without spaces' do
+        it 'registers an offense and corrects a hash rocket without spaces' do
           expect_offense(<<~RUBY)
             { 1=>2, a: b }
                ^^ Surrounding space missing for operator `=>`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            { 1 => 2, a: b }
           RUBY
         end
       end
@@ -434,11 +425,18 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
       context 'and Layout/HashAlignment:EnforcedHashRocketStyle is key' do
         let(:hash_style) { 'key' }
 
-        it 'registers an offense for a hash rocket without spaces' do
+        it 'registers an offense and corrects a hash rocket without spaces' do
           expect_offense(<<~RUBY)
             {
               1=>2,
                ^^ Surrounding space missing for operator `=>`.
+              a: b
+            }
+          RUBY
+
+          expect_correction(<<~RUBY)
+            {
+              1 => 2,
               a: b
             }
           RUBY
@@ -459,16 +457,21 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
       end
     end
 
-    it 'registers an offense for match operators without space' do
+    it 'registers an offense and corrects match operators without space' do
       expect_offense(<<~RUBY)
         x=~/abc/
          ^^ Surrounding space missing for operator `=~`.
         y !~/abc/
           ^^ Surrounding space missing for operator `!~`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        x =~ /abc/
+        y !~ /abc/
+      RUBY
     end
 
-    it 'registers an offense for various assignments without space' do
+    it 'registers an offense and corrects various assignments without space' do
       expect_offense(<<~RUBY)
         x||=0
          ^^^ Surrounding space missing for operator `||=`.
@@ -491,9 +494,22 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
         A||=0
          ^^^ Surrounding space missing for operator `||=`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        x ||= 0
+        y &&= 0
+        z *= 2
+        @a = 0
+        @@a = 0
+        a,b = 0
+        A = 0
+        x[3] = 0
+        $A = 0
+        A ||= 0
+      RUBY
     end
 
-    it 'registers an offense for equality operators without space' do
+    it 'registers an offense and corrects equality operators without space' do
       expect_offense(<<~RUBY)
         x==0
          ^^ Surrounding space missing for operator `==`.
@@ -502,39 +518,66 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
         Hash===z
             ^^^ Surrounding space missing for operator `===`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        x == 0
+        y != 0
+        Hash === z
+      RUBY
     end
 
-    it 'registers an offense for - without space with negative lhs operand' do
+    it 'registers an offense and corrects `-` without space with a negative ' \
+      'lhs operand' do
       expect_offense(<<~RUBY)
         -1-arg
           ^ Surrounding space missing for operator `-`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        -1 - arg
+      RUBY
     end
 
-    it 'registers an offense for inheritance < without space' do
+    it 'registers an offense and corrects inheritance < without space' do
       expect_offense(<<~RUBY)
         class ShowSourceTestClass<ShowSourceTestSuperClass
                                  ^ Surrounding space missing for operator `<`.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        class ShowSourceTestClass < ShowSourceTestSuperClass
+        end
+      RUBY
     end
 
-    it 'registers an offense for hash rocket without space at rescue' do
+    it 'registers an offense and corrects hash rocket without ' \
+      'space at rescue' do
       expect_offense(<<~RUBY)
         begin
         rescue Exception=>e
                         ^^ Surrounding space missing for operator `=>`.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+        rescue Exception => e
+        end
+      RUBY
     end
 
-    it "doesn't eat a newline when auto-correcting" do
-      new_source = autocorrect_source(<<~RUBY)
+    it 'registers an offense and corrects string concatination ' \
+      'without messing up new lines' do
+      expect_offense(<<~RUBY)
         'Here is a'+
+                   ^ Surrounding space missing for operator `+`.
         'joined string'+
+                       ^ Surrounding space missing for operator `+`.
         'across three lines'
       RUBY
-      expect(new_source).to eq(<<~RUBY)
+
+      expect_correction(<<~RUBY)
         'Here is a' +
         'joined string' +
         'across three lines'
@@ -571,7 +614,8 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
       end
     end
 
-    it 'registers an offense for assignment with many spaces on either side' do
+    it 'registers an offense and corrects assignment with ' \
+      'too many spaces on either side' do
       expect_offense(<<~RUBY)
         x   = 0
             ^ Operator `=` should be surrounded by a single space.
@@ -580,32 +624,25 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
         z[0]  =  0
               ^ Operator `=` should be surrounded by a single space.
       RUBY
-    end
 
-    it 'auto-corrects assignment with too many spaces on either side' do
-      new_source = autocorrect_source(<<~RUBY)
-        x  = 0
-        y =   0
-        z  =   0
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         x = 0
-        y = 0
-        z = 0
+        y += 0
+        z[0] = 0
       RUBY
     end
 
-    it 'registers an offense for ternary operator with too many spaces' do
+    it 'registers an offense and corrects ternary operator with ' \
+      'too many spaces' do
       expect_offense(<<~RUBY)
         x == 0  ? 1 :  2
                     ^ Operator `:` should be surrounded by a single space.
                 ^ Operator `?` should be surrounded by a single space.
       RUBY
-    end
 
-    it 'auto-corrects a ternary operator too many spaces' do
-      new_source = autocorrect_source('x == 0  ? 1 :  2')
-      expect(new_source).to eq('x == 0 ? 1 : 2')
+      expect_correction(<<~RUBY)
+        x == 0 ? 1 : 2
+      RUBY
     end
 
     it_behaves_like 'modifier with extra space', 'if'
@@ -613,7 +650,8 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
     it_behaves_like 'modifier with extra space', 'while'
     it_behaves_like 'modifier with extra space', 'until'
 
-    it 'registers an offense for binary operators that could be unary' do
+    it 'registers an offense and corrects binary operators ' \
+      'that could be unary' do
       expect_offense(<<~RUBY)
         a -  3
           ^ Operator `-` should be surrounded by a single space.
@@ -622,34 +660,26 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
         z +  0
           ^ Operator `+` should be surrounded by a single space.
       RUBY
-    end
 
-    it 'auto-corrects missing space in binary operators that could be unary' do
-      new_source = autocorrect_source(<<~RUBY)
-        a -  3
-        x &   0xff
-        z +  0
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         a - 3
         x & 0xff
         z + 0
       RUBY
     end
 
-    it 'registers an offense for arguments to a method' do
+    it 'registers an offense and corrects arguments to a method' do
       expect_offense(<<~RUBY)
         puts 1 +  2
                ^ Operator `+` should be surrounded by a single space.
       RUBY
+
+      expect_correction(<<~RUBY)
+        puts 1 + 2
+      RUBY
     end
 
-    it 'auto-corrects missing space in arguments to a method' do
-      new_source = autocorrect_source('puts 1 +  2')
-      expect(new_source).to eq('puts 1 + 2')
-    end
-
-    it 'registers an offense for operators with too many spaces' do
+    it 'registers an offense and corrects operators with too many spaces' do
       expect_offense(<<~RUBY)
         x +=  a
           ^^ Operator `+=` should be surrounded by a single space.
@@ -675,41 +705,81 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
            ^^ Operator `-=` should be surrounded by a single space.
                    ^^ Operator `&&` should be surrounded by a single space.
       RUBY
+
+      expect_correction(<<~RUBY)
+        x += a
+        a + b
+        b - c
+        c * d
+        d / e
+        e % f
+        f ^ g
+        g | h
+        h & i
+        i || j
+        y -= k && l
+      RUBY
     end
 
-    it 'auto-corrects missing space' do
-      new_source = autocorrect_source(
-        <<~RUBY
-          x +=  a  + b -  c  * d /  e  % f  ^ g   | h &  i  ||  j
-          y  -=  k   &&        l
-        RUBY
-      )
-      expect(new_source).to eq(<<~RUBY)
+    it 'registers an offense and corrects operators with ' \
+      'too many spaces on the same line' do
+      expect_offense(<<~RUBY)
+        x +=  a  + b -  c  * d /  e  % f  ^ g   | h &  i  ||  j
+                                                          ^^ Operator `||` should be surrounded by a single space.
+                                                    ^ Operator `&` should be surrounded by a single space.
+                                                ^ Operator `|` should be surrounded by a single space.
+                                          ^ Operator `^` should be surrounded by a single space.
+                                     ^ Operator `%` should be surrounded by a single space.
+                               ^ Operator `/` should be surrounded by a single space.
+                           ^ Operator `*` should be surrounded by a single space.
+                     ^ Operator `-` should be surrounded by a single space.
+                 ^ Operator `+` should be surrounded by a single space.
+          ^^ Operator `+=` should be surrounded by a single space.
+        y  -=  k   &&        l
+                   ^^ Operator `&&` should be surrounded by a single space.
+           ^^ Operator `-=` should be surrounded by a single space.
+      RUBY
+
+      expect_correction(<<~RUBY)
         x += a + b - c * d / e % f ^ g | h & i || j
         y -= k && l
       RUBY
     end
 
-    it 'registers an offense for a setter call with too many spaces' do
+    it 'registers an offense and corrects a setter call with too many spaces' do
       expect_offense(<<~RUBY)
         x.y  =  2
              ^ Operator `=` should be surrounded by a single space.
       RUBY
+
+      expect_correction(<<~RUBY)
+        x.y = 2
+      RUBY
     end
 
-    it 'registers an offense for a hash rocket with too many spaces' do
+    it 'registers an offense and corrects a hash rocket with too many spaces' do
       expect_offense(<<~RUBY)
         { 1  =>   2, a: b }
              ^^ Operator `=>` should be surrounded by a single space.
       RUBY
+
+      expect_correction(<<~RUBY)
+        { 1 => 2, a: b }
+      RUBY
     end
 
-    it 'registers an offense for a hash rocket with an extra space' \
+    it 'registers an offense and corrects a hash rocket with an extra space' \
       'on multiple line' do
       expect_offense(<<~RUBY)
         {
           1 =>  2
             ^^ Operator `=>` should be surrounded by a single space.
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        {
+          1 => 2
         }
       RUBY
     end
@@ -727,7 +797,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
     context 'when does not allowed for alignment' do
       let(:allow_for_alignment) { false }
 
-      it 'accepts an extra space' do
+      it 'registers an offense and corrects an extra space' do
         expect_offense(<<~RUBY)
           {
             1 =>  2,
@@ -735,19 +805,33 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
             11 => 3
           }
         RUBY
+
+        expect_correction(<<~RUBY)
+          {
+            1 => 2,
+            11 => 3
+          }
+        RUBY
       end
     end
 
-    it 'registers an offense for match operators with too many spaces' do
+    it 'registers an offense and corrects match operators ' \
+      'with too many spaces' do
       expect_offense(<<~RUBY)
         x  =~ /abc/
            ^^ Operator `=~` should be surrounded by a single space.
         y !~   /abc/
           ^^ Operator `!~` should be surrounded by a single space.
       RUBY
+
+      expect_correction(<<~RUBY)
+        x =~ /abc/
+        y !~ /abc/
+      RUBY
     end
 
-    it 'registers an offense for various assignments with too many spaces' do
+    it 'registers an offense and corrects various assignments ' \
+      'with too many spaces' do
       expect_offense(<<~RUBY)
         x ||=  0
           ^^^ Operator `||=` should be surrounded by a single space.
@@ -772,9 +856,24 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
         A  +=    0
            ^^ Operator `+=` should be surrounded by a single space.
       RUBY
+
+      expect_correction(<<~RUBY)
+        x ||= 0
+        y &&= 0
+        z *= 2
+        @a = 0
+        @@a = 0
+        a,b = 0
+        A = 0
+        x[3] = 0
+        $A = 0
+        A ||= 0
+        A += 0
+      RUBY
     end
 
-    it 'registers an offense for equality operators with too many spaces' do
+    it 'registers an offense and corrects equality operators ' \
+      'with too many spaces' do
       expect_offense(<<~RUBY)
         x  ==  0
            ^^ Operator `==` should be surrounded by a single space.
@@ -783,29 +882,51 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
         Hash   ===   z
                ^^^ Operator `===` should be surrounded by a single space.
       RUBY
+
+      expect_correction(<<~RUBY)
+        x == 0
+        y != 0
+        Hash === z
+      RUBY
     end
 
-    it 'registers an offense for - with too many spaces with ' \
+    it 'registers an offense and corrects `-` with too many spaces with ' \
        'negative lhs operand' do
       expect_offense(<<~RUBY)
         -1  - arg
             ^ Operator `-` should be surrounded by a single space.
       RUBY
+
+      expect_correction(<<~RUBY)
+        -1 - arg
+      RUBY
     end
 
-    it 'registers an offense for inheritance < with too many spaces' do
+    it 'registers an offense and corrects inheritance < with too many spaces' do
       expect_offense(<<~RUBY)
         class Foo  <  Bar
                    ^ Operator `<` should be surrounded by a single space.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Bar
+        end
+      RUBY
     end
 
-    it 'registers an offense for hash rocket with too many spaces at rescue' do
+    it 'registers an offense and corrects hash rocket with ' \
+      'too many spaces at rescue' do
       expect_offense(<<~RUBY)
         begin
         rescue Exception   =>      e
                            ^^ Operator `=>` should be surrounded by a single space.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+        rescue Exception => e
         end
       RUBY
     end

--- a/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
@@ -10,52 +10,71 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
       expect_no_offenses('each { puts }')
     end
 
-    it 'registers an offense for left brace without outer space' do
+    it 'registers an offense and corrects left brace without outer space' do
       expect_offense(<<~RUBY)
         each{ puts }
             ^ Space missing to the left of {.
       RUBY
+
+      expect_correction(<<~RUBY)
+        each { puts }
+      RUBY
     end
 
-    it 'registers an offense for opposite + correct style' do
+    it 'registers an offense and corrects opposite + correct style' do
       expect_offense(<<~RUBY)
         each{ puts }
             ^ Space missing to the left of {.
         each { puts }
       RUBY
+
+      expect_correction(<<~RUBY)
+        each { puts }
+        each { puts }
+      RUBY
     end
 
-    it 'registers an offense for multiline block where left brace has no ' \
-       'outer space' do
+    it 'registers an offense and corrects multiline block where the left ' \
+      'brace has no outer space' do
       expect_offense(<<~RUBY)
         foo.map{ |a|
                ^ Space missing to the left of {.
           a.bar.to_s
         }
       RUBY
-    end
 
-    it 'auto-corrects missing space' do
-      new_source = autocorrect_source('each{ puts }')
-      expect(new_source).to eq('each { puts }')
+      expect_correction(<<~RUBY)
+        foo.map { |a|
+          a.bar.to_s
+        }
+      RUBY
     end
   end
 
   context 'when EnforcedStyle is no_space' do
     let(:cop_config) { { 'EnforcedStyle' => 'no_space' } }
 
-    it 'registers an offense for braces surrounded by spaces' do
+    it 'registers an offense and corrects braces surrounded by spaces' do
       expect_offense(<<~RUBY)
         each { puts }
             ^ Space detected to the left of {.
       RUBY
+
+      expect_correction(<<~RUBY)
+        each{ puts }
+      RUBY
     end
 
-    it 'registers an offense for correct + opposite style' do
+    it 'registers an offense and corrects correct + opposite style' do
       expect_offense(<<~RUBY)
         each{ puts }
         each { puts }
             ^ Space detected to the left of {.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        each{ puts }
+        each{ puts }
       RUBY
     end
 
@@ -95,16 +114,15 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
       expect_no_offenses('->{}')
     end
 
-    it 'registers an offense for empty braces' do
+    it 'registers an offense and corrects empty braces' do
       expect_offense(<<~RUBY)
         -> {}
           ^ Space detected to the left of {.
       RUBY
-    end
 
-    it 'auto-corrects unwanted space' do
-      new_source = autocorrect_source('-> {}')
-      expect(new_source).to eq('->{}')
+      expect_correction(<<~RUBY)
+        ->{}
+      RUBY
     end
   end
 
@@ -120,16 +138,15 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
       expect_no_offenses('-> {}')
     end
 
-    it 'registers an offense for empty braces' do
+    it 'registers an offense and corrects empty braces' do
       expect_offense(<<~RUBY)
         ->{}
           ^ Space missing to the left of {.
       RUBY
-    end
 
-    it 'auto-corrects missing space' do
-      new_source = autocorrect_source('->{}')
-      expect(new_source).to eq('-> {}')
+      expect_correction(<<~RUBY)
+        -> {}
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/layout/space_before_comma_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_comma_spec.rb
@@ -3,24 +3,38 @@
 RSpec.describe RuboCop::Cop::Layout::SpaceBeforeComma do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for block argument with space before comma' do
+  it 'registers an offense and corrects block argument ' \
+    'with space before comma' do
     expect_offense(<<~RUBY)
       each { |s , t| }
                ^ Space found before comma.
     RUBY
+
+    expect_correction(<<~RUBY)
+      each { |s, t| }
+    RUBY
   end
 
-  it 'registers an offense for array index with space before comma' do
+  it 'registers an offense and corrects array index with space before comma' do
     expect_offense(<<~RUBY)
       formats[0 , 1]
                ^ Space found before comma.
     RUBY
+
+    expect_correction(<<~RUBY)
+      formats[0, 1]
+    RUBY
   end
 
-  it 'registers an offense for method call arg with space before comma' do
+  it 'registers an offense and corrects method call arg ' \
+    'with space before comma' do
     expect_offense(<<~RUBY)
       a(1 , 2)
          ^ Space found before comma.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      a(1, 2)
     RUBY
   end
 
@@ -28,13 +42,16 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeComma do
     expect_no_offenses('a(1, 2)')
   end
 
-  it 'auto-corrects space before comma' do
-    new_source = autocorrect_source('each { |s , t| a(1 , formats[0 , 1])}')
-    expect(new_source).to eq('each { |s, t| a(1, formats[0, 1])}')
-  end
-
   it 'handles more than one space before a comma' do
-    new_source = autocorrect_source('each { |s  , t| a(1  , formats[0  , 1])}')
-    expect(new_source).to eq('each { |s, t| a(1, formats[0, 1])}')
+    expect_offense(<<~RUBY)
+      each { |s  , t| a(1  , formats[0  , 1])}
+                                      ^^ Space found before comma.
+                         ^^ Space found before comma.
+               ^^ Space found before comma.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      each { |s, t| a(1, formats[0, 1])}
+    RUBY
   end
 end

--- a/spec/rubocop/cop/layout/space_before_comment_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_comment_spec.rb
@@ -3,10 +3,14 @@
 RSpec.describe RuboCop::Cop::Layout::SpaceBeforeComment do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for missing space before an EOL comment' do
+  it 'registers an offense and corrects missing space before an EOL comment' do
     expect_offense(<<~RUBY)
       a += 1# increment
             ^^^^^^^^^^^ Put a space before an end-of-line comment.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      a += 1 # increment
     RUBY
   end
 
@@ -24,10 +28,5 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeComment do
       Doc comment
       =end
     RUBY
-  end
-
-  it 'auto-corrects missing space' do
-    new_source = autocorrect_source('a += 1# increment')
-    expect(new_source).to eq('a += 1 # increment')
   end
 end

--- a/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
@@ -6,41 +6,30 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeFirstArg, :config do
   let(:cop_config) { { 'AllowForAlignment' => true } }
 
   context 'for method calls without parentheses' do
-    it 'registers an offense for method call with two spaces before the ' \
-       'first arg' do
+    it 'registers an offense and corrects method call with two spaces ' \
+      'before the first arg' do
       expect_offense(<<~RUBY)
         something  x
                  ^^ Put one space between the method name and the first argument.
         a.something  y, z
                    ^^ Put one space between the method name and the first argument.
       RUBY
-    end
 
-    it 'auto-corrects extra space' do
-      new_source = autocorrect_source(<<~RUBY)
-        something  x
-        a.something   y, z
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         something x
         a.something y, z
       RUBY
     end
 
     context 'when using safe navigation operator' do
-      it 'registers an offense for method call with two spaces before the ' \
-         'first arg' do
+      it 'registers an offense and corrects method call with two spaces ' \
+        'before the first arg' do
         expect_offense(<<~RUBY)
           a&.something  y, z
                       ^^ Put one space between the method name and the first argument.
         RUBY
-      end
 
-      it 'auto-corrects extra space' do
-        new_source = autocorrect_source(<<~RUBY)
-          a&.something  y, z
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
+        expect_correction(<<~RUBY)
           a&.something y, z
         RUBY
       end
@@ -52,6 +41,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeFirstArg, :config do
         something'hello'
         a.something'hello world'
       RUBY
+
       expect(cop.messages)
         .to eq(['Put one space between the method name and the first ' \
                 'argument.'] * 2)
@@ -62,6 +52,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeFirstArg, :config do
         something'hello'
         a.something'hello world'
       RUBY
+
       expect(new_source).to eq(<<~RUBY)
         something 'hello'
         a.something 'hello world'
@@ -111,7 +102,8 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeFirstArg, :config do
     context 'when AllowForAlignment is false' do
       let(:cop_config) { { 'AllowForAlignment' => false } }
 
-      it 'does not accept method calls with aligned first arguments' do
+      it 'registers an offense and corrects method calls ' \
+        'with aligned first arguments' do
         expect_offense(<<~RUBY)
           form.inline_input   :full_name,     as: :string
                            ^^^ Put one space between the method name and the first argument.
@@ -122,6 +114,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeFirstArg, :config do
                            ^^^ Put one space between the method name and the first argument.
           form.masked_input   :phone_number,  as: :tel
                            ^^^ Put one space between the method name and the first argument.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          form.inline_input :full_name,     as: :string
+          form.disabled_input :password,      as: :passwd
+          form.masked_input :zip_code,      as: :string
+          form.masked_input :email_address, as: :email
+          form.masked_input :phone_number,  as: :tel
         RUBY
       end
     end

--- a/spec/rubocop/cop/layout/space_before_semicolon_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_semicolon_spec.rb
@@ -8,10 +8,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeSemicolon do
   end
   let(:brace_config) { {} }
 
-  it 'registers an offense for space before semicolon' do
+  it 'registers an offense and corrects space before semicolon' do
     expect_offense(<<~RUBY)
       x = 1 ; y = 2
            ^ Space found before semicolon.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x = 1; y = 2
     RUBY
   end
 
@@ -19,14 +23,16 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeSemicolon do
     expect_no_offenses('x = 1; y = 2')
   end
 
-  it 'auto-corrects space before semicolon' do
-    new_source = autocorrect_source('x = 1 ; y = 2')
-    expect(new_source).to eq('x = 1; y = 2')
-  end
+  it 'registers an offense and corrects more than one space ' \
+    'before a semicolon' do
+    expect_offense(<<~RUBY)
+      x = 1  ; y = 2
+           ^^ Space found before semicolon.
+    RUBY
 
-  it 'handles more than one space before a semicolon' do
-    new_source = autocorrect_source('x = 1  ; y = 2')
-    expect(new_source).to eq('x = 1; y = 2')
+    expect_correction(<<~RUBY)
+      x = 1; y = 2
+    RUBY
   end
 
   context 'inside block braces' do
@@ -55,11 +61,15 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeSemicolon do
 
       it_behaves_like 'common behavior'
 
-      it 'registers an offense for a space between an opening brace and a ' \
-         'semicolon' do
+      it 'registers an offense and corrects a space between an opening brace ' \
+        'and a semicolon' do
         expect_offense(<<~RUBY)
           test { ; }
                 ^ Space found before semicolon.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          test {; }
         RUBY
       end
     end

--- a/spec/rubocop/cop/layout/space_in_lambda_literal_spec.rb
+++ b/spec/rubocop/cop/layout/space_in_lambda_literal_spec.rb
@@ -6,10 +6,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
   context 'when configured to enforce spaces' do
     let(:cop_config) { { 'EnforcedStyle' => 'require_space' } }
 
-    it 'registers an offense for no space between -> and (' do
+    it 'registers an offense and corrects no space between -> and (' do
       expect_offense(<<~RUBY)
         a = ->(b, c) { b + c }
             ^^^^^^^^ Use a space between `->` and `(` in lambda literals.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a = -> (b, c) { b + c }
       RUBY
     end
 
@@ -30,60 +34,55 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
       expect_no_offenses('a = ->{ b + c }')
     end
 
-    it 'registers an offense for no space in the inner nested lambda' do
+    it 'registers an offense and corrects no space ' \
+      'in the inner nested lambda' do
       expect_offense(<<~RUBY)
         a = -> (b = ->(c) {}, d) { b + d }
                     ^^^^^ Use a space between `->` and `(` in lambda literals.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a = -> (b = -> (c) {}, d) { b + d }
+      RUBY
     end
 
-    it 'registers an offense for no space in the outer nested lambda' do
+    it 'registers an offense and corrects no space ' \
+      'in the outer nested lambda' do
       expect_offense(<<~RUBY)
         a = ->(b = -> (c) {}, d) { b + d }
             ^^^^^^^^^^^^^^^^^^^^ Use a space between `->` and `(` in lambda literals.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a = -> (b = -> (c) {}, d) { b + d }
+      RUBY
     end
 
-    it 'registers an offense for no space in both lambdas when nested' do
+    it 'registers an offense and corrects no space ' \
+      'in both lambdas when nested' do
       expect_offense(<<~RUBY)
         a = ->(b = ->(c) {}, d) { b + d }
                    ^^^^^ Use a space between `->` and `(` in lambda literals.
             ^^^^^^^^^^^^^^^^^^^ Use a space between `->` and `(` in lambda literals.
       RUBY
-    end
 
-    it 'autocorrects an offense for no space between -> and (' do
-      code = 'a = ->(b, c) { b + c }'
-      expected = 'a = -> (b, c) { b + c }'
-      expect(autocorrect_source(code)).to eq(expected)
-    end
-
-    it 'autocorrects an offense for no space in the inner nested lambda' do
-      code = 'a = -> (b = ->(c) {}, d) { b + d }'
-      expected = 'a = -> (b = -> (c) {}, d) { b + d }'
-      expect(autocorrect_source(code)).to eq(expected)
-    end
-
-    it 'autocorrects an offense for no space in the outer nested lambda' do
-      code = 'a = ->(b = -> (c) {}, d) { b + d }'
-      expected = 'a = -> (b = -> (c) {}, d) { b + d }'
-      expect(autocorrect_source(code)).to eq(expected)
-    end
-
-    it 'autocorrects an offense for no space in both lambdas when nested' do
-      code = 'a = ->(b = ->(c) {}, d) { b + d }'
-      expected = 'a = -> (b = -> (c) {}, d) { b + d }'
-      expect(autocorrect_source(code)).to eq(expected)
+      expect_correction(<<~RUBY)
+        a = -> (b = -> (c) {}, d) { b + d }
+      RUBY
     end
   end
 
   context 'when configured to enforce no space' do
     let(:cop_config) { { 'EnforcedStyle' => 'require_no_space' } }
 
-    it 'registers an offense for a space between -> and (' do
+    it 'registers an offense and corrects a space between -> and (' do
       expect_offense(<<~RUBY)
         a = -> (b, c) { b + c }
             ^^^^^^^^^ Do not use spaces between `->` and `(` in lambda literals.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a = ->(b, c) { b + c }
       RUBY
     end
 
@@ -104,63 +103,49 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
       expect_no_offenses('a = -> { b + c }')
     end
 
-    it 'registers an offense for spaces between -> and (' do
+    it 'registers an offense and corrects spaces between -> and (' do
       expect_offense(<<~RUBY)
         a = ->   (b, c) { b + c }
             ^^^^^^^^^^^ Do not use spaces between `->` and `(` in lambda literals.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a = ->(b, c) { b + c }
+      RUBY
     end
 
-    it 'registers an offense for a space in the inner nested lambda' do
+    it 'registers an offense and corrects a space in the inner nested lambda' do
       expect_offense(<<~RUBY)
         a = ->(b = -> (c) {}, d) { b + d }
                    ^^^^^^ Do not use spaces between `->` and `(` in lambda literals.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a = ->(b = ->(c) {}, d) { b + d }
+      RUBY
     end
 
-    it 'registers an offense for a space in the outer nested lambda' do
+    it 'registers an offense and corrects a space in the outer nested lambda' do
       expect_offense(<<~RUBY)
         a = -> (b = ->(c) {}, d) { b + d }
             ^^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and `(` in lambda literals.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a = ->(b = ->(c) {}, d) { b + d }
+      RUBY
     end
 
-    it 'registers two offenses for a space in both lambdas when nested' do
+    it 'register offenses and correct spaces in both lambdas when nested' do
       expect_offense(<<~RUBY)
         a = -> (b = -> (c) {}, d) { b + d }
                     ^^^^^^ Do not use spaces between `->` and `(` in lambda literals.
             ^^^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and `(` in lambda literals.
       RUBY
-    end
 
-    it 'autocorrects an offense for a space between -> and (' do
-      code = 'a = -> (b, c) { b + c }'
-      expected = 'a = ->(b, c) { b + c }'
-      expect(autocorrect_source(code)).to eq(expected)
-    end
-
-    it 'autocorrects an offense for spaces between -> and (' do
-      code = 'a = ->   (b, c) { b + c }'
-      expected = 'a = ->(b, c) { b + c }'
-      expect(autocorrect_source(code)).to eq(expected)
-    end
-
-    it 'autocorrects an offense for a space in the inner nested lambda' do
-      code = 'a = ->(b = -> (c) {}, d) { b + d }'
-      expected = 'a = ->(b = ->(c) {}, d) { b + d }'
-      expect(autocorrect_source(code)).to eq(expected)
-    end
-
-    it 'autocorrects an offense for a space in the outer nested lambda' do
-      code = 'a = -> (b = ->(c) {}, d) { b + d }'
-      expected = 'a = ->(b = ->(c) {}, d) { b + d }'
-      expect(autocorrect_source(code)).to eq(expected)
-    end
-
-    it 'autocorrects two offenses for a space in both lambdas when nested' do
-      code = 'a = -> (b = -> (c) {}, d) { b + d }'
-      expected = 'a = ->(b = ->(c) {}, d) { b + d }'
-      expect(autocorrect_source(code)).to eq(expected)
+      expect_correction(<<~RUBY)
+        a = ->(b = ->(c) {}, d) { b + d }
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/layout/space_inside_array_literal_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_array_literal_brackets_spec.rb
@@ -19,33 +19,39 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       expect_no_offenses('a = []')
     end
 
-    it 'registers an offense for empty brackets with one space inside' do
+    it 'registers an offense and corrects empty brackets with 1 space inside' do
       expect_offense(<<~RUBY)
         a = [ ]
             ^^^ Do not use space inside empty array brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a = []
+      RUBY
     end
 
-    it 'registers an offense for empty brackets with lots of space inside' do
+    it 'registers an offense and corrects empty brackets ' \
+      'with multiple spaces inside' do
       expect_offense(<<~RUBY)
         a = [     ]
             ^^^^^^^ Do not use space inside empty array brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a = []
+      RUBY
     end
 
-    it 'auto-corrects an unwanted single space' do
-      new_source = autocorrect_source('a = [ ]')
-      expect(new_source).to eq('a = []')
-    end
+    it 'registers an offense and corrects multiline spaces' do
+      expect_offense(<<~RUBY)
+        a = [
+            ^ Do not use space inside empty array brackets.
+        ]
+      RUBY
 
-    it 'auto-corrects multiple unwanted spaces' do
-      new_source = autocorrect_source('a = [           ]')
-      expect(new_source).to eq('a = []')
-    end
-
-    it 'auto-corrects multiline spaces' do
-      new_source = autocorrect_source("a = [\n]")
-      expect(new_source).to eq('a = []')
+      expect_correction(<<~RUBY)
+        a = []
+      RUBY
     end
   end
 
@@ -56,28 +62,28 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       expect_no_offenses('a = [ ]')
     end
 
-    it 'registers offense for empty brackets with no space inside' do
+    it 'registers an offense and corrects empty brackets ' \
+      'with no space inside' do
       expect_offense(<<~RUBY)
         a = []
             ^^ Use one space inside empty array brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a = [ ]
+      RUBY
     end
 
-    it 'registers offense for empty brackets with more than one space inside' do
+    it 'registers an offense and corrects empty brackets ' \
+      'with more than one space inside' do
       expect_offense(<<~RUBY)
         a = [      ]
             ^^^^^^^^ Use one space inside empty array brackets.
       RUBY
-    end
 
-    it 'auto-corrects missing space' do
-      new_source = autocorrect_source('a = []')
-      expect(new_source).to eq('a = [ ]')
-    end
-
-    it 'auto-corrects too many spaces' do
-      new_source = autocorrect_source('a = [      ]')
-      expect(new_source).to eq('a = [ ]')
+      expect_correction(<<~RUBY)
+        a = [ ]
+      RUBY
     end
   end
 
@@ -191,53 +197,82 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       expect_no_offenses('subject.[](0)')
     end
 
-    it 'registers offense in array brackets with leading whitespace' do
+    it 'registers an offense and corrects array brackets ' \
+      'with leading whitespace' do
       expect_offense(<<~RUBY)
         [ 2, 3, 4]
          ^ Do not use space inside array brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        [2, 3, 4]
+      RUBY
     end
 
-    it 'registers offense in array brackets with trailing whitespace' do
+    it 'registers an offense and corrects array brackets ' \
+      'with trailing whitespace' do
       expect_offense(<<~RUBY)
         [b, c, d   ]
                 ^^^ Do not use space inside array brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        [b, c, d]
+      RUBY
     end
 
-    it 'registers offense in correct array when two on one line' do
+    it 'registers an offense and corrects an array when two on one line' do
       expect_offense(<<~RUBY)
         ['qux', 'baz'  ] - ['baz']
                      ^^ Do not use space inside array brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        ['qux', 'baz'] - ['baz']
+      RUBY
     end
 
-    it 'registers offense in multiline array on end bracket' do
+    it 'registers an offense and corrects multiline array on end bracket' do
       expect_offense(<<~RUBY)
         ['ok',
          'still good',
          'not good' ]
                    ^ Do not use space inside array brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        ['ok',
+         'still good',
+         'not good']
+      RUBY
     end
 
-    it 'registers offense in multiline array on end bracket' \
+    it 'registers an offense and corrects multiline array on end bracket' \
        'with trailing method' do
       expect_offense(<<~RUBY)
         [:good,
          :bad  ].compact
              ^^ Do not use space inside array brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        [:good,
+         :bad].compact
+      RUBY
     end
 
-    it 'register offense when 2 arrays on one line' do
+    it 'registers an offense and corrects 2 arrays on one line' do
       expect_offense(<<~RUBY)
         [2,3,4] - [ 3,4]
                    ^ Do not use space inside array brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        [2,3,4] - [3,4]
+      RUBY
     end
 
-    it 'registers offense when contains an array literal as ' \
+    it 'registers an offense and corrects an array literal as ' \
        'an argument with trailing whitespace after a heredoc is started' do
       expect_offense(<<~RUBY)
         ActiveRecord::Base.connection.execute(<<-SQL, [self.class.to_s ]).first["count"]
@@ -246,67 +281,22 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
           WHERE widget_type = $1
         SQL
       RUBY
+
+      expect_correction(<<~RUBY)
+        ActiveRecord::Base.connection.execute(<<-SQL, [self.class.to_s]).first["count"]
+          SELECT COUNT(widgets.id) FROM widgets
+          WHERE widget_type = $1
+        SQL
+      RUBY
     end
 
-    context 'auto-corrects' do
-      it 'fixes multiple offenses in one set of array brackets' do
-        new_source = autocorrect_source(<<~RUBY)
-          [ 89, 90, 91 ]
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          [89, 90, 91]
-        RUBY
-      end
-
-      it 'fixes multiple offenses in two sets of array brackets' do
-        new_source = autocorrect_source(<<~RUBY)
-          [ 89, 90, 91] + [ 1, 7, 9]
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          [89, 90, 91] + [1, 7, 9]
-        RUBY
-      end
-
-      it 'fixes multiline offenses but does not fuss with alignment' do
-        new_source = autocorrect_source(<<~RUBY)
-          [ :foo,
-            :bar,
-            nil   ]
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          [:foo,
-            :bar,
-            nil]
-        RUBY
-      end
-
-      it 'fixes multiline offenses with trailing method' do
-        new_source = autocorrect_source(<<~RUBY)
-          [   a,
-              b,
-              c   ].compact
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          [a,
-              b,
-              c].compact
-        RUBY
-      end
-
-      it 'ignores multiline array with whitespace before end bracket' do
-        new_source = autocorrect_source(<<~RUBY)
-          stuff = [
-            a,
-            b
-             ]
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          stuff = [
-            a,
-            b
-             ]
-        RUBY
-      end
+    it 'accepts a multiline array with whitespace before end bracket' do
+      expect_no_offenses(<<~RUBY)
+        stuff = [
+          a,
+          b
+           ]
+      RUBY
     end
   end
 
@@ -390,111 +380,80 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       expect_no_offenses('subject.[](0)')
     end
 
-    it 'registers offense in array brackets with no leading whitespace' do
+    it 'registers an offense and corrects array brackets ' \
+      'with no leading whitespace' do
       expect_offense(<<~RUBY)
         [2, 3, 4 ]
         ^ Use space inside array brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        [ 2, 3, 4 ]
+      RUBY
     end
 
-    it 'registers offense in array brackets with no trailing whitespace' do
+    it 'registers an offense and corrects array brackets ' \
+      'with no trailing whitespace' do
       expect_offense(<<~RUBY)
         [ b, c, d]
                  ^ Use space inside array brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        [ b, c, d ]
+      RUBY
     end
 
-    it 'registers offense in correct array when two on one line' do
+    it 'registers an offense and corrects an array missing whitespace ' \
+      'when there is more than one array on a line' do
       expect_offense(<<~RUBY)
         [ 'qux', 'baz'] - [ 'baz' ]
                       ^ Use space inside array brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        [ 'qux', 'baz' ] - [ 'baz' ]
+      RUBY
     end
 
-    it 'registers offense in multiline array on end bracket' do
+    it 'registers an offense and corrects multiline array on end bracket' do
       expect_offense(<<~RUBY)
         [ 'ok',
           'still good',
           'not good']
                     ^ Use space inside array brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        [ 'ok',
+          'still good',
+          'not good' ]
+      RUBY
     end
 
-    it 'registers offense in multiline array on end bracket' \
+    it 'registers an offense and corrects multiline array on end bracket' \
        'with trailing method' do
       expect_offense(<<~RUBY)
         [ :good,
           :bad].compact
               ^ Use space inside array brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        [ :good,
+          :bad ].compact
+      RUBY
     end
 
-    it 'register offense when 2 arrays on one line' do
+    it 'register an offense and corrects when 2 arrays are on one line' do
       expect_offense(<<~RUBY)
         [ 2, 3, 4 ] - [3, 4 ]
                       ^ Use space inside array brackets.
       RUBY
-    end
 
-    context 'auto-corrects' do
-      it 'fixes multiple offenses in one set of array brackets' do
-        new_source = autocorrect_source(<<~RUBY)
-          [89, 90, 91]
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          [ 89, 90, 91 ]
-        RUBY
-      end
-
-      it 'fixes multiple offenses in two sets of array brackets' do
-        new_source = autocorrect_source(<<~RUBY)
-          [ 89, 90, 91] + [ 1, 7, 9]
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          [ 89, 90, 91 ] + [ 1, 7, 9 ]
-        RUBY
-      end
-
-      it 'fixes multiline offenses but does not fuss with alignment' do
-        new_source = autocorrect_source(<<~RUBY)
-          [:foo,
-           :bar,
-           nil]
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          [ :foo,
-           :bar,
-           nil ]
-        RUBY
-      end
-
-      it 'fixes multiline offenses with trailing method' do
-        new_source = autocorrect_source(<<~RUBY)
-          [a,
-           b,
-           c].compact
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          [ a,
-           b,
-           c ].compact
-        RUBY
-      end
-
-      it 'ignores multiline array with no whitespace before end bracket' do
-        new_source = autocorrect_source(<<~RUBY)
-          stuff = [
-            a,
-            b
-          ]
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          stuff = [
-            a,
-            b
-          ]
-        RUBY
-      end
+      expect_correction(<<~RUBY)
+        [ 2, 3, 4 ] - [ 3, 4 ]
+      RUBY
     end
   end
 
@@ -533,17 +492,25 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       RUBY
     end
 
-    it 'registers offense if space between 2 closing brackets' do
+    it 'registers an offense and corrects space between 2 closing brackets' do
       expect_offense(<<~RUBY)
         [ 1, [ 2,3,4 ], [ 5,6,7 ] ]
                                  ^ Do not use space inside array brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        [ 1, [ 2,3,4 ], [ 5,6,7 ]]
+      RUBY
     end
 
-    it 'registers offense if space between 2 opening brackets' do
+    it 'registers an offense and corrects space between 2 opening brackets' do
       expect_offense(<<~RUBY)
         [ [ 2,3,4 ], [ 5,6,7 ], 8 ]
          ^ Do not use space inside array brackets.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [[ 2,3,4 ], [ 5,6,7 ], 8 ]
       RUBY
     end
 
@@ -555,17 +522,53 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
     end
 
     context 'multiline array does not collapse successive right-brackets' do
-      it 'registers offense' do
+      it 'registers an offense and corrects' do
         expect_offense(<<~RUBY)
           multiline = [[ 1, 2, 3, 4 ],
             [ 3, 4, 5, 6 ] ]
                           ^ Do not use space inside array brackets.
         RUBY
+
+        expect_correction(<<~RUBY)
+          multiline = [ [ 1, 2, 3, 4 ],
+            [ 3, 4, 5, 6 ]]
+        RUBY
       end
     end
 
+    it 'registers an offense and corrects 2-dimensional array ' \
+      'with extra spaces' do
+      expect_offense(<<~RUBY)
+        [ [ a, b ], [ 1, 7 ] ]
+                            ^ Do not use space inside array brackets.
+         ^ Do not use space inside array brackets.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [[ a, b ], [ 1, 7 ]]
+      RUBY
+    end
+
+    it 'registers an offense and corrects 3-dimensional array ' \
+      'with extra spaces' do
+      expect_offense(<<~RUBY)
+        [ [a, b ], [foo, [bar, baz] ] ]
+                                     ^ Do not use space inside array brackets.
+                                   ^ Do not use space inside array brackets.
+                                  ^ Use space inside array brackets.
+                         ^ Use space inside array brackets.
+                   ^ Use space inside array brackets.
+          ^ Use space inside array brackets.
+         ^ Do not use space inside array brackets.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [[ a, b ], [ foo, [ bar, baz ]]]
+      RUBY
+    end
+
     context 'multiline array does not collapse successive left-brackets' do
-      it 'registers offense' do
+      it 'registers an offense' do
         # In this example, we cannot use `expect_offense` because the offense
         # has no highlight (actually, a zero-width `column_range`) so our caret
         # would not match.
@@ -574,18 +577,31 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
             [ 1, 2, 3, 4 ],
             [ 3, 4, 5, 6 ]]
         RUBY
+
         expect(cop.offenses.size).to eq(1)
         offense = cop.offenses.first
         expect(offense.line).to eq(1)
         expect(offense.column_range).to eq(13...13) # thus, can't expect_offense
-        expect(offense.message).to eql(
-          'Do not use space inside array brackets.'
-        )
+        expect(offense.message).to eq('Do not use space inside array brackets.')
+      end
+
+      it 'auto-corrects' do
+        new_source = autocorrect_source(<<~RUBY)
+          multiline = [
+            [ 1, 2, 3, 4 ],
+            [ 3, 4, 5, 6 ]]
+        RUBY
+
+        expect(new_source).to eq(<<~RUBY)
+          multiline = [
+            [ 1, 2, 3, 4 ],
+            [ 3, 4, 5, 6 ] ]
+        RUBY
       end
     end
 
     context 'multiline array does not collapse any successive brackets' do
-      it 'registers offense' do
+      it 'registers an offense' do
         # In this example, we cannot use `expect_offense` because the offense
         # has no highlight (actually, a zero-width `column_range`) so our caret
         # would not match.
@@ -595,49 +611,25 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
             [ b, c ]
           ]
         RUBY
+
         expect(cop.offenses.size).to eq(1)
         offense = cop.offenses.first
         expect(offense.line).to eq(1)
         expect(offense.column_range).to eq(9...9) # thus, can't expect_offense
-        expect(offense.message).to eql(
-          'Do not use space inside array brackets.'
-        )
-      end
-    end
-
-    context 'auto-corrects' do
-      it 'fixes 2-dimensional array with extra spaces' do
-        new_source = autocorrect_source(<<~RUBY)
-          [ [ a, b ], [ 1, 7 ] ]
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          [[ a, b ], [ 1, 7 ]]
-        RUBY
+        expect(offense.message).to eq('Do not use space inside array brackets.')
       end
 
-      it 'fixes offensive 3-dimensional array' do
-        new_source = autocorrect_source(<<~RUBY)
-          [ [a, b ], [foo, [bar, baz] ] ]
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          [[ a, b ], [ foo, [ bar, baz ]]]
-        RUBY
-      end
-
-      it 'ignores multi-dimensional multiline array with no ' \
-         'whitespace before end bracket' do
-        new_source = autocorrect_source(<<~RUBY)
-          stuff = [
-            a,
+      it 'does not auto-corrects' do
+        source = <<~RUBY
+          array = [
+            [ a ],
             [ b, c ]
-            ]
+          ]
         RUBY
-        expect(new_source).to eq(<<~RUBY)
-          stuff = [
-            a,
-            [ b, c ]
-            ]
-        RUBY
+
+        new_source = autocorrect_source(source)
+
+        expect(new_source).to eq(source)
       end
     end
   end

--- a/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
@@ -45,26 +45,23 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
       RUBY
     end
 
-    it 'registers an offense for empty braces with space inside' do
+    it 'registers an offense and corrects empty braces with space inside' do
       expect_offense(<<~RUBY)
         each { }
               ^ Space inside empty braces detected.
       RUBY
+
+      expect_correction(<<~RUBY)
+        each {}
+      RUBY
     end
 
-    it 'auto-corrects unwanted space' do
-      new_source = autocorrect_source('each { }')
-      expect(new_source).to eq('each {}')
-    end
-
-    it 'does not auto-correct when braces are not empty' do
-      old_source = <<-RUBY
+    it 'accepts braces that are not empty' do
+      expect_no_offenses(<<~RUBY)
         a {
           b
         }
       RUBY
-      new_source = autocorrect_source(old_source)
-      expect(new_source).to eq(old_source)
     end
   end
 
@@ -75,16 +72,15 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
       expect_no_offenses('each { }')
     end
 
-    it 'registers an offense for empty braces with no space inside' do
+    it 'registers an offense and corrects empty braces with no space inside' do
       expect_offense(<<~RUBY)
         each {}
              ^^ Space missing inside empty braces.
       RUBY
-    end
 
-    it 'auto-corrects missing space' do
-      new_source = autocorrect_source('each {}')
-      expect(new_source).to eq('each { }')
+      expect_correction(<<~RUBY)
+        each { }
+      RUBY
     end
   end
 
@@ -105,21 +101,29 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     expect_no_offenses('each{ puts }')
   end
 
-  it 'registers an offense for left brace without inner space' do
+  it 'registers an offense and corrects left brace without inner space' do
     expect_offense(<<~RUBY)
       each {puts }
             ^ Space missing inside {.
     RUBY
+
+    expect_correction(<<~RUBY)
+      each { puts }
+    RUBY
   end
 
-  it 'registers an offense for right brace without inner space' do
+  it 'registers an offense and corrects right brace without inner space' do
     expect_offense(<<~RUBY)
       each { puts}
                  ^ Space missing inside }.
     RUBY
+
+    expect_correction(<<~RUBY)
+      each { puts }
+    RUBY
   end
 
-  it 'registers offenses for both braces without inner space' do
+  it 'register offenses and correct both braces without inner space' do
     expect_offense(<<~RUBY)
       a {}
       b { }
@@ -128,11 +132,12 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
             ^ Space missing inside {.
                 ^ Space missing inside }.
     RUBY
-  end
 
-  it 'auto-corrects missing space' do
-    new_source = autocorrect_source('each {puts}')
-    expect(new_source).to eq('each { puts }')
+    expect_correction(<<~RUBY)
+      a {}
+      b {}
+      each { puts }
+    RUBY
   end
 
   context 'with passed in parameters' do
@@ -141,10 +146,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
         expect_no_offenses('each { |x| puts }')
       end
 
-      it 'registers an offense for left brace without inner space' do
+      it 'registers an offense and corrects left brace without inner space' do
         expect_offense(<<~RUBY)
           each {|x| puts }
                ^^ Space between { and | missing.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          each { |x| puts }
         RUBY
       end
     end
@@ -158,37 +167,24 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
         RUBY
       end
 
-      it 'registers an offense for left brace without inner space' do
+      it 'registers an offense and corrects left brace without inner space' do
         expect_offense(<<~RUBY)
           each {|x|
                ^^ Space between { and | missing.
             puts
           }
         RUBY
-      end
 
-      it 'auto-corrects missing space' do
-        new_source = autocorrect_source(<<-SOURCE)
-          each {|x|
-            puts
-          }
-        SOURCE
-
-        expect(new_source).to eq(<<-NEW_SOURCE)
+        expect_correction(<<~RUBY)
           each { |x|
             puts
           }
-        NEW_SOURCE
+        RUBY
       end
     end
 
     it 'accepts new lambda syntax' do
       expect_no_offenses('->(x) { x }')
-    end
-
-    it 'auto-corrects missing space' do
-      new_source = autocorrect_source('each {|x| puts }')
-      expect(new_source).to eq('each { |x| puts }')
     end
 
     context 'and BlockDelimiters cop enabled' do
@@ -197,19 +193,27 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
                             'Layout/SpaceInsideBlockBraces' => cop_config)
       end
 
-      it 'does auto-correction for single-line blocks' do
-        new_source = autocorrect_source('each {|x| puts}')
-        expect(new_source).to eq('each { |x| puts }')
+      it 'registers an offense and corrects for single-line blocks' do
+        expect_offense(<<~RUBY)
+          each {|x| puts}
+                        ^ Space missing inside }.
+               ^^ Space between { and | missing.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          each { |x| puts }
+        RUBY
       end
 
-      it 'does auto-correction for multi-line blocks' do
-        old_source = <<~RUBY
+      it 'registers an offense and corrects multi-line blocks' do
+        expect_offense(<<~RUBY)
           each {|x|
+               ^^ Space between { and | missing.
             puts
           }
         RUBY
-        new_source = autocorrect_source(old_source)
-        expect(new_source).to eq(<<~RUBY)
+
+        expect_correction(<<~RUBY)
           each { |x|
             puts
           }
@@ -226,20 +230,19 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
         }
       end
 
-      it 'registers an offense for left brace with inner space' do
+      it 'registers an offense and corrects left brace with inner space' do
         expect_offense(<<~RUBY)
           each { |x| puts }
                 ^ Space between { and | detected.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          each {|x| puts }
         RUBY
       end
 
       it 'accepts new lambda syntax' do
         expect_no_offenses('->(x) { x }')
-      end
-
-      it 'auto-corrects unwanted space' do
-        new_source = autocorrect_source('each { |x| puts }')
-        expect(new_source).to eq('each {|x| puts }')
       end
 
       it 'accepts left brace without inner space' do
@@ -261,27 +264,30 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
       expect_no_offenses('each {puts}')
     end
 
-    it 'registers an offense for left brace with inner space' do
+    it 'registers an offense and corrects left brace with inner space' do
       expect_offense(<<~RUBY)
         each { puts}
               ^ Space inside { detected.
       RUBY
+
+      expect_correction(<<~RUBY)
+        each {puts}
+      RUBY
     end
 
-    it 'registers an offense for right brace with inner space' do
+    it 'registers an offense and corrects right brace with inner space' do
       expect_offense(<<~RUBY)
         each {puts }
                   ^ Space inside } detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        each {puts}
       RUBY
     end
 
     it 'accepts left brace without outer space' do
       expect_no_offenses('each{puts}')
-    end
-
-    it 'auto-corrects unwanted space' do
-      new_source = autocorrect_source('each{ puts }')
-      expect(new_source).to eq('each{puts}')
     end
 
     context 'with passed in parameters' do
@@ -290,20 +296,19 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
           expect_no_offenses('each { |x| puts}')
         end
 
-        it 'registers an offense for left brace without inner space' do
+        it 'registers an offense and corrects left brace without inner space' do
           expect_offense(<<~RUBY)
             each {|x| puts}
                  ^^ Space between { and | missing.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            each { |x| puts}
           RUBY
         end
 
         it 'accepts new lambda syntax' do
           expect_no_offenses('->(x) {x}')
-        end
-
-        it 'auto-corrects missing space' do
-          new_source = autocorrect_source('each {|x| puts}')
-          expect(new_source).to eq('each { |x| puts}')
         end
       end
 
@@ -316,10 +321,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
           }
         end
 
-        it 'registers an offense for left brace with inner space' do
+        it 'registers an offense and corrects left brace with inner space' do
           expect_offense(<<~RUBY)
             each { |x| puts}
                   ^ Space between { and | detected.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            each {|x| puts}
           RUBY
         end
 
@@ -327,8 +336,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
           expect_no_offenses('->(x) {x}')
         end
 
-        it 'does not register an offense when braces are aligned in ' \
-           'multiline block' do
+        it 'accepts when braces are aligned in multiline block' do
           expect_no_offenses(<<~RUBY)
             items.map {|item|
               item.do_something
@@ -346,11 +354,6 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
 
           expect(cop.offenses.size).to eq(1)
           expect(cop.messages).to eq(['Space inside } detected.'])
-        end
-
-        it 'auto-corrects unwanted space' do
-          new_source = autocorrect_source('each { |x| puts}')
-          expect(new_source).to eq('each {|x| puts}')
         end
       end
     end

--- a/spec/rubocop/cop/layout/space_inside_reference_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_reference_brackets_spec.rb
@@ -10,32 +10,26 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
       expect_no_offenses('a[]')
     end
 
-    it 'registers an offense for empty brackets with one space inside' do
+    it 'registers an offense and corrects empty brackets with 1 space inside' do
       expect_offense(<<~RUBY)
         foo[ ]
            ^^^ Do not use space inside empty reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        foo[]
+      RUBY
     end
 
-    it 'registers an offense for empty brackets with lots of space inside' do
+    it 'registers an offense and corrects empty brackets ' \
+      'with multiple spaces inside' do
       expect_offense(<<~RUBY)
         a[     ]
          ^^^^^^^ Do not use space inside empty reference brackets.
       RUBY
-    end
 
-    it 'auto-corrects whitespaces in empty brackets' do
-      new_source = autocorrect_source(<<~RUBY)
-        a[ ]
-        a[    ]
-        a[ ] = foo
-        a[   ] = bar
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         a[]
-        a[]
-        a[] = foo
-        a[] = bar
       RUBY
     end
   end
@@ -47,32 +41,26 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
       expect_no_offenses('a[ ]')
     end
 
-    it 'registers offense for empty brackets with no space inside' do
+    it 'registers offense and corrects empty brackets with no space inside' do
       expect_offense(<<~RUBY)
         foo[]
            ^^ Use one space inside empty reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        foo[ ]
+      RUBY
     end
 
-    it 'registers offense for empty brackets with more than one space inside' do
+    it 'registers offense and corrects empty brackets ' \
+      'with more than one space inside' do
       expect_offense(<<~RUBY)
         a[      ]
          ^^^^^^^^ Use one space inside empty reference brackets.
       RUBY
-    end
 
-    it 'auto-corrects multiple offenses for empty brackets' do
-      new_source = autocorrect_source(<<~RUBY)
-        a[]
-        a[    ]
-        a[] = foo
-        a[   ] = bar
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         a[ ]
-        a[ ]
-        a[ ] = foo
-        a[ ] = bar
       RUBY
     end
   end
@@ -109,27 +97,39 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
       RUBY
     end
 
-    it 'registers an offense when a reference bracket with a leading whitespace
-        is assigned by another reference bracket' do
+    it 'registers an offense and corrects when a reference bracket with a ' \
+      'leading whitespace is assigned by another reference bracket' do
       expect_offense(<<~RUBY)
         a[ "foo"] = b["something"]
           ^ Do not use space inside reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a["foo"] = b["something"]
+      RUBY
     end
 
-    it 'registers an offense when a reference bracket with a trailing whitespace
-        is assigned by another reference bracket' do
+    it 'registers an offense and correcs when a reference bracket with a ' \
+      'trailing whitespace is assigned by another reference bracket' do
       expect_offense(<<~RUBY)
         a["foo" ] = b["something"]
                ^ Do not use space inside reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a["foo"] = b["something"]
+      RUBY
     end
 
-    it 'registers an offense when a reference bracket is assigned by another
-        reference bracket with trailing whitespace' do
+    it 'registers an offense and corrects when a reference bracket is ' \
+      'assigned by another reference bracket with trailing whitespace' do
       expect_offense(<<~RUBY)
         a["foo"] = b["something" ]
                                 ^ Do not use space inside reference brackets.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a["foo"] = b["something"]
       RUBY
     end
 
@@ -148,57 +148,92 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
       expect_no_offenses('a[[ 1, 2 ]]')
     end
 
-    it 'registers offense in ref brackets with leading whitespace' do
+    it 'registers an offense and corrects ref brackets ' \
+      'with leading whitespace' do
       expect_offense(<<~RUBY)
         a[  :key]
           ^^ Do not use space inside reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a[:key]
+      RUBY
     end
 
-    it 'registers offense in ref brackets with trailing whitespace' do
+    it 'registers an offense and corrects ref brackets ' \
+      'with trailing whitespace' do
       expect_offense(<<~RUBY)
         b[:key ]
               ^ Do not use space inside reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        b[:key]
+      RUBY
     end
 
-    it 'registers offense in second ref brackets with leading whitespace' do
+    it 'registers an offense and corrects second ref brackets ' \
+      'with leading whitespace' do
       expect_offense(<<~RUBY)
         a[:key][ "key"]
                 ^ Do not use space inside reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a[:key]["key"]
+      RUBY
     end
 
-    it 'registers offense in second ref brackets with trailing whitespace' do
+    it 'registers an offense and corrects second ref brackets ' \
+      'with trailing whitespace' do
       expect_offense(<<~RUBY)
         a[1][:key   ]
                  ^^^ Do not use space inside reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a[1][:key]
+      RUBY
     end
 
-    it 'registers offense in third ref brackets with leading whitespace' do
+    it 'registers an offense and corrects third ref brackets ' \
+      'with leading whitespace' do
       expect_offense(<<~RUBY)
         a[:key][3][ :key]
                    ^ Do not use space inside reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a[:key][3][:key]
+      RUBY
     end
 
-    it 'registers offense in third ref brackets with trailing whitespace' do
+    it 'registers an offense and corrects third ref brackets ' \
+      'with trailing whitespace' do
       expect_offense(<<~RUBY)
         a[var]["key", 3][:key ]
                              ^ Do not use space inside reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a[var]["key", 3][:key]
+      RUBY
     end
 
-    it 'registers multiple offenses in one set of ref brackets' do
+    it 'registers multiple offenses and corrects one set of ref brackets' do
       expect_offense(<<~RUBY)
         b[ 89  ]
           ^ Do not use space inside reference brackets.
              ^^ Do not use space inside reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        b[89]
+      RUBY
     end
 
-    it 'registers multiple offenses for multiple sets of ref brackets' do
+    it 'registers multiple offenses and corrects ' \
+      'multiple sets of ref brackets' do
       expect_offense(<<~RUBY)
         a[ :key]["foo"  ][   0 ]
           ^ Do not use space inside reference brackets.
@@ -206,43 +241,48 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
                           ^^^ Do not use space inside reference brackets.
                               ^ Do not use space inside reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a[:key]["foo"][0]
+      RUBY
     end
 
-    it 'registers offense in outer ref brackets' do
+    it 'registers an offense and corrects outer ref brackets' do
       expect_offense(<<~RUBY)
         record[ options[:attribute] ]
                ^ Do not use space inside reference brackets.
                                    ^ Do not use space inside reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        record[options[:attribute]]
+      RUBY
     end
 
-    context 'auto-correct' do
-      it 'fixes multiple offenses in one set of ref brackets' do
-        new_source = autocorrect_source(<<~RUBY)
-          bar[ 89  ]
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          bar[89]
-        RUBY
-      end
+    it 'register and correct multiple offenses for multiple sets ' \
+      'of ref brackets' do
+      expect_offense(<<~RUBY)
+        b[ :key]["foo"  ][   0 ]
+          ^ Do not use space inside reference brackets.
+                      ^^ Do not use space inside reference brackets.
+                          ^^^ Do not use space inside reference brackets.
+                              ^ Do not use space inside reference brackets.
+      RUBY
 
-      it 'fixes multiple offenses for multiple sets of ref brackets' do
-        new_source = autocorrect_source(<<~RUBY)
-          b[ :key]["foo"  ][   0 ]
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          b[:key]["foo"][0]
-        RUBY
-      end
+      expect_correction(<<~RUBY)
+        b[:key]["foo"][0]
+      RUBY
+    end
 
-      it 'avoids altering array brackets' do
-        new_source = autocorrect_source(<<~RUBY)
-          j[ "pop"] = [89, nil, ""    ]
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          j["pop"] = [89, nil, ""    ]
-        RUBY
-      end
+    it 'accpets extra spacing in array brackets' do
+      expect_offense(<<~RUBY)
+        j[ "pop"] = [89, nil, ""    ]
+          ^ Do not use space inside reference brackets.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        j["pop"] = [89, nil, ""    ]
+      RUBY
     end
   end
 
@@ -281,27 +321,39 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
       RUBY
     end
 
-    it 'registers an offense when a reference bracket with no leading whitespace
-        is assigned by another reference bracket' do
+    it 'registers an offense and corrects when a reference bracket with no ' \
+      'leading whitespace is assigned by another reference bracket' do
       expect_offense(<<~RUBY)
         a["foo" ] = b[ "something" ]
          ^ Use space inside reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a[ "foo" ] = b[ "something" ]
+      RUBY
     end
 
-    it 'registers an offense when a reference bracket with no trailing
-        whitespace is assigned by another reference bracket' do
+    it 'registers an offense and corrects when a reference bracket with no ' \
+      'trailing whitespace is assigned by another reference bracket' do
       expect_offense(<<~RUBY)
         a[ "foo"] = b[ "something" ]
                 ^ Use space inside reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a[ "foo" ] = b[ "something" ]
+      RUBY
     end
 
-    it 'registers an offense when a reference bracket is assigned by another
-        reference bracket with no trailing whitespace' do
+    it 'registers an offense and corrects when a reference bracket is ' \
+      'assigned by another reference bracket with no trailing whitespace' do
       expect_offense(<<~RUBY)
         a[ "foo" ] = b[ "something"]
                                    ^ Use space inside reference brackets.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a[ "foo" ] = b[ "something" ]
       RUBY
     end
 
@@ -320,57 +372,92 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
       expect_no_offenses('a[ [1, 2] ]')
     end
 
-    it 'registers offense in ref brackets with no leading whitespace' do
+    it 'registers an offense and corrects ref brackets ' \
+      'with no leading whitespace' do
       expect_offense(<<~RUBY)
         a[:key ]
          ^ Use space inside reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a[ :key ]
+      RUBY
     end
 
-    it 'registers offense in ref brackets with no trailing whitespace' do
+    it 'registers an offense and corrects ref brackets ' \
+      'with no trailing whitespace' do
       expect_offense(<<~RUBY)
         b[ :key]
                ^ Use space inside reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        b[ :key ]
+      RUBY
     end
 
-    it 'registers offense in second ref brackets with no leading whitespace' do
+    it 'registers an offense and corrects second ref brackets ' \
+      'with no leading whitespace' do
       expect_offense(<<~RUBY)
         a[ :key ]["key" ]
                  ^ Use space inside reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a[ :key ][ "key" ]
+      RUBY
     end
 
-    it 'registers offense in second ref brackets with no trailing whitespace' do
+    it 'registers an offense and corrects second ref brackets ' \
+      'with no trailing whitespace' do
       expect_offense(<<~RUBY)
         a[ 5, 1 ][ :key]
                        ^ Use space inside reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a[ 5, 1 ][ :key ]
+      RUBY
     end
 
-    it 'registers offense in third ref brackets with no leading whitespace' do
+    it 'registers an offense and corrects third ref brackets ' \
+      'with no leading whitespace' do
       expect_offense(<<~RUBY)
         a[ :key ][ 3 ][:key ]
                       ^ Use space inside reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a[ :key ][ 3 ][ :key ]
+      RUBY
     end
 
-    it 'registers offense in third ref brackets with no trailing whitespace' do
+    it 'registers an offense and correct third ref brackets ' \
+      'with no trailing whitespace' do
       expect_offense(<<~RUBY)
         a[ var ][ "key" ][ :key]
                                ^ Use space inside reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a[ var ][ "key" ][ :key ]
+      RUBY
     end
 
-    it 'registers multiple offenses in one set of ref brackets' do
+    it 'registers and corrects multiple offenses in one set of ref brackets' do
       expect_offense(<<~RUBY)
         b[89]
          ^ Use space inside reference brackets.
             ^ Use space inside reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        b[ 89 ]
+      RUBY
     end
 
-    it 'registers multiple offenses for multiple sets of ref brackets' do
+    it 'registers and corrects multiple offenses for multiple sets ' \
+      'of ref brackets' do
       expect_offense(<<~RUBY)
         a[:key]["foo" ][0]
          ^ Use space inside reference brackets.
@@ -379,35 +466,16 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
                        ^ Use space inside reference brackets.
                          ^ Use space inside reference brackets.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a[ :key ][ "foo" ][ 0 ]
+      RUBY
     end
 
-    context 'auto-correct' do
-      it 'fixes multiple offenses in one set of ref brackets' do
-        new_source = autocorrect_source(<<~RUBY)
-          bar[89]
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          bar[ 89 ]
-        RUBY
-      end
-
-      it 'fixes multiple offenses for multiple sets of ref brackets' do
-        new_source = autocorrect_source(<<~RUBY)
-          b[:key][ "foo"][0 ]
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          b[ :key ][ "foo" ][ 0 ]
-        RUBY
-      end
-
-      it 'avoids altering array brackets' do
-        new_source = autocorrect_source(<<~RUBY)
-          j[ "pop"] = [89, nil, ""    ]
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          j[ "pop" ] = [89, nil, ""    ]
-        RUBY
-      end
+    it 'accepts spaces in array brackets' do
+      expect_no_offenses(<<~RUBY)
+        j = [89, nil, ""    ]
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/layout/space_inside_string_interpolation_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_string_interpolation_spec.rb
@@ -84,20 +84,11 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
     end
 
     context 'for well-formatted string interpolations' do
-      let(:source) do
-        <<~'RUBY'
+      it 'accepts excess literal spacing' do
+        expect_no_offenses(<<~'RUBY')
           "Variable is    #{var}      "
           "  Variable is  #{var}"
         RUBY
-      end
-
-      it 'does not register an offense for excess literal spacing' do
-        expect_no_offenses(source)
-      end
-
-      it 'does not correct valid string interpolations' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(source)
       end
     end
 
@@ -173,20 +164,11 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
     end
 
     context 'for well-formatted string interpolations' do
-      let(:source) do
-        <<~'RUBY'
+      it 'does not register an offense for excess literal spacing' do
+        expect_no_offenses(<<~'RUBY')
           "Variable is    #{ var }      "
           "  Variable is  #{ var }"
         RUBY
-      end
-
-      it 'does not register an offense for excess literal spacing' do
-        expect_no_offenses(source)
-      end
-
-      it 'does not correct valid string interpolations' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(source)
       end
     end
 

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -154,21 +154,27 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
   it_behaves_like('non-special string literal interpolation', %("foo"))
 
   it 'handles double quotes in single quotes when auto-correction' do
-    corrected = autocorrect_source(<<~'RUBY')
+    expect_offense(<<~'RUBY')
       "this is #{'"'} silly"
+                 ^^^ Literal interpolation detected.
     RUBY
-    expect(corrected).to eq(<<~'RUBY')
+
+    expect_correction(<<~'RUBY')
       "this is \" silly"
     RUBY
   end
 
   it 'handles backslach in single quotes when auto-correction' do
-    corrected = autocorrect_source(<<~'RUBY')
+    expect_offense(<<~'RUBY')
       x = "ABC".gsub(/(A)(B)(C)/, "D#{'\2'}F")
+                                      ^^^^ Literal interpolation detected.
       "this is #{'\n'} silly"
+                 ^^^^ Literal interpolation detected.
       "this is #{%q(\n)} silly"
+                 ^^^^^^ Literal interpolation detected.
     RUBY
-    expect(corrected).to eq(<<~'RUBY')
+
+    expect_correction(<<~'RUBY')
       x = "ABC".gsub(/(A)(B)(C)/, "D\\2F")
       "this is \\n silly"
       "this is \\n silly"
@@ -176,12 +182,16 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
   end
 
   it 'handles backslach in double quotes when auto-correction' do
-    corrected = autocorrect_source(<<~'RUBY')
+    expect_offense(<<~'RUBY')
       "this is #{"\n"} silly"
+                 ^^^^ Literal interpolation detected.
       "this is #{%(\n)} silly"
+                 ^^^^^ Literal interpolation detected.
       "this is #{%Q(\n)} silly"
+                 ^^^^^^ Literal interpolation detected.
     RUBY
-    expect(corrected).to eq(<<~'RUBY')
+
+    expect_correction(<<~'RUBY')
       "this is 
        silly"
       "this is 


### PR DESCRIPTION
This converts most of the lint and layout tests to use `expect_correction`. I found that some tests can't be converted to use `expect_offense` and `expect_correction` because the offense has a zero length range. I forget the exact cops, but this typically happened with white space and extra blank lines. There are other test cases that could be converted, but they will require a full rewrite of the test file to follow the new pattern