### PR TITLE
[Fix #7836] Fix breaking autocorrect for `Style/BlockDelimiters`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#7842](https://github.com/rubocop-hq/rubocop/issues/7842): Fix a false positive for `Lint/RaiseException` when raising Exception with explicit namespace. ([@koic][])
+* [#7836](https://github.com/rubocop-hq/rubocop/issues/7836): Fix breaking autocorrect for `Style/BlockDelimiters` with `semantic` config. ([@tejasbubane][])
 
 ## 0.81.0 (2020-04-01)
 

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -338,7 +338,13 @@ module RuboCop
         def correction_would_break_code?(node)
           return unless node.keywords?
 
-          node.send_node.arguments? && !node.send_node.parenthesized?
+          (node.send_node.arguments? &&
+           !node.send_node.parenthesized?) ||
+            contains_rescue_or_ensure?(node.children.compact)
+        end
+
+        def contains_rescue_or_ensure?(children)
+          children.any? { |c| c.rescue_type? || c.ensure_type? }
         end
 
         def functional_method?(method_name)

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -137,6 +137,36 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       RUBY
     end
 
+    context 'target_ruby_version >= 2.5', :ruby25 do
+      it 'registers an offense for multi-line block with do-end '\
+         'if it contains rescue but does no corrections' do
+        expect_offense(<<~RUBY)
+          foo = map do |x|
+                    ^^ Prefer `{...}` over `do...end` for functional blocks.
+            x.something_dangerous!
+          rescue StandardError => e
+            puts 'oh no'
+          end
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense for multi-line block with do-end '\
+         'if it contains ensure but does no corrections' do
+        expect_offense(<<~RUBY)
+          foo = map do |x|
+                    ^^ Prefer `{...}` over `do...end` for functional blocks.
+            x.something_dangerous!
+          ensure
+            puts 'oh no'
+          end
+        RUBY
+
+        expect_no_corrections
+      end
+    end
+
     it 'accepts a single line block with {} if used in an if statement' do
       expect_no_offenses('return if any? { |x| x }')
     end


### PR DESCRIPTION
With `semantic` style, do not autocorrect to braces if block contains
`rescue` or `ensure`.

Closes #7836

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/