### PR TITLE
allow paremeter name `pp` for `pretty_print`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#7636](https://github.com/rubocop-hq/rubocop/issues/7636): Remove `console` from `Lint/Debugger` to prevent false positives. ([@gsamokovarov][])
 * [#7641](https://github.com/rubocop-hq/rubocop/issues/7641): **(Breaking)** Remove `Style/BracesAroundHashParameters` cop. ([@pocke][])
 * Add the method name to highlight area of `Layout/EmptyLineBetweenDefs` to help provide more context. ([@rrosenblum][])
+* [#7652](https://github.com/rubocop-hq/rubocop/pull/7652): Allow `pp` to allowed names of `Naming/MethodParameterName` cop in default config. ([@masarakki][])
 
 ## 0.79.0 (2020-01-06)
 
@@ -4337,3 +4338,4 @@
 [@gfyoung]: https://github.com/gfyoung
 [@Tietew]: https://github.com/Tietew
 [@hanachin]: https://github.com/hanachin
+[@masarakki]: https://github.com/masarakki

--- a/config/default.yml
+++ b/config/default.yml
@@ -2065,6 +2065,7 @@ Naming/MethodParameterName:
     - ip
     - db
     - os
+    - pp
   # Forbidden names that will register an offense
   ForbiddenNames: []
 

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -546,7 +546,7 @@ Name | Default value | Configurable values
 --- | --- | ---
 MinNameLength | `3` | Integer
 AllowNamesEndingInNumbers | `true` | Boolean
-AllowedNames | `io`, `id`, `to`, `by`, `on`, `in`, `at`, `ip`, `db`, `os` | Array
+AllowedNames | `io`, `id`, `to`, `by`, `on`, `in`, `at`, `ip`, `db`, `os`, `pp` | Array
 ForbiddenNames | `[]` | Array
 
 ## Naming/PredicateName


### PR DESCRIPTION
`pp` is standard parameter name for `PrettyPrint`



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/