### PR TITLE
Improved shared context. Refactor & simplify some specs.

### DIFF
--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -38,25 +38,65 @@ RSpec.shared_context 'isolated environment', :isolated_environment do
   end
 end
 
-# `cop_config` must be declared with #let.
-RSpec.shared_context 'config', :config do
-  let(:config) do
-    # Module#<
-    raise '`config` must be used in `describe SomeCopClass do .. end`' unless described_class < RuboCop::Cop::Cop
+# This context assumes nothing and defines `cop`, among others.
+RSpec.shared_context 'config', :config do # rubocop:disable Metrics/BlockLength
+  ### Meant to be overriden at will
 
-    hash = { 'AllCops' => { 'TargetRubyVersion' => ruby_version } }
-    hash['AllCops']['TargetRailsVersion'] = rails_version if rails_version
-    if respond_to?(:cop_config)
-      cop_name = described_class.cop_name
-      hash[cop_name] = RuboCop::ConfigLoader
-                       .default_configuration[cop_name]
-                       .merge('Enabled' => true) # in case it is 'pending'
-                       .merge(cop_config)
+  let(:source) { 'code = {some: :ruby}' }
+
+  let(:cop_class) do
+    if described_class.is_a?(Class) && described_class < RuboCop::Cop::Cop
+      described_class
+    else
+      RuboCop::Cop::Cop
     end
+  end
 
-    hash = other_cops.merge hash if respond_to?(:other_cops)
+  let(:cop_config) { {} }
+
+  let(:other_cops) { {} }
+
+  let(:cop_options) { {} }
+
+  ### Utilities
+
+  def source_range(range, buffer: source_buffer)
+    Parser::Source::Range.new(buffer, range.begin,
+                              range.exclude_end? ? range.end : range.end + 1)
+  end
+
+  ### Usefull intermediary steps (less likely to be overriden)
+
+  let(:processed_source) { parse_source(source, 'test') }
+
+  let(:source_buffer) { processed_source.buffer }
+
+  let(:all_cops_config) do
+    rails = { 'TargetRubyVersion' => ruby_version }
+    rails['TargetRailsVersion'] = rails_version if rails_version
+    rails
+  end
+
+  let(:cur_cop_config) do
+    RuboCop::ConfigLoader
+      .default_configuration.for_cop(cop_class)
+      .merge({
+               'Enabled' => true, # in case it is 'pending'
+               'AutoCorrect' => true # in case defaults set it to false
+             })
+      .merge(cop_config)
+  end
+
+  let(:config) do
+    hash = { 'AllCops' => all_cops_config,
+             cop_class.cop_name => cur_cop_config }.merge!(other_cops)
 
     RuboCop::Config.new(hash, "#{Dir.pwd}/.rubocop.yml")
+  end
+
+  let(:cop) do
+    cop_class.new(config, cop_options)
+             .tap { |cop| cop.processed_source = processed_source }
   end
 end
 

--- a/spec/rubocop/cop/alignment_corrector_spec.rb
+++ b/spec/rubocop/cop/alignment_corrector_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::AlignmentCorrector do
-  let(:cop) { RuboCop::Cop::Test::AlignmentDirective.new }
+RSpec.describe RuboCop::Cop::AlignmentCorrector, :config do
+  let(:cop_class) { RuboCop::Cop::Test::AlignmentDirective }
 
   describe '#correct' do
     context 'simple indentation' do

--- a/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
+++ b/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Bundler::DuplicatedGem, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'Include' => ['**/Gemfile'] } }
 
   context 'when investigating Ruby files' do

