### PR TITLE
Enable `NewCops` for RuboCop development

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ require:
   - rubocop-rspec
 
 AllCops:
+  NewCops: enable
   Exclude:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -47,7 +47,7 @@ module RuboCop
     end
 
     def_delegators :@hash, :[], :[]=, :delete, :each, :key?, :keys, :each_key,
-                   :map, :merge, :to_h, :to_hash
+                   :map, :merge, :to_h, :to_hash, :transform_values
     def_delegators :@validator, :validate, :target_ruby_version
 
     def to_s

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -181,7 +181,7 @@ module RuboCop
     end
 
     def transform(config)
-      Hash[config.map { |cop, params| [cop, yield(params)] }]
+      config.transform_values { |params| yield(params) }
     end
 
     def gem_config_path(gem_name, relative_config_path)


### PR DESCRIPTION
Pending cops will be enabled by default in RuboCop 1.0.

This PR enables `NewCops` for RuboCop development. It will be a verification that enables pending cops.

And this PR suppresses the following offense.

```console
% cd path/to/rubocop
% bundle exec rake
(snip)

lib/rubocop/config_loader_resolver.rb:184:7: C:
Style/HashTransformValues: Prefer transform_values over Hash[_.map {...}].
      Hash[config.map { |cop, params| [cop, yield(params)] }]
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1144 files inspected, 1 offense detected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
