### PR TITLE
Show pending status in cop status of manual

### DIFF
--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2476,7 +2476,7 @@ PreferHashRocketsForNonAlnumEndingSymbols | `false` | Boolean
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | No | Yes (Unsafe) | - | -
+Pending | No | Yes (Unsafe) | - | -
 
 This cop looks for uses of `_.each_with_object({}) {...}`,
 `_.map {...}.to_h`, and `Hash[_.map {...}]` that are actually just
@@ -2506,7 +2506,7 @@ This cop should only be enabled on Ruby version 2.5 or newer
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | No | Yes (Unsafe) | - | -
+Pending | No | Yes (Unsafe) | - | -
 
 This cop looks for uses of `_.each_with_object({}) {...}`,
 `_.map {...}.to_h`, and `Hash[_.map {...}]` that are actually just

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -44,7 +44,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
                   end
     cop_config = cop_instance.cop_config
     content = [[
-      cop_config.fetch('Enabled') ? 'Enabled' : 'Disabled',
+      cop_status(cop_config.fetch('Enabled')),
       cop_config.fetch('Safe', true) ? 'Yes' : 'No',
       autocorrect,
       cop_config.fetch('VersionAdded', '-'),
@@ -236,6 +236,12 @@ task generate_cops_documentation: :yard_for_generate_documentation do
       .sort
       .map { |department| table_of_content_for_department(cops, department) }
       .join("\n")
+  end
+
+  def cop_status(status)
+    return 'Disabled' unless status
+
+    status == 'pending' ? 'Pending' : 'Enabled'
   end
 
   def assert_manual_synchronized


### PR DESCRIPTION
Follow up of #5979.

This PR shows pending status in cop status of manual.
The pending status is not enabled status and may lead to misreading.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
