### PR TITLE
[Fix #7936] Mark as Lint/BooleanSymbol unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [#7860](https://github.com/rubocop-hq/rubocop/issues/7860): Change `AllowInHeredoc` option of `Layout/TrailingWhitespace` to `true` by default. ([@koic][])
 * [#7094](https://github.com/rubocop-hq/rubocop/issues/7094): Clarify alignment in `Layout/MultilineOperationIndentation`. ([@jonas054][])
 * [#7390](https://github.com/rubocop-hq/rubocop/issues/7390): **(Breaking)** Enabling a cop overrides disabling its department. ([@jonas054][])
+* [#7936](https://github.com/rubocop-hq/rubocop/issues/7936): Mark `Lint/BooleanSymbol` as unsafe. ([@laurmurclar][])
 
 ## 0.82.0 (2020-04-16)
 
@@ -4487,3 +4488,4 @@
 [@DracoAter]: https://github.com/DracoAter
 [@diogoosorio]: https://github.com/diogoosorio
 [@jeffcarbs]: https://github.com/jeffcarbs
+[@laurmurclar]: https://github.com/laurmurclar

--- a/config/default.yml
+++ b/config/default.yml
@@ -1342,8 +1342,9 @@ Lint/BigDecimalNew:
 Lint/BooleanSymbol:
   Description: 'Check for `:true` and `:false` symbols.'
   Enabled: true
+  Safe: false
   VersionAdded: '0.50'
-  VersionChanged: '0.81'
+  VersionChanged: '0.83'
 
 Lint/CircularArgumentReference:
   Description: "Default values in optional keyword arguments and optional ordinal arguments should not refer back to the name of the argument."

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -166,7 +166,7 @@ BigDecimal(123.456, 3)
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.50 | 0.81
+Enabled | No | Yes (Unsafe) | 0.50 | 0.83
 
 This cop checks for `:true` and `:false` symbols.
 In most cases it would be a typo.


### PR DESCRIPTION
Fixes https://github.com/rubocop-hq/rubocop/issues/7936

This PR marks [Lint/BooleanSymbol](https://docs.rubocop.org/en/stable/cops_lint/#lintbooleansymbol) as unsafe. 

As mentioned in the issue, the auto-corrected code is not equivalent to the problem code and therefore can't be run safely without changing the meaning of the code. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
