### PR TITLE
[Fix #8012] Fix incorrect autocorrect for `Lint/DeprecatedOpenSSLConstant`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#8008](https://github.com/rubocop-hq/rubocop/issues/8008): Fix an error for `Lint/SuppressedException` when empty rescue block in `def`. ([@koic][])
+* [#8012](https://github.com/rubocop-hq/rubocop/issues/8012): Fix an incorrect autocorrect for `Lint/DeprecatedOpenSSLConstant` when deprecated OpenSSL constant is used in a block. ([@koic][])
 
 ## 0.84.0 (2020-05-21)
 

--- a/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
+++ b/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
@@ -88,9 +88,7 @@ module RuboCop
         end
 
         def correction_range(node)
-          begin_pos = node.loc.selector.column
-          end_pos = node.loc.expression.last_column
-          range_between(begin_pos, end_pos)
+          range_between(node.loc.dot.end_pos, node.loc.expression.end_pos)
         end
 
         def openssl_class(node)

--- a/spec/rubocop/cop/lint/deprecated_open_ssl_constant_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_open_ssl_constant_spec.rb
@@ -88,6 +88,23 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedOpenSSLConstant do
     RUBY
   end
 
+  context 'when used in a block' do
+    it 'registers an offense when using ::Digest class methods on an algorithm constant and corrects' do
+      expect_offense(<<~RUBY)
+        do_something do
+          OpenSSL::Digest::SHA1.new
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `OpenSSL::Digest.new('SHA1')` instead of `OpenSSL::Digest::SHA1.new`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something do
+          OpenSSL::Digest.new('SHA1')
+        end
+      RUBY
+    end
+  end
+
   it 'does not register an offense when building digest using an algorithm string' do
     expect_no_offenses(<<~RUBY)
       OpenSSL::Digest.new('SHA256')


### PR DESCRIPTION
Fixes #8012.

This PR fixes an incorrect autocorrect for `Lint/DeprecatedOpenSSLConstant` when deprecated OpenSSL constant is used in a block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
