### PR TITLE
[Fix #7619] Support autocorrect of legacy names for `Migration/DepartmentName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#7619](https://github.com/rubocop-hq/rubocop/issues/7619): Support autocorrect of legacy cop names for `Migration/DepartmentName`. ([@koic][])
+
 ### Bug fixes
 
 * [#7639](https://github.com/rubocop-hq/rubocop/pull/7639): Fix logical operator edge case in `omit_parentheses` style of `Style/MethodCallWithArgsParentheses`. ([@gsamokovarov][])

--- a/lib/rubocop/cop/migration/department_name.rb
+++ b/lib/rubocop/cop/migration/department_name.rb
@@ -35,8 +35,13 @@ module RuboCop
 
         def autocorrect(range)
           shall_warn = false
-          qualified_cop_name = Cop.registry.qualified_cop_name(range.source,
+          cop_name = range.source
+          qualified_cop_name = Cop.registry.qualified_cop_name(cop_name,
                                                                nil, shall_warn)
+          unless qualified_cop_name.include?('/')
+            qualified_cop_name = qualified_legacy_cop_name(cop_name)
+          end
+
           ->(corrector) { corrector.replace(range, qualified_cop_name) }
         end
 
@@ -52,6 +57,14 @@ module RuboCop
 
         def valid_content_token?(content_token)
           !DISABLING_COPS_CONTENT_TOKEN.match(content_token).nil?
+        end
+
+        def qualified_legacy_cop_name(cop_name)
+          legacy_cop_names = RuboCop::ConfigObsoletion::OBSOLETE_COPS.keys
+
+          legacy_cop_names.detect do |legacy_cop_name|
+            legacy_cop_name.split('/')[1] == cop_name
+          end
         end
       end
     end

--- a/spec/rubocop/cop/migration/department_name_spec.rb
+++ b/spec/rubocop/cop/migration/department_name_spec.rb
@@ -53,6 +53,23 @@ RSpec.describe RuboCop::Cop::Migration::DepartmentName do
         # rubocop : enable Style/Alias, Layout/LineLength
       RUBY
     end
+
+    it 'registers offenses and corrects when using a legacy cop name' do
+      expect_offense(<<~RUBY, 'file.rb')
+        # rubocop:disable SingleSpaceBeforeFirstArg, Layout/LineLength
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^ Department name is missing.
+        name             "apache_kafka"
+      RUBY
+
+      # `Style/SingleSpaceBeforeFirstArg` is a legacy name that has been
+      # renamed to `Layout/SpaceBeforeFirstArg`. In the autocorrection,
+      # the department name is complemented by the legacy cop name.
+      # Migration to the new name is expected to be modified using Gry gem.
+      expect_correction(<<~RUBY)
+        # rubocop:disable Style/SingleSpaceBeforeFirstArg, Layout/LineLength
+        name             "apache_kafka"
+      RUBY
+    end
   end
 
   context 'when a disable comment has cop names with departments' do


### PR DESCRIPTION
Fixes #7619.

This PR supports autocorrect of legacy names for `Migration/DepartmentName`.

Auto-correction for legacy names complements legacy department names.
Migration to new cop names are expected to be modified using Gry gem.
https://github.com/pocke/gry

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
