### PR TITLE
Have correctors accept node instead of range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#7863](https://github.com/rubocop-hq/rubocop/issues/7863): Corrector now accepts nodes in addition to ranges. ([@marcandre][])
 * [#7862](https://github.com/rubocop-hq/rubocop/issues/7862): Corrector now has a `wrap` method. ([@marcandre][])
 * [#7850](https://github.com/rubocop-hq/rubocop/issues/7850): Make it possible to enable/disable pending cops. ([@koic][])
 * [#7861](https://github.com/rubocop-hq/rubocop/issues/7861): Make it to allow `Style/CaseEquality` when the receiver is a constant. ([@rafaelfranca][])

--- a/lib/rubocop/cop/bundler/insecure_protocol_source.rb
+++ b/lib/rubocop/cop/bundler/insecure_protocol_source.rb
@@ -53,7 +53,7 @@ module RuboCop
         def autocorrect(node)
           lambda do |corrector|
             corrector.replace(
-              node.first_argument.loc.expression, "'https://rubygems.org'"
+              node.first_argument, "'https://rubygems.org'"
             )
           end
         end

--- a/lib/rubocop/cop/corrector.rb
+++ b/lib/rubocop/cop/corrector.rb
@@ -72,18 +72,18 @@ module RuboCop
 
       # Removes the source range.
       #
-      # @param [Parser::Source::Range] range
-      def remove(range)
-        validate_range range
+      # @param [Parser::Source::Range, Rubocop::AST::Node] range or node
+      def remove(node_or_range)
+        range = to_range(node_or_range)
         @source_rewriter.remove(range)
       end
 
       # Inserts new code before the given source range.
       #
-      # @param [Parser::Source::Range] range
+      # @param [Parser::Source::Range, Rubocop::AST::Node] range or node
       # @param [String] content
-      def insert_before(range, content)
-        validate_range range
+      def insert_before(node_or_range, content)
+        range = to_range(node_or_range)
         # TODO: Fix Cops using bad ranges instead
         if range.end_pos > @source_buffer.source.size
           range = range.with(end_pos: @source_buffer.source.size)
@@ -94,38 +94,38 @@ module RuboCop
 
       # Inserts new code after the given source range.
       #
-      # @param [Parser::Source::Range] range
+      # @param [Parser::Source::Range, Rubocop::AST::Node] range or node
       # @param [String] content
-      def insert_after(range, content)
-        validate_range range
+      def insert_after(node_or_range, content)
+        range = to_range(node_or_range)
         @source_rewriter.insert_after(range, content)
       end
 
       # Wraps the given source range with the given before and after texts
       #
-      # @param [Parser::Source::Range] range
+      # @param [Parser::Source::Range, Rubocop::AST::Node] range or node
       # @param [String] before
       # @param [String] after
-      def wrap(range, before, after)
-        validate_range range
+      def wrap(node_or_range, before, after)
+        range = to_range(node_or_range)
         @source_rewriter.wrap(range, before, after)
       end
 
       # Replaces the code of the source range `range` with `content`.
       #
-      # @param [Parser::Source::Range] range
+      # @param [Parser::Source::Range, Rubocop::AST::Node] range or node
       # @param [String] content
-      def replace(range, content)
-        validate_range range
+      def replace(node_or_range, content)
+        range = to_range(node_or_range)
         @source_rewriter.replace(range, content)
       end
 
       # Removes `size` characters prior to the source range.
       #
-      # @param [Parser::Source::Range] range
+      # @param [Parser::Source::Range, Rubocop::AST::Node] range or node
       # @param [Integer] size
-      def remove_preceding(range, size)
-        validate_range range
+      def remove_preceding(node_or_range, size)
+        range = to_range(node_or_range)
         to_remove = Parser::Source::Range.new(range.source_buffer,
                                               range.begin_pos - size,
                                               range.begin_pos)
@@ -136,10 +136,10 @@ module RuboCop
       # If `size` is greater than the size of `range`, the removed region can
       # overrun the end of `range`.
       #
-      # @param [Parser::Source::Range] range
+      # @param [Parser::Source::Range, Rubocop::AST::Node] range or node
       # @param [Integer] size
-      def remove_leading(range, size)
-        validate_range range
+      def remove_leading(node_or_range, size)
+        range = to_range(node_or_range)
         to_remove = Parser::Source::Range.new(range.source_buffer,
                                               range.begin_pos,
                                               range.begin_pos + size)
@@ -150,10 +150,10 @@ module RuboCop
       # If `size` is greater than the size of `range`, the removed region can
       # overrun the beginning of `range`.
       #
-      # @param [Parser::Source::Range] range
+      # @param [Parser::Source::Range, Rubocop::AST::Node] range or node
       # @param [Integer] size
-      def remove_trailing(range, size)
-        validate_range range
+      def remove_trailing(node_or_range, size)
+        range = to_range(node_or_range)
         to_remove = Parser::Source::Range.new(range.source_buffer,
                                               range.end_pos - size,
                                               range.end_pos)
@@ -163,11 +163,25 @@ module RuboCop
       private
 
       # :nodoc:
-      def validate_range(range)
-        buffer = range.source_buffer
+      def to_range(node_or_range)
+        range = case node_or_range
+                when ::RuboCop::AST::Node, ::Parser::Source::Comment
+                  node_or_range.loc.expression
+                when ::Parser::Source::Range
+                  node_or_range
+                else
+                  raise TypeError,
+                        'Expected a Parser::Source::Range, Comment or ' \
+                        "Rubocop::AST::Node, got #{node_or_range.class}"
+                end
+        validate_buffer(range.source_buffer)
+        range
+      end
+
+      def validate_buffer(buffer)
         return if buffer == @source_buffer
 
-        unless buffer.is_a?(Parser::Source::Buffer)
+        unless buffer.is_a?(::Parser::Source::Buffer)
           # actually this should be enforced by parser gem
           raise 'Corrector expected range source buffer to be a ' \
                 "Parser::Source::Buffer, but got #{buffer.class}"

--- a/lib/rubocop/cop/correctors/condition_corrector.rb
+++ b/lib/rubocop/cop/correctors/condition_corrector.rb
@@ -10,8 +10,7 @@ module RuboCop
 
           lambda do |corrector|
             corrector.replace(node.loc.keyword, node.inverse_keyword)
-            corrector.replace(condition.source_range,
-                              condition.children.first.source)
+            corrector.replace(condition, condition.children.first.source)
           end
         end
 

--- a/lib/rubocop/cop/correctors/empty_line_corrector.rb
+++ b/lib/rubocop/cop/correctors/empty_line_corrector.rb
@@ -18,7 +18,7 @@ module RuboCop
         end
 
         def insert_before(node)
-          ->(corrector) { corrector.insert_before(node.source_range, "\n") }
+          ->(corrector) { corrector.insert_before(node, "\n") }
         end
       end
     end

--- a/lib/rubocop/cop/correctors/lambda_literal_to_method_corrector.rb
+++ b/lib/rubocop/cop/correctors/lambda_literal_to_method_corrector.rb
@@ -44,13 +44,13 @@ module RuboCop
       end
 
       def replace_selector(corrector)
-        corrector.replace(method.source_range, 'lambda')
+        corrector.replace(method, 'lambda')
       end
 
       def remove_arguments(corrector)
         return if arguments.empty_and_without_delimiters?
 
-        corrector.remove(arguments.source_range)
+        corrector.remove(arguments)
       end
 
       def insert_arguments(corrector)
@@ -62,7 +62,7 @@ module RuboCop
 
       def remove_leading_whitespace(corrector)
         corrector.remove_preceding(
-          arguments.source_range,
+          arguments,
           arguments.source_range.begin_pos -
             block_node.send_node.source_range.end_pos
         )

--- a/lib/rubocop/cop/correctors/line_break_corrector.rb
+++ b/lib/rubocop/cop/correctors/line_break_corrector.rb
@@ -38,9 +38,9 @@ module RuboCop
           return unless eol_comment
 
           text = eol_comment.loc.expression.source
-          corrector.insert_before(node.source_range,
+          corrector.insert_before(node,
                                   text + "\n" + (' ' * node.loc.keyword.column))
-          corrector.remove(eol_comment.loc.expression)
+          corrector.remove(eol_comment)
         end
 
         private

--- a/lib/rubocop/cop/correctors/percent_literal_corrector.rb
+++ b/lib/rubocop/cop/correctors/percent_literal_corrector.rb
@@ -26,7 +26,7 @@ module RuboCop
       def wrap_contents(node, contents, char, delimiters)
         lambda do |corrector|
           corrector.replace(
-            node.source_range,
+            node,
             "%#{char}#{delimiters[0]}#{contents}#{delimiters[1]}"
           )
         end

--- a/lib/rubocop/cop/correctors/string_literal_corrector.rb
+++ b/lib/rubocop/cop/correctors/string_literal_corrector.rb
@@ -13,9 +13,9 @@ module RuboCop
           lambda do |corrector|
             str = node.str_content
             if style == :single_quotes
-              corrector.replace(node.source_range, to_string_literal(str))
+              corrector.replace(node, to_string_literal(str))
             else
-              corrector.replace(node.source_range, str.inspect)
+              corrector.replace(node, str.inspect)
             end
           end
         end

--- a/lib/rubocop/cop/internal_affairs/offense_location_keyword.rb
+++ b/lib/rubocop/cop/internal_affairs/offense_location_keyword.rb
@@ -28,7 +28,7 @@ module RuboCop
         def autocorrect(node)
           (*, keyword) = offending_location_argument(node.parent)
 
-          ->(corrector) { corrector.replace(node.source_range, ":#{keyword}") }
+          ->(corrector) { corrector.replace(node, ":#{keyword}") }
         end
 
         private

--- a/lib/rubocop/cop/layout/dot_position.rb
+++ b/lib/rubocop/cop/layout/dot_position.rb
@@ -44,7 +44,7 @@ module RuboCop
             when :leading
               corrector.insert_before(selector_range(node), dot)
             when :trailing
-              corrector.insert_after(node.receiver.source_range, dot)
+              corrector.insert_after(node.receiver, dot)
             end
           end
         end

--- a/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
+++ b/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
@@ -169,7 +169,7 @@ module RuboCop
         end
 
         def add_correct_closing_paren(node, corrector)
-          corrector.insert_after(node.arguments.last.source_range, ')')
+          corrector.insert_after(node.arguments.last, ')')
         end
 
         def remove_incorrect_closing_paren(node, corrector)
@@ -249,7 +249,7 @@ module RuboCop
         def add_correct_external_trailing_comma(node, corrector)
           return unless external_trailing_comma?(node)
 
-          corrector.insert_after(node.arguments.last.source_range, ',')
+          corrector.insert_after(node.arguments.last, ',')
         end
 
         def remove_incorrect_external_trailing_comma(node, corrector)

--- a/lib/rubocop/cop/layout/heredoc_indentation.rb
+++ b/lib/rubocop/cop/layout/heredoc_indentation.rb
@@ -184,14 +184,14 @@ module RuboCop
         def adjust_minus(corrector, node)
           heredoc_beginning = node.loc.expression.source
           corrected = heredoc_beginning.sub(/<<-?/, '<<~')
-          corrector.replace(node.loc.expression, corrected)
+          corrector.replace(node, corrected)
         end
 
         def correct_by_library(node)
           lambda do |corrector|
             corrector.replace(node.loc.heredoc_body, indented_body(node))
             corrected = ".#{STRIP_METHODS[style]}"
-            corrector.insert_after(node.loc.expression, corrected)
+            corrector.insert_after(node, corrected)
           end
         end
 

--- a/lib/rubocop/cop/layout/multiline_block_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_block_layout.rb
@@ -129,7 +129,7 @@ module RuboCop
 
           block_start_col = node.source_range.column
 
-          corrector.insert_before(first_node.source_range,
+          corrector.insert_before(first_node,
                                   "\n  #{' ' * block_start_col}")
         end
 

--- a/lib/rubocop/cop/layout/space_around_block_parameters.rb
+++ b/lib/rubocop/cop/layout/space_around_block_parameters.rb
@@ -43,9 +43,9 @@ module RuboCop
           lambda do |corrector|
             if target.is_a?(RuboCop::AST::Node)
               if target.parent.children.first == target
-                corrector.insert_before(target.source_range, ' ')
+                corrector.insert_before(target, ' ')
               else
-                corrector.insert_after(target.source_range, ' ')
+                corrector.insert_after(target, ' ')
               end
             elsif target.source =~ /^\s+$/
               corrector.remove(target)

--- a/lib/rubocop/cop/layout/space_in_lambda_literal.rb
+++ b/lib/rubocop/cop/layout/space_in_lambda_literal.rb
@@ -46,7 +46,7 @@ module RuboCop
           children = lambda_node.parent.children
           lambda do |corrector|
             if style == :require_space
-              corrector.insert_before(children[1].source_range, ' ')
+              corrector.insert_before(children[1], ' ')
             else
               corrector.remove(space_after_arrow(lambda_node))
             end

--- a/lib/rubocop/cop/layout/space_inside_range_literal.rb
+++ b/lib/rubocop/cop/layout/space_inside_range_literal.rb
@@ -35,7 +35,7 @@ module RuboCop
 
           lambda do |corrector|
             corrector.replace(
-              node.source_range,
+              node,
               expression
                 .sub(/\s+#{operator_escaped}/, operator)
                 .sub(/#{operator_escaped}\s+/, operator)

--- a/lib/rubocop/cop/lint/boolean_symbol.rb
+++ b/lib/rubocop/cop/lint/boolean_symbol.rb
@@ -41,7 +41,7 @@ module RuboCop
               corrector.remove(parent.loc.operator)
               boolean_literal = "#{node.source} =>"
             end
-            corrector.replace(node.loc.expression, boolean_literal)
+            corrector.replace(node, boolean_literal)
           end
         end
       end

--- a/lib/rubocop/cop/lint/inherit_exception.rb
+++ b/lib/rubocop/cop/lint/inherit_exception.rb
@@ -77,7 +77,7 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            corrector.replace(node.loc.expression, preferred_base_class)
+            corrector.replace(node, preferred_base_class)
           end
         end
 

--- a/lib/rubocop/cop/lint/literal_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/literal_in_interpolation.rb
@@ -37,7 +37,7 @@ module RuboCop
           return if node.dstr_type? # nested, fixed in next iteration
 
           value = autocorrected_value(node)
-          ->(corrector) { corrector.replace(node.parent.source_range, value) }
+          ->(corrector) { corrector.replace(node.parent, value) }
         end
 
         private

--- a/lib/rubocop/cop/lint/multiple_comparison.rb
+++ b/lib/rubocop/cop/lint/multiple_comparison.rb
@@ -39,7 +39,7 @@ module RuboCop
           new_center = "#{center.source} && #{center.source}"
 
           lambda do |corrector|
-            corrector.replace(center.source_range, new_center)
+            corrector.replace(center, new_center)
           end
         end
       end

--- a/lib/rubocop/cop/lint/non_deterministic_require_order.rb
+++ b/lib/rubocop/cop/lint/non_deterministic_require_order.rb
@@ -52,12 +52,12 @@ module RuboCop
         def autocorrect(node)
           if unsorted_dir_block?(node)
             lambda do |corrector|
-              corrector.replace(node.loc.expression, "#{node.source}.sort.each")
+              corrector.replace(node, "#{node.source}.sort.each")
             end
           else
             lambda do |corrector|
               source = node.receiver.source
-              corrector.replace(node.loc.expression, "#{source}.sort.each")
+              corrector.replace(node, "#{source}.sort.each")
             end
           end
         end

--- a/lib/rubocop/cop/lint/number_conversion.rb
+++ b/lib/rubocop/cop/lint/number_conversion.rb
@@ -55,7 +55,7 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            corrector.replace(node.loc.expression,
+            corrector.replace(node,
                               correct_method(node, node.receiver))
           end
         end

--- a/lib/rubocop/cop/lint/redundant_string_coercion.rb
+++ b/lib/rubocop/cop/lint/redundant_string_coercion.rb
@@ -38,7 +38,7 @@ module RuboCop
           lambda do |corrector|
             receiver = node.receiver
             corrector.replace(
-              node.source_range,
+              node,
               if receiver
                 receiver.source
               else

--- a/lib/rubocop/cop/lint/uri_regexp.rb
+++ b/lib/rubocop/cop/lint/uri_regexp.rb
@@ -54,7 +54,7 @@ module RuboCop
             argument = arg ? "(#{arg.source})" : ''
 
             corrector.replace(
-              node.loc.expression,
+              node,
               "#{top_level}URI::DEFAULT_PARSER.make_regexp#{argument}"
             )
           end

--- a/lib/rubocop/cop/mixin/hash_transform_method.rb
+++ b/lib/rubocop/cop/mixin/hash_transform_method.rb
@@ -161,7 +161,7 @@ module RuboCop
 
         def set_new_body_expression(transforming_body_expr, corrector)
           corrector.replace(
-            block_node.body.loc.expression,
+            block_node.body,
             transforming_body_expr.loc.expression.source
           )
         end

--- a/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
+++ b/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
@@ -73,7 +73,7 @@ module RuboCop
             node.body&.each_descendant(:lvar) do |var|
               next unless var.children.first == offending_name
 
-              corrector.replace(var.loc.expression, preferred_name)
+              corrector.replace(var, preferred_name)
             end
           end
         end

--- a/lib/rubocop/cop/style/alias.rb
+++ b/lib/rubocop/cop/style/alias.rb
@@ -115,7 +115,7 @@ module RuboCop
           lambda do |corrector|
             new, old = *send_node.arguments
             replacement = "alias #{identifier(new)} #{identifier(old)}"
-            corrector.replace(send_node.source_range, replacement)
+            corrector.replace(send_node, replacement)
           end
         end
 
@@ -125,15 +125,15 @@ module RuboCop
               'alias_method ' \
               ":#{identifier(node.new_identifier)}, " \
               ":#{identifier(node.old_identifier)}"
-            corrector.replace(node.source_range, replacement)
+            corrector.replace(node, replacement)
           end
         end
 
         def correct_alias_with_symbol_args(node)
           lambda do |corrector|
-            corrector.replace(node.new_identifier.source_range,
+            corrector.replace(node.new_identifier,
                               node.new_identifier.source[1..-1])
-            corrector.replace(node.old_identifier.source_range,
+            corrector.replace(node.old_identifier,
                               node.old_identifier.source[1..-1])
           end
         end

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -97,12 +97,12 @@ module RuboCop
           return unless correctable_send?(node)
 
           corrector.replace(whitespace_before_arg(node), '(')
-          corrector.insert_after(node.last_argument.source_range, ')')
+          corrector.insert_after(node.last_argument, ')')
         end
 
         def correct_setter(node, corrector)
-          corrector.insert_before(node.receiver.source_range, '(')
-          corrector.insert_after(node.last_argument.source_range, ')')
+          corrector.insert_before(node.receiver, '(')
+          corrector.insert_after(node.last_argument, ')')
         end
 
         # ! is a special case:
@@ -124,8 +124,7 @@ module RuboCop
         def correct_other(node, corrector)
           return if node.source_range.begin.is?('(')
 
-          corrector.insert_before(node.source_range, '(')
-          corrector.insert_after(node.source_range, ')')
+          corrector.wrap(node, '(', ')')
         end
 
         def correctable_send?(node)

--- a/lib/rubocop/cop/style/array_join.rb
+++ b/lib/rubocop/cop/style/array_join.rb
@@ -30,7 +30,7 @@ module RuboCop
           array, join_arg = join_candidate?(node).map(&:source)
 
           lambda do |corrector|
-            corrector.replace(node.source_range, "#{array}.join(#{join_arg})")
+            corrector.replace(node, "#{array}.join(#{join_arg})")
           end
         end
       end

--- a/lib/rubocop/cop/style/character_literal.rb
+++ b/lib/rubocop/cop/style/character_literal.rb
@@ -33,9 +33,9 @@ module RuboCop
             # special character like \n
             # or ' which needs to use "" or be escaped.
             if string.length == 2 || string == "'"
-              corrector.replace(node.source_range, %("#{string}"))
+              corrector.replace(node, %("#{string}"))
             elsif string.length == 1 # normal character
-              corrector.replace(node.source_range, "'#{string}'")
+              corrector.replace(node, "'#{string}'")
             end
           end
         end

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -458,7 +458,7 @@ module RuboCop
         def correct_if_branches(corrector, cop, node)
           if_branch, elsif_branches, else_branch = extract_tail_branches(node)
 
-          corrector.insert_before(node.source_range, lhs(if_branch))
+          corrector.insert_before(node, lhs(if_branch))
           replace_branch_assignment(corrector, if_branch)
           correct_branches(corrector, elsif_branches)
           replace_branch_assignment(corrector, else_branch)
@@ -475,13 +475,13 @@ module RuboCop
                           source
                         end
 
-          corrector.replace(branch.source_range, replacement)
+          corrector.replace(branch, replacement)
         end
 
         def correct_branches(corrector, branches)
           branches.each do |branch|
             *_, assignment = *branch
-            corrector.replace(branch.source_range, assignment.source)
+            corrector.replace(branch, assignment.source)
           end
         end
       end
@@ -494,7 +494,7 @@ module RuboCop
 
           def correct(node)
             lambda do |corrector|
-              corrector.replace(node.source_range, correction(node))
+              corrector.replace(node, correction(node))
             end
           end
 
@@ -547,7 +547,7 @@ module RuboCop
           end
 
           def move_branch_inside_condition(corrector, branch, assignment)
-            corrector.insert_before(branch.loc.expression, assignment.source)
+            corrector.insert_before(branch, assignment.source)
           end
         end
       end
@@ -589,7 +589,7 @@ module RuboCop
           def move_branch_inside_condition(corrector, branch, condition,
                                            assignment, column)
             branch_assignment = tail(branch)
-            corrector.insert_before(branch_assignment.loc.expression,
+            corrector.insert_before(branch_assignment,
                                     assignment.source)
 
             remove_whitespace_in_branches(corrector, branch, condition, column)
@@ -611,7 +611,7 @@ module RuboCop
             when_branches, else_branch = extract_tail_branches(node)
 
             lambda do |corrector|
-              corrector.insert_before(node.source_range, lhs(else_branch))
+              corrector.insert_before(node, lhs(else_branch))
               correct_branches(corrector, when_branches)
               replace_branch_assignment(corrector, else_branch)
 
@@ -652,7 +652,7 @@ module RuboCop
           def move_branch_inside_condition(corrector, branch, condition,
                                            assignment, column)
             branch_assignment = tail(branch)
-            corrector.insert_before(branch_assignment.loc.expression,
+            corrector.insert_before(branch_assignment,
                                     assignment.source)
 
             remove_whitespace_in_branches(corrector, branch, condition, column)

--- a/lib/rubocop/cop/style/dir.rb
+++ b/lib/rubocop/cop/style/dir.rb
@@ -33,7 +33,7 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            corrector.replace(node.source_range, '__dir__')
+            corrector.replace(node, '__dir__')
           end
         end
 

--- a/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
+++ b/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
@@ -34,7 +34,7 @@ module RuboCop
 
         def autocorrect(comment)
           lambda do |corrector|
-            corrector.replace(comment.loc.expression, '')
+            corrector.replace(comment, '')
           end
         end
 

--- a/lib/rubocop/cop/style/double_cop_disable_directive.rb
+++ b/lib/rubocop/cop/style/double_cop_disable_directive.rb
@@ -45,7 +45,7 @@ module RuboCop
                    end
 
           lambda do |corrector|
-            corrector.replace(comment.loc.expression,
+            corrector.replace(comment,
                               comment.text[/#{prefix} \S+/])
           end
         end

--- a/lib/rubocop/cop/style/each_for_simple_loop.rb
+++ b/lib/rubocop/cop/style/each_for_simple_loop.rb
@@ -42,7 +42,7 @@ module RuboCop
 
             max += 1 if range_type == :irange
 
-            corrector.replace(node.send_node.source_range,
+            corrector.replace(node.send_node,
                               "#{max - min}.times")
           end
         end

--- a/lib/rubocop/cop/style/each_with_object.rb
+++ b/lib/rubocop/cop/style/each_with_object.rb
@@ -48,15 +48,15 @@ module RuboCop
 
             first_arg, second_arg = *node.arguments
 
-            corrector.replace(first_arg.loc.expression, second_arg.source)
-            corrector.replace(second_arg.loc.expression, first_arg.source)
+            corrector.replace(first_arg, second_arg.source)
+            corrector.replace(second_arg, first_arg.source)
 
             return_value = return_value(node.body)
 
             if return_value_occupies_whole_line?(return_value)
               corrector.remove(whole_line_expression(return_value))
             else
-              corrector.remove(return_value.loc.expression)
+              corrector.remove(return_value)
             end
           end
         end

--- a/lib/rubocop/cop/style/empty_method.rb
+++ b/lib/rubocop/cop/style/empty_method.rb
@@ -57,7 +57,7 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            corrector.replace(node.source_range, corrected(node))
+            corrector.replace(node, corrected(node))
           end
         end
 

--- a/lib/rubocop/cop/style/even_odd.rb
+++ b/lib/rubocop/cop/style/even_odd.rb
@@ -38,7 +38,7 @@ module RuboCop
             replacement_method = replacement_method(arg, method)
 
             correction = "#{base_number.source}.#{replacement_method}?"
-            ->(corrector) { corrector.replace(node.source_range, correction) }
+            ->(corrector) { corrector.replace(node, correction) }
           end
         end
 

--- a/lib/rubocop/cop/style/expand_path_arguments.rb
+++ b/lib/rubocop/cop/style/expand_path_arguments.rb
@@ -97,7 +97,7 @@ module RuboCop
               autocorrect_expand_path(corrector, current_path, default_dir)
             elsif (default_dir = pathname_parent_expand_path(node)) ||
                   (default_dir = pathname_new_parent_expand_path(node))
-              corrector.replace(default_dir.loc.expression, '__dir__')
+              corrector.replace(default_dir, '__dir__')
               remove_parent_method(corrector, default_dir)
             end
           end
@@ -145,8 +145,8 @@ module RuboCop
           else
             new_path = "'#{parent_path(stripped_current_path)}'"
 
-            corrector.replace(current_path.loc.expression, new_path)
-            corrector.replace(default_dir.loc.expression, '__dir__')
+            corrector.replace(current_path, new_path)
+            corrector.replace(default_dir, '__dir__')
           end
         end
 

--- a/lib/rubocop/cop/style/format_string.rb
+++ b/lib/rubocop/cop/style/format_string.rb
@@ -104,7 +104,7 @@ module RuboCop
 
           corrected = "#{style}(#{node.receiver.source}, #{args})"
 
-          corrector.replace(node.loc.expression, corrected)
+          corrector.replace(node, corrected)
         end
 
         def autocorrect_to_percent(corrector, node)
@@ -119,7 +119,7 @@ module RuboCop
                    "[#{param_args.map(&:source).join(', ')}]"
                  end
 
-          corrector.replace(node.loc.expression, "#{format} % #{args}")
+          corrector.replace(node, "#{format} % #{args}")
         end
       end
     end

--- a/lib/rubocop/cop/style/hash_each_methods.rb
+++ b/lib/rubocop/cop/style/hash_each_methods.rb
@@ -60,7 +60,7 @@ module RuboCop
         end
 
         def correct_implicit(node, corrector, method_name)
-          corrector.replace(node.loc.expression, method_name)
+          corrector.replace(node, method_name)
           correct_args(node, corrector)
         end
 
@@ -70,14 +70,14 @@ module RuboCop
           return correct_implicit(node, corrector, name) unless receiver
 
           new_source = receiver.source + ".#{name}"
-          corrector.replace(node.loc.expression, new_source)
+          corrector.replace(node, new_source)
         end
 
         def correct_args(node, corrector)
           args = node.parent.arguments
           name, = *args.children.find { |arg| used?(arg) }
 
-          corrector.replace(args.source_range, "|#{name}|")
+          corrector.replace(args, "|#{name}|")
         end
 
         def kv_range(outer_node)

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -188,11 +188,9 @@ module RuboCop
         end
 
         def autocorrect_hash_rockets(corrector, pair_node)
-          key = pair_node.key.source_range
           op = pair_node.loc.operator
 
-          corrector.insert_after(key, pair_node.inverse_delimiter(true))
-          corrector.insert_before(key, ':')
+          corrector.wrap(pair_node.key, ':', pair_node.inverse_delimiter(true))
           corrector.remove(range_with_surrounding_space(range: op))
         end
 

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -63,7 +63,7 @@ module RuboCop
                         else
                           to_modifier_form(node)
                         end
-          ->(corrector) { corrector.replace(node.source_range, replacement) }
+          ->(corrector) { corrector.replace(node, replacement) }
         end
 
         private

--- a/lib/rubocop/cop/style/lambda.rb
+++ b/lib/rubocop/cop/style/lambda.rb
@@ -109,13 +109,13 @@ module RuboCop
         end
 
         def autocorrect_method_to_literal(corrector, node)
-          corrector.replace(node.send_node.source_range, '->')
+          corrector.replace(node.send_node, '->')
 
           return unless node.arguments?
 
           arg_str = "(#{lambda_arg_string(node.arguments)})"
 
-          corrector.insert_after(node.send_node.source_range, arg_str)
+          corrector.insert_after(node.send_node, arg_str)
           corrector.remove(arguments_with_whitespace(node))
         end
 

--- a/lib/rubocop/cop/style/lambda_call.rb
+++ b/lib/rubocop/cop/style/lambda_call.rb
@@ -37,7 +37,7 @@ module RuboCop
               receiver = node.receiver.source
               replacement = node.source.sub("#{receiver}.", "#{receiver}.call")
 
-              corrector.replace(node.source_range, replacement)
+              corrector.replace(node, replacement)
             else
               add_parentheses(node, corrector) unless node.parenthesized?
               corrector.remove(node.loc.selector)
@@ -54,7 +54,7 @@ module RuboCop
 
         def add_parentheses(node, corrector)
           if node.arguments.empty?
-            corrector.insert_after(node.source_range, '()')
+            corrector.insert_after(node, '()')
           else
             corrector.replace(args_begin(node), '(')
             corrector.insert_after(args_end(node), ')')

--- a/lib/rubocop/cop/style/module_function.rb
+++ b/lib/rubocop/cop/style/module_function.rb
@@ -98,9 +98,9 @@ module RuboCop
 
           lambda do |corrector|
             if extend_self_node?(node)
-              corrector.replace(node.source_range, 'module_function')
+              corrector.replace(node, 'module_function')
             else
-              corrector.replace(node.source_range, 'extend self')
+              corrector.replace(node, 'extend self')
             end
           end
         end

--- a/lib/rubocop/cop/style/multiline_if_modifier.rb
+++ b/lib/rubocop/cop/style/multiline_if_modifier.rb
@@ -29,7 +29,7 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            corrector.replace(node.source_range, to_normal_if(node))
+            corrector.replace(node, to_normal_if(node))
           end
         end
 

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -77,11 +77,9 @@ module RuboCop
             if splat_value
               correct_splat_expansion(corrector, expr, splat_value)
             elsif node.array_type? && !node.bracketed?
-              corrector.insert_before(expr, '[')
-              corrector.insert_after(expr, ']')
+              corrector.wrap(expr, '[', ']')
             elsif requires_parentheses?(node)
-              corrector.insert_before(expr, '(')
-              corrector.insert_after(expr, ')')
+              corrector.wrap(expr, '(', ')')
             end
 
             corrector.insert_after(expr, '.freeze')

--- a/lib/rubocop/cop/style/next.rb
+++ b/lib/rubocop/cop/style/next.rb
@@ -152,13 +152,13 @@ module RuboCop
             "next #{node.inverse_keyword} #{node.condition.source}\n" \
             "#{' ' * node.source_range.column}#{body.source}"
 
-          corrector.replace(node.source_range, replacement)
+          corrector.replace(node, replacement)
         end
 
         def autocorrect_block(corrector, node)
           next_code = "next #{node.inverse_keyword} #{node.condition.source}"
 
-          corrector.insert_before(node.source_range, next_code)
+          corrector.insert_before(node, next_code)
 
           corrector.remove(cond_range(node, node.condition))
           corrector.remove(end_range(node))

--- a/lib/rubocop/cop/style/nil_comparison.rb
+++ b/lib/rubocop/cop/style/nil_comparison.rb
@@ -49,7 +49,7 @@ module RuboCop
                      else
                        node.source.sub(/\s*={2,3}\s*nil/, '.nil?')
                      end
-          ->(corrector) { corrector.replace(node.source_range, new_code) }
+          ->(corrector) { corrector.replace(node, new_code) }
         end
 
         private

--- a/lib/rubocop/cop/style/non_nil_check.rb
+++ b/lib/rubocop/cop/style/non_nil_check.rb
@@ -111,15 +111,15 @@ module RuboCop
 
           return if expr == new_code
 
-          ->(corrector) { corrector.replace(node.source_range, new_code) }
+          ->(corrector) { corrector.replace(node, new_code) }
         end
 
         def autocorrect_non_nil(node, inner_node)
           lambda do |corrector|
             if inner_node.receiver
-              corrector.replace(node.source_range, inner_node.receiver.source)
+              corrector.replace(node, inner_node.receiver.source)
             else
-              corrector.replace(node.source_range, 'self')
+              corrector.replace(node, 'self')
             end
           end
         end
@@ -127,7 +127,7 @@ module RuboCop
         def autocorrect_unless_nil(node, receiver)
           lambda do |corrector|
             corrector.replace(node.parent.loc.keyword, 'if')
-            corrector.replace(node.source_range, receiver.source)
+            corrector.replace(node, receiver.source)
           end
         end
       end

--- a/lib/rubocop/cop/style/not.rb
+++ b/lib/rubocop/cop/style/not.rb
@@ -69,7 +69,7 @@ module RuboCop
         def correct_with_parens(range, node)
           lambda do |corrector|
             corrector.replace(range, '!(')
-            corrector.insert_after(node.source_range, ')')
+            corrector.insert_after(node, ')')
           end
         end
 

--- a/lib/rubocop/cop/style/numeric_literal_prefix.rb
+++ b/lib/rubocop/cop/style/numeric_literal_prefix.rb
@@ -59,7 +59,7 @@ module RuboCop
         def autocorrect(node)
           lambda do |corrector|
             type = literal_type(node)
-            corrector.replace(node.source_range,
+            corrector.replace(node,
                               send(:"format_#{type}", node.source))
           end
         end

--- a/lib/rubocop/cop/style/numeric_literals.rb
+++ b/lib/rubocop/cop/style/numeric_literals.rb
@@ -48,7 +48,7 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            corrector.replace(node.source_range, format_number(node))
+            corrector.replace(node, format_number(node))
           end
         end
 

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -73,7 +73,7 @@ module RuboCop
           _, replacement = check(node)
 
           lambda do |corrector|
-            corrector.replace(node.loc.expression, replacement)
+            corrector.replace(node, replacement)
           end
         end
 

--- a/lib/rubocop/cop/style/one_line_conditional.rb
+++ b/lib/rubocop/cop/style/one_line_conditional.rb
@@ -36,7 +36,7 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            corrector.replace(node.source_range, replacement(node))
+            corrector.replace(node, replacement(node))
           end
         end
 

--- a/lib/rubocop/cop/style/or_assignment.rb
+++ b/lib/rubocop/cop/style/or_assignment.rb
@@ -69,7 +69,7 @@ module RuboCop
           end
 
           lambda do |corrector|
-            corrector.replace(node.source_range,
+            corrector.replace(node,
                               "#{variable} ||= #{default.source}")
           end
         end

--- a/lib/rubocop/cop/style/percent_q_literals.rb
+++ b/lib/rubocop/cop/style/percent_q_literals.rb
@@ -39,7 +39,7 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            corrector.replace(node.source_range, corrected(node.source))
+            corrector.replace(node, corrected(node.source))
           end
         end
 

--- a/lib/rubocop/cop/style/perl_backrefs.rb
+++ b/lib/rubocop/cop/style/perl_backrefs.rb
@@ -24,10 +24,10 @@ module RuboCop
             backref, = *node
             parent_type = node.parent ? node.parent.type : nil
             if %i[dstr xstr regexp].include?(parent_type)
-              corrector.replace(node.source_range,
+              corrector.replace(node,
                                 "{Regexp.last_match(#{backref})}")
             else
-              corrector.replace(node.source_range,
+              corrector.replace(node,
                                 "Regexp.last_match(#{backref})")
             end
           end

--- a/lib/rubocop/cop/style/proc.rb
+++ b/lib/rubocop/cop/style/proc.rb
@@ -26,7 +26,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          ->(corrector) { corrector.replace(node.source_range, 'proc') }
+          ->(corrector) { corrector.replace(node, 'proc') }
         end
       end
     end

--- a/lib/rubocop/cop/style/raise_args.rb
+++ b/lib/rubocop/cop/style/raise_args.rb
@@ -58,7 +58,7 @@ module RuboCop
                           correction_compact_to_exploded(node)
                         end
 
-          ->(corrector) { corrector.replace(node.source_range, replacement) }
+          ->(corrector) { corrector.replace(node, replacement) }
         end
 
         private

--- a/lib/rubocop/cop/style/random_with_offset.rb
+++ b/lib/rubocop/cop/style/random_with_offset.rb
@@ -66,13 +66,13 @@ module RuboCop
         def autocorrect(node)
           lambda do |corrector|
             if integer_op_rand?(node)
-              corrector.replace(node.source_range,
+              corrector.replace(node,
                                 corrected_integer_op_rand(node))
             elsif rand_op_integer?(node)
-              corrector.replace(node.source_range,
+              corrector.replace(node,
                                 corrected_rand_op_integer(node))
             elsif rand_modified?(node)
-              corrector.replace(node.source_range,
+              corrector.replace(node,
                                 corrected_rand_modified(node))
             end
           end

--- a/lib/rubocop/cop/style/redundant_condition.rb
+++ b/lib/rubocop/cop/style/redundant_condition.rb
@@ -48,11 +48,11 @@ module RuboCop
             if node.ternary?
               correct_ternary(corrector, node)
             elsif node.modifier_form? || !node.else_branch
-              corrector.replace(node.source_range, node.if_branch.source)
+              corrector.replace(node, node.if_branch.source)
             else
               corrected = make_ternary_form(node)
 
-              corrector.replace(node.source_range, corrected)
+              corrector.replace(node, corrected)
             end
           end
         end
@@ -116,8 +116,7 @@ module RuboCop
 
           return unless node.else_branch.range_type?
 
-          corrector.insert_before(node.else_branch.loc.expression, '(')
-          corrector.insert_after(node.else_branch.loc.expression, ')')
+          corrector.wrap(node.else_branch, '(', ')')
         end
       end
     end

--- a/lib/rubocop/cop/style/redundant_conditional.rb
+++ b/lib/rubocop/cop/style/redundant_conditional.rb
@@ -40,7 +40,7 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            corrector.replace(node.loc.expression, replacement_condition(node))
+            corrector.replace(node, replacement_condition(node))
           end
         end
 

--- a/lib/rubocop/cop/style/redundant_exception.rb
+++ b/lib/rubocop/cop/style/redundant_exception.rb
@@ -32,17 +32,17 @@ module RuboCop
           exploded?(node) do |command, message|
             return lambda do |corrector|
               if node.parenthesized?
-                corrector.replace(node.source_range,
+                corrector.replace(node,
                                   "#{command}(#{message.source})")
               else
-                corrector.replace(node.source_range,
+                corrector.replace(node,
                                   "#{command} #{message.source}")
               end
             end
           end
           compact?(node) do |new_call, message|
             lambda do |corrector|
-              corrector.replace(new_call.source_range, message.source)
+              corrector.replace(new_call, message.source)
             end
           end
         end

--- a/lib/rubocop/cop/style/redundant_interpolation.rb
+++ b/lib/rubocop/cop/style/redundant_interpolation.rb
@@ -72,13 +72,13 @@ module RuboCop
 
         def autocorrect_variable_interpolation(embedded_node, node)
           replacement = "#{embedded_node.loc.expression.source}.to_s"
-          ->(corrector) { corrector.replace(node.loc.expression, replacement) }
+          ->(corrector) { corrector.replace(node, replacement) }
         end
 
         def autocorrect_single_variable_interpolation(embedded_node, node)
           variable_loc = embedded_node.children.first.loc
           replacement = "#{variable_loc.expression.source}.to_s"
-          ->(corrector) { corrector.replace(node.loc.expression, replacement) }
+          ->(corrector) { corrector.replace(node, replacement) }
         end
 
         def autocorrect_other(embedded_node, node)

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -71,7 +71,7 @@ module RuboCop
         private
 
         def correct_without_arguments(return_node, corrector)
-          corrector.replace(return_node.source_range, 'nil')
+          corrector.replace(return_node, 'nil')
         end
 
         def correct_with_arguments(return_node, corrector)
@@ -91,15 +91,13 @@ module RuboCop
         end
 
         def add_brackets(corrector, node)
-          kids = node.children.map(&:source_range)
-          corrector.insert_before(kids.first, '[')
-          corrector.insert_after(kids.last, ']')
+          corrector.insert_before(node.children.first, '[')
+          corrector.insert_after(node.children.last, ']')
         end
 
         def add_braces(corrector, node)
-          kids = node.children.map(&:source_range)
-          corrector.insert_before(kids.first, '{')
-          corrector.insert_after(kids.last, '}')
+          corrector.insert_before(node.children.first, '{')
+          corrector.insert_after(node.children.last, '}')
         end
 
         # rubocop:disable Metrics/CyclomaticComplexity

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -110,7 +110,7 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            corrector.remove(node.receiver.source_range)
+            corrector.remove(node.receiver)
             corrector.remove(node.loc.dot)
           end
         end

--- a/lib/rubocop/cop/style/rescue_modifier.rb
+++ b/lib/rubocop/cop/style/rescue_modifier.rb
@@ -64,7 +64,7 @@ module RuboCop
             "\n#{offset(node)}end"
 
           lambda do |corrector|
-            corrector.replace(node.source_range, correction)
+            corrector.replace(node, correction)
           end
         end
       end

--- a/lib/rubocop/cop/style/return_nil.rb
+++ b/lib/rubocop/cop/style/return_nil.rb
@@ -60,7 +60,7 @@ module RuboCop
         def autocorrect(node)
           lambda do |corrector|
             corrected = style == :return ? 'return' : 'return nil'
-            corrector.replace(node.source_range, corrected)
+            corrector.replace(node, corrected)
           end
         end
 

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -131,7 +131,7 @@ module RuboCop
           comments = comments(node)
           return if comments.empty?
 
-          corrector.insert_before(method_call.loc.expression,
+          corrector.insert_before(method_call,
                                   "#{comments.map(&:text).join("\n")}\n")
         end
 

--- a/lib/rubocop/cop/style/self_assignment.rb
+++ b/lib/rubocop/cop/style/self_assignment.rb
@@ -88,7 +88,7 @@ module RuboCop
         def apply_autocorrect(node, rhs, operator, new_rhs)
           lambda do |corrector|
             corrector.insert_before(node.loc.operator, operator)
-            corrector.replace(rhs.source_range, new_rhs.source)
+            corrector.replace(rhs, new_rhs.source)
           end
         end
       end

--- a/lib/rubocop/cop/style/special_global_vars.rb
+++ b/lib/rubocop/cop/style/special_global_vars.rb
@@ -145,7 +145,7 @@ module RuboCop
               node = node.parent
             end
 
-            corrector.replace(node.source_range, replacement(node, global_var))
+            corrector.replace(node, replacement(node, global_var))
           end
         end
 

--- a/lib/rubocop/cop/style/stabby_lambda_parentheses.rb
+++ b/lib/rubocop/cop/style/stabby_lambda_parentheses.rb
@@ -57,10 +57,7 @@ module RuboCop
 
         def missing_parentheses_corrector(node)
           lambda do |corrector|
-            args_loc = node.loc.expression
-
-            corrector.insert_before(args_loc, '(')
-            corrector.insert_after(args_loc, ')')
+            corrector.wrap(node, '(', ')')
           end
         end
 

--- a/lib/rubocop/cop/style/string_hash_keys.rb
+++ b/lib/rubocop/cop/style/string_hash_keys.rb
@@ -41,7 +41,7 @@ module RuboCop
         def autocorrect(node)
           lambda do |corrector|
             symbol_content = node.str_content.to_sym.inspect
-            corrector.replace(node.source_range, symbol_content)
+            corrector.replace(node, symbol_content)
           end
         end
       end

--- a/lib/rubocop/cop/style/symbol_array.rb
+++ b/lib/rubocop/cop/style/symbol_array.rb
@@ -81,7 +81,7 @@ module RuboCop
           end
 
           lambda do |corrector|
-            corrector.replace(node.source_range, "[#{syms.join(', ')}]")
+            corrector.replace(node, "[#{syms.join(', ')}]")
           end
         end
 

--- a/lib/rubocop/cop/style/symbol_literal.rb
+++ b/lib/rubocop/cop/style/symbol_literal.rb
@@ -23,7 +23,7 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            corrector.replace(node.source_range, node.source.delete(%q('")))
+            corrector.replace(node, node.source.delete(%q('")))
           end
         end
       end

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -207,8 +207,7 @@ module RuboCop
 
         def correct_unparenthesized(condition)
           lambda do |corrector|
-            corrector.insert_before(condition.source_range, '(')
-            corrector.insert_after(condition.source_range, ')')
+            corrector.wrap(condition, '(', ')')
           end
         end
 

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -161,7 +161,7 @@ module RuboCop
           return unless names_match?(node) && !node.predicate_method? && kind
 
           lambda do |corrector|
-            corrector.replace(node.source_range,
+            corrector.replace(node,
                               accessor(kind, node.method_name))
           end
         end

--- a/lib/rubocop/cop/style/variable_interpolation.rb
+++ b/lib/rubocop/cop/style/variable_interpolation.rb
@@ -29,7 +29,7 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            corrector.replace(node.source_range, "{#{node.source}}")
+            corrector.replace(node, "{#{node.source}}")
           end
         end
 

--- a/lib/rubocop/cop/style/while_until_modifier.rb
+++ b/lib/rubocop/cop/style/while_until_modifier.rb
@@ -43,7 +43,7 @@ module RuboCop
                     "#{node.condition.source}"
 
           lambda do |corrector|
-            corrector.replace(node.source_range, oneline)
+            corrector.replace(node, oneline)
           end
         end
 

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -93,7 +93,7 @@ module RuboCop
           end
 
           lambda do |corrector|
-            corrector.replace(node.source_range, "[#{words.join(', ')}]")
+            corrector.replace(node, "[#{words.join(', ')}]")
           end
         end
       end

--- a/lib/rubocop/cop/style/zero_length_predicate.rb
+++ b/lib/rubocop/cop/style/zero_length_predicate.rb
@@ -37,7 +37,7 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            corrector.replace(node.loc.expression, replacement(node))
+            corrector.replace(node, replacement(node))
           end
         end
 

--- a/manual/development.md
+++ b/manual/development.md
@@ -256,15 +256,15 @@ And then define the `autocorrect` method on the cop side:
 def autocorrect(node)
   lambda do |corrector|
     internal_expression = node.children[0].children[0].source
-    corrector.replace(node.loc.expression, "#{internal_expression}.any?")
+    corrector.replace(node, "#{internal_expression}.any?")
   end
 end
 ```
 
 The corrector allows you to `insert_after` and `insert_before` or
-`replace` in a specific range of the code.
+`replace` a specific node or in any specific range of the code.
 
-The range can be determined on `node.location` where it brings specific
+Range can be determined on `node.location` where it brings specific
 ranges for expression or other internal information that the node holds.
 
 ### Configuration
@@ -290,7 +290,7 @@ def autocorrect(node)
     internal_expression = node.children[0].children[0].source
     replacement = cop_config['ReplaceAnyWith'] || "any?"
     new_expression = "#{internal_expression}.#{replacement}"
-    corrector.replace(node.loc.expression, new_expression)
+    corrector.replace(node, new_expression)
   end
 end
 ```

--- a/spec/rubocop/cop/corrector_spec.rb
+++ b/spec/rubocop/cop/corrector_spec.rb
@@ -78,6 +78,25 @@ RSpec.describe RuboCop::Cop::Corrector do
       end.to rewrite_to 'true a false'
     end
 
+    it 'accepts a node instead of a range' do
+      expect do |corrector|
+        corrector.replace(node.rhs, 'maybe')
+      end.to rewrite_to 'true and maybe'
+    end
+
+    it 'raises a useful error if not given a node or a range' do
+      # rubocop:disable Style/MultilineBlockChain
+      expect do
+        do_rewrite { |corr| corr.replace(1..3, 'oops') }
+      end.to raise_error(RuboCop::ErrorWithAnalyzedFileLocation) do |e|
+        expect(e.cause.message).to eq(
+          'Expected a Parser::Source::Range, Comment or Rubocop::AST::Node, ' \
+          'got Range'
+        )
+      end
+      # rubocop:enable Style/MultilineBlockChain
+    end
+
     context 'when range is from incorrect source' do
       let(:other_source) { parse_source(source) }
       let(:op_other) do


### PR DESCRIPTION
This PR allows correctors to accept nodes in addition to ranges.

E.g: `corrector.insert_before(node, 'blah')`

Also provides better errors in case of wrong argument
Before: "undefined method `source_buffer' for 1..3:Range"
After: "Expected a Parser::Source::Range or Rubocop::AST::Node, got Range"

I don't think it would be particularly useful, but we could actually accept ranges like `1..3` if we wanted too...

This assumes #7862 is merged.