### PR TITLE
Add line length autocorrect for blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#7639](https://github.com/rubocop-hq/rubocop/pull/7639): Fix logical operator edge case in `omit_parentheses` style of `Style/MethodCallWithArgsParentheses`. ([@gsamokovarov][])
 
+### New features
+
+* [#7659](https://github.com/rubocop-hq/rubocop/pull/7659): Layout/LineLength autocorrect now breaks up long lines with blocks. ([@maxh][])
+
 ### Changes
 
 * [#7636](https://github.com/rubocop-hq/rubocop/issues/7636): Remove `console` from `Lint/Debugger` to prevent false positives. ([@gsamokovarov][])

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -19,19 +19,25 @@ module RuboCop
       #
       # If autocorrection is enabled, the following Layout cops
       # are recommended to further format the broken lines.
+      # (Many of these are enabled by default.)
       #
-      #   - ParameterAlignment
       #   - ArgumentAlignment
+      #   - BlockAlignment
+      #   - BlockDelimiters
+      #   - BlockEndNewline
       #   - ClosingParenthesisIndentation
       #   - FirstArgumentIndentation
       #   - FirstArrayElementIndentation
       #   - FirstHashElementIndentation
       #   - FirstParameterIndentation
       #   - HashAlignment
+      #   - IndentationWidth
       #   - MultilineArrayLineBreaks
+      #   - MultilineBlockLayout
       #   - MultilineHashBraceLayout
       #   - MultilineHashKeyLineBreaks
       #   - MultilineMethodArgumentLineBreaks
+      #   - ParameterAlignment
       #
       # Together, these cops will pretty print hashes, arrays,
       # method calls, etc. For example, let's say the max columns
@@ -60,6 +66,10 @@ module RuboCop
         include LineLengthHelp
 
         MSG = 'Line is too long. [%<length>d/%<max>d]'
+
+        def on_block(node)
+          check_for_breakable_block(node)
+        end
 
         def on_potential_breakable_node(node)
           check_for_breakable_node(node)
@@ -106,6 +116,25 @@ module RuboCop
           tokens.reverse_each do |token|
             range = breakable_range_after_semicolon(token)
             breakable_range_by_line_index[range.line - 1] = range if range
+          end
+        end
+
+        def check_for_breakable_block(block_node)
+          return unless block_node.single_line?
+
+          line_index = block_node.loc.line - 1
+          range = breakable_block_range(block_node)
+          pos = range.begin_pos + 1
+
+          breakable_range_by_line_index[line_index] =
+            range_between(pos, pos + 1)
+        end
+
+        def breakable_block_range(block_node)
+          if block_node.arguments?
+            block_node.arguments.loc.end
+          else
+            block_node.loc.begin
           end
         end
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2886,19 +2886,25 @@ method calls with argument lists.
 
 If autocorrection is enabled, the following Layout cops
 are recommended to further format the broken lines.
+(Many of these are enabled by default.)
 
-  - ParameterAlignment
   - ArgumentAlignment
+  - BlockAlignment
+  - BlockDelimiters
+  - BlockEndNewline
   - ClosingParenthesisIndentation
   - FirstArgumentIndentation
   - FirstArrayElementIndentation
   - FirstHashElementIndentation
   - FirstParameterIndentation
   - HashAlignment
+  - IndentationWidth
   - MultilineArrayLineBreaks
+  - MultilineBlockLayout
   - MultilineHashBraceLayout
   - MultilineHashKeyLineBreaks
   - MultilineMethodArgumentLineBreaks
+  - ParameterAlignment
 
 Together, these cops will pretty print hashes, arrays,
 method calls, etc. For example, let's say the max columns

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -735,6 +735,64 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
       end
     end
 
+    context 'long blocks' do
+      context 'braces' do
+        it 'adds an offense and does correct it' do
+          expect_offense(<<~RUBY)
+            foo.select { |bar| 4444000039123123129993912312312999199291203123123 }
+                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [70/40]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo.select { |bar|
+             4444000039123123129993912312312999199291203123123 }
+          RUBY
+        end
+      end
+
+      context 'do/end' do
+        it 'adds an offense and does correct it' do
+          expect_offense(<<~RUBY)
+            foo.select do |bar| 4444000039123123129993912312312999199291203123 end
+                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [70/40]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo.select do |bar|
+             4444000039123123129993912312312999199291203123 end
+          RUBY
+        end
+      end
+
+      context 'let block' do
+        it 'adds an offense and does correct it' do
+          expect_offense(<<~RUBY)
+            let(:foobar) { BazBazBaz::BazBazBaz::BazBazBaz::BazBazBaz.baz(baz12) }
+                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [70/40]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            let(:foobar) {
+             BazBazBaz::BazBazBaz::BazBazBaz::BazBazBaz.baz(baz12) }
+          RUBY
+        end
+      end
+
+      context 'no spaces' do
+        it 'adds an offense and does correct it' do
+          expect_offense(<<~RUBY)
+            let(:foobar){BazBazBaz::BazBazBaz::BazBazBaz::BazBazBaz.baz(baz12345)}
+                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [70/40]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            let(:foobar){
+            BazBazBaz::BazBazBaz::BazBazBaz::BazBazBaz.baz(baz12345)}
+          RUBY
+        end
+      end
+    end
+
     context 'semicolon' do
       context 'when under limit' do
         it 'does not add any offenses' do


### PR DESCRIPTION
Shortens long lines by inserting a line break into blocks like this:

```rb
# original
foo.bar { |baz| batbatbatbatbatbatbatbat(baz) }

# auto-corrected after this PR
foo.bar { |baz|
batbatbatbatbatbatbatbat(baz) }

# auto-corrected after other block alignment cops run
# (just one example -- final output depends on config)
foo.bar do |baz|
  batbatbatbatbatbatbatbat(baz)
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
