### PR TITLE
Display version with cop added when pending cops warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 * [#7745](https://github.com/rubocop-hq/rubocop/issues/7745): Suppress a pending cop warnings when pending cop's department is disabled. ([@koic][])
 * [#7759](https://github.com/rubocop-hq/rubocop/issues/7759): Fix an error for `Layout/LineLength` cop when using lambda syntax that argument is not enclosed in parentheses. ([@koic][])
 
+### Changes
+
+* [#7765](https://github.com/rubocop-hq/rubocop/pull/7765): When warning about a pending cop, display the version with the cop added. ([@koic][])
+
 ## 0.80.0 (2020-02-18)
 
 ### New features

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -16,6 +16,8 @@ module RuboCop
     include FileFinder
     extend Forwardable
 
+    CopConfig = Struct.new(:name, :metadata)
+
     DEFAULT_RAILS_VERSION = 5.0
     attr_reader :loaded_path
 
@@ -219,11 +221,14 @@ module RuboCop
     end
 
     def pending_cops
-      keys.select do |qualified_cop_name|
+      keys.each_with_object([]) do |qualified_cop_name, pending_cops|
         department = department_of(qualified_cop_name)
         next if department && department['Enabled'] == false
 
-        self[qualified_cop_name]['Enabled'] == 'pending'
+        cop_metadata = self[qualified_cop_name]
+        next unless cop_metadata['Enabled'] == 'pending'
+
+        pending_cops << CopConfig.new(qualified_cop_name, cop_metadata)
       end
     end
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -92,7 +92,7 @@ module RuboCop
           add_excludes_from_files(config, config_file)
         end
         merge_with_default(config, config_file).tap do |merged_config|
-          warn_on_pending_cops(merged_config)
+          warn_on_pending_cops(merged_config.pending_cops)
         end
       end
 
@@ -116,8 +116,7 @@ module RuboCop
                                    end
       end
 
-      def warn_on_pending_cops(config)
-        pending_cops = config.pending_cops
+      def warn_on_pending_cops(pending_cops)
         return if pending_cops.empty?
 
         warn Rainbow('The following cops were added to RuboCop, but are not ' \
@@ -125,8 +124,12 @@ module RuboCop
                      '`false` in your `.rubocop.yml` file:').yellow
 
         pending_cops.each do |cop|
-          warn Rainbow(" - #{cop}").yellow
+          warn Rainbow(
+            " - #{cop.name} (#{cop.metadata['VersionAdded']})"
+          ).yellow
         end
+
+        warn Rainbow('For more information: https://docs.rubocop.org/en/latest/versioning/').yellow
       end
 
       # Merges the given configuration with the default one. If

--- a/manual/versioning.md
+++ b/manual/versioning.md
@@ -5,5 +5,20 @@ RuboCop is stable between major versions, both in terms of API and cops.
 New cops introduced between major versions are set to a special pending
 status and are not enabled by default. A warning is emitted if such cops
 are not explicitly enabled or disabled in the user configuration.
+Please set `Enabled` to either `true` or `false` in your `.rubocop.yml` file.
+
+`Style/ANewCop` is an example of a newly added pending cop:
+
+```yaml
+Style/ANewCop:
+  Enabled: true
+```
+
+or
+
+```yaml
+Style/ANewCop:
+  Enabled: false
+```
 
 On major version updates, pending cops are enabled in bulk.

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -240,6 +240,10 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           2 files inspected, no offenses detected
         INSPECTED_OUTPUT
 
+        let(:versioning_manual_url) { <<~VERSIONING_MANUAL_URL.chop }
+          For more information: https://docs.rubocop.org/en/latest/versioning/
+        VERSIONING_MANUAL_URL
+
         before do
           create_file('rubocop_ext.rb', <<~RUBY)
             module RuboCop
@@ -263,6 +267,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
               Style/SomeCop:
                 Description: Something
                 Enabled: pending
+                VersionAdded: '0.80'
             YAML
           end
 
@@ -273,7 +278,14 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             remaining_range =
               pending_cop_warning.length..-(inspected_output.length + 1)
             pending_cops = output[remaining_range].split("\n")
-            expect(pending_cops).to include(' - Style/SomeCop')
+
+            expect(pending_cops).to include(
+              ' - Style/SomeCop (0.80)'
+            )
+
+            manual_url = output[remaining_range].split("\n").last
+
+            expect(manual_url).to eq(versioning_manual_url)
           end
         end
 


### PR DESCRIPTION
Follow up of https://github.com/rubocop-hq/rubocop/pull/7757#issuecomment-591358283.

When warning about a pending cop, this PR displays the version with the cop added.

## Before

```console
% rubocop
The following cops were added to RuboCop, but are not configured. Please
set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Style/HashEachMethods
 - Style/HashTransformKeys
 - Style/HashTransformValues
```

## After

```console
% rubocop
The following cops were added to RuboCop, but are not configured. Please
set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Style/HashEachMethods (0.80)
 - Style/HashTransformKeys (0.80)
 - Style/HashTransformValues (0.80)
For more information: https://docs.rubocop.org/en/latest/versioning/
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
