### PR TITLE
Support autocorrection for `Lint/AmbiguousOperator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#7916](https://github.com/rubocop-hq/rubocop/pull/7916): Support autocorrection for `Lint/AmbiguousRegexpLiteral`. ([@koic][])
 * [#7917](https://github.com/rubocop-hq/rubocop/pull/7917): Support autocorrection for `Lint/UselessAccessModifier`. ([@koic][])
 * [#595](https://github.com/rubocop-hq/rubocop/issues/595): Add ERB pre-processing for configuration files. ([@jonas054][])
+* [#7918](https://github.com/rubocop-hq/rubocop/pull/7918): Support autocorrection for `Lint/AmbiguousOperator`. ([@koic][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1317,6 +1317,7 @@ Lint/AmbiguousOperator:
   StyleGuide: '#method-invocation-parens'
   Enabled: true
   VersionAdded: '0.17'
+  VersionChanged: '0.83'
 
 Lint/AmbiguousRegexpLiteral:
   Description: >-

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -37,7 +37,7 @@ foo = ->(bar) { bar.baz }
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.17 | -
+Enabled | Yes | Yes  | 0.17 | 0.83
 
 This cop checks for ambiguous operators in the first argument of a
 method invocation without parentheses.

--- a/spec/rubocop/cop/lint/ambiguous_operator_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_operator_spec.rb
@@ -3,14 +3,89 @@
 RSpec.describe RuboCop::Cop::Lint::AmbiguousOperator do
   subject(:cop) { described_class.new }
 
+  context 'with `+` unary operator in the first argument' do
+    context 'without parentheses' do
+      context 'without whitespaces on the right of the operator' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            do_something(+24)
+            do_something +42
+                         ^ Ambiguous positive number operator. Parenthesize the method arguments if it's surely a positive number operator, or add a whitespace to the right of the `+` if it should be a addition.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            do_something(+24)
+            do_something(+42)
+          RUBY
+        end
+      end
+
+      context 'with a whitespace on the right of the operator' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            do_something + 42
+          RUBY
+        end
+      end
+    end
+
+    context 'with parentheses around the operator' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          do_something(+42)
+        RUBY
+      end
+    end
+  end
+
+  context 'with `-` unary operator in the first argument' do
+    context 'without parentheses' do
+      context 'without whitespaces on the right of the operator' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            do_something(-24)
+            do_something -42
+                         ^ Ambiguous negative number operator. Parenthesize the method arguments if it's surely a negative number operator, or add a whitespace to the right of the `-` if it should be a subtraction.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            do_something(-24)
+            do_something(-42)
+          RUBY
+        end
+      end
+
+      context 'with a whitespace on the right of the operator' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            do_something - 42
+          RUBY
+        end
+      end
+    end
+
+    context 'with parentheses around the operator' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          do_something(-42)
+        RUBY
+      end
+    end
+  end
+
   context 'with a splat operator in the first argument' do
     context 'without parentheses' do
       context 'without whitespaces on the right of the operator' do
-        it 'registers an offense' do
+        it 'registers an offense and corrects' do
           expect_offense(<<~RUBY)
             array = [1, 2, 3]
             puts *array
                  ^ Ambiguous splat operator. Parenthesize the method arguments if it's surely a splat operator, or add a whitespace to the right of the `*` if it should be a multiplication.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            array = [1, 2, 3]
+            puts(*array)
           RUBY
         end
       end
@@ -38,11 +113,16 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousOperator do
   context 'with a block ampersand in the first argument' do
     context 'without parentheses' do
       context 'without whitespaces on the right of the operator' do
-        it 'registers an offense' do
+        it 'registers an offense and corrects' do
           expect_offense(<<~RUBY)
             process = proc { do_something }
             2.times &process
                     ^ Ambiguous block operator. Parenthesize the method arguments if it's surely a block operator, or add a whitespace to the right of the `&` if it should be a binary AND.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            process = proc { do_something }
+            2.times(&process)
           RUBY
         end
       end
@@ -62,6 +142,39 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousOperator do
         expect_no_offenses(<<~RUBY)
           process = proc { do_something }
           2.times(&process)
+        RUBY
+      end
+    end
+  end
+
+  context 'with a keyword splat operator in the first argument' do
+    context 'without parentheses' do
+      context 'without whitespaces on the right of the operator' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            do_something **kwargs
+                         ^^ Ambiguous keyword splat operator. Parenthesize the method arguments if it's surely a keyword splat operator, or add a whitespace to the right of the `**` if it should be a exponent.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            do_something(**kwargs)
+          RUBY
+        end
+      end
+
+      context 'with a whitespace on the right of the operator' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            do_something ** kwargs
+          RUBY
+        end
+      end
+    end
+
+    context 'with parentheses around the keyword splat operator' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          do_something(**kwargs)
         RUBY
       end
     end


### PR DESCRIPTION
This PR supports autocorrection for `Lint/AmbiguousOperator`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
