### PR TITLE
Fix CI errors

### DIFF
--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1520,7 +1520,7 @@ rather than meant to be part of the resulting symbols.
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.75 | -
+Pending | Yes | No | 0.81 | -
 
 This cop checks for `raise` or `fail` statements which are
 raising `Exception` class.

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -294,6 +294,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             create_file('.rubocop.yml', <<~YAML)
               require: rubocop_ext
 
+              Lint:
+                Enabled: false
               Style:
                 Enabled: false
 


### PR DESCRIPTION
This PR fixes the following two CI errors.

First, this PR updates the metadata for `Lint/RaiseException`.

Follow d5b25ef.

Second, this PR commits a workaround patch. It should be updated to a test that is not affected by a pending department in future.

```console
% bundle exec rspec ./spec/rubocop/cli/cli_options_spec.rb:307
(snip)

Run options: include {:focus=>true, :locations=>{"./spec/rubocop/cli/cli_options_spec.rb"=>[307]}}

Randomized with seed 31394
F

Failures:

  1) RuboCop::CLI --only when one cop is given when specifying a pending cop when Style department is disabled does not show pending cop warning
     Failure/Error: expect(output).to eq(inspected_output)

       expected: "Inspecting 2 files\n..\n\n2 files inspected, no offenses detected\n"
            got: "The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true...ocop.org/en/latest/versioning/\nInspecting 2 files\n..\n\n2 files inspected, no offenses detected\n"

       (compared using ==)

       Diff:
       @@ -1,3 +1,6 @@
       +The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
       + - Lint/RaiseException (0.81)
       +For more information: https://docs.rubocop.org/en/latest/versioning/
        Inspecting 2 files
        ..

     # ./spec/rubocop/cli/cli_options_spec.rb:307:in `block (6 levels) in <top (required)>'
     # ./spec/support/cli_spec_behavior.rb:26:in `block (2 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:29:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/path_util.rb:67:in `chdir'
     # ./lib/rubocop/path_util.rb:67:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:28:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'

Finished in 1.28 seconds (files took 1.2 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/rubocop/cli/cli_options_spec.rb:306 # RuboCop::CLI --only when one cop is given when specifying a pending cop when Style department is disabled does not show pending cop warning

Randomized with seed 31394
```

https://app.circleci.com/jobs/github/rubocop-hq/rubocop/89963

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
