### PR TITLE
Replace Node#str_content with StrNode#value

### DIFF
--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -306,8 +306,6 @@ module RuboCop
         {(send $_ ...) (block (send $_ ...) ...)}
       PATTERN
 
-      def_node_matcher :str_content, '(str $_)'
-
       def const_name
         return unless const_type?
 

--- a/lib/rubocop/ast/node/regexp_node.rb
+++ b/lib/rubocop/ast/node/regexp_node.rb
@@ -26,7 +26,7 @@ module RuboCop
 
       # @return [String] a string of regexp content
       def content
-        children.select(&:str_type?).map(&:str_content).join
+        children.select(&:str_type?).map(&:value).join
       end
     end
   end

--- a/lib/rubocop/ast/node/str_node.rb
+++ b/lib/rubocop/ast/node/str_node.rb
@@ -11,6 +11,14 @@ module RuboCop
       def heredoc?
         loc.is_a?(Parser::Source::Map::Heredoc)
       end
+
+      def value
+        if str_type?
+          super
+        else
+          each_child_node(:str, :dstr, :xstr).map(&:value).join
+        end
+      end
     end
   end
 end

--- a/lib/rubocop/cop/correctors/string_literal_corrector.rb
+++ b/lib/rubocop/cop/correctors/string_literal_corrector.rb
@@ -11,7 +11,7 @@ module RuboCop
           return if node.dstr_type?
 
           lambda do |corrector|
-            str = node.str_content
+            str = node.value
             if style == :single_quotes
               corrector.replace(node.source_range, to_string_literal(str))
             else

--- a/lib/rubocop/cop/gemspec/required_ruby_version.rb
+++ b/lib/rubocop/cop/gemspec/required_ruby_version.rb
@@ -64,11 +64,11 @@ module RuboCop
         def extract_ruby_version(required_ruby_version)
           if required_ruby_version.array_type?
             required_ruby_version = required_ruby_version.children.detect do |v|
-              v.str_content =~ /[>=]/
+              v.value =~ /[>=]/
             end
           end
 
-          required_ruby_version.str_content.match(/(\d\.\d)/)[1]
+          required_ruby_version.value.match(/(\d\.\d)/)[1]
         end
 
         def message(required_ruby_version, target_ruby_version)

--- a/lib/rubocop/cop/lint/implicit_string_concatenation.rb
+++ b/lib/rubocop/cop/lint/implicit_string_concatenation.rb
@@ -82,17 +82,9 @@ module RuboCop
 
         def display_str(node)
           if node.source =~ /\n/
-            str_content(node).inspect
+            node.value.inspect
           else
             node.source
-          end
-        end
-
-        def str_content(node)
-          if node.str_type?
-            node.children[0]
-          else
-            node.children.map { |c| str_content(c) }.join
           end
         end
       end

--- a/lib/rubocop/cop/mixin/ordered_gem_node.rb
+++ b/lib/rubocop/cop/mixin/ordered_gem_node.rb
@@ -43,7 +43,7 @@ module RuboCop
       end
 
       def find_gem_name(gem_node)
-        return gem_node.str_content if gem_node.str_type?
+        return gem_node.value if gem_node.str_type?
 
         find_gem_name(gem_node.receiver)
       end

--- a/lib/rubocop/cop/security/open.rb
+++ b/lib/rubocop/cop/security/open.rb
@@ -38,7 +38,7 @@ module RuboCop
 
         def safe?(node)
           if simple_string?(node)
-            safe_argument?(node.str_content)
+            safe_argument?(node.value)
           elsif composite_string?(node)
             safe?(node.children.first)
           else

--- a/lib/rubocop/cop/style/string_hash_keys.rb
+++ b/lib/rubocop/cop/style/string_hash_keys.rb
@@ -40,7 +40,7 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            symbol_content = node.str_content.to_sym.inspect
+            symbol_content = node.value.to_sym.inspect
             corrector.replace(node.source_range, symbol_content)
           end
         end

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -71,7 +71,7 @@ module RuboCop
 
         def complex_content?(strings)
           strings.any? do |s|
-            string = s.str_content.dup.force_encoding(::Encoding::UTF_8)
+            string = s.value.dup.force_encoding(::Encoding::UTF_8)
             !string.valid_encoding? ||
               string !~ word_regex || string =~ / /
           end

--- a/spec/rubocop/ast/str_node_spec.rb
+++ b/spec/rubocop/ast/str_node_spec.rb
@@ -56,4 +56,31 @@ RSpec.describe RuboCop::AST::StrNode do
       it { expect(str_node.heredoc?).to be(true) }
     end
   end
+
+  describe '#value' do
+    context 'with a normal string' do
+      let(:source) { "'foo'" }
+
+      it { expect(str_node.value).to eq('foo') }
+    end
+
+    context 'with a string with interpolation' do
+      let(:source) { '"foo #{bar} baz"' }
+
+      it { expect(str_node.value).to eq('foo  baz') }
+    end
+
+    context 'with a heredoc' do
+      let(:source) do
+        <<~RUBY
+          <<-CODE
+            foo
+            bar
+          CODE
+        RUBY
+      end
+
+      it { expect(str_node.value).to eq("  foo\n  bar\n") }
+    end
+  end
 end


### PR DESCRIPTION
This is a small step in a quest to move overly generic methods from `Node` into the relevant node extensions. In this case `Node#str_content` is moved to `StrNode#value`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