--- a/spec/rubocop/cop/bundler/gem_comment_spec.rb
+++ b/spec/rubocop/cop/bundler/gem_comment_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Bundler::GemComment, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     {
       'Include' => ['**/Gemfile'],

--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     {
       'TreatCommentsAsGroupSeparators' => treat_comments_as_group_separators,

--- a/spec/rubocop/cop/gemspec/ordered_dependencies_spec.rb
+++ b/spec/rubocop/cop/gemspec/ordered_dependencies_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Gemspec::OrderedDependencies, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     {
       'TreatCommentsAsGroupSeparators' => treat_comments_as_group_separators,

--- a/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
+++ b/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'target ruby version > 2.7', :ruby27 do
     it 'registers an offense when `required_ruby_version` is lower than ' \
        '`TargetRubyVersion`' do

--- a/spec/rubocop/cop/gemspec/ruby_version_globals_usage_spec.rb
+++ b/spec/rubocop/cop/gemspec/ruby_version_globals_usage_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Gemspec::RubyVersionGlobalsUsage, :config do
-  subject(:cop) { described_class.new(config) }
-
   it 'registers an offense when using `RUBY_VERSION`' do
     expect_offense(<<~RUBY, '/path/to/foo.gemspec')
       Gem::Specification.new do |spec|

--- a/spec/rubocop/cop/layout/assignment_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/assignment_indentation_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::AssignmentIndentation, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:config) do
     RuboCop::Config.new('Layout/AssignmentIndentation' => {
                           'IndentationWidth' => cop_indent

--- a/spec/rubocop/cop/layout/block_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/block_alignment_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     { 'EnforcedStyleAlignWith' => 'either' }
   end

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:config) do
     RuboCop::Config.new(
       'Layout/ClassStructure' => {

--- a/spec/rubocop/cop/layout/def_end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/def_end_alignment_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::DefEndAlignment, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:source) do
     <<~RUBY
       foo def a

--- a/spec/rubocop/cop/layout/dot_position_spec.rb
+++ b/spec/rubocop/cop/layout/dot_position_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::DotPosition, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'Leading dots style' do
     let(:cop_config) { { 'EnforcedStyle' => 'leading' } }
 

--- a/spec/rubocop/cop/layout/empty_comment_spec.rb
+++ b/spec/rubocop/cop/layout/empty_comment_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::EmptyComment, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     { 'AllowBorderComment' => true, 'AllowMarginComment' => true }
   end

--- a/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'AllowAdjacentOneLineDefs' => false } }
 
   it 'finds offenses in inner classes' do

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'EnforcedStyle is `around`' do
     let(:cop_config) { { 'EnforcedStyle' => 'around' } }
 

--- a/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when extra lines' do
     it 'registers offense for empty line before arg' do
       inspect_source(<<~RUBY)

--- a/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBlockBody, :config do
-  subject(:cop) { described_class.new(config) }
-
   # Test blocks using both {} and do..end
   [%w[{ }], %w[do end]].each do |open, close|
     context "when EnforcedStyle is no_empty_lines for #{open} #{close} block" do

--- a/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:extra_begin) { 'Extra empty line detected at class body beginning.' }
   let(:extra_end) { 'Extra empty line detected at class body end.' }
   let(:missing_begin) { 'Empty line missing at class body beginning.' }

--- a/spec/rubocop/cop/layout/empty_lines_around_module_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_module_body_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:extra_begin) { 'Extra empty line detected at module body beginning.' }
   let(:extra_end) { 'Extra empty line detected at module body end.' }
   let(:missing_begin) { 'Empty line missing at module body beginning.' }

--- a/spec/rubocop/cop/layout/end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/end_alignment_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     { 'EnforcedStyleAlignWith' => 'keyword', 'AutoCorrect' => true }
   end

--- a/spec/rubocop/cop/layout/end_of_line_spec.rb
+++ b/spec/rubocop/cop/layout/end_of_line_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
-  subject(:cop) { described_class.new(config) }
-
   shared_examples 'all configurations' do
     it 'accepts an empty file' do
       inspect_source_file('')

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
-  subject(:cop) { described_class.new(config) }
-
   shared_examples 'common behavior' do
     it 'registers an offense and corrects alignment with token ' \
       'not preceded by space' do

--- a/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     { 'EnforcedStyle' => style }
   end

--- a/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:config) do
     supported_styles = {
       'SupportedStyles' => %w[consistent align_parentheses]

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     {
       'EnforcedHashRocketStyle' => 'key',

--- a/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:allow_heredoc) { true }
   let(:other_cops) do
     {

--- a/spec/rubocop/cop/layout/indentation_consistency_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_consistency_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'EnforcedStyle' => 'normal' } }
 
   context 'with top-level code' do

--- a/spec/rubocop/cop/layout/leading_comment_space_spec.rb
+++ b/spec/rubocop/cop/layout/leading_comment_space_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace, :config do
-  subject(:cop) { described_class.new(config) }
-
   it 'registers an offense and corrects comment without leading space' do
     expect_offense(<<~RUBY)
       #missing space

--- a/spec/rubocop/cop/layout/leading_empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/leading_empty_lines_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::LeadingEmptyLines, :config do
-  subject(:cop) { described_class.new(config) }
-
   it 'allows an empty input' do
     expect_no_offenses('')
   end

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'Max' => 80, 'IgnoredPatterns' => nil } }
 
   let(:config) do

--- a/spec/rubocop/cop/layout/multiline_array_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_array_brace_layout_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::MultilineArrayBraceLayout, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
   it 'ignores implicit arrays' do

--- a/spec/rubocop/cop/layout/multiline_assignment_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_assignment_layout_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:supported_types) { %w[if] }
 
   let(:cop_config) do

--- a/spec/rubocop/cop/layout/multiline_hash_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_hash_brace_layout_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::MultilineHashBraceLayout, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
   it 'ignores implicit hashes' do

--- a/spec/rubocop/cop/layout/multiline_method_call_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_brace_layout_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallBraceLayout, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
   it 'ignores implicit calls' do

--- a/spec/rubocop/cop/layout/multiline_method_definition_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_definition_brace_layout_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::MultilineMethodDefinitionBraceLayout, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
   it 'ignores implicit defs' do

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
-  subject(:cop) { described_class.new(config) }
-
   it 'accepts the modifier form' do
     expect_no_offenses('test rescue nil')
   end

--- a/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
-  subject(:cop) { described_class.new(config) }
-
   shared_examples 'common behavior' do
     it 'accepts an empty block' do
       expect_no_offenses('{}.each {}')

