### PR TITLE
Bump RuboCop Performance to 1.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'bump', require: false
 gem 'pry'
 gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.7'
-gem 'rubocop-performance', '~> 1.5.0'
+gem 'rubocop-performance', '~> 1.6.0'
 gem 'rubocop-rspec', '~> 1.33.0'
 # Workaround for cc-test-reporter with SimpleCov 0.18.
 # Stop upgrading SimpleCov until the following issue will be resolved.

--- a/lib/rubocop/cop/layout/end_of_line.rb
+++ b/lib/rubocop/cop/layout/end_of_line.rb
@@ -75,8 +75,8 @@ module RuboCop
                               style
                             end
           case effective_style
-          when :lf then MSG_DETECTED if /\r$/.match?(line)
-          else MSG_MISSING unless /\r$/.match?(line)
+          when :lf then MSG_DETECTED if line.end_with?("\r", "\r\n")
+          else MSG_MISSING unless line.end_with?("\r\n")
           end
         end
 

--- a/lib/rubocop/cop/style/bare_percent_literals.rb
+++ b/lib/rubocop/cop/style/bare_percent_literals.rb
@@ -64,7 +64,7 @@ module RuboCop
         end
 
         def requires_bare_percent?(source)
-          style == :bare_percent && source =~ /^%Q/
+          style == :bare_percent && source.start_with?('%Q')
         end
 
         def add_offense_for_wrong_style(node, good, bad)


### PR DESCRIPTION
RuboCop Performance 1.6.0 has been released.
https://github.com/rubocop-hq/rubocop-performance/releases/tag/v1.6.0

This PR bumps RuboCop Performance to 1.6.0 and suppresses the following new offenses.

```console
% bundle exec rake
(snip)

Offenses:

lib/rubocop/cop/layout/end_of_line.rb:78:41: C: Performance/EndWith: Use
String#end_with? instead of a regex match anchored to the end of the
string.
          when :lf then MSG_DETECTED if /\r$/.match?(line)
                                        ^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/layout/end_of_line.rb:79:35: C: Performance/EndWith: Use
String#end_with? instead of a regex match anchored to the end of the
string.
          else MSG_MISSING unless /\r$/.match?(line)
                                  ^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/style/bare_percent_literals.rb:67:37: C:
Performance/StartWith: Use String#start_with? instead of a regex match
anchored to the beginning of the string.
          style == :bare_percent && source =~ /^%Q/
                                    ^^^^^^^^^^^^^^^

1058 files inspected, 3 offenses detected
RuboCop failed!
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
