### PR TITLE
[Fix #595] Add ERB pre-processing for configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#7895](https://github.com/rubocop-hq/rubocop/pull/7895): Include `.simplecov` file by default. ([@robotdana][])
 * [#7916](https://github.com/rubocop-hq/rubocop/pull/7916): Support autocorrection for `Lint/AmbiguousRegexpLiteral`. ([@koic][])
 * [#7917](https://github.com/rubocop-hq/rubocop/pull/7917): Support autocorrection for `Lint/UselessAccessModifier`. ([@koic][])
+* [#595](https://github.com/rubocop-hq/rubocop/issues/595): Add ERB pre-processing for configuration files. ([@jonas054][])
 
 ### Bug fixes
 

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -237,6 +237,21 @@ Style/For:
 In this example the `Exclude` would only include `bar.rb`.
 
 
+## Pre-processing
+
+Configuration files are pre-processed using the ERB templating mechanism. This
+makes it possible to add dynamic content that will be evaluated when the
+configuation file is read. For example, you could let RuboCop ignore all files
+ignored by Git.
+
+```yaml
+AllCops:
+  Exclude:
+  <% `git status --ignored --porcelain`.lines.grep(/^!! /).each do |path| %>
+    - <%= path.sub(/^!! /, '') %>
+  <% end %>
+```
+
 ## Defaults
 
 The file [config/default.yml][1] under the RuboCop home directory contains the


### PR DESCRIPTION
A typical use case for this new feature would be excluding files that are ignored by Git.