--- a/spec/rubocop/cop/layout/space_around_equals_in_parameter_default_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_equals_in_parameter_default_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when EnforcedStyle is space' do
     let(:cop_config) { { 'EnforcedStyle' => 'space' } }
 

--- a/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'EnforcedStyle' => 'space' } }
 
   context 'when EnforcedStyle is space' do

--- a/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::SpaceBeforeFirstArg, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'AllowForAlignment' => true } }
 
   context 'for method calls without parentheses' do

--- a/spec/rubocop/cop/layout/space_in_lambda_literal_spec.rb
+++ b/spec/rubocop/cop/layout/space_in_lambda_literal_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when configured to enforce spaces' do
     let(:cop_config) { { 'EnforcedStyle' => 'require_space' } }
 

--- a/spec/rubocop/cop/layout/space_inside_array_literal_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_array_literal_brackets_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
-  subject(:cop) { described_class.new(config) }
-
   it 'does not register offense for any kind of reference brackets' do
     expect_no_offenses(<<~RUBY)
       a[1]

--- a/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'EnforcedStyle' => 'space' } }
 
   context 'with space inside empty braces not allowed' do

--- a/spec/rubocop/cop/layout/space_inside_parens_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_parens_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::SpaceInsideParens, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when EnforcedStyle is no_space' do
     let(:cop_config) { { 'EnforcedStyle' => 'no_space' } }
 

--- a/spec/rubocop/cop/layout/space_inside_reference_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_reference_brackets_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'with space inside empty brackets not allowed' do
     let(:cop_config) { { 'EnforcedStyleForEmptyBrackets' => 'no_space' } }
 

--- a/spec/rubocop/cop/layout/space_inside_string_interpolation_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_string_interpolation_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when EnforcedStyle is no_space' do
     let(:cop_config) { { 'EnforcedStyle' => 'no_space' } }
 

--- a/spec/rubocop/cop/layout/trailing_empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_empty_lines_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when EnforcedStyle is final_newline' do
     let(:cop_config) { { 'EnforcedStyle' => 'final_newline' } }
 

--- a/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'AllowInHeredoc' => false } }
 
   it 'registers an offense for a line ending with space' do

--- a/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'AllowSafeAssignment' => true } }
 
   it 'registers an offense for lvar assignment in condition' do

--- a/spec/rubocop/cop/lint/boolean_symbol_spec.rb
+++ b/spec/rubocop/cop/lint/boolean_symbol_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::BooleanSymbol, :config do
-  subject(:cop) { described_class.new(config) }
-
   it 'registers an offense when using `:true`' do
     expect_offense(<<~RUBY)
       :true

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
-  subject(:cop) { described_class.new(config) }
-
   shared_examples_for 'debugger' do |name, src|
     it "reports an offense for a #{name} call" do
       inspect_source(src)

--- a/spec/rubocop/cop/lint/empty_when_spec.rb
+++ b/spec/rubocop/cop/lint/empty_when_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::EmptyWhen, :config do
-  subject(:cop) { described_class.new(config) }
-
   before do
     inspect_source(source)
   end

--- a/spec/rubocop/cop/lint/erb_new_arguments_spec.rb
+++ b/spec/rubocop/cop/lint/erb_new_arguments_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::ErbNewArguments, :config do
-  subject(:cop) { described_class.new(config) }
-
   context '<= Ruby 2.5', :ruby25 do
     it 'does not register an offense when using `ERB.new` ' \
        'with non-keyword arguments' do

--- a/spec/rubocop/cop/lint/inherit_exception_spec.rb
+++ b/spec/rubocop/cop/lint/inherit_exception_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::InheritException, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when class inherits from `Exception`' do
     context 'with enforced style set to `runtime_error`' do
       let(:cop_config) { { 'EnforcedStyle' => 'runtime_error' } }

--- a/spec/rubocop/cop/lint/missing_cop_enable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/missing_cop_enable_directive_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::MissingCopEnableDirective, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when the maximum range size is infinite' do
     let(:cop_config) { { 'MaximumRangeSize' => Float::INFINITY } }
 

--- a/spec/rubocop/cop/lint/ordered_magic_comments_spec.rb
+++ b/spec/rubocop/cop/lint/ordered_magic_comments_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::OrderedMagicComments, :config do
-  subject(:cop) { described_class.new(config) }
-
   it 'registers an offense and corrects when an `encoding` magic comment ' \
     'does not precede all other magic comments' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/lint/raise_exception_spec.rb
+++ b/spec/rubocop/cop/lint/raise_exception_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::RaiseException, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'AllowedImplicitNamespaces' => ['Gem'] } }
 
   it 'registers an offense for `raise` with `::Exception`' do

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -1,16 +1,8 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective do
+RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
   describe '.check' do
-    let(:cop) do
-      cop = described_class.new
-      cop.instance_variable_get(:@options)[:auto_correct] = true
-      cop.processed_source = processed_source
-      cop
-    end
-    let(:processed_source) do
-      RuboCop::ProcessedSource.new(source, ruby_version)
-    end
+    let(:cop_options) { { auto_correct: true } }
     let(:comments) { processed_source.comments }
     let(:corrected_source) do
       RuboCop::Cop::Corrector
