### PR TITLE
Update target_ruby.rb

### DIFF
--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -7,7 +7,7 @@ module RuboCop
     DEFAULT_VERSION = KNOWN_RUBIES.first
 
     OBSOLETE_RUBIES = {
-      1.9 => '0.50', 2.0 => '0.50', 2.1 => '0.58', 2.2 => '0.69', 2.3 => '0.82'
+      1.9 => '0.50', 2.0 => '0.50', 2.1 => '0.58', 2.2 => '0.69', 2.3 => '0.81'
     }.freeze
     private_constant :KNOWN_RUBIES, :OBSOLETE_RUBIES
 


### PR DESCRIPTION
rubocop 0.81 is the last version to support 2.3 mode, not 0.82.

This is a partical revert of 44a5bee006bb075
