### PR TITLE
[Fix #7795] Make `Layout/EmptyLineAfterGuardClause` aware of `and return`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#7793](https://github.com/rubocop-hq/rubocop/pull/7793): Prefer `include?` over `member?` in `Style/CollectionMethods`. ([@dmolesUC][])
 * [#7654](https://github.com/rubocop-hq/rubocop/issues/7654): Support `with_fixed_indentation` option for `Layout/ArrayAlignment` cop. ([@nikitasakov][])
 * [#7783](https://github.com/rubocop-hq/rubocop/pull/7783): Support Ruby 2.7's numbered parameter for `Style/RedundantSort`. ([@koic][])
+* [#7795](https://github.com/rubocop-hq/rubocop/issues/7795): Make `Layout/EmptyLineAfterGuardClause` aware of case where `and` or `or` is used before keyword that break control (e.g. `and return`). ([@koic][])
 
 ### Bug fixes
 

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -469,7 +469,13 @@ module RuboCop
         irange_type? || erange_type?
       end
 
-      def_node_matcher :guard_clause?, <<~PATTERN
+      def guard_clause?
+        node = and_type? || or_type? ? rhs : self
+
+        node.match_guard_clause?
+      end
+
+      def_node_matcher :match_guard_clause?, <<~PATTERN
         [${(send nil? {:raise :fail} ...) return break next} single_line?]
       PATTERN
 

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -163,6 +163,44 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
+  it 'registers an offense and corrects when using `and return` ' \
+     'before guard condition' do
+    expect_offense(<<~RUBY)
+      def foo
+        render :foo and return if condition
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
+        do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        render :foo and return if condition
+
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using `or return` ' \
+     'before guard condition' do
+    expect_offense(<<~RUBY)
+      def foo
+        render :foo or return if condition
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
+        do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        render :foo or return if condition
+
+        do_something
+      end
+    RUBY
+  end
+
   it 'accepts modifier if' do
     expect_no_offenses(<<~RUBY)
       def foo


### PR DESCRIPTION
Resolves #7795.

This PR makes `Layout/EmptyLineAfterGuardClause` aware of `and return`.

It was proposed based on the following code controlled by Rails controller.

```ruby
render :foo and return if condition

do_something
```

I think that it can be generalized as a control flow.

```ruby
foo(arg) and return if condition

do_something
```

So it will be newly detected by `Layout/EmptyLineAfterGuardClause` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
