### PR TITLE
[Fix #7953] Fix an error for `Lint/AmbiguousOperator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#7953](https://github.com/rubocop-hq/rubocop/issues/7953): Fix an error for `Lint/AmbiguousOperator` when a method with no arguments is used in advance. ([@koic][])
+
 ### Changes
 
 * [#7952](https://github.com/rubocop-hq/rubocop/pull/7952): **(Breaking)** Change the max line length of `Layout/LineLength` to 120 by default. ([@koic][])

--- a/lib/rubocop/cop/lint/ambiguous_operator.rb
+++ b/lib/rubocop/cop/lint/ambiguous_operator.rb
@@ -60,8 +60,10 @@ module RuboCop
           end
 
           ast.each_node(:send).find do |send_node|
-            offense_position?(send_node.first_argument, diagnostic) &&
-              unary_operator?(send_node.first_argument, diagnostic)
+            first_argument = send_node.first_argument
+
+            first_argument &&
+              offense_position?(first_argument, diagnostic) && unary_operator?(first_argument, diagnostic)
           end
         end
 

--- a/spec/rubocop/cop/lint/ambiguous_operator_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_operator_spec.rb
@@ -20,6 +20,21 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousOperator do
         end
       end
 
+      context 'without whitespaces on the right of the operator when a method with no arguments is used in advance' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            do_something
+            do_something +42
+                         ^ Ambiguous positive number operator. Parenthesize the method arguments if it's surely a positive number operator, or add a whitespace to the right of the `+` if it should be a addition.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            do_something
+            do_something(+42)
+          RUBY
+        end
+      end
+
       context 'with a whitespace on the right of the operator' do
         it 'does not register an offense' do
           expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #7953.

This PR fixes the following error for `Lint/AmbiguousOperator` when a method with no arguments is used in advance.

```console
% cat example.rb
foo
bar +1

% bundle exec rubocop --only Lint/AmbiguousOperator -d
(snip)

An error occurred while Lint/AmbiguousOperator cop was inspecting
/Users/koic/src/github.com/koic/rubocop-issues/7953/example.rb.
undefined method `source_range' for nil:NilClass
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/lint/ambiguous_operator.rb:75:in
`offense_position?'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/lint/ambiguous_operator.rb:63:in
`block in find_offense_node_by'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
