### PR TITLE
Workaround for cc-test-reporter with SimpleCov 0.18

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,10 @@ gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.5.0'
 gem 'rubocop-rspec', '~> 1.33.0'
-gem 'simplecov', '~> 0.10'
+# Workaround for cc-test-reporter with SimpleCov 0.18.
+# Stop upgrading SimpleCov until the following issue will be resolved.
+# https://github.com/codeclimate/test-reporter/issues/418
+gem 'simplecov', '~> 0.10', '< 0.18'
 gem 'test-queue'
 gem 'yard', '~> 0.9'
 


### PR DESCRIPTION
This PR fixes the following build error when using cc-test-reporter with SimpleCov 0.18.

```console
$ #!/bin/bash -eo pipefail
./tmp/cc-test-reporter before-build
COVERAGE=true bundle exec rake spec
./tmp/cc-test-reporter format-coverage --output
tmp/codeclimate.$CIRCLE_JOB.json
Starting test-queue master (/tmp/test_queue_228_47138309905180.sock)

==> Summary (2 workers in 36.1115s)

    [ 1]                         8753 examples, 0 failures, 9 pending
    254 suites in 36.1034s      (pid 160 exit 0 )
    [ 2]                         6772 examples, 0 failures, 2 pending
    239 suites in 36.1054s      (pid 161 exit 0 )

Coverage report generated for RSpec, rspec-1, rspec-2, rspec-fork-163,
rspec-fork-164, rspec-fork-165 to /home/circleci/project/coverage. 21266
/ 21459 LOC (99.1%) covered.
Error: json: cannot unmarshal object into Go struct field input.coverage
of type []formatters.NullInt
Usage:
  cc-test-reporter format-coverage [coverage file] [flags]

Flags:
      --add-prefix string   add this prefix to file paths
  -t, --input-type string   type of input source to use [clover,
cobertura, coverage.py, excoveralls, gcov, gocov, jacoco, lcov,
simplecov, xccov]
  -o, --output string       output path (default "coverage/codeclimate.json")
  -p, --prefix string       the root directory where the
    coverage analysis was performed (default "/home/circleci/project")

Global Flags:
  -d, --debug   run in debug mode

Exited with code exit status 255
```

https://circleci.com/gh/rubocop-hq/rubocop/83619

This patch is a workaround until the following issue will be resolved.
https://github.com/codeclimate/test-reporter/issues/418

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
