### PR TITLE
Add .simplecov to rubocop default include list

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 SimpleCov.start do
   add_filter '/spec/'
   add_filter '/vendor/bundle/'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#7895](https://github.com/rubocop-hq/rubocop/pull/7895): Include `.simplecov` file by default. ([@robotdana][])
+
 ### Bug fixes
 
 * [#7882](https://github.com/rubocop-hq/rubocop/pull/7882): Fix `Style/CaseEquality` when `AllowOnConstant` is `true` and the method receiver is implicit. ([@rafaelfranca][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -35,6 +35,7 @@ AllCops:
     - '**/*.watchr'
     - '**/.irbrc'
     - '**/.pryrc'
+    - '**/.simplecov'
     - '**/buildfile'
     - '**/Appraisals'
     - '**/Berksfile'

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
 
   RUBY_FILENAMES = %w[.irbrc
                       .pryrc
+                      .simplecov
                       Appraisals
                       Berksfile
                       Brewfile


### PR DESCRIPTION
This list looks fairly comprehensive, so lets add .simplecov the ruby config file for simplecov gem

https://github.com/colszowka/simplecov#using-simplecov-for-centralized-config