### PR TITLE
Support inline scoping of node macros

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,11 @@ Naming/PredicateName:
     - def_node_matcher
     - def_node_search
 
+Style/AccessModifierDeclarations:
+  # Our node pattern macros require inline access modifiers to be
+  # correctly scoped.
+  Enabled: false
+
 Style/FormatStringToken:
   # Because we parse a lot of source codes from strings. Percent arrays
   # look like unannotated format string tokens to this cop.

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -85,7 +85,7 @@ module RuboCop
         @mutable_attributes[:parent]
       end
 
-      def parent=(node)
+      protected def parent=(node)
         @mutable_attributes[:parent] = node
       end
 
@@ -97,8 +97,6 @@ module RuboCop
       def complete?
         @mutable_attributes.frozen?
       end
-
-      protected :parent= # rubocop:disable Style/AccessModifierDeclarations
 
       # Override `AST::Node#updated` so that `AST::Processor` does not try to
       # mutate our ASTs. Since we keep references from children to parents and
@@ -319,15 +317,12 @@ module RuboCop
         end
       end
 
-      def_node_matcher :defined_module0, <<~PATTERN
+      private def_node_matcher :defined_module0, <<~PATTERN
         {(class (const $_ $_) ...)
          (module (const $_ $_) ...)
          (casgn $_ $_        (send (const nil? {:Class :Module}) :new ...))
          (casgn $_ $_ (block (send (const nil? {:Class :Module}) :new ...) ...))}
       PATTERN
-      # rubocop:disable Style/AccessModifierDeclarations
-      private :defined_module0
-      # rubocop:enable Style/AccessModifierDeclarations
 
       def defined_module
         namespace, name = *defined_module0

--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -708,6 +708,8 @@ module RuboCop
 
         location = caller_locations(1, 1).first
         class_eval(src, location.path, location.lineno)
+
+        method_name
       end
 
       # Define a method which recurses over the descendants of an AST node,
@@ -725,6 +727,8 @@ module RuboCop
         else
           node_search_all(method_name, compiler, called_from)
         end
+
+        method_name
       end
 
       def node_search_first(method_name, compiler, called_from)

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -1607,4 +1607,18 @@ RSpec.describe RuboCop::NodePattern do
       it_behaves_like 'invalid'
     end
   end
+
+  describe 'macros' do
+    describe '#def_node_matcher' do
+      let(:macro) { RuboCop::AST::Node.method(:def_node_matcher) }
+
+      it { expect(macro.call(:foo?, 'send_type?')).to eq(:foo?) }
+    end
+
+    describe '#def_node_search' do
+      let(:macro) { RuboCop::AST::Node.method(:def_node_search) }
+
+      it { expect(macro.call(:bar?, 'send_type?')).to eq(:bar?) }
+    end
+  end
 end


### PR DESCRIPTION
This is a rather simple change, that allows inline access scoping of node macros, e.g.:

```ruby
private def_node_matcher :string?, 'str_type?'
```

Simply enabled by returning the name of the defined method from the `#def_node_matcher` and `#def_node_search` methods.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
