### PR TITLE
Fix a false positive for `Lint/LiteralAsCondition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#7899](https://github.com/rubocop-hq/rubocop/issues/7899): Fix an infinite loop error for `Layout/SpaceAroundOperators` with `Layout/ExtraSpacing` when using `ForceEqualSignAlignment: true`. ([@koic][])
 * [#7885](https://github.com/rubocop-hq/rubocop/issues/7885): Fix `Style/IfUnlessModifier` logic when tabs are used for indentation. ([@jonas054][])
 * [#7909](https://github.com/rubocop-hq/rubocop/pull/7909): Fix a false positive for `Lint/ParenthesesAsGroupedExpression` when using an intended grouped parentheses. ([@koic][])
+* [#7913](https://github.com/rubocop-hq/rubocop/pull/7913): Fix a false positive for `Lint/LiteralAsCondition` when using `true` literal in `while` and similar cases. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/literal_as_condition.rb
+++ b/lib/rubocop/cop/lint/literal_as_condition.rb
@@ -10,25 +10,24 @@ module RuboCop
       # @example
       #
       #   # bad
-      #
       #   if 20
       #     do_something
       #   end
       #
-      # @example
-      #
       #   # bad
-      #
       #   if some_var && true
       #     do_something
       #   end
       #
-      # @example
-      #
       #   # good
-      #
       #   if some_var && some_condition
       #     do_something
+      #   end
+      #
+      #   # good
+      #   # When using a boolean value for an infinite loop.
+      #   while true
+      #     break if condition
       #   end
       class LiteralAsCondition < Cop
         MSG = 'Literal `%<literal>s` appeared as a condition.'
@@ -38,20 +37,18 @@ module RuboCop
         end
 
         def on_while(node)
-          check_for_literal(node)
-        end
+          return if condition(node).true_type?
 
-        def on_while_post(node)
           check_for_literal(node)
         end
+        alias on_while_post on_while
 
         def on_until(node)
-          check_for_literal(node)
-        end
+          return if condition(node).false_type?
 
-        def on_until_post(node)
           check_for_literal(node)
         end
+        alias on_until_post on_until
 
         def on_case(case_node)
           if case_node.condition

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -993,23 +993,24 @@ if/while/until.
 
 ```ruby
 # bad
-
 if 20
   do_something
 end
-```
-```ruby
-# bad
 
+# bad
 if some_var && true
   do_something
 end
-```
-```ruby
-# good
 
+# good
 if some_var && some_condition
   do_something
+end
+
+# good
+# When using a boolean value for an infinite loop.
+while true
+  break if condition
 end
 ```
 

--- a/spec/rubocop/cop/lint/literal_as_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_as_condition_spec.rb
@@ -176,4 +176,36 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition do
       end
     RUBY
   end
+
+  it 'accepts `true` literal in `while`' do
+    expect_no_offenses(<<~RUBY)
+      while true
+        break if condition
+      end
+    RUBY
+  end
+
+  it 'accepts `true` literal in post-loop `while`' do
+    expect_no_offenses(<<~RUBY)
+      begin
+        break if condition
+      end while true
+    RUBY
+  end
+
+  it 'accepts `false` literal in `until`' do
+    expect_no_offenses(<<~RUBY)
+      until false
+        break if condition
+      end
+    RUBY
+  end
+
+  it 'accepts `false` literal in post-loop `until`' do
+    expect_no_offenses(<<~RUBY)
+      begin
+        break if condition
+      end until false
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR fixes a false positive for `Lint/LiteralAsCondition` when using `true` literal in `while` and similar cases.

`while true` is a known idiom. Normally `loop` is used, OTOH `while true` may be selected for speeding up. Users use these methods depending on use case. That was introduced as part of RubyKaigi 2019.
https://rubykaigi.org/2019/presentations/ktou.html

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
