### PR TITLE
Accept pending cops in the development build

### DIFF
--- a/spec/support/suppress_pending_warning.rb
+++ b/spec/support/suppress_pending_warning.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+#
+# This is a file that supports testing. An open class has been applied to
+# `RuboCop::ConfigLoader.warn_on_pending_cops` to suppress pending cop
+# warnings during testing.
+#
+module RuboCop
+  class ConfigLoader
+    class << self
+      def warn_on_pending_cops(config)
+        # noop
+      end
+    end
+  end
+end


### PR DESCRIPTION
Follow up of https://github.com/rubocop-hq/rubocop/pull/7646#discussion_r365585616.

This PR accepts pending cops in the development build.

Some tests fail with the following warnings when using the `Enabled: pending` status.

```console
% bundle exec rake spec
(snip)

1) RuboCop::CLI --only when one cop is given accepts cop names from
plugins
     Failure/Error: raise output

     RuntimeError:
       The following cops were added to RuboCop, but are not
configured. Please set Enabled to either `true` or `false` in your
`.rubocop.yml` file:
        - Style/ZeroLengthPredicate
       Inspecting 2 files
       ..

       2 files inspected, no offenses detected
     # ./spec/rubocop/cli/cli_options_spec.rb:213:in `block (4 levels)
in <top (required)>'
     # ./spec/support/cli_spec_behavior.rb:26:in `block (2 levels) in
<top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:29:in `block (4 levels) in
<top (required)>'
     # ./lib/rubocop/path_util.rb:67:in `chdir'
     # ./lib/rubocop/path_util.rb:67:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:28:in `block (3 levels) in
<top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in
<top (required)>'
```

This PR prevents those tests from catching a pending cop warning.
OTOH, this PR supplements the E2E test for a pending cop warning.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
