### PR TITLE
Fix  Node Pattern documentation

### DIFF
--- a/manual/node_pattern.md
+++ b/manual/node_pattern.md
@@ -230,6 +230,7 @@ For example, the previous example is basically the same as:
 
 ```
 (pair ^^hash $_value)
+```
 
 ## `` ` `` for descendants
 


### PR DESCRIPTION
There was an unclosed code block that was messing up everything below "` for descendants"

[This is the documentation](https://docs.rubocop.org/en/latest/node_pattern/#using-node-matcher-macros)

And it looks like:

<img width="761" alt="Screen Shot 2020-02-23 at 12 54 17 PM" src="https://user-images.githubusercontent.com/104916/75118909-a769a800-563b-11ea-9b40-e09b2ce2ad50.png">
