### PR TITLE
7709 redundant condition range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#7719](https://github.com/rubocop-hq/rubocop/issues/7719): Fix `Style/NestedParenthesizedCalls` cop for newline. ([@tejasbubane][])
+* [#7709](https://github.com/rubocop-hq/rubocop/issues/7709): Fix correction of `Style/RedundantCondition` when the else branch contains a range. ([@rrosenblum][])
 
 ## 0.80.0 (2020-02-18)
 

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -96,6 +96,22 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition do
           RUBY
         end
       end
+
+      it 'registers an offense and corrects when the else branch ' \
+        'contains an irange' do
+        expect_offense(<<~RUBY)
+          if foo
+          ^^^^^^ Use double pipes `||` instead.
+            foo
+          else
+            1..2
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo || (1..2)
+        RUBY
+      end
     end
 
     describe '#autocorrection' do
@@ -199,6 +215,30 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition do
         expect_offense(<<~RUBY)
           b ? b : c
             ^^^^^ Use double pipes `||` instead.
+        RUBY
+      end
+
+      it 'registers an offense and corrects when the else branch ' \
+        'contains an irange' do
+        expect_offense(<<~RUBY)
+          time_period = updated_during ? updated_during : 2.days.ago..Time.now
+                                       ^^^^^^^^^^^^^^^^^^ Use double pipes `||` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          time_period = updated_during || (2.days.ago..Time.now)
+        RUBY
+      end
+
+      it 'registers an offense and corrects when the else branch ' \
+        'contains an erange' do
+        expect_offense(<<~RUBY)
+          time_period = updated_during ? updated_during : 2.days.ago...Time.now
+                                       ^^^^^^^^^^^^^^^^^^ Use double pipes `||` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          time_period = updated_during || (2.days.ago...Time.now)
         RUBY
       end
     end

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition do
   subject(:cop) { described_class.new }
 
   context 'when regular condition (if)' do
-    it 'registers no offense' do
+    it 'accepts different when the condition does not match the branch' do
       expect_no_offenses(<<~RUBY)
         if a
           b
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition do
       RUBY
     end
 
-    it 'registers no offense for elsif' do
+    it 'accepts elsif' do
       expect_no_offenses(<<~RUBY)
         if a
           b
@@ -27,7 +27,52 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition do
     end
 
     context 'when condition and if_branch are same' do
-      it 'registers an offense' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          if b
+          ^^^^ Use double pipes `||` instead.
+            b
+          else
+            c
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          b || c
+        RUBY
+      end
+
+      it 'registers an offense and corrects complex one liners' do
+        expect_offense(<<~RUBY)
+          if b
+          ^^^^ Use double pipes `||` instead.
+            b
+          else
+            (c || d)
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          b || (c || d)
+        RUBY
+      end
+
+      it 'registers an offense and corrects modifier nodes offense' do
+        expect_offense(<<~RUBY)
+          if b
+          ^^^^ Use double pipes `||` instead.
+            b
+          else
+            c while d
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          b || (c while d)
+        RUBY
+      end
+
+      it 'registers an offense and corrects multiline nodes' do
         expect_offense(<<~RUBY)
           if b
           ^^^^ Use double pipes `||` instead.
@@ -37,64 +82,83 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition do
               z)
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          b || y(x,
+              z)
+        RUBY
       end
 
-      context 'when else_branch is complex' do
-        it 'registers no offense' do
-          expect_no_offenses(<<~RUBY)
-            if b
-              b
-            else
-              c
-              d
-            end
-          RUBY
-        end
+      it 'auto-corrects when using `<<` method higher precedence ' \
+         'than `||` operator' do
+        expect_offense(<<~RUBY)
+          ary << if foo
+                 ^^^^^^ Use double pipes `||` instead.
+                   foo
+                 else
+                   bar
+                 end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          ary << (foo || bar)
+        RUBY
       end
 
-      context 'when using elsif branch' do
-        it 'registers no offense' do
-          expect_no_offenses(<<~RUBY)
-            if a
-              a
-            elsif cond
-              d
-            end
-          RUBY
-        end
+      it 'accepts complex else branches' do
+        expect_no_offenses(<<~RUBY)
+          if b
+            b
+          else
+            c
+            d
+          end
+        RUBY
       end
 
-      context 'when using modifier if' do
-        it 'registers an offense' do
-          expect_offense(<<~RUBY)
-            bar if bar
-            ^^^^^^^^^^ This condition is not needed.
-          RUBY
-        end
+      it 'accepts an elsif branch' do
+        expect_no_offenses(<<~RUBY)
+          if a
+            a
+          elsif cond
+            d
+          end
+        RUBY
       end
 
-      context 'when `if` condition and `then` branch are the same ' \
-              'and it has no `else` branch' do
-        it 'registers an offense' do
-          expect_offense(<<~RUBY)
-            if do_something
-            ^^^^^^^^^^^^^^^ This condition is not needed.
-              do_something
-            end
-          RUBY
-        end
+      it 'registers an offense and corrects when using modifier if' do
+        expect_offense(<<~RUBY)
+          bar if bar
+          ^^^^^^^^^^ This condition is not needed.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          bar
+        RUBY
       end
 
