### PR TITLE
[Fix #7825] Fix crash for `Layout/MultilineMethodCallIndentation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [#7806](https://github.com/rubocop-hq/rubocop/pull/7806): Fix an error for `Lint/ErbNewArguments` cop when inspecting `ActionView::Template::Handlers::ERB.new`. ([@koic][])
 * [#7814](https://github.com/rubocop-hq/rubocop/issues/7814): Fix a false positive for `Migrate/DepartmentName` cop when inspecting an unexpected disabled comment format. ([@koic][])
 * [#7728](https://github.com/rubocop-hq/rubocop/issues/7728): Fix an error for `Style/OneLineConditional` when one of the branches contains a self keyword. ([@koic][])
+* [#7825](https://github.com/rubocop-hq/rubocop/issues/7825): Fix crash for `Layout/MultilineMethodCallIndentation` with key access to hash. ([@tejasbubane][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -193,7 +193,7 @@ module RuboCop
           node = node.receiver while node.receiver
           # ascend to first call which has a dot
           node = node.parent
-          node = node.parent until node.loc.dot
+          node = node.parent until node.loc.respond_to?(:dot) && node.loc.dot
 
           return if node.loc.dot.line != node.first_line
 

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -304,6 +304,15 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
         RUBY
       end
 
+      context 'target_ruby_version >= 2.5', :ruby25 do
+        it 'accepts key access to hash' do
+          expect_no_offenses(<<~RUBY)
+            hash[key] { 10 / 0 }
+              .fmap { |x| x * 3 }
+          RUBY
+        end
+      end
+
       it 'accepts 3 aligned methods' do
         expect_no_offenses(<<~RUBY)
           a_class.new(severity, location, 'message', 'CopName')


### PR DESCRIPTION
When block passed to class constant.

Closes #7825 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/