### PR TITLE
[Fix #7536] Improve documentation for Style/TrailingCommaIn… cops

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -3826,9 +3826,10 @@ Style/TrailingCommaInArrayLiteral:
   StyleGuide: '#no-trailing-array-commas'
   Enabled: true
   VersionAdded: '0.53'
+  # If `comma`, the cop requires a comma after the last item in an array,
   # but only when each item is on its own line.
   # If `consistent_comma`, the cop requires a comma after the last item of all
-  # non-empty array literals.
+  # non-empty, multiline array literals.
   EnforcedStyleForMultiline: no_comma
   SupportedStylesForMultiline:
     - comma
@@ -3841,7 +3842,7 @@ Style/TrailingCommaInHashLiteral:
   # If `comma`, the cop requires a comma after the last item in a hash,
   # but only when each item is on its own line.
   # If `consistent_comma`, the cop requires a comma after the last item of all
-  # non-empty hash literals.
+  # non-empty, multiline hash literals.
   EnforcedStyleForMultiline: no_comma
   SupportedStylesForMultiline:
     - comma

--- a/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
@@ -4,6 +4,13 @@ module RuboCop
   module Cop
     module Style
       # This cop checks for trailing comma in argument lists.
+      # The supported styles are:
+      #
+      # - `consistent_comma`: Requires a comma after the last argument,
+      # for all parenthesized method calls with arguments.
+      # - `comma`: Requires a comma after the last argument, but only for
+      # parenthesized method calls where each argument is on its own line.
+      # - `no_comma`: Does not requires a comma after the last argument.
       #
       # @example EnforcedStyleForMultiline: consistent_comma
       #   # bad
@@ -20,6 +27,11 @@ module RuboCop
       #
       #   # good
       #   method(
+      #     1, 2, 3,
+      #   )
+      #
+      #   # good
+      #   method(
       #     1,
       #     2,
       #   )
@@ -30,6 +42,28 @@ module RuboCop
       #
       #   # good
       #   method(1, 2)
+      #
+      #   # bad
+      #   method(
+      #     1, 2,
+      #     3,
+      #   )
+      #
+      #   # good
+      #   method(
+      #     1, 2,
+      #     3
+      #   )
+      #
+      #   # bad
+      #   method(
+      #     1, 2, 3,
+      #   )
+      #
+      #   # good
+      #   method(
+      #     1, 2, 3
+      #   )
       #
       #   # good
       #   method(

--- a/lib/rubocop/cop/style/trailing_comma_in_array_literal.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_array_literal.rb
@@ -4,15 +4,31 @@ module RuboCop
   module Cop
     module Style
       # This cop checks for trailing comma in array literals.
+      # The configuration options are:
+      #
+      # - `consistent_comma`: Requires a comma after the
+      # last item of all non-empty, multiline array literals.
+      # - `comma`: Requires a comma after last item in an array,
+      # but only when each item is on its own line.
+      # - `no_comma`: Does not requires a comma after the
+      # last item in an array
       #
       # @example EnforcedStyleForMultiline: consistent_comma
       #   # bad
       #   a = [1, 2,]
       #
       #   # good
+      #   a = [1, 2]
+      #
+      #   # good
       #   a = [
       #     1, 2,
       #     3,
+      #   ]
+      #
+      #   # good
+      #   a = [
+      #     1, 2, 3,
       #   ]
       #
       #   # good
@@ -24,6 +40,31 @@ module RuboCop
       # @example EnforcedStyleForMultiline: comma
       #   # bad
       #   a = [1, 2,]
+      #
+      #   # good
+      #   a = [1, 2]
+      #
+      #   # bad
+      #   a = [
+      #     1, 2,
+      #     3,
+      #   ]
+      #
+      #   # good
+      #   a = [
+      #     1, 2,
+      #     3
+      #   ]
+      #
+      #   # bad
+      #   a = [
+      #     1, 2, 3,
+      #   ]
+      #
+      #   # good
+      #   a = [
+      #     1, 2, 3
+      #   ]
       #
       #   # good
       #   a = [

--- a/lib/rubocop/cop/style/trailing_comma_in_hash_literal.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_hash_literal.rb
@@ -4,10 +4,22 @@ module RuboCop
   module Cop
     module Style
       # This cop checks for trailing comma in hash literals.
+      # The configuration options are:
+      #
+      # - `consistent_comma`: Requires a comma after the
+      # last item of all non-empty, multiline hash literals.
+      # - `comma`: Requires a comma after the last item in a hash,
+      # but only when each item is on its own line.
+      # - `no_comma`: Does not requires a comma after the
+      # last item in a hash
       #
       # @example EnforcedStyleForMultiline: consistent_comma
+      #
       #   # bad
       #   a = { foo: 1, bar: 2, }
+      #
+      #   # good
+      #   a = { foo: 1, bar: 2 }
       #
       #   # good
       #   a = {
@@ -17,13 +29,44 @@ module RuboCop
       #
       #   # good
       #   a = {
+      #     foo: 1, bar: 2, qux: 3,
+      #   }
+      #
+      #   # good
+      #   a = {
       #     foo: 1,
       #     bar: 2,
       #   }
       #
       # @example EnforcedStyleForMultiline: comma
+      #
       #   # bad
       #   a = { foo: 1, bar: 2, }
+      #
+      #   # good
+      #   a = { foo: 1, bar: 2 }
+      #
+      #   # bad
+      #   a = {
+      #     foo: 1, bar: 2,
+      #     qux: 3,
+      #   }
+      #
+      #   # good
+      #   a = {
+      #     foo: 1, bar: 2,
+      #     qux: 3
+      #   }
+      #
+      #   # bad
+      #   a = {
+      #     foo: 1, bar: 2, qux: 3,
+      #   }
+      #
+      #   # good
+      #   a = {
+      #     foo: 1, bar: 2, qux: 3
+      #   }
       #
       #   # good
       #   a = {
@@ -32,6 +75,7 @@ module RuboCop
       #   }
       #
       # @example EnforcedStyleForMultiline: no_comma (default)
+      #
       #   # bad
       #   a = { foo: 1, bar: 2, }
       #

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -6962,6 +6962,13 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 Enabled | Yes | Yes  | 0.36 | -
 
 This cop checks for trailing comma in argument lists.
+The supported styles are:
+
+- `consistent_comma`: Requires a comma after the last argument,
+for all parenthesized method calls with arguments.
+- `comma`: Requires a comma after the last argument, but only for
+parenthesized method calls where each argument is on its own line.
+- `no_comma`: Does not requires a comma after the last argument.
 
 ### Examples
 
@@ -6982,6 +6989,11 @@ method(
 
 # good
 method(
+  1, 2, 3,
+)
+
+# good
+method(
   1,
   2,
 )
@@ -6994,6 +7006,28 @@ method(1, 2,)
 
 # good
 method(1, 2)
+
+# bad
+method(
+  1, 2,
+  3,
+)
+
+# good
+method(
+  1, 2,
+  3
+)
+
+# bad
+method(
+  1, 2, 3,
+)
+
+# good
+method(
+  1, 2, 3
+)
 
 # good
 method(
@@ -7034,6 +7068,14 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 Enabled | Yes | Yes  | 0.53 | -
 
 This cop checks for trailing comma in array literals.
+The configuration options are:
+
+- `consistent_comma`: Requires a comma after the
+last item of all non-empty, multiline array literals.
+- `comma`: Requires a comma after last item in an array,
+but only when each item is on its own line.
+- `no_comma`: Does not requires a comma after the
+last item in an array
 
 ### Examples
 
@@ -7044,9 +7086,17 @@ This cop checks for trailing comma in array literals.
 a = [1, 2,]
 
 # good
+a = [1, 2]
+
+# good
 a = [
   1, 2,
   3,
+]
+
+# good
+a = [
+  1, 2, 3,
 ]
 
 # good
@@ -7060,6 +7110,31 @@ a = [
 ```ruby
 # bad
 a = [1, 2,]
+
+# good
+a = [1, 2]
+
+# bad
+a = [
+  1, 2,
+  3,
+]
+
+# good
+a = [
+  1, 2,
+  3
+]
+
+# bad
+a = [
+  1, 2, 3,
+]
+
+# good
+a = [
+  1, 2, 3
+]
 
 # good
 a = [
@@ -7097,6 +7172,14 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 Enabled | Yes | Yes  | 0.53 | -
 
 This cop checks for trailing comma in hash literals.
+The configuration options are:
+
+- `consistent_comma`: Requires a comma after the
+last item of all non-empty, multiline hash literals.
+- `comma`: Requires a comma after the last item in a hash,
+but only when each item is on its own line.
+- `no_comma`: Does not requires a comma after the
+last item in a hash
 
 ### Examples
 
@@ -7107,9 +7190,17 @@ This cop checks for trailing comma in hash literals.
 a = { foo: 1, bar: 2, }
 
 # good
+a = { foo: 1, bar: 2 }
+
+# good
 a = {
   foo: 1, bar: 2,
   qux: 3,
+}
+
+# good
+a = {
+  foo: 1, bar: 2, qux: 3,
 }
 
 # good
@@ -7123,6 +7214,31 @@ a = {
 ```ruby
 # bad
 a = { foo: 1, bar: 2, }
+
+# good
+a = { foo: 1, bar: 2 }
+
+# bad
+a = {
+  foo: 1, bar: 2,
+  qux: 3,
+}
+
+# good
+a = {
+  foo: 1, bar: 2,
+  qux: 3
+}
+
+# bad
+a = {
+  foo: 1, bar: 2, qux: 3,
+}
+
+# good
+a = {
+  foo: 1, bar: 2, qux: 3
+}
 
 # good
 a = {


### PR DESCRIPTION
Close #7536

Improved documentation for `Style/TrailingCommaInArguments`, `Style/TrailingCommaInArrayLiteral` and `Style/TrailingCommaInHashLiteral` by adding following things:
- Added description for `EnforcedStyleForMultiline` configuration options. 
- Added more examples to distinguish between  `comma` and `consistent_comma`
- Corrected Style/TrailingCommaInArrayLiteral and Style/TrailingCommaInHashLiteral related comments in `config/default.yml `

----

Before submitting the PR make sure the following are checked:

- [x]   Wrote good commit messages.
- [x]   Commit message starts with [Fix #issue-number] (if the related issue exists).
- [x]   Feature branch is up-to-date with master (if not - rebase it).
- [x]   Squashed related commits together.
- [x]   The PR relates to only one subject with a clear title and description in grammatically correct, complete sentences.
- [x]   Run bundle exec rake default. It executes all tests and RuboCop for itself, and generates the documentation.

