### PR TITLE
Explicit config

### DIFF
--- a/spec/rubocop/cop/lint/empty_when_spec.rb
+++ b/spec/rubocop/cop/lint/empty_when_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe RuboCop::Cop::Lint::EmptyWhen, :config do
     end
   end
 
+  let(:cop_config) { { 'AllowComments' => false } }
+
   let(:message) { 'Avoid `when` branches without a body.' }
 
   context 'when a `when` body is missing' do

--- a/spec/rubocop/cop/lint/suppressed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/suppressed_exception_spec.rb
@@ -3,29 +3,33 @@
 RSpec.describe RuboCop::Cop::Lint::SuppressedException, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense for empty rescue block' do
-    expect_offense(<<~RUBY)
-      begin
-        something
-      rescue
-      ^^^^^^ Do not suppress exceptions.
-        #do nothing
-      end
-    RUBY
+  context 'with AllowComments set to false' do
+    let(:cop_config) { { 'AllowComments' => false } }
+
+    it 'registers an offense for empty rescue block' do
+      expect_offense(<<~RUBY)
+        begin
+          something
+        rescue
+        ^^^^^^ Do not suppress exceptions.
+          #do nothing
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for rescue with body' do
+      expect_no_offenses(<<~RUBY)
+        begin
+          something
+          return
+        rescue
+          file.close
+        end
+      RUBY
+    end
   end
 
-  it 'does not register an offense for rescue with body' do
-    expect_no_offenses(<<~RUBY)
-      begin
-        something
-        return
-      rescue
-        file.close
-      end
-    RUBY
-  end
-
-  context 'AllowComments' do
+  context 'with AllowComments set to true' do
     let(:cop_config) { { 'AllowComments' => true } }
 
     it 'does not register an offense for empty rescue with comment' do


### PR DESCRIPTION
The current `:config` shared context only takes into account the defaults when a `cop_config` is defined (See [#7970] & [#7999]). These two specs are modified to state explicitly what is being tested; if instead `let(:cop_config) { {} }` the specs fail, which can be surprising.