### PR TITLE
[Fix #4245] Arbitrary files on command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 * [#7860](https://github.com/rubocop-hq/rubocop/issues/7860): Change `AllowInHeredoc` option of `Layout/TrailingWhitespace` to `true` by default. ([@koic][])
 * [#7094](https://github.com/rubocop-hq/rubocop/issues/7094): Clarify alignment in `Layout/MultilineOperationIndentation`. ([@jonas054][])
+* [#4245](https://github.com/rubocop-hq/rubocop/issues/4245): **(Breaking)** Inspect all files given on command line unless `--only-recognized-file-types` is given. ([@jonas054][])
 * [#7390](https://github.com/rubocop-hq/rubocop/issues/7390): **(Breaking)** Enabling a cop overrides disabling its department. ([@jonas054][])
 
 ## 0.82.0 (2020-04-16)

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -103,6 +103,7 @@ module RuboCop
     def add_configuration_options(opts)
       option(opts, '-c', '--config FILE')
       option(opts, '--force-exclusion')
+      option(opts, '--only-recognized-file-types')
       option(opts, '--ignore-parent-exclusion')
       option(opts, '--force-default-config')
       add_auto_gen_options(opts)
@@ -415,6 +416,9 @@ module RuboCop
       force_exclusion:                  ['Force excluding files specified in the',
                                          'configuration `Exclude` even if they are',
                                          'explicitly passed as arguments.'],
+      only_recognized_file_types:       ['Inspect files given on the command line only if',
+                                         'they are listed in AllCops/Include parameters',
+                                         'of user configuration or default configuration.'],
       ignore_disable_comments:          ['Run cops even when they are disabled locally',
                                          'with a comment.'],
       ignore_parent_exclusion:          ['Prevent from inheriting AllCops/Exclude from',

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -61,7 +61,12 @@ module RuboCop
 
     def find_target_files(paths)
       target_finder = TargetFinder.new(@config_store, @options)
-      target_files = target_finder.find(paths, :only_recognized_file_types)
+      mode = if @options[:only_recognized_file_types]
+               :only_recognized_file_types
+             else
+               :all_file_types
+             end
+      target_files = target_finder.find(paths, mode)
       target_files.each(&:freeze).freeze
     end
 

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -61,7 +61,7 @@ module RuboCop
 
     def find_target_files(paths)
       target_finder = TargetFinder.new(@config_store, @options)
-      target_files = target_finder.find(paths)
+      target_files = target_finder.find(paths, :only_recognized_file_types)
       target_files.each(&:freeze).freeze
     end
 

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -27,7 +27,7 @@ module RuboCop
     # (if any). If args is empty, recursively find all Ruby source
     # files under the current directory
     # @return [Array] array of file paths
-    def find(args)
+    def find(args, mode)
       return target_files_in_dir if args.empty?
 
       files = []
@@ -36,7 +36,7 @@ module RuboCop
         files += if File.directory?(arg)
                    target_files_in_dir(arg.chomp(File::SEPARATOR))
                  else
-                   process_explicit_path(arg)
+                   process_explicit_path(arg, mode)
                  end
       end
 
@@ -169,10 +169,12 @@ module RuboCop
       ruby_file?(file) || configured_include?(file)
     end
 
-    def process_explicit_path(path)
+    def process_explicit_path(path, mode)
       files = path.include?('*') ? Dir[path] : [path]
 
-      files.select! { |file| included_file?(file) }
+      if mode == :only_recognized_file_types || force_exclusion?
+        files.select! { |file| included_file?(file) }
+      end
 
       return files unless force_exclusion?
 

--- a/manual/basic_usage.md
+++ b/manual/basic_usage.md
@@ -128,6 +128,7 @@ Command flag                    | Description
 `-F/--fail-fast`                | Inspect files in order of modification time and stops after first file with offenses.
 `   --fail-level`               | Minimum [severity](configuration.md#severity) for exit with error code. Full severity name or upper case initial can be given. Normally, auto-corrected offenses are ignored. Use `A` or `autocorrect` if you'd like them to trigger failure.
 `   --force-exclusion`          | Force excluding files specified in the configuration `Exclude` even if they are explicitly passed as arguments.
+`   --only-recognized-file-types` | Inspect files given on the command line only if they are listed in `AllCops`/`Include` parameters of user configuration or default configuration.
 `-h/--help`                     | Print usage information.
 `   --ignore-parent-exclusion`  | Ignores all Exclude: settings from all .rubocop.yml files present in parent folders. This is useful when you are importing submodules when you want to test them without being affected by the parent module's rubocop settings.
 `   --init`                     | Generate a .rubocop.yml file in the current directory.

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -1542,6 +1542,41 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     end
   end
 
+  describe '--only-recognized-file-types' do
+    let(:target_file) { 'example.something' }
+    let(:exit_code) { cli.run(['--only-recognized-file-types', target_file]) }
+
+    before do
+      create_file(target_file, '#' * 90)
+    end
+
+    context 'when explicitly included' do
+      before do
+        create_file('.rubocop.yml', <<~YAML)
+          AllCops:
+            Include:
+              - #{target_file}
+        YAML
+      end
+
+      it 'includes the file given on the command line' do
+        expect(exit_code).to eq(1)
+      end
+    end
+
+    context 'when not explicitly included' do
+      it 'does not include the file given on the command line' do
+        expect(exit_code).to eq(0)
+      end
+
+      context 'but option is not given' do
+        it 'includes the file given on the command line' do
+          expect(cli.run([target_file])).to eq(1)
+        end
+      end
+    end
+  end
+
   describe '--stdin' do
     it 'causes source code to be read from stdin' do
       begin

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -43,6 +43,9 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                   --force-exclusion            Force excluding files specified in the
                                                configuration `Exclude` even if they are
                                                explicitly passed as arguments.
+                  --only-recognized-file-types Inspect files given on the command line only if
+                                               they are listed in AllCops/Include parameters
+                                               of user configuration or default configuration.
                   --ignore-parent-exclusion    Prevent from inheriting AllCops/Exclude from
                                                parent folders.
                   --force-default-config       Use default configuration even if configuration

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -79,8 +79,8 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
     create_empty_file('.hidden/ruby4.rb')
   end
 
-  describe '#find' do
-    let(:found_files) { target_finder.find(args) }
+  describe '#find(..., :only_recognized_file_types)' do
+    let(:found_files) { target_finder.find(args, :only_recognized_file_types) }
     let(:found_basenames) { found_files.map { |f| File.basename(f) } }
     let(:args) { [] }
 
@@ -296,6 +296,243 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       it 'includes them' do
         expect(found_basenames)
           .to contain_exactly('executable', 'file', 'ruby1.rb', 'ruby2.rb')
+      end
+    end
+
+    context 'when input is passed on stdin' do
+      let(:options) do
+        {
+          force_exclusion: force_exclusion,
+          debug: debug,
+          stdin: 'def example; end'
+        }
+      end
+      let(:args) { ['Untitled'] }
+
+      it 'includes the file' do
+        expect(found_basenames).to eq(['Untitled'])
+      end
+    end
+  end
+
+  describe '#find(..., :all_file_types)' do
+    let(:found_files) { target_finder.find(args, :all_file_types) }
+    let(:found_basenames) { found_files.map { |f| File.basename(f) } }
+    let(:args) { [] }
+
+    it 'returns absolute paths' do
+      expect(found_files.empty?).to be(false)
+      found_files.each do |file|
+        expect(file.sub(/^[A-Z]:/, '')).to start_with('/')
+      end
+    end
+
+    it 'does not find hidden files' do
+      expect(found_files).not_to include('.hidden/ruby4.rb')
+    end
+
+    context 'when no argument is passed' do
+      let(:args) { [] }
+
+      it 'finds files under the current directory' do
+        RuboCop::PathUtil.chdir('dir1') do
+          expect(found_files.empty?).to be(false)
+          found_files.each do |file|
+            expect(file).to include('/dir1/')
+            expect(file).not_to include('/dir2/')
+          end
+        end
+      end
+    end
+
+    context 'when a directory path is passed' do
+      let(:args) { ['../dir2'] }
+
+      it 'finds files under the specified directory' do
+        RuboCop::PathUtil.chdir('dir1') do
+          expect(found_files.empty?).to be(false)
+          found_files.each do |file|
+            expect(file).to include('/dir2/')
+            expect(file).not_to include('/dir1/')
+          end
+        end
+      end
+    end
+
+    context 'when a hidden directory path is passed' do
+      let(:args) { ['.hidden'] }
+
+      it 'finds files under the specified directory' do
+        expect(found_files.size).to be(1)
+        expect(found_files.first).to include('.hidden/ruby4.rb')
+      end
+    end
+
+    context 'when a non-ruby file is passed' do
+      let(:args) { ['dir2/file'] }
+
+      it "doesn't pick the file" do
+        expect(found_basenames).to contain_exactly('file')
+      end
+    end
+
+    context 'when files with a ruby extension are passed' do
+      let(:args) { RUBY_EXTENSIONS.map { |ext| "dir2/file#{ext}" } }
+
+      it 'picks all the ruby files' do
+        expect(found_basenames)
+          .to eq(RUBY_EXTENSIONS.map { |ext| "file#{ext}" })
+      end
+
+      context 'when local AllCops/Include lists two patterns' do
+        before do
+          create_file('.rubocop.yml', <<-YAML)
+            AllCops:
+              Include:
+                - '**/*.rb'
+                - '**/*.arb'
+          YAML
+        end
+
+        it 'picks all the ruby files' do
+          expect(found_basenames)
+            .to eq(RUBY_EXTENSIONS.map { |ext| "file#{ext}" })
+        end
+
+        context 'when a subdirectory AllCops/Include only lists one pattern' do
+          before do
+            create_file('dir2/.rubocop.yml', <<-YAML)
+              AllCops:
+                Include:
+                  - '**/*.ruby'
+            YAML
+          end
+
+          it 'picks all the ruby files' do
+            expect(found_basenames)
+              .to eq(RUBY_EXTENSIONS.map { |ext| "file#{ext}" })
+          end
+        end
+      end
+    end
+
+    context 'when a file with a ruby filename is passed' do
+      let(:args) { RUBY_FILENAMES.map { |name| "dir2/#{name}" } }
+
+      it 'picks all the ruby files' do
+        expect(found_basenames).to eq(RUBY_FILENAMES)
+      end
+    end
+
+    context 'when files with ruby interpreters are passed' do
+      let(:args) { RUBY_INTERPRETERS.map { |name| "dir2/#{name}" } }
+
+      before do
+        RUBY_INTERPRETERS.each do |interpreter|
+          create_file("dir2/#{interpreter}", "#!/usr/bin/#{interpreter}")
+        end
+      end
+
+      it 'picks all the ruby files' do
+        expect(found_basenames).to eq(RUBY_INTERPRETERS)
+      end
+    end
+
+    context 'when a pattern is passed' do
+      let(:args) { ['dir1/*2.rb'] }
+
+      it 'finds files which match the pattern' do
+        expect(found_basenames).to eq(['ruby2.rb'])
+      end
+    end
+
+    context 'when same paths are passed' do
+      let(:args) { %w[dir1 dir1] }
+
+      it 'does not return duplicated file paths' do
+        count = found_basenames.count { |f| f == 'ruby1.rb' }
+        expect(count).to eq(1)
+      end
+    end
+
+    context 'when some paths are specified in the configuration Exclude ' \
+            'and they are explicitly passed as arguments' do
+      before do
+        create_file('.rubocop.yml', <<~YAML)
+          AllCops:
+            Exclude:
+              - dir1/ruby1.rb
+              - 'dir2/*'
+        YAML
+
+        create_file('dir1/.rubocop.yml', <<~YAML)
+          AllCops:
+            Exclude:
+              - executable
+        YAML
+      end
+
+      let(:args) do
+        ['dir1/ruby1.rb', 'dir1/ruby2.rb', 'dir1/exe*', 'dir2/ruby3.rb']
+      end
+
+      context 'normally' do
+        it 'does not exclude them' do
+          expect(found_basenames)
+            .to eq(['ruby1.rb', 'ruby2.rb', 'executable', 'ruby3.rb'])
+        end
+      end
+
+      context "when it's forced to adhere file exclusion configuration" do
+        let(:force_exclusion) { true }
+
+        it 'excludes them' do
+          expect(found_basenames).to eq(['ruby2.rb'])
+        end
+      end
+    end
+
+    context 'when some non-known Ruby files are specified in the ' \
+            'configuration Include and they are explicitly passed ' \
+            'as arguments' do
+      before do
+        create_file('.rubocop.yml', <<~YAML)
+          AllCops:
+            Include:
+              - dir1/file
+        YAML
+      end
+
+      let(:args) do
+        ['dir1/file']
+      end
+
+      it 'includes them' do
+        expect(found_basenames)
+          .to contain_exactly('file')
+      end
+    end
+
+    context 'when some non-known Ruby files are specified in the ' \
+            'configuration Include and they are not explicitly passed ' \
+            'as arguments' do
+      before do
+        create_file('.rubocop.yml', <<~YAML)
+          AllCops:
+            Include:
+              - '**/*.rb'
+              - dir1/file
+        YAML
+      end
+
+      let(:args) do
+        ['dir1/**/*']
+      end
+
+      it 'includes them' do
+        expect(found_basenames).to contain_exactly('executable', 'file',
+                                                   'file.txt', 'ruby1.rb',
+                                                   'ruby2.rb')
       end
     end
 


### PR DESCRIPTION
The default for file names on the command line that are not recognized as a Ruby file now becomes to inspect the files. With the `--only-recognized-file-types` option, the old behavior of skipping the file is kept.