### PR TITLE
[Fix #7647] Handle numblock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#7639](https://github.com/rubocop-hq/rubocop/pull/7639): Fix logical operator edge case in `omit_parentheses` style of `Style/MethodCallWithArgsParentheses`. ([@gsamokovarov][])
 * [#7661](https://github.com/rubocop-hq/rubocop/pull/7661): Fix to return correct info from multi-line regexp. ([@Tietew][])
 * [#7655](https://github.com/rubocop-hq/rubocop/issues/7655): Fix an error when processing a regexp with a line break at the start of capture parenthesis. ([@koic][])
+* [#7647](https://github.com/rubocop-hq/rubocop/issues/7647): Fix an `undefined method on_numblock` error when using Ruby 2.7's numbered parameters. ([@hanachin][])
 
 ### Changes
 
@@ -4335,3 +4336,4 @@
 [@pawptart]: https://github.com/pawptart
 [@gfyoung]: https://github.com/gfyoung
 [@Tietew]: https://github.com/Tietew
+[@hanachin]: https://github.com/hanachin

--- a/lib/rubocop/ast/traversal.rb
+++ b/lib/rubocop/ast/traversal.rb
@@ -185,6 +185,15 @@ module RuboCop
       alias on_when    on_case
       alias on_irange  on_case
       alias on_erange  on_case
+
+      def on_numblock(node)
+        children = node.children
+        child = children[0]
+        send(:"on_#{child.type}", child)
+        return unless (child = children[2])
+
+        send(:"on_#{child.type}", child)
+      end
     end
   end
 end


### PR DESCRIPTION
Fix #7647 

```yaml
# 7647/.rubocop.yml
AllCops:
  TargetRubyVersion: 2.7
```

```ruby
#!/usr/bin/env ruby
# frozen_string_literal: true

# 7647/test.rb

def hello(meaning)
  spliters = [',', '.', '!']
  spliters.each { meaning = meaning.split(_1).first }
  meaning.delete('"').strip.gsub("\r\n", '; ')
end
```

```
$ pwd
/home/sei/src/github.com/rubocop-hq/rubocop
$ cd 7647
$ ../exe/rubocop
Inspecting 1 file
.

1 file inspected, no offenses detected
```


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
