### PR TITLE
[Fix #7791] Fix an error for `Layout/BlockEndNewline`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#7779](https://github.com/rubocop-hq/rubocop/issues/7779): Fix a false positive for `Style/MultilineMethodCallIndentation` when using Ruby 2.7's numbered parameter. ([@koic][])
 * [#7733](https://github.com/rubocop-hq/rubocop/issues/7733): Fix rubocop-junit-formatter imcompatibility XML for JUnit formatter. ([@koic][])
 * [#7767](https://github.com/rubocop-hq/rubocop/issues/7767): Skip array literals in `Style/HashTransformValues` and `Style/HashTransformKeys`. ([@tejasbubane][])
+* [#7791](https://github.com/rubocop-hq/rubocop/issues/7791): Fix an error on auto-correction for `Layout/BlockEndNewline` when `}` of multiline block without processing is not on its own line. ([@koic][])
 
 ## 0.80.1 (2020-02-29)
 

--- a/lib/rubocop/cop/layout/block_end_newline.rb
+++ b/lib/rubocop/cop/layout/block_end_newline.rb
@@ -52,9 +52,11 @@ module RuboCop
         end
 
         def delimiter_range(node)
-          Parser::Source::Range.new(node.loc.expression.source_buffer,
-                                    node.children.last.loc.expression.end_pos,
-                                    node.loc.expression.end_pos)
+          Parser::Source::Range.new(
+            node.loc.expression.source_buffer,
+            node.children.compact.last.loc.expression.end_pos,
+            node.loc.expression.end_pos
+          )
         end
       end
     end

--- a/spec/rubocop/cop/layout/block_end_newline_spec.rb
+++ b/spec/rubocop/cop/layout/block_end_newline_spec.rb
@@ -44,4 +44,19 @@ RSpec.describe RuboCop::Cop::Layout::BlockEndNewline do
       }
     RUBY
   end
+
+  it 'registers an offense and corrects when `}` of multiline block ' \
+     'without processing is not on its own line' do
+    expect_offense(<<~RUBY)
+      test {
+        |foo| }
+              ^ Expression at 2, 9 should be on its own line.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      test {
+        |foo|
+      }
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #7791.

This PR fixes an error on auto-correction for `Layout/BlockEndNewline` when `}` of multiline block without processing is not on its own line.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
