### PR TITLE
Better separation of concerns between Team and Commissioner

### DIFF
--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -36,7 +36,6 @@ module RuboCop
 
       def investigate(processed_source)
         reset_errors
-        remove_irrelevant_cops(processed_source.file_path)
         reset_callbacks
         prepare(processed_source)
         invoke_custom_processing(@cops, processed_source)
@@ -61,26 +60,6 @@ module RuboCop
 
       def reset_errors
         @errors = []
-      end
-
-      def remove_irrelevant_cops(filename)
-        @cops.reject! do |cop|
-          cop.excluded_file?(filename) ||
-            !support_target_ruby_version?(cop) ||
-            !support_target_rails_version?(cop)
-        end
-      end
-
-      def support_target_ruby_version?(cop)
-        return true unless cop.class.respond_to?(:support_target_ruby_version?)
-
-        cop.class.support_target_ruby_version?(cop.target_ruby_version)
-      end
-
-      def support_target_rails_version?(cop)
-        return true unless cop.class.respond_to?(:support_target_rails_version?)
-
-        cop.class.support_target_rails_version?(cop.target_rails_version)
       end
 
       def reset_callbacks

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -102,21 +102,21 @@ module RuboCop
 
       private
 
-      def offenses(processed_source)
+      def offenses(processed_source) # rubocop:disable Metrics/AbcSize
         # The autocorrection process may have to be repeated multiple times
         # until there are no corrections left to perform
         # To speed things up, run auto-correcting cops by themselves, and only
         # run the other cops when no corrections are left
         autocorrect_cops, other_cops = cops.partition(&:autocorrect?)
 
-        autocorrect =
-          investigate(autocorrect_cops, processed_source) do |offenses|
-            # We corrected some errors. Another round of inspection will be
-            # done, and any other offenses will be caught then, so we don't
-            # need to continue.
-            return offenses if autocorrect(processed_source.buffer,
-                                           autocorrect_cops)
-          end
+        autocorrect = investigate(autocorrect_cops, processed_source)
+
+        if autocorrect(processed_source.buffer, autocorrect_cops)
+          # We corrected some errors. Another round of inspection will be
+          # done, and any other offenses will be caught then, so we don't
+          # need to continue.
+          return autocorrect.offenses
+        end
 
         other = investigate(other_cops, processed_source)
 
@@ -131,7 +131,6 @@ module RuboCop
 
         commissioner = Commissioner.new(cops, forces_for(cops), @options)
         offenses = commissioner.investigate(processed_source)
-        yield offenses if block_given?
 
         Investigation.new(offenses, commissioner.errors)
       end

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -129,7 +129,7 @@ module RuboCop
       def investigate(cops, processed_source)
         return Investigation.new([], {}) if cops.empty?
 
-        commissioner = Commissioner.new(cops, forces_for(cops))
+        commissioner = Commissioner.new(cops, forces_for(cops), @options)
         offenses = commissioner.investigate(processed_source)
         yield offenses if block_given?
 

--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -64,16 +64,8 @@ module CopHelper
   end
 
   def _investigate(cop, processed_source)
-    forces = RuboCop::Cop::Force.all.each_with_object([]) do |klass, instances|
-      next unless cop.join_force?(klass)
-
-      instances << klass.new([cop])
-    end
-
-    commissioner =
-      RuboCop::Cop::Commissioner.new([cop], forces, raise_error: true)
-    commissioner.investigate(processed_source)
-    commissioner
+    team = RuboCop::Cop::Team.new([cop], nil, raise_error: true)
+    team.inspect_file(processed_source)
   end
 end
 

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -183,7 +183,7 @@ module RuboCop
     def autocorrect_redundant_disables(file, source, cop, offenses)
       cop.processed_source = source
 
-      team = Cop::Team.new(RuboCop::Cop::Registry.new, nil, @options)
+      team = Cop::Team.mobilize(RuboCop::Cop::Registry.new, nil, @options)
       team.autocorrect(source.buffer, [cop])
 
       return [] unless team.updated_source_file?
@@ -295,7 +295,7 @@ module RuboCop
 
     def inspect_file(processed_source)
       config = @config_store.for(processed_source.path)
-      team = Cop::Team.new(mobilized_cop_classes(config), config, @options)
+      team = Cop::Team.mobilize(mobilized_cop_classes(config), config, @options)
       offenses = team.inspect_file(processed_source)
       @errors.concat(team.errors)
       @warnings.concat(team.warnings)
