### PR TITLE
Remove spurious "and" from the versioning doc

### DIFF
--- a/manual/versioning.md
+++ b/manual/versioning.md
@@ -4,6 +4,6 @@ RuboCop is stable between major versions, both in terms of API and cops.
 
 New cops introduced between major versions are set to a special pending
 status and are not enabled by default. A warning is emitted if such cops
-and are not explicitly enabled or disabled in the user configuration.
+are not explicitly enabled or disabled in the user configuration.
 
 On major version updates, pending cops are enabled in bulk.


### PR DESCRIPTION
**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
