### PR TITLE
Fix an auto-correction bug in Lint/BooleanSymbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug fixes
 
+* [#7871](https://github.com/rubocop-hq/rubocop/pull/7871): Fix an auto-correction bug in `Lint/BooleanSymbol`. ([@knu][])
 * [#7842](https://github.com/rubocop-hq/rubocop/issues/7842): Fix a false positive for `Lint/RaiseException` when raising Exception with explicit namespace. ([@koic][])
 * [#7834](https://github.com/rubocop-hq/rubocop/issues/7834): Fix `Lint/UriRegexp` to register offense with array arguments. ([@tejasbubane][])
 * [#7841](https://github.com/rubocop-hq/rubocop/issues/7841): Fix an error for `Style/TrailingCommaInBlockArgs` when lambda literal (`->`) has multiple arguments. ([@koic][])
@@ -4447,3 +4448,4 @@
 [@yuritomanek]: https://github.com/yuritomanek
 [@egze]: https://github.com/egze
 [@rafaelfranca]: https://github.com/rafaelfranca
+[@knu]: https://github.com/knu

--- a/lib/rubocop/cop/lint/boolean_symbol.rb
+++ b/lib/rubocop/cop/lint/boolean_symbol.rb
@@ -37,7 +37,7 @@ module RuboCop
           lambda do |corrector|
             boolean_literal = node.source.delete(':')
             parent = node.parent
-            if parent&.pair_type?
+            if parent&.pair_type? && node.equal?(parent.children[0])
               corrector.remove(parent.loc.operator)
               boolean_literal = "#{node.source} =>"
             end

--- a/spec/rubocop/cop/lint/boolean_symbol_spec.rb
+++ b/spec/rubocop/cop/lint/boolean_symbol_spec.rb
@@ -47,6 +47,18 @@ RSpec.describe RuboCop::Cop::Lint::BooleanSymbol, :config do
         { false => :bar }
       RUBY
     end
+
+    it 'registers an offense when using `key: :false`' do
+      expect_offense(<<~RUBY)
+        { false: :false }
+                 ^^^^^^ Symbol with a boolean name - you probably meant to use `false`.
+          ^^^^^ Symbol with a boolean name - you probably meant to use `false`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        { false => false }
+      RUBY
+    end
   end
 
   it 'does not register an offense when using regular symbol' do


### PR DESCRIPTION
It replaces a boolean symbol in a hash value as if it were a key,
generating a broken piece of code.

```ruby
# before
{ null: :false }

# wrong (current behavior)
{ null :false => }

# wrong (fixed behavior)
{ null: false }
```

```ruby
# before
{ false: :false }

# wrong (current behavior)
{ false => :false => }

# wrong (fixed behavior)
{ false => false }
```

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
