### PR TITLE
Add auto-correction for `Lint/BooleanSymbol` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#7809](https://github.com/rubocop-hq/rubocop/pull/7809): Add auto-correction for `Style/EndBlock` cop. ([@tejasbubane][])
 * [#7739](https://github.com/rubocop-hq/rubocop/pull/7739): Add `IgnoreNotImplementedMethods` configuration to `Lint/UnusedMethodArgument`. ([@tejasbubane][])
 * [#7740](https://github.com/rubocop-hq/rubocop/issues/7740): Add `AllowModifiersOnSymbols` configuration to `Style/AccessModifierDeclarations`. ([@tejasbubane][])
+* [#7812](https://github.com/rubocop-hq/rubocop/pull/7812): Add auto-correction for `Lint/BooleanSymbol` cop. ([@tejasbubane][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1323,6 +1323,7 @@ Lint/BooleanSymbol:
   Description: 'Check for `:true` and `:false` symbols.'
   Enabled: true
   VersionAdded: '0.50'
+  VersionChanged: '0.81'
 
 Lint/CircularArgumentReference:
   Description: "Default values in optional keyword arguments and optional ordinal arguments should not refer back to the name of the argument."

--- a/lib/rubocop/cop/lint/boolean_symbol.rb
+++ b/lib/rubocop/cop/lint/boolean_symbol.rb
@@ -32,6 +32,18 @@ module RuboCop
 
           add_offense(node, message: format(MSG, boolean: node.value))
         end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            boolean_literal = node.source.delete(':')
+            parent = node.parent
+            if parent&.pair_type?
+              corrector.remove(parent.loc.operator)
+              boolean_literal = "#{node.source} =>"
+            end
+            corrector.replace(node.loc.expression, boolean_literal)
+          end
+        end
       end
     end
   end

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -166,7 +166,7 @@ BigDecimal(123.456, 3)
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.50 | -
+Enabled | Yes | Yes  | 0.50 | 0.81
 
 This cop checks for `:true` and `:false` symbols.
 In most cases it would be a typo.

--- a/spec/rubocop/cop/lint/boolean_symbol_spec.rb
+++ b/spec/rubocop/cop/lint/boolean_symbol_spec.rb
@@ -8,12 +8,20 @@ RSpec.describe RuboCop::Cop::Lint::BooleanSymbol, :config do
       :true
       ^^^^^ Symbol with a boolean name - you probably meant to use `true`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      true
+    RUBY
   end
 
   it 'registers an offense when using `:false`' do
     expect_offense(<<~RUBY)
       :false
       ^^^^^^ Symbol with a boolean name - you probably meant to use `false`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      false
     RUBY
   end
 
@@ -23,12 +31,20 @@ RSpec.describe RuboCop::Cop::Lint::BooleanSymbol, :config do
         { true: 'Foo' }
           ^^^^ Symbol with a boolean name - you probably meant to use `true`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        { true => 'Foo' }
+      RUBY
     end
 
     it 'registers an offense when using `false:`' do
       expect_offense(<<~RUBY)
-        { false: 'Bar' }
+        { false: :bar }
           ^^^^^ Symbol with a boolean name - you probably meant to use `false`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        { false => :bar }
       RUBY
     end
   end


### PR DESCRIPTION
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/