### PR TITLE
Add #wrap to corrector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#7862](https://github.com/rubocop-hq/rubocop/issues/7862): Corrector now has a `wrap` method. ([@marcandre][])
 * [#7850](https://github.com/rubocop-hq/rubocop/issues/7850): Make it possible to enable/disable pending cops. ([@koic][])
 
 ### Bug fixes

--- a/lib/rubocop/cop/corrector.rb
+++ b/lib/rubocop/cop/corrector.rb
@@ -101,6 +101,16 @@ module RuboCop
         @source_rewriter.insert_after(range, content)
       end
 
+      # Wraps the given source range with the given before and after texts
+      #
+      # @param [Parser::Source::Range] range
+      # @param [String] before
+      # @param [String] after
+      def wrap(range, before, after)
+        validate_range range
+        @source_rewriter.wrap(range, before, after)
+      end
+
       # Replaces the code of the source range `range` with `content`.
       #
       # @param [Parser::Source::Range] range

--- a/spec/rubocop/cop/corrector_spec.rb
+++ b/spec/rubocop/cop/corrector_spec.rb
@@ -50,6 +50,12 @@ RSpec.describe RuboCop::Cop::Corrector do
       end.to rewrite_to 'true and nil; false'
     end
 
+    it 'allows insertion before and after a source range' do
+      expect do |corrector|
+        corrector.wrap(operator, '(', ')')
+      end.to rewrite_to 'true (and) false'
+    end
+
     it 'allows replacement of a range' do
       expect { |c| c.replace(operator, 'or') }.to rewrite_to 'true or false'
     end


### PR DESCRIPTION
Please expose `@source_rewriter`'s `wrap` method which can be particularly useful (equivalent to `insert_before` + `insert_after`)

