### PR TITLE
Add option to allow case equality when the receiver is a constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#7850](https://github.com/rubocop-hq/rubocop/issues/7850): Make it possible to enable/disable pending cops. ([@koic][])
+* [#7861](https://github.com/rubocop-hq/rubocop/issues/7861): Make it to allow `Style/CaseEquality` when the receiver is a constant. ([@rafaelfranca][])
 
 ### Bug fixes
 
@@ -4438,3 +4439,4 @@
 [@dmolesUC]: https://github.com/dmolesUC
 [@yuritomanek]: https://github.com/yuritomanek
 [@egze]: https://github.com/egze
+[@rafaelfranca]: https://github.com/rafaelfranca

--- a/config/default.yml
+++ b/config/default.yml
@@ -2417,6 +2417,15 @@ Style/CaseEquality:
   StyleGuide: '#no-case-equality'
   Enabled: true
   VersionAdded: '0.9'
+  # If AllowOnConstant is enabled, the cop will ignore violations when the receiver of
+  # the case equality operator is a constant.
+  #
+  #   # bad
+  #   /string/ === "string"
+  #
+  #   # good
+  #   String === "string"
+  AllowOnConstant: false
 
 Style/CharacterLiteral:
   Description: 'Checks for uses of character literals.'

--- a/lib/rubocop/cop/style/case_equality.rb
+++ b/lib/rubocop/cop/style/case_equality.rb
@@ -16,13 +16,36 @@ module RuboCop
       #   (1..100).include?(7)
       #   some_string =~ /something/
       #
+      # @example AllowOnConstant
+      #   # Style/CaseEquality:
+      #   #   AllowOnConstant: true
+      #
+      #   # bad
+      #   (1..100) === 7
+      #   /something/ === some_string
+      #
+      #   # good
+      #   Array === something
+      #   (1..100).include?(7)
+      #   some_string =~ /something/
+      #
       class CaseEquality < Cop
         MSG = 'Avoid the use of the case equality operator `===`.'
 
-        def_node_matcher :case_equality?, '(send _ :=== _)'
+        def_node_matcher :case_equality?, '(send #const? :=== _)'
 
         def on_send(node)
           case_equality?(node) { add_offense(node, location: :selector) }
+        end
+
+        private
+
+        def const?(node)
+          if cop_config.fetch('AllowOnConstant', false)
+            !node.const_type?
+          else
+            true
+          end
         end
       end
     end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -557,6 +557,27 @@ something.is_a?(Array)
 (1..100).include?(7)
 some_string =~ /something/
 ```
+#### AllowOnConstant
+
+```ruby
+# Style/CaseEquality:
+#   AllowOnConstant: true
+
+# bad
+(1..100) === 7
+/something/ === some_string
+
+# good
+Array === something
+(1..100).include?(7)
+some_string =~ /something/
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AllowOnConstant | `false` | Boolean
 
 ### References
 

--- a/spec/rubocop/cop/style/case_equality_spec.rb
+++ b/spec/rubocop/cop/style/case_equality_spec.rb
@@ -1,12 +1,37 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::CaseEquality do
-  subject(:cop) { described_class.new }
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
 
   it 'registers an offense for ===' do
     expect_offense(<<~RUBY)
       Array === var
             ^^^ Avoid the use of the case equality operator `===`.
     RUBY
+  end
+
+  context 'when constant checks are allowed' do
+    let(:config) do
+      RuboCop::Config.new(
+        'Style/CaseEquality' => {
+          'AllowOnConstant' => true
+        }
+      )
+    end
+
+    it 'does not register an offense for === when the receiver is a constant' do
+      expect_no_offenses(<<~RUBY)
+        Array === var
+      RUBY
+    end
+
+    it 'registers an offense for === when the receiver is not a constant' do
+      expect_offense(<<~RUBY)
+        /OMG/ === "OMG"
+              ^^^ Avoid the use of the case equality operator `===`.
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
For some constant, specially direct subclasses of `BasicObject`, using `is_a?` is not an option since `BasicObject` doesn't respond to that method.

In those cases it would be interesting to allow this config so apps can opt-out that cop only when the receiver is a constant.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
