### PR TITLE
[Fix #7682] Fix `Style/InverseMethods` autofix leaving parenthesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#7719](https://github.com/rubocop-hq/rubocop/issues/7719): Fix `Style/NestedParenthesizedCalls` cop for newline. ([@tejasbubane][])
 * [#7709](https://github.com/rubocop-hq/rubocop/issues/7709): Fix correction of `Style/RedundantCondition` when the else branch contains a range. ([@rrosenblum][])
+* [#7682](https://github.com/rubocop-hq/rubocop/issues/7682): Fix `Style/InverseMethods` autofix leaving parenthesis. ([@tejasbubane][])
 
 ## 0.80.0 (2020-02-18)
 

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -109,10 +109,7 @@ module RuboCop
             corrector.remove(not_to_receiver(node, method_call))
             corrector.replace(method_call.loc.selector,
                               inverse_methods[method].to_s)
-
-            if EQUALITY_METHODS.include?(method)
-              corrector.remove(end_parentheses(node, method_call))
-            end
+            remove_end_parenthesis(corrector, node, method, method_call)
           end
         end
 
@@ -186,6 +183,13 @@ module RuboCop
 
         def dot_range(loc)
           range_between(loc.dot.begin_pos, loc.expression.end_pos)
+        end
+
+        def remove_end_parenthesis(corrector, node, method, method_call)
+          return unless EQUALITY_METHODS.include?(method) ||
+                        method_call.parent.begin_type?
+
+          corrector.remove(end_parentheses(node, method_call))
         end
       end
     end

--- a/spec/rubocop/cop/style/inverse_methods_spec.rb
+++ b/spec/rubocop/cop/style/inverse_methods_spec.rb
@@ -76,6 +76,12 @@ RSpec.describe RuboCop::Cop::Style::InverseMethods do
 
       expect(new_source).to eq('foo.any? { |f| f.even? }')
     end
+
+    it 'corrects inverse any? inside parens' do
+      new_source = autocorrect_source('!(foo.any? &:working?)')
+
+      expect(new_source).to eq('foo.none? &:working?')
+    end
   end
 
   shared_examples 'all variable types' do |variable|


### PR DESCRIPTION
Closes https://github.com/rubocop-hq/rubocop/issues/7682

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/