### PR TITLE
[Fix #7831] Fix a false positive for `Style/HashEachMethods`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [#7814](https://github.com/rubocop-hq/rubocop/issues/7814): Fix a false positive for `Migrate/DepartmentName` cop when inspecting an unexpected disabled comment format. ([@koic][])
 * [#7728](https://github.com/rubocop-hq/rubocop/issues/7728): Fix an error for `Style/OneLineConditional` when one of the branches contains a self keyword. ([@koic][])
 * [#7825](https://github.com/rubocop-hq/rubocop/issues/7825): Fix crash for `Layout/MultilineMethodCallIndentation` with key access to hash. ([@tejasbubane][])
+* [#7831](https://github.com/rubocop-hq/rubocop/issues/7831): Fix a false positive for `Style/HashEachMethods` when receiver is implicit. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/hash_each_methods.rb
+++ b/lib/rubocop/cop/style/hash_each_methods.rb
@@ -40,6 +40,8 @@ module RuboCop
 
         def register_kv_offense(node)
           kv_each(node) do |target, method|
+            return unless target.receiver.receiver
+
             msg = format(message, prefer: "each_#{method[0..-2]}",
                                   current: "#{method}.each")
 

--- a/spec/rubocop/cop/style/hash_each_methods_spec.rb
+++ b/spec/rubocop/cop/style/hash_each_methods_spec.rb
@@ -69,25 +69,15 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods do
     end
 
     context 'when receiver is implicit' do
-      it 'registers an offense and auto-corrects keys.each with each_key' do
-        expect_offense(<<~RUBY)
+      it 'does not register an offense for `keys.each`' do
+        expect_no_offenses(<<~RUBY)
           keys.each { |k| p k }
-          ^^^^^^^^^ Use `each_key` instead of `keys.each`.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          each_key { |k| p k }
         RUBY
       end
 
-      it 'registers an offense and auto-corrects values.each with each_value' do
-        expect_offense(<<~RUBY)
+      it 'does not register an offense for `values.each`' do
+        expect_no_offenses(<<~RUBY)
           values.each { |v| p v }
-          ^^^^^^^^^^^ Use `each_value` instead of `values.each`.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          each_value { |v| p v }
         RUBY
       end
 


### PR DESCRIPTION
Fixes #7831.

This PR fix a false positive for `Style/HashEachMethods` when there is no receiver for `keys` and `values`.

The following is an examples.

```ruby
values.each { |k, v| do_something(k, v) }
keys.each { |k, v| do_something(k, v) }
```

False negatives occur in cases such as object that inherit Hash, but that is perhaps a corner case.
I think it is more worthwhile to resolve the false positives with common naming of `values`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
