### PR TITLE
Allow Generator to take version_added parameter

### DIFF
--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -132,11 +132,12 @@ module RuboCop
         ).inject
       end
 
-      def inject_config(config_file_path: 'config/default.yml')
+      def inject_config(config_file_path: 'config/default.yml',
+                        version_added: bump_minor_version)
         injector =
           ConfigurationInjector.new(configuration_file_path: config_file_path,
                                     badge: badge,
-                                    version_added: bump_minor_version)
+                                    version_added: version_added)
 
         injector.inject do
           output.puts(format(CONFIGURATION_ADDED_MESSAGE,

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -280,6 +280,28 @@ RSpec.describe RuboCop::Cop::Generator do
                  "#{path}.\n")
       end
     end
+
+    context 'with version provided' do
+      it 'uses the provided version' do
+        expect(File).to receive(:write).with(path, <<~YAML)
+          Style/Alias:
+            Enabled: true
+
+          Style/FakeCop:
+            Description: 'TODO: Write a description of the cop.'
+            Enabled: pending
+            VersionAdded: '1.52'
+
+          Style/Lambda:
+            Enabled: true
+
+          Style/SpecialGlobalVars:
+            Enabled: true
+        YAML
+
+        generator.inject_config(config_file_path: path, version_added: '1.52')
+      end
+    end
   end
 
   describe '#snake_case' do


### PR DESCRIPTION
Other libraries like `rubocop-rspec` which rely on rubocop's generator
will be able to provide in their own version to be used in generated config. 

example: https://github.com/rubocop-hq/rubocop-rspec/pull/905

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/