### PR TITLE
[#7842] Fix a false positive for `Lint/RaiseException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#7842](https://github.com/rubocop-hq/rubocop/issues/7842): Fix a false positive for `Lint/RaiseException` when raising Exception with explicit namespace. ([@koic][])
+
 ## 0.81.0 (2020-04-01)
 
 ### New features

--- a/lib/rubocop/cop/lint/raise_exception.rb
+++ b/lib/rubocop/cop/lint/raise_exception.rb
@@ -16,12 +16,12 @@ module RuboCop
         MSG = 'Use `StandardError` over `Exception`.'
 
         def_node_matcher :exception?, <<~PATTERN
-          (send nil? ${:raise :fail} (const _ :Exception) ... )
+          (send nil? ${:raise :fail} (const {cbase nil?} :Exception) ... )
         PATTERN
 
         def_node_matcher :exception_new_with_message?, <<~PATTERN
           (send nil? ${:raise :fail}
-            (send (const _ :Exception) :new ... ))
+            (send (const {cbase nil?} :Exception) :new ... ))
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/lint/raise_exception_spec.rb
+++ b/spec/rubocop/cop/lint/raise_exception_spec.rb
@@ -80,4 +80,11 @@ RSpec.describe RuboCop::Cop::Lint::RaiseException do
   it 'does not register an offense for `fail` without arguments' do
     expect_no_offenses('fail')
   end
+
+  it 'does not register an offense when raising Exception with explicit ' \
+     'namespace' do
+    expect_no_offenses(<<~RUBY)
+      raise Foo::Exception
+    RUBY
+  end
 end


### PR DESCRIPTION
Resolve part of #7842.

This PR fixes a false positive for `Lint/RaiseException` when raising Exception with explicit namespace.

`Exception` belonging to a namespace is expected to inherit `StandardError`.

This PR makes `Lint/RaiseException` aware of the following differences:

```ruby
Gem::Exception.new.is_a?(StandardError) # => true
Exception.new.is_a?(StandardError)      # => false
```

On the other hand, the following case have not been resolved by this PR.

```ruby
module Gem
  def self.foo
    raise Exception
  end
end

Gem.foo #=> Gem::Exception
```

The above case will be resolved separately from this PR.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
