### PR TITLE
Support Ruby 2.7's numbered parameter for `Lint/SafeNavigationChain`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#7783](https://github.com/rubocop-hq/rubocop/pull/7783): Support Ruby 2.7's numbered parameter for `Style/RedundantSort`. ([@koic][])
 * [#7795](https://github.com/rubocop-hq/rubocop/issues/7795): Make `Layout/EmptyLineAfterGuardClause` aware of case where `and` or `or` is used before keyword that break control (e.g. `and return`). ([@koic][])
 * [#7786](https://github.com/rubocop-hq/rubocop/pull/7786): Support Ruby 2.7's pattern match for `Layout/ElseAlignment` cop. ([@koic][])
+* [#7784](https://github.com/rubocop-hq/rubocop/pull/7784): Support Ruby 2.7's numbered parameter for `Lint/SafeNavigationChain`. ([@koic][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/lint/safe_navigation_chain.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_chain.rb
@@ -32,7 +32,7 @@ module RuboCop
         def_node_matcher :bad_method?, <<~PATTERN
           {
             (send $(csend ...) $_ ...)
-            (send $(block (csend ...) ...) $_ ...)
+            (send $({block numblock} (csend ...) ...) $_ ...)
           }
         PATTERN
 

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -89,6 +89,17 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
     RUBY
   end
 
+  context '>= Ruby 2.7', :ruby27 do
+    it 'registers an offense for ordinary method chain exists after ' \
+       'safe navigation method call with a block using numbered parameter' do
+      expect_offense(<<~RUBY)
+        something
+        x&.select { foo(_1) }.bar
+                             ^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+  end
+
   it 'registers an offense for safe navigation with < operator' do
     expect_offense(<<~RUBY)
       x&.foo < bar


### PR DESCRIPTION
This PR supports Ruby 2.7's numbered parameter for `Lint/SafeNavigationChain`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
