### PR TITLE
Fix incorrect formatting

### DIFF
--- a/lib/rubocop/cop/style/symbol_array.rb
+++ b/lib/rubocop/cop/style/symbol_array.rb
@@ -11,8 +11,8 @@ module RuboCop
       #
       # Configuration option: MinSize
       # If set, arrays with fewer elements than this value will not trigger the
-      # cop. For example, a `MinSize of `3` will not enforce a style on an array
-      # of 2 or fewer elements.
+      # cop. For example, a `MinSize` of `3` will not enforce a style on an
+      # array of 2 or fewer elements.
       #
       # @example EnforcedStyle: percent (default)
       #   # good

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -6701,8 +6701,8 @@ projects which do not want to use that syntax.
 
 Configuration option: MinSize
 If set, arrays with fewer elements than this value will not trigger the
-cop. For example, a `MinSize of `3` will not enforce a style on an array
-of 2 or fewer elements.
+cop. For example, a `MinSize` of `3` will not enforce a style on an
+array of 2 or fewer elements.
 
 ### Examples
 


### PR DESCRIPTION
The formatting was incorrect:

<img width="299" alt="image" src="https://user-images.githubusercontent.com/5748627/74038443-e1467780-49c8-11ea-89b4-d647c5364c5c.png">


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
