### PR TITLE
Display `N/A` for pending cop warnings without `VersionAdded` specified

### DIFF
--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -132,9 +132,9 @@ module RuboCop
                      '`false` in your `.rubocop.yml` file:').yellow
 
         pending_cops.each do |cop|
-          warn Rainbow(
-            " - #{cop.name} (#{cop.metadata['VersionAdded']})"
-          ).yellow
+          version = cop.metadata['VersionAdded'] || 'N/A'
+
+          warn Rainbow(" - #{cop.name} (#{version})").yellow
         end
 
         warn Rainbow('For more information: https://docs.rubocop.org/en/latest/versioning/').yellow

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -294,6 +294,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
         context 'when Style department is enabled' do
           let(:new_cops_option) { '' }
+          let(:version_added) { "VersionAdded: '0.80'" }
 
           before do
             create_file('.rubocop.yml', <<~YAML)
@@ -306,25 +307,44 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
               Style/SomeCop:
                 Description: Something
                 Enabled: pending
-                VersionAdded: '0.80'
+                #{version_added}
             YAML
           end
 
-          it 'accepts cop names from plugins with a pending cop warning' do
-            expect(output).to start_with(pending_cop_warning)
-            expect(output).to end_with(inspected_output)
+          context 'when `VersionAdded` is specified' do
+            it 'accepts cop names from plugins with a pending cop warning' do
+              expect(output).to start_with(pending_cop_warning)
+              expect(output).to end_with(inspected_output)
 
-            remaining_range =
-              pending_cop_warning.length..-(inspected_output.length + 1)
-            pending_cops = output[remaining_range].split("\n")
+              remaining_range =
+                pending_cop_warning.length..-(inspected_output.length + 1)
+              pending_cops = output[remaining_range].split("\n")
 
-            expect(pending_cops).to include(
-              ' - Style/SomeCop (0.80)'
-            )
+              expect(pending_cops).to include(' - Style/SomeCop (0.80)')
 
-            manual_url = output[remaining_range].split("\n").last
+              manual_url = output[remaining_range].split("\n").last
 
-            expect(manual_url).to eq(versioning_manual_url)
+              expect(manual_url).to eq(versioning_manual_url)
+            end
+          end
+
+          context 'when `VersionAdded` is not specified' do
+            let(:version_added) { '' }
+
+            it 'accepts cop names from plugins with a pending cop warning' do
+              expect(output).to start_with(pending_cop_warning)
+              expect(output).to end_with(inspected_output)
+
+              remaining_range =
+                pending_cop_warning.length..-(inspected_output.length + 1)
+              pending_cops = output[remaining_range].split("\n")
+
+              expect(pending_cops).to include(' - Style/SomeCop (N/A)')
+
+              manual_url = output[remaining_range].split("\n").last
+
+              expect(manual_url).to eq(versioning_manual_url)
+            end
           end
 
           context 'when using `--disable-pending-cops` command-line option' do


### PR DESCRIPTION
This PR displays `N/A` for pending cop warnings without `VersionAdded` specified.
3rd party cop may not have `VersionAdded` specified.

## Before

```console
% rubocop
The following cops were added to RuboCop, but are not configured. Please
set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Style/VersionAddedIsNotSpecified ()
For more information: https://docs.rubocop.org/en/latest/versioning/
```

## After

```console
% rubocop
The following cops were added to RuboCop, but are not configured. Please
set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Style/VersionAddedIsNotSpecified (N/A)
For more information: https://docs.rubocop.org/en/latest/versioning/
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