-      context 'when using ternary if in `else` branch' do
-        it 'registers no offense' do
-          expect_no_offenses(<<~RUBY)
-            if a
-              a
-            else
-              b ? c : d
-            end
-          RUBY
-        end
+      it 'registers an offense and corrects when `if` condition and `then` ' \
+        'branch are the same and it has no `else` branch' do
+        expect_offense(<<~RUBY)
+          if do_something
+          ^^^^^^^^^^^^^^^ This condition is not needed.
+            do_something
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          do_something
+        RUBY
+      end
+
+      it 'accepts when using ternary if in `else` branch' do
+        expect_no_offenses(<<~RUBY)
+          if a
+            a
+          else
+            b ? c : d
+          end
+        RUBY
       end
 
       it 'registers an offense and corrects when the else branch ' \
@@ -113,108 +177,55 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition do
         RUBY
       end
     end
-
-    describe '#autocorrection' do
-      it 'auto-corrects offense' do
-        new_source = autocorrect_source(<<~RUBY)
-          if b
-            b
-          else
-            c
-          end
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          b || c
-        RUBY
-      end
-
-      it 'auto-corrects multiline sendNode offense' do
-        new_source = autocorrect_source(<<~RUBY)
-          if b
-            b
-          else
-            y(x,
-              z)
-          end
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          b || y(x,
-              z)
-        RUBY
-      end
-
-      it 'auto-corrects one-line node offense' do
-        new_source = autocorrect_source(<<~RUBY)
-          if b
-            b
-          else
-            (c || d)
-          end
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          b || (c || d)
-        RUBY
-      end
-
-      it 'auto-corrects modifier nodes offense' do
-        new_source = autocorrect_source(<<~RUBY)
-          if b
-            b
-          else
-            c while d
-          end
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          b || (c while d)
-        RUBY
-      end
-
-      it 'auto-corrects modifer if statements' do
-        new_source = autocorrect_source('bar if bar')
-
-        expect(new_source).to eq('bar')
-      end
-
-      it 'auto-corrects when using `<<` method higher precedence ' \
-         'than `||` operator' do
-        new_source = autocorrect_source(<<~RUBY)
-          ary << if foo
-                   foo
-                 else
-                   bar
-                 end
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          ary << (foo || bar)
-        RUBY
-      end
-
-      it 'when `if` condition and `then` branch are the same ' \
-         'and it has no `else` branch' do
-        new_source = autocorrect_source(<<~RUBY)
-          if do_something
-            do_something
-          end
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          do_something
-        RUBY
-      end
-    end
   end
 
-  context 'when ternary expression (?:)' do
-    it 'registers no offense' do
+  context 'ternary expression (?:)' do
+    it 'accepts expressions when the condition and if branch do not match' do
       expect_no_offenses('b ? d : c')
     end
 
     context 'when condition and if_branch are same' do
-      it 'registers an offense' do
+      it 'registers an offense and corrects' do
         expect_offense(<<~RUBY)
           b ? b : c
             ^^^^^ Use double pipes `||` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          b || c
+        RUBY
+      end
+
+      it 'registers an offense and corrects nested vars' do
+        expect_offense(<<~RUBY)
+          b.x ? b.x : c
+              ^^^^^^^ Use double pipes `||` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          b.x || c
+        RUBY
+      end
+
+      it 'registers an offense and corrects class vars' do
+        expect_offense(<<~RUBY)
+          @b ? @b : c
+             ^^^^^^ Use double pipes `||` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          @b || c
+        RUBY
+      end
+
+      it 'registers an offense and corrects functions' do
+        expect_offense(<<~RUBY)
+          a = b(x) ? b(x) : c
+                   ^^^^^^^^ Use double pipes `||` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a = b(x) || c
         RUBY
       end
 
@@ -242,28 +253,6 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition do
         RUBY
       end
     end
-
-    describe '#autocorrection' do
-      it 'auto-corrects vars' do
-        new_source = autocorrect_source('a = b ? b : c')
-        expect(new_source).to eq('a = b || c')
-      end
-
-      it 'auto-corrects nested vars' do
-        new_source = autocorrect_source('b.x ? b.x : c')
-        expect(new_source).to eq('b.x || c')
-      end
-
-      it 'auto-corrects class vars' do
-        new_source = autocorrect_source('@b ? @b : c')
-        expect(new_source).to eq('@b || c')
-      end
-
-      it 'auto-corrects functions' do
-        new_source = autocorrect_source('a = b(x) ? b(x) : c')
-        expect(new_source).to eq('a = b(x) || c')
-      end
-    end
   end
 
   context 'when inverted condition (unless)' do
@@ -287,33 +276,20 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition do
             b
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          b || y(x, z)
+        RUBY
       end
 
-      context 'when unless branch is complex' do
-        it 'registers no offense' do
-          expect_no_offenses(<<~RUBY)
-            unless b
-              c
-              d
-            else
-              b
-            end
-          RUBY
-        end
-      end
-    end
-
-    describe '#autocorrection' do
-      it 'auto-corrects offense' do
-        new_source = autocorrect_source(<<~RUBY)
+      it 'accepts complex unless branches' do
+        expect_no_offenses(<<~RUBY)
           unless b
             c
+            d
           else
             b
           end
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          b || c
         RUBY
       end
     end


### PR DESCRIPTION
This fixes #7709. The solution is to wrap the range in parentheses. This did make me wonder whether it would be valuable to have a lint cop that checks for double pipe or followed by a range.