### PR TITLE
[Fix #7733] Fix rubocop-junit-formatter imcompatibility XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#7654](https://github.com/rubocop-hq/rubocop/issues/7654): Support `with_fixed_indentation` option for `Layout/ArrayAlignment` cop. ([@nikitasakov][])
 
+### Bug fixes
+
+* [#7733](https://github.com/rubocop-hq/rubocop/issues/7733): Fix rubocop-junit-formatter imcompatibility XML for JUnit formatter. ([@koic][])
+
 ## 0.80.1 (2020-02-29)
 
 ### Bug fixes

--- a/spec/rubocop/formatter/junit_formatter_spec.rb
+++ b/spec/rubocop/formatter/junit_formatter_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe RuboCop::Formatter::JUnitFormatter do
   let(:output) { StringIO.new }
 
   describe '#file_finished' do
-    it 'displays parsable text' do
-      cop = RuboCop::Cop::Cop.new
+    before do
+      cop = RuboCop::Cop::Layout::SpaceInsideBlockBraces.new
       source_buffer = Parser::Source::Buffer.new('test', 1)
       source_buffer.source = %w[foo bar baz].join("\n")
 
@@ -26,29 +26,52 @@ RSpec.describe RuboCop::Formatter::JUnitFormatter do
       formatter.file_finished('test_2', cop.offenses)
 
       formatter.finished(nil)
+    end
 
-      expect(output.string).to eq(<<~XML.chop)
+    it 'displays start of parsable text' do
+      expect(output.string).to start_with(<<~XML)
         <?xml version='1.0'?>
         <testsuites>
           <testsuite name='rubocop'>
-            <testcase classname='test_1' name='Cop/Cop'>
-              <failure type='Cop/Cop' message='message 1'>
-                test:1:1
-              </failure>
-              <failure type='Cop/Cop' message='message 2'>
-                test:3:2
-              </failure>
-            </testcase>
-            <testcase classname='test_2' name='Cop/Cop'>
-              <failure type='Cop/Cop' message='message 1'>
-                test:1:1
-              </failure>
-              <failure type='Cop/Cop' message='message 2'>
-                test:3:2
-              </failure>
-            </testcase>
+      XML
+    end
+
+    it 'displays end of parsable text' do
+      expect(output.string).to end_with(<<~XML.chop)
           </testsuite>
         </testsuites>
+      XML
+    end
+
+    it "displays an offfense for `classname='test_1` in parsable text" do
+      expect(output.string).to include(<<-XML)
+    <testcase classname='test_1' name='Layout/SpaceInsideBlockBraces'>
+      <failure type='Layout/SpaceInsideBlockBraces' message='message 1'>
+        test:1:1
+      </failure>
+      <failure type='Layout/SpaceInsideBlockBraces' message='message 2'>
+        test:3:2
+      </failure>
+    </testcase>
+      XML
+    end
+
+    it "displays an offfense for `classname='test_2` in parsable text" do
+      expect(output.string).to include(<<-XML)
+    <testcase classname='test_2' name='Layout/SpaceInsideBlockBraces'>
+      <failure type='Layout/SpaceInsideBlockBraces' message='message 1'>
+        test:1:1
+      </failure>
+      <failure type='Layout/SpaceInsideBlockBraces' message='message 2'>
+        test:3:2
+      </failure>
+    </testcase>
+      XML
+    end
+
+    it 'displays a non-offfense element in parsable text' do
+      expect(output.string).to include(<<~XML)
+        <testcase classname='test_1' name='Style/Alias'/>
       XML
     end
   end


### PR DESCRIPTION
## Summary

Fixes #7733.

This PR fixes rubocop-junit-formatter imcompatibility XML for JUnit formatter

The original rubocop-junit-formatter displayed all cops with or without offenses.
https://github.com/mikian/rubocop-junit-formatter/blob/v0.1.4/lib/rubocop/formatter/junit_formatter.rb#L9

It then displays all cops in XML elements, like the original rubocop-junit-formatter.

## Other Information

In the future, it would be preferable to display only enabled cops.
https://github.com/mikian/rubocop-junit-formatter/blob/v0.1.4/lib/rubocop/formatter/junit_formatter.rb#L7-L8

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
