### PR TITLE
Fix the command flags table

### DIFF
--- a/manual/basic_usage.md
+++ b/manual/basic_usage.md
@@ -116,11 +116,11 @@ Command flag                    | Description
 `-c/--config`                   | Run with specified config file.
 `-C/--cache`                    | Store and reuse results for faster operation.
 `-d/--debug`                    | Displays some extra debug output.
-    --disable-pending-cops      | Run without pending cops.
+`   --disable-pending-cops`     | Run without pending cops.
 `   --disable-uncorrectable`    | Used with --auto-correct to annotate any offenses that do not support autocorrect with `rubocop:todo` comments.
 `-D/--[no-]display-cop-names`   | Displays cop names in offense messages. Default is true.
 `   --display-only-fail-level-offenses` | Only output offense messages at the specified `--fail-level` or above
-    --enable-pending-cops       | Run with pending cops.
+`   --enable-pending-cops`      | Run with pending cops.
 `   --except`                   | Run all cops enabled by configuration except the specified cop(s) and/or departments.
 `   --exclude-limit`            | Limit how many individual files `--auto-gen-config` can list in `Exclude` parameters, default is 15.
 `-E/--extra-details`            | Displays extra details in offense messages.


### PR DESCRIPTION
[This](https://github.com/rubocop-hq/rubocop/commit/61090b15d99c0c4b174d9c50c92ccab039f1af85) commit broke the table and this PR fixes it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* n/a Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* n/a Added tests.
* n/a Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* n/a Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
