### PR TITLE
[Fix #8035] Fix a false positive for `Lint/DeprecatedOpenSSLConstant`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#8017](https://github.com/rubocop-hq/rubocop/pull/8017): Fix a false positive for `Lint/SuppressedException` when empty rescue with comment in `def`. ([@koic][])
 * [#7990](https://github.com/rubocop-hq/rubocop/issues/7990): Fix resolving `inherit_gem` in remote configs. ([@CvX][])
 * [#8035](https://github.com/rubocop-hq/rubocop/issues/8035): Fix a false positive for `Lint/DeprecatedOpenSSLConstant` when using double quoted string argument. ([@koic][])
+* [#8035](https://github.com/rubocop-hq/rubocop/issues/8035): Fix a false positive for `Lint/DeprecatedOpenSSLConstant` when argument is a variable, method, or consntant. ([@koic][])
 
 ## 0.84.0 (2020-05-21)
 

--- a/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
+++ b/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
@@ -53,6 +53,8 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          return if node.arguments.any? { |arg| arg.variable? || arg.send_type? || arg.const_type? }
+
           add_offense(node) if algorithm_const(node)
         end
 

--- a/spec/rubocop/cop/lint/deprecated_open_ssl_constant_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_open_ssl_constant_spec.rb
@@ -66,6 +66,25 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedOpenSSLConstant do
     RUBY
   end
 
+  it 'does not register an offense with cipher constant and argument is a variable' do
+    expect_no_offenses(<<~RUBY)
+      mode = "cbc"
+      OpenSSL::Cipher::AES128.new(mode)
+    RUBY
+  end
+
+  it 'does not register an offense with cipher constant and send argument is a method' do
+    expect_no_offenses(<<~RUBY)
+      OpenSSL::Cipher::AES128.new(do_something)
+    RUBY
+  end
+
+  it 'does not register an offense with cipher constant and argument is a constant' do
+    expect_no_offenses(<<~RUBY)
+      OpenSSL::Cipher::AES128.new(MODE)
+    RUBY
+  end
+
   it 'registers an offense when building an instance using an digest constant and corrects' do
     expect_offense(<<~RUBY)
       OpenSSL::Digest::SHA256.new


### PR DESCRIPTION
Fixes #8035.

This PR fixes a false positive for `Lint/DeprecatedOpenSSLConstant` when argument is a variable, method, or constant.

```console
% cat example.rb
MODE = 'cbc'
OpenSSL::Cipher::AES256.new(MODE)

% bundle exec rubocop --only Lint/DeprecatedOpenSSLConstant -a
(snip)

Offenses:

example.rb:2:1: W: [Corrected] Lint/DeprecatedOpenSSLConstant: Use
OpenSSL::Cipher.new('AES-256-MODE') instead of OpenSSL::Cipher::AES256.new(MODE).
OpenSSL::Cipher::AES256.new(MODE)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected

% cat example.rb
MODE = 'cbc'
OpenSSL::Cipher.new('AES-256-MODE')
```

RuboCop does not have a tracing feature a value of variable, (method,) and constant yet.
This PR accepts cases where these values are used to prevent auto-correction mistakes.

On the other hand, this change produces false negatives for the deprecated APIs.
If it is difficult to accept false negatives, I will update this PR to warn against these cases and auto-correction will not performed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
