### PR TITLE
Suppress an offenses when using `rubocop --enable-pending-cops`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ InternalAffairs/NodeDestructuring:
 # Offense count: 50
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 186
+  Max: 187
 
 # Offense count: 209
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/lib/rubocop/ast/node/array_node.rb
+++ b/lib/rubocop/ast/node/array_node.rb
@@ -18,6 +18,19 @@ module RuboCop
         each_child_node.to_a
       end
 
+      # Calls the given block for all values in the `array` literal.
+      #
+      # @yieldparam [Node] node each node
+      # @return [self] if a block is given
+      # @return [Enumerator] if no block is given
+      def each_value(&block)
+        return to_enum(__method__) unless block_given?
+
+        values.each(&block)
+
+        self
+      end
+
       # Checks whether the `array` literal is delimited by square brackets.
       #
       # @return [Boolean] whether the array is enclosed in square brackets

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -55,7 +55,10 @@ module RuboCop
       end
 
       def add_missing_namespaces(path, hash)
-        hash.keys.each do |key|
+        # Using `hash.each_key` will cause the
+        # `can't add a new key into hash during iteration` error
+        hash_keys = hash.keys
+        hash_keys.each do |key|
           q = Cop::Cop.qualified_cop_name(key, path)
           next if q == key
 

--- a/lib/rubocop/cop/lint/percent_string_array.rb
+++ b/lib/rubocop/cop/lint/percent_string_array.rb
@@ -42,7 +42,7 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            node.values.each do |value|
+            node.each_value do |value|
               range = value.loc.expression
 
               match = range.source.match(TRAILING_QUOTE)

--- a/spec/rubocop/ast/array_node_spec.rb
+++ b/spec/rubocop/ast/array_node_spec.rb
@@ -31,6 +31,24 @@ RSpec.describe RuboCop::AST::ArrayNode do
     end
   end
 
+  describe '#each_value' do
+    let(:source) { '[1, 2, 3]' }
+
+    context 'with block' do
+      it { expect(array_node.each_value {}.is_a?(described_class)).to be(true) }
+      it do
+        ret = []
+        array_node.each_value { |i| ret << i.to_s }
+
+        expect(ret).to eq(['(int 1)', '(int 2)', '(int 3)'])
+      end
+    end
+
+    context 'without block' do
+      it { expect(array_node.each_value.is_a?(Enumerator)).to be(true) }
+    end
+  end
+
   describe '#square_brackets?' do
     context 'with square brackets' do
       let(:source) { '[1, 2, 3]' }


### PR DESCRIPTION
This PR suppresses a RuboCop offenses when using `rubocop --enable-pending-cops`.

```console
% path/to/rubocop
% ./exe/rubocop --enable-pending-cops
(snip)

Offenses:

lib/rubocop/config_loader.rb:58:14: C: Style/HashEachMethods: Use
each_key instead of keys.each.
        hash.keys.each do |key|
             ^^^^^^^^^
lib/rubocop/cop/lint/percent_string_array.rb:45:18: C:
Style/HashEachMethods: Use each_value instead of values.each.
            node.values.each do |value|
                 ^^^^^^^^^^^

1142 files inspected, 2 offenses detected
```

`Style/HashEachMethods` cop will be enabled by default in RuboCop 1.0.

And this PR adds `each_value` method to `ArrayNode` for prevents the following `NoMethodError`.

```console
RuboCop::ErrorWithAnalyzedFileLocation:
 cause: #<NoMethodError: undefined method `each_value' for
  #<RuboCop::AST::ArrayNode:0x00007fb46e9d5628>
  Did you mean?  each_node>
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
