### PR TITLE
Add required Ruby version to generated cops manual

### DIFF
--- a/lib/rubocop/cop/mixin/target_ruby_version.rb
+++ b/lib/rubocop/cop/mixin/target_ruby_version.rb
@@ -4,12 +4,16 @@ module RuboCop
   module Cop
     # Common functionality for checking target ruby version.
     module TargetRubyVersion
+      def required_minimum_ruby_version
+        @minimum_target_ruby_version
+      end
+
       def minimum_target_ruby_version(version)
         @minimum_target_ruby_version = version
       end
 
       def support_target_ruby_version?(version)
-        @minimum_target_ruby_version <= version
+        required_minimum_ruby_version <= version
       end
     end
   end

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -657,6 +657,10 @@ end
 
 ## Lint/ErbNewArguments
 
+!!! Note
+
+    Required Ruby version: 2.6
+
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
 Enabled | Yes | Yes  | 0.56 | -

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2712,6 +2712,10 @@ PreferHashRocketsForNonAlnumEndingSymbols | `false` | Boolean
 
 ## Style/HashTransformKeys
 
+!!! Note
+
+    Required Ruby version: 2.5
+
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
 Pending | No | Yes (Unsafe) | 0.80 | -

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -14,8 +14,10 @@ task generate_cops_documentation: :yard_for_generate_documentation do
     cops.with_department(department).sort!
   end
 
+  # rubocop:disable Metrics/AbcSize
   def cops_body(config, cop, description, examples_objects, pars)
     content = h2(cop.cop_name)
+    content << required_ruby_version(cop)
     content << properties(cop.new(config))
     content << "#{description}\n"
     content << examples(examples_objects) if examples_objects.count.positive?
@@ -23,12 +25,24 @@ task generate_cops_documentation: :yard_for_generate_documentation do
     content << references(config, cop)
     content
   end
+  # rubocop:enable Metrics/AbcSize
 
   def examples(examples_object)
     examples_object.each_with_object(h3('Examples').dup) do |example, content|
       content << h4(example.name) unless example.name == ''
       content << code_example(example)
     end
+  end
+
+  def required_ruby_version(cop)
+    return '' unless cop.respond_to?(:required_minimum_ruby_version)
+
+    <<~NOTE
+      !!! Note
+
+          Required Ruby version: #{cop.required_minimum_ruby_version}
+
+    NOTE
   end
 
   # rubocop:disable Metrics/MethodLength


### PR DESCRIPTION
Follow up to https://github.com/rubocop-hq/rubocop/pull/7921#discussion_r422328979.

This PR adds required Ruby version to cops manual generated by `rake generate_cops_documentation`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
