### PR TITLE
[Fix #8008] Fix an error for `Lint/SuppressedException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#8008](https://github.com/rubocop-hq/rubocop/issues/8008): Fix an error for `Lint/SuppressedException` when empty rescue block in `def`. ([@koic][])
+
 ## 0.84.0 (2020-05-21)
 
 ### New features

--- a/lib/rubocop/cop/lint/suppressed_exception.rb
+++ b/lib/rubocop/cop/lint/suppressed_exception.rb
@@ -82,6 +82,8 @@ module RuboCop
             end_line = ancestor.loc.end.line
             break
           end
+          return false unless end_line
+
           processed_source[node.first_line...end_line].any? { |line| comment_line?(line) }
         end
       end

--- a/spec/rubocop/cop/lint/suppressed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/suppressed_exception_spec.rb
@@ -41,6 +41,16 @@ RSpec.describe RuboCop::Cop::Lint::SuppressedException, :config do
       RUBY
     end
 
+    it 'registers an offense for empty rescue block in `def`' do
+      expect_offense(<<~RUBY)
+        def foo
+          do_something
+        rescue
+        ^^^^^^ Do not suppress exceptions.
+        end
+      RUBY
+    end
+
     it 'registers an offense for empty rescue on single line with a comment after it' do
       expect_offense(<<~RUBY)
         RSpec.describe Dummy do


### PR DESCRIPTION
Fixes #8008.

This PR fixes an error for `Lint/SuppressedException` when empty rescue block in `def`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
