### PR TITLE
Updates docs to be more explicit when using formatters

### DIFF
--- a/manual/formatters.md
+++ b/manual/formatters.md
@@ -69,7 +69,7 @@ lib/foo.rb:6:5: C: Style/Documentation: Missing top-level class documentation co
 Behaves like Progress Formatter except that it will not show any offenses.
 
 ```sh
-$ rubocop
+$ rubocop --format autogenconf
 Inspecting 26 files
 ..W.C....C..CWCW.C...WC.CC
 
@@ -81,7 +81,7 @@ Inspecting 26 files
 The `clang` formatter displays the offenses in a manner similar to `clang`:
 
 ```sh
-$ rubocop test.rb
+$ rubocop --format clang test.rb
 Inspecting 1 file
 W
 
@@ -166,7 +166,11 @@ W:  4:  5: Layout/DefEndAlignment: end at 4, 4 is not aligned with if at 2, 2
 
 ### Quiet Formatter
 
-Behaves like Simple Formatter if there are offenses. Completely quiet otherwise.
+Behaves like Simple Formatter if there are offenses. Completely quiet otherwise:
+
+```sh
+$ rubocop --format quiet
+```
 
 ### File List Formatter
 


### PR DESCRIPTION
I found it hard to realize how to use the "Auto Gen Config" formatter from the documentation. I ended up finding the right parameter in the code: [`lib/rubocop/formatter/formatter_set.rb`](https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/formatter/formatter_set.rb).

I thought it'd be worth being explicit on how to use each formatter in the documentation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
