### PR TITLE
Remove deprecated development Rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,12 +18,6 @@ require 'rubocop/rake_task'
 
 Dir['tasks/**/*.rake'].each { |t| load t }
 
-desc 'Deprecated: Run test and RuboCop in parallel'
-task :parallel do
-  warn '`rake parallel` is deprecated. Use `rake default` instead.'
-  Rake::Task[:default].execute
-end
-
 desc 'Run RuboCop over itself'
 RuboCop::RakeTask.new(:internal_investigation).tap do |task|
   if RUBY_ENGINE == 'ruby' &&

--- a/tasks/spec_runner.rake
+++ b/tasks/spec_runner.rake
@@ -116,18 +116,3 @@ desc 'Run RSpec code examples with ASCII encoding'
 task :ascii_spec do
   RuboCop::SpecRunner.new(external_encoding: 'ASCII').run_specs
 end
-
-namespace :parallel do
-  desc 'Deprecated: Run RSpec code examples in parallel'
-  task :spec do
-    warn '`rake parallel:spec` is deprecated. Use `rake spec` instead.'
-    Rake::Task[:spec].execute
-  end
-
-  desc 'Deprecated: Run RSpec code examples in parallel with ASCII encoding'
-  task :ascii_spec do
-    warn '`rake parallel:ascii_spec` is deprecated. Use `rake ascii_spec` ' \
-         'instead.'
-    Rake::Task[:ascii_spec].execute
-  end
-end


### PR DESCRIPTION
This PR removes the following deprecated development Rake tasks.

```console
% cd repo/to/rubocop
% bundle exec rake -T | grep Deprecated
rake parallel                             # Deprecated: Run test and
RuboCop in parallel
rake parallel:ascii_spec                  # Deprecated: Run RSpec code
examples in parallel with ASCII encoding
rake parallel:spec                        # Deprecated: Run RSpec code
examples in parallel
```

These tasks has been removed from RuboCop 0.59.1.
https://github.com/rubocop-hq/rubocop/commit/19b69083d2dc9960700e2ecc29040327a3913feb

These are used only for RuboCop repository development, they will be safely removed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
