### PR TITLE
Fix false positives for Lint/ParenthesesAsGroupedExpression 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug fixes
 
+* [#8039](https://github.com/rubocop-hq/rubocop/pull/8039): Fix false positives for `Lint/ParenthesesAsGroupedExpression` in when using operators or chain functions. ([@CamilleDrapier][])
 * [#8196](https://github.com/rubocop-hq/rubocop/issues/8196): Fix a false positive for `Style/RedundantFetchBlock` when using with `Rails.cache`. ([@fatkodima][])
 * [#8195](https://github.com/rubocop-hq/rubocop/issues/8195): Fix an error for `Style/RedundantFetchBlock` when using `#fetch` with empty block. ([@koic][])
 * [#8193](https://github.com/rubocop-hq/rubocop/issues/8193): Fix a false positive for `Style/RedundantRegexpCharacterClass` when using `[\b]`. ([@owst][])
@@ -4633,3 +4634,4 @@
 [@mauro-oto]: https://github.com/mauro-oto
 [@fatkodima]: https://github.com/fatkodima
 [@karlwithak]: https://github.com/karlwithak
+[@CamilleDrapier]: https://github.com/CamilleDrapier

--- a/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
+++ b/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
@@ -48,17 +48,22 @@ module RuboCop
             return true
           end
 
-          node.operator_method? || node.setter_method? || grouped_parentheses?(node)
+          node.operator_method? || node.setter_method? || chained_calls?(node) ||
+            operator_keyword?(node)
         end
 
         def first_argument_starts_with_left_parenthesis?(node)
           node.first_argument.source.start_with?('(')
         end
 
-        def grouped_parentheses?(node)
+        def chained_calls?(node)
           first_argument = node.first_argument
+          first_argument.send_type? && (node.children.last&.children&.count || 0) > 1
+        end
 
-          first_argument.send_type? && first_argument.receiver&.begin_type?
+        def operator_keyword?(node)
+          first_argument = node.first_argument
+          first_argument.operator_keyword?
         end
 
         def spaces_before_left_parenthesis(node)

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression do
     RUBY
   end
 
+  it 'does not register an offense for expression followed by an operator' do
+    expect_no_offenses(<<~RUBY)
+      func (x) || y
+    RUBY
+  end
+
+  it 'does not register an offense for expression followed by chained expression' do
+    expect_no_offenses(<<~RUBY)
+      func (x).func.func.func.func.func
+    RUBY
+  end
+
   it 'does not register an offense for math expression' do
     expect_no_offenses(<<~RUBY)
       puts (2 + 3) * 4


### PR DESCRIPTION
This PR fixes the following false positive for `Lint/ParenthesesAsGroupedExpression`

- when an expression is followed by an operator

```ruby
func (x) || y
```

- when an expression is followed by a chain of functions

```ruby
func (x).func.func.func.func.func
```

This PR adds some reproduction tests.

-----------------

I was initially thinking of changing the auto-correct to produce things such as `func((x) || y)` and `func((x).func.func.func.func.func)`, but since we probably do not want `eq (x).to_i` to become suddenly `eq((x).to_i)` (https://github.com/rubocop-hq/rubocop/pull/7909), I went with ignoring these pasterns. This is because the current auto-correct behavior breaks the code for these pasterns. Please do tell me if we would prefer going in another direction 🙏 

I'm not very comfortable with these language nodes, so please treat this PR as an humble attempt 🙏 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
