### PR TITLE
Support autocorrection for `Layout/ConditionPosition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#7937](https://github.com/rubocop-hq/rubocop/pull/7937): Support autocorrection for `Style/IfWithSemicolon`. ([@koic][])
 * [#3696](https://github.com/rubocop-hq/rubocop/issues/3696): Add `AllowComments` option to `Lint/EmptyWhen` cop. ([@koic][])
 * [#7910](https://github.com/rubocop-hq/rubocop/pull/7910): Support autocorrection for `Lint/ParenthesesAsGroupedExpression`. ([@koic][])
+* [#7925](https://github.com/rubocop-hq/rubocop/pull/7925): Support autocorrection for `Layout/ConditionPosition`. ([@koic][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -376,6 +376,7 @@ Layout/ConditionPosition:
   StyleGuide: '#same-line-condition'
   Enabled: true
   VersionAdded: '0.53'
+  VersionChanged: '0.83'
 
 Layout/DefEndAlignment:
   Description: 'Align ends corresponding to defs correctly.'

--- a/lib/rubocop/cop/layout/condition_position.rb
+++ b/lib/rubocop/cop/layout/condition_position.rb
@@ -23,6 +23,8 @@ module RuboCop
       #     do_something
       #   end
       class ConditionPosition < Cop
+        include RangeHelp
+
         MSG = 'Place the condition on the same line as `%<keyword>s`.'
 
         def on_if(node)
@@ -34,9 +36,17 @@ module RuboCop
         def on_while(node)
           check(node)
         end
+        alias on_until on_while
 
-        def on_until(node)
-          check(node)
+        def autocorrect(node)
+          lambda do |corrector|
+            range = range_by_whole_lines(
+              node.source_range, include_final_newline: true
+            )
+
+            corrector.insert_after(node.parent.loc.keyword, " #{node.source}")
+            corrector.remove(range)
+          end
         end
 
         private

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -713,7 +713,7 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.53 | -
+Enabled | Yes | Yes  | 0.53 | 0.83
 
 This cop checks for conditions that are not on the same line as
 if/while/until.

--- a/spec/rubocop/cop/layout/condition_position_spec.rb
+++ b/spec/rubocop/cop/layout/condition_position_spec.rb
@@ -4,11 +4,16 @@ RSpec.describe RuboCop::Cop::Layout::ConditionPosition do
   subject(:cop) { described_class.new }
 
   %w[if unless while until].each do |keyword|
-    it 'registers an offense for condition on the next line' do
+    it 'registers an offense and corrects for condition on the next line' do
       expect_offense(<<~RUBY)
         #{keyword}
         x == 10
         ^^^^^^^ Place the condition on the same line as `#{keyword}`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        #{keyword} x == 10
         end
       RUBY
     end
@@ -29,13 +34,21 @@ RSpec.describe RuboCop::Cop::Layout::ConditionPosition do
     end
   end
 
-  it 'registers an offense for elsif condition on the next line' do
+  it 'registers an offense and corrects for elsif condition on the next line' do
     expect_offense(<<~RUBY)
       if something
         test
       elsif
         something
         ^^^^^^^^^ Place the condition on the same line as `elsif`.
+        test
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if something
+        test
+      elsif something
         test
       end
     RUBY


### PR DESCRIPTION
This PR supports autocorrection for `Layout/ConditionPosition`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
