### PR TITLE
[Fix #7712] Fix an incorrect autocorrect for `Style/OrAssignment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#7688](https://github.com/rubocop-hq/rubocop/issues/7688): Fix a bug in `Style/MethodCallWithArgsParentheses` that made `--auto-gen-config` crash. ([@buehmann][])
 * [#7203](https://github.com/rubocop-hq/rubocop/issues/7203): Fix an infinite loop error for `Style/TernaryParentheses` with `Style/RedundantParentheses` when using `EnforcedStyle: require_parentheses_when_complex`. ([@koic][])
 * [#7708](https://github.com/rubocop-hq/rubocop/issues/7708): Make it possible to use EOL `rubocop:disable` comments on comment lines. ([@jonas054][])
+* [#7712](https://github.com/rubocop-hq/rubocop/issues/7712): Fix an incorrect autocorrect for `Style/OrAssignment` when using `elsif` branch. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/or_assignment.rb
+++ b/lib/rubocop/cop/style/or_assignment.rb
@@ -34,7 +34,7 @@ module RuboCop
             (if
               ({lvar ivar cvar gvar} _var)
               ({lvar ivar cvar gvar} _var)
-              _))
+              $_))
         PATTERN
 
         def_node_matcher :unless_assignment?, <<~PATTERN
@@ -51,7 +51,8 @@ module RuboCop
         end
 
         def on_lvasgn(node)
-          return unless ternary_assignment?(node)
+          return unless (else_branch = ternary_assignment?(node))
+          return if else_branch.if_type?
 
           add_offense(node)
         end

--- a/spec/rubocop/cop/style/or_assignment_spec.rb
+++ b/spec/rubocop/cop/style/or_assignment_spec.rb
@@ -321,4 +321,18 @@ RSpec.describe RuboCop::Cop::Style::OrAssignment do
       RUBY
     end
   end
+
+  context 'when using `elsif` statement' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        foo = if foo
+                foo
+              elsif
+                bar
+              else
+                'default'
+              end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #7712.

This PR fixes an incorrect autocorrect for `Style/OrAssignment` when using `elsif` branch.

The following is a reproduction procedure.

```ruby
% cat example.rb
foo = if foo
        foo
      elsif
        bar
      else
        'default'
      end
```

It is changed to the code with syntax error as follows.

```console
% bundle exec rubocop -a --only Style/OrAssignment
(snip)

% cat example.rb
foo ||= elsif
          bar
        else
         'default'

% ruby -c example.rb
example.rb:1: syntax error, unexpected `elsif'
foo ||= elsif
```

The or assignment operator replaced when using `elsif` branch is complicated.
The PR will accept the above case without offense.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
