### PR TITLE
[Fix #8005] Always inspect anonymous sources

### DIFF
--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -211,8 +211,9 @@ module RuboCop
       alias name cop_name
 
       def relevant_file?(file)
-        file_name_matches_any?(file, 'Include', true) &&
-          !file_name_matches_any?(file, 'Exclude', false)
+        file == RuboCop::AST::ProcessedSource::STRING_SOURCE_NAME ||
+          file_name_matches_any?(file, 'Include', true) &&
+            !file_name_matches_any?(file, 'Exclude', false)
       end
 
       def excluded_file?(file)

--- a/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
+++ b/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RuboCop::Cop::Bundler::DuplicatedGem, :config do
 
   context 'when investigating Ruby files' do
     it 'does not register any offenses' do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~RUBY, 'foo.rb')
         # cop will not read these contents
         gem('rubocop')
         gem('rubocop')

--- a/spec/rubocop/cop/bundler/gem_comment_spec.rb
+++ b/spec/rubocop/cop/bundler/gem_comment_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Cop::Bundler::GemComment, :config do
 
   context 'when investigating Ruby files' do
     it 'does not register any offenses' do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~RUBY, 'foo.rb')
         gem('rubocop')
       RUBY
     end

--- a/spec/rubocop/cop/bundler/insecure_protocol_source_spec.rb
+++ b/spec/rubocop/cop/bundler/insecure_protocol_source_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Bundler::InsecureProtocolSource do
-  subject(:cop) { described_class.new(config) }
-
-  let(:config) { RuboCop::Config.new }
-
+RSpec.describe RuboCop::Cop::Bundler::InsecureProtocolSource, :config do
   it 'registers an offense when using `source :gemcutter`' do
     expect_offense(<<~RUBY)
       source :gemcutter

--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -3,8 +3,7 @@
 RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
   let(:cop_config) do
     {
-      'TreatCommentsAsGroupSeparators' => treat_comments_as_group_separators,
-      'Include' => nil
+      'TreatCommentsAsGroupSeparators' => treat_comments_as_group_separators
     }
   end
   let(:treat_comments_as_group_separators) { false }

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -304,6 +304,30 @@ RSpec.describe RuboCop::Cop::Cop, :config do
     end
   end
 
+  describe '#relevant_file?' do
+    subject { cop.relevant_file?(file) }
+
+    let(:cop_config) { { 'Include' => ['foo.rb'] } }
+
+    context 'when the file matches the Include configuration' do
+      let(:file) { 'foo.rb' }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when the file doesn\'t match the Include configuration' do
+      let(:file) { 'bar.rb' }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when the file is an anonymous source' do
+      let(:file) { '(string)' }
+
+      it { is_expected.to be(true) }
+    end
+  end
+
   describe '#safe_autocorrect?' do
     subject { cop.safe_autocorrect? }
 

--- a/spec/rubocop/cop/gemspec/duplicated_assignment_spec.rb
+++ b/spec/rubocop/cop/gemspec/duplicated_assignment_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Gemspec::DuplicatedAssignment do
-  subject(:cop) { described_class.new(config) }
-
-  let(:config) { RuboCop::Config.new }
-
+RSpec.describe RuboCop::Cop::Gemspec::DuplicatedAssignment, :config do
   it 'registers an offense when using `name=` twice' do
     expect_offense(<<~RUBY)
       Gem::Specification.new do |spec|

--- a/spec/rubocop/cop/gemspec/ordered_dependencies_spec.rb
+++ b/spec/rubocop/cop/gemspec/ordered_dependencies_spec.rb
@@ -3,8 +3,7 @@
 RSpec.describe RuboCop::Cop::Gemspec::OrderedDependencies, :config do
   let(:cop_config) do
     {
-      'TreatCommentsAsGroupSeparators' => treat_comments_as_group_separators,
-      'Include' => nil
+      'TreatCommentsAsGroupSeparators' => treat_comments_as_group_separators
     }
   end
   let(:treat_comments_as_group_separators) { false }

--- a/spec/rubocop/cop/gemspec/ruby_version_globals_usage_spec.rb
+++ b/spec/rubocop/cop/gemspec/ruby_version_globals_usage_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::Gemspec::RubyVersionGlobalsUsage, :config do
   it 'registers an offense when using `RUBY_VERSION`' do
-    expect_offense(<<~RUBY, '/path/to/foo.gemspec')
+    expect_offense(<<~RUBY)
       Gem::Specification.new do |spec|
         RUBY_VERSION
         ^^^^^^^^^^^^ Do not use `RUBY_VERSION` in gemspec file.

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -616,7 +616,7 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
     end
 
     it 'processes excluded files with issue' do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~RUBY, 'foo.rb')
         begin
           foo
         rescue

--- a/spec/rubocop/cop/style/rescue_modifier_spec.rb
+++ b/spec/rubocop/cop/style/rescue_modifier_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe RuboCop::Cop::Style::RescueModifier do
     end
 
     it 'processes excluded files with issue' do
-      expect_no_offenses('foo rescue bar')
+      expect_no_offenses('foo rescue bar', 'foo.rb')
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/rubocop-hq/rubocop/issues/8005.

When using the `expect_offense` and `expect_no_offenses` spec helpers, the processed source is given the special filename "(string)", unless a mock filename is passed as its second argument.

Since https://github.com/rubocop-hq/rubocop/pull/7970, the default configuration for the cop under test is loaded when using the `config` shared context. If this configuration features an `Include` key, `expect_offense` won't work unless a matching mock filename is specified.

Instead of forcing specs for cops with a default `Include` configuration to do that, I think we can always inspect anonymous sources.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
