### PR TITLE
Fix Lint::FormatParameterMismatch cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#8081](https://github.com/rubocop-hq/rubocop/issues/8081): Fix a false positive for `Lint/SuppressedException` when empty rescue block in `do` block. ([@koic][])
 * [#8096](https://github.com/rubocop-hq/rubocop/issues/8096): Fix a false positive for `Lint/SuppressedException` when empty rescue block in defs. ([@koic][])
 * [#8108](https://github.com/rubocop-hq/rubocop/issues/8108): Fix infinite loop in `Layout/HeredocIndentation` auto-correct. ([@jonas054][])
+* [#8042](https://github.com/rubocop-hq/rubocop/pull/8042): Fix raising error in `Lint::FormatParameterMismatch` when it handles invalid format strings and add new offense. ([@andrykonchin][])
 
 ## 0.85.0 (2020-06-01)
 
@@ -4571,3 +4572,4 @@
 [@jschneid]: https://github.com/jschneid
 [@ric2b]: https://github.com/ric2b
 [@burnettk]: https://github.com/burnettk
+[@andrykonchin]: https://github.com/andrykonchin

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -1100,6 +1100,10 @@ This lint sees if there is a mismatch between the number of
 expected fields for format/sprintf/#% and what is actually
 passed as arguments.
 
+In addition it checks whether different formats are used in the same
+format string. Do not mix numbered, unnumbered, and named formats in
+the same format string.
+
 === Examples
 
 [source,ruby]
@@ -1114,6 +1118,20 @@ format('A value: %s and another: %i', a_value)
 # good
 
 format('A value: %s and another: %i', a_value, another)
+----
+
+[source,ruby]
+----
+# bad
+
+format('Unnumbered format: %s and numbered: %2$s', a_value, another)
+----
+
+[source,ruby]
+----
+# good
+
+format('Numbered format: %1$s and numbered %2$s', a_value, another)
 ----
 
 == Lint/HeredocMethodCallPosition

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -43,6 +43,7 @@ module RuboCop
           num_of_format_args, num_of_expected_fields = count_matches(node)
 
           return false if num_of_format_args == :unknown
+          return false if num_of_expected_fields == :unknown
 
           matched_arguments_count?(num_of_expected_fields, num_of_format_args)
         end
@@ -113,6 +114,8 @@ module RuboCop
           return :unknown unless node.str_type?
 
           format_string = RuboCop::Cop::Utils::FormatString.new(node.source)
+
+          return :unknown unless format_string.valid?
           return 1 if format_string.named_interpolation?
 
           max_digit_dollar_num = format_string.max_digit_dollar_num

--- a/lib/rubocop/cop/utils/format_string.rb
+++ b/lib/rubocop/cop/utils/format_string.rb
@@ -97,6 +97,10 @@ module RuboCop
           @format_sequences ||= parse
         end
 
+        def valid?
+          !mixed_formats?
+        end
+
         def named_interpolation?
           format_sequences.any?(&:name)
         end
@@ -113,6 +117,20 @@ module RuboCop
               Regexp.last_match
             )
           end
+        end
+
+        def mixed_formats?
+          formats = format_sequences.map do |seq|
+            if seq.name
+              :named
+            elsif seq.max_digit_dollar_num
+              :numbered
+            else
+              :unnumbered
+            end
+          end
+
+          formats.uniq.size > 1
         end
       end
     end

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -171,6 +171,12 @@ RSpec.describe RuboCop::Cop::Lint::FormatParameterMismatch do
     end
   end
 
+  context 'when format is invalid' do
+    it 'does not register an offense' do
+      expect_no_offenses("format('%s %2$s', 'foo', 'bar')")
+    end
+  end
+
   # Regression: https://github.com/rubocop-hq/rubocop/issues/3869
   context 'when passed an empty array' do
     it 'does not register an offense' do

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -172,8 +172,11 @@ RSpec.describe RuboCop::Cop::Lint::FormatParameterMismatch do
   end
 
   context 'when format is invalid' do
-    it 'does not register an offense' do
-      expect_no_offenses("format('%s %2$s', 'foo', 'bar')")
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        format('%s %2$s', 'foo', 'bar')
+        ^^^^^^ Format string is invalid because formatting sequence types (numbered, named or unnumbered) are mixed.
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/utils/format_string_spec.rb
+++ b/spec/rubocop/cop/utils/format_string_spec.rb
@@ -80,4 +80,36 @@ RSpec.describe RuboCop::Cop::Utils::FormatString do
     it_behaves_like 'named format sequence', '%+0<num>8.2f'
     it_behaves_like 'named format sequence', '%+08<num>.2f'
   end
+
+  describe '#valid?' do
+    it 'returns true when there are only unnumbered formats' do
+      fs = described_class.new('%s %d')
+      expect(fs.valid?).to eq true
+    end
+
+    it 'returns true when there are only numbered formats' do
+      fs = described_class.new('%1$s %2$d')
+      expect(fs.valid?).to eq true
+    end
+
+    it 'returns true when there are only named formats' do
+      fs = described_class.new('%{foo}s')
+      expect(fs.valid?).to eq true
+    end
+
+    it 'returns false when there are unnumbered and numbered formats' do
+      fs = described_class.new('%s %1$d')
+      expect(fs.valid?).to eq false
+    end
+
+    it 'returns false when there are unnumbered and named formats' do
+      fs = described_class.new('%s %{foo}d')
+      expect(fs.valid?).to eq false
+    end
+
+    it 'returns false when there are numbered and named formats' do
+      fs = described_class.new('%1$s %{foo}d')
+      expect(fs.valid?).to eq false
+    end
+  end
 end


### PR DESCRIPTION
The cop failed to process format string in invalid format and raised exception. There are several cases when format string contains valid segments but these segments aren't compatible.

For instance numbered format cannot be mixed with unnumbered or named. Such format string will lead to ArgumentError when code is executed but sometimes it's needed e.g. in tests to check how the code handles such invalid format strings.

Example of such code - [tests in RubySpec project](https://github.com/ruby/spec/blob/master/core/string/modulo_spec.rb#L186-L187)

## Changes

- check whether current format string is valid in `Lint::FormatParameterMismatch` cope
- added offense "Format string is invalid because formatting sequence types (numbered, named or unnumbered) are mixed." it if it's invalid
- added `#valid?` method to `Utils::FormatString` class to check mixing of formats

## Example

Running Rubocop on this code (where numbered format is mixed with unnumbered):

```ruby
format('%s %2$s', 'foo', 'bar')
```
leads to the following error

```
     ArgumentError:
       comparison of Integer with nil failed
     # ./lib/rubocop/cop/utils/format_string.rb:105:in `max'
     # ./lib/rubocop/cop/utils/format_string.rb:105:in `max_digit_dollar_num'
     # ./lib/rubocop/cop/lint/format_parameter_mismatch.rb:118:in `expected_fields_count'
     # ./lib/rubocop/cop/lint/format_parameter_mismatch.rb:96:in `count_format_matches'
     # ./lib/rubocop/cop/lint/format_parameter_mismatch.rb:79:in `count_matches'
     # ./lib/rubocop/cop/lint/format_parameter_mismatch.rb:43:in `offending_node?'
     # ./lib/rubocop/cop/lint/format_parameter_mismatch.rb:31:in `on_send'
     # ./lib/rubocop/cop/commissioner.rb:57:in `block (2 levels) in trigger_responding_cops'
     # ./lib/rubocop/cop/commissioner.rb:136:in `with_cop_error_handling'
     # ./lib/rubocop/cop/commissioner.rb:56:in `block in trigger_responding_cops'
     # ./lib/rubocop/cop/commissioner.rb:55:in `each'
     # ./lib/rubocop/cop/commissioner.rb:55:in `trigger_responding_cops'
     # ./lib/rubocop/cop/commissioner.rb:32:in `block (2 levels) in <class:Commissioner>'
     # ./lib/rubocop/cop/commissioner.rb:44:in `investigate'
     # ./lib/rubocop/rspec/cop_helper.rb:75:in `_investigate'
     # ./lib/rubocop/rspec/cop_helper.rb:22:in `inspect_source'
     # ./lib/rubocop/rspec/expect_offense.rb:127:in `expect_no_offenses'
     # ./spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb:168:in `block (3 levels) in <top (required)>'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
