### PR TITLE
[Fix #7740] Make `Style/AccessModifierDeclarations` not flag symbol method-name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#7699](https://github.com/rubocop-hq/rubocop/pull/7699): Add new `Lint/StructNewOverride` cop. ([@ybiquitous][])
 * [#7809](https://github.com/rubocop-hq/rubocop/pull/7809): Add auto-correction for `Style/EndBlock` cop. ([@tejasbubane][])
 * [#7739](https://github.com/rubocop-hq/rubocop/pull/7739): Add `IgnoreNotImplementedMethods` configuration to `Lint/UnusedMethodArgument`. ([@tejasbubane][])
+* [#7740](https://github.com/rubocop-hq/rubocop/issues/7740): Add `AllowModifiersOnSymbols` configuration to `Style/AccessModifierDeclarations`. ([@tejasbubane][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -2212,10 +2212,12 @@ Style/AccessModifierDeclarations:
   Description: 'Checks style of how access modifiers are used.'
   Enabled: true
   VersionAdded: '0.57'
+  VersionChanged: '0.81'
   EnforcedStyle: group
   SupportedStyles:
     - inline
     - group
+  AllowModifiersOnSymbols: true
 
 Style/Alias:
   Description: 'Use alias instead of alias_method.'

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -98,7 +98,7 @@ module RuboCop
         @mutable_attributes.frozen?
       end
 
-      protected :parent= # rubocop:disable Style/AccessModifierDeclarations
+      protected :parent=
 
       # Override `AST::Node#updated` so that `AST::Processor` does not try to
       # mutate our ASTs. Since we keep references from children to parents and
@@ -313,9 +313,8 @@ module RuboCop
          (casgn $_ $_        (send (const nil? {:Class :Module}) :new ...))
          (casgn $_ $_ (block (send (const nil? {:Class :Module}) :new ...) ...))}
       PATTERN
-      # rubocop:disable Style/AccessModifierDeclarations
+
       private :defined_module0
-      # rubocop:enable Style/AccessModifierDeclarations
 
       def defined_module
         namespace, name = *defined_module0

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4,10 +4,13 @@
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.57 | -
+Enabled | Yes | No | 0.57 | 0.81
 
 Access modifiers should be declared to apply to a group of methods
 or inline before each method, depending on configuration.
+EnforcedStyle config covers only method definitions.
+Applications of visibility methods to symbols can be controlled
+using AllowModifiersOnSymbols config.
 
 ### Examples
 
@@ -15,7 +18,6 @@ or inline before each method, depending on configuration.
 
 ```ruby
 # bad
-
 class Foo
 
   private def bar; end
@@ -24,7 +26,6 @@ class Foo
 end
 
 # good
-
 class Foo
 
   private
@@ -38,7 +39,6 @@ end
 
 ```ruby
 # bad
-
 class Foo
 
   private
@@ -49,11 +49,30 @@ class Foo
 end
 
 # good
-
 class Foo
 
   private def bar; end
   private def baz; end
+
+end
+```
+#### AllowModifiersOnSymbols: true
+
+```ruby
+# good
+class Foo
+
+  private :bar, :baz
+
+end
+```
+#### AllowModifiersOnSymbols: false
+
+```ruby
+# bad
+class Foo
+
+  private :bar, :baz
 
 end
 ```
@@ -63,6 +82,7 @@ end
 Name | Default value | Configurable values
 --- | --- | ---
 EnforcedStyle | `group` | `inline`, `group`
+AllowModifiersOnSymbols | `true` | Boolean
 
 ## Style/Alias
 

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -12,6 +12,33 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
         end
       RUBY
     end
+
+    context 'allow access modifiers on symbols' do
+      let(:cop_config) { { 'AllowModifiersOnSymbols' => true } }
+
+      it 'accepts when argument to #{access_modifier} is a symbol' do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            foo
+            #{access_modifier} :bar
+          end
+        RUBY
+      end
+    end
+
+    context 'do not allow access modifiers on symbols' do
+      let(:cop_config) { { 'AllowModifiersOnSymbols' => false } }
+
+      it 'accepts when argument to #{access_modifier} is a symbol' do
+        expect_offense(<<~RUBY)
+          class Foo
+            foo
+            #{access_modifier} :bar
+            #{'^' * access_modifier.length} `#{access_modifier}` should not be inlined in method definitions.
+          end
+        RUBY
+      end
+    end
   end
 
   context 'when `group` is configured' do
@@ -27,17 +54,6 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
           class Test
             #{access_modifier} def foo; end
             #{'^' * access_modifier.length} `#{access_modifier}` should not be inlined in method definitions.
-          end
-        RUBY
-      end
-
-      it "offends when #{access_modifier} is inlined with a symbol" do
-        expect_offense(<<~RUBY)
-          class Test
-            #{access_modifier} :foo
-            #{'^' * access_modifier.length} `#{access_modifier}` should not be inlined in method definitions.
-
-            def foo; end
           end
         RUBY
       end


### PR DESCRIPTION
Closes #7740

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/