### PR TITLE
[Fix #7881] Call act_on_options earlier in CLI#run()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#7882](https://github.com/rubocop-hq/rubocop/pull/7882): Fix `Style/CaseEquality` when `AllowOnConstant` is `true` and the method receiver is implicit. ([@rafaelfranca][])
 * [#7790](https://github.com/rubocop-hq/rubocop/issues/7790): Fix `--parallel` and `--ignore-parent-exclusion` combination. ([@jonas054][])
+* [#7881](https://github.com/rubocop-hq/rubocop/issues/7881): Fix `--parallel` and `--force-default-config` combination. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -35,9 +35,8 @@ module RuboCop
       if @options[:init]
         run_command(:init)
       else
-        set_options_to_config_loader
-        validate_options_vs_config
         act_on_options
+        validate_options_vs_config
         apply_default_formatter
         execute_runners
       end
@@ -84,6 +83,8 @@ module RuboCop
     end
 
     def act_on_options
+      set_options_to_config_loader
+
       @config_store.options_config = @options[:config] if @options[:config]
       @config_store.force_default_config! if @options[:force_default_config]
 

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -66,6 +66,20 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           expect($stdout.string).to match(/Inspecting 1 file/)
         end
       end
+
+      context 'in combination with --force-default-config' do
+        before do
+          create_file('.rubocop.yml', ['ALLCOPS:', # Faulty configuration
+                                       '  Exclude:',
+                                       '    - subdir/*'])
+          create_file('test.rb', 'puts 1')
+        end
+
+        it 'does not parse local configuration' do
+          cli.run ['--parallel', '--force-default-config']
+          expect($stdout.string).to match(/Inspecting 1 file/)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This fixes another problem that's similar to the one reported in #7790. The problem is still that configuration is read and cached when we validate options vs configuration. By acting on all options first, we make sure that the first time we read configuration, it's done according to the given options. Specifically, it's the `--force-default-config` option that's now being respected.