### PR TITLE
Update documentation to reflect current precedence in TargetRuby

### DIFF
--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -485,14 +485,16 @@ inspected code must run on. For example, enforcing using Ruby 2.3+ safe
 navigation operator rather than `try` can help make your code shorter and
 more consistent... _unless_ it must run on Ruby 2.2.
 
-If `.ruby-version` exists in the directory RuboCop is invoked in, RuboCop
-will use the version specified by it. Otherwise, users may let RuboCop
-know the oldest version of Ruby which your project supports with:
+Users may let RuboCop know the oldest version of Ruby which your project
+supports with:
 
 ```yaml
 AllCops:
   TargetRubyVersion: 2.2
 ```
+
+Otherwise, RuboCop will then check your project for `.ruby-version` and
+use the version specified by it.
 
 ### Automatically Generated Configuration
 


### PR DESCRIPTION
In debugging some Rubocop configuration, I came across some documentation that seems to be out of date.

- `.ruby-version` has not been preferred to `TargetRubyVersion:` since https://github.com/rubocop-hq/rubocop/pull/3261
- `.ruby-version` has not had to be in the same directory as the `rubocop` invocation since https://github.com/rubocop-hq/rubocop/pull/5326
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* ~~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* ~~Added tests.~~
* ~~Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).~~
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
