### PR TITLE
[Fix #7708] Support EOL disable comments on comment lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#7675](https://github.com/rubocop-hq/rubocop/issues/7675): Fix a false negative for `Layout/SpaceBeforeFirstArg` when a vertical argument positions are aligned. ([@koic][])
 * [#7688](https://github.com/rubocop-hq/rubocop/issues/7688): Fix a bug in `Style/MethodCallWithArgsParentheses` that made `--auto-gen-config` crash. ([@buehmann][])
 * [#7203](https://github.com/rubocop-hq/rubocop/issues/7203): Fix an infinite loop error for `Style/TernaryParentheses` with `Style/RedundantParentheses` when using `EnforcedStyle: require_parentheses_when_complex`. ([@koic][])
+* [#7708](https://github.com/rubocop-hq/rubocop/issues/7708): Make it possible to use EOL `rubocop:disable` comments on comment lines. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -113,13 +113,18 @@ module RuboCop
     def each_mentioned_cop
       each_directive do |comment, cop_names, disabled|
         comment_line_number = comment.loc.expression.line
-        single_line = !comment_only_line?(comment_line_number)
+        single_line = !comment_only_line?(comment_line_number) ||
+                      directive_on_comment_line?(comment)
 
         cop_names.each do |cop_name|
           yield qualified_cop_name(cop_name), disabled, comment_line_number,
                 single_line
         end
       end
+    end
+
+    def directive_on_comment_line?(comment)
+      comment.text[1..-1].match(COMMENT_DIRECTIVE_REGEXP)
     end
 
     def each_directive

--- a/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-# The Lint/RedundantCopEnableDirective cop needs to be disabled so as
-# to be able to provide a (bad) example of an unneeded enable.
+# The Lint/RedundantCopEnableDirective and Lint/RedundantCopDisableDirective
+# cops need to be disabled so as to be able to provide a (bad) example of an
+# unneeded enable.
 
 # rubocop:disable Lint/RedundantCopEnableDirective
+# rubocop:disable Lint/RedundantCopDisableDirective
 module RuboCop
   module Cop
     module Lint
@@ -21,15 +23,15 @@ module RuboCop
       #   foo = 1
       # @example
       #   # bad
-      #   # rubocop:disable Layout/LineLength
-      #   baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarrrrrrrrrrrrr
-      #   # rubocop:enable Layout/LineLength
+      #   # rubocop:disable Style/StringLiterals
+      #   foo = "1"
+      #   # rubocop:enable Style/StringLiterals
       #   baz
       #   # rubocop:enable all
       #
       #   # good
-      #   # rubocop:disable Layout/LineLength
-      #   baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarrrrrrrrrrrrr
+      #   # rubocop:disable Style/StringLiterals
+      #   foo = "1"
       #   # rubocop:enable all
       #   baz
       class RedundantCopEnableDirective < Cop
@@ -112,3 +114,6 @@ module RuboCop
     end
   end
 end
+
+# rubocop:enable Lint/RedundantCopDisableDirective
+# rubocop:enable Lint/RedundantCopEnableDirective

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -585,6 +585,13 @@ comment.
 for x in (0..19) # rubocop:disable Style/For
 ```
 
+If you want to disable a cop that inspects comments, you can do so by
+adding an "inner comment" on the comment line.
+
+```ruby
+# coding: utf-8 # rubocop:disable Style/Encoding
+```
+
 Running `rubocop --[safe-]auto-correct --disable-uncorrectable` will
 create comments to disable all offenses that can't be automatically
 corrected.

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1593,15 +1593,15 @@ foo = 1
 ```
 ```ruby
 # bad
-# rubocop:disable Layout/LineLength
-baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarrrrrrrrrrrrr
-# rubocop:enable Layout/LineLength
+# rubocop:disable Style/StringLiterals
+foo = "1"
+# rubocop:enable Style/StringLiterals
 baz
 # rubocop:enable all
 
 # good
-# rubocop:disable Layout/LineLength
-baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarrrrrrrrrrrrr
+# rubocop:disable Style/StringLiterals
+foo = "1"
 # rubocop:enable all
 baz
 ```

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -54,7 +54,9 @@ RSpec.describe RuboCop::CommentConfig do
         '"result is #{}"',
         '# rubocop:enable Lint/EmptyInterpolation',
         '# rubocop:disable RSpec/Example',
-        '# rubocop:disable Custom2/Number9'                  # 48
+        '# rubocop:disable Custom2/Number9',                 # 48
+        '',
+        '#=SomeDslDirective # rubocop:disable Layout/LeadingCommentSpace'
       ].join("\n")
     end
 
@@ -161,6 +163,11 @@ RSpec.describe RuboCop::CommentConfig do
 
     it 'supports disabling cops with numbers in their name' do
       expect(disabled_lines_of_cop('Custom2/Number9')).to include(48)
+    end
+
+    it 'supports disabling cops on a comment line with an EOL comment' do
+      expect(disabled_lines_of_cop('Layout/LeadingCommentSpace'))
+        .to eq([7, 8, 9, 50])
     end
   end
 end


### PR DESCRIPTION
A hash mark `#` on a comment line doesn't start a new comment, so we have to pretend that it does in order to support disabling of cops on a single comment line.