### PR TITLE
Add `VersionAdded` metadata to cops who missing the version

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1594,7 +1594,7 @@ Lint/RedundantRequireStatement:
 Lint/RedundantSplatExpansion:
   Description: 'Checks for splat unnecessarily being called on literals.'
   Enabled: true
-  VersionChanged: '0.76'
+  VersionAdded: '0.76'
 
 Lint/RedundantStringCoercion:
   Description: 'Checks for Object#to_s usage in string interpolation.'
@@ -1725,6 +1725,7 @@ Lint/Syntax:
 Lint/ToJSON:
   Description: 'Ensure #to_json includes an optional argument.'
   Enabled: true
+  VersionAdded: '0.66'
 
 Lint/UnderscorePrefixedVariableName:
   Description: 'Do not use prefix `_` for a variable that is used.'
@@ -1908,6 +1909,7 @@ Migration/DepartmentName:
                  Check that cop names in rubocop:disable (etc) comments are
                  given with department name.
   Enabled: true
+  VersionAdded: '0.75'
 
 #################### Naming ##############################
 
@@ -2958,7 +2960,7 @@ Style/LambdaCall:
   Description: 'Use lambda.call(...) instead of lambda.(...).'
   StyleGuide: '#proc-call'
   Enabled: true
-  VersionAdded: '0.13.1'
+  VersionAdded: '0.13'
   VersionChanged: '0.14'
   EnforcedStyle: call
   SupportedStyles:

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1638,7 +1638,7 @@ require 'unloaded_feature'
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | - | 0.76
+Enabled | Yes | Yes  | 0.76 | -
 
 This cop checks for unneeded usages of splat expansion
 
@@ -2382,7 +2382,7 @@ into RuboCop's offenses.
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | - | -
+Enabled | Yes | Yes  | 0.66 | -
 
 This cop checks to make sure `#to_json` includes an optional argument.
 When overriding `#to_json`, callers may invoke JSON

--- a/manual/cops_migration.md
+++ b/manual/cops_migration.md
@@ -4,7 +4,7 @@
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | - | -
+Enabled | Yes | Yes  | 0.75 | -
 
 Check that cop names in rubocop:disable comments are given with
 department name.

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3042,7 +3042,7 @@ EnforcedStyle | `line_count_dependent` | `line_count_dependent`, `lambda`, `lite
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.13.1 | 0.14
+Enabled | Yes | Yes  | 0.13 | 0.14
 
 This cop checks for use of the lambda.(args) syntax.
 

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe 'RuboCop Project', type: :feature do
       end
     end
 
+    it 'requires a nicely formatted `VersionAdded` metadata for all cops' do
+      cop_names.each do |name|
+        version = config[name]['VersionAdded']
+        expect(version.nil?).to(be(false),
+                                "VersionAdded is required for #{name}.")
+        expect(version).to(match(/\A\d+\.\d+\z/),
+                           "#{version} should be format ('X.Y') for #{name}.")
+      end
+    end
+
     it 'have a period at EOL of description' do
       cop_names.each do |name|
         description = config[name]['Description']


### PR DESCRIPTION
All cops have `VersionAdded`. This PR adds `VersionAdded` metadata to cops who missing the version.

The cops who were missing `VersionAdded` are:

- Migration/DepartmentName (0.75) ... https://github.com/rubocop-hq/rubocop/commit/1f84782
- Lint/RedundantSplatExpansion (0.76) ... https://github.com/rubocop-hq/rubocop/commit/ba43182
- Lint/ToJSON (0.66) ... https://github.com/rubocop-hq/rubocop/commit/a823c57

Also `VersionAdded` does not include tiny version.

This PR will add these rules to the project_spec.rb.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
