### PR TITLE
Fix a false positive for `Lint/SuppressedException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#8008](https://github.com/rubocop-hq/rubocop/issues/8008): Fix an error for `Lint/SuppressedException` when empty rescue block in `def`. ([@koic][])
 * [#8012](https://github.com/rubocop-hq/rubocop/issues/8012): Fix an incorrect autocorrect for `Lint/DeprecatedOpenSSLConstant` when deprecated OpenSSL constant is used in a block. ([@koic][])
+* [#8017](https://github.com/rubocop-hq/rubocop/pull/8017): Fix a false positive for `Lint/SuppressedException` when empty rescue with comment in `def`. ([@koic][])
 
 ## 0.84.0 (2020-05-21)
 

--- a/lib/rubocop/cop/lint/suppressed_exception.rb
+++ b/lib/rubocop/cop/lint/suppressed_exception.rb
@@ -78,7 +78,7 @@ module RuboCop
 
         def comment_between_rescue_and_end?(node)
           end_line = nil
-          node.each_ancestor(:kwbegin) do |ancestor|
+          node.each_ancestor(:kwbegin, :def) do |ancestor|
             end_line = ancestor.loc.end.line
             break
           end

--- a/spec/rubocop/cop/lint/suppressed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/suppressed_exception_spec.rb
@@ -25,6 +25,29 @@ RSpec.describe RuboCop::Cop::Lint::SuppressedException, :config do
         end
       RUBY
     end
+
+    context 'when empty rescue for `def`' do
+      it 'registers an offense for empty rescue without comment' do
+        expect_offense(<<~RUBY)
+          def foo
+            do_something
+          rescue
+          ^^^^^^ Do not suppress exceptions.
+          end
+        RUBY
+      end
+
+      it 'registers an offense for empty rescue with comment' do
+        expect_offense(<<~RUBY)
+          def foo
+            do_something
+          rescue
+          ^^^^^^ Do not suppress exceptions.
+            # do nothing
+          end
+        RUBY
+      end
+    end
   end
 
   context 'with AllowComments set to true' do
@@ -41,14 +64,26 @@ RSpec.describe RuboCop::Cop::Lint::SuppressedException, :config do
       RUBY
     end
 
-    it 'registers an offense for empty rescue block in `def`' do
-      expect_offense(<<~RUBY)
-        def foo
-          do_something
-        rescue
-        ^^^^^^ Do not suppress exceptions.
-        end
-      RUBY
+    context 'when empty rescue for `def`' do
+      it 'registers an offense for empty rescue without comment' do
+        expect_offense(<<~RUBY)
+          def foo
+            do_something
+          rescue
+          ^^^^^^ Do not suppress exceptions.
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for empty rescue with comment' do
+        expect_no_offenses(<<~RUBY)
+          def foo
+            do_something
+          rescue
+            # do nothing
+          end
+        RUBY
+      end
     end
 
     it 'registers an offense for empty rescue on single line with a comment after it' do


### PR DESCRIPTION
This PR fixes a false positive for `Lint/SuppressedException` when empty rescue with comment in `def`.

```console
% cat example.rb
def foo
  do_something
rescue
  # noop
end

% bundle exec rubocop --only Lint/SuppressedException
(snip)

Inspecting 1 file
W

Offenses:

example.rb:3:1: W: Lint/SuppressedException: Do not suppress exceptions.
rescue
^^^^^^

1 file inspected, 1 offense detected
```

The above code should not be warned because `AllowComments: true` by defualt.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
