### PR TITLE
Remove `save_screenshot` from `Lint/Debugger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * [#7834](https://github.com/rubocop-hq/rubocop/issues/7834): Fix `Lint/UriRegexp` to register offense with array arguments. ([@tejasbubane][])
 * [#7841](https://github.com/rubocop-hq/rubocop/issues/7841): Fix an error for `Style/TrailingCommaInBlockArgs` when lambda literal (`->`) has multiple arguments. ([@koic][])
 
+### Changes
+
+* Remove Capybara's `save_screenshot` from `Lint/Debugger`. ([@AndrewKvalheim][])
+
 ## 0.81.0 (2020-04-01)
 
 ### New features
@@ -4434,3 +4438,4 @@
 [@dmolesUC]: https://github.com/dmolesUC
 [@yuritomanek]: https://github.com/yuritomanek
 [@egze]: https://github.com/egze
+[@AndrewKvalheim]: https://github.com/AndrewKvalheim

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -48,8 +48,7 @@ module RuboCop
              {:pry :remote_pry :pry_remote :console} ...)
            (send (const {nil? (cbase)} :Pry) :rescue ...)
            (send nil? {:save_and_open_page
-                      :save_and_open_screenshot
-                      :save_screenshot} ...)}
+                      :save_and_open_screenshot} ...)}
         PATTERN
 
         def_node_matcher :binding_irb_call?, <<~PATTERN

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -27,9 +27,6 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
   include_examples 'debugger',
                    'capybara debug method',
                    'save_and_open_screenshot'
-  include_examples 'debugger',
-                   'capybara debug method',
-                   'save_screenshot'
   include_examples 'debugger', 'debugger with an argument', 'debugger foo'
   include_examples 'debugger', 'byebug with an argument', 'byebug foo'
   include_examples 'debugger',
@@ -47,9 +44,6 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
   include_examples 'debugger',
                    'capybara debug method with an argument',
                    'save_and_open_screenshot foo'
-  include_examples 'debugger',
-                   'capybara debug method with an argument',
-                   'save_screenshot foo'
 
   include_examples 'debugger', 'remote_byebug', 'remote_byebug'
   include_examples 'debugger', 'web console binding', 'binding.console'
@@ -68,7 +62,7 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
 
   ALL_COMMANDS = %w[debugger byebug console pry remote_pry pry_remote irb
                     save_and_open_page save_and_open_screenshot
-                    save_screenshot remote_byebug].freeze
+                    remote_byebug].freeze
 
   ALL_COMMANDS.each do |src|
     it "does not report an offense for a #{src} in comments" do


### PR DESCRIPTION
The behavior of `Lint/Debugger` across possible debugging methods is inconsistent:

| Method | Interactive | Reported |
| - | - | - |
| `puts` | No | No |
| `save_page` | No | No |
| `save_screenshot` | No | **Yes** |
| `pry` | Yes | Yes |
| `save_and_open_page` | Yes | Yes |
| `save_and_open_screenshot` | Yes | Yes |

Capybara's `save_screenshot` probably shouldn't be reported, as it just writes a file noninteractively.

---

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
