### PR TITLE
Fix apparent typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ automatically fix some of the problems for you.
 $ gem install rubocop
 ```
 
-If you'd rather install RuboCop using `bundler`, require it in your `Gemfile`:
+If you'd rather install RuboCop using `bundler`, add a line for it in your `Gemfile` (but set the `require` option to `false`, as it is a standalone tool):
 
 ```rb
 gem 'rubocop', require: false

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ automatically fix some of the problems for you.
 $ gem install rubocop
 ```
 
-If you'd rather install RuboCop using `bundler`, don't require it in your `Gemfile`:
+If you'd rather install RuboCop using `bundler`, require it in your `Gemfile`:
 
 ```rb
 gem 'rubocop', require: false


### PR DESCRIPTION
Generally if you want to install something using `bundler`, you _do_ require it in your `Gemfile`.
