### PR TITLE
[Fix #7688] Support MethodCallWithArgsParentheses.new without config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#7655](https://github.com/rubocop-hq/rubocop/issues/7655): Fix an error when processing a regexp with a line break at the start of capture parenthesis. ([@koic][])
 * [#7647](https://github.com/rubocop-hq/rubocop/issues/7647): Fix an `undefined method on_numblock` error when using Ruby 2.7's numbered parameters. ([@hanachin][])
 * [#7675](https://github.com/rubocop-hq/rubocop/issues/7675): Fix a false negative for `Layout/SpaceBeforeFirstArg` when a vertical argument positions are aligned. ([@koic][])
+* [#7688](https://github.com/rubocop-hq/rubocop/issues/7688): Fix a bug in `Style/MethodCallWithArgsParentheses` that made `--auto-gen-config` crash. ([@buehmann][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/configurable_enforced_style.rb
+++ b/lib/rubocop/cop/mixin/configurable_enforced_style.rb
@@ -60,6 +60,10 @@ module RuboCop
       alias conflicting_styles_detected no_acceptable_style!
       alias unrecognized_style_detected no_acceptable_style!
 
+      def style_configured?
+        cop_config.key?(style_parameter_name)
+      end
+
       def style
         @style ||= begin
           s = cop_config[style_parameter_name].to_sym

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -150,6 +150,8 @@ module RuboCop
 
         def initialize(*)
           super
+          return unless style_configured?
+
           case style
           when :require_parentheses
             extend RequireParentheses
@@ -157,6 +159,9 @@ module RuboCop
             extend OmitParentheses
           end
         end
+
+        # @abstract Overridden in style modules
+        def autocorrect(_node); end
 
         private
 


### PR DESCRIPTION
Closes #7688. Caused by #7623.

Going forward, `Cop#support_autocorrect?` should probably be turned into
a class method.