### PR TITLE
Add `VersionAdded` to Style/HashTransformKeys, Style/HashTransformValues

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -2820,11 +2820,13 @@ Style/HashSyntax:
 Style/HashTransformKeys:
   Description: 'Prefer `transform_keys` over `each_with_object` and `map`.'
   Enabled: 'pending'
+  VersionAdded: '0.80'
   Safe: false
 
 Style/HashTransformValues:
   Description: 'Prefer `transform_values` over `each_with_object` and `map`.'
   Enabled: 'pending'
+  VersionAdded: '0.80'
   Safe: false
 
 Style/IdenticalConditionalBranches:

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2532,7 +2532,7 @@ PreferHashRocketsForNonAlnumEndingSymbols | `false` | Boolean
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Pending | No | Yes (Unsafe) | - | -
+Pending | No | Yes (Unsafe) | 0.80 | -
 
 This cop looks for uses of `_.each_with_object({}) {...}`,
 `_.map {...}.to_h`, and `Hash[_.map {...}]` that are actually just
@@ -2562,7 +2562,7 @@ This cop should only be enabled on Ruby version 2.5 or newer
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Pending | No | Yes (Unsafe) | - | -
+Pending | No | Yes (Unsafe) | 0.80 | -
 
 This cop looks for uses of `_.each_with_object({}) {...}`,
 `_.map {...}.to_h`, and `Hash[_.map {...}]` that are actually just


### PR DESCRIPTION
This PR added `VersionAdded` to `Style/HashTransformKeys` and `Style/HashTransformValue`.
This Cops was added at #7663 and published at 0.80.0.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
