### PR TITLE
Support autocorrection for `Lint/AmbiguousRegexpLiteral`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#7895](https://github.com/rubocop-hq/rubocop/pull/7895): Include `.simplecov` file by default. ([@robotdana][])
+* [#7916](https://github.com/rubocop-hq/rubocop/pull/7916): Support autocorrection for `Lint/AmbiguousRegexpLiteral`. ([@koic][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1324,6 +1324,7 @@ Lint/AmbiguousRegexpLiteral:
                  a method invocation without parentheses.
   Enabled: true
   VersionAdded: '0.17'
+  VersionChanged: '0.83'
 
 Lint/AssignmentInCondition:
   Description: "Don't use assignment in conditions."

--- a/lib/rubocop/cop/lint/ambiguous_operator.rb
+++ b/lib/rubocop/cop/lint/ambiguous_operator.rb
@@ -44,6 +44,11 @@ module RuboCop
           diagnostic.reason == :ambiguous_prefix
         end
 
+        def find_offense_node_by(diagnostic)
+          # TODO: When implementing auto-correction, this method should return
+          # an offense node passed as first argument of `add_offense` method.
+        end
+
         def alternative_message(diagnostic)
           operator = diagnostic.location.source
           hash = AMBIGUITIES[operator]

--- a/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
+++ b/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
@@ -28,10 +28,24 @@ module RuboCop
               "if it's surely a regexp literal, or add a whitespace to the " \
               'right of the `/` if it should be a division.'
 
+        def autocorrect(node)
+          lambda do |corrector|
+            add_parentheses(node, corrector)
+          end
+        end
+
         private
 
         def relevant_diagnostic?(diagnostic)
           diagnostic.reason == :ambiguous_literal
+        end
+
+        def find_offense_node_by(diagnostic)
+          node = processed_source.ast.each_node(:regexp).find do |regexp_node|
+            regexp_node.source_range.begin_pos == diagnostic.location.begin_pos
+          end
+
+          node.parent
         end
 
         def alternative_message(_diagnostic)

--- a/lib/rubocop/cop/lint/useless_else_without_rescue.rb
+++ b/lib/rubocop/cop/lint/useless_else_without_rescue.rb
@@ -40,6 +40,11 @@ module RuboCop
           diagnostic.reason == :useless_else
         end
 
+        def find_offense_node_by(diagnostic)
+          # TODO: When implementing auto-correction, this method should return
+          # an offense node passed as first argument of `add_offense` method.
+        end
+
         def alternative_message(_diagnostic)
           MSG
         end

--- a/lib/rubocop/cop/mixin/parser_diagnostic.rb
+++ b/lib/rubocop/cop/mixin/parser_diagnostic.rb
@@ -26,7 +26,7 @@ module RuboCop
                       d.message.capitalize
                     end
 
-          add_offense(nil,
+          add_offense(find_offense_node_by(d),
                       location: d.location,
                       message: message,
                       severity: d.level)

--- a/lib/rubocop/cop/style/lambda_call.rb
+++ b/lib/rubocop/cop/style/lambda_call.rb
@@ -52,26 +52,6 @@ module RuboCop
             implicit_style? && !node.implicit_call?
         end
 
-        def add_parentheses(node, corrector)
-          if node.arguments.empty?
-            corrector.insert_after(node, '()')
-          else
-            corrector.replace(args_begin(node), '(')
-            corrector.insert_after(args_end(node), ')')
-          end
-        end
-
-        def args_begin(node)
-          loc = node.loc
-          selector =
-            node.super_type? || node.yield_type? ? loc.keyword : loc.selector
-          selector.end.resize(1)
-        end
-
-        def args_end(node)
-          node.loc.expression.end
-        end
-
         def message(_node)
           if explicit_style?
             'Prefer the use of `lambda.call(...)` over `lambda.(...)`.'

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -26,6 +26,26 @@ module RuboCop
           node.loc.end.is?(')')
       end
 
+      def add_parentheses(node, corrector)
+        if node.arguments.empty?
+          corrector.insert_after(node, '()')
+        else
+          corrector.replace(args_begin(node), '(')
+          corrector.insert_after(args_end(node), ')')
+        end
+      end
+
+      def args_begin(node)
+        loc = node.loc
+        selector =
+          node.super_type? || node.yield_type? ? loc.keyword : loc.selector
+        selector.end.resize(1)
+      end
+
+      def args_end(node)
+        node.loc.expression.end
+      end
+
       def on_node(syms, sexp, excludes = [], &block)
         return to_enum(:on_node, syms, sexp, excludes) unless block_given?
 

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -66,7 +66,7 @@ do_something(*some_array)
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.17 | -
+Enabled | Yes | Yes  | 0.17 | 0.83
 
 This cop checks for ambiguous regexp literals in the first argument of
 a method invocation without parentheses.

--- a/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
@@ -5,10 +5,54 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousRegexpLiteral do
 
   context 'with a regexp literal in the first argument' do
     context 'without parentheses' do
-      it 'registers an offense' do
+      it 'registers an offense and corrects when single argument' do
         expect_offense(<<~RUBY)
           p /pattern/
             ^ Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal, or add a whitespace to the right of the `/` if it should be a division.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          p(/pattern/)
+        RUBY
+      end
+
+      it 'registers an offense and corrects when multiple arguments' do
+        expect_offense(<<~RUBY)
+          p /pattern/, foo
+            ^ Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal, or add a whitespace to the right of the `/` if it should be a division.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          p(/pattern/, foo)
+        RUBY
+      end
+
+      it 'registers an offense and corrects when using block argument' do
+        expect_offense(<<~RUBY)
+          p /pattern/, foo do |arg|
+            ^ Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal, or add a whitespace to the right of the `/` if it should be a division.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          p(/pattern/, foo) do |arg|
+          end
+        RUBY
+      end
+
+      it 'registers an offense and corrects when nesting' do
+        expect_offense(<<~RUBY)
+          p /pattern/ do
+            ^ Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal, or add a whitespace to the right of the `/` if it should be a division.
+            p /pattern/
+              ^ Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal, or add a whitespace to the right of the `/` if it should be a division.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          p(/pattern/) do
+            p(/pattern/)
+          end
         RUBY
       end
     end


### PR DESCRIPTION
This PR supports autocorrection for `Lint/AmbiguousRegexpLiteral`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
