### PR TITLE
[Fix #8027] Avoid avoidable `File.directory?` in RuboCop::ConfigStore

### DIFF
--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -75,7 +75,7 @@ module RuboCop
 
     def validate_options_vs_config
       if @options[:parallel] &&
-         !@config_store.for(Dir.pwd).for_all_cops['UseCache']
+         !@config_store.for_dir(Dir.pwd).for_all_cops['UseCache']
         raise OptionArgumentError, '-P/--parallel uses caching to speed up ' \
                                    'execution, so combining with AllCops: ' \
                                    'UseCache: false is not allowed.'
@@ -123,7 +123,7 @@ module RuboCop
         if @options[:auto_gen_config]
           formatter = 'autogenconf'
         else
-          cfg = @config_store.for(Dir.pwd).for_all_cops
+          cfg = @config_store.for_dir(Dir.pwd).for_all_cops
           formatter = cfg['DefaultFormatter'] || 'progress'
         end
         [[formatter, @options[:output_path]]]

--- a/lib/rubocop/cli/command/auto_genenerate_config.rb
+++ b/lib/rubocop/cli/command/auto_genenerate_config.rb
@@ -25,10 +25,10 @@ module RuboCop
         private
 
         def maybe_run_line_length_cop
-          if !line_length_enabled?(@config_store.for(Dir.pwd))
+          if !line_length_enabled?(@config_store.for_dir(Dir.pwd))
             skip_line_length_cop(PHASE_1_DISABLED)
           elsif !same_max_line_length?(
-            @config_store.for(Dir.pwd), ConfigLoader.default_configuration
+            @config_store.for_dir(Dir.pwd), ConfigLoader.default_configuration
           )
             skip_line_length_cop(PHASE_1_OVERRIDDEN)
           else

--- a/lib/rubocop/config_store.rb
+++ b/lib/rubocop/config_store.rb
@@ -29,14 +29,24 @@ module RuboCop
       @options_config = ConfigLoader.default_configuration
     end
 
-    def for(file_or_dir)
-      return @options_config if @options_config
+    def for_file(file)
+      for_dir(File.dirname(file))
+    end
 
+    # If type (file/dir) is known beforehand,
+    # prefer using #for_file or #for_dir for improved performance
+    def for(file_or_dir)
       dir = if File.directory?(file_or_dir)
               file_or_dir
             else
               File.dirname(file_or_dir)
             end
+      for_dir(dir)
+    end
+
+    def for_dir(dir)
+      return @options_config if @options_config
+
       @path_cache[dir] ||= ConfigLoader.configuration_file_for(dir)
       path = @path_cache[dir]
       @object_cache[path] ||= begin

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -33,7 +33,7 @@ module RuboCop
 
       def requires_file_removal?(file_count, config_store)
         file_count > 1 &&
-          file_count > config_store.for('.').for_all_cops['MaxFilesInCache']
+          file_count > config_store.for_dir('.').for_all_cops['MaxFilesInCache']
       end
 
       def remove_oldest_files(files, dirs, cache_root, verbose)
@@ -60,7 +60,7 @@ module RuboCop
     end
 
     def self.cache_root(config_store)
-      root = config_store.for('.').for_all_cops['CacheRootDirectory']
+      root = config_store.for_dir('.').for_all_cops['CacheRootDirectory']
       root ||= if ENV.key?('XDG_CACHE_HOME')
                  # Include user ID in the path to make sure the user has write
                  # access.
@@ -72,7 +72,7 @@ module RuboCop
     end
 
     def self.allow_symlinks_in_cache_location?(config_store)
-      config_store.for('.').for_all_cops['AllowSymlinksInCacheRootDirectory']
+      config_store.for_dir('.').for_all_cops['AllowSymlinksInCacheRootDirectory']
     end
 
     def initialize(file, team, options, config_store, cache_root = nil)
@@ -143,7 +143,7 @@ module RuboCop
       digester = Digest::SHA1.new
       mode = File.stat(file).mode
       digester.update(
-        "#{file}#{mode}#{config_store.for(file).signature}"
+        "#{file}#{mode}#{config_store.for_file(file).signature}"
       )
       digester.file(file)
       digester.hexdigest

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -129,7 +129,7 @@ module RuboCop
     end
 
     def file_offense_cache(file)
-      config = @config_store.for(file)
+      config = @config_store.for_file(file)
       cache = cached_result(file, standby_team(config)) if cached_run?
 
       if cache&.valid?
@@ -168,7 +168,7 @@ module RuboCop
     end
 
     def redundant_cop_disable_directive(file)
-      config = @config_store.for(file)
+      config = @config_store.for_file(file)
       if config.for_cop(Cop::Lint::RedundantCopDisableDirective)
                .fetch('Enabled')
         cop = Cop::Lint::RedundantCopDisableDirective.new(config, @options)
@@ -214,7 +214,7 @@ module RuboCop
       @cached_run ||=
         (@options[:cache] == 'true' ||
          @options[:cache] != 'false' &&
-         @config_store.for(Dir.pwd).for_all_cops['UseCache']) &&
+         @config_store.for_dir(Dir.pwd).for_all_cops['UseCache']) &&
         # When running --auto-gen-config, there's some processing done in the
         # cops related to calculating the Max parameters for Metrics cops. We
         # need to do that processing and cannot use caching.
