### PR TITLE
Add examples of `AllowForAlignment` option for `Layout/SpaceAroundOperators`

### DIFF
--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -6,6 +6,10 @@ module RuboCop
       # Checks that operators have space around them, except for ** which
       # should or shouldn't have surrounding space depending on configuration.
       #
+      # This cop has `AllowForAlignment` option. When `true`, allows most
+      # uses of extra spacing if the intent is to align with an operator on
+      # the previous or next line, not counting empty lines or comment lines.
+      #
       # @example
       #   # bad
       #   total = 3*4
@@ -16,6 +20,20 @@ module RuboCop
       #   total = 3 * 4
       #   "apple" + "juice"
       #   my_number = 38 / 4
+      #
+      # @example AllowForAlignment: true (default)
+      #   # good
+      #   {
+      #     1 =>  2,
+      #     11 => 3
+      #   }
+      #
+      # @example AllowForAlignment: false
+      #   # bad
+      #   {
+      #     1 =>  2,
+      #     11 => 3
+      #   }
       #
       # @example EnforcedStyleForExponentOperator: no_space (default)
       #   # bad

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -4037,6 +4037,10 @@ Enabled | Yes | Yes  | 0.49 | -
 Checks that operators have space around them, except for ** which
 should or shouldn't have surrounding space depending on configuration.
 
+This cop has `AllowForAlignment` option. When `true`, allows most
+uses of extra spacing if the intent is to align with an operator on
+the previous or next line, not counting empty lines or comment lines.
+
 ### Examples
 
 ```ruby
@@ -4049,6 +4053,24 @@ my_number = 38/4
 total = 3 * 4
 "apple" + "juice"
 my_number = 38 / 4
+```
+#### AllowForAlignment: true (default)
+
+```ruby
+# good
+{
+  1 =>  2,
+  11 => 3
+}
+```
+#### AllowForAlignment: false
+
+```ruby
+# bad
+{
+  1 =>  2,
+  11 => 3
+}
 ```
 #### EnforcedStyleForExponentOperator: no_space (default)
 


### PR DESCRIPTION
This is only document change.

This commit adds examples of `AllowForAlignment` option for `Layout/SpaceAroundOperators` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
