### PR TITLE
[Fix #8045] `rake generate_cops_documentation` generates AsciiDoc

### DIFF
--- a/doc/modules/ROOT/pages/cops_layout.adoc
+++ b/doc/modules/ROOT/pages/cops_layout.adoc
@@ -406,10 +406,10 @@ blah { |i|
 | -
 |===
 
-This cop checks how the __when__s of a _case_ expression
-are indented in relation to its _case_ or _end_ keyword.
+This cop checks how the ``when``s of a `case` expression
+are indented in relation to its `case` or `end` keyword.
 
-It will register a separate offense for each misaligned _when_.
+It will register a separate offense for each misaligned `when`.
 
 === Examples
 
@@ -656,8 +656,8 @@ end
 | Name | Default value | Configurable values
 
 | Categories
-| `+{"module_inclusion"=>["include", "prepend", "extend"]}+`
-|
+| `{"module_inclusion"=>["include", "prepend", "extend"]}`
+| 
 
 | ExpectedOrder
 | `module_inclusion`, `constants`, `public_class_methods`, `initializer`, `public_methods`, `protected_methods`, `private_methods`
@@ -3167,7 +3167,7 @@ use the older rubies, you should introduce some library to your project
 (e.g. ActiveSupport, Powerpack or Unindent).
 Note: When ``Layout/LineLength``'s `AllowHeredoc` is false (not default),
       this cop does not add any offenses for long here documents to
-      avoid ``Layout/LineLength``'s offenses.
+      avoid `Layout/LineLength`'s offenses.
 
 === Examples
 
@@ -3497,7 +3497,7 @@ class A
 end
 ----
 
-==== IgnoredPatterns: ['{caret}\s*module']
+==== IgnoredPatterns: ['^\s*module']
 
 [source,ruby]
 ----
@@ -3582,7 +3582,7 @@ end
 
 This cop checks whether comments have a leading space after the
 `#` denoting the start of the comment. The leading space is not
-required for some RDoc special syntax, like `pass:c[#++]`, `#--`,
+required for some RDoc special syntax, like `#++`, `#--`,
 `#:nodoc`, `=begin`- and `=end` comments, "shebang" directives,
 or rackup options.
 
@@ -5471,7 +5471,7 @@ x = 1; y = 2
 | -
 |===
 
-This cop checks for spaces between `+->+` and opening parameter
+This cop checks for spaces between `->` and opening parameter
 parenthesis (`(`) in lambda literals.
 
 === Examples

--- a/doc/modules/ROOT/pages/cops_lint.adoc
+++ b/doc/modules/ROOT/pages/cops_lint.adoc
@@ -911,7 +911,7 @@ end
 | 0.83
 |===
 
-This cop checks for _return_ from an _ensure_ block.
+This cop checks for `return` from an `ensure` block.
 Explicit return from an ensure block alters the control flow
 as the return will take precedence over any exception being raised,
 and the exception will be silently thrown away as if it were rescued.
@@ -1436,7 +1436,7 @@ This cop checks for interpolated literals.
 | -
 |===
 
-This cop checks for uses of _begin...end while/until something_.
+This cop checks for uses of `begin...end while/until something`.
 
 === Examples
 
@@ -1498,8 +1498,8 @@ end
 | -
 |===
 
-This cop checks that there is an `+# rubocop:enable ...+` statement
-after a `+# rubocop:disable ...+` statement. This will prevent leaving
+This cop checks that there is an `# rubocop:enable ...` statement
+after a `# rubocop:disable ...` statement. This will prevent leaving
 cop disables on wide ranges of code, that latter contributors to
 a file wouldn't be aware of.
 
@@ -1737,7 +1737,7 @@ end
 | -
 |===
 
-`+Dir[...]+` and `+Dir.glob(...)+` do not make any guarantees about
+`Dir[...]` and `Dir.glob(...)` do not make any guarantees about
 the order in which files are returned. The final order is
 determined by the operating system and file system.
 This means that using them in cases where the order matters,
@@ -2463,7 +2463,7 @@ end
 | 0.27.1
 |===
 
-This cop checks for _rescue_ blocks targeting the Exception class.
+This cop checks for `rescue` blocks targeting the Exception class.
 
 === Examples
 
@@ -3040,7 +3040,7 @@ g.count #=> 2
 | 0.81
 |===
 
-This cop checks for _rescue_ blocks with no body.
+This cop checks for `rescue` blocks with no body.
 
 === Examples
 
@@ -3283,7 +3283,7 @@ This cop checks for using Fixnum or Bignum constant.
 
 This cop checks for unreachable code.
 The check are based on the presence of flow of control
-statement in non-final position in _begin_(implicit) blocks.
+statement in non-final position in `begin` (implicit) blocks.
 
 === Examples
 
@@ -3778,7 +3778,7 @@ This cop checks for every useless assignment to local variable in every
 scope.
 The basic idea for this cop was from the warning of `ruby -cw`:
 
-assigned but unused variable - foo
+  assigned but unused variable - foo
 
 Currently this cop has advanced logic that detects unreferenced
 reassignments and properly handles varied cases such as branch, loop,

--- a/doc/modules/ROOT/pages/cops_metrics.adoc
+++ b/doc/modules/ROOT/pages/cops_metrics.adoc
@@ -71,7 +71,7 @@ The cop can be configured to ignore blocks passed to certain methods.
 | Array
 
 | Exclude
-| `+**/*.gemspec+`
+| `**/*.gemspec`
 | Array
 |===
 

--- a/doc/modules/ROOT/pages/cops_naming.adoc
+++ b/doc/modules/ROOT/pages/cops_naming.adoc
@@ -313,7 +313,7 @@ anything/using_snake_case.rake
 
 | Regex
 | `<none>`
-|
+| 
 
 | IgnoreExecutableScripts
 | `true`
@@ -431,7 +431,7 @@ EOS
 | Name | Default value | Configurable values
 
 | ForbiddenDelimiters
-| `+(?-mix:(^\|\s)(EO[A-Z]{1}\|END)(\s\|$))+`
+| `(?-mix:(^|\s)(EO[A-Z]{1}|END)(\s|$))`
 | Array
 |===
 
@@ -574,10 +574,10 @@ snake_case or camelCase, for their names.
 
 This cop has `IgnoredPatterns` configuration option.
 
-Naming/MethodName:
+  Naming/MethodName:
     IgnoredPatterns:
-      - '\A\s__onSelectionBulkChange\s__'
-      - '\A\s__onSelectionCleared\s__'
+      - '\A\s*onSelectionBulkChange\s*'
+      - '\A\s*onSelectionCleared\s*'
 
 Method names matching patterns are always allowed.
 
@@ -765,7 +765,7 @@ end
 | Array
 
 | Exclude
-| `+spec/**/*+`
+| `spec/**/*`
 | Array
 |===
 

--- a/doc/modules/ROOT/pages/cops_style.adoc
+++ b/doc/modules/ROOT/pages/cops_style.adoc
@@ -990,7 +990,7 @@ You can customize the mapping from undesired method to desired method.
 
 e.g. to use `detect` over `find`:
 
-Style/CollectionMethods:
+  Style/CollectionMethods:
     PreferredMethods:
       find: detect
 
@@ -1023,8 +1023,8 @@ items.include?
 | Name | Default value | Configurable values
 
 | PreferredMethods
-| `+{"collect"=>"map", "collect!"=>"map!", "inject"=>"reduce", "detect"=>"find", "find_all"=>"select", "member?"=>"include?"}+`
-|
+| `{"collect"=>"map", "collect!"=>"map!", "inject"=>"reduce", "detect"=>"find", "find_all"=>"select", "member?"=>"include?"}`
+| 
 |===
 
 === References
@@ -1533,7 +1533,7 @@ an offense is reported.
 | Name | Default value | Configurable values
 
 | Notice
-| `+^Copyright (\(c\) )?2[0-9]{3} .++`
+| `^Copyright (\(c\) )?2[0-9]{3} .+`
 | String
 
 | AutocorrectNotice
@@ -1801,7 +1801,7 @@ end
 | Name | Default value | Configurable values
 
 | Exclude
-| `+spec/**/*+`, `+test/**/*+`
+| `spec/**/*`, `test/**/*`
 | Array
 |===
 
@@ -1922,7 +1922,7 @@ end
 | Name | Default value | Configurable values
 
 | Exclude
-| `+spec/**/*+`, `+test/**/*+`
+| `spec/**/*`, `test/**/*`
 | Array
 
 | RequireForNonPublicMethods
@@ -2645,14 +2645,13 @@ Pathname.new(__dir__).expand_path
 
 This cop enforces consistency when using exponential notation
 for numbers in the code (eg 1.2e4). Different styles are supported:
-
 * `scientific` which enforces a mantissa between 1 (inclusive)
-             and 10 (exclusive).
+               and 10 (exclusive).
 * `engineering` which enforces the exponent to be a multiple of 3
-              and the mantissa to be between 0.1 (inclusive)
-              and 10 (exclusive).
+                and the mantissa to be between 0.1 (inclusive)
+                and 10 (exclusive).
 * `integral` which enforces the mantissa to always be a whole number
-           without trailing zeroes.
+             without trailing zeroes.
 
 === Examples
 
@@ -3403,14 +3402,14 @@ NOTE: Required Ruby version: 2.5
 | -
 |===
 
-This cop looks for uses of `+_.each_with_object({}) {...}+`,
-`+_.map {...}.to_h+`, and `+Hash[_.map {...}]+` that are actually just
+This cop looks for uses of `_.each_with_object({}) {...}`,
+`_.map {...}.to_h`, and `Hash[_.map {...}]` that are actually just
 transforming the keys of a hash, and tries to use a simpler & faster
 call to `transform_keys` instead.
 
 This can produce false positives if we are transforming an enumerable
 of key-value-like pairs that isn't actually a hash, e.g.:
-`+[[k1, v1], [k2, v2], ...]+`
+`[[k1, v1], [k2, v2], ...]`
 
 This cop should only be enabled on Ruby version 2.5 or newer
 (`transform_keys` was added in Ruby 2.5.)
@@ -3440,14 +3439,14 @@ This cop should only be enabled on Ruby version 2.5 or newer
 | -
 |===
 
-This cop looks for uses of `+_.each_with_object({}) {...}+`,
-`+_.map {...}.to_h+`, and `+Hash[_.map {...}]+` that are actually just
+This cop looks for uses of `_.each_with_object({}) {...}`,
+`_.map {...}.to_h`, and `Hash[_.map {...}]` that are actually just
 transforming the values of a hash, and tries to use a simpler & faster
 call to `transform_values` instead.
 
 This can produce false positives if we are transforming an enumerable
 of key-value-like pairs that isn't actually a hash, e.g.:
-`+[[k1, v1], [k2, v2], ...]+`
+`[[k1, v1], [k2, v2], ...]`
 
 This cop should only be enabled on Ruby version 2.4 or newer
 (`transform_values` was added in Ruby 2.4.)
@@ -3886,12 +3885,12 @@ end
 | Name | Default value | Configurable values
 
 | InverseMethods
-| `+{:any?=>:none?, :even?=>:odd?, :===>:!=, :=~=>:!~, :<=>:>=, :>=>:<=}+`
-|
+| `{:any?=>:none?, :even?=>:odd?, :===>:!=, :=~=>:!~, :<=>:>=, :>=>:<=}`
+| 
 
 | InverseBlocks
-| `+{:select=>:reject, :select!=>:reject!}+`
-|
+| `{:select=>:reject, :select!=>:reject!}`
+| 
 |===
 
 == Style/IpAddresses
@@ -4124,9 +4123,9 @@ the `IncludedMacros` list.
 
 Precedence of options is all follows:
 
-. `IgnoredMethods`
-. `IgnoredPatterns`
-. `IncludedMacros`
+1. `IgnoredMethods`
+2. `IgnoredPatterns`
+3. `IncludedMacros`
 
 eg. If a method is listed in both
 `IncludedMacros` and `IgnoredMethods`, then the latter takes
@@ -4135,17 +4134,19 @@ precedence (that is, the method is ignored).
 In the alternative style (omit_parentheses), there are three additional
 options.
 
-. `AllowParenthesesInChaining` is `false` by default. Setting it to
-`true` allows the presence of parentheses in the last call during
-method chaining.
-. `AllowParenthesesInMultilineCall` is `false` by default. Setting it
- to `true` allows the presence of parentheses in multi-line method
- calls.
-. `AllowParenthesesInCamelCaseMethod` is `false` by default. This
- allows the presence of parentheses when calling a method whose name
- begins with a capital letter and which has no arguments. Setting it
- to `true` allows the presence of parentheses in such a method call
- even with arguments.
+1. `AllowParenthesesInChaining` is `false` by default. Setting it to
+   `true` allows the presence of parentheses in the last call during
+   method chaining.
+
+2. `AllowParenthesesInMultilineCall` is `false` by default. Setting it
+    to `true` allows the presence of parentheses in multi-line method
+    calls.
+
+3. `AllowParenthesesInCamelCaseMethod` is `false` by default. This
+    allows the presence of parentheses when calling a method whose name
+    begins with a capital letter and which has no arguments. Setting it
+    to `true` allows the presence of parentheses in such a method call
+    even with arguments.
 
 === Examples
 
@@ -6151,7 +6152,7 @@ bar.baz > 0
 | Array
 
 | Exclude
-| `+spec/**/*+`
+| `spec/**/*`
 | Array
 |===
 
@@ -6500,8 +6501,8 @@ default.
 | Name | Default value | Configurable values
 
 | PreferredDelimiters
-| `+{"default"=>"()", "%i"=>"[]", "%I"=>"[]", "%r"=>"{}", "%w"=>"[]", "%W"=>"[]"}+`
-|
+| `{"default"=>"()", "%i"=>"[]", "%I"=>"[]", "%r"=>"{}", "%w"=>"[]", "%W"=>"[]"}`
+| 
 |===
 
 === References
@@ -7215,8 +7216,9 @@ This cop checks for redundant uses of `self`.
 The usage of `self` is only needed when:
 
 * Sending a message to same object with zero arguments in
-presence of a method name clash with an argument or a local
-variable.
+  presence of a method name clash with an argument or a local
+  variable.
+
 * Calling an attribute writer to prevent an local variable assignment.
 
 Note, with using explicit self you can only send messages with public or
@@ -7329,7 +7331,7 @@ arr.max_by(&:foo)
 | -
 |===
 
-This cop identifies places where `+sort_by { ... }+` can be replaced by
+This cop identifies places where `sort_by { ... }` can be replaced by
 `sort`.
 
 === Examples
@@ -7495,14 +7497,15 @@ The cop to check `rescue` in its modifier form is added for following
 reasons:
 
 * The syntax of modifier form `rescue` can be misleading because it
-might led us to believe that `rescue` handles the given exception
-but it actually rescue all exceptions to return the given rescue
-block. In this case, value returned by handle_error or
-SomeException.
+  might led us to believe that `rescue` handles the given exception
+  but it actually rescue all exceptions to return the given rescue
+  block. In this case, value returned by handle_error or
+  SomeException.
+
 * Modifier form `rescue` would rescue all the exceptions. It would
-silently skip all exception or errors and handle the error.
-Example: If `NoMethodError` is raised, modifier form rescue would
-handle the exception.
+  silently skip all exception or errors and handle the error.
+  Example: If `NoMethodError` is raised, modifier form rescue would
+  handle the exception.
 
 === Examples
 
@@ -8136,7 +8139,7 @@ end
 | Name | Default value | Configurable values
 
 | Methods
-| `+{"reduce"=>["acc", "elem"]}+`, `+{"inject"=>["acc", "elem"]}+`
+| `{"reduce"=>["acc", "elem"]}`, `{"inject"=>["acc", "elem"]}`
 | Array
 |===
 
@@ -8576,8 +8579,8 @@ from the String class.
 | Name | Default value | Configurable values
 
 | PreferredMethods
-| `+{"intern"=>"to_sym"}+`
-|
+| `{"intern"=>"to_sym"}`
+| 
 |===
 
 == Style/Strip
@@ -9219,28 +9222,6 @@ required. Blocks with only one argument and a trailing comma require
 that comma to be present. Blocks with more than one argument never
 require a trailing comma.
 
-[source,ruby]
-----
-add do |foo, bar,|
-   foo + bar
-  end
-
-# good
- add do |foo, bar|
-   foo + bar
- end
-
-# good
-  add do |foo,|
-   foo
- end
-
-# good
- add do
-    foo + bar
- end
-----
-
 === Examples
 
 [source,ruby]
@@ -9248,7 +9229,7 @@ add do |foo, bar,|
 # bad
 add { |foo, bar,| foo + bar }
 
- # good
+# good
 add { |foo, bar| foo + bar }
 
 # good
@@ -9258,6 +9239,24 @@ add { |foo,| foo }
 add { foo }
 
 # bad
+add do |foo, bar,|
+  foo + bar
+end
+
+# good
+add do |foo, bar|
+  foo + bar
+end
+
+# good
+add do |foo,|
+  foo
+end
+
+# good
+add do
+  foo + bar
+end
 ----
 
 == Style/TrailingCommaInHashLiteral
@@ -9563,7 +9562,7 @@ end
 | -
 |===
 
-This cop looks for _unless_ expressions with _else_ clauses.
+This cop looks for `unless` expressions with `else` clauses.
 
 === Examples
 
@@ -9662,7 +9661,7 @@ This cop checks for variable interpolation (like "#@ivar").
 | -
 |===
 
-This cop checks for _when;_ uses in _case_ expressions.
+This cop checks for `when;` uses in `case` expressions.
 
 === Examples
 
@@ -9836,8 +9835,8 @@ array of 2 or fewer elements.
 | Integer
 
 | WordRegex
-| `+(?-mix:\A(?:\p{Word}\|\p{Word}-\p{Word}\|\n\|\t)+\z)+`
-|
+| `(?-mix:\A(?:\p{Word}|\p{Word}-\p{Word}|\n|\t)+\z)`
+| 
 |===
 
 === References

--- a/lib/rubocop/cop/layout/case_indentation.rb
+++ b/lib/rubocop/cop/layout/case_indentation.rb
@@ -3,10 +3,10 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks how the *when*s of a *case* expression
-      # are indented in relation to its *case* or *end* keyword.
+      # This cop checks how the ``when``s of a `case` expression
+      # are indented in relation to its `case` or `end` keyword.
       #
-      # It will register a separate offense for each misaligned *when*.
+      # It will register a separate offense for each misaligned `when`.
       #
       # @example
       #   # If Layout/EndAlignment is set to keyword style (default)

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -8,22 +8,24 @@ module RuboCop
       # `Categories` allows us to map macro names into a category.
       #
       # Consider an example of code style that covers the following order:
-      # - Module inclusion (include, prepend, extend)
-      # - Constants
-      # - Associations (has_one, has_many)
-      # - Public attribute macros (attr_accessor, attr_writer, attr_reader)
-      # - Other macros (validates, validate)
-      # - Public class methods
-      # - Initializer
-      # - Public instance methods
-      # - Protected attribute macros (attr_accessor, attr_writer, attr_reader)
-      # - Protected instance methods
-      # - Private attribute macros (attr_accessor, attr_writer, attr_reader)
-      # - Private instance methods
+      #
+      # * Module inclusion (include, prepend, extend)
+      # * Constants
+      # * Associations (has_one, has_many)
+      # * Public attribute macros (attr_accessor, attr_writer, attr_reader)
+      # * Other macros (validates, validate)
+      # * Public class methods
+      # * Initializer
+      # * Public instance methods
+      # * Protected attribute macros (attr_accessor, attr_writer, attr_reader)
+      # * Protected instance methods
+      # * Private attribute macros (attr_accessor, attr_writer, attr_reader)
+      # * Private instance methods
       #
       # You can configure the following order:
       #
-      # ```yaml
+      # [source,yaml]
+      # ----
       #  Layout/ClassStructure:
       #    ExpectedOrder:
       #      - module_inclusion
@@ -40,13 +42,14 @@ module RuboCop
       #      - private_attribute_macros
       #      - private_delegate
       #      - private_methods
-      # ```
+      # ----
       #
       # Instead of putting all literals in the expected order, is also
       # possible to group categories of macros. Visibility levels are handled
       # automatically.
       #
-      # ```yaml
+      # [source,yaml]
+      # ----
       #  Layout/ClassStructure:
       #    Categories:
       #      association:
@@ -63,7 +66,7 @@ module RuboCop
       #        - include
       #        - prepend
       #        - extend
-      # ```
+      # ----
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/layout/first_argument_indentation.rb
+++ b/lib/rubocop/cop/layout/first_argument_indentation.rb
@@ -7,7 +7,7 @@ module RuboCop
       # Arguments after the first one are checked by Layout/ArgumentAlignment,
       # not by this cop.
       #
-      # For indenting the first parameter of method *definitions*, check out
+      # For indenting the first parameter of method _definitions_, check out
       # Layout/FirstParameterIndentation.
       #
       # @example

--- a/lib/rubocop/cop/layout/first_parameter_indentation.rb
+++ b/lib/rubocop/cop/layout/first_parameter_indentation.rb
@@ -7,9 +7,9 @@ module RuboCop
       # definition. Parameters after the first one are checked by
       # Layout/ParameterAlignment, not by this cop.
       #
-      # For indenting the first argument of method *calls*, check out
+      # For indenting the first argument of method _calls_, check out
       # Layout/FirstArgumentIndentation, which supports options related to
-      # nesting that are irrelevant for method *definitions*.
+      # nesting that are irrelevant for method _definitions_.
       #
       # @example
       #

--- a/lib/rubocop/cop/layout/hash_alignment.rb
+++ b/lib/rubocop/cop/layout/hash_alignment.rb
@@ -7,16 +7,16 @@ module RuboCop
       # literal are aligned according to configuration. The configuration
       # options are:
       #
-      #   - key (left align keys, one space before hash rockets and values)
-      #   - separator (align hash rockets and colons, right align keys)
-      #   - table (left align keys, hash rockets, and values)
+      # * key (left align keys, one space before hash rockets and values)
+      # * separator (align hash rockets and colons, right align keys)
+      # * table (left align keys, hash rockets, and values)
       #
       # The treatment of hashes passed as the last argument to a method call
       # can also be configured. The options are:
       #
-      #   - always_inspect
-      #   - always_ignore
-      #   - ignore_implicit (without curly braces)
+      # * always_inspect
+      # * always_ignore
+      # * ignore_implicit (without curly braces)
       #
       # Alternatively you can specify multiple allowed styles. That's done by
       # passing a list of styles to EnforcedStyles.

--- a/lib/rubocop/cop/layout/heredoc_indentation.rb
+++ b/lib/rubocop/cop/layout/heredoc_indentation.rb
@@ -8,7 +8,7 @@ module RuboCop
       # In Ruby 2.3 or newer, squiggly heredocs (`<<~`) should be used. If you
       # use the older rubies, you should introduce some library to your project
       # (e.g. ActiveSupport, Powerpack or Unindent).
-      # Note: When `Layout/LineLength`'s `AllowHeredoc` is false (not default),
+      # Note: When ``Layout/LineLength``'s `AllowHeredoc` is false (not default),
       #       this cop does not add any offenses for long here documents to
       #       avoid `Layout/LineLength`'s offenses.
       #

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -21,23 +21,23 @@ module RuboCop
       # are recommended to further format the broken lines.
       # (Many of these are enabled by default.)
       #
-      #   - ArgumentAlignment
-      #   - BlockAlignment
-      #   - BlockDelimiters
-      #   - BlockEndNewline
-      #   - ClosingParenthesisIndentation
-      #   - FirstArgumentIndentation
-      #   - FirstArrayElementIndentation
-      #   - FirstHashElementIndentation
-      #   - FirstParameterIndentation
-      #   - HashAlignment
-      #   - IndentationWidth
-      #   - MultilineArrayLineBreaks
-      #   - MultilineBlockLayout
-      #   - MultilineHashBraceLayout
-      #   - MultilineHashKeyLineBreaks
-      #   - MultilineMethodArgumentLineBreaks
-      #   - ParameterAlignment
+      # * ArgumentAlignment
+      # * BlockAlignment
+      # * BlockDelimiters
+      # * BlockEndNewline
+      # * ClosingParenthesisIndentation
+      # * FirstArgumentIndentation
+      # * FirstArrayElementIndentation
+      # * FirstHashElementIndentation
+      # * FirstParameterIndentation
+      # * HashAlignment
+      # * IndentationWidth
+      # * MultilineArrayLineBreaks
+      # * MultilineBlockLayout
+      # * MultilineHashBraceLayout
+      # * MultilineHashKeyLineBreaks
+      # * MultilineMethodArgumentLineBreaks
+      # * ParameterAlignment
       #
       # Together, these cops will pretty print hashes, arrays,
       # method calls, etc. For example, let's say the max columns

--- a/lib/rubocop/cop/lint/ensure_return.rb
+++ b/lib/rubocop/cop/lint/ensure_return.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for *return* from an *ensure* block.
+      # This cop checks for `return` from an `ensure` block.
       # Explicit return from an ensure block alters the control flow
       # as the return will take precedence over any exception being raised,
       # and the exception will be silently thrown away as if it were rescued.

--- a/lib/rubocop/cop/lint/loop.rb
+++ b/lib/rubocop/cop/lint/loop.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for uses of *begin...end while/until something*.
+      # This cop checks for uses of `begin...end while/until something`.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/non_local_exit_from_iterator.rb
+++ b/lib/rubocop/cop/lint/non_local_exit_from_iterator.rb
@@ -6,13 +6,13 @@ module RuboCop
       # This cop checks for non-local exits from iterators without a return
       # value. It registers an offense under these conditions:
       #
-      #  - No value is returned,
-      #  - the block is preceded by a method chain,
-      #  - the block has arguments,
-      #  - the method which receives the block is not `define_method`
-      #    or `define_singleton_method`,
-      #  - the return is not contained in an inner scope, e.g. a lambda or a
-      #    method definition.
+      # * No value is returned,
+      # * the block is preceded by a method chain,
+      # * the block has arguments,
+      # * the method which receives the block is not `define_method`
+      # or `define_singleton_method`,
+      # * the return is not contained in an inner scope, e.g. a lambda or a
+      # method definition.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/redundant_require_statement.rb
+++ b/lib/rubocop/cop/lint/redundant_require_statement.rb
@@ -8,9 +8,9 @@ module RuboCop
       # The following features are unnecessary `require` statement because
       # they are already loaded.
       #
-      # ruby -ve 'p $LOADED_FEATURES.reject { |feature| %r|/| =~ feature }'
-      # ruby 2.2.8p477 (2017-09-14 revision 59906) [x86_64-darwin13]
-      # ["enumerator.so", "rational.so", "complex.so", "thread.rb"]
+      #   ruby -ve 'p $LOADED_FEATURES.reject { |feature| %r|/| =~ feature }'
+      #   ruby 2.2.8p477 (2017-09-14 revision 59906) [x86_64-darwin13]
+      #   ["enumerator.so", "rational.so", "complex.so", "thread.rb"]
       #
       # This cop targets Ruby 2.2 or higher containing these 4 features.
       #

--- a/lib/rubocop/cop/lint/rescue_exception.rb
+++ b/lib/rubocop/cop/lint/rescue_exception.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for *rescue* blocks targeting the Exception class.
+      # This cop checks for `rescue` blocks targeting the Exception class.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/suppressed_exception.rb
+++ b/lib/rubocop/cop/lint/suppressed_exception.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for *rescue* blocks with no body.
+      # This cop checks for `rescue` blocks with no body.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/unreachable_code.rb
+++ b/lib/rubocop/cop/lint/unreachable_code.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Lint
       # This cop checks for unreachable code.
       # The check are based on the presence of flow of control
-      # statement in non-final position in *begin*(implicit) blocks.
+      # statement in non-final position in `begin` (implicit) blocks.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/useless_else_without_rescue.rb
+++ b/lib/rubocop/cop/lint/useless_else_without_rescue.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Lint
       # This cop checks for useless `else` in `begin..end` without `rescue`.
       #
-      # Note: This syntax is no longer valid on Ruby 2.6 or higher and
+      # NOTE: This syntax is no longer valid on Ruby 2.6 or higher and
       # this cop is going to be removed at some point the future.
       #
       # @example

--- a/lib/rubocop/cop/lint/useless_setter_call.rb
+++ b/lib/rubocop/cop/lint/useless_setter_call.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop checks for setter call to local variable as the final
       # expression of a function definition.
       #
-      # Note: There are edge cases in which the local variable references a
+      # NOTE: There are edge cases in which the local variable references a
       # value that is also accessible outside the local scope. This is not
       # detected by the cop, and it can yield a false positive.
       #

--- a/lib/rubocop/cop/style/array_join.rb
+++ b/lib/rubocop/cop/style/array_join.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for uses of "\*" as a substitute for *join*.
+      # This cop checks for uses of "*" as a substitute for _join_.
       #
       # Not all cases can reliably checked, due to Ruby's dynamic
       # types, so we consider only cases when the first argument is an

--- a/lib/rubocop/cop/style/copyright.rb
+++ b/lib/rubocop/cop/style/copyright.rb
@@ -8,8 +8,8 @@ module RuboCop
       # The default regexp for an acceptable copyright notice can be found in
       # config/default.yml. The default can be changed as follows:
       #
-      #     Style/Copyright:
-      #       Notice: '^Copyright (\(c\) )?2\d{3} Acme Inc'
+      #  Style/Copyright:
+      #    Notice: '^Copyright (\(c\) )?2\d{3} Acme Inc'
       #
       # This regex string is treated as an unanchored regex. For each file
       # that RuboCop scans, a comment that matches this regex must be found or

--- a/lib/rubocop/cop/style/empty_method.rb
+++ b/lib/rubocop/cop/style/empty_method.rb
@@ -8,7 +8,7 @@ module RuboCop
       # line (compact style), but it can be configured to enforce the `end`
       # to go on its own line (expanded style).
       #
-      # Note: A method definition is not considered empty if it contains
+      # NOTE: A method definition is not considered empty if it contains
       #       comments.
       #
       # @example EnforcedStyle: compact (default)

--- a/lib/rubocop/cop/style/exponential_notation.rb
+++ b/lib/rubocop/cop/style/exponential_notation.rb
@@ -5,12 +5,12 @@ module RuboCop
     module Style
       # This cop enforces consistency when using exponential notation
       # for numbers in the code (eg 1.2e4). Different styles are supported:
-      # - `scientific` which enforces a mantissa between 1 (inclusive)
+      # * `scientific` which enforces a mantissa between 1 (inclusive)
       #                and 10 (exclusive).
-      # - `engineering` which enforces the exponent to be a multiple of 3
+      # * `engineering` which enforces the exponent to be a multiple of 3
       #                 and the mantissa to be between 0.1 (inclusive)
       #                 and 10 (exclusive).
-      # - `integral` which enforces the mantissa to always be a whole number
+      # * `integral` which enforces the mantissa to always be a whole number
       #              without trailing zeroes.
       #
       # @example EnforcedStyle: scientific (default)

--- a/lib/rubocop/cop/style/format_string_token.rb
+++ b/lib/rubocop/cop/style/format_string_token.rb
@@ -5,11 +5,10 @@ module RuboCop
     module Style
       # Use a consistent style for named format string tokens.
       #
-      # **Note:**
-      # `unannotated` style cop only works for strings
+      # NOTE: `unannotated` style cop only works for strings
       # which are passed as arguments to those methods:
       # `printf`, `sprintf`, `format`, `%`.
-      # The reason is that *unannotated* format is very similar
+      # The reason is that _unannotated_ format is very similar
       # to encoded URLs or Date/Time formatting strings.
       #
       # @example EnforcedStyle: annotated (default)

--- a/lib/rubocop/cop/style/hash_each_methods.rb
+++ b/lib/rubocop/cop/style/hash_each_methods.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Style
       # This cop checks for uses of `each_key` and `each_value` Hash methods.
       #
-      # Note: If you have an array of two-element arrays, you can put
+      # NOTE: If you have an array of two-element arrays, you can put
       #   parentheses around the block arguments to indicate that you're not
       #   working with a hash, and suppress RuboCop offenses.
       #

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -13,11 +13,11 @@ module RuboCop
       # The supported styles are:
       #
       # * ruby19 - forces use of the 1.9 syntax (e.g. `{a: 1}`) when hashes have
-      #   all symbols for keys
+      # all symbols for keys
       # * hash_rockets - forces use of hash rockets for all hashes
       # * no_mixed_keys - simply checks for hashes with mixed syntaxes
       # * ruby19_no_mixed_keys - forces use of ruby 1.9 syntax and forbids mixed
-      #   syntax hashes
+      # syntax hashes
       #
       # @example EnforcedStyle: ruby19 (default)
       #   # bad

--- a/lib/rubocop/cop/style/negated_if.rb
+++ b/lib/rubocop/cop/style/negated_if.rb
@@ -6,9 +6,9 @@ module RuboCop
       # Checks for uses of if with a negated condition. Only ifs
       # without else are considered. There are three different styles:
       #
-      #   - both
-      #   - prefix
-      #   - postfix
+      # * both
+      # * prefix
+      # * postfix
       #
       # @example EnforcedStyle: both (default)
       #   # enforces `unless` for `prefix` and `postfix` conditionals

--- a/lib/rubocop/cop/style/negated_unless.rb
+++ b/lib/rubocop/cop/style/negated_unless.rb
@@ -6,9 +6,9 @@ module RuboCop
       # Checks for uses of unless with a negated condition. Only unless
       # without else are considered. There are three different styles:
       #
-      #   - both
-      #   - prefix
-      #   - postfix
+      # * both
+      # * prefix
+      # * postfix
       #
       # @example EnforcedStyle: both (default)
       #   # enforces `if` for `prefix` and `postfix` conditionals

--- a/lib/rubocop/cop/style/non_nil_check.rb
+++ b/lib/rubocop/cop/style/non_nil_check.rb
@@ -11,7 +11,7 @@ module RuboCop
       #
       # With `IncludeSemanticChanges` set to `true`, this cop reports offenses
       # for `!x.nil?` and autocorrects that and `x != nil` to solely `x`, which
-      # is **usually** OK, but might change behavior.
+      # is *usually* OK, but might change behavior.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
@@ -6,11 +6,11 @@ module RuboCop
       # This cop checks for trailing comma in argument lists.
       # The supported styles are:
       #
-      # - `consistent_comma`: Requires a comma after the last argument,
+      # * `consistent_comma`: Requires a comma after the last argument,
       # for all parenthesized method calls with arguments.
-      # - `comma`: Requires a comma after the last argument, but only for
+      # * `comma`: Requires a comma after the last argument, but only for
       # parenthesized method calls where each argument is on its own line.
-      # - `no_comma`: Requires that there is no comma after the last
+      # * `no_comma`: Requires that there is no comma after the last
       # argument.
       #
       # @example EnforcedStyleForMultiline: consistent_comma

--- a/lib/rubocop/cop/style/trailing_comma_in_array_literal.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_array_literal.rb
@@ -6,11 +6,11 @@ module RuboCop
       # This cop checks for trailing comma in array literals.
       # The configuration options are:
       #
-      # - `consistent_comma`: Requires a comma after the
+      # * `consistent_comma`: Requires a comma after the
       # last item of all non-empty, multiline array literals.
-      # - `comma`: Requires a comma after last item in an array,
+      # * `comma`: Requires a comma after last item in an array,
       # but only when each item is on its own line.
-      # - `no_comma`: Does not requires a comma after the
+      # * `no_comma`: Does not requires a comma after the
       # last item in an array
       #
       # @example EnforcedStyleForMultiline: consistent_comma

--- a/lib/rubocop/cop/style/trailing_comma_in_block_args.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_block_args.rb
@@ -12,7 +12,7 @@ module RuboCop
       #   # bad
       #   add { |foo, bar,| foo + bar }
       #
-      #    # good
+      #   # good
       #   add { |foo, bar| foo + bar }
       #
       #   # good
@@ -22,24 +22,24 @@ module RuboCop
       #   add { foo }
       #
       #   # bad
-      #  add do |foo, bar,|
-      #    foo + bar
+      #   add do |foo, bar,|
+      #     foo + bar
       #   end
       #
-      #  # good
-      #  add do |foo, bar|
-      #    foo + bar
-      #  end
-      #
-      #  # good
-      #   add do |foo,|
-      #    foo
-      #  end
-      #
-      #  # good
-      #  add do
+      #   # good
+      #   add do |foo, bar|
       #     foo + bar
-      #  end
+      #   end
+      #
+      #   # good
+      #   add do |foo,|
+      #     foo
+      #   end
+      #
+      #   # good
+      #   add do
+      #     foo + bar
+      #   end
       class TrailingCommaInBlockArgs < Cop
         MSG = 'Useless trailing comma present in block arguments.'
 

--- a/lib/rubocop/cop/style/trailing_comma_in_hash_literal.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_hash_literal.rb
@@ -6,11 +6,11 @@ module RuboCop
       # This cop checks for trailing comma in hash literals.
       # The configuration options are:
       #
-      # - `consistent_comma`: Requires a comma after the
+      # * `consistent_comma`: Requires a comma after the
       # last item of all non-empty, multiline hash literals.
-      # - `comma`: Requires a comma after the last item in a hash,
+      # * `comma`: Requires a comma after the last item in a hash,
       # but only when each item is on its own line.
-      # - `no_comma`: Does not requires a comma after the
+      # * `no_comma`: Does not requires a comma after the
       # last item in a hash
       #
       # @example EnforcedStyleForMultiline: consistent_comma

--- a/lib/rubocop/cop/style/unless_else.rb
+++ b/lib/rubocop/cop/style/unless_else.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop looks for *unless* expressions with *else* clauses.
+      # This cop looks for `unless` expressions with `else` clauses.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/when_then.rb
+++ b/lib/rubocop/cop/style/when_then.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for *when;* uses in *case* expressions.
+      # This cop checks for `when;` uses in `case` expressions.
       #
       # @example
       #   # bad

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -29,6 +29,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
 
   def examples(examples_object)
     examples_object.each_with_object(h3('Examples').dup) do |example, content|
+      content << "\n" unless content.end_with?("\n\n")
       content << h4(example.name) unless example.name == ''
       content << code_example(example)
     end
@@ -37,12 +38,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
   def required_ruby_version(cop)
     return '' unless cop.respond_to?(:required_minimum_ruby_version)
 
-    <<~NOTE
-      !!! Note
-
-          Required Ruby version: #{cop.required_minimum_ruby_version}
-
-    NOTE
+    "NOTE: Required Ruby version: #{cop.required_minimum_ruby_version}\n\n"
   end
 
   # rubocop:disable Metrics/MethodLength
@@ -52,7 +48,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
       'VersionChanged'
     ]
     autocorrect = if cop_instance.support_autocorrect?
-                    "Yes #{'(Unsafe)' unless cop_instance.safe_autocorrect?}"
+                    "Yes#{' (Unsafe)' unless cop_instance.safe_autocorrect?}"
                   else
                     'No'
                   end
@@ -70,29 +66,29 @@ task generate_cops_documentation: :yard_for_generate_documentation do
 
   def h2(title)
     content = +"\n"
-    content << "## #{title}\n"
+    content << "== #{title}\n"
     content << "\n"
     content
   end
 
   def h3(title)
     content = +"\n"
-    content << "### #{title}\n"
+    content << "=== #{title}\n"
     content << "\n"
     content
   end
 
   def h4(title)
-    content = +"#### #{title}\n"
+    content = +"==== #{title}\n"
     content << "\n"
     content
   end
 
   def code_example(ruby_code)
-    content = +"```ruby\n"
+    content = +"[source,ruby]\n----\n"
     content << ruby_code.text.gsub('@good', '# good')
                         .gsub('@bad', '# bad').strip
-    content << "\n```\n"
+    content << "\n----\n"
     content
   end
 
@@ -144,11 +140,14 @@ task generate_cops_documentation: :yard_for_generate_documentation do
 
   def to_table(header, content)
     table = [
-      header.join(' | '),
-      Array.new(header.size, '---').join(' | ')
-    ]
-    table.concat(content.map { |c| c.join(' | ') })
-    table.join("\n") + "\n"
+      '|===',
+      "| #{header.join(' | ')}\n\n"
+    ].join("\n")
+    marked_contents = content.map do |plain_content|
+      plain_content.map { |c| "| #{c}" }.join("\n")
+    end
+    table << marked_contents.join("\n\n")
+    table << "\n|===\n"
   end
 
   def format_table_value(val)
