### PR TITLE
Add `--safe` command-line flag to Basic Usage

### DIFF
--- a/manual/basic_usage.md
+++ b/manual/basic_usage.md
@@ -137,6 +137,7 @@ Command flag                    | Description
 `-o/--out`                      | Write output to a file instead of STDOUT.
 `   --parallel`                 | Use available CPUs to execute inspection in parallel.
 `-r/--require`                  | Require Ruby file (see [Loading Extensions](extensions.md#loading-extensions)).
+`   --safe`                     | Run only safe cops.
 `   --safe-auto-correct`        | Omit cops annotated as "not safe". See [Auto-correct](auto_correct.md).
 `   --show-cops`                | Shows available cops and their configuration.
 `-s/--stdin`                    | Pipe source from STDIN. This is useful for editor integration. Takes one argument, a path, relative to the root of the project. RuboCop will use this path to determine which cops are enabled (via eg. Include/Exclude), and so that certain cops like Naming/FileName can be checked.


### PR DESCRIPTION
This PR adds `--safe` command-line flag to Basic Usage manual.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
