### PR TITLE
[Fix #7850] Make it possible to enable/disable pending cops

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ InternalAffairs/NodeDestructuring:
 # Offense count: 50
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 183
+  Max: 186
 
 # Offense count: 209
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#7850](https://github.com/rubocop-hq/rubocop/issues/7850): Make it possible to enable/disable pending cops. ([@koic][])
+
 ### Bug fixes
 
 * [#7842](https://github.com/rubocop-hq/rubocop/issues/7842): Fix a false positive for `Lint/RaiseException` when raising Exception with explicit namespace. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -97,6 +97,14 @@ AllCops:
   # to true in the same configuration.
   EnabledByDefault: false
   DisabledByDefault: false
+  # New cops introduced between major versions are set to a special pending status
+  # and are not enabled by default with warning message.
+  # Change this behavior by overriding either `NewCops: enable` or `NewCops: disable`.
+  # When `NewCops` is `enable`, pending cops are enabled in bulk. Can be overridden by
+  # the `--enable-pending-cops` command-line option.
+  # When `NewCops` is `disable`, pending cops are disabled in bulk. Can be overridden by
+  # the `--disable-pending-cops` command-line option.
+  NewCops: pending
   # Enables the result cache if `true`. Can be overridden by the `--cache` command
   # line option.
   UseCache: true

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -83,10 +83,7 @@ module RuboCop
     end
 
     def act_on_options
-      ConfigLoader.debug = @options[:debug]
-      ConfigLoader.auto_gen_config = @options[:auto_gen_config]
-      ConfigLoader.ignore_parent_exclusion = @options[:ignore_parent_exclusion]
-      ConfigLoader.options_config = @options[:config]
+      set_options_to_config_loader
 
       @config_store.options_config = @options[:config] if @options[:config]
       @config_store.force_default_config! if @options[:force_default_config]
@@ -100,6 +97,15 @@ module RuboCop
         # color output explicitly forced off
         Rainbow.enabled = false
       end
+    end
+
+    def set_options_to_config_loader
+      ConfigLoader.debug = @options[:debug]
+      ConfigLoader.auto_gen_config = @options[:auto_gen_config]
+      ConfigLoader.disable_pending_cops = @options[:disable_pending_cops]
+      ConfigLoader.enable_pending_cops = @options[:enable_pending_cops]
+      ConfigLoader.ignore_parent_exclusion = @options[:ignore_parent_exclusion]
+      ConfigLoader.options_config = @options[:config]
     end
 
     def handle_exiting_options

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -116,6 +116,14 @@ module RuboCop
       @for_all_cops ||= self['AllCops'] || {}
     end
 
+    def disabled_new_cops?
+      for_all_cops['NewCops'] == 'disable'
+    end
+
+    def enabled_new_cops?
+      for_all_cops['NewCops'] == 'enable'
+    end
+
     def file_to_include?(file)
       relative_file_path = path_relative_to_config(file)
 

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -154,6 +154,7 @@ module RuboCop
       end
     end
 
+    # rubocop:disable Metrics/MethodLength
     def add_boolean_flags(opts)
       option(opts, '-F', '--fail-fast')
       option(opts, '-C', '--cache FLAG')
@@ -162,6 +163,8 @@ module RuboCop
       option(opts, '-E', '--extra-details')
       option(opts, '-S', '--display-style-guide')
       option(opts, '-a', '--auto-correct')
+      option(opts, '--disable-pending-cops')
+      option(opts, '--enable-pending-cops')
       option(opts, '--ignore-disable-comments')
 
       option(opts, '--safe')
@@ -172,6 +175,7 @@ module RuboCop
       option(opts, '-V', '--verbose-version')
       option(opts, '-P', '--parallel')
     end
+    # rubocop:enable Metrics/MethodLength
 
     def add_aliases(opts)
       option(opts, '-l', '--lint') do
@@ -438,7 +442,9 @@ module RuboCop
       debug:                            'Display debug info.',
       display_cop_names:                ['Display cop names in offense messages.',
                                          'Default is true.'],
+      disable_pending_cops:             'Run without pending cops.',
       display_style_guide:              'Display style guide URLs in offense messages.',
+      enable_pending_cops:              'Run with pending cops.',
       extra_details:                    'Display extra details in offense messages.',
       lint:                             'Run only lint cops.',
       safe:                             'Run only safe cops.',

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -314,7 +314,7 @@ module RuboCop
 
         cop_classes.reject! { |c| c.match?(@options[:except]) }
 
-        Cop::Registry.new(cop_classes)
+        Cop::Registry.new(cop_classes, @options)
       end
     end
 

--- a/manual/basic_usage.md
+++ b/manual/basic_usage.md
@@ -116,9 +116,11 @@ Command flag                    | Description
 `-c/--config`                   | Run with specified config file.
 `-C/--cache`                    | Store and reuse results for faster operation.
 `-d/--debug`                    | Displays some extra debug output.
+    --disable-pending-cops      | Run without pending cops.
 `   --disable-uncorrectable`    | Used with --auto-correct to annotate any offenses that do not support autocorrect with `rubocop:todo` comments.
 `-D/--[no-]display-cop-names`   | Displays cop names in offense messages. Default is true.
 `   --display-only-fail-level-offenses` | Only output offense messages at the specified `--fail-level` or above
+    --enable-pending-cops       | Run with pending cops.
 `   --except`                   | Run all cops enabled by configuration except the specified cop(s) and/or departments.
 `   --exclude-limit`            | Limit how many individual files `--auto-gen-config` can list in `Exclude` parameters, default is 15.
 `-E/--extra-details`            | Displays extra details in offense messages.

--- a/manual/versioning.md
+++ b/manual/versioning.md
@@ -54,7 +54,25 @@ For more information: https://docs.rubocop.org/en/latest/versioning/
 You can see that 3 new cops were added in RuboCop 0.80 and it's up to you
 to decide if you want to enable or disable them.
 
-To suppress this message set `Enabled` to either `true` or `false` in your `.rubocop.yml` file.
+To suppress this message set `NewCops` to either `enable` or `disable` in your `.rubocop.yml` file.
+
+The following setting or using `rubocop --enable-pending-cops` command-line option, pending cops are enabled in bulk.
+
+```yaml
+AllCops:
+  NewCops: enable
+```
+
+The following setting or using `rubocop --disable-pending-cops` command-line option, pending cops are disabled in bulk.
+
+```yaml
+AllCops:
+  NewCops: disable
+```
+
+The command-line options takes precedence over `.rubocop.yml` file.
+
+Or set `Enabled` to either `true` or `false` in your `.rubocop.yml` file.
 
 `Style/ANewCop` is an example of a newly added pending cop:
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1093,6 +1093,24 @@ RSpec.describe RuboCop::ConfigLoader do
       end
     end
 
+    context 'does not set `pending`, `disable`, or `enable` to `NewCops`' do
+      before do
+        create_file(configuration_path, <<~YAML)
+          AllCops:
+            NewCops: true
+        YAML
+      end
+
+      it 'gets a warning message' do
+        expect do
+          load_file
+        end.to raise_error(
+          RuboCop::ValidationError,
+          /invalid true for `NewCops` found in/
+        )
+      end
+    end
+
     context 'when the file does not exist' do
       let(:configuration_path) { 'file_that_does_not_exist.yml' }
 

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -110,6 +110,8 @@ RSpec.describe RuboCop::Options, :isolated_environment do
               -E, --extra-details              Display extra details in offense messages.
               -S, --display-style-guide        Display style guide URLs in offense messages.
               -a, --auto-correct               Auto-correct offenses.
+                  --disable-pending-cops       Run without pending cops.
+                  --enable-pending-cops        Run with pending cops.
                   --ignore-disable-comments    Run cops even when they are disabled locally
                                                with a comment.
                   --safe                       Run only safe cops.


### PR DESCRIPTION
Resolves #7850.

This PR will add `--enable-pending-cops` and `--disable-pending-cops` command-line options and `NewCops` will be provided in .rubocop.yml.

When `NewCops` is `enable`, pending cops are enabled in bulk.

```yaml
AllCops:
  NewCops: enable
```

Can be overridden by the `--enable-pending-cops` command-line option.

When `NewCops` is `disable`, pending cops are disabled in bulk.

```yaml
AllCops:
  NewCops: disable
```

Can be overridden by the `--disable-pending-cops` command-line option.

The default value of `NewCops` is `pending`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
