### PR TITLE
Update docs for TrailingCommaInArguments cop

### DIFF
--- a/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
@@ -10,7 +10,8 @@ module RuboCop
       # for all parenthesized method calls with arguments.
       # - `comma`: Requires a comma after the last argument, but only for
       # parenthesized method calls where each argument is on its own line.
-      # - `no_comma`: Does not requires a comma after the last argument.
+      # - `no_comma`: Requires that there is no comma after the last
+      # argument.
       #
       # @example EnforcedStyleForMultiline: consistent_comma
       #   # bad

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -7175,7 +7175,8 @@ The supported styles are:
 for all parenthesized method calls with arguments.
 - `comma`: Requires a comma after the last argument, but only for
 parenthesized method calls where each argument is on its own line.
-- `no_comma`: Does not requires a comma after the last argument.
+- `no_comma`: Requires that there is no comma after the last
+argument.
 
 ### Examples
 


### PR DESCRIPTION
The existing documentation for the `no_comma` option does not clearly indicate that the cop requires that there is no comma present. It only states that a comma is not required.

Also, there is a grammatical error in the existing documentation.