@@ -294,7 +294,7 @@ module RuboCop
     end
 
     def inspect_file(processed_source)
-      config = @config_store.for(processed_source.path)
+      config = @config_store.for_file(processed_source.path)
       team = Cop::Team.mobilize(mobilized_cop_classes(config), config, @options)
       offenses = team.inspect_file(processed_source)
       @errors.concat(team.errors)
@@ -360,7 +360,7 @@ module RuboCop
     end
 
     def get_processed_source(file)
-      ruby_version = @config_store.for(file).target_ruby_version
+      ruby_version = @config_store.for_file(file).target_ruby_version
 
       if @options[:stdin]
         ProcessedSource.new(@options[:stdin], ruby_version, file)

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
   let(:file) { 'example.rb' }
   let(:options) { {} }
   let(:config_store) do
-    instance_double(RuboCop::ConfigStore, for: RuboCop::Config.new)
+    instance_double(RuboCop::ConfigStore, for_dir: RuboCop::Config.new)
   end
   let(:cache_root) { "#{Dir.pwd}/rubocop_cache" }
   let(:offenses) do
@@ -42,8 +42,8 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
       # Hello
       x = 1
     RUBY
-    allow(config_store).to receive(:for).with('example.rb')
-                                        .and_return(RuboCop::Config.new)
+    allow(config_store).to receive(:for_file).with('example.rb')
+                                             .and_return(RuboCop::Config.new)
     allow(team).to receive(:external_dependency_checksum).and_return('foo')
   end
 
@@ -192,7 +192,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
 
         context 'and symlink attack protection is disabled' do
           before do
-            allow(config_store).to receive(:for).with('.').and_return(
+            allow(config_store).to receive(:for_dir).with('.').and_return(
               RuboCop::Config.new(
                 'AllCops' => {
                   'AllowSymlinksInCacheRootDirectory' => true
@@ -302,8 +302,8 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
   describe '.cleanup' do
     before do
       cfg = RuboCop::Config.new('AllCops' => { 'MaxFilesInCache' => 1 })
-      allow(config_store).to receive(:for).with('.').and_return(cfg)
-      allow(config_store).to receive(:for).with('other.rb').and_return(cfg)
+      allow(config_store).to receive(:for_dir).with('.').and_return(cfg)
+      allow(config_store).to receive(:for_file).with('other.rb').and_return(cfg)
       create_file('other.rb', ['x = 1'])
       $stdout = StringIO.new
     end
@@ -341,7 +341,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
         'AllCops' => { 'CacheRootDirectory' => cache_root_directory }
       }
       config = RuboCop::Config.new(all_cops)
-      allow(config_store).to receive(:for).with('.').and_return(config)
+      allow(config_store).to receive(:for_dir).with('.').and_return(config)
     end
 
     context 'when CacheRootDirectory not set' do


### PR DESCRIPTION
Closes #8027 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/