### PR TITLE
[Fix #7767] Skip array literals in `Style/HashTransformValues` & `Style/HashTransformKeys`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#7779](https://github.com/rubocop-hq/rubocop/issues/7779): Fix a false positive for `Style/MultilineMethodCallIndentation` when using Ruby 2.7's numbered parameter. ([@koic][])
 * [#7733](https://github.com/rubocop-hq/rubocop/issues/7733): Fix rubocop-junit-formatter imcompatibility XML for JUnit formatter. ([@koic][])
+* [#7767](https://github.com/rubocop-hq/rubocop/issues/7767): Skip array literals in `Style/HashTransformValues` and `Style/HashTransformKeys`. ([@tejasbubane][])
 
 ## 0.80.1 (2020-02-29)
 

--- a/lib/rubocop/cop/style/hash_transform_keys.rb
+++ b/lib/rubocop/cop/style/hash_transform_keys.rb
@@ -31,7 +31,9 @@ module RuboCop
 
         def_node_matcher :on_bad_each_with_object, <<~PATTERN
           (block
-            ({send csend} !(send _ :each_with_index) :each_with_object (hash))
+            ({send csend}
+              !{(send _ :each_with_index) (array ...)}
+              :each_with_object (hash))
             (args
               (mlhs
                 (arg $_)
@@ -55,7 +57,9 @@ module RuboCop
         def_node_matcher :on_bad_map_to_h, <<~PATTERN
           ({send csend}
             (block
-              ({send csend} !(send _ :each_with_index) {:map :collect})
+              ({send csend}
+                !{(send _ :each_with_index) (array ...)}
+                {:map :collect})
               (args
                 (arg $_)
                 (arg _val))

--- a/lib/rubocop/cop/style/hash_transform_values.rb
+++ b/lib/rubocop/cop/style/hash_transform_values.rb
@@ -31,7 +31,9 @@ module RuboCop
 
         def_node_matcher :on_bad_each_with_object, <<~PATTERN
           (block
-            ({send csend} !(send _ :each_with_index) :each_with_object (hash))
+            ({send csend}
+              !{(send _ :each_with_index) (array ...)}
+              :each_with_object (hash))
             (args
               (mlhs
                 (arg _key)
@@ -55,7 +57,9 @@ module RuboCop
         def_node_matcher :on_bad_map_to_h, <<~PATTERN
           ({send csend}
             (block
-              ({send csend} !(send _ :each_with_index) {:map :collect})
+              ({send csend}
+                !{(send _ :each_with_index) (array ...)}
+                 {:map :collect})
               (args
                 (arg _key)
                 (arg $_))

--- a/spec/rubocop/cop/style/hash_transform_keys_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_keys_spec.rb
@@ -53,6 +53,12 @@ RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
       RUBY
     end
 
+    it 'does not flag each_with_object when its receiver is array literal' do
+      expect_no_offenses(<<~RUBY)
+        [1, 2, 3].each_with_object({}) {|(k, v), h| h[foo(k)] = v}
+      RUBY
+    end
+
     it 'flags _.map{...}.to_h when transform_keys could be used' do
       expect_offense(<<~RUBY)
         x.map {|k, v| [k.to_sym, v]}.to_h
@@ -77,6 +83,12 @@ RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
 
     it 'does not flag key transformation in the absence of to_h' do
       expect_no_offenses('x.map {|k, v| [k.to_sym, v]}')
+    end
+
+    it 'does not flag key transformation when receiver is array literal' do
+      expect_no_offenses(<<~RUBY)
+        [1, 2, 3].map {|k, v| [k.to_sym, v]}.to_h
+      RUBY
     end
 
     it 'correctly autocorrects each_with_object' do

--- a/spec/rubocop/cop/style/hash_transform_values_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_values_spec.rb
@@ -53,6 +53,12 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
       RUBY
     end
 
+    it 'does not flag each_with_object when receiver is array literal' do
+      expect_no_offenses(<<~RUBY)
+        [1, 2, 3].each_with_object({}) {|(k, v), h| h[k] = foo(v)}
+      RUBY
+    end
+
     it 'flags _.map {...}.to_h when transform_values could be used' do
       expect_offense(<<~RUBY)
         x.map {|k, v| [k, foo(v)]}.to_h
@@ -77,6 +83,12 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
 
     it 'does not flag value transformation in the absence of to_h' do
       expect_no_offenses('x.map {|k, v| [k, foo(v)]}')
+    end
+
+    it 'does not flag value transformation when receiver is array literal' do
+      expect_no_offenses(<<~RUBY)
+        [1, 2, 3].map {|k, v| [k, foo(v)]}.to_h
+      RUBY
     end
 
     it 'correctly autocorrects each_with_object' do


### PR DESCRIPTION
Because arrays do not have `transform_values` & `transform_keys` methods. 

Closes https://github.com/rubocop-hq/rubocop/issues/7767

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/