### PR TITLE
Add auto-correction for `Style/EndBlock` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#7784](https://github.com/rubocop-hq/rubocop/pull/7784): Support Ruby 2.7's numbered parameter for `Lint/SafeNavigationChain`. ([@koic][])
 * [#7331](https://github.com/rubocop-hq/rubocop/issues/7331): Add `forbidden` option to `Style/ModuleFunction` cop. ([@weh][])
 * [#7699](https://github.com/rubocop-hq/rubocop/pull/7699): Add new `Lint/StructNewOverride` cop. ([@ybiquitous][])
+* [#7809](https://github.com/rubocop-hq/rubocop/pull/7809): Add auto-correction for `Style/EndBlock` cop. ([@tejasbubane][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -2711,6 +2711,7 @@ Style/EndBlock:
   StyleGuide: '#no-END-blocks'
   Enabled: true
   VersionAdded: '0.9'
+  VersionChanged: '0.81'
 
 Style/EvalWithLocation:
   Description: 'Pass `__FILE__` and `__LINE__` to `eval` method, as they are used by backtraces.'

--- a/lib/rubocop/cop/style/end_block.rb
+++ b/lib/rubocop/cop/style/end_block.rb
@@ -19,6 +19,12 @@ module RuboCop
         def on_postexe(node)
           add_offense(node, location: :keyword)
         end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(node.loc.keyword, 'at_exit')
+          end
+        end
       end
     end
   end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1909,7 +1909,7 @@ This cop checks ensures source files have no utf-8 encoding comments.
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.9 | -
+Enabled | Yes | Yes  | 0.9 | 0.81
 
 This cop checks for END blocks.
 

--- a/spec/rubocop/cop/style/end_block_spec.rb
+++ b/spec/rubocop/cop/style/end_block_spec.rb
@@ -3,10 +3,20 @@
 RSpec.describe RuboCop::Cop::Style::EndBlock do
   subject(:cop) { described_class.new }
 
-  it 'reports an offense for an END block' do
+  it 'reports an offense and corrects END block' do
     expect_offense(<<~RUBY)
       END { test }
       ^^^ Avoid the use of `END` blocks. Use `Kernel#at_exit` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      at_exit { test }
+    RUBY
+  end
+
+  it 'does not report offenses for other blocks' do
+    expect_no_offenses(<<~RUBY)
+      end_block { test }
     RUBY
   end
 end


### PR DESCRIPTION
`Style/EndBlock` seems like a simple cop & should support safe auto-correction.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/