@@ -161,9 +160,18 @@ task generate_cops_documentation: :yard_for_generate_documentation do
           val.map { |config| format_table_value(config) }.join(', ')
         end
       else
-        "`#{val.nil? ? '<none>' : val}`"
+        wrap_backtick(val.nil? ? '<none>' : val)
       end
     value.gsub("#{Dir.pwd}/", '').rstrip
+  end
+
+  def wrap_backtick(value)
+    if value.is_a?(String)
+      # Use `+` to prevent text like `**/*.gemspec` from being bold.
+      value.start_with?('*') ? "`+#{value}+`" : "`#{value}`"
+    else
+      "`#{value}`"
+    end
   end
 
   def references(config, cop)
@@ -174,18 +182,18 @@ task generate_cops_documentation: :yard_for_generate_documentation do
     return '' if urls.empty?
 
     content = h3('References')
-    content << urls.map { |url| "* [#{url}](#{url})" }.join("\n")
+    content << urls.map { |url| "* #{url}" }.join("\n")
     content << "\n"
     content
   end
 
   def print_cops_of_department(cops, department, config)
     selected_cops = cops_of_department(cops, department)
-    content = +"# #{department}\n"
+    content = +"= #{department}\n"
     selected_cops.each do |cop|
       content << print_cop_with_doc(cop, config)
     end
