### PR TITLE
Mark unsafe for `Style/OptionalArguments` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * [#4245](https://github.com/rubocop-hq/rubocop/issues/4245): **(Breaking)** Inspect all files given on command line unless `--only-recognized-file-types` is given. ([@jonas054][])
 * [#7390](https://github.com/rubocop-hq/rubocop/issues/7390): **(Breaking)** Enabling a cop overrides disabling its department. ([@jonas054][])
 * [#7936](https://github.com/rubocop-hq/rubocop/issues/7936): Mark `Lint/BooleanSymbol` as unsafe. ([@laurmurclar][])
+* [#7948](https://github.com/rubocop-hq/rubocop/pull/7948): Mark unsafe for `Style/OptionalArguments`. ([@koic][])
 
 ## 0.82.0 (2020-04-16)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -3435,7 +3435,9 @@ Style/OptionalArguments:
                  of the argument list.
   StyleGuide: '#optional-arguments'
   Enabled: true
+  Safe: false
   VersionAdded: '0.33'
+  VersionChanged: '0.83'
 
 Style/OrAssignment:
   Description: 'Recommend usage of double pipe equals (||=) where applicable.'

--- a/lib/rubocop/cop/style/optional_arguments.rb
+++ b/lib/rubocop/cop/style/optional_arguments.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Style
       # This cop checks for optional arguments to methods
-      # that do not come at the end of the argument list
+      # that do not come at the end of the argument list.
       #
       # @example
       #   # bad

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -5024,10 +5024,10 @@ SuspiciousParamNames | `options`, `opts`, `args`, `params`, `parameters` | Array
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.33 | -
+Enabled | No | No | 0.33 | 0.83
 
 This cop checks for optional arguments to methods
-that do not come at the end of the argument list
+that do not come at the end of the argument list.
 
 ### Examples
 


### PR DESCRIPTION
This PR marks unsafe for `Style/OptionalArguments` cop because changing method signature makes interface incompatible.
The incompatibility between good example and bad example shows that.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
