### PR TITLE
Change enforced style to `conditionals` for `Style/AndOr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 * [#7952](https://github.com/rubocop-hq/rubocop/pull/7952): **(Breaking)** Change the max line length of `Layout/LineLength` to 120 by default. ([@koic][])
+* [#7959](https://github.com/rubocop-hq/rubocop/pull/7959): Change enforced style to conditionals for `Style/AndOr`. ([@koic][])
 
 ## 0.83.0 (2020-05-11)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -2274,7 +2274,7 @@ Style/AndOr:
   VersionChanged: '0.25'
   # Whether `and` and `or` are banned only in conditionals (conditionals)
   # or completely (always).
-  EnforcedStyle: always
+  EnforcedStyle: conditionals
   SupportedStyles:
     - always
     - conditionals

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -7,7 +7,7 @@ module RuboCop
       # `||` instead. It can be configured to check only in conditions or in
       # all contexts.
       #
-      # @example EnforcedStyle: always (default)
+      # @example EnforcedStyle: always
       #   # bad
       #   foo.save and return
       #
@@ -22,7 +22,7 @@ module RuboCop
       #   if foo && bar
       #   end
       #
-      # @example EnforcedStyle: conditionals
+      # @example EnforcedStyle: conditionals (default)
       #   # bad
       #   if foo and bar
       #   end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -139,7 +139,7 @@ all contexts.
 
 ### Examples
 
-#### EnforcedStyle: always (default)
+#### EnforcedStyle: always
 
 ```ruby
 # bad
@@ -156,7 +156,7 @@ foo.save && return
 if foo && bar
 end
 ```
-#### EnforcedStyle: conditionals
+#### EnforcedStyle: conditionals (default)
 
 ```ruby
 # bad
@@ -178,7 +178,7 @@ end
 
 Name | Default value | Configurable values
 --- | --- | ---
-EnforcedStyle | `always` | `always`, `conditionals`
+EnforcedStyle | `conditionals` | `always`, `conditionals`
 
 ### References
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -507,7 +507,11 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
     context 'via the config' do
       before do
-        create_file('example.rb', 'do_something or raise')
+        create_file('example.rb', <<~RUBY)
+          if foo and bar
+            do_something
+          end
+        RUBY
         create_file('.rubocop.yml', <<~YAML)
           AllCops:
             StyleGuideCopsOnly: #{guide_cops_only}
@@ -548,10 +552,10 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
             expect($stdout.string).to eq(<<~RESULT)
 
-              1  Layout/LineLength
+              3  Layout/LineLength
               1  Style/AndOr
               --
-              2  Total
+              4  Total
 
             RESULT
           end
@@ -569,9 +573,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
             expect($stdout.string).to eq(<<~RESULT)
 
-              1  Layout/LineLength
+              3  Layout/LineLength
               --
-              1  Total
+              3  Total
 
             RESULT
           end
@@ -585,10 +589,10 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
             expect($stdout.string).to eq(<<~RESULT)
 
-              1  Layout/LineLength
+              3  Layout/LineLength
               1  Style/AndOr
               --
-              2  Total
+              4  Total
 
             RESULT
           end


### PR DESCRIPTION
This PR changes enforced style to `conditionals` for `Style/AndOr` cop.
It forward porting from https://github.com/rubocop-hq/rubocop-rails/pull/224.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
