### PR TITLE
Remove a print debug code

### DIFF
--- a/lib/rubocop/cop/mixin/hash_transform_method.rb
+++ b/lib/rubocop/cop/mixin/hash_transform_method.rb
@@ -51,7 +51,6 @@ module RuboCop
       end
 
       def handle_possible_offense(node, match, match_desc)
-        puts node.class
         captures = extract_captures(match)
 
         # If key didn't actually change either, this is most likely a false


### PR DESCRIPTION
Follow up of https://github.com/rubocop-hq/rubocop/pull/7663/files#r381151515.

This PR removes a print debug code.

It would be better if print debug could be detected by project automation in the future.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
