### PR TITLE
Nested methods doc fix

### DIFF
--- a/lib/rubocop/cop/lint/nested_method_definition.rb
+++ b/lib/rubocop/cop/lint/nested_method_definition.rb
@@ -31,14 +31,14 @@ module RuboCop
       #   # good
       #
       #   def foo
-      #     self.class_eval do
+      #     self.class.class_eval do
       #       def bar
       #       end
       #     end
       #   end
       #
       #   def foo
-      #     self.module_exec do
+      #     self.class.module_exec do
       #       def bar
       #       end
       #     end

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1224,14 +1224,14 @@ end
 # good
 
 def foo
-  self.class_eval do
+  self.class.class_eval do
     def bar
     end
   end
 end
 
 def foo
-  self.module_exec do
+  self.class.module_exec do
     def bar
     end
   end


### PR DESCRIPTION
As-is, the code examples for the `Lint/NestedMethodDefinition` cop are wrong: both `class_eval` and `module_exec` are available on the class and module level respectively, and not on an instance. Only the eigenclass example, and, ironically, the "bad" example of just using `def` directly, actually work.
