### PR TITLE
Prefer `include?` over `member?` in `Style/CollectionMethods`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#7793](https://github.com/rubocop-hq/rubocop/pull/7793): Prefer `include?` over `member?` in `Style/CollectionMethods`. ([@dmolesUC][])
 * [#7654](https://github.com/rubocop-hq/rubocop/issues/7654): Support `with_fixed_indentation` option for `Layout/ArrayAlignment` cop. ([@nikitasakov][])
 
 ### Bug fixes
@@ -4389,3 +4390,4 @@
 [@djudd]: https://github.com/djudd
 [@jemmaissroff]: https://github.com/jemmaissroff
 [@nikitasakov]: https://github.com/nikitasakov
+[@dmolesUC]: https://github.com/dmolesUC

--- a/config/default.yml
+++ b/config/default.yml
@@ -2455,7 +2455,7 @@ Style/ClassVars:
 # Align with the style guide.
 Style/CollectionMethods:
   Description: 'Preferred collection methods.'
-  StyleGuide: '#map-find-select-reduce-size'
+  StyleGuide: '#map-find-select-reduce-include-size'
   Enabled: false
   VersionAdded: '0.9'
   VersionChanged: '0.27'
@@ -2472,6 +2472,7 @@ Style/CollectionMethods:
     inject: 'reduce'
     detect: 'find'
     find_all: 'select'
+    member?: 'include?'
 
 Style/ColonMethodCall:
   Description: 'Do not use :: for method call.'

--- a/lib/rubocop/cop/style/collection_methods.rb
+++ b/lib/rubocop/cop/style/collection_methods.rb
@@ -27,6 +27,7 @@ module RuboCop
       #   items.inject
       #   items.detect
       #   items.find_all
+      #   items.member?
       #
       #   # good
       #   items.map
@@ -34,6 +35,7 @@ module RuboCop
       #   items.reduce
       #   items.find
       #   items.select
+      #   items.include?
       #
       class CollectionMethods < Cop
         include MethodPreference

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -752,6 +752,7 @@ items.collect!
 items.inject
 items.detect
 items.find_all
+items.member?
 
 # good
 items.map
@@ -759,17 +760,18 @@ items.map!
 items.reduce
 items.find
 items.select
+items.include?
 ```
 
 ### Configurable attributes
 
 Name | Default value | Configurable values
 --- | --- | ---
-PreferredMethods | `{"collect"=>"map", "collect!"=>"map!", "inject"=>"reduce", "detect"=>"find", "find_all"=>"select"}` | 
+PreferredMethods | `{"collect"=>"map", "collect!"=>"map!", "inject"=>"reduce", "detect"=>"find", "find_all"=>"select", "member?"=>"include?"}` | 
 
 ### References
 
-* [https://rubystyle.guide#map-find-select-reduce-size](https://rubystyle.guide#map-find-select-reduce-size)
+* [https://rubystyle.guide#map-find-select-reduce-include-size](https://rubystyle.guide#map-find-select-reduce-include-size)
 
 ## Style/ColonMethodCall
 

--- a/spec/rubocop/cop/style/collection_methods_spec.rb
+++ b/spec/rubocop/cop/style/collection_methods_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe RuboCop::Cop::Style::CollectionMethods, :config do
       'collect' => 'map',
       'inject' => 'reduce',
       'detect' => 'find',
-      'find_all' => 'select'
+      'find_all' => 'select',
+      'member?' => 'include?'
     }
   }
 


### PR DESCRIPTION
Updates `Style/CollectionMethods` cop to prefer `include?` over `member?`.

Per [ruby-style-guide#804](https://github.com/rubocop-hq/ruby-style-guide/issues/804).