### PR TITLE
Fix an error for `Lint/ErbNewArguments` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#7767](https://github.com/rubocop-hq/rubocop/issues/7767): Skip array literals in `Style/HashTransformValues` and `Style/HashTransformKeys`. ([@tejasbubane][])
 * [#7791](https://github.com/rubocop-hq/rubocop/issues/7791): Fix an error on auto-correction for `Layout/BlockEndNewline` when `}` of multiline block without processing is not on its own line. ([@koic][])
 * [#7778](https://github.com/rubocop-hq/rubocop/issues/7778): Fix a false positive for `Layout/EndAlignment` when a non-whitespace is used before the `end` keyword. ([@koic][])
+* [#7806](https://github.com/rubocop-hq/rubocop/pull/7806): Fix an error for `Lint/ErbNewArguments` cop when inspecting `ActionView::Template::Handlers::ERB.new`. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/erb_new_arguments.rb
+++ b/lib/rubocop/cop/lint/erb_new_arguments.rb
@@ -84,7 +84,7 @@ module RuboCop
 
         def on_send(node)
           erb_new_with_non_keyword_arguments(node) do |arguments|
-            return if correct_arguments?(arguments)
+            return if arguments.empty? || correct_arguments?(arguments)
 
             arguments[1..3].each_with_index do |argument, i|
               next if !argument || argument.hash_type?

--- a/spec/rubocop/cop/lint/erb_new_arguments_spec.rb
+++ b/spec/rubocop/cop/lint/erb_new_arguments_spec.rb
@@ -108,5 +108,14 @@ RSpec.describe RuboCop::Cop::Lint::ErbNewArguments, :config do
         ERB.new(str)
       RUBY
     end
+
+    context 'when using `ActionView::Template::Handlers::ERB.new`' do
+      it 'does not register an offense when using `ERB.new` ' \
+         'without arguments' do
+        expect_no_offenses(<<~RUBY)
+          ERB.new
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR fixes the following error for `Lint/ErbNewArguments` cop when inspecting `ActionView::Template::Handlers::ERB.new`.

```console
% cd path/to/rails/rails # rails/rails@f265e0dd
% bundle exec rubocop -d --only Lint/ErbNewArguments
actionview/lib/action_view/template/handlers.rb
For /Users/koic/src/github.com/rails/rails: configuration from
/Users/koic/src/github.com/rubocop-hq/rubocop/config/default.yml
Inspecting 1 file
Scanning
/Users/koic/src/github.com/rails/rails/actionview/lib/action_view/template/handlers.rb
An error occurred while Lint/ErbNewArguments cop was inspecting
/Users/koic/src/github.com/rails/rails/actionview/lib/action_view/template/handlers.rb:14:45.
undefined method `each_with_index' for nil:NilClass
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/lint/erb_new_arguments.rb:89:in
`block in on_send'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/lint/erb_new_arguments.rb:90:in
`erb_new_with_non_keyword_arguments'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/lint/erb_new_arguments.rb:86:in
`on_send'
```

`ActionView::Template::Handlers::ERB` accepts `new` method without arguments, unlike standard `ERB`.

Below is the code that caused the error.

```ruby
base.register_template_handler :erb, ERB.new
```

https://github.com/rails/rails/blob/v6.0.2.2/actionview/lib/action_view/template/handlers.rb#L16

It is an error if the standard `ERB.new` without arguments is used.
Therefore standard `ERB.new` and `ActionView::Template::Handlers::ERB.new` do not conflict.

```console
% ruby -rerb -ve 'ERB.new'
ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin17]
Traceback (most recent call last):
        2: from -e:1:in `<main>'
        1: from -e:1:in `new'
/Users/koic/.rbenv/versions/2.7.0/lib/ruby/2.7.0/erb.rb:809:in
`initialize': wrong number of arguments (given 0, expected 1..4) (ArgumentError)
```

So including this patch in the cop will not interfere with linting to standard `ERB`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
