### PR TITLE
Fix `Style/CaseEquality` when `AllowOnConstant` is `true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#7882](https://github.com/rubocop-hq/rubocop/pull/7882): Fix `Style/CaseEquality` when `AllowOnConstant` is `true` and the method receiver is implicit. ([@rafaelfranca][])
+
 ## 0.82.0 (2020-04-16)
 
 ### New features

--- a/lib/rubocop/cop/style/case_equality.rb
+++ b/lib/rubocop/cop/style/case_equality.rb
@@ -42,7 +42,7 @@ module RuboCop
 
         def const?(node)
           if cop_config.fetch('AllowOnConstant', false)
-            !node.const_type?
+            !node&.const_type?
           else
             true
           end

--- a/spec/rubocop/cop/style/case_equality_spec.rb
+++ b/spec/rubocop/cop/style/case_equality_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe RuboCop::Cop::Style::CaseEquality do
       )
     end
 
+    it 'does not fail when the receiver is implicit' do
+      expect_no_offenses(<<~RUBY)
+        puts "No offense"
+      RUBY
+    end
+
     it 'does not register an offense for === when the receiver is a constant' do
       expect_no_offenses(<<~RUBY)
         Array === var


### PR DESCRIPTION
When the method receiver is implicit it was failing with a NoMethodError in `nil` error.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ x Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
