### PR TITLE
[Fix #7841] Fix an error for `Style/TrailingCommaInBlockArgs` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#7842](https://github.com/rubocop-hq/rubocop/issues/7842): Fix a false positive for `Lint/RaiseException` when raising Exception with explicit namespace. ([@koic][])
 * [#7834](https://github.com/rubocop-hq/rubocop/issues/7834): Fix `Lint/UriRegexp` to register offense with array arguments. ([@tejasbubane][])
+* [#7841](https://github.com/rubocop-hq/rubocop/issues/7841): Fix an error for `Style/TrailingCommaInBlockArgs` when lambda literal (`->`) has multiple arguments. ([@koic][])
 
 ## 0.81.0 (2020-04-01)
 

--- a/lib/rubocop/cop/style/trailing_comma_in_block_args.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_block_args.rb
@@ -44,6 +44,9 @@ module RuboCop
         MSG = 'Useless trailing comma present in block arguments.'
 
         def on_block(node)
+          # lambda literal (`->`) never has block arguments.
+          return if node.send_node.lambda_literal?
+
           return unless useless_trailing_comma?(node)
 
           add_offense(node, location: last_comma(node).pos)

--- a/spec/rubocop/cop/style/trailing_comma_in_block_args_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_block_args_spec.rb
@@ -139,4 +139,32 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInBlockArgs do
       RUBY
     end
   end
+
+  context 'when `->` has multiple arguments' do
+    it 'does not registers an offense' do
+      expect_no_offenses(<<~RUBY)
+        -> (foo, bar) { do_something(foo, bar) }
+      RUBY
+    end
+  end
+
+  context 'when `lambda` has multiple arguments' do
+    it 'does not register an offense when more than one argument is ' \
+       'present with no trailing comma' do
+      expect_no_offenses(<<~RUBY)
+        lambda { |foo, bar| do_something(foo, bar) }
+      RUBY
+    end
+
+    it "registers an offense and corrects when a trailing comma isn't needed" do
+      expect_offense(<<~RUBY)
+        lambda { |foo, bar,| do_something(foo, bar) }
+                          ^ Useless trailing comma present in block arguments.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        lambda { |foo, bar| do_something(foo, bar) }
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #7841.

This PR fixes an error for `Style/TrailingCommaInBlockArgs` cop when lambda literal (`->`) has multiple arguments. It will not be checked in the case of lambda literal because lambda literal (`->`) never have a block arguments.

```console
# Valid syntax
% ruby -ce '-> (foo, bar) { do_something(foo, bar) }'
Syntax OK

# Syntax error
% ruby -ce '-> { |foo| do_something }'
-e:1: syntax error, unexpected '|'
-> { |foo| do_something }
      ^

# Also syntax error
% ruby -ce '-> (foo, bar,) { do_something(foo, bar) }'
-e:1: syntax error, unexpected ')'
-> (foo, bar,) { do_something(foo, bar) }
              ^
-e:1: syntax error, unexpected '}', expecting end-of-input
r,) { do_something(foo, bar) }
                              ^
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
