### PR TITLE
[Fix #7675] Fix a false negative for `Layout/SpaceBeforeFirstArg`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#7661](https://github.com/rubocop-hq/rubocop/pull/7661): Fix to return correct info from multi-line regexp. ([@Tietew][])
 * [#7655](https://github.com/rubocop-hq/rubocop/issues/7655): Fix an error when processing a regexp with a line break at the start of capture parenthesis. ([@koic][])
 * [#7647](https://github.com/rubocop-hq/rubocop/issues/7647): Fix an `undefined method on_numblock` error when using Ruby 2.7's numbered parameters. ([@hanachin][])
+* [#7675](https://github.com/rubocop-hq/rubocop/issues/7675): Fix a false negative for `Layout/SpaceBeforeFirstArg` when a vertical argument positions are aligned. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/space_before_first_arg.rb
+++ b/lib/rubocop/cop/layout/space_before_first_arg.rb
@@ -54,12 +54,20 @@ module RuboCop
 
         def expect_params_after_method_name?(node)
           return false if node.parenthesized?
+          return true if no_space_between_method_name_and_first_argument?(node)
 
           first_arg = node.first_argument
 
           same_line?(first_arg, node) &&
             !(allow_for_alignment? &&
               aligned_with_something?(first_arg.source_range))
+        end
+
+        def no_space_between_method_name_and_first_argument?(node)
+          end_pos_of_method_name = node.loc.selector.end_pos
+          begin_pos_of_argument = node.first_argument.source_range.begin_pos
+
+          end_pos_of_method_name == begin_pos_of_argument
         end
       end
     end

--- a/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
@@ -59,6 +59,31 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeFirstArg, :config do
       RUBY
     end
 
+    context 'when a vertical argument positions are aligned' do
+      it 'registers an offense' do
+        inspect_source(<<~RUBY)
+          obj = a_method(arg, arg2)
+          obj.no_parenthesized'asdf'
+        RUBY
+
+        expect(cop.messages).to eq(
+          ['Put one space between the method name and the first argument.']
+        )
+      end
+
+      it 'auto-corrects missing space' do
+        new_source = autocorrect_source(<<~RUBY)
+          obj = a_method(arg, arg2)
+          obj.no_parenthesized'asdf'
+        RUBY
+
+        expect(new_source).to eq(<<~RUBY)
+          obj = a_method(arg, arg2)
+          obj.no_parenthesized 'asdf'
+        RUBY
+      end
+    end
+
     it 'accepts a method call with one space before the first arg' do
       expect_no_offenses(<<~RUBY)
         something x


### PR DESCRIPTION
Fixes #7675.

This PR fixes a false negative for `Layout/SpaceBeforeFirstArg` when a vertical argument positions are aligned.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
