### PR TITLE
Make the config loader Bundler-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#7886](https://github.com/rubocop-hq/rubocop/issues/7886): Fix a bug in `AllowComments` logic in `Lint/SuppressedException`. ([@jonas054][])
 * [#7991](https://github.com/rubocop-hq/rubocop/issues/7991): Fix an error for `Layout/EmptyLinesAroundAttributeAccessor` when attribute method is method chained. ([@koic][])
 * [#7993](https://github.com/rubocop-hq/rubocop/issues/7993): Fix a false positive for `Migration/DepartmentName` when a disable comment contains an unexpected character for department name. ([@koic][])
+* [#7983](https://github.com/rubocop-hq/rubocop/pull/7983): Make the config loader Bundler-aware. ([@CvX][])
 
 ### Changes
 
@@ -4538,3 +4539,4 @@
 [@jeffcarbs]: https://github.com/jeffcarbs
 [@laurmurclar]: https://github.com/laurmurclar
 [@jethrodaniel]: https://github.com/jethrodaniel
+[@CvX]: https://github.com/CvX

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -208,8 +208,14 @@ module RuboCop
     end
 
     def gem_config_path(gem_name, relative_config_path)
-      spec = Gem::Specification.find_by_name(gem_name)
-      File.join(spec.gem_dir, relative_config_path)
+      if defined?(Bundler)
+        gem = Bundler.load.specs[gem_name].first
+        gem_path = gem.full_gem_path if gem
+      end
+
+      gem_path ||= Gem::Specification.find_by_name(gem_name).gem_dir
+
+      File.join(gem_path, relative_config_path)
     rescue Gem::LoadError => e
       raise Gem::LoadError,
             "Unable to find gem #{gem_name}; is the gem installed? #{e}"


### PR DESCRIPTION
Before this change, when inheriting a configuration from a gem, rubocop:

1. would fail to find it, if the gem specified in the Gemfile has a `path` or `git` option (because rubygems is unaware of those gems)
2. would always load the config of the latest installed version of a gem, regardless of the version specified in the Gemfile

This commit changes that, so if executed in the context of Bundler (`defined?(Bundler)`) it will first try to get the gem path via Bundler, and fallback to the previous `Gem::Specification` path when not found.

This solves the two mentioned issues while maintaining the possibility to run rubocop in a globally installed context, i.e. without Bundler.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