@@ -246,9 +238,9 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective do
                           'Unnecessary disabling of `Lint/Debugger`.'])
                 expect(cop.highlights).to eq(%w[ClassLength Debugger])
                 expect($stderr.string).to eq(<<~OUTPUT)
-                  (string): Warning: no department given for MethodLength.
-                  (string): Warning: no department given for ClassLength.
-                  (string): Warning: no department given for Debugger.
+                  test: Warning: no department given for MethodLength.
+                  test: Warning: no department given for ClassLength.
+                  test: Warning: no department given for Debugger.
                 OUTPUT
               end
             end

--- a/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::RedundantRequireStatement, :config do
-  subject(:cop) { described_class.new(config) }
-
   it "registers an offense and corrects when using `require 'enumerator'`" do
     expect_offense(<<~RUBY)
       require 'enumerator'

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     { 'AcceptedMethods' => %w[present? blank? try presence] }
   end

--- a/spec/rubocop/cop/lint/safe_navigation_consistency_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_consistency_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::SafeNavigationConsistency, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     { 'AllowedMethods' => %w[present? blank? try presence] }
   end

--- a/spec/rubocop/cop/lint/shadowed_argument_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_argument_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::ShadowedArgument, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'IgnoreImplicitReferences' => false } }
 
   describe 'method argument shadowing' do

--- a/spec/rubocop/cop/lint/suppressed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/suppressed_exception_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::SuppressedException, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'with AllowComments set to false' do
     let(:cop_config) { { 'AllowComments' => false } }
 

--- a/spec/rubocop/cop/lint/underscore_prefixed_variable_name_spec.rb
+++ b/spec/rubocop/cop/lint/underscore_prefixed_variable_name_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'AllowKeywordBlockArguments' => false } }
 
   context 'when an underscore-prefixed variable is used' do

--- a/spec/rubocop/cop/lint/unified_integer_spec.rb
+++ b/spec/rubocop/cop/lint/unified_integer_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::UnifiedInteger, :config do
-  subject(:cop) { described_class.new(config) }
-
   shared_examples 'registers an offense' do |klass|
     context "when #{klass}" do
       context 'without any decorations' do

--- a/spec/rubocop/cop/lint/unused_block_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_block_argument_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'AllowUnusedKeywordArguments' => false } }
 
   shared_examples 'auto-correction' do |name, old_source, new_source|

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     {
       'AllowUnusedKeywordArguments' => false,

--- a/spec/rubocop/cop/metrics/abc_size_spec.rb
+++ b/spec/rubocop/cop/metrics/abc_size_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when Max is 0' do
     let(:cop_config) { { 'Max' => 0 } }
 

--- a/spec/rubocop/cop/metrics/block_length_spec.rb
+++ b/spec/rubocop/cop/metrics/block_length_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Metrics::BlockLength, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'Max' => 2, 'CountComments' => false } }
 
   shared_examples 'ignoring an offense on an excluded method' do |excluded|

--- a/spec/rubocop/cop/metrics/block_nesting_spec.rb
+++ b/spec/rubocop/cop/metrics/block_nesting_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Metrics::BlockNesting, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'Max' => 2 } }
 
   it 'accepts `Max` levels of nesting' do

--- a/spec/rubocop/cop/metrics/class_length_spec.rb
+++ b/spec/rubocop/cop/metrics/class_length_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'Max' => 5, 'CountComments' => false } }
 
   it 'rejects a class with more than 5 lines' do

--- a/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when Max is 1' do
     let(:cop_config) { { 'Max' => 1 } }
 

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'Max' => 5, 'CountComments' => false } }
 
   context 'when method is an instance method' do

--- a/spec/rubocop/cop/metrics/module_length_spec.rb
+++ b/spec/rubocop/cop/metrics/module_length_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Metrics::ModuleLength, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'Max' => 5, 'CountComments' => false } }
 
   it 'rejects a module with more than 5 lines' do

--- a/spec/rubocop/cop/metrics/parameter_lists_spec.rb
+++ b/spec/rubocop/cop/metrics/parameter_lists_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Metrics::ParameterLists, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     {
       'Max' => 4,

--- a/spec/rubocop/cop/metrics/perceived_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/perceived_complexity_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when Max is 1' do
     let(:cop_config) { { 'Max' => 1 } }
 

--- a/spec/rubocop/cop/naming/block_parameter_name_spec.rb
+++ b/spec/rubocop/cop/naming/block_parameter_name_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Naming::BlockParameterName, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     {
       'MinNameLength' => 2,

--- a/spec/rubocop/cop/naming/heredoc_delimiter_case_spec.rb
+++ b/spec/rubocop/cop/naming/heredoc_delimiter_case_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Naming::HeredocDelimiterCase, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:config) do
     RuboCop::Config.new(described_class.badge.to_s => cop_config)
   end

--- a/spec/rubocop/cop/naming/heredoc_delimiter_naming_spec.rb
+++ b/spec/rubocop/cop/naming/heredoc_delimiter_naming_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Naming::HeredocDelimiterNaming, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:config) do
     RuboCop::Config.new(described_class.badge.to_s => cop_config)
   end

