### PR TITLE
[Fix #3696] Add `AllowComments` option to `Lint/EmptyWhen` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#595](https://github.com/rubocop-hq/rubocop/issues/595): Add ERB pre-processing for configuration files. ([@jonas054][])
 * [#7918](https://github.com/rubocop-hq/rubocop/pull/7918): Support autocorrection for `Lint/AmbiguousOperator`. ([@koic][])
 * [#7937](https://github.com/rubocop-hq/rubocop/pull/7937): Support autocorrection for `Style/IfWithSemicolon`. ([@koic][])
+* [#3696](https://github.com/rubocop-hq/rubocop/issues/3696): Add `AllowComments` option to `Lint/EmptyWhen` cop. ([@robotdana][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1415,7 +1415,9 @@ Lint/EmptyInterpolation:
 Lint/EmptyWhen:
   Description: 'Checks for `when` branches with empty bodies.'
   Enabled: true
+  AllowComments: true
   VersionAdded: '0.45'
+  VersionChanged: '0.83'
 
 Lint/EnsureReturn:
   Description: 'Do not use return in an ensure block.'

--- a/lib/rubocop/cop/lint/empty_when.rb
+++ b/lib/rubocop/cop/lint/empty_when.rb
@@ -8,26 +8,49 @@ module RuboCop
       # @example
       #
       #   # bad
-      #
       #   case foo
-      #   when bar then 1
-      #   when baz then # nothing
+      #   when bar
+      #     do_something
+      #   when baz
       #   end
       #
       # @example
       #
       #   # good
-      #
-      #   case foo
-      #   when bar then 1
-      #   when baz then 2
+      #   case condition
+      #   when foo
+      #     do_something
+      #   when bar
+      #     nil
       #   end
+      #
+      # @example AllowComments: true (default)
+      #
+      #   # good
+      #   case condition
+      #   when foo
+      #     do_something
+      #   when bar
+      #     # noop
+      #   end
+      #
+      # @example AllowComments: false
+      #
+      #   # bad
+      #   case condition
+      #   when foo
+      #     do_something
+      #   when bar
+      #     # do nothing
+      #   end
+      #
       class EmptyWhen < Cop
         MSG = 'Avoid `when` branches without a body.'
 
         def on_case(node)
           node.each_when do |when_node|
             next if when_node.body
+            next if cop_config['AllowComments'] && comment_lines?(node)
 
             add_offense(when_node, location: when_node.source_range)
           end

--- a/lib/rubocop/cop/lint/suppressed_exception.rb
+++ b/lib/rubocop/cop/lint/suppressed_exception.rb
@@ -73,12 +73,6 @@ module RuboCop
 
           add_offense(node)
         end
-
-        private
-
-        def comment_lines?(node)
-          processed_source[line_range(node)].any? { |line| comment_line?(line) }
-        end
       end
     end
   end

--- a/lib/rubocop/cop/style/empty_method.rb
+++ b/lib/rubocop/cop/style/empty_method.rb
@@ -90,10 +90,6 @@ module RuboCop
           compact_style? ? '; ' : "\n#{indent}"
         end
 
-        def comment_lines?(node)
-          processed_source[line_range(node)].any? { |line| comment_line?(line) }
-        end
-
         def compact?(node)
           node.single_line?
         end

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -17,6 +17,10 @@ module RuboCop
         line_source =~ /^\s*#/
       end
 
+      def comment_lines?(node)
+        processed_source[line_range(node)].any? { |line| comment_line?(line) }
+      end
+
       def line_range(node)
         node.first_line..node.last_line
       end

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -595,7 +595,7 @@ This cop checks for empty interpolation.
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.45 | -
+Enabled | Yes | No | 0.45 | 0.83
 
 This cop checks for the presence of `when` branches without a body.
 
@@ -603,20 +603,49 @@ This cop checks for the presence of `when` branches without a body.
 
 ```ruby
 # bad
-
 case foo
-when bar then 1
-when baz then # nothing
+when bar
+  do_something
+when baz
 end
 ```
 ```ruby
 # good
-
-case foo
-when bar then 1
-when baz then 2
+case condition
+when foo
+  do_something
+when bar
+  nil
 end
 ```
+#### AllowComments: true (default)
+
+```ruby
+# good
+case condition
+when foo
+  do_something
+when bar
+  # noop
+end
+```
+#### AllowComments: false
+
+```ruby
+# bad
+case condition
+when foo
+  do_something
+when bar
+  # do nothing
+end
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AllowComments | `true` | Boolean
 
 ## Lint/EnsureReturn
 

--- a/spec/rubocop/cop/lint/empty_when_spec.rb
+++ b/spec/rubocop/cop/lint/empty_when_spec.rb
@@ -147,4 +147,30 @@ RSpec.describe RuboCop::Cop::Lint::EmptyWhen, :config do
       end
     RUBY
   end
+
+  context 'when `AllowComments: true`' do
+    let(:cop_config) { { 'AllowComments' => true } }
+
+    it_behaves_like 'code without offense', <<~RUBY
+      case condition
+      when foo
+        do_something
+      when bar
+        # do nothing
+      end
+    RUBY
+  end
+
+  context 'when `AllowComments: false`' do
+    let(:cop_config) { { 'AllowComments' => false } }
+
+    it_behaves_like 'code with offense', <<~RUBY
+      case condition
+      when foo
+        do_something
+      when bar
+        # do nothing
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #3696 and #3754.

This PR add `AllowComments` option to `Lint/EmptyWhen` cop.
This option is enabled by default based on user feedback. It is also the same default as the option of `Lint/SuppressedException` set in #7805.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
