### PR TITLE
Add missing "Versioning" doc to the manual

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ pages:
 - Contributing: contributing.md
 - Development: development.md
 - Node Pattern: node_pattern.md
+- Versioning: versioning.md
 - Cops Documentation:
     - Layout Cops: cops_layout.md
     - Linting Cops: cops_lint.md


### PR DESCRIPTION
Right now https://docs.rubocop.org/en/latest/versioning.md gives 404
error. It is fixed by adding the "Versioning" doc to list of documents.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
