### PR TITLE
Add rake task to release to rubygems and github

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#7793](https://github.com/rubocop-hq/rubocop/pull/7793): Prefer `include?` over `member?` in `Style/CollectionMethods`. ([@dmolesUC][])
 * [#7654](https://github.com/rubocop-hq/rubocop/issues/7654): Support `with_fixed_indentation` option for `Layout/ArrayAlignment` cop. ([@nikitasakov][])
+* [#7803](https://github.com/rubocop-hq/rubocop/pull/7803): Add rake task `release_github_rubygems` to release gem on GitHub Packages and rubygems. ([@shockwavenn][])
 
 ### Bug fixes
 
@@ -4396,3 +4397,4 @@
 [@nikitasakov]: https://github.com/nikitasakov
 [@dmolesUC]: https://github.com/dmolesUC
 [@yuritomanek]: https://github.com/yuritomanek
+[@shockwavenn]: https://github.com/shockwavenn

--- a/Rakefile
+++ b/Rakefile
@@ -126,3 +126,11 @@ task documentation_syntax_check: :yard_for_generate_documentation do
   end
   abort unless ok
 end
+
+desc 'Release gem to github release and rubygems'
+task :release_github_rubygems do
+  Rake::Task['release'].invoke
+  `gem push --key github \
+   --host https://rubygems.pkg.github.com/rubocop-hq \
+   pkg/rubocop-#{RuboCop::Version::STRING}.gem`
+end


### PR DESCRIPTION
I think it's never hurt to release this gem not only to rubygems.org, but also on [GitHub packages](https://github.com/features/packages)

I'm not sure of exact of release process (didn't find any info), but I think rake task `rake release` is used.
If so - I created new task `release_github_rubygems` which first call `rake release` and after push resulting gem to Github packages.

Please not, that person, who perform releases should execute 
```
echo ":github: Bearer GH_TOKEN" >> ~/.gem/credentials
```
before pushing gem. GH_TOKEN can be generated [here](https://github.com/settings/tokens) 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