--- a/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Naming::MemoizedInstanceVariableName, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'with default EnforcedStyleForLeadingUnderscores => disallowed' do
     let(:cop_config) do
       { 'EnforcedStyleForLeadingUnderscores' => 'disallowed' }

--- a/spec/rubocop/cop/naming/method_name_spec.rb
+++ b/spec/rubocop/cop/naming/method_name_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
-  subject(:cop) { described_class.new(config) }
-
   shared_examples 'never accepted' do |enforced_style|
     it 'registers an offense for mixed snake case and camel case in attr.' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/naming/method_parameter_name_spec.rb
+++ b/spec/rubocop/cop/naming/method_parameter_name_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Naming::MethodParameterName, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     {
       'MinNameLength' => 3,

--- a/spec/rubocop/cop/naming/predicate_name_spec.rb
+++ b/spec/rubocop/cop/naming/predicate_name_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Naming::PredicateName, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'with restricted prefixes' do
     let(:cop_config) do
       { 'NamePrefix' => %w[has_ is_],

--- a/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'with default config' do
     context 'with explicit rescue' do
       context 'with `Exception` variable' do

--- a/spec/rubocop/cop/naming/variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/variable_name_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Naming::VariableName, :config do
-  subject(:cop) { described_class.new(config) }
-
   shared_examples 'always accepted' do
     it 'accepts screaming snake case globals' do
       expect_no_offenses('$MY_GLOBAL = 0')

--- a/spec/rubocop/cop/naming/variable_number_spec.rb
+++ b/spec/rubocop/cop/naming/variable_number_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
-  subject(:cop) { described_class.new(config) }
-
   shared_examples 'offense' do |style, variable, style_to_allow_offenses|
     it "registers an offense for #{Array(variable).first} in #{style}" do
       inspect_source(Array(variable).map { |v| "#{v} = 1" }.join("\n"))

--- a/spec/rubocop/cop/security/json_load_spec.rb
+++ b/spec/rubocop/cop/security/json_load_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Security::JSONLoad, :config do
-  subject(:cop) { described_class.new(config) }
-
   it 'registers an offense and corrects JSON.load' do
     expect_offense(<<~RUBY)
       JSON.load(arg)

--- a/spec/rubocop/cop/security/marshal_load_spec.rb
+++ b/spec/rubocop/cop/security/marshal_load_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Security::MarshalLoad, :config do
-  subject(:cop) { described_class.new(config) }
-
   it 'registers an offense for using Marshal.load' do
     expect_offense(<<~RUBY)
       Marshal.load('{}')

--- a/spec/rubocop/cop/security/yaml_load_spec.rb
+++ b/spec/rubocop/cop/security/yaml_load_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Security::YAMLLoad, :config do
-  subject(:cop) { described_class.new(config) }
-
   it 'does not register an offense for YAML.dump' do
     expect_no_offenses(<<~RUBY)
       YAML.dump("foo")

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
-  subject(:cop) { described_class.new(config) }
-
   shared_examples 'always accepted' do |access_modifier|
     it 'accepts when #{access_modifier} is a hash literal value' do
       expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/style/alias_spec.rb
+++ b/spec/rubocop/cop/style/alias_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::Alias, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when EnforcedStyle is prefer_alias_method' do
     let(:cop_config) { { 'EnforcedStyle' => 'prefer_alias_method' } }
 

--- a/spec/rubocop/cop/style/ascii_comments_spec.rb
+++ b/spec/rubocop/cop/style/ascii_comments_spec.rb
@@ -22,8 +22,6 @@ RSpec.describe RuboCop::Cop::Style::AsciiComments do
   end
 
   context 'when certain non-ascii chars are allowed', :config do
-    subject(:cop) { described_class.new(config) }
-
     let(:cop_config) { { 'AllowedChars' => ['∂'] } }
 
     it 'accepts comment with allowed non-ascii chars' do

--- a/spec/rubocop/cop/style/bare_percent_literals_spec.rb
+++ b/spec/rubocop/cop/style/bare_percent_literals_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::BarePercentLiterals, :config do
-  subject(:cop) { described_class.new(config) }
-
   shared_examples 'accepts other delimiters' do
     it 'accepts __FILE__' do
       expect_no_offenses('__FILE__')

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
-  subject(:cop) { described_class.new(config) }
-
   shared_examples 'syntactic styles' do
     it 'registers an offense for a single line block with do-end' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'nested style' do
     let(:cop_config) { { 'EnforcedStyle' => 'nested' } }
 

--- a/spec/rubocop/cop/style/class_check_spec.rb
+++ b/spec/rubocop/cop/style/class_check_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::ClassCheck, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when enforced style is is_a?' do
     let(:cop_config) { { 'EnforcedStyle' => 'is_a?' } }
 

--- a/spec/rubocop/cop/style/command_literal_spec.rb
+++ b/spec/rubocop/cop/style/command_literal_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:config) do
     supported_styles = {
       'SupportedStyles' => %w[backticks percent_x mixed]

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     { 'Keywords' => %w[TODO FIXME OPTIMIZE HACK REVIEW] }
   end

--- a/spec/rubocop/cop/style/copyright_spec.rb
+++ b/spec/rubocop/cop/style/copyright_spec.rb
@@ -6,8 +6,6 @@ def expect_copyright_offense(cop, source)
 end
 
 RSpec.describe RuboCop::Cop::Style::Copyright, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'Notice' => 'Copyright (\(c\) )?2015 Acme Inc' } }
 
   it 'does not register an offense when the notice is present' do

