### PR TITLE
[Fix #7991] Fix an error for `Layout/EmptyLinesAroundAttributeAccessor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#7967](https://github.com/rubocop-hq/rubocop/pull/7967): `Style/SlicingWithRange` cop now supports any expression as its first index. ([@zverok][])
 * [#7972](https://github.com/rubocop-hq/rubocop/issues/7972): Fix an incorrect autocrrect for `Style/HashSyntax` when using a return value uses `return`. ([@koic][])
 * [#7886](https://github.com/rubocop-hq/rubocop/issues/7886): Fix a bug in `AllowComments` logic in `Lint/SuppressedException`. ([@jonas054][])
+* [#7991](https://github.com/rubocop-hq/rubocop/issues/7991): Fix an error for `Layout/EmptyLinesAroundAttributeAccessor` when attribute method is method chained. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/empty_lines_around_attribute_accessor.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_attribute_accessor.rb
@@ -70,7 +70,7 @@ module RuboCop
           return if next_line_empty?(node.last_line)
 
           next_line_node = next_line_node(node)
-          return if next_line_node.nil? || allow_alias?(next_line_node) || attribute_or_allowed_method?(next_line_node)
+          return unless require_empty_line?(next_line_node)
 
           add_offense(node)
         end
@@ -87,6 +87,12 @@ module RuboCop
 
         def next_line_empty?(line)
           processed_source[line].blank?
+        end
+
+        def require_empty_line?(node)
+          return false unless node&.respond_to?(:type)
+
+          !allow_alias?(node) && !attribute_or_allowed_method?(node)
         end
 
         def next_line_node(node)

--- a/spec/rubocop/cop/layout/empty_lines_around_attribute_accessor_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_attribute_accessor_spec.rb
@@ -67,6 +67,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAttributeAccessor, :config 
     RUBY
   end
 
+  it 'accepts code when attribute method is method chained' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        attr.foo
+      end
+    RUBY
+  end
+
   context 'when `AllowAliasSyntax: true`' do
     let(:cop_config) do
       { 'AllowAliasSyntax' => true }


### PR DESCRIPTION
Fixes #7991.

This PR fixes an error for `Layout/EmptyLinesAroundAttributeAccessor` when attribute method is method chained.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
