### PR TITLE
[Fix #7993] Fix a false positive for `Migration/DepartmentName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#7972](https://github.com/rubocop-hq/rubocop/issues/7972): Fix an incorrect autocrrect for `Style/HashSyntax` when using a return value uses `return`. ([@koic][])
 * [#7886](https://github.com/rubocop-hq/rubocop/issues/7886): Fix a bug in `AllowComments` logic in `Lint/SuppressedException`. ([@jonas054][])
 * [#7991](https://github.com/rubocop-hq/rubocop/issues/7991): Fix an error for `Layout/EmptyLinesAroundAttributeAccessor` when attribute method is method chained. ([@koic][])
+* [#7993](https://github.com/rubocop-hq/rubocop/issues/7993): Fix a false positive for `Migration/DepartmentName` when a disable comment contains an unexpected character for department name. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/migration/department_name.rb
+++ b/lib/rubocop/cop/migration/department_name.rb
@@ -27,9 +27,9 @@ module RuboCop
             Regexp.last_match(4).scan(/[^,]+|[\W]+/) do |name|
               trimmed_name = name.strip
 
-              break if contain_plain_comment?(trimmed_name)
-
               check_cop_name(trimmed_name, comment, offset) unless valid_content_token?(trimmed_name)
+
+              break if contain_unexpected_character_for_department_name?(name)
 
               offset += name.length
             end
@@ -64,8 +64,8 @@ module RuboCop
             !DISABLING_COPS_CONTENT_TOKEN.match(content_token).nil?
         end
 
-        def contain_plain_comment?(name)
-          name == '#'
+        def contain_unexpected_character_for_department_name?(name)
+          name.match?(%r{[^A-z/, ]})
         end
 
         def qualified_legacy_cop_name(cop_name)

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -629,6 +629,12 @@ Running `rubocop --[safe-]auto-correct --disable-uncorrectable` will
 create comments to disable all offenses that can't be automatically
 corrected.
 
+Do not write anything other than cop name in the disabling comment. E.g.:
+
+```ruby
+# rubocop:disable Layout/LineLength --This is a bad comment that includes other than cop name.
+```
+
 ## Setting the style guide URL
 
 You can specify the base URL of the style guide using `StyleGuideBaseURL`.

--- a/spec/rubocop/cop/migration/department_name_spec.rb
+++ b/spec/rubocop/cop/migration/department_name_spec.rb
@@ -90,6 +90,15 @@ RSpec.describe RuboCop::Cop::Migration::DepartmentName do
     end
   end
 
+  context 'when a disable comment contains an unexpected character for department name' do
+    it 'accepts' do
+      expect_no_offenses(<<~RUBY)
+        # rubocop:disable Style/Alias -- because something, something, and something
+        alias :ala :bala
+      RUBY
+    end
+  end
+
   # `Migration/DepartmentName` cop's role is to complement a department name.
   # The role would be simple if another feature could detect unexpected
   # disable comment format.


### PR DESCRIPTION
Fixes #7993.

This PR fixes a false positive for `Migration/DepartmentName` cop when a disable comment contains an unexpected character for department name.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
