### PR TITLE
Support Ruby 2.7's numbered parameter for `Style/Lambda`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#7740](https://github.com/rubocop-hq/rubocop/issues/7740): Add `AllowModifiersOnSymbols` configuration to `Style/AccessModifierDeclarations`. ([@tejasbubane][])
 * [#7812](https://github.com/rubocop-hq/rubocop/pull/7812): Add auto-correction for `Lint/BooleanSymbol` cop. ([@tejasbubane][])
 * [#7823](https://github.com/rubocop-hq/rubocop/pull/7823): Add `IgnoredMethods` configuration in `Metrics/AbcSize`, `Metrics/CyclomaticComplexity`, and `Metrics/PerceivedComplexity` cops. ([@drenmi][])
+* [#7816](https://github.com/rubocop-hq/rubocop/pull/7816): Support Ruby 2.7's numbered parameter for `Style/Lambda`. ([@koic][])
 
 ### Bug fixes
 

--- a/lib/rubocop/ast/builder.rb
+++ b/lib/rubocop/ast/builder.rb
@@ -20,6 +20,7 @@ module RuboCop
         args:         ArgsNode,
         array:        ArrayNode,
         block:        BlockNode,
+        numblock:     BlockNode,
         break:        BreakNode,
         case_match:   CaseMatchNode,
         case:         CaseNode,

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -484,7 +484,7 @@ module RuboCop
          (send (const nil? :Proc) :new)}
       PATTERN
 
-      def_node_matcher :lambda?, '(block (send nil? :lambda) ...)'
+      def_node_matcher :lambda?, '({block numblock} (send nil? :lambda) ...)'
       def_node_matcher :lambda_or_proc?, '{lambda? proc?}'
 
       def_node_matcher :class_constructor?, <<~PATTERN

--- a/lib/rubocop/ast/node/block_node.rb
+++ b/lib/rubocop/ast/node/block_node.rb
@@ -24,7 +24,11 @@ module RuboCop
       #
       # @return [Array<Node>]
       def arguments
-        node_parts[1]
+        if numblock_type?
+          [] # Numbered parameters have no block arguments.
+        else
+          node_parts[1]
+        end
       end
 
       # The body of this block.

--- a/lib/rubocop/cop/style/lambda.rb
+++ b/lib/rubocop/cop/style/lambda.rb
@@ -73,6 +73,7 @@ module RuboCop
                       location: node.send_node.source_range,
                       message: message(node, selector))
         end
+        alias on_numblock on_block
 
         def autocorrect(node)
           if node.send_node.source == 'lambda'

--- a/spec/rubocop/ast/block_node_spec.rb
+++ b/spec/rubocop/ast/block_node_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe RuboCop::AST::BlockNode do
 
       it { expect(block_node.arguments.size).to eq(2) }
     end
+
+    context '>= Ruby 2.7', :ruby27 do
+      context 'using numbered parameters' do
+        let(:source) { 'foo { _1 }' }
+
+        it { expect(block_node.arguments.empty?).to be(true) }
+      end
+    end
   end
 
   describe '#arguments?' do
@@ -58,6 +66,14 @@ RSpec.describe RuboCop::AST::BlockNode do
       let(:source) { 'foo { |q, *z| bar(q, z) }' }
 
       it { expect(block_node.arguments?).to be_truthy }
+    end
+
+    context '>= Ruby 2.7', :ruby27 do
+      context 'using numbered parameters' do
+        let(:source) { 'foo { _1 }' }
+
+        it { expect(block_node.arguments?).to be false }
+      end
     end
   end
 

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -194,6 +194,38 @@ RSpec.describe RuboCop::Cop::Style::Lambda, :config do
       end
     end
 
+    context '>= Ruby 2.7', :ruby27 do
+      context 'when using numbered parameter' do
+        context 'with a single line lambda method call' do
+          let(:source) { 'f = lambda { _1 }' }
+
+          it_behaves_like 'registers an offense',
+                          'Use the `-> { ... }` lambda literal syntax for ' \
+                          'single line lambdas.'
+          it_behaves_like 'auto-correct', 'f = -> { _1 }'
+        end
+
+        context 'with a multiline lambda method call' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              l = lambda do
+                _1
+              end
+            RUBY
+          end
+        end
+
+        context 'with a single line lambda literal' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              lambda = -> { _1 }
+              lambda.(1)
+            RUBY
+          end
+        end
+      end
+    end
+
     context 'with a multiline lambda literal' do
       context 'with arguments' do
         let(:source) do


### PR DESCRIPTION
This PR supports Ruby 2.7's numbered parameter for `Style/Lambda`.

And this PR maps `numblock` to `BlockNode`.
I considered the introduction of `NumblockNode`, but most will overlap with `BlockNode`. IMHO, probably `NumblockNode` class does not need to be split now.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
