### PR TITLE
[Fix #7716] Fix an infinite loop error for `Style/TernaryParentheses`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#7647](https://github.com/rubocop-hq/rubocop/issues/7647): Fix an `undefined method on_numblock` error when using Ruby 2.7's numbered parameters. ([@hanachin][])
 * [#7675](https://github.com/rubocop-hq/rubocop/issues/7675): Fix a false negative for `Layout/SpaceBeforeFirstArg` when a vertical argument positions are aligned. ([@koic][])
 * [#7688](https://github.com/rubocop-hq/rubocop/issues/7688): Fix a bug in `Style/MethodCallWithArgsParentheses` that made `--auto-gen-config` crash. ([@buehmann][])
+* [#7203](https://github.com/rubocop-hq/rubocop/issues/7203): Fix an infinite loop error for `Style/TernaryParentheses` with `Style/RedundantParentheses` when using `EnforcedStyle: require_parentheses_when_complex`. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -162,7 +162,7 @@ module RuboCop
         # `RedundantParentheses` cop is enabled, it will cause an infinite loop
         # as they compete to add and remove the parentheses respectively.
         def infinite_loop?
-          require_parentheses? &&
+          (require_parentheses? || require_parentheses_when_complex?) &&
             redundant_parentheses_enabled?
         end
 

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -414,14 +414,21 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
 
   context 'when `RedundantParenthesis` would cause an infinite loop' do
     let(:redundant_parens_enabled) { true }
-    let(:cop_config) do
-      {
-        'EnforcedStyle' => 'require_parentheses',
-        'SupportedStyles' => %w[require_parentheses require_no_parentheses]
-      }
+
+    context 'when `EnforcedStyle: require_parentheses`' do
+      let(:cop_config) do
+        { 'EnforcedStyle' => 'require_parentheses' }
+      end
+
+      it_behaves_like 'code without offense', 'foo = bar? ? a : b'
     end
 
-    it_behaves_like 'code without offense',
-                    'foo = bar? ? a : b'
+    context 'when `EnforcedStyle: require_parentheses_when_complex`' do
+      let(:cop_config) do
+        { 'EnforcedStyle' => 'require_parentheses_when_complex' }
+      end
+
+      it_behaves_like 'code without offense', '!condition.nil? ? foo : bar'
+    end
   end
 end


### PR DESCRIPTION
Fix #7716.

This PR fixes an infinite loop error for `Style/TernaryParentheses` with `Style/RedundantParentheses` when using `EnforcedStyle: require_parentheses_when_complex`.

```ruby
# example.rb
!foo.nil? ? 1 : 2
```

```yaml
# .rubocop.yml
Style/TernaryParentheses:
  EnforcedStyle: require_parentheses_when_complex
```

First, auto-corrected by `Style/TernaryParentheses` (`EnforcedStyle: require_parentheses_when_complex`).

```console
% bundle exec rubocop -a --only Style/TernaryParentheses

Offenses:

example.rb:2:1: C: [Corrected] Style/TernaryParentheses: Use parentheses
for ternary expressions with complex conditions.
!foo.nil? ? 1 : 2
^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
```

```diff
% git diff example.rb
diff --git a/7716/example.rb b/7716/example.rb
index ae08c67..31212d8 100644
--- a/7716/example.rb
+++ b/7716/example.rb
@@ -1,2 +1,2 @@
 # example.rb
 -!foo.nil? ? 1 : 2
 +(!foo.nil?) ? 1 : 2
```

Next, auto-corrected by `Style/RedundantParentheses`.

```console
% bundle exec rubocop -a --only Style/RedundantParentheses

Offenses:

example.rb:2:1: C: [Corrected] Style/RedundantParentheses: Don't use
parentheses around an unary operation.
(!foo.nil?) ? 1 : 2
^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
```

This will return to the original code.

```diff
% git diff example.rb
diff --git a/7716/example.rb b/7716/example.rb
index 31212d8..ae08c67 100644
--- a/7716/example.rb
+++ b/7716/example.rb
@@ -1,2 +1,2 @@
 # example.rb
 -(!foo.nil?) ? 1 : 2
 +!foo.nil? ? 1 : 2
```

That caused the infinite loop in `Style/TernaryParentheses` (`EnforcedStyle: require_parentheses_when_complex`) and `Style/RedundantParentheses`.

With this PR, `Style/TernaryParentheses` cop makes aware of `Style/RedundantParentheses` cop when setting `EnforcedStyle: require_parentheses_when_complex`.

This does the same thing as `EnforcedStyle: require_parentheses` for infinite loop error.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