-    file_name = "#{Dir.pwd}/manual/cops_#{department.downcase}.md"
+    file_name = "#{Dir.pwd}/doc/modules/ROOT/pages/cops_#{department.downcase}.adoc"
     File.open(file_name, 'w') do |file|
       puts "* generated #{file_name}"
       file.write(content.strip + "\n")
@@ -218,27 +226,27 @@ task generate_cops_documentation: :yard_for_generate_documentation do
 
   def table_of_content_for_department(cops, department)
     type_title = department[0].upcase + department[1..-1]
-    filename = "cops_#{department.downcase}.md"
-    content = +"### Department [#{type_title}](#{filename})\n\n"
+    filename = "cops_#{department.downcase}.adoc"
+    content = +"=== Department xref:#{filename}[#{type_title}]\n\n"
     cops_of_department(cops, department.to_sym).each do |cop|
       anchor = cop.cop_name.sub('/', '').downcase
-      content << "* [#{cop.cop_name}](#{filename}##{anchor})\n"
+      content << "* xref:#{filename}#_#{anchor}[#{cop.cop_name}]\n"
     end
 
     content
   end
 
   def print_table_of_contents(cops)
-    path = "#{Dir.pwd}/manual/cops.md"
+    path = "#{Dir.pwd}/doc/modules/ROOT/pages/cops.adoc"
     original = File.read(path)