@@ -380,7 +380,7 @@ module RuboCop
     def standby_team(config)
       @team_by_config ||= {}
       @team_by_config[config.object_id] ||=
-        Cop::Team.new(mobilized_cop_classes(config), config, @options)
+        Cop::Team.mobilize(mobilized_cop_classes(config), config, @options)
     end
   end
 end

--- a/spec/rubocop/cop/commissioner_spec.rb
+++ b/spec/rubocop/cop/commissioner_spec.rb
@@ -20,24 +20,6 @@ RSpec.describe RuboCop::Cop::Commissioner do
       expect(commissioner.investigate(processed_source)).to eq [1]
     end
 
-    context 'when a cop has no interest in the file' do
-      it 'returns all offenses except the ones of the cop' do
-        cops = []
-        cops << instance_double(RuboCop::Cop::Cop, offenses: %w[foo],
-                                                   excluded_file?: false)
-        cops << instance_double(RuboCop::Cop::Cop, excluded_file?: true)
-        cops << instance_double(RuboCop::Cop::Cop, offenses: %w[baz],
-                                                   excluded_file?: false)
-        cops.each(&:as_null_object)
-
-        commissioner = described_class.new(cops, [])
-        source = ''
-        processed_source = parse_source(source)
-
-        expect(commissioner.investigate(processed_source)).to eq %w[foo baz]
-      end
-    end
-
     it 'traverses the AST and invoke cops specific callbacks' do
       expect(cop).to receive(:on_def).once
 

--- a/spec/rubocop/cop/layout/leading_empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/leading_empty_lines_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe RuboCop::Cop::Layout::LeadingEmptyLines, :config do
         RUBY
 
         options = { auto_correct: true, stdin: true }
-        team = RuboCop::Cop::Team.new(cops, config, options)
+        team = RuboCop::Cop::Team.mobilize(cops, config, options)
         team.inspect_file(parse_source(source_with_offenses, nil))
         new_source = options[:stdin]
 

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -122,6 +122,16 @@ RSpec.describe RuboCop::Cop::Team do
       it 'returns offenses from cops' do
         expect(cop_names).to include('Layout/LineLength')
       end
+
+      context 'when a cop has no interest in the file' do
+        it 'returns all offenses except the ones of the cop' do
+          allow_any_instance_of(RuboCop::Cop::Layout::LineLength)
+            .to receive(:excluded_file?).and_return(true)
+
+          expect(cop_names).to include('Lint/AmbiguousOperator')
+          expect(cop_names).not_to include('Layout/LineLength')
+        end
+      end
     end
 
     context 'when autocorrection is enabled' do

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Team do
-  subject(:team) { described_class.new(cop_classes, config, options) }
+  subject(:team) { described_class.mobilize(cop_classes, config, options) }
 
   let(:cop_classes) { RuboCop::Cop::Cop.registry }
   let(:config) { RuboCop::ConfigLoader.default_configuration }
@@ -389,7 +389,7 @@ RSpec.describe RuboCop::Cop::Team do
 
       it 'has a different checksum for the whole team' do
         original_checksum = team.external_dependency_checksum
-        new_team = described_class.new(new_cop_classes, config, options)
+        new_team = described_class.mobilize(new_cop_classes, config, options)
         new_checksum = new_team.external_dependency_checksum
         expect(original_checksum).not_to eq(new_checksum)
       end

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
   let(:cops) { RuboCop::Cop::Cop.all }
   let(:registry) { RuboCop::Cop::Cop.registry }
   let(:team) do
-    RuboCop::Cop::Team.new(
+    RuboCop::Cop::Team.mobilize(
       registry,
       RuboCop::ConfigLoader.default_configuration,
       options


### PR DESCRIPTION
Excluding non-relevant cops is a duty of `Team`, not `Commissioner`.

Before this PR:
* a second call to `Commissioner#investigate` could be missing a cop that was excluded previously
* a force might be added by Team for a single cop that is later judged to be non relevant by a `Commissioner` but the later can't exclude the force now
* cops judged not relevant by the `Commissioner` were still looped through (e.g. in `autocorrect_all_cops`)

PR also includes some code cleanup. This is a prelude to #7968