### PR TITLE
Change `AllowComments` of `Lint/SuppressedException` to true by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Changes
 
 * [#7797](https://github.com/rubocop-hq/rubocop/pull/7797): Allow unicode-display_width dependency version 1.7.0. ([@yuritomanek][])
+* [#7779](https://github.com/rubocop-hq/rubocop/issues/7779): Change `AllowComments` option of `Lint/SuppressedException` to true by default. ([@koic][])
 
 ## 0.80.1 (2020-02-29)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1712,9 +1712,9 @@ Lint/SuppressedException:
   Description: "Don't suppress exceptions."
   StyleGuide: '#dont-hide-exceptions'
   Enabled: true
-  AllowComments: false
+  AllowComments: true
   VersionAdded: '0.9'
-  VersionChanged: '0.77'
+  VersionChanged: '0.81'
 
 Lint/Syntax:
   Description: 'Checks syntax error.'

--- a/lib/rubocop/cop/lint/suppressed_exception.rb
+++ b/lib/rubocop/cop/lint/suppressed_exception.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Lint
       # This cop checks for *rescue* blocks with no body.
       #
-      # @example AllowComments: false (default)
+      # @example
       #
       #   # bad
       #   def some_method
@@ -14,23 +14,9 @@ module RuboCop
       #   end
       #
       #   # bad
-      #   def some_method
-      #     do_something
-      #   rescue
-      #     # do nothing
-      #   end
-      #
-      #   # bad
       #   begin
       #     do_something
       #   rescue
-      #   end
-      #
-      #   # bad
-      #   begin
-      #     do_something
-      #   rescue
-      #     # do nothing
       #   end
       #
       #   # good
@@ -47,32 +33,36 @@ module RuboCop
       #     handle_exception
       #   end
       #
-      # @example AllowComments: true
-      #
-      #   # bad
-      #   def some_method
-      #     do_something
-      #   rescue
-      #   end
-      #
-      #   # bad
-      #   begin
-      #     do_something
-      #   rescue
-      #   end
+      # @example AllowComments: true (default)
       #
       #   # good
       #   def some_method
       #     do_something
       #   rescue
-      #     # do nothing but comment
+      #     # do nothing
       #   end
       #
       #   # good
       #   begin
       #     do_something
       #   rescue
-      #     # do nothing but comment
+      #     # do nothing
+      #   end
+      #
+      # @example AllowComments: false
+      #
+      #   # bad
+      #   def some_method
+      #     do_something
+      #   rescue
+      #     # do nothing
+      #   end
+      #
+      #   # bad
+      #   begin
+      #     do_something
+      #   rescue
+      #     # do nothing
       #   end
       class SuppressedException < Cop
         MSG = 'Do not suppress exceptions.'

--- a/lib/rubocop/formatter/clang_style_formatter.rb
+++ b/lib/rubocop/formatter/clang_style_formatter.rb
@@ -29,7 +29,7 @@ module RuboCop
 
           report_line(offense.location)
           report_highlighted_area(offense.highlighted_area)
-        rescue IndexError # rubocop:disable Lint/SuppressedException
+        rescue IndexError
           # range is not on a valid line; perhaps the source file is empty
         end
       end

--- a/lib/rubocop/formatter/tap_formatter.rb
+++ b/lib/rubocop/formatter/tap_formatter.rb
@@ -56,7 +56,7 @@ module RuboCop
 
           report_line(offense.location)
           report_highlighted_area(offense.highlighted_area)
-        rescue IndexError # rubocop:disable Lint/SuppressedException
+        rescue IndexError
           # range is not on a valid line; perhaps the source file is empty
         end
       end

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -163,7 +163,7 @@ module RuboCop
         ast, comments, tokens = parser.tokenize(@buffer)
 
         ast.respond_to?(:complete!) && ast.complete!
-      rescue Parser::SyntaxError # rubocop:disable Lint/SuppressedException
+      rescue Parser::SyntaxError
         # All errors are in diagnostics. No need to handle exception.
       end
 

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -2279,13 +2279,11 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.9 | 0.77
+Enabled | Yes | No | 0.9 | 0.81
 
 This cop checks for *rescue* blocks with no body.
 
 ### Examples
-
-#### AllowComments: false (default)
 
 ```ruby
 # bad
@@ -2295,23 +2293,9 @@ rescue
 end
 
 # bad
-def some_method
-  do_something
-rescue
-  # do nothing
-end
-
-# bad
 begin
   do_something
 rescue
-end
-
-# bad
-begin
-  do_something
-rescue
-  # do nothing
 end
 
 # good
@@ -2328,33 +2312,38 @@ rescue
   handle_exception
 end
 ```
-#### AllowComments: true
+#### AllowComments: true (default)
+
+```ruby
+# good
+def some_method
+  do_something
+rescue
+  # do nothing
+end
+
+# good
+begin
+  do_something
+rescue
+  # do nothing
+end
+```
+#### AllowComments: false
 
 ```ruby
 # bad
 def some_method
   do_something
 rescue
+  # do nothing
 end
 
 # bad
 begin
   do_something
 rescue
-end
-
-# good
-def some_method
-  do_something
-rescue
-  # do nothing but comment
-end
-
-# good
-begin
-  do_something
-rescue
-  # do nothing but comment
+  # do nothing
 end
 ```
 
@@ -2362,7 +2351,7 @@ end
 
 Name | Default value | Configurable values
 --- | --- | ---
-AllowComments | `false` | Boolean
+AllowComments | `true` | Boolean
 
 ### References
 


### PR DESCRIPTION
## Summary

Follow https://github.com/rubocop-hq/rubocop/issues/7052#issuecomment-494360787.

This PR changes `AllowComments` option of `Lint/SuppressedException` to true by default.

As is used in RuboCop repo itself, it is a common practice to use source code comments to explain when exception handling is not performed.

## Related Information

I think that `Suppressing Exceptions` rule can be refined to a suitable example.
https://github.com/rubocop-hq/ruby-style-guide#dont-hide-exceptions

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
