### PR TITLE
Allow unicode-display_width 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 * [#7733](https://github.com/rubocop-hq/rubocop/issues/7733): Fix rubocop-junit-formatter imcompatibility XML for JUnit formatter. ([@koic][])
 * [#7767](https://github.com/rubocop-hq/rubocop/issues/7767): Skip array literals in `Style/HashTransformValues` and `Style/HashTransformKeys`. ([@tejasbubane][])
 
+### Changes
+
+* [#7797](https://github.com/rubocop-hq/rubocop/pull/7797): Allow unicode-display_width dependency version 1.7.0. ([@yuritomanek][])
+
 ## 0.80.1 (2020-02-29)
 
 ### Bug fixes
@@ -4391,3 +4395,4 @@
 [@jemmaissroff]: https://github.com/jemmaissroff
 [@nikitasakov]: https://github.com/nikitasakov
 [@dmolesUC]: https://github.com/dmolesUC
+[@yuritomanek]: https://github.com/yuritomanek

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('rexml')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
-  s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 1.7')
+  s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 2.0')
 
   s.add_development_dependency('bundler', '>= 1.15.0', '< 3.0')
 end


### PR DESCRIPTION
Updating rubocop.gemspec to allow `unicode-display_width:1.7.0`

All tests pass against version 1.7.0, so we assume that there are no breaking changes and the dependency is safe to update.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
