### PR TITLE
[Fix #7972] Fix an incorrect autocrrect for `Style/HashSyntax`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#7953](https://github.com/rubocop-hq/rubocop/issues/7953): Fix an error for `Lint/AmbiguousOperator` when a method with no arguments is used in advance. ([@koic][])
 * [#7962](https://github.com/rubocop-hq/rubocop/issues/7962): Fix a false positive for `Lint/ParenthesesAsGroupedExpression` when heredoc has a space between the same string as the method name and `(`. ([@koic][])
 * [#7967](https://github.com/rubocop-hq/rubocop/pull/7967): `Style/SlicingWithRange` cop now supports any expression as its first index. ([@zverok][])
+* [#7972](https://github.com/rubocop-hq/rubocop/issues/7972): Fix an incorrect autocrrect for `Style/HashSyntax` when using a return value uses `return`. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -168,11 +168,7 @@ module RuboCop
         end
 
         def autocorrect_ruby19(corrector, pair_node)
-          key = pair_node.key.source_range
-          op = pair_node.loc.operator
-
-          range = key.join(op)
-          range = range_with_surrounding_space(range: range, side: :right)
+          range = range_for_autocorrect_ruby19(pair_node)
 
           space = argument_without_space?(pair_node.parent) ? ' ' : ''
 
@@ -180,6 +176,17 @@ module RuboCop
             range,
             range.source.sub(/^:(.*\S)\s*=>\s*$/, space.to_s + '\1: ')
           )
+
+          hash_node = pair_node.parent
+          corrector.wrap(hash_node, '{', '}') if hash_node.parent&.return_type? && !hash_node.braces?
+        end
+
+        def range_for_autocorrect_ruby19(pair_node)
+          key = pair_node.key.source_range
+          operator = pair_node.loc.operator
+
+          range = key.join(operator)
+          range_with_surrounding_space(range: range, side: :right)
         end
 
         def argument_without_space?(node)

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -139,6 +139,30 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         new_source = autocorrect_source('foo:bar => 1')
         expect(new_source).to eq('foo bar: 1')
       end
+
+      context 'when using a return value uses `return`' do
+        it 'registers an offense and corrects when not enclosed in parentheses' do
+          expect_offense(<<~RUBY)
+            return :key => value
+                   ^^^^^^^ Use the new Ruby 1.9 hash syntax.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            return {key: value}
+          RUBY
+        end
+
+        it 'registers an offense and corrects when enclosed in parentheses' do
+          expect_offense(<<~RUBY)
+            return {:key => value}
+                    ^^^^^^^ Use the new Ruby 1.9 hash syntax.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            return {key: value}
+          RUBY
+        end
+      end
     end
 
     context 'with SpaceAroundOperators disabled' do


### PR DESCRIPTION
Fixes #7972.

Fix an incorrect autocorrect for `Style/HashSyntax` when using a return value uses `return`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
