### PR TITLE
[Fix #7962] Fix a false positive for `Lint/ParenthesesAsGroupedExpression`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#7953](https://github.com/rubocop-hq/rubocop/issues/7953): Fix an error for `Lint/AmbiguousOperator` when a method with no arguments is used in advance. ([@koic][])
+* [#7962](https://github.com/rubocop-hq/rubocop/issues/7962): Fix a false positive for `Lint/ParenthesesAsGroupedExpression` when heredoc has a space between the same string as the method name and `(`. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
+++ b/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
@@ -21,9 +21,7 @@ module RuboCop
         MSG = '`(...)` interpreted as grouped expression.'
 
         def on_send(node)
-          return unless node.arguments.one?
-          return if node.operator_method? || node.setter_method?
-          return if grouped_parentheses?(node)
+          return if valid_context?(node)
 
           space_length = spaces_before_left_parenthesis(node)
           return unless space_length.positive?
@@ -44,6 +42,16 @@ module RuboCop
         end
 
         private
+
+        def valid_context?(node)
+          return true unless node.arguments.one? && first_arugment_starts_with_left_parenthesis?(node)
+
+          node.operator_method? || node.setter_method? || grouped_parentheses?(node)
+        end
+
+        def first_arugment_starts_with_left_parenthesis?(node)
+          node.first_argument.source.start_with?('(')
+        end
 
         def grouped_parentheses?(node)
           first_argument = node.first_argument

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -74,6 +74,17 @@ RSpec.describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression do
     expect_no_offenses('assert_equal (0..1.9), acceleration.domain')
   end
 
+  it 'does not register an offesne when heredoc has a space between the same string as the method name and `(`' do
+    expect_no_offenses(<<~RUBY)
+      foo(
+        <<~EOS
+          foo (
+          )
+        EOS
+      )
+    RUBY
+  end
+
   context 'when using safe navigation operator' do
     it 'registers an offense and corrects for method call with space before ' \
        'the parenthesis' do


### PR DESCRIPTION
Fixes #7962.

This PR fixes the following false positive for `Lint/ParenthesesAsGroupedExpression` when heredoc has a space between the same string as the method name and `(`.

```ruby
foo(
  <<~EOS
    foo (
    )
  EOS
)
```

This PR adds a reproduction test and reverts a required logic removed by #7909.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
