### PR TITLE
[Fix #6289] Naming/FileName: Add ExpectMatchingClass option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#6289](https://github.com/rubocop-hq/rubocop/issues/6289): Add new `CheckDefinitionPathHierarchy` option for `Naming/FileName`. ([@jschneid][])
+
 ### Bug fixes
 
 * [#8008](https://github.com/rubocop-hq/rubocop/issues/8008): Fix an error for `Lint/SuppressedException` when empty rescue block in `def`. ([@koic][])
@@ -4542,3 +4546,4 @@
 [@laurmurclar]: https://github.com/laurmurclar
 [@jethrodaniel]: https://github.com/jethrodaniel
 [@CvX]: https://github.com/CvX
+[@jschneid]: https://github.com/jschneid

--- a/config/default.yml
+++ b/config/default.yml
@@ -2031,6 +2031,10 @@ Naming/FileName:
   # It further expects it to be nested inside modules which match the names
   # of subdirectories in its path.
   ExpectMatchingDefinition: false
+  # When `false`, changes the behavior of ExpectMatchingDefinition to match only
+  # whether each source file's class or module name matches the file name --
+  # not whether the nested module hierarchy matches the subdirectory path.
+  CheckDefinitionPathHierarchy: true
   # If non-`nil`, expect all source file names to match the following regex.
   # Only the file name itself is matched, not the entire file path.
   # Use anchors as necessary if you want to match the entire name rather than

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -242,6 +242,7 @@ Name | Default value | Configurable values
 --- | --- | ---
 Exclude | `[]` | Array
 ExpectMatchingDefinition | `false` | Boolean
+CheckDefinitionPathHierarchy | `true` | Boolean
 Regex | `<none>` | 
 IgnoreExecutableScripts | `true` | Boolean
 AllowedAcronyms | `CLI`, `DSL`, `ACL`, `API`, `ASCII`, `CPU`, `CSS`, `DNS`, `EOF`, `GUID`, `HTML`, `HTTP`, `HTTPS`, `ID`, `IP`, `JSON`, `LHS`, `QPS`, `RAM`, `RHS`, `RPC`, `SLA`, `SMTP`, `SQL`, `SSH`, `TCP`, `TLS`, `TTL`, `UDP`, `UI`, `UID`, `UUID`, `URI`, `URL`, `UTF8`, `VM`, `XML`, `XMPP`, `XSRF`, `XSS` | Array


### PR DESCRIPTION
https://github.com/rubocop-hq/rubocop/issues/6289 describes a limitation of the existing `ExpectMatchingDefinition: true` option on the `Naming/FileName` cop: It generates false positives when run on a project with classes which (by design) aren't namespaced with modules to match their file paths.

This PR addresses that issue by adding a new option to the `Naming/FileName` cop: `CheckDefinitionPathHieararchy`. This defaults to `true`; if set to `false`, it modifies the `ExpectMatchingDefinition` option to _only_  check whether each source file's class or module name matches the file name -- not whether the nested module hierarchy matches the subdirectory path.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
