### PR TITLE
[Fix #7654] Support with_fixed_indentation option for Layout/ArrayAlignment cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Add `BracesRequiredMethods` parameter to `Style/BlockDelimiters` to require braces for specific methods such as Sorbet's `sig`. ([@maxh][])
 * [#7686](https://github.com/rubocop-hq/rubocop/pull/7686): Add new `JUnitFormatter` formatter based on `rubocop-junit-formatter` gem. ([@koic][])
 * [#7715](https://github.com/rubocop-hq/rubocop/pull/7715): Add `Steepfile` to default `Include` list. ([@ybiquitous][])
+* [#7654](https://github.com/rubocop-hq/rubocop/issues/7654): Support `with_fixed_indentation` option for `Layout/ArrayAlignment` cop. ([@nikitasakov][])
 
 ### Bug fixes
 
@@ -4378,3 +4379,4 @@
 [@masarakki]: https://github.com/masarakki
 [@djudd]: https://github.com/djudd
 [@jemmaissroff]: https://github.com/jemmaissroff
+[@nikitasakov]: https://github.com/nikitasakov

--- a/config/default.yml
+++ b/config/default.yml
@@ -255,10 +255,30 @@ Layout/ArrayAlignment:
   Description: >-
                  Align the elements of an array literal if they span more than
                  one line.
-  StyleGuide: '#align-multiline-arrays'
+  StyleGuide: '#no-double-indent'
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.77'
+  # Alignment of elements of a multi-line array.
+  #
+  # The `with_first_parameter` style aligns the following lines along the same
+  # column as the first element.
+  #
+  #     array = [1, 2, 3,
+  #              4, 5, 6]
+  #
+  # The `with_fixed_indentation` style aligns the following lines with one
+  # level of indentation relative to the start of the line with start of array.
+  #
+  #     array = [1, 2, 3,
+  #       4, 5, 6]
+  EnforcedStyle: with_first_element
+  SupportedStyles:
+    - with_first_element
+    - with_fixed_indentation
+  # By default, the indentation width from Layout/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
 
 Layout/AssignmentIndentation:
   Description: >-

--- a/lib/rubocop/cop/layout/array_alignment.rb
+++ b/lib/rubocop/cop/layout/array_alignment.rb
@@ -6,32 +6,75 @@ module RuboCop
       # Here we check if the elements of a multi-line array literal are
       # aligned.
       #
-      # @example
+      # @example EnforcedStyle: with_first_element (default)
+      #   # good
+      #
+      #   array = [1, 2, 3,
+      #            4, 5, 6]
+      #   array = ['run',
+      #            'forrest',
+      #            'run']
+      #
       #   # bad
-      #   a = [1, 2, 3,
+      #
+      #   array = [1, 2, 3,
       #     4, 5, 6]
       #   array = ['run',
       #        'forrest',
       #        'run']
       #
+      # @example EnforcedStyle: with_fixed_indentation
       #   # good
-      #   a = [1, 2, 3,
-      #        4, 5, 6]
-      #   a = ['run',
-      #        'forrest',
-      #        'run']
+      #
+      #   array = [1, 2, 3,
+      #     4, 5, 6]
+      #
+      #   # bad
+      #
+      #   array = [1, 2, 3,
+      #            4, 5, 6]
       class ArrayAlignment < Cop
         include Alignment
 
-        MSG = 'Align the elements of an array literal if they span more ' \
-              'than one line.'
+        ALIGN_ELEMENTS_MSG = 'Align the elements of an array literal ' \
+          'if they span more than one line.'
+
+        FIXED_INDENT_MSG = 'Use one level of indentation for elements ' \
+          'following the first line of a multi-line array.'
 
         def on_array(node)
-          check_alignment(node.children)
+          return if node.children.size < 2
+
+          check_alignment(node.children, base_column(node, node.children))
         end
 
         def autocorrect(node)
           AlignmentCorrector.correct(processed_source, node, column_delta)
+        end
+
+        private
+
+        def message(_node)
+          fixed_indentation? ? FIXED_INDENT_MSG : ALIGN_ELEMENTS_MSG
+        end
+
+        def fixed_indentation?
+          cop_config['EnforcedStyle'] == 'with_fixed_indentation'
+        end
+
+        def base_column(node, args)
+          if fixed_indentation?
+            lineno = target_method_lineno(node)
+            line = node.source_range.source_buffer.source_line(lineno)
+            indentation_of_line = /\S.*/.match(line).begin(0)
+            indentation_of_line + configured_indentation_width
+          else
+            display_column(args.first.source_range)
+          end
+        end
+
+        def target_method_lineno(node)
+          node.loc.line
         end
       end
     end

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -124,25 +124,49 @@ aligned.
 
 ### Examples
 
+#### EnforcedStyle: with_first_element (default)
+
 ```ruby
+# good
+
+array = [1, 2, 3,
+         4, 5, 6]
+array = ['run',
+         'forrest',
+         'run']
+
 # bad
-a = [1, 2, 3,
+
+array = [1, 2, 3,
   4, 5, 6]
 array = ['run',
      'forrest',
      'run']
-
-# good
-a = [1, 2, 3,
-     4, 5, 6]
-a = ['run',
-     'forrest',
-     'run']
 ```
+#### EnforcedStyle: with_fixed_indentation
+
+```ruby
+# good
+
+array = [1, 2, 3,
+  4, 5, 6]
+
+# bad
+
+array = [1, 2, 3,
+         4, 5, 6]
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `with_first_element` | `with_first_element`, `with_fixed_indentation`
+IndentationWidth | `<none>` | Integer
 
 ### References
 
-* [https://rubystyle.guide#align-multiline-arrays](https://rubystyle.guide#align-multiline-arrays)
+* [https://rubystyle.guide#no-double-indent](https://rubystyle.guide#no-double-indent)
 
 ## Layout/AssignmentIndentation
 

--- a/spec/rubocop/cop/layout/array_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/array_alignment_spec.rb
@@ -1,133 +1,332 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::ArrayAlignment do
-  subject(:cop) { described_class.new }
+  subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense and corrects misaligned array elements' do
-    expect_offense(<<~RUBY)
-      array = [
-        a,
-         b,
-         ^ Align the elements of an array literal if they span more than one line.
-        c,
-         d
-         ^ Align the elements of an array literal if they span more than one line.
-      ]
-    RUBY
-
-    expect_correction(<<~RUBY)
-      array = [
-        a,
-        b,
-        c,
-        d
-      ]
-    RUBY
+  let(:config) do
+    RuboCop::Config.new('Layout/ArrayAlignment' => cop_config,
+                        'Layout/IndentationWidth' => {
+                          'Width' => indentation_width
+                        })
   end
+  let(:indentation_width) { 2 }
 
-  it 'accepts aligned array keys' do
-    expect_no_offenses(<<~RUBY)
-      array = [
-        a,
-        b,
-        c,
-        d
-      ]
-    RUBY
-  end
+  context 'when aligned with first parameter' do
+    let(:cop_config) do
+      {
+        'EnforcedStyle' => 'with_first_element'
+      }
+    end
 
-  it 'accepts single line array' do
-    expect_no_offenses('array = [ a, b ]')
-  end
+    it 'registers an offense and corrects misaligned array elements' do
+      expect_offense(<<~RUBY)
+        array = [a,
+           b,
+           ^ Align the elements of an array literal if they span more than one line.
+          c,
+          ^ Align the elements of an array literal if they span more than one line.
+           d]
+           ^ Align the elements of an array literal if they span more than one line.
+      RUBY
 
-  it 'accepts several elements per line' do
-    expect_no_offenses(<<~RUBY)
-      array = [ a, b,
-                c, d ]
-    RUBY
-  end
+      expect_correction(<<~RUBY)
+        array = [a,
+                 b,
+                 c,
+                 d]
+      RUBY
+    end
 
-  it 'accepts aligned array with fullwidth characters' do
-    expect_no_offenses(<<~RUBY)
-      puts 'Ｒｕｂｙ', [ a,
-                         b ]
-    RUBY
-  end
+    it 'accepts aligned array keys' do
+      expect_no_offenses(<<~RUBY)
+        array = [a,
+                 b,
+                 c,
+                 d]
+      RUBY
+    end
 
-  it 'does not auto-correct array within array with too much indentation' do
-    expect_offense(<<~RUBY)
-      [:l1,
+    it 'accepts single line array' do
+      expect_no_offenses('array = [ a, b ]')
+    end
+
+    it 'accepts several elements per line' do
+      expect_no_offenses(<<~RUBY)
+        array = [ a, b,
+                  c, d ]
+      RUBY
+    end
+
+    it 'accepts aligned array with fullwidth characters' do
+      expect_no_offenses(<<~RUBY)
+        puts 'Ｒｕｂｙ', [ a,
+                           b ]
+      RUBY
+    end
+
+    it 'does not auto-correct array within array with too much indentation' do
+      expect_offense(<<~RUBY)
+        [:l1,
+          [:l2,
+          ^^^^^ Align the elements of an array literal if they span more than one line.
+            [:l3,
+            ^^^^^ Align the elements of an array literal if they span more than one line.
+             [:l4]]]]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [:l1,
+         [:l2,
+           [:l3,
+            [:l4]]]]
+      RUBY
+    end
+
+    it 'does not auto-correct array within array with too little indentation' do
+      expect_offense(<<~RUBY)
+        [:l1,
         [:l2,
         ^^^^^ Align the elements of an array literal if they span more than one line.
-
           [:l3,
           ^^^^^ Align the elements of an array literal if they span more than one line.
            [:l4]]]]
-    RUBY
+      RUBY
 
-    expect_correction(<<~RUBY)
-      [:l1,
-       [:l2,
+      expect_correction(<<~RUBY)
+        [:l1,
+         [:l2,
+           [:l3,
+            [:l4]]]]
+      RUBY
+    end
 
-         [:l3,
-          [:l4]]]]
-    RUBY
+    it 'does not indent heredoc strings in autocorrect' do
+      expect_offense(<<~RUBY)
+        var = [
+               { :type => 'something',
+                 :sql => <<EOF
+        Select something
+        from atable
+        EOF
+               },
+              { :type => 'something',
+              ^^^^^^^^^^^^^^^^^^^^^^^ Align the elements of an array literal if they span more than one line.
+                :sql => <<EOF
+        Select something
+        from atable
+        EOF
+              }
+        ]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        var = [
+               { :type => 'something',
+                 :sql => <<EOF
+        Select something
+        from atable
+        EOF
+               },
+               { :type => 'something',
+                 :sql => <<EOF
+        Select something
+        from atable
+        EOF
+               }
+        ]
+      RUBY
+    end
+
+    it 'accepts the first element being on a new row' do
+      expect_no_offenses(<<~RUBY)
+        array = [
+          a,
+          b,
+          c,
+          d
+        ]
+      RUBY
+    end
+
+    it 'auto-corrects array if the first element being on a new row' do
+      expect_offense(<<~RUBY)
+        array = [
+          a,
+           b,
+           ^ Align the elements of an array literal if they span more than one line.
+          c,
+           d
+           ^ Align the elements of an array literal if they span more than one line.
+        ]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array = [
+          a,
+          b,
+          c,
+          d
+        ]
+      RUBY
+    end
   end
 
-  it 'does not auto-correct array within array with too little indentation' do
-    expect_offense(<<~RUBY)
-      [:l1,
-      [:l2,
-      ^^^^^ Align the elements of an array literal if they span more than one line.
+  context 'when aligned with fixed indentation' do
+    let(:cop_config) do
+      {
+        'EnforcedStyle' => 'with_fixed_indentation'
+      }
+    end
 
-        [:l3,
-        ^^^^^ Align the elements of an array literal if they span more than one line.
-         [:l4]]]]
-    RUBY
+    it 'registers an offense and corrects misaligned array elements' do
+      expect_offense(<<~RUBY)
+        array = [a,
+           b,
+           ^ Use one level of indentation for elements following the first line of a multi-line array.
+          c,
+           d]
+           ^ Use one level of indentation for elements following the first line of a multi-line array.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      [:l1,
-       [:l2,
+      expect_correction(<<~RUBY)
+        array = [a,
+          b,
+          c,
+          d]
+      RUBY
+    end
 
-         [:l3,
-          [:l4]]]]
-    RUBY
-  end
+    it 'accepts aligned array keys' do
+      expect_no_offenses(<<~RUBY)
+        array = [a,
+          b,
+          c,
+          d]
+      RUBY
+    end
 
-  it 'does not indent heredoc strings in autocorrect' do
-    expect_offense(<<~RUBY)
-      var = [
-             { :type => 'something',
-               :sql => <<EOF
-      Select something
-      from atable
-      EOF
-             },
-            { :type => 'something',
-            ^^^^^^^^^^^^^^^^^^^^^^^ Align the elements of an array literal if they span more than one line.
-              :sql => <<EOF
-      Select something
-      from atable
-      EOF
-            }
-      ]
-    RUBY
+    it 'accepts single line array' do
+      expect_no_offenses('array = [ a, b ]')
+    end
 
-    expect_correction(<<~RUBY)
-      var = [
-             { :type => 'something',
-               :sql => <<EOF
-      Select something
-      from atable
-      EOF
-             },
-             { :type => 'something',
-               :sql => <<EOF
-      Select something
-      from atable
-      EOF
-             }
-      ]
-    RUBY
+    it 'accepts several elements per line' do
+      expect_no_offenses(<<~RUBY)
+        array = [ a, b,
+          c, d ]
+      RUBY
+    end
+
+    it 'accepts aligned array with fullwidth characters' do
+      expect_no_offenses(<<~RUBY)
+        puts 'Ｒｕｂｙ', [ a,
+          b ]
+      RUBY
+    end
+
+    it 'does not auto-correct array within array with too much indentation' do
+      expect_offense(<<~RUBY)
+        [:l1,
+           [:l2,
+           ^^^^^ Use one level of indentation for elements following the first line of a multi-line array.
+              [:l3,
+              ^^^^^ Use one level of indentation for elements following the first line of a multi-line array.
+                [:l4]]]]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [:l1,
+          [:l2,
+             [:l3,
+               [:l4]]]]
+      RUBY
+    end
+
+    it 'does not auto-correct array within array with too little indentation' do
+      expect_offense(<<~RUBY)
+        [:l1,
+         [:l2,
+         ^^^^^ Use one level of indentation for elements following the first line of a multi-line array.
+          [:l3,
+          ^^^^^ Use one level of indentation for elements following the first line of a multi-line array.
+            [:l4]]]]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [:l1,
+          [:l2,
+           [:l3,
+             [:l4]]]]
+      RUBY
+    end
+
+    it 'does not indent heredoc strings in autocorrect' do
+      expect_offense(<<~RUBY)
+        var = [
+          { :type => 'something',
+            :sql => <<EOF
+        Select something
+        from atable
+        EOF
+          },
+         { :type => 'something',
+         ^^^^^^^^^^^^^^^^^^^^^^^ Use one level of indentation for elements following the first line of a multi-line array.
+           :sql => <<EOF
+        Select something
+        from atable
+        EOF
+         }
+        ]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        var = [
+          { :type => 'something',
+            :sql => <<EOF
+        Select something
+        from atable
+        EOF
+          },
+          { :type => 'something',
+            :sql => <<EOF
+        Select something
+        from atable
+        EOF
+          }
+        ]
+      RUBY
+    end
+
+    it 'accepts the first element being on a new row' do
+      expect_no_offenses(<<~RUBY)
+        array = [
+          a,
+          b,
+          c,
+          d
+        ]
+      RUBY
+    end
+
+    it 'auto-corrects array if the first element being on a new row' do
+      expect_offense(<<~RUBY)
+        array = [
+          a,
+           b,
+           ^ Use one level of indentation for elements following the first line of a multi-line array.
+          c,
+           d
+           ^ Use one level of indentation for elements following the first line of a multi-line array.
+        ]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array = [
+          a,
+          b,
+          c,
+          d
+        ]
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
## Tension

Hello 👋

We have `with_fixed_indentation` option for `Layout/ArgumentAlignment` and `Layout/ParameterAlignment`. So we can write our code this way:
```ruby
foo :bar,
  :baz
```
```ruby
method_call(a,
  b)
```

And we in our company decided to use this style (with `with_fixed_indentation`) for all alignments. But we can't use this this option for `Layout/ArrayAlignment` because it doesn't support this flag.

We want to write multi-line arrays in this style:
```ruby
array = [a,
  b]
```
in order to have the same style of code in whole project in all cases.

## Changes

I've used these cops as examples:
- https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/layout/argument_alignment.rb
- https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/layout/parameter_alignment.rb

Extended exciting `Layout/ArrayAlignment`. So now it supports `with_fixed_indentation`.

## Tests

- I took the old tests.
- Moved them to `context 'when aligned with first parameter'` (when `with_first_parameter`)
- Created `context 'when aligned with fixed indentation'` (when `with_fixed_indentation`) and wrote the same tests as for `with_first_parameter`.
- Added tests with case when the first element on the new line to both contexts.
Ex. it is okay for both options:
```ruby
array = [
  a,
  b,
  c,
  d
]
```

## Basic Checklist
Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