-    content = +"<!-- START_COP_LIST -->\n"
+    content = +"// START_COP_LIST\n\n"
 
     content << table_contents(cops)
 
-    content << "\n<!-- END_COP_LIST -->"
+    content << "\n// END_COP_LIST"
 
     content = original.sub(
-      /<!-- START_COP_LIST -->.+<!-- END_COP_LIST -->/m, content
+      %r{// START_COP_LIST.+// END_COP_LIST}m, content
     )
     File.write(path, content)
   end


### PR DESCRIPTION
Fixes #8045.

This PR updates `rake generate_cops_documentation` to generate document for AsciiDoc.

Each generated document will be changed as follows:

- manual/cops_bundler.md -> doc/modules/ROOT/pages/cops_bundler.adoc
- manual/cops_gemspec.md -> doc/modules/ROOT/pages/cops_gemspec.adoc
- manual/cops_layout.md  -> doc/modules/ROOT/pages/cops_layout.adoc
- manual/cops_lint.md    -> doc/modules/ROOT/pages/cops_lint.adoc
- manual/cops_metrics.md -> doc/modules/ROOT/pages/cops_metrics.adoc
- manual/cops_naming.md  -> doc/modules/ROOT/pages/cops_naming.adoc
- manual/cops_style.md   -> doc/modules/ROOT/pages/cops_style.adoc

And this PR also changes some cop's documents to AsciiDoc format.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
