### PR TITLE
Support autocorrection for `Lint/UselessAccessModifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#7895](https://github.com/rubocop-hq/rubocop/pull/7895): Include `.simplecov` file by default. ([@robotdana][])
 * [#7916](https://github.com/rubocop-hq/rubocop/pull/7916): Support autocorrection for `Lint/AmbiguousRegexpLiteral`. ([@koic][])
+* [#7917](https://github.com/rubocop-hq/rubocop/pull/7917): Support autocorrection for `Lint/UselessAccessModifier`. ([@koic][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1810,7 +1810,7 @@ Lint/UselessAccessModifier:
   Description: 'Checks for useless access modifiers.'
   Enabled: true
   VersionAdded: '0.20'
-  VersionChanged: '0.47'
+  VersionChanged: '0.83'
   ContextCreatingMethods: []
   MethodCreatingMethods: []
 

--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -125,6 +125,8 @@ module RuboCop
       #     delegate :method_a, to: :method_b
       #   end
       class UselessAccessModifier < Cop
+        include RangeHelp
+
         MSG = 'Useless `%<current>s` access modifier.'
 
         def on_class(node)
@@ -143,6 +145,16 @@ module RuboCop
 
         def on_sclass(node)
           check_node(node.children[1]) # singleton class body
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            range = range_by_whole_lines(
+              node.source_range, include_final_newline: true
+            )
+
+            corrector.remove(range)
+          end
         end
 
         private

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -2773,7 +2773,7 @@ URI::DEFAULT_PARSER.make_regexp('http://example.com')
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.20 | 0.47
+Enabled | Yes | Yes  | 0.20 | 0.83
 
 This cop checks for redundant access modifiers, including those with no
 code, those which are repeated, and leading `public` modifiers in a


### PR DESCRIPTION
This PR supports autocorrection for `Lint/UselessAccessModifier`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
