### PR TITLE
[Fix #7778] Fix a false positive for `Layout/EndAlignment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#7733](https://github.com/rubocop-hq/rubocop/issues/7733): Fix rubocop-junit-formatter imcompatibility XML for JUnit formatter. ([@koic][])
 * [#7767](https://github.com/rubocop-hq/rubocop/issues/7767): Skip array literals in `Style/HashTransformValues` and `Style/HashTransformKeys`. ([@tejasbubane][])
 * [#7791](https://github.com/rubocop-hq/rubocop/issues/7791): Fix an error on auto-correction for `Layout/BlockEndNewline` when `}` of multiline block without processing is not on its own line. ([@koic][])
+* [#7778](https://github.com/rubocop-hq/rubocop/issues/7778): Fix a false positive for `Layout/EndAlignment` when a non-whitespace is used before the `end` keyword. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/end_keyword_alignment.rb
+++ b/lib/rubocop/cop/mixin/end_keyword_alignment.rb
@@ -20,7 +20,7 @@ module RuboCop
         return if ignored_node?(node)
 
         end_loc = node.loc.end
-        return unless end_loc # Discard modifier forms of if/while/until.
+        return if accept_end_kw_alignment?(end_loc)
 
         matching = matching_ranges(end_loc, align_ranges)
 
@@ -47,6 +47,11 @@ module RuboCop
                           align_line: align_with.line,
                           align_col: align_with.column)
         add_offense(node, location: end_loc, message: msg)
+      end
+
+      def accept_end_kw_alignment?(end_loc)
+        end_loc.nil? || # Discard modifier forms of if/while/until.
+          processed_source.lines[end_loc.line - 1] !~ /\A[ \t]*end/
       end
 
       def style_parameter_name

--- a/spec/rubocop/cop/layout/end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/end_alignment_spec.rb
@@ -277,14 +277,8 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
   end
 
   context 'when end is preceded by something else than whitespace' do
-    it 'registers an offense and does not correct' do
-      expect_offense(<<~RUBY)
-        module A
-        puts a end
-               ^^^ `end` at 2, 7 is not aligned with `module` at 1, 0.
-      RUBY
-
-      expect_correction(<<~RUBY)
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
         module A
         puts a end
       RUBY


### PR DESCRIPTION
Resolves #7778.

This PR resolves a false positive for `Layout/EndAlignment` when a non-whitespace is used before the `end` keyword.

```console
% cat example.rb
if cond
else 'foo' end

% bundle exec rubocop -a --only Layout/EndAlignment
(snip)

Inspecting 1 file
W

Offenses:

example.rb:2:12: W: Layout/EndAlignment: end at 2, 11 is not aligned
with if at 1, 0.
else 'foo' end
           ^^^

1 file inspected, 1 offense detected
```

This PR changes to not offense it.

I think the responsibility will be clear if different (maybe new) cop like `Layout/BlockEndNewline` cop handle the offense case.
So I think this role is preferably separated by `Layout/EndAlignment` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
