### PR TITLE
[Fix #7390] Override disabled department for enabled cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 * [#7860](https://github.com/rubocop-hq/rubocop/issues/7860): Change `AllowInHeredoc` option of `Layout/TrailingWhitespace` to `true` by default. ([@koic][])
 * [#7094](https://github.com/rubocop-hq/rubocop/issues/7094): Clarify alignment in `Layout/MultilineOperationIndentation`. ([@jonas054][])
+* [#7390](https://github.com/rubocop-hq/rubocop/issues/7390): **(Breaking)** Enabling a cop overrides disabling its department. ([@jonas054][])
 
 ## 0.82.0 (2020-04-16)
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -261,9 +261,13 @@ module RuboCop
 
     def enable_cop?(qualified_cop_name, cop_options)
       department = department_of(qualified_cop_name)
+      cop_enabled = cop_options.fetch('Enabled') do
+        !for_all_cops['DisabledByDefault']
+      end
+      return true if cop_enabled == 'override_department'
       return false if department && department['Enabled'] == false
 
-      cop_options.fetch('Enabled') { !for_all_cops['DisabledByDefault'] }
+      cop_enabled
     end
 
     def department_of(qualified_cop_name)

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -36,7 +36,7 @@ module RuboCop
         FileFinder.root_level = nil
       end
 
-      def load_file(file)
+      def load_file(file) # rubocop:disable Metrics/AbcSize
         path = File.absolute_path(file.is_a?(RemoteConfig) ? file.file : file)
 
         hash = load_yaml_configuration(path)
@@ -46,6 +46,7 @@ module RuboCop
 
         add_missing_namespaces(path, hash)
 
+        resolver.override_department_setting_for_cops({}, hash)
         resolver.resolve_inheritance_from_gems(hash)
         resolver.resolve_inheritance(path, hash, file, debug?)
 

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -206,7 +206,8 @@ module RuboCop
                        SafeAutoCorrect
                        AutoCorrect].include?(key) && value.is_a?(String)
 
-        next if key == 'Enabled' && value == 'pending'
+        next if key == 'Enabled' &&
+                %w[pending override_department].include?(value)
 
         raise ValidationError, msg_not_boolean(parent, key, value)
       end

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -446,6 +446,23 @@ Style:
 All cops are then enabled by default. Only cops explicitly disabled
 using `Enabled: false` in user configuration files are disabled.
 
+If a department is disabled, cops in that department can still be individually
+enabled, and that setting overrides the setting for its department in the same
+configuration file and in any inherited file.
+
+```yaml
+inherit_from: config_that_disables_the_metrics_department.yml
+
+Metrics/MethodLength:
+  Enabled: true
+
+Style:
+  Enabled: false
+
+Style/Alias:
+  Enabled: true
+```
+
 ### Severity
 
 Each cop has a default severity level based on which department it belongs


### PR DESCRIPTION
Implement the more intuitive functionality, that if a cop sets `Enabled: true` in user configuration, it will be enabled even if its department is disabled in the same configuration file, or in any inherited file.