### PR TITLE
Support autocorrection for `Lint/EnsureReturn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#3696](https://github.com/rubocop-hq/rubocop/issues/3696): Add `AllowComments` option to `Lint/EmptyWhen` cop. ([@koic][])
 * [#7910](https://github.com/rubocop-hq/rubocop/pull/7910): Support autocorrection for `Lint/ParenthesesAsGroupedExpression`. ([@koic][])
 * [#7925](https://github.com/rubocop-hq/rubocop/pull/7925): Support autocorrection for `Layout/ConditionPosition`. ([@koic][])
+* [#7934](https://github.com/rubocop-hq/rubocop/pull/7934): Support autocorrection for `Lint/EnsureReturn`. ([@koic][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1425,6 +1425,7 @@ Lint/EnsureReturn:
   StyleGuide: '#no-return-ensure'
   Enabled: true
   VersionAdded: '0.9'
+  VersionChanged: '0.83'
 
 Lint/ErbNewArguments:
   Description: 'Use `:trim_mode` and `:eoutvar` keyword arguments to `ERB.new`.'

--- a/lib/rubocop/cop/lint/ensure_return.rb
+++ b/lib/rubocop/cop/lint/ensure_return.rb
@@ -29,6 +29,8 @@ module RuboCop
       #     do_something_else
       #   end
       class EnsureReturn < Cop
+        include RangeHelp
+
         MSG = 'Do not return from an `ensure` block.'
 
         def on_ensure(node)
@@ -37,7 +39,22 @@ module RuboCop
           return unless ensure_body
 
           ensure_body.each_node(:return) do |return_node|
-            add_offense(return_node)
+            next if return_node.arguments.size >= 2
+
+            add_offense(return_node, location: :keyword)
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            if node.arguments?
+              corrector.replace(node, node.source.gsub(/return\s*/, ''))
+            else
+              range = range_by_whole_lines(
+                node.loc.expression, include_final_newline: true
+              )
+              corrector.remove(range)
+            end
           end
         end
       end

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -651,7 +651,7 @@ AllowComments | `true` | Boolean
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.9 | -
+Enabled | Yes | Yes  | 0.9 | 0.83
 
 This cop checks for *return* from an *ensure* block.
 Explicit return from an ensure block alters the control flow

--- a/spec/rubocop/cop/lint/ensure_return_spec.rb
+++ b/spec/rubocop/cop/lint/ensure_return_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::Lint::EnsureReturn do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for return in ensure' do
+  it 'registers an offense and corrects for return in ensure' do
     expect_offense(<<~RUBY)
       begin
         something
@@ -11,6 +11,35 @@ RSpec.describe RuboCop::Cop::Lint::EnsureReturn do
         file.close
         return
         ^^^^^^ Do not return from an `ensure` block.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      begin
+        something
+      ensure
+        file.close
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects for return with argument in ensure' do
+    expect_offense(<<~RUBY)
+      begin
+        foo
+      ensure
+        bar
+        return baz
+        ^^^^^^ Do not return from an `ensure` block.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      begin
+        foo
+      ensure
+        bar
+        baz
       end
     RUBY
   end
@@ -22,6 +51,16 @@ RSpec.describe RuboCop::Cop::Lint::EnsureReturn do
         return
       ensure
         file.close
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when returning multiple values in `ensure`" do
+    expect_no_offenses(<<~RUBY)
+      begin
+        something
+      ensure
+        return foo, bar
       end
     RUBY
   end


### PR DESCRIPTION
This PR supports autocorrection for `Lint/EnsureReturn`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
