### PR TITLE
Support autocorrection for `Lint/ParenthesesAsGroupedExpression`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#7918](https://github.com/rubocop-hq/rubocop/pull/7918): Support autocorrection for `Lint/AmbiguousOperator`. ([@koic][])
 * [#7937](https://github.com/rubocop-hq/rubocop/pull/7937): Support autocorrection for `Style/IfWithSemicolon`. ([@koic][])
 * [#3696](https://github.com/rubocop-hq/rubocop/issues/3696): Add `AllowComments` option to `Lint/EmptyWhen` cop. ([@koic][])
+* [#7910](https://github.com/rubocop-hq/rubocop/pull/7910): Support autocorrection for `Lint/ParenthesesAsGroupedExpression`. ([@koic][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1571,6 +1571,7 @@ Lint/ParenthesesAsGroupedExpression:
   StyleGuide: '#parens-no-spaces'
   Enabled: true
   VersionAdded: '0.12'
+  VersionChanged: '0.83'
 
 Lint/PercentStringArray:
   Description: >-

--- a/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
+++ b/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
@@ -30,9 +30,18 @@ module RuboCop
 
           range = space_range(node.first_argument.source_range, space_length)
 
-          add_offense(nil, location: range)
+          add_offense(node, location: range)
         end
         alias on_csend on_send
+
+        def autocorrect(node)
+          space_length = spaces_before_left_parenthesis(node)
+          range = space_range(node.first_argument.source_range, space_length)
+
+          lambda do |corrector|
+            corrector.remove(range)
+          end
+        end
 
         private
 

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1449,7 +1449,7 @@ p [''.frozen?, ''.encoding] #=> [true, #<Encoding:US-ASCII>]
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.12 | -
+Enabled | Yes | Yes  | 0.12 | 0.83
 
 Checks for space between the name of a called method and a left
 parenthesis.

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -3,19 +3,27 @@
 RSpec.describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for method call with space before the ' \
-     'parenthesis' do
+  it 'registers an offense and corrects for method call with space before ' \
+     'the parenthesis' do
     expect_offense(<<~RUBY)
       a.func (x)
             ^ `(...)` interpreted as grouped expression.
     RUBY
+
+    expect_correction(<<~RUBY)
+      a.func(x)
+    RUBY
   end
 
-  it 'registers an offense for predicate method call with space ' \
+  it 'registers an offense and corrects for predicate method call with space ' \
      'before the parenthesis' do
     expect_offense(<<~RUBY)
       is? (x)
          ^ `(...)` interpreted as grouped expression.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      is?(x)
     RUBY
   end
 
@@ -67,11 +75,15 @@ RSpec.describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression do
   end
 
   context 'when using safe navigation operator' do
-    it 'registers an offense for method call with space before the ' \
-       'parenthesis' do
+    it 'registers an offense and corrects for method call with space before ' \
+       'the parenthesis' do
       expect_offense(<<~RUBY)
         a&.func (x)
                ^ `(...)` interpreted as grouped expression.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a&.func(x)
       RUBY
     end
   end


### PR DESCRIPTION
Follow up to https://github.com/rubocop-hq/rubocop/pull/7909.

This PR supports autocorrection for `Lint/ParenthesesAsGroupedExpression`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
