### PR TITLE
[Fix #7860] Change `AllowInHeredoc` option of `Layout/TrailingWhitespace` to `true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#7882](https://github.com/rubocop-hq/rubocop/pull/7882): Fix `Style/CaseEquality` when `AllowOnConstant` is `true` and the method receiver is implicit. ([@rafaelfranca][])
 
+### Changes
+
+* [#7860](https://github.com/rubocop-hq/rubocop/issues/7860): Change `AllowInHeredoc` option of `Layout/TrailingWhitespace` to `true` by default. ([@koic][])
+
 ## 0.82.0 (2020-04-16)
 
 ### New features

--- a/config/default.yml
+++ b/config/default.yml
@@ -1295,8 +1295,8 @@ Layout/TrailingWhitespace:
   StyleGuide: '#no-trailing-whitespace'
   Enabled: true
   VersionAdded: '0.49'
-  VersionChanged: '0.55'
-  AllowInHeredoc: false
+  VersionChanged: '0.83'
+  AllowInHeredoc: true
 
 #################### Lint ##################################
 ### Warnings

--- a/lib/rubocop/cop/layout/trailing_whitespace.rb
+++ b/lib/rubocop/cop/layout/trailing_whitespace.rb
@@ -14,14 +14,14 @@ module RuboCop
       #   # good
       #   x = 0
       #
-      # @example AllowInHeredoc: false (default)
+      # @example AllowInHeredoc: false
       #   # The line in this example contains spaces after the 0.
       #   # bad
       #   code = <<~RUBY
       #     x = 0
       #   RUBY
       #
-      # @example AllowInHeredoc: true
+      # @example AllowInHeredoc: true (default)
       #   # The line in this example contains spaces after the 0.
       #   # good
       #   code = <<~RUBY

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -4987,7 +4987,7 @@ EnforcedStyle | `final_newline` | `final_newline`, `final_blank_line`
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.49 | 0.55
+Enabled | Yes | Yes  | 0.49 | 0.83
 
 This cop looks for trailing whitespace in the source code.
 
@@ -5002,7 +5002,7 @@ x = 0
 # good
 x = 0
 ```
-#### AllowInHeredoc: false (default)
+#### AllowInHeredoc: false
 
 ```ruby
 # The line in this example contains spaces after the 0.
@@ -5011,7 +5011,7 @@ code = <<~RUBY
   x = 0
 RUBY
 ```
-#### AllowInHeredoc: true
+#### AllowInHeredoc: true (default)
 
 ```ruby
 # The line in this example contains spaces after the 0.
@@ -5025,7 +5025,7 @@ RUBY
 
 Name | Default value | Configurable values
 --- | --- | ---
-AllowInHeredoc | `false` | Boolean
+AllowInHeredoc | `true` | Boolean
 
 ### References
 


### PR DESCRIPTION
Fixes #7860.

This PR changes `AllowInHeredoc` option of `Layout/TrailingWhitespace` to `true` by default. The default behavior will be more safe.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
