### PR TITLE
Improve documentation for Lint/UselessSetterCall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [#7641](https://github.com/rubocop-hq/rubocop/issues/7641): **(Breaking)** Remove `Style/BracesAroundHashParameters` cop. ([@pocke][])
 * Add the method name to highlight area of `Layout/EmptyLineBetweenDefs` to help provide more context. ([@rrosenblum][])
 * [#7652](https://github.com/rubocop-hq/rubocop/pull/7652): Allow `pp` to allowed names of `Naming/MethodParameterName` cop in default config. ([@masarakki][])
+* [#7309](https://github.com/rubocop-hq/rubocop/pull/7309): Mark `Lint/UselessSetterCall` an "not safe" and improve documentation. ([@jonas054][])
 
 ## 0.79.0 (2020-01-06)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1783,6 +1783,8 @@ Lint/UselessSetterCall:
   Description: 'Checks for useless setter call to a local variable.'
   Enabled: true
   VersionAdded: '0.13'
+  VersionChanged: '0.80'
+  Safe: false
 
 Lint/Void:
   Description: 'Possible use of operator/literal/variable in void context.'

--- a/lib/rubocop/cop/lint/useless_setter_call.rb
+++ b/lib/rubocop/cop/lint/useless_setter_call.rb
@@ -6,6 +6,10 @@ module RuboCop
       # This cop checks for setter call to local variable as the final
       # expression of a function definition.
       #
+      # Note: There are edge cases in which the local variable references a
+      # value that is also accessible outside the local scope. This is not
+      # detected by the cop, and it can yield a false positive.
+      #
       # @example
       #
       #   # bad

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -2946,10 +2946,14 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.13 | -
+Enabled | No | No | 0.13 | 0.80
 
 This cop checks for setter call to local variable as the final
 expression of a function definition.
+
+Note: There are edge cases in which the local variable references a
+value that is also accessible outside the local scope. This is not
+detected by the cop, and it can yield a false positive.
 
 ### Examples
 


### PR DESCRIPTION
This closes #7309, which was an attempt to fix false positives with code. It was deemed too complex, so we're adding documentation for a, hopefully, very rare problem.

The cop configuration now marks the cop as "not safe".