### PR TITLE
Ignore --parallel when passed with incompatible option

### DIFF
--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -320,9 +320,9 @@ module RuboCop
       return unless @options.key?(:parallel)
 
       if @options[:cache] == 'false'
-        raise OptionArgumentError, '-P/--parallel uses caching to speed up ' \
-                                   'execution, so combining with --cache ' \
-                                   'false is not allowed.'
+        @options.delete(:parallel)
+        warn '-P/--parallel uses caching to speed up execution, so combining '\
+             'with --cache false will ignore --parallel.'
       end
 
       validate_parallel_with_combo_option
@@ -332,13 +332,18 @@ module RuboCop
       combos = {
         auto_gen_config: '-P/--parallel uses caching to speed up execution, ' \
                          'while --auto-gen-config needs a non-cached run, ' \
-                         'so they cannot be combined.',
-        fail_fast: '-P/--parallel cannot be combined with -F/--fail-fast.',
-        auto_correct: '-P/--parallel cannot be combined with --auto-correct.'
+                         'so ignoring --parallel.',
+        fail_fast: '-P/--parallel cannot be combined with -F/--fail-fast, so '\
+                   'ignoring --parallel.',
+        auto_correct: '-P/--parallel cannot be combined with --auto-correct, '\
+                      'so ignoring --parallel.'
       }
 
       combos.each do |key, msg|
-        raise OptionArgumentError, msg if @options.key?(key)
+        next unless @options.key?(key)
+
+        @options.delete(:parallel)
+        warn msg
       end
     end
 

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -186,11 +186,12 @@ RSpec.describe RuboCop::Options, :isolated_environment do
 
     describe '--parallel' do
       context 'combined with --cache false' do
-        it 'fails with an error message' do
+        it 'succeeds with an error message' do
           msg = ['-P/--parallel uses caching to speed up execution, so ',
-                 'combining with --cache false is not allowed.'].join
-          expect { options.parse %w[--parallel --cache false] }
-            .to raise_error(RuboCop::OptionArgumentError, msg)
+                 'combining with --cache false will ignore --parallel.'].join
+          options.parse %w[--parallel --cache false]
+
+          expect($stderr.string).to eq(msg)
         end
       end
 


### PR DESCRIPTION
Allow setting of parallel and combination with incompatible options. Will output a warning if combined but still execute without the `--parallel` option enabled.

https://github.com/rubocop-hq/rubocop/issues/7544

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
