### PR TITLE
Fix Style/NestedParenthesizedCalls docs

### DIFF
--- a/lib/rubocop/cop/style/nested_parenthesized_calls.rb
+++ b/lib/rubocop/cop/style/nested_parenthesized_calls.rb
@@ -8,10 +8,10 @@ module RuboCop
       #
       # @example
       #   # good
-      #   method1(method2(arg), method3(arg))
+      #   method1(method2(arg))
       #
       #   # bad
-      #   method1(method2 arg, method3, arg)
+      #   method1(method2 arg)
       class NestedParenthesizedCalls < Cop
         include RangeHelp
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4411,10 +4411,10 @@ of a parenthesized method call.
 
 ```ruby
 # good
-method1(method2(arg), method3(arg))
+method1(method2(arg))
 
 # bad
-method1(method2 arg, method3, arg)
+method1(method2 arg)
 ```
 
 ### Configurable attributes


### PR DESCRIPTION
method1(method2 arg, method3, arg) is not equivalent to method1(method2 arg, method3, arg)

method1(method2 arg, method3 arg) would be incorrect as well

method1(method2 arg) vs method1(method2(arg)) would be an example that illustrates the code standards and is correct in terms of syntax

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
