### PR TITLE
[Fix rubocop-hq/rubocop-performance#95] Fix to return correct info from multi-line regexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#7639](https://github.com/rubocop-hq/rubocop/pull/7639): Fix logical operator edge case in `omit_parentheses` style of `Style/MethodCallWithArgsParentheses`. ([@gsamokovarov][])
+* [#7661](https://github.com/rubocop-hq/rubocop/pull/7661): Fix to return correct info from multi-line regexp. ([@Tietew][])
 
 ### Changes
 
@@ -4330,3 +4331,4 @@
 [@pirj]: https://github.com/pirj
 [@pawptart]: https://github.com/pawptart
 [@gfyoung]: https://github.com/gfyoung
+[@Tietew]: https://github.com/Tietew

--- a/lib/rubocop/ast/node/regexp_node.rb
+++ b/lib/rubocop/ast/node/regexp_node.rb
@@ -21,14 +21,12 @@ module RuboCop
 
       # @return [RuboCop::AST::Node] a regopt node
       def regopt
-        first, second = *self
-        first.regopt_type? ? first : second
+        children.last
       end
 
       # @return [String] a string of regexp content
       def content
-        str = children.first
-        str.str_content || ''
+        children.select(&:str_type?).map(&:str_content).join
       end
     end
   end

--- a/spec/rubocop/ast/regexp_node_spec.rb
+++ b/spec/rubocop/ast/regexp_node_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe RuboCop::AST::RegexpNode do
       it { expect(regexp_node.to_regexp).to eq(eval(source)) }
     end
 
+    context 'with a multi-line regexp without option' do
+      let(:source) { "/\n.+\n/" }
+
+      it { expect(regexp_node.to_regexp).to eq(eval(source)) }
+    end
+
     context 'with an empty regexp with option' do
       let(:source) { '//ix' }
 
@@ -31,6 +37,12 @@ RSpec.describe RuboCop::AST::RegexpNode do
 
     context 'with a regexp with option' do
       let(:source) { '/.+/imx' }
+
+      it { expect(regexp_node.to_regexp).to eq(eval(source)) }
+    end
+
+    context 'with a multi-line regexp with option' do
+      let(:source) { "/\n.+\n/ix" }
 
       it { expect(regexp_node.to_regexp).to eq(eval(source)) }
     end
@@ -54,6 +66,13 @@ RSpec.describe RuboCop::AST::RegexpNode do
       it { expect(regopt.children.empty?).to be(true) }
     end
 
+    context 'with a multi-line regexp without option' do
+      let(:source) { "/\n.+\n/" }
+
+      it { expect(regopt.regopt_type?).to be(true) }
+      it { expect(regopt.children.empty?).to be(true) }
+    end
+
     context 'with an empty regexp with option' do
       let(:source) { '//ix' }
 
@@ -63,6 +82,13 @@ RSpec.describe RuboCop::AST::RegexpNode do
 
     context 'with a regexp with option' do
       let(:source) { '/.+/imx' }
+
+      it { expect(regopt.regopt_type?).to be(true) }
+      it { expect(regopt.children).to eq(%i[i m x]) }
+    end
+
+    context 'with a multi-line regexp with option' do
+      let(:source) { "/\n.+\n/imx" }
 
       it { expect(regopt.regopt_type?).to be(true) }
       it { expect(regopt.children).to eq(%i[i m x]) }
@@ -84,6 +110,12 @@ RSpec.describe RuboCop::AST::RegexpNode do
       it { expect(content).to eq('.+') }
     end
 
+    context 'with a multi-line regexp without option' do
+      let(:source) { "/\n.+\n/" }
+
+      it { expect(content).to eq("\n.+\n") }
+    end
+
     context 'with an empty regexp with option' do
       let(:source) { '//ix' }
 
@@ -94,6 +126,12 @@ RSpec.describe RuboCop::AST::RegexpNode do
       let(:source) { '/.+/imx' }
 
       it { expect(content).to eq('.+') }
+    end
+
+    context 'with a multi-line regexp with option' do
+      let(:source) { "/\n.+\n/imx" }
+
+      it { expect(content).to eq("\n.+\n") }
     end
   end
 end


### PR DESCRIPTION
Fixes rubocop-hq/rubocop-performance#95.

This PR fixes `RuboCop::AST::RegexpNode` to return correct information
from multi-line regexp.

- `#regopt` - find regopt node instead of checking first node.
- `#content` - join all child string nodes instead of returning first node.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