--- a/spec/rubocop/cop/style/date_time_spec.rb
+++ b/spec/rubocop/cop/style/date_time_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::DateTime, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'AllowCoercion' => false } }
 
   it 'registers an offense when using DateTime for current time' do

--- a/spec/rubocop/cop/style/dir_spec.rb
+++ b/spec/rubocop/cop/style/dir_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::Dir, :config do
-  subject(:cop) { described_class.new(config) }
-
   shared_examples 'auto-correct' do |original, expected|
     it 'auto-corrects' do
       new_source = autocorrect_source(original)

--- a/spec/rubocop/cop/style/documentation_method_spec.rb
+++ b/spec/rubocop/cop/style/documentation_method_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:require_for_non_public_methods) { false }
 
   let(:config) do

--- a/spec/rubocop/cop/style/empty_method_spec.rb
+++ b/spec/rubocop/cop/style/empty_method_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
-  subject(:cop) { described_class.new(config) }
-
   before do
     inspect_source(source)
   end

--- a/spec/rubocop/cop/style/encoding_spec.rb
+++ b/spec/rubocop/cop/style/encoding_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::Encoding, :config do
-  subject(:cop) { described_class.new(config) }
-
   it 'registers no offense when no encoding present' do
     expect_no_offenses(<<~RUBY)
       def foo() end

--- a/spec/rubocop/cop/style/expand_path_arguments_spec.rb
+++ b/spec/rubocop/cop/style/expand_path_arguments_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::ExpandPathArguments, :config do
-  subject(:cop) { described_class.new(config) }
-
   it "registers an offense when using `File.expand_path('..', __FILE__)`" do
     expect_offense(<<~RUBY)
       File.expand_path('..', __FILE__)

--- a/spec/rubocop/cop/style/exponential_notation_spec.rb
+++ b/spec/rubocop/cop/style/exponential_notation_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::ExponentialNotation, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'EnforcedStyle is scientific' do
     let(:cop_config) { { 'EnforcedStyle' => 'scientific' } }
 

--- a/spec/rubocop/cop/style/float_division_spec.rb
+++ b/spec/rubocop/cop/style/float_division_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::FloatDivision, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'EnforcedStyle is left_coerce' do
     let(:cop_config) { { 'EnforcedStyle' => 'left_coerce' } }
 

--- a/spec/rubocop/cop/style/for_spec.rb
+++ b/spec/rubocop/cop/style/for_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::For, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when each is the enforced style' do
     let(:cop_config) { { 'EnforcedStyle' => 'each' } }
 

--- a/spec/rubocop/cop/style/format_string_spec.rb
+++ b/spec/rubocop/cop/style/format_string_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::FormatString, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when enforced style is sprintf' do
     let(:cop_config) { { 'EnforcedStyle' => 'sprintf' } }
 

--- a/spec/rubocop/cop/style/format_string_token_spec.rb
+++ b/spec/rubocop/cop/style/format_string_token_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:enforced_style) { :annotated }
 
   let(:cop_config) do

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'always' do
     let(:cop_config) do
       { 'Enabled'       => true,

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -1,18 +1,15 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Style::GuardClause do
-  let(:cop) { described_class.new(config) }
-  let(:config) do
-    RuboCop::Config.new(
+RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
+  let(:other_cops) do
+    {
       'Layout/LineLength' => {
         'Enabled' => line_length_enabled,
         'Max' => 80
-      },
-      'Style/GuardClause' => cop_config
-    )
+      }
+    }
   end
   let(:line_length_enabled) { true }
-  let(:cop_config) { {} }
 
   shared_examples 'reports offense' do |body|
     it 'reports an offense if method body is if / unless without else' do

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'configured to enforce ruby19 style' do
     context 'with SpaceAroundOperators enabled' do
       let(:config) do

--- a/spec/rubocop/cop/style/hash_transform_keys_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_keys_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when using Ruby 2.5 or newer', :ruby25 do
     context 'with inline block' do
       it 'flags each_with_object when transform_keys could be used' do

--- a/spec/rubocop/cop/style/hash_transform_values_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_values_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'with inline block' do
     it 'flags each_with_object when transform_values could be used' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/if_inside_else_spec.rb
+++ b/spec/rubocop/cop/style/if_inside_else_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::IfInsideElse, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     { 'AllowIfModifier' => false }
   end

