### PR TITLE
[Fix #7739] Allow methods raising NotImplementedError in `Lint/UnusedMethodArgument`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#7331](https://github.com/rubocop-hq/rubocop/issues/7331): Add `forbidden` option to `Style/ModuleFunction` cop. ([@weh][])
 * [#7699](https://github.com/rubocop-hq/rubocop/pull/7699): Add new `Lint/StructNewOverride` cop. ([@ybiquitous][])
 * [#7809](https://github.com/rubocop-hq/rubocop/pull/7809): Add auto-correction for `Style/EndBlock` cop. ([@tejasbubane][])
+* [#7739](https://github.com/rubocop-hq/rubocop/pull/7739): Add `IgnoreNotImplementedMethods` configuration to `Lint/UnusedMethodArgument`. ([@tejasbubane][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1768,9 +1768,10 @@ Lint/UnusedMethodArgument:
   StyleGuide: '#underscore-unused-vars'
   Enabled: true
   VersionAdded: '0.21'
-  VersionChanged: '0.35'
+  VersionChanged: '0.81'
   AllowUnusedKeywordArguments: false
   IgnoreEmptyMethods: true
+  IgnoreNotImplementedMethods: true
 
 Lint/UriEscapeUnescape:
   Description: >-

--- a/lib/rubocop/cop/lint/unused_method_argument.rb
+++ b/lib/rubocop/cop/lint/unused_method_argument.rb
@@ -38,8 +38,33 @@ module RuboCop
       #   def do_something(unused)
       #   end
       #
+      # @example IgnoreNotImplementedMethods: true (default)
+      #   # good
+      #   def do_something(unused)
+      #     raise NotImplementedError
+      #   end
+      #
+      #   def do_something_else(unused)
+      #     fail "TODO"
+      #   end
+      #
+      # @example IgnoreNotImplementedMethods: false
+      #   # bad
+      #   def do_something(unused)
+      #     raise NotImplementedError
+      #   end
+      #
+      #   def do_something_else(unused)
+      #     fail "TODO"
+      #   end
+      #
       class UnusedMethodArgument < Cop
         include UnusedArgument
+
+        def_node_matcher :not_implemented?, <<~PATTERN
+          {(send nil? :raise (const nil? :NotImplementedError))
+           (send nil? :fail ...)}
+        PATTERN
 
         def autocorrect(node)
           UnusedArgCorrector.correct(processed_source, node)
@@ -51,14 +76,15 @@ module RuboCop
           return unless variable.method_argument?
           return if variable.keyword_argument? &&
                     cop_config['AllowUnusedKeywordArguments']
-
-          if cop_config['IgnoreEmptyMethods']
-            body = variable.scope.node.body
-
-            return if body.nil?
-          end
+          return if ignored_method?(variable.scope.node.body)
 
           super
+        end
+
+        def ignored_method?(body)
+          cop_config['IgnoreEmptyMethods'] && body.nil? ||
+            cop_config['IgnoreNotImplementedMethods'] &&
+              not_implemented?(body)
         end
 
         def message(variable)

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -2636,7 +2636,7 @@ AllowUnusedKeywordArguments | `false` | Boolean
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.21 | 0.35
+Enabled | Yes | Yes  | 0.21 | 0.81
 
 This cop checks for unused method arguments.
 
@@ -2683,6 +2683,30 @@ end
 def do_something(unused)
 end
 ```
+#### IgnoreNotImplementedMethods: true (default)
+
+```ruby
+# good
+def do_something(unused)
+  raise NotImplementedError
+end
+
+def do_something_else(unused)
+  fail "TODO"
+end
+```
+#### IgnoreNotImplementedMethods: false
+
+```ruby
+# bad
+def do_something(unused)
+  raise NotImplementedError
+end
+
+def do_something_else(unused)
+  fail "TODO"
+end
+```
 
 ### Configurable attributes
 
@@ -2690,6 +2714,7 @@ Name | Default value | Configurable values
 --- | --- | ---
 AllowUnusedKeywordArguments | `false` | Boolean
 IgnoreEmptyMethods | `true` | Boolean
+IgnoreNotImplementedMethods | `true` | Boolean
 
 ### References
 


### PR DESCRIPTION
Closes #7739

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/