### PR TITLE
Support autocorrection for `Style/IfWithSemicolon`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#7917](https://github.com/rubocop-hq/rubocop/pull/7917): Support autocorrection for `Lint/UselessAccessModifier`. ([@koic][])
 * [#595](https://github.com/rubocop-hq/rubocop/issues/595): Add ERB pre-processing for configuration files. ([@jonas054][])
 * [#7918](https://github.com/rubocop-hq/rubocop/pull/7918): Support autocorrection for `Lint/AmbiguousOperator`. ([@koic][])
+* [#7937](https://github.com/rubocop-hq/rubocop/pull/7937): Support autocorrection for `Style/IfWithSemicolon`. ([@koic][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -2951,6 +2951,7 @@ Style/IfWithSemicolon:
   StyleGuide: '#no-semicolon-ifs'
   Enabled: true
   VersionAdded: '0.9'
+  VersionChanged: '0.83'
 
 Style/ImplicitRuntimeError:
   Description: >-

--- a/lib/rubocop/cop/style/if_with_semicolon.rb
+++ b/lib/rubocop/cop/style/if_with_semicolon.rb
@@ -19,10 +19,26 @@ module RuboCop
         MSG = 'Do not use if x; Use the ternary operator instead.'
 
         def on_normal_if_unless(node)
+          return unless node.else_branch
+
           beginning = node.loc.begin
           return unless beginning&.is?(';')
 
           add_offense(node)
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(node, correct_to_ternary(node))
+          end
+        end
+
+        private
+
+        def correct_to_ternary(node)
+          else_code = node.else_branch ? node.else_branch.source : 'nil'
+
+          "#{node.condition.source} ? #{node.if_branch.source} : #{else_code}"
         end
       end
     end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2986,7 +2986,7 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.9 | -
+Enabled | Yes | Yes  | 0.9 | 0.83
 
 Checks for uses of semicolon in if statements.
 

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -3,15 +3,23 @@
 RSpec.describe RuboCop::Cop::Style::IfWithSemicolon do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for one line if/;/end' do
+  it 'registers an offense and corrects for one line if/;/end' do
     expect_offense(<<~RUBY)
       if cond; run else dont end
       ^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use if x; Use the ternary operator instead.
     RUBY
+
+    expect_correction(<<~RUBY)
+      cond ? run : dont
+    RUBY
   end
 
-  it 'accepts one line if/then/end' do
-    expect_no_offenses('if cond then run else dont end')
+  it 'accepts without `else` branch' do
+    # This case is corrected to a modifier form by `Style/IfUnlessModifier` cop.
+    # Therefore, this cop does not handle it.
+    expect_no_offenses(<<~RUBY)
+      if cond; run end
+    RUBY
   end
 
   it 'can handle modifier conditionals' do


### PR DESCRIPTION
This PR supports autocorrection for `Style/IfWithSemicolon` cop.
And it change to accept the following case that without `else` branch.

```ruby
if cond; run end
```

That case is corrected to a modifier form by `Style/IfUnlessModifier` cop.

```ruby
run if cond
```

Therefore, this cop does not handle it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