--- a/spec/rubocop/cop/style/ip_addresses_spec.rb
+++ b/spec/rubocop/cop/style/ip_addresses_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::IpAddresses, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { {} }
 
   it 'does not register an offense on an empty string' do

--- a/spec/rubocop/cop/style/lambda_call_spec.rb
+++ b/spec/rubocop/cop/style/lambda_call_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when style is set to call' do
     let(:cop_config) { { 'EnforcedStyle' => 'call' } }
 

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::Lambda, :config do
-  subject(:cop) { described_class.new(config) }
-
   shared_examples 'registers an offense' do |message|
     it 'registers an offense' do
       inspect_source(source)

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when EnforcedStyle is require_parentheses (default)' do
     let(:cop_config) do
       { 'IgnoredMethods' => %w[puts] }

--- a/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     { 'IgnoredMethods' => %w[s] }
   end

--- a/spec/rubocop/cop/style/method_def_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_def_parentheses_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'require_parentheses' do
     let(:cop_config) { { 'EnforcedStyle' => 'require_parentheses' } }
 

--- a/spec/rubocop/cop/style/min_max_spec.rb
+++ b/spec/rubocop/cop/style/min_max_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::MinMax, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'with an array literal containing calls to `#min` and `#max`' do
     context 'when the expression stands alone' do
       it 'registers an offense if the receivers match' do

--- a/spec/rubocop/cop/style/mixin_grouping_spec.rb
+++ b/spec/rubocop/cop/style/mixin_grouping_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::MixinGrouping, :config do
-  subject(:cop) { described_class.new(config) }
-
   before do
     inspect_source(source)
   end

--- a/spec/rubocop/cop/style/module_function_spec.rb
+++ b/spec/rubocop/cop/style/module_function_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::ModuleFunction, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when enforced style is `module_function`' do
     let(:cop_config) { { 'EnforcedStyle' => 'module_function' } }
 

--- a/spec/rubocop/cop/style/multiline_memoization_spec.rb
+++ b/spec/rubocop/cop/style/multiline_memoization_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::MultilineMemoization, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:message) { 'Wrap multiline memoization blocks in `begin` and `end`.' }
 
   before do

--- a/spec/rubocop/cop/style/multiline_method_signature_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_signature_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::MultilineMethodSignature, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when arguments span multiple lines' do
     context 'when defining an instance method' do
       it 'registers an offense when `end` is on the following line' do

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:prefix) { nil }
 
   shared_examples 'mutable objects' do |o|

--- a/spec/rubocop/cop/style/next_spec.rb
+++ b/spec/rubocop/cop/style/next_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::Next, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'MinBodyLength' => 1 } }
 
   shared_examples 'iterators' do |condition|

--- a/spec/rubocop/cop/style/nil_comparison_spec.rb
+++ b/spec/rubocop/cop/style/nil_comparison_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::NilComparison, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'configured with predicate preferred' do
     let(:cop_config) { { 'EnforcedStyle' => 'predicate' } }
 

--- a/spec/rubocop/cop/style/non_nil_check_spec.rb
+++ b/spec/rubocop/cop/style/non_nil_check_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::NonNilCheck, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when not allowing semantic changes' do
     let(:cop_config) do
       {

--- a/spec/rubocop/cop/style/not_spec.rb
+++ b/spec/rubocop/cop/style/not_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::Not, :config do
-  subject(:cop) { described_class.new(config) }
-
   it 'registers an offense for not' do
     expect_offense(<<~RUBY)
       not test

--- a/spec/rubocop/cop/style/numeric_literal_prefix_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literal_prefix_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'octal literals' do
     context 'when config is zero_with_o' do
       let(:cop_config) do

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::NumericLiterals, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'MinDigits' => 5 } }
 
   it 'registers an offense for a long undelimited integer' do

--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
-  subject(:cop) { described_class.new(config) }
-
   before do
     inspect_source(source)
   end

--- a/spec/rubocop/cop/style/option_hash_spec.rb
+++ b/spec/rubocop/cop/style/option_hash_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::OptionHash, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'SuspiciousParamNames' => suspicious_names } }
   let(:suspicious_names) { ['options'] }
 

--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::ParallelAssignment, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:config) do
     RuboCop::Config.new('Layout/IndentationWidth' => { 'Width' => 2 })
   end

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'AllowSafeAssignment' => true } }
 
   it 'registers an offense for parentheses around condition' do

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     { 'PreferredDelimiters' => { 'default' => '[]' } }
   end

--- a/spec/rubocop/cop/style/percent_q_literals_spec.rb
+++ b/spec/rubocop/cop/style/percent_q_literals_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::PercentQLiterals, :config do
-  subject(:cop) { described_class.new(config) }
-
   shared_examples 'accepts quote characters' do
     it 'accepts single quotes' do
       expect_no_offenses("'hi'")

