### PR TITLE
Remove duplicate dependency development gem

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -42,5 +42,4 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 1.7')
 
   s.add_development_dependency('bundler', '>= 1.15.0', '< 3.0')
-  s.add_development_dependency('pry')
 end


### PR DESCRIPTION
This PR suppress the following warning.

```console
% cd path/to/rubocop
% bundle install
Your Gemfile lists the gem pry (>= 0) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once.
While it's not a problem now, it could cause errors if you change the
version of one of them later.
Using rake 12.3.3
Using public_suffix 4.0.3

(snip)
```

`pry` gem is already in the Gemfile.
This looks like it was accidentally added in #7663.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
