### PR TITLE
More powerful SlicingWithRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#7953](https://github.com/rubocop-hq/rubocop/issues/7953): Fix an error for `Lint/AmbiguousOperator` when a method with no arguments is used in advance. ([@koic][])
 * [#7962](https://github.com/rubocop-hq/rubocop/issues/7962): Fix a false positive for `Lint/ParenthesesAsGroupedExpression` when heredoc has a space between the same string as the method name and `(`. ([@koic][])
+* [#7967](https://github.com/rubocop-hq/rubocop/pull/7967): `Style/SlicingWithRange` cop now supports any expression as its first index. ([@zverok][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/slicing_with_range.rb
+++ b/lib/rubocop/cop/style/slicing_with_range.rb
@@ -19,7 +19,7 @@ module RuboCop
 
         MSG = 'Prefer ary[n..] over ary[n..-1].'
 
-        def_node_matcher :range_till_minus_one?, '(irange (int _) (int -1))'
+        def_node_matcher :range_till_minus_one?, '(irange !nil? (int -1))'
 
         def on_send(node)
           return unless node.method?(:[]) && node.arguments.count == 1

--- a/spec/rubocop/cop/style/slicing_with_range_spec.rb
+++ b/spec/rubocop/cop/style/slicing_with_range_spec.rb
@@ -23,6 +23,17 @@ RSpec.describe RuboCop::Cop::Style::SlicingWithRange, :config do
       RUBY
     end
 
+    it 'reports an offense for slicing from expression to ..-1' do
+      expect_offense(<<~RUBY)
+        ary[fetch_start(true).first..-1]
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer ary[n..] over ary[n..-1].
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ary[fetch_start(true).first..]
+      RUBY
+    end
+
     it 'reports no offense for excluding end' do
       expect_no_offenses(<<~RUBY)
         ary[1...-1]


### PR DESCRIPTION
Supports any expression as start index (only int previously), as noticed here: https://github.com/rubocop-hq/rubocop/pull/7921#issuecomment-627615843.
Still correctly ignores startless range.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* ~[ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