--- a/spec/rubocop/cop/style/preferred_hash_methods_spec.rb
+++ b/spec/rubocop/cop/style/preferred_hash_methods_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::PreferredHashMethods, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'with enforced `short` style' do
     let(:cop_config) { { 'EnforcedStyle' => 'short' } }
 

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when enforced style is compact' do
     let(:cop_config) { { 'EnforcedStyle' => 'compact' } }
 

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
-  subject(:cop) { described_class.new(config) }
-
   it 'reports an offense for single line def with redundant begin block' do
     expect_offense(<<~RUBY)
       def func; begin; x; y; rescue; z end; end

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'AllowMultipleReturnValues' => false } }
 
   it 'reports an offense for def with only a return' do

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:config) do
     supported_styles = {
       'SupportedStyles' => %w[slashes percent_r mixed]

--- a/spec/rubocop/cop/style/rescue_standard_error_spec.rb
+++ b/spec/rubocop/cop/style/rescue_standard_error_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RescueStandardError, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'implicit' do
     let(:cop_config) do
       { 'EnforcedStyle' => 'implicit',

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'ConvertCodeThatCanStartToReturnNil' => false } }
 
   let(:message) do

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::Semicolon, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'AllowAsExpressionSeparator' => false } }
 
   it 'registers an offense for a single expression' do

--- a/spec/rubocop/cop/style/signal_exception_spec.rb
+++ b/spec/rubocop/cop/style/signal_exception_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::SignalException, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when enforced style is `semantic`' do
     let(:cop_config) { { 'EnforcedStyle' => 'semantic' } }
 

--- a/spec/rubocop/cop/style/single_line_block_params_spec.rb
+++ b/spec/rubocop/cop/style/single_line_block_params_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::SingleLineBlockParams, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     { 'Methods' =>
       [{ 'reduce' => %w[a e] },

--- a/spec/rubocop/cop/style/slicing_with_range_spec.rb
+++ b/spec/rubocop/cop/style/slicing_with_range_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::SlicingWithRange, :config do
-  subject(:cop) { described_class.new(config) }
-
   context '<= Ruby 2.5', :ruby25 do
     it 'reports no offense for array slicing with -1' do
       expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/style/special_global_vars_spec.rb
+++ b/spec/rubocop/cop/style/special_global_vars_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when style is use_english_names' do
     let(:cop_config) { { 'EnforcedStyle' => 'use_english_names' } }
 

--- a/spec/rubocop/cop/style/stabby_lambda_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/stabby_lambda_parentheses_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::StabbyLambdaParentheses, :config do
-  subject(:cop) { described_class.new(config) }
-
   shared_examples 'common' do
     it 'does not check the old lambda syntax' do
       expect_no_offenses('lambda(&:nil?)')

--- a/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'configured with single quotes preferred' do
     let(:cop_config) { { 'EnforcedStyle' => 'single_quotes' } }
 

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'configured with single quotes preferred' do
     let(:cop_config) { { 'EnforcedStyle' => 'single_quotes' } }
 

--- a/spec/rubocop/cop/style/string_methods_spec.rb
+++ b/spec/rubocop/cop/style/string_methods_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::StringMethods, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'intern' => 'to_sym' } }
 
   it 'registers an offense' do

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
-  subject(:cop) { described_class.new(config) }
-
   before do
     # Reset data which is shared by all instances of SymbolArray
     described_class.largest_brackets = -Float::INFINITY

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'IgnoredMethods' => %w[respond_to] } }
 
   it 'registers an offense for a block with parameterless method call on ' \

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
-  subject(:cop) { described_class.new(config) }
-
   before do
     inspect_source(source)
   end

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
-  subject(:cop) { described_class.new(config) }
-
   shared_examples 'single line lists' do |extra_info|
     it 'registers an offense for trailing comma in a method call' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/trailing_comma_in_array_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_array_literal_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::TrailingCommaInArrayLiteral, :config do
-  subject(:cop) { described_class.new(config) }
-
   shared_examples 'single line lists' do |extra_info|
     it 'registers an offense for trailing comma' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/trailing_comma_in_hash_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_hash_literal_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::TrailingCommaInHashLiteral, :config do
-  subject(:cop) { described_class.new(config) }
-
   shared_examples 'single line lists' do |extra_info|
     it 'registers an offense for trailing comma in a literal' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/trivial_accessors_spec.rb
+++ b/spec/rubocop/cop/style/trivial_accessors_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::TrivialAccessors, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { {} }
 
   it 'registers an offense on instance reader' do

--- a/spec/rubocop/cop/style/unpack_first_spec.rb
+++ b/spec/rubocop/cop/style/unpack_first_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::UnpackFirst, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'registers offense' do
     it 'when using `#unpack` with `#first`' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::WordArray, :config do
-  subject(:cop) { described_class.new(config) }
-
   before do
     # Reset data which is shared by all instances of WordArray
     described_class.largest_brackets = -Float::INFINITY

--- a/spec/rubocop/cop/style/yoda_condition_spec.rb
+++ b/spec/rubocop/cop/style/yoda_condition_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::YodaCondition, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:error_message) { 'Reverse the order of the operands `%s`.' }
 
   shared_examples 'accepts' do |code|


### PR DESCRIPTION
I feel there are ways to clean some specs up with default rspec `let` groups.

How does this look for a start?

Stumbling upon this when working on #7868 because some specs are really abusing the API for autocorrection.