### PR TITLE
[Fix #7855] show pending cops warnings in case passing configurationfile with -c option

### DIFF
--- a/lib/rubocop/config_store.rb
+++ b/lib/rubocop/config_store.rb
@@ -23,6 +23,8 @@ module RuboCop
       loaded_config = ConfigLoader.load_file(options_config)
       @options_config = ConfigLoader.merge_with_default(loaded_config,
                                                         options_config)
+
+      check_pending_cops(loaded_config)
     end
 
     def force_default_config!
@@ -43,6 +45,16 @@ module RuboCop
                                 print "For #{dir}: " if ConfigLoader.debug?
                                 ConfigLoader.configuration_from_file(path)
                               end
+    end
+
+    private
+
+    def check_pending_cops(loaded_config)
+      @options_config.tap do |merged_config|
+        unless ConfigLoader.possible_new_cops?(loaded_config)
+          ConfigLoader.warn_on_pending_cops(merged_config.pending_cops)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fix  #7855

Without `-c` option rubocop do some manipulation with config files here: 

https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/config_loader.rb#L96

But in case we pass directly config file with `-c` option all that we do with configs happening here: https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/config_store.rb#L22 so there we get missing warnings check; 

I fixed it. but specs needed, and I have no idea where to add it, any suggestions? Also should it be some refactoring here? Maybe there are other things missing? 

cc @koic @bbatsov @pirj 


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
