### PR TITLE
[Fix #7655] Fix an error when processing a line break regexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#7639](https://github.com/rubocop-hq/rubocop/pull/7639): Fix logical operator edge case in `omit_parentheses` style of `Style/MethodCallWithArgsParentheses`. ([@gsamokovarov][])
 * [#7661](https://github.com/rubocop-hq/rubocop/pull/7661): Fix to return correct info from multi-line regexp. ([@Tietew][])
+* [#7655](https://github.com/rubocop-hq/rubocop/issues/7655): Fix an error when processing a regexp with a line break at the start of capture parenthesis. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/variable_force.rb
+++ b/lib/rubocop/cop/variable_force.rb
@@ -190,7 +190,10 @@ module RuboCop
       end
 
       def regexp_captured_names(node)
-        regexp_string = node.children[0].children[0] || ''
+        regexp_string = node.children.select(&:str_type?).map do |child|
+          child.children.first
+        end.join || ''
+
         regexp = Regexp.new(regexp_string)
 
         regexp.named_captures.keys

--- a/spec/rubocop/cop/variable_force_spec.rb
+++ b/spec/rubocop/cop/variable_force_spec.rb
@@ -29,5 +29,22 @@ RSpec.describe RuboCop::Cop::VariableForce do
         expect { force.process_node(node) }.not_to raise_error
       end
     end
+
+    context 'when processing a regexp with a line break at ' \
+            'the start of capture parenthesis' do
+      let(:node) do
+        s(:match_with_lvasgn,
+          s(:regexp,
+            s(:str, "(\n"),
+            s(:str, "  pattern\n"),
+            s(:str, ')'),
+            s(:regopt)),
+          s(:send, nil?, :string))
+      end
+
+      it 'does not raise an error' do
+        expect { force.process_node(node) }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #7655.

This PR fixes the following error when processing a regexp with a line break at the start of capture parenthesis.

```console
% cat examle.rb
/(
  pattern
)/ =~ string

% bundle exec rubocop -d
(snip)

An error occurred while VariableForce cop was inspecting
/Users/koic/src/github.com/koic/rubocop-issues/7655/examle.rb.
end pattern with unmatched parenthesis: /(
/
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/variable_force.rb:194:in
`initialize'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/variable_force.rb:194:in
`new'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/variable_force.rb:194:in
`regexp_captured_names'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/variable_force.rb:174:in
`process_regexp_named_captures'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/variable_force.rb:86:in
`process_node'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/variable_force.rb:80:in `investigate'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
