### PR TITLE
Fix `Lint/UriRegexp` to register offense with array arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#7842](https://github.com/rubocop-hq/rubocop/issues/7842): Fix a false positive for `Lint/RaiseException` when raising Exception with explicit namespace. ([@koic][])
+* [#7834](https://github.com/rubocop-hq/rubocop/issues/7834): Fix `Lint/UriRegexp` to register offense with array arguments. ([@tejasbubane][])
 
 ## 0.81.0 (2020-04-01)
 

--- a/lib/rubocop/cop/lint/uri_regexp.rb
+++ b/lib/rubocop/cop/lint/uri_regexp.rb
@@ -21,7 +21,7 @@ module RuboCop
         def_node_matcher :uri_regexp_with_argument?, <<~PATTERN
           (send
             (const ${nil? cbase} :URI) :regexp
-            (str $_))
+            ${(str _) (array ...)})
         PATTERN
 
         def_node_matcher :uri_regexp_without_argument?, <<~PATTERN
@@ -32,7 +32,7 @@ module RuboCop
         def on_send(node)
           uri_regexp_with_argument?(node) do |double_colon, arg|
             register_offense(
-              node, top_level: double_colon ? '::' : '', arg: "('#{arg}')"
+              node, top_level: double_colon ? '::' : '', arg: "(#{arg.source})"
             )
           end
 
@@ -51,7 +51,7 @@ module RuboCop
             double_colon, arg = captured_values
 
             top_level = double_colon ? '::' : ''
-            argument = arg ? "('#{arg}')" : ''
+            argument = arg ? "(#{arg.source})" : ''
 
             corrector.replace(
               node.loc.expression,

--- a/spec/rubocop/cop/lint/uri_regexp_spec.rb
+++ b/spec/rubocop/cop/lint/uri_regexp_spec.rb
@@ -49,4 +49,40 @@ RSpec.describe RuboCop::Cop::Lint::UriRegexp do
       ::URI::DEFAULT_PARSER.make_regexp
     RUBY
   end
+
+  context 'array argument' do
+    it 'registers an offense and corrects using `URI.regexp` with '\
+       'literal arrays' do
+      expect_offense(<<~RUBY)
+        URI.regexp(['http', 'https'])
+            ^^^^^^ `URI.regexp(['http', 'https'])` is obsolete and should not be used. Instead, use `URI::DEFAULT_PARSER.make_regexp(['http', 'https'])`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        URI::DEFAULT_PARSER.make_regexp(['http', 'https'])
+      RUBY
+    end
+
+    it 'registers an offense and corrects using `URI.regexp` with %w arrays' do
+      expect_offense(<<~RUBY)
+        URI.regexp(%w[http https])
+            ^^^^^^ `URI.regexp(%w[http https])` is obsolete and should not be used. Instead, use `URI::DEFAULT_PARSER.make_regexp(%w[http https])`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        URI::DEFAULT_PARSER.make_regexp(%w[http https])
+      RUBY
+    end
+
+    it 'registers an offense and corrects using `URI.regexp` with %i arrays' do
+      expect_offense(<<~RUBY)
+        URI.regexp(%i[http https])
+            ^^^^^^ `URI.regexp(%i[http https])` is obsolete and should not be used. Instead, use `URI::DEFAULT_PARSER.make_regexp(%i[http https])`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        URI::DEFAULT_PARSER.make_regexp(%i[http https])
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Closes #7834

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/