### PR TITLE
Fix a false positive for `Lint/ParenthesesAsGroupedExpression`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#7903](https://github.com/rubocop-hq/rubocop/pull/7903): Fix an incorrect autocorrect for `Style/HashTransformKeys` and `Style/HashTransformValues` cops when line break before `to_h` method. ([@diogoosorio][], [@koic][])
 * [#7899](https://github.com/rubocop-hq/rubocop/issues/7899): Fix an infinite loop error for `Layout/SpaceAroundOperators` with `Layout/ExtraSpacing` when using `ForceEqualSignAlignment: true`. ([@koic][])
 * [#7885](https://github.com/rubocop-hq/rubocop/issues/7885): Fix `Style/IfUnlessModifier` logic when tabs are used for indentation. ([@jonas054][])
+* [#7909](https://github.com/rubocop-hq/rubocop/pull/7909): Fix a false positive for `Lint/ParenthesesAsGroupedExpression` when using an intended grouped parentheses. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
+++ b/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
@@ -9,14 +9,12 @@ module RuboCop
       # @example
       #
       #   # bad
-      #
-      #   puts (x + y)
-      #
-      # @example
+      #   do_something (foo)
       #
       #   # good
-      #
-      #   puts(x + y)
+      #   do_something(foo)
+      #   do_something (2 + 3) * 4
+      #   do_something (foo * bar).baz
       class ParenthesesAsGroupedExpression < Cop
         include RangeHelp
 
@@ -25,8 +23,7 @@ module RuboCop
         def on_send(node)
           return unless node.arguments.one?
           return if node.operator_method? || node.setter_method?
-
-          return unless node.first_argument.source.start_with?('(')
+          return if grouped_parentheses?(node)
 
           space_length = spaces_before_left_parenthesis(node)
           return unless space_length.positive?
@@ -38,6 +35,12 @@ module RuboCop
         alias on_csend on_send
 
         private
+
+        def grouped_parentheses?(node)
+          first_argument = node.first_argument
+
+          first_argument.send_type? && first_argument.receiver&.begin_type?
+        end
 
         def spaces_before_left_parenthesis(node)
           receiver = node.receiver

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1424,13 +1424,12 @@ parenthesis.
 
 ```ruby
 # bad
+do_something (foo)
 
-puts (x + y)
-```
-```ruby
 # good
-
-puts(x + y)
+do_something(foo)
+do_something (2 + 3) * 4
+do_something (foo * bar).baz
 ```
 
 ### References

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -19,10 +19,15 @@ RSpec.describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression do
     RUBY
   end
 
-  it 'registers an offense for math expression' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense for math expression' do
+    expect_no_offenses(<<~RUBY)
       puts (2 + 3) * 4
-          ^ `(...)` interpreted as grouped expression.
+    RUBY
+  end
+
+  it 'does not register an offense for math expression with `to_i`' do
+    expect_no_offenses(<<~RUBY)
+      do_something.eq (foo * bar).to_i
     RUBY
   end
 


### PR DESCRIPTION
This PR fixes a false positive for `Lint/ParenthesesAsGroupedExpression` when using an intended grouped parentheses.

```ruby
puts (2 + 3) * 4
```

I noticed this false positive in implementing this cop's auto-correction. So, I plan to open a PR that implements auto-correction separately from this PR.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
