### PR TITLE
Fix an error when running `--only` or `--except` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#7790](https://github.com/rubocop-hq/rubocop/issues/7790): Fix `--parallel` and `--ignore-parent-exclusion` combination. ([@jonas054][])
 * [#7881](https://github.com/rubocop-hq/rubocop/issues/7881): Fix `--parallel` and `--force-default-config` combination. ([@jonas054][])
 * [#7635](https://github.com/rubocop-hq/rubocop/issues/7635): Fix a false positive for `Style/MultilineWhenThen` when `then` required for a body of `when` is used. ([@koic][])
+* [#7905](https://github.com/rubocop-hq/rubocop/pull/7905): Fix an error when running `rubocop --only` or `rubocop --except` options without cop name argument. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -83,6 +83,12 @@ module RuboCop
 
     def add_cop_selection_csv_option(option, opts)
       option(opts, "--#{option} [COP1,COP2,...]") do |list|
+        unless list
+          message = "--#{option} argument should be [COP1,COP2,...]."
+
+          raise OptionArgumentError, message
+        end
+
         @options[:"#{option}"] =
           if list.empty?
             ['']

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -555,6 +555,15 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           RESULT
       end
     end
+
+    context 'when a cop name is not specified' do
+      it 'displays how to use `--only` option' do
+        expect(cli.run(%w[--except -a Lint/NumberConverion])).to eq(2)
+        expect($stderr.string).to eq(<<~MESSAGE)
+          --except argument should be [COP1,COP2,...].
+        MESSAGE
+      end
+    end
   end
 
   describe '--except' do
@@ -672,6 +681,15 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
             RESULT
         end
+      end
+    end
+
+    context 'when a cop name is not specified' do
+      it 'displays how to use `--except` option' do
+        expect(cli.run(%w[--except])).to eq(2)
+        expect($stderr.string).to eq(<<~MESSAGE)
+          --except argument should be [COP1,COP2,...].
+        MESSAGE
       end
     end
   end


### PR DESCRIPTION
This PR fixes an error when running `rubocop --only` or `rubocop --except` options without cop name argument.

## Before

```consle
% rubocop --only
undefined method `empty?' for nil:NilClass
/Users/koic/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rubocop-0.82.0/lib/rubocop/options.rb:87:in `block in add_cop_selection_csv_option'
/Users/koic/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rubocop-0.82.0/lib/rubocop/options.rb:206:in `block in option'
/Users/koic/.rbenv/versions/2.7.1/lib/ruby/2.7.0/optparse.rb:1589:in `block in parse_in_order'
/Users/koic/.rbenv/versions/2.7.1/lib/ruby/2.7.0/optparse.rb:1575:in `catch'
```

## After

```console
% rubocop --only
--only argument should be [COP1,COP2,...].
```

The same is true for `rubocop --except`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
