### PR TITLE
[Fix #7745] Suppress pending cop warnings when department is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#7719](https://github.com/rubocop-hq/rubocop/issues/7719): Fix `Style/NestedParenthesizedCalls` cop for newline. ([@tejasbubane][])
 * [#7709](https://github.com/rubocop-hq/rubocop/issues/7709): Fix correction of `Style/RedundantCondition` when the else branch contains a range. ([@rrosenblum][])
 * [#7682](https://github.com/rubocop-hq/rubocop/issues/7682): Fix `Style/InverseMethods` autofix leaving parenthesis. ([@tejasbubane][])
+* [#7745](https://github.com/rubocop-hq/rubocop/issues/7745): Suppress a pending cop warnings when pending cop's department is disabled. ([@koic][])
 
 ## 0.80.0 (2020-02-18)
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -117,11 +117,8 @@ module RuboCop
       end
 
       def warn_on_pending_cops(config)
-        pending_cops = config.keys.select do |key|
-          config[key]['Enabled'] == 'pending'
-        end
-
-        return if pending_cops.none?
+        pending_cops = config.pending_cops
+        return if pending_cops.empty?
 
         warn Rainbow('The following cops were added to RuboCop, but are not ' \
                      'configured. Please set Enabled to either `true` or ' \


### PR DESCRIPTION
Fixes #7745.

This PR suppresses a pending cop warnings when pending cop's department is disabled.

## Context

```console
% rubocop -V
0.80.0 (using Parser 2.7.0.2, running on ruby 2.7.0 x86_64-darwin17)
```

```yaml
% cat .rubocop.yml
Style:
  Enabled: false
```

## Before

The following pending cop warning is displayed for disabled Style department.

```console
% bundle exec rubocop
The following cops were added to RuboCop, but are not configured. Please
set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Style/HashEachMethods
 - Style/HashTransformKeys
 - Style/HashTransformValues
Inspecting 0 files

0 files inspected, no offenses detected
```

## After

A pending cop warning is not displayed for disabled Style department.

```console
% bundle exec rubocop
Inspecting 0 files

0 files inspected, no offenses detected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
