### PR TITLE
Use Regexp/String method #match? instead of #match

### DIFF
--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -124,7 +124,7 @@ module RuboCop
     end
 
     def directive_on_comment_line?(comment)
-      comment.text[1..-1].match(COMMENT_DIRECTIVE_REGEXP)
+      comment.text[1..-1].match?(COMMENT_DIRECTIVE_REGEXP)
     end
 
     def each_directive

--- a/lib/rubocop/cop/correctors/lambda_literal_to_method_corrector.rb
+++ b/lib/rubocop/cop/correctors/lambda_literal_to_method_corrector.rb
@@ -129,7 +129,7 @@ module RuboCop
       end
 
       def separating_space?
-        block_begin.source_buffer.source[block_begin.begin_pos + 2].match(/\s/)
+        block_begin.source_buffer.source[block_begin.begin_pos + 2].match?(/\s/)
       end
     end
   end

--- a/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
+++ b/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
@@ -190,7 +190,7 @@ module RuboCop
         def safe_to_remove_line_containing_closing_paren?(node)
           last_line = processed_source[node.loc.end.line - 1]
           # Safe to remove if last line only contains `)`, `,`, and whitespace.
-          last_line.match(/^[ ]*\)[ ]{0,20},{0,1}[ ]*$/)
+          last_line.match?(/^[ ]*\)[ ]{0,20},{0,1}[ ]*$/)
         end
 
         def incorrect_parenthesis_removal_end(node)

--- a/lib/rubocop/cop/lint/nested_percent_literal.rb
+++ b/lib/rubocop/cop/lint/nested_percent_literal.rb
@@ -42,7 +42,7 @@ module RuboCop
         def contains_percent_literals?(node)
           node.each_child_node.any? do |child|
             literal = child.children.first.to_s.scrub
-            REGEXES.any? { |regex| literal.match(regex) }
+            REGEXES.any? { |regex| literal.match?(regex) }
           end
         end
       end

--- a/lib/rubocop/cop/migration/department_name.rb
+++ b/lib/rubocop/cop/migration/department_name.rb
@@ -64,8 +64,8 @@ module RuboCop
         end
 
         def valid_content_token?(content_token)
-          !/\W+/.match(content_token).nil? ||
-            !DISABLING_COPS_CONTENT_TOKEN.match(content_token).nil?
+          /\W+/.match?(content_token) ||
+            DISABLING_COPS_CONTENT_TOKEN.match?(content_token)
         end
 
         def contain_unexpected_character_for_department_name?(name)

--- a/lib/rubocop/cop/mixin/configurable_formatting.rb
+++ b/lib/rubocop/cop/mixin/configurable_formatting.rb
@@ -23,7 +23,7 @@ module RuboCop
       end
 
       def valid_name?(node, name, given_style = style)
-        name.match(self.class::FORMATS.fetch(given_style)) ||
+        name.match?(self.class::FORMATS.fetch(given_style)) ||
           class_emitter_method?(node, name)
       end
 

--- a/lib/rubocop/cop/mixin/ignored_pattern.rb
+++ b/lib/rubocop/cop/mixin/ignored_pattern.rb
@@ -18,7 +18,7 @@ module RuboCop
       end
 
       def matches_ignored_pattern?(line)
-        ignored_patterns.any? { |pattern| Regexp.new(pattern).match(line) }
+        ignored_patterns.any? { |pattern| Regexp.new(pattern).match?(line) }
       end
 
       def ignored_patterns

--- a/lib/rubocop/cop/mixin/line_length_help.rb
+++ b/lib/rubocop/cop/mixin/line_length_help.rb
@@ -18,7 +18,7 @@ module RuboCop
 
         return false unless comment
 
-        comment.text.match(CommentConfig::COMMENT_DIRECTIVE_REGEXP)
+        comment.text.match?(CommentConfig::COMMENT_DIRECTIVE_REGEXP)
       end
 
       def allow_uri?

--- a/lib/rubocop/cop/naming/predicate_name.rb
+++ b/lib/rubocop/cop/naming/predicate_name.rb
@@ -67,7 +67,7 @@ module RuboCop
         private
 
         def allowed_method_name?(method_name, prefix)
-          !method_name.match(/^#{prefix}[^0-9]/) ||
+          !method_name.match?(/^#{prefix}[^0-9]/) ||
             method_name == expected_name(method_name, prefix) ||
             method_name.end_with?('=') ||
             allowed_methods.include?(method_name)

--- a/lib/rubocop/cop/style/inline_comment.rb
+++ b/lib/rubocop/cop/style/inline_comment.rb
@@ -23,7 +23,7 @@ module RuboCop
         def investigate(processed_source)
           processed_source.each_comment do |comment|
             next if comment_line?(processed_source[comment.loc.line - 1]) ||
-                    comment.text.match(/\A# rubocop:(enable|disable)/)
+                    comment.text.match?(/\A# rubocop:(enable|disable)/)
 
             add_offense(comment)
           end


### PR DESCRIPTION
Minor performance optimization.

Replaced calls of `#match` method with `#match?` for `String`/`Regexp` classes in boolean context when matching details like captured substrings are ignored e.g.

```ruby
REGEXES.any? { |regex| literal.match(regex) }
```
becomes

```ruby
REGEXES.any? { |regex| literal.match?(regex) }
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
