### PR TITLE
[Fix #7790] Set options in ConfigLoader earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#7882](https://github.com/rubocop-hq/rubocop/pull/7882): Fix `Style/CaseEquality` when `AllowOnConstant` is `true` and the method receiver is implicit. ([@rafaelfranca][])
+* [#7790](https://github.com/rubocop-hq/rubocop/issues/7790): Fix `--parallel` and `--ignore-parent-exclusion` combination. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -35,6 +35,7 @@ module RuboCop
       if @options[:init]
         run_command(:init)
       else
+        set_options_to_config_loader
         validate_options_vs_config
         act_on_options
         apply_default_formatter
@@ -83,8 +84,6 @@ module RuboCop
     end
 
     def act_on_options
-      set_options_to_config_loader
-
       @config_store.options_config = @options[:config] if @options[:config]
       @config_store.force_default_config! if @options[:force_default_config]
 

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -47,6 +47,25 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           expect($stdout.string).not_to match(/Running parallel inspection/)
         end
       end
+
+      context 'in combination with --ignore-parent-exclusion' do
+        before do
+          create_file('.rubocop.yml', ['AllCops:',
+                                       '  Exclude:',
+                                       '    - subdir/*'])
+          create_file('subdir/.rubocop.yml', ['AllCops:',
+                                              '  Exclude:',
+                                              '    - foobar'])
+          create_file('subdir/test.rb', 'puts 1')
+        end
+
+        it 'does ignore the exclusion in the parent directory configuration' do
+          Dir.chdir('subdir') do
+            cli.run ['--parallel', '--ignore-parent-exclusion']
+          end
+          expect($stdout.string).to match(/Inspecting 1 file/)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Transferring options to the `ConfigLoader` must be done before we validate the `--parallel` flag against configuration. Since we cache the configuration when reading it to perform validation, the cached configuration will not take all the given options into account, which leads to different behavior when running the actual inspection if the `--parallel` flag is given.