### PR TITLE
[Fix #7705] Fix problem of `Style/OneLineConditional` cop with elsif.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Bug fixes
 
+* [#7705](https://github.com/rubocop-hq/rubocop/issues/7705): Fix problem of one_line_conditional cop with elsif conditionals. ([@Lykos][])
 * [#7644](https://github.com/rubocop-hq/rubocop/issues/7644): Fix patterns with named wildcards in unions. ([@marcandre][])
 * [#7639](https://github.com/rubocop-hq/rubocop/pull/7639): Fix logical operator edge case in `omit_parentheses` style of `Style/MethodCallWithArgsParentheses`. ([@gsamokovarov][])
 * [#7661](https://github.com/rubocop-hq/rubocop/pull/7661): Fix to return correct info from multi-line regexp. ([@Tietew][])
@@ -4357,3 +4358,4 @@
 [@masarakki]: https://github.com/masarakki
 [@djudd]: https://github.com/djudd
 [@jemmaissroff]: https://github.com/jemmaissroff
+[@Lykos]: https://github.com/Lykos

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -350,7 +350,7 @@ This cop can be configured with the EnforcedStyleForLeadingUnderscores
 directive. It can be configured to allow for memoized instance variables
 prefixed with an underscore. Prefixing ivars with an underscore is a
 convention that is used to implicitly indicate that an ivar should not
-be set or referenced outside of the memoization method.
+be set or referencd outside of the memoization method.
 
 ### Examples
 

--- a/spec/rubocop/cop/style/one_line_conditional_spec.rb
+++ b/spec/rubocop/cop/style/one_line_conditional_spec.rb
@@ -12,6 +12,15 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional do
     end
   end
 
+  shared_examples 'multiline offense' do
+    it 'registers an offense where multiline should be used' do
+      inspect_source(source)
+      expect(cop.messages)
+        .to eq(['Use multiple lines for ' \
+                '`if/then/elsif/then/else/end` constructs.'])
+    end
+  end
+
   shared_examples 'no offense' do
     it 'does not register an offense' do
       expect_no_offenses(source)
@@ -36,6 +45,40 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional do
 
       include_examples 'no offense'
     end
+  end
+
+  context 'one line if/then/elsif/then/else/end' do
+    let(:source) { 'if cond then run elsif elscond then elsrun else dont end' }
+
+    include_examples 'multiline offense'
+    include_examples 'autocorrect', <<~RUBY.chomp
+      if cond
+        run
+      elsif elscond
+        elsrun
+      else
+        dont
+      end
+    RUBY
+  end
+
+  context 'one line if/then/elsif/then/else/end with multiple elsifs' do
+    let(:source) do
+      'if c0 then r0 elsif c1 then r1 elsif c2 then r2 else r3 end'
+    end
+
+    include_examples 'multiline offense'
+    include_examples 'autocorrect', <<~RUBY.chomp
+      if c0
+        r0
+      elsif c1
+        r1
+      elsif c2
+        r2
+      else
+        r3
+      end
+    RUBY
   end
 
   context 'one line if/then/else/end when `then` branch has no body' do


### PR DESCRIPTION
One line conditionals with elsif branches are now transformed into multiline versions. Before this change, they were broken and autocorrect produced code that resulted in a syntax error. See Issue #7705 for more details.