### PR TITLE
Add RequiredBracesMethods param to BlockDelimiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#7619](https://github.com/rubocop-hq/rubocop/issues/7619): Support autocorrect of legacy cop names for `Migration/DepartmentName`. ([@koic][])
 * [#7659](https://github.com/rubocop-hq/rubocop/pull/7659): Layout/LineLength autocorrect now breaks up long lines with blocks. ([@maxh][])
 * [#7677](https://github.com/rubocop-hq/rubocop/pull/7677): Add a cop for `Hash#each_key` and `Hash#each_value`. ([@jemmaissroff][])
+* Add `BracesRequiredMethods` parameter to `Style/BlockDelimiters` to require braces for specific methods such as Sorbet's `sig`. ([@maxh][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -2357,6 +2357,12 @@ Style/BlockDelimiters:
   #   # also good
   #   collection.each do |element| puts element end
   AllowBracesOnProceduralOneLiners: false
+  # The BracesRequiredMethods overrides all other configurations except
+  # IgnoredMethods. It can be used to enforce that all blocks for specific
+  # methods use braces. For example, you can use this to enforce Sorbet
+  # signatures use braces even when the rest of your codebase enforces
+  # the `line_count_based` style.
+  BracesRequiredMethods: []
 
 Style/CaseEquality:
   Description: 'Avoid explicit use of the case equality operator(===).'

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -473,6 +473,33 @@ words.each { |word|
   word.flip.flop
 }
 ```
+#### BracesRequiredMethods: ['sig']
+
+```ruby
+# Methods listed in the BracesRequiredMethods list, such as 'sig'
+# in this example, will require `{...}` braces. This option takes
+# precedence over all other configurations except IgnoredMethods.
+
+# bad
+sig do
+  params(
+    foo: string,
+  ).void
+end
+def bar(foo)
+  puts foo
+end
+
+# good
+sig {
+  params(
+    foo: string,
+  ).void
+}
+def bar(foo)
+  puts foo
+end
+```
 
 ### Configurable attributes
 
@@ -483,6 +510,7 @@ ProceduralMethods | `benchmark`, `bm`, `bmbm`, `create`, `each_with_object`, `me
 FunctionalMethods | `let`, `let!`, `subject`, `watch` | Array
 IgnoredMethods | `lambda`, `proc`, `it` | Array
 AllowBracesOnProceduralOneLiners | `false` | Boolean
+BracesRequiredMethods | `[]` | Array
 
 ### References
 

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -691,4 +691,87 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       end
     end
   end
+
+  context 'BracesRequiredMethods' do
+    cop_config = {
+      'EnforcedStyle' => 'line_count_based',
+      'BracesRequiredMethods' => %w[sig]
+    }
+
+    let(:cop_config) { cop_config }
+
+    describe 'BracesRequiredMethods methods' do
+      it 'allows braces' do
+        expect_no_offenses(<<~RUBY)
+          sig {
+            params(
+              foo: string,
+            ).void
+          }
+          def consume(foo)
+            foo
+          end
+        RUBY
+      end
+
+      it 'registers an offense with do' do
+        expect_offense(<<~RUBY)
+          sig do
+              ^^ Brace delimiters `{...}` required for 'sig' method.
+            params(
+              foo: string,
+            ).void
+          end
+          def consume(foo)
+            foo
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          sig {
+            params(
+              foo: string,
+            ).void
+          }
+          def consume(foo)
+            foo
+          end
+        RUBY
+      end
+    end
+
+    describe 'other methods' do
+      it 'allows braces' do
+        expect_no_offenses(<<~RUBY)
+          other_method do
+            params(
+              foo: string,
+            ).void
+          end
+          def consume(foo)
+            foo
+          end
+        RUBY
+      end
+
+      it 'auto-corrects { and } to do and end' do
+        source = <<~RUBY
+          each{ |x|
+            some_method
+            other_method
+          }
+        RUBY
+
+        expected_source = <<~RUBY
+          each do |x|
+            some_method
+            other_method
+          end
+        RUBY
+
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq(expected_source)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The motivating use case for this in our codebase is to switch [Sorbet](https://sorbet.org/) `sig` declarations from `do...end` to `{...}`:

Syntax highlight for do/end on type signatures are distracting:
![image](https://user-images.githubusercontent.com/1289501/72665849-f9326900-39d1-11ea-9dff-07adc9754ec8.png)

Braces are less distracting:
![image](https://user-images.githubusercontent.com/1289501/72665853-04859480-39d2-11ea-80b9-7686ca8e2697.png)

Currently the first is enforced by `line_count_based`, which we want for all other methods.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
