### PR TITLE
Lazy enlisting

### DIFF
--- a/lib/rubocop/rspec/stub_cop.rb
+++ b/lib/rubocop/rspec/stub_cop.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module RSpec
+    # Mixin for `stub_cop`
+    #
+    # This mixin makes it easier to define cops that don't exist.
+    #
+    # @example Usage
+    #
+    #     before do
+    #       stub_cop('RSpec/AllYourSpecsAreWrong')
+    #       stub_cop('RSpec/AndThatsWhy') do
+    #         def on_block(node)
+    #           add_offense(node)
+    #         end
+    #       end
+    #     end
+    #
+    # NOTE: stubbing real cops is a criminal offence!
+    module StubCop
+      def stub_cop(class_name, &block)
+        cop_class = Class.new(RuboCop::Cop::Cop, &block)
+        cop_class.define_singleton_method(:name) { class_name }
+        # OR
+        # cop_class.instance_eval <<~RUBY, __FILE__, __LINE__ + 1
+        #   def name
+        #     :"#{class_name}
+        #   end
+        # RUBY
+        # if you're afraid of closures or something
+        stub_const(class_name, cop_class)
+      end
+    end
+  end
+end

--- a/lib/rubocop/rspec/support.rb
+++ b/lib/rubocop/rspec/support.rb
@@ -4,10 +4,13 @@
 
 require_relative 'cop_helper'
 require_relative 'host_environment_simulation_helper'
-require_relative 'shared_contexts'
 require_relative 'expect_offense'
+require_relative 'shared_contexts'
+require_relative 'stub_cop'
 
 RSpec.configure do |config|
   config.include CopHelper
+  config.include RuboCop::RSpec::ExpectOffense
+  config.include RuboCop::RSpec::StubCop
   config.include HostEnvironmentSimulatorHelper
 end

--- a/spec/rubocop/cop/registry_spec.rb
+++ b/spec/rubocop/cop/registry_spec.rb
@@ -4,24 +4,8 @@ RSpec.describe RuboCop::Cop::Registry do
   subject(:registry) { described_class.new(cops, options) }
 
   let(:cops) do
-    stub_const('RuboCop::Cop::Test', Module.new)
-    stub_const('RuboCop::Cop::RSpec', Module.new)
-
-    module RuboCop
-      module Cop
-        module Test
-          # Create another cop with a different namespace
-          class FirstArrayElementIndentation < Cop
-          end
-        end
-
-        module RSpec
-          # Define a dummy rspec cop which has special namespace inflection
-          class Foo < Cop
-          end
-        end
-      end
-    end
+    stub_cop('RuboCop::Cop::Test::FirstArrayElementIndentation')
+    stub_cop('RuboCop::Cop::RSpec::Foo')
 
     [
       RuboCop::Cop::Lint::BooleanSymbol,

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -368,11 +368,9 @@ RSpec.describe RuboCop::Cop::Team do
 
     context 'when cop with different checksum joins' do
       before do
-        module Test
-          class CopWithExternalDeps < ::RuboCop::Cop::Cop
-            def external_dependency_checksum
-              'something other than nil'
-            end
+        stub_cop('Test::CopWithExternalDeps') do
+          def external_dependency_checksum
+            'something other than nil'
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,8 +33,6 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = 'spec/examples.txt'
   config.disable_monkey_patching!
 
-  config.include RuboCop::RSpec::ExpectOffense
-
   config.order = :random
   Kernel.srand config.seed
 


### PR DESCRIPTION
There's a problem in specs ...
I wouldn't be surprised if you stopped reading after this point, since it's usually not a worthwhile justification.
But please take a moment and bear with me.

If we define a cop for testing purposes like that:
```ruby
module Dept
  class MyCop < RuboCop::Cop::Cop
    # ...
  end
end
```
you'll end up with a constant littering the root namespace.
https://rspec.rubystyle.guide/#declare-constants
https://fili.pp.ru/leaky-constants.html

It's not a big deal if you pick unique class and namespace each time or are brave enough to deal with potential side effects.

The following is arguably better:
```ruby
klass =
  Class.new(RuboCop::Cop::Cop) do
    def external_dependency_checksum
      'something other than nil'
    end
  end
stub_const('Dept::MyCop', klass)
```

But there's a problem with this approach:

```
  1) RuboCop::Cop::Team#external_dependency_checksum when cop with different checksum joins has a different checksum for the whole team
     Failure/Error: new(*class_name.split('::').last(2))

     NoMethodError:
       undefined method `split' for nil:NilClass
     # ./lib/rubocop/cop/badge.rb:26:in `for'
     # ./lib/rubocop/cop/cop.rb:66:in `badge'
     # ./lib/rubocop/cop/registry.rb:35:in `enlist'
     # ./lib/rubocop/cop/cop.rb:62:in `inherited'
     # ./spec/rubocop/cop/team_spec.rb:372:in `initialize'
     # ./spec/rubocop/cop/team_spec.rb:372:in `new'
     # ./spec/rubocop/cop/team_spec.rb:372:in `block (4 levels) in <top (required)>'
```

Backtrace explains it all, but in a nutshell there's a pesky `def self.included` in `Cop` that enlists the newly defined cop for a department. And to get the department, it needs a name. Which is `nil` for `Class.new`.

Ha! Easy-peasy you think: define a class method `name` on that cop.
Not so easy it turns out:

```ruby
class A
  def self.inherited(base)
    fail 'Ooopsie!' unless base.name
  end
end

class B < A # ok
end

Class.new do # boom!
  def self.name
    'Multipassport!'
  end
end
```

And guess what? `self.inherited` is called **before** the block is evaluated.
`Class.new` to blame you would say!
But it's not. Here's another example for you.

```ruby
class A
  def self.inherited(base)
    fail 'Traitor!' unless base.surname
  end
end

class B < A
  def self.surname
    'Schtirlitz'
  end
end
```

```
NoMethodError: undefined method `surname' for B:Class
```

Srsly? WTH, Ruby? They have to quack, but some of them are real and have to have names and other things!

Ok, if it's not `Class.new` to blame, it's a premature `inherited` hook. What do we do?

Lazy enlist to the rescue!

This started off as https://github.com/rubocop-hq/rubocop/pull/8018#discussion_r429582159

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/