### PR TITLE
[Fix #7719] Fix `Style/NestedParenthesizedCalls` cop for newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#7719](https://github.com/rubocop-hq/rubocop/issues/7719): Fix `Style/NestedParenthesizedCalls` cop for newline. ([@tejasbubane][])
+
 ## 0.80.0 (2020-02-18)
 
 ### New features

--- a/lib/rubocop/cop/style/nested_parenthesized_calls.rb
+++ b/lib/rubocop/cop/style/nested_parenthesized_calls.rb
@@ -35,8 +35,8 @@ module RuboCop
           last_arg = nested.last_argument.source_range
 
           leading_space =
-            range_with_surrounding_space(range: first_arg,
-                                         side: :left).begin.resize(1)
+            range_with_surrounding_space(range: first_arg.begin,
+                                         side: :left)
 
           lambda do |corrector|
             corrector.replace(leading_space, '(')

--- a/spec/rubocop/cop/style/nested_parenthesized_calls_spec.rb
+++ b/spec/rubocop/cop/style/nested_parenthesized_calls_spec.rb
@@ -100,4 +100,18 @@ RSpec.describe RuboCop::Cop::Style::NestedParenthesizedCalls do
       expect_no_offenses('expect(object1.attr = 1).to eq 1')
     end
   end
+
+  context 'backslash newline in method call' do
+    let(:source) do
+      <<~RUBY
+        puts(nex \
+               5)
+      RUBY
+    end
+
+    it 'auto-corrects by adding parentheses' do
+      new_source = autocorrect_source(source.strip)
+      expect(new_source).to eq('puts(nex(5))')
+    end
+  end
 end


### PR DESCRIPTION
Closes https://github.com/rubocop-hq/rubocop/issues/7719

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/