### PR TITLE
[Fix #7635] Fix a false positive for `Style/MultilineWhenThen`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#7882](https://github.com/rubocop-hq/rubocop/pull/7882): Fix `Style/CaseEquality` when `AllowOnConstant` is `true` and the method receiver is implicit. ([@rafaelfranca][])
 * [#7790](https://github.com/rubocop-hq/rubocop/issues/7790): Fix `--parallel` and `--ignore-parent-exclusion` combination. ([@jonas054][])
 * [#7881](https://github.com/rubocop-hq/rubocop/issues/7881): Fix `--parallel` and `--force-default-config` combination. ([@jonas054][])
+* [#7635](https://github.com/rubocop-hq/rubocop/issues/7635): Fix a false positive for `Style/MultilineWhenThen` when `then` required for a body of `when` is used. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/multiline_when_then.rb
+++ b/lib/rubocop/cop/style/multiline_when_then.rb
@@ -22,6 +22,12 @@ module RuboCop
       #   when bar then do_something
       #   end
       #
+      #   # good
+      #   case foo
+      #   when bar then do_something(arg1,
+      #                              arg2)
+      #   end
+      #
       class MultilineWhenThen < Cop
         include RangeHelp
 
@@ -32,7 +38,10 @@ module RuboCop
           return unless node.then?
 
           # Single line usage of `then` is not an offense
-          return if !node.children.last.nil? && !node.multiline? && node.then?
+          return if !node.children.last.nil? && !node.multiline?
+
+          # Requires `then` for write `when` and its body on the same line.
+          return if require_then?(node)
 
           # With more than one statements after then, there's not offense
           return if accept_node_type?(node.body)
@@ -48,6 +57,12 @@ module RuboCop
               )
             )
           end
+        end
+
+        def require_then?(when_node)
+          return false unless when_node.body
+
+          when_node.loc.line == when_node.body.loc.line
         end
 
         def accept_node_type?(node)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4206,6 +4206,12 @@ end
 case foo
 when bar then do_something
 end
+
+# good
+case foo
+when bar then do_something(arg1,
+                           arg2)
+end
 ```
 
 ### References

--- a/spec/rubocop/cop/style/multiline_when_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_when_then_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe RuboCop::Cop::Style::MultilineWhenThen do
     RUBY
   end
 
+  it "doesn't register an offense when `then` required for a body of `when` " \
+     'is used' do
+    expect_no_offenses(<<~RUBY)
+      case cond
+      when foo then do_something(arg1,
+                                 arg2)
+      end
+    RUBY
+  end
+
   it "doesn't register an offense for multiline when statement
   with then followed by other lines" do
     expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #7635

This PR fixes a false positive for `Style/MultilineWhenThen` when `then` required for a body of `when` is used.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
