### PR TITLE
[Fix #7759] Fix an error for `Layout/LineLength`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#7709](https://github.com/rubocop-hq/rubocop/issues/7709): Fix correction of `Style/RedundantCondition` when the else branch contains a range. ([@rrosenblum][])
 * [#7682](https://github.com/rubocop-hq/rubocop/issues/7682): Fix `Style/InverseMethods` autofix leaving parenthesis. ([@tejasbubane][])
 * [#7745](https://github.com/rubocop-hq/rubocop/issues/7745): Suppress a pending cop warnings when pending cop's department is disabled. ([@koic][])
+* [#7759](https://github.com/rubocop-hq/rubocop/issues/7759): Fix an error for `Layout/LineLength` cop when using lambda syntax that argument is not enclosed in parentheses. ([@koic][])
 
 ## 0.80.0 (2020-02-18)
 

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -131,7 +131,7 @@ module RuboCop
         end
 
         def breakable_block_range(block_node)
-          if block_node.arguments?
+          if block_node.arguments? && !block_node.lambda?
             block_node.arguments.loc.end
           else
             block_node.loc.begin

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -791,6 +791,36 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           RUBY
         end
       end
+
+      context 'lambda syntax' do
+        context 'when argument is enclosed in parentheses' do
+          it 'registers an offense and corrects' do
+            expect_offense(<<~RUBY)
+              ->(x) { fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo }
+                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [70/40]
+            RUBY
+
+            expect_correction(<<~RUBY)
+              ->(x) {
+               fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo }
+            RUBY
+          end
+        end
+
+        context 'when argument is not enclosed in parentheses' do
+          it 'registers an offense and corrects' do
+            expect_offense(<<~RUBY)
+              -> x { foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo }
+                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [70/40]
+            RUBY
+
+            expect_correction(<<~RUBY)
+              -> x {
+               foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo }
+            RUBY
+          end
+        end
+      end
     end
 
     context 'semicolon' do


### PR DESCRIPTION
Fixes #7759.

This PR fixes the following error for `Layout/LineLength` cop when using lambda syntax that argument is not enclosed in parentheses.

```ruby
% cat example.rb
-> x {}
```

```console
% bundle exec rubocop --only Layout/LineLength -d
(snip)

An error occurred while Layout/LineLength cop was inspecting
/Users/koic/src/github.com/koic/rubocop-issues/7759/example.rb:1:0.
undefined method `begin_pos' for nil:NilClass
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/layout/line_length.rb:127:in
`check_for_breakable_block'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/layout/line_length.rb:71:in
`on_block'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/commissioner.rb:57:in
`block (2 levels) in trigger_responding_cops'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/commissioner.rb:136:in
`with_cop_error_handling'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
