### PR TITLE
[Fix #7928] Fix a false message for `Style/GuardClause`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [#7885](https://github.com/rubocop-hq/rubocop/issues/7885): Fix `Style/IfUnlessModifier` logic when tabs are used for indentation. ([@jonas054][])
 * [#7909](https://github.com/rubocop-hq/rubocop/pull/7909): Fix a false positive for `Lint/ParenthesesAsGroupedExpression` when using an intended grouped parentheses. ([@koic][])
 * [#7913](https://github.com/rubocop-hq/rubocop/pull/7913): Fix a false positive for `Lint/LiteralAsCondition` when using `true` literal in `while` and similar cases. ([@koic][])
+* [#7928](https://github.com/rubocop-hq/rubocop/issues/7928): Fix a false message for `Style/GuardClause` when using `and` or `or` operators for guard clause in `then` or `else` branches. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/guard_clause.rb
+++ b/lib/rubocop/cop/style/guard_clause.rb
@@ -35,6 +35,17 @@ module RuboCop
       #   # good
       #   raise 'exception' if something
       #   ok
+      #
+      #   # bad
+      #   if something
+      #     foo || raise('exception')
+      #   else
+      #     ok
+      #   end
+      #
+      #   # good
+      #   foo || raise('exception') if something
+      #   ok
       class GuardClause < Cop
         include MinBodyLength
         include StatementModifier
@@ -69,7 +80,8 @@ module RuboCop
                else
                  opposite_keyword(node)
                end
-          register_offense(node, guard_clause.source, kw)
+
+          register_offense(node, guard_clause_source(guard_clause), kw)
         end
 
         private
@@ -96,6 +108,16 @@ module RuboCop
           add_offense(node,
                       location: :keyword,
                       message: format(MSG, example: example))
+        end
+
+        def guard_clause_source(guard_clause)
+          parent = guard_clause.parent
+
+          if parent.and_type? || parent.or_type?
+            guard_clause.parent.source
+          else
+            guard_clause.source
+          end
         end
 
         def too_long_for_single_line?(node, example)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2589,6 +2589,17 @@ end
 # good
 raise 'exception' if something
 ok
+
+# bad
+if something
+  foo || raise('exception')
+else
+  ok
+end
+
+# good
+foo || raise('exception') if something
+ok
 ```
 
 ### Configurable attributes

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -107,6 +107,58 @@ RSpec.describe RuboCop::Cop::Style::GuardClause do
     RUBY
   end
 
+  it 'registers an offense when using `|| raise` in `then` branch' do
+    expect_offense(<<~RUBY)
+      def func
+        if something
+        ^^ Use a guard clause (`work || raise('message') if something`) instead of wrapping the code inside a conditional expression.
+          work || raise('message')
+        else
+          test
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using `|| raise` in `else` branch' do
+    expect_offense(<<~RUBY)
+      def func
+        if something
+        ^^ Use a guard clause (`test || raise('message') unless something`) instead of wrapping the code inside a conditional expression.
+          work
+        else
+          test || raise('message')
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using `and return` in `then` branch' do
+    expect_offense(<<~RUBY)
+      def func
+        if something
+        ^^ Use a guard clause (`work and return if something`) instead of wrapping the code inside a conditional expression.
+          work and return
+        else
+          test
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using `and return` in `else` branch' do
+    expect_offense(<<~RUBY)
+      def func
+        if something
+        ^^ Use a guard clause (`test and return unless something`) instead of wrapping the code inside a conditional expression.
+          work
+        else
+          test and return
+        end
+      end
+    RUBY
+  end
+
   it 'accepts a method which body does not end with if / unless' do
     expect_no_offenses(<<~RUBY)
       def func


### PR DESCRIPTION
Fixes #7928.

This PR fixes a false message for `Style/GuardClause` when using `and` or `or` operators for guard clause in `then` or `else` branches.


The following is an example:

```console
% cat example.rb
if cond
  foo || raise('hi')
else
  bar
end
```

## Before

```console
% bundle exec rubocop --only Style/GuardClause
(snip)
Offenses:

example.rb:1:1: C: Style/GuardClause: Use a guard clause (raise('hi') if cond) instead of wrapping the code inside a conditional expression.
if cond
^^

1 file inspected, 1 offense detected
```

## After

```console
% bundle exec rubocop --only Style/GuardClause
(snip)

Offenses:

example.rb:1:1: C: Style/GuardClause: Use a guard clause (foo || raise('hi') if cond) instead of wrapping the code inside a conditional
expression.
if cond
^^

1 file inspected, 1 offense detected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
