### PR TITLE
Fix a false positive for `Layout/SpaceAroundMethodCallOperator`

### DIFF
--- a/lib/rubocop/cop/layout/space_around_method_call_operator.rb
+++ b/lib/rubocop/cop/layout/space_around_method_call_operator.rb
@@ -72,7 +72,7 @@ module RuboCop
           left = previous_token(operator)
           right = next_token(operator)
 
-          if valid_right_token?(right, operator)
+          if !right.comment? && valid_right_token?(right, operator)
             no_space_offenses(node, operator, right, MSG)
           end
           return unless valid_left_token?(left, operator)
@@ -121,7 +121,9 @@ module RuboCop
 
         def right_token_for_auto_correction(operator)
           right_token = next_token(operator)
-          return right_token if valid_right_token?(right_token, operator)
+          if !right_token.comment? && valid_right_token?(right_token, operator)
+            return right_token
+          end
 
           operator
         end

--- a/spec/rubocop/cop/layout/space_around_method_call_operator_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_method_call_operator_spec.rb
@@ -177,6 +177,28 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundMethodCallOperator do
         foo.bar.buzz
       RUBY
     end
+
+    context 'when there is a space between `.` operator and a comment' do
+      it 'does not register an offense when there is not a space before `.`' do
+        expect_no_offenses(<<~RUBY)
+          foo. # comment
+            bar.baz
+        RUBY
+      end
+
+      it 'registers an offense when there is a space before `.`' do
+        expect_offense(<<~RUBY)
+          foo . # comment
+             ^ Avoid using spaces around a method call operator.
+            bar.baz
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo. # comment
+            bar.baz
+        RUBY
+      end
+    end
   end
 
   context 'safe navigation operator' do


### PR DESCRIPTION
This PR fixes the following false positive for `Layout/SpaceAroundMethodCallOperator` cop when there is a space between `.` operator and a comment.

```ruby
foo. # comment
  bar.baz
```

```console
% rubocop --only Layout/SpaceAroundMethodCallOperator
(snip)

Inspecting 1 file
C

Offenses:

example.rb:1:5: C: Layout/SpaceAroundMethodCallOperator: Avoid using
spaces around a method call operator.
foo. # comment
    ^

1 file inspected, 1 offense detected
```

Also this PR does not add to the changelog entry because `Layout/SpaceAroundMethodCallOperator` cop has not been released yet.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
