### PR TITLE
Fix the next release version

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1091,7 +1091,7 @@ Layout/SpaceAroundKeyword:
 Layout/SpaceAroundMethodCallOperator:
   Description: 'Checks method call operators to not have spaces around them.'
   Enabled: pending
-  VersionAdded: '0.81'
+  VersionAdded: '0.82'
 
 Layout/SpaceAroundOperators:
   Description: 'Use a single space around operators.'
@@ -2645,7 +2645,7 @@ Style/DisableCopsWithinSourceCodeDirective:
   Description: >-
                  Forbids disabling/enabling cops within source code.
   Enabled: false
-  VersionAdded: '0.75'
+  VersionAdded: '0.82'
 
 Style/Documentation:
   Description: 'Document classes and non-namespace modules.'

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -7,7 +7,7 @@ module RuboCop
     DEFAULT_VERSION = KNOWN_RUBIES.first
 
     OBSOLETE_RUBIES = {
-      1.9 => '0.50', 2.0 => '0.50', 2.1 => '0.58', 2.2 => '0.69', 2.3 => '0.81'
+      1.9 => '0.50', 2.0 => '0.50', 2.1 => '0.58', 2.2 => '0.69', 2.3 => '0.82'
     }.freeze
     private_constant :KNOWN_RUBIES, :OBSOLETE_RUBIES
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -4079,7 +4079,7 @@ something = 123 if test
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Pending | Yes | Yes  | 0.81 | -
+Pending | Yes | Yes  | 0.82 | -
 
 Checks method call operators to not have spaces around them.
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1363,7 +1363,7 @@ path = __dir__
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Disabled | Yes | Yes  | 0.75 | -
+Disabled | Yes | Yes  | 0.82 | -
 
 Detects comments to enable/disable RuboCop.
 This is useful if want to make sure that every RuboCop error gets fixed


### PR DESCRIPTION
Follow #7384, #7857, and #7869.

This PR fixes the next release version with 0.82 because RuboCop 0.81 has been released. This version (0.82) is based on #7851.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
