### PR TITLE
[Fix #7779] Fix a false positive for `Style/MultilineMethodCallIndentation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#7654](https://github.com/rubocop-hq/rubocop/issues/7654): Support `with_fixed_indentation` option for `Layout/ArrayAlignment` cop. ([@nikitasakov][])
 
+### Bug fixes
+
+* [#7779](https://github.com/rubocop-hq/rubocop/issues/7779): Fix a false positive for `Style/MultilineMethodCallIndentation` when using Ruby 2.7's numbered parameter. ([@koic][])
+
 ## 0.80.1 (2020-02-29)
 
 ### Bug fixes

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -291,7 +291,7 @@ module RuboCop
       ## Destructuring
 
       def_node_matcher :receiver, <<~PATTERN
-        {(send $_ ...) (block (send $_ ...) ...)}
+        {(send $_ ...) ({block numblock} (send $_ ...) ...)}
       PATTERN
 
       def_node_matcher :str_content, '(str $_)'

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -248,6 +248,17 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
         RUBY
       end
 
+      context '>= Ruby 2.7', :ruby27 do
+        it 'accepts methods being aligned with method that is an argument' \
+           'when using numbered parameter' do
+          expect_no_offenses(<<~RUBY)
+            File.read('data.yml')
+                .then { YAML.safe_load _1 }
+                .transform_values(&:downcase)
+          RUBY
+        end
+      end
+
       it 'accepts methods being aligned with method that is an argument in ' \
          'assignment' do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #7779.

This PR fixes a false positive for `Style/MultilineMethodCallIndentation` when using Ruby 2.7's numbered parameter.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
