### PR TITLE
Update `VersionChanged` from 1.0 to 0.84

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -861,7 +861,7 @@ Layout/LineLength:
   StyleGuide: '#80-character-limits'
   Enabled: true
   VersionAdded: '0.25'
-  VersionChanged: '1.0'
+  VersionChanged: '0.84'
   AutoCorrect: false
   Max: 120
   # To make it possible to copy or click on URIs in the code, we allow lines

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -3000,7 +3000,7 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.25 | 1.0
+Enabled | Yes | Yes  | 0.25 | 0.84
 
 This cop checks the length of lines in the source code.
 The maximum length is configurable.


### PR DESCRIPTION
Follow up to https://github.com/rubocop-hq/rubocop/pull/7985#discussion_r426227175.

RuboCop 0.84 will be cut before RuboCop 1.0.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
