### PR TITLE
Fix an incorrect autocorrect for hash transform methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#7881](https://github.com/rubocop-hq/rubocop/issues/7881): Fix `--parallel` and `--force-default-config` combination. ([@jonas054][])
 * [#7635](https://github.com/rubocop-hq/rubocop/issues/7635): Fix a false positive for `Style/MultilineWhenThen` when `then` required for a body of `when` is used. ([@koic][])
 * [#7905](https://github.com/rubocop-hq/rubocop/pull/7905): Fix an error when running `rubocop --only` or `rubocop --except` options without cop name argument. ([@koic][])
+* [#7903](https://github.com/rubocop-hq/rubocop/pull/7903): Fix an incorrect autocorrect for `Style/HashTransformKeys` and `Style/HashTransformValues` cops when line break before `to_h` method. ([@diogoosorio][], [@koic][])
 
 ### Changes
 
@@ -4476,3 +4477,4 @@
 [@knu]: https://github.com/knu
 [@saurabhmaurya15]: https://github.com/saurabhmaurya15
 [@DracoAter]: https://github.com/DracoAter
+[@diogoosorio]: https://github.com/diogoosorio

--- a/lib/rubocop/cop/mixin/hash_transform_method.rb
+++ b/lib/rubocop/cop/mixin/hash_transform_method.rb
@@ -132,7 +132,14 @@ module RuboCop
         end
 
         def self.from_map_to_h(node, match)
-          strip_trailing_chars = node.parent&.block_type? ? 0 : '.to_h'.length
+          strip_trailing_chars = 0
+
+          unless node.parent&.block_type?
+            map_range = node.children.first.source_range
+            node_range = node.source_range
+            strip_trailing_chars = node_range.end_pos - map_range.end_pos
+          end
+
           new(match, node.children.first, 0, strip_trailing_chars)
         end
 

--- a/spec/rubocop/cop/style/hash_transform_keys_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_keys_spec.rb
@@ -66,6 +66,19 @@ RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
       RUBY
     end
 
+    it 'flags _.map{...}.to_h when transform_keys could be used ' \
+       'when line break before `to_h`' do
+      expect_offense(<<~RUBY)
+        x.map {|k, v| [k.to_sym, v]}.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `map {...}.to_h`.
+          to_h
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.transform_keys {|k| k.to_sym}
+      RUBY
+    end
+
     it 'does not flag _.map{...}.to_h when both key & value are transformed' do
       expect_no_offenses('x.map {|k, v| [k.to_sym, foo(v)]}.to_h')
     end

--- a/spec/rubocop/cop/style/hash_transform_values_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_values_spec.rb
@@ -65,6 +65,19 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
     RUBY
   end
 
+  it 'flags _.map {...}.to_h when transform_values could be used ' \
+     'when line break before `to_h`' do
+    expect_offense(<<~RUBY)
+      x.map {|k, v| [k, foo(v)]}.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `map {...}.to_h`.
+        to_h
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x.transform_values {|v| foo(v)}
+    RUBY
+  end
+
   it 'does not flag _.map{...}.to_h when both key & value are transformed' do
     expect_no_offenses('x.map {|k, v| [k.to_sym, foo(v)]}.to_h')
   end


### PR DESCRIPTION
Follow up to rubocop-hq/rubocop-rails#239.

This PR fixes an incorrect autocorrect for `Style/HashTransformKeys` and `Style/HashTransformValues` cops when line break before `to_h` method.

In the future, duplicate code in RuboCop Rails may be removed, making it dependent on RuboCop core code. It centralizes the resolution of problems.

cc @diogoosorio

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
