### PR TITLE
[Fix #7094] Clarify alignment in MultilineOperationIndentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changes
 
 * [#7860](https://github.com/rubocop-hq/rubocop/issues/7860): Change `AllowInHeredoc` option of `Layout/TrailingWhitespace` to `true` by default. ([@koic][])
+* [#7094](https://github.com/rubocop-hq/rubocop/issues/7094): Clarify alignment in `Layout/MultilineOperationIndentation`. ([@jonas054][])
 
 ## 0.82.0 (2020-04-16)
 

--- a/lib/rubocop/cop/layout/multiline_operation_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_operation_indentation.rb
@@ -6,30 +6,39 @@ module RuboCop
       # This cop checks the indentation of the right hand side operand in
       # binary operations that span more than one line.
       #
+      # The `aligned` style checks that operators are aligned if they are part
+      # of an `if` or `while` condition, a `return` statement, etc. In other
+      # contexts, the second operand should be indented regardless of enforced
+      # style.
+      #
       # @example EnforcedStyle: aligned (default)
       #   # bad
       #   if a +
       #       b
-      #     something
+      #     something &&
+      #     something_else
       #   end
       #
       #   # good
       #   if a +
       #      b
-      #     something
+      #     something &&
+      #       something_else
       #   end
       #
       # @example EnforcedStyle: indented
       #   # bad
       #   if a +
       #      b
-      #     something
+      #     something &&
+      #     something_else
       #   end
       #
       #   # good
       #   if a +
       #       b
-      #     something
+      #     something &&
+      #       something_else
       #   end
       #
       class MultilineOperationIndentation < Cop

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -3736,6 +3736,11 @@ Enabled | Yes | Yes  | 0.49 | -
 This cop checks the indentation of the right hand side operand in
 binary operations that span more than one line.
 
+The `aligned` style checks that operators are aligned if they are part
+of an `if` or `while` condition, a `return` statement, etc. In other
+contexts, the second operand should be indented regardless of enforced
+style.
+
 ### Examples
 
 #### EnforcedStyle: aligned (default)
@@ -3744,13 +3749,15 @@ binary operations that span more than one line.
 # bad
 if a +
     b
-  something
+  something &&
+  something_else
 end
 
 # good
 if a +
    b
-  something
+  something &&
+    something_else
 end
 ```
 #### EnforcedStyle: indented
@@ -3759,13 +3766,15 @@ end
 # bad
 if a +
    b
-  something
+  something &&
+  something_else
 end
 
 # good
 if a +
     b
-  something
+  something &&
+    something_else
 end
 ```
 


### PR DESCRIPTION
Update the cop documentation to make it more clear which operands should be aligned, and which should always be indented.