### PR TITLE
[Fix #8035] Fix a false positive for `Lint/DeprecatedOpenSSLConstant`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#8012](https://github.com/rubocop-hq/rubocop/issues/8012): Fix an incorrect autocorrect for `Lint/DeprecatedOpenSSLConstant` when deprecated OpenSSL constant is used in a block. ([@koic][])
 * [#8017](https://github.com/rubocop-hq/rubocop/pull/8017): Fix a false positive for `Lint/SuppressedException` when empty rescue with comment in `def`. ([@koic][])
 * [#7990](https://github.com/rubocop-hq/rubocop/issues/7990): Fix resolving `inherit_gem` in remote configs. ([@CvX][])
+* [#8035](https://github.com/rubocop-hq/rubocop/issues/8035): Fix the following false positive for `Lint/DeprecatedOpenSSLConstant` when using double quoted string argument. ([@koic][])
 
 ## 0.84.0 (2020-05-21)
 

--- a/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
+++ b/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
@@ -106,7 +106,11 @@ module RuboCop
         end
 
         def sanitize_arguments(arguments)
-          arguments.flat_map { |arg| arg.source.tr(":'", '').split('-') }
+          arguments.flat_map do |arg|
+            argument = arg.str_type? ? arg.value : arg.source
+
+            argument.tr(":'", '').split('-')
+          end
         end
 
         def replacement_args(node)

--- a/spec/rubocop/cop/lint/deprecated_open_ssl_constant_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_open_ssl_constant_spec.rb
@@ -27,6 +27,17 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedOpenSSLConstant do
     RUBY
   end
 
+  it 'registers an offense with cipher constant and double quoted string argument and corrects' do
+    expect_offense(<<~RUBY)
+      OpenSSL::Cipher::AES128.new("GCM")
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `OpenSSL::Cipher.new('AES-128-GCM')` instead of `OpenSSL::Cipher::AES128.new("GCM")`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      OpenSSL::Cipher.new('AES-128-GCM')
+    RUBY
+  end
+
   it 'registers an offense with AES + blocksize constant and mode argument and corrects' do
     expect_offense(<<~RUBY)
       OpenSSL::Cipher::AES128.new(:GCM)


### PR DESCRIPTION
Fixes #8035.

This PR fixes the following false positive for `Lint/DeprecatedOpenSSLConstant` when using double quoted string argument.

```console
% cat example.rb
OpenSSL::Cipher::AES256.new('cbc')
OpenSSL::Cipher::AES256.new("cbc")

% bundle exec rubocop --only Lint/DeprecatedOpenSSLConstant -a
(snip)

Offenses:

example.rb:1:1: W: [Corrected] Lint/DeprecatedOpenSSLConstant: Use
OpenSSL::Cipher.new('AES-256-cbc') instead of OpenSSL::Cipher::AES256.new('cbc').
OpenSSL::Cipher::AES256.new('cbc')
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
example.rb:2:1: W: [Corrected] Lint/DeprecatedOpenSSLConstant: Use
OpenSSL::Cipher.new('AES-256-"cbc"') instead of OpenSSL::Cipher::AES256.new("cbc").
OpenSSL::Cipher::AES256.new("cbc")
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

% cat example.rb
OpenSSL::Cipher.new('AES-256-cbc')
OpenSSL::Cipher.new('AES-256-"cbc"')
```

#8035 has another different false positive, which resolves as another PR.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
