### PR TITLE
Ruby 2.3 cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 * [#7990](https://github.com/rubocop-hq/rubocop/issues/7990): Fix resolving `inherit_gem` in remote configs. ([@CvX][])
 * [#8035](https://github.com/rubocop-hq/rubocop/issues/8035): Fix a false positive for `Lint/DeprecatedOpenSSLConstant` when using double quoted string argument. ([@koic][])
 
+### Changes
+
+* [#8056](https://github.com/rubocop-hq/rubocop/pull/8056): **(Breaking)** Remove support for unindent/active_support/powerpack from `Layout/HeredocIndentation`, so it only recommends using squiggy heredoc. ([@bquorning][])
+
 ## 0.84.0 (2020-05-21)
 
 ### New features

--- a/config/default.yml
+++ b/config/default.yml
@@ -2868,8 +2868,7 @@ Style/FrozenStringLiteralComment:
   SupportedStyles:
     # `always` will always add the frozen string literal comment to a file
     # regardless of the Ruby version or if `freeze` or `<<` are called on a
-    # string literal. If you run code against multiple versions of Ruby, it is
-    # possible that this will create errors in Ruby 2.3.0+.
+    # string literal. It is possible that this will create errors.
     - always
     # `always_true` will add the frozen string literal comment to a file,
     # similarly to the `always` style, but will also change any disabled

--- a/config/default.yml
+++ b/config/default.yml
@@ -790,13 +790,7 @@ Layout/HeredocIndentation:
   StyleGuide: '#squiggly-heredocs'
   Enabled: true
   VersionAdded: '0.49'
-  VersionChanged: '0.77'
-  EnforcedStyle: squiggly
-  SupportedStyles:
-    - squiggly
-    - active_support
-    - powerpack
-    - unindent
+  VersionChanged: '0.85'
 
 Layout/IndentationConsistency:
   Description: 'Keep indentation straight.'

--- a/config/default.yml
+++ b/config/default.yml
@@ -2216,7 +2216,7 @@ Security/JSONLoad:
   Description: >-
                  Prefer usage of `JSON.parse` over `JSON.load` due to potential
                  security issues. See reference for more information.
-  Reference: 'https://ruby-doc.org/stdlib-2.3.0/libdoc/json/rdoc/JSON.html#method-i-load'
+  Reference: 'https://ruby-doc.org/stdlib-2.7.0/libdoc/json/rdoc/JSON.html#method-i-load'
   Enabled: true
   VersionAdded: '0.43'
   VersionChanged: '0.44'
@@ -2229,7 +2229,7 @@ Security/MarshalLoad:
   Description: >-
                  Avoid using of `Marshal.load` or `Marshal.restore` due to potential
                  security issues. See reference for more information.
-  Reference: 'https://ruby-doc.org/core-2.3.3/Marshal.html#module-Marshal-label-Security+considerations'
+  Reference: 'https://ruby-doc.org/core-2.7.0/Marshal.html#module-Marshal-label-Security+considerations'
   Enabled: true
   VersionAdded: '0.47'
 
@@ -2243,7 +2243,7 @@ Security/YAMLLoad:
   Description: >-
                  Prefer usage of `YAML.safe_load` over `YAML.load` due to potential
                  security issues. See reference for more information.
-  Reference: 'https://ruby-doc.org/stdlib-2.3.3/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security'
+  Reference: 'https://ruby-doc.org/stdlib-2.7.0/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security'
   Enabled: true
   VersionAdded: '0.47'
   SafeAutoCorrect: false

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -535,9 +535,9 @@ Style/PerlBackrefs:
 == Setting the target Ruby version
 
 Some checks are dependent on the version of the Ruby interpreter which the
-inspected code must run on. For example, enforcing using Ruby 2.3+ safe
-navigation operator rather than `try` can help make your code shorter and
-more consistent... _unless_ it must run on Ruby 2.2.
+inspected code must run on. For example, enforcing using Ruby 2.6+ endless
+ranges `foo[n..]` rather than `foo[n..-1]` can help make your code shorter and
+more consistent... _unless_ it must run on e.g. Ruby 2.5.
 
 Users may let RuboCop know the oldest version of Ruby which your project
 supports with:
@@ -545,7 +545,7 @@ supports with:
 [source,yaml]
 ----
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.5
 ----
 
 Otherwise, RuboCop will then check your project for `.ruby-version` and

--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -3157,21 +3157,17 @@ opening HEREDOC tag.
 | Yes
 | Yes
 | 0.49
-| 0.77
+| 0.85
 |===
 
 This cop checks the indentation of the here document bodies. The bodies
 are indented one step.
-In Ruby 2.3 or newer, squiggly heredocs (`<<~`) should be used. If you
-use the older rubies, you should introduce some library to your project
-(e.g. ActiveSupport, Powerpack or Unindent).
+
 Note: When ``Layout/LineLength``'s `AllowHeredoc` is false (not default),
       this cop does not add any offenses for long here documents to
       avoid `Layout/LineLength`'s offenses.
 
 === Examples
-
-==== EnforcedStyle: squiggly (default)
 
 [source,ruby]
 ----
@@ -3181,58 +3177,10 @@ something
 RUBY
 
 # good
-# When EnforcedStyle is squiggly, bad code is auto-corrected to the
-# following code.
 <<~RUBY
   something
 RUBY
 ----
-
-==== EnforcedStyle: active_support
-
-[source,ruby]
-----
-# good
-# When EnforcedStyle is active_support, bad code is auto-corrected to
-# the following code.
-<<-RUBY.strip_heredoc
-  something
-RUBY
-----
-
-==== EnforcedStyle: powerpack
-
-[source,ruby]
-----
-# good
-# When EnforcedStyle is powerpack, bad code is auto-corrected to
-# the following code.
-<<-RUBY.strip_indent
-  something
-RUBY
-----
-
-==== EnforcedStyle: unindent
-
-[source,ruby]
-----
-# good
-# When EnforcedStyle is unindent, bad code is auto-corrected to
-# the following code.
-<<-RUBY.unindent
-  something
-RUBY
-----
-
-=== Configurable attributes
-
-|===
-| Name | Default value | Configurable values
-
-| EnforcedStyle
-| `squiggly`
-| `squiggly`, `active_support`, `powerpack`, `unindent`
-|===
 
 === References
 

--- a/docs/modules/ROOT/pages/cops_security.adoc
+++ b/docs/modules/ROOT/pages/cops_security.adoc
@@ -71,7 +71,7 @@ JSON.parse("{}")
 
 === References
 
-* https://ruby-doc.org/stdlib-2.3.0/libdoc/json/rdoc/JSON.html#method-i-load
+* https://ruby-doc.org/stdlib-2.7.0/libdoc/json/rdoc/JSON.html#method-i-load
 
 == Security/MarshalLoad
 
@@ -106,7 +106,7 @@ Marshal.load(Marshal.dump({}))
 
 === References
 
-* https://ruby-doc.org/core-2.3.3/Marshal.html#module-Marshal-label-Security+considerations
+* https://ruby-doc.org/core-2.7.0/Marshal.html#module-Marshal-label-Security+considerations
 
 == Security/Open
 
@@ -171,4 +171,4 @@ YAML.dump("foo")
 
 === References
 
-* https://ruby-doc.org/stdlib-2.3.3/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security
+* https://ruby-doc.org/stdlib-2.7.0/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -3036,8 +3036,7 @@ to frozen string literals.
 It will add the comment `# frozen_string_literal: true` to the top of
 files to enable frozen string literals. Frozen string literals may be
 default in future Ruby. The comment will be added below a shebang and
-encoding comment. The frozen string literal comment is only valid in
-Ruby 2.3+.
+encoding comment.
 
 Note that the cop will ignore files where the comment exists but is set
 to `false` instead of `true`.

--- a/lib/rubocop/cop/layout/heredoc_indentation.rb
+++ b/lib/rubocop/cop/layout/heredoc_indentation.rb
@@ -5,66 +5,31 @@ module RuboCop
     module Layout
       # This cop checks the indentation of the here document bodies. The bodies
       # are indented one step.
-      # In Ruby 2.3 or newer, squiggly heredocs (`<<~`) should be used. If you
-      # use the older rubies, you should introduce some library to your project
-      # (e.g. ActiveSupport, Powerpack or Unindent).
+      #
       # Note: When ``Layout/LineLength``'s `AllowHeredoc` is false (not default),
       #       this cop does not add any offenses for long here documents to
       #       avoid `Layout/LineLength`'s offenses.
       #
-      # @example EnforcedStyle: squiggly (default)
+      # @example
       #   # bad
       #   <<-RUBY
       #   something
       #   RUBY
       #
       #   # good
-      #   # When EnforcedStyle is squiggly, bad code is auto-corrected to the
-      #   # following code.
       #   <<~RUBY
       #     something
       #   RUBY
       #
-      # @example EnforcedStyle: active_support
-      #   # good
-      #   # When EnforcedStyle is active_support, bad code is auto-corrected to
-      #   # the following code.
-      #   <<-RUBY.strip_heredoc
-      #     something
-      #   RUBY
-      #
-      # @example EnforcedStyle: powerpack
-      #   # good
-      #   # When EnforcedStyle is powerpack, bad code is auto-corrected to
-      #   # the following code.
-      #   <<-RUBY.strip_indent
-      #     something
-      #   RUBY
-      #
-      # @example EnforcedStyle: unindent
-      #   # good
-      #   # When EnforcedStyle is unindent, bad code is auto-corrected to
-      #   # the following code.
-      #   <<-RUBY.unindent
-      #     something
-      #   RUBY
       #
       class HeredocIndentation < Cop
         include Heredoc
-        include ConfigurableEnforcedStyle
 
         RUBY23_TYPE_MSG = 'Use %<indentation_width>d spaces for indentation ' \
                           'in a heredoc by using `<<~` instead of ' \
                           '`%<current_indent_type>s`.'
         RUBY23_WIDTH_MSG = 'Use %<indentation_width>d spaces for '\
                            'indentation in a heredoc.'
-        LIBRARY_MSG = 'Use %<indentation_width>d spaces for indentation in a ' \
-                      'heredoc by using %<method>s.'
-        STRIP_METHODS = {
-          unindent: 'unindent',
-          active_support: 'strip_heredoc',
-          powerpack: 'strip_indent'
-        }.freeze
 
         def on_heredoc(node)
           body = heredoc_body(node)
@@ -85,38 +50,14 @@ module RuboCop
         end
 
         def autocorrect(node)
-          check_style!
-
-          case style
-          when :squiggly
-            correct_by_squiggly(node)
-          else
-            correct_by_library(node)
-          end
+          correct_by_squiggly(node)
         end
 
         private
 
         def message(node)
-          case style
-          when :squiggly
-            current_indent_type = "<<#{heredoc_indent_type(node)}"
-            ruby23_message(indentation_width, current_indent_type)
-          when nil
-            method = "some library(e.g. ActiveSupport's `String#strip_heredoc`)"
-            library_message(indentation_width, method)
-          else
-            method = "`String##{STRIP_METHODS[style]}`"
-            library_message(indentation_width, method)
-          end
-        end
-
-        def library_message(indentation_width, method)
-          format(
-            LIBRARY_MSG,
-            indentation_width: indentation_width,
-            method: method
-          )
+          current_indent_type = "<<#{heredoc_indent_type(node)}"
+          ruby23_message(indentation_width, current_indent_type)
         end
 
         def ruby23_message(indentation_width, current_indent_type)
@@ -185,21 +126,6 @@ module RuboCop
           heredoc_beginning = node.loc.expression.source
           corrected = heredoc_beginning.sub(/<<-?/, '<<~')
           corrector.replace(node, corrected)
-        end
-
-        def correct_by_library(node)
-          lambda do |corrector|
-            corrector.replace(node.loc.heredoc_body, indented_body(node))
-            corrected = ".#{STRIP_METHODS[style]}"
-            corrector.insert_after(node, corrected)
-          end
-        end
-
-        def check_style!
-          return if style
-
-          raise Warning, "Auto-correction does not work for #{cop_name}. " \
-                         'Please configure EnforcedStyle.'
         end
 
         def indented_body(node)

--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -8,8 +8,7 @@ module RuboCop
       # It will add the comment `# frozen_string_literal: true` to the top of
       # files to enable frozen string literals. Frozen string literals may be
       # default in future Ruby. The comment will be added below a shebang and
-      # encoding comment. The frozen string literal comment is only valid in
-      # Ruby 2.3+.
+      # encoding comment.
       #
       # Note that the cop will ignore files where the comment exists but is set
       # to `false` instead of `true`.

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -873,7 +873,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     it 'shows reference entry' do
       create_file('example1.rb', "JSON.load('{}')")
       file = abs('example1.rb')
-      url = 'https://ruby-doc.org/stdlib-2.3.0/libdoc/json/rdoc/JSON.html' \
+      url = 'https://ruby-doc.org/stdlib-2.7.0/libdoc/json/rdoc/JSON.html' \
             '#method-i-load'
 
       expect(cli.run(['--format',

--- a/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
@@ -41,65 +41,6 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
 
   shared_examples 'all heredoc type' do |quote|
     context "quoted by #{quote}" do
-      let(:cop_config) do
-        { 'EnforcedStyle' => :powerpack }
-      end
-
-      include_examples 'offense', 'not indented', <<~RUBY, <<~CORRECTION
-        <<#{quote}RUBY2#{quote}
-        \#{foo}
-        bar
-        RUBY2
-      RUBY
-        <<#{quote}RUBY2#{quote}.strip_indent
-          \#{foo}
-          bar
-        RUBY2
-      CORRECTION
-      include_examples 'offense', 'minus level indented', <<~RUBY, <<~CORRECTION
-        def foo
-          <<#{quote}RUBY2#{quote}
-        \#{foo}
-        bar
-        RUBY2
-        end
-      RUBY
-        def foo
-          <<#{quote}RUBY2#{quote}.strip_indent
-            \#{foo}
-            bar
-        RUBY2
-        end
-      CORRECTION
-      include_examples 'offense', 'not indented, with `-`',
-                       <<~RUBY, <<~CORRECTION
-                         <<-#{quote}RUBY2#{quote}
-                         \#{foo}
-                         bar
-                         RUBY2
-                       RUBY
-                         <<-#{quote}RUBY2#{quote}.strip_indent
-                           \#{foo}
-                           bar
-                         RUBY2
-                       CORRECTION
-      include_examples 'offense', 'minus level indented, with `-`',
-                       <<~RUBY, <<~CORRECTION
-                         def foo
-                           <<-#{quote}RUBY2#{quote}
-                         \#{foo}
-                         bar
-                           RUBY2
-                         end
-                       RUBY
-                         def foo
-                           <<-#{quote}RUBY2#{quote}.strip_indent
-                             \#{foo}
-                             bar
-                           RUBY2
-                         end
-                       CORRECTION
-
       it 'does not register an offense when not indented but with ' \
          'whitespace, with `-`' do
         expect_no_offenses(<<-RUBY)
@@ -141,16 +82,6 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
       context 'when Layout/LineLength is configured' do
         let(:allow_heredoc) { false }
 
-        include_examples 'offense', 'short heredoc', <<~RUBY, <<~CORRECTION
-          <<#{quote}RUBY2#{quote}
-          12
-          RUBY2
-        RUBY
-          <<#{quote}RUBY2#{quote}.strip_indent
-            12
-          RUBY2
-        CORRECTION
-
         include_examples 'accept', 'long heredoc', <<~RUBY
           <<#{quote}RUBY2#{quote}
           12345678
@@ -158,140 +89,125 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
         RUBY
       end
 
-      it 'displays a message with suggestion powerpack' do
-        expect_offense(<<~RUBY)
-          <<-RUBY2
-          foo
-          ^^^ Use 2 spaces for indentation in a heredoc by using `String#strip_indent`.
-          RUBY2
-        RUBY
-      end
-
-      context 'EnforcedStyle is `squiggly`' do
-        let(:cop_config) do
-          { 'EnforcedStyle' => :squiggly }
-        end
-
-        include_examples 'offense', 'not indented', <<~RUBY, <<~CORRECTION
-          <<~#{quote}RUBY2#{quote}
+      include_examples 'offense', 'not indented', <<~RUBY, <<~CORRECTION
+        <<~#{quote}RUBY2#{quote}
+        something
+        RUBY2
+      RUBY
+        <<~#{quote}RUBY2#{quote}
           something
-          RUBY2
-        RUBY
-          <<~#{quote}RUBY2#{quote}
+        RUBY2
+      CORRECTION
+      include_examples 'offense', 'minus level indented',
+                       <<~RUBY, <<~CORRECTION
+                         def foo
+                           <<~#{quote}RUBY2#{quote}
+                         something
+                           RUBY2
+                         end
+                       RUBY
+                         def foo
+                           <<~#{quote}RUBY2#{quote}
+                             something
+                           RUBY2
+                         end
+                       CORRECTION
+      include_examples 'offense', 'too deep indented', <<~RUBY, <<~CORRECTION
+        <<~#{quote}RUBY2#{quote}
             something
-          RUBY2
-        CORRECTION
-        include_examples 'offense', 'minus level indented',
-                         <<~RUBY, <<~CORRECTION
-                           def foo
-                             <<~#{quote}RUBY2#{quote}
-                           something
-                             RUBY2
-                           end
-                         RUBY
-                           def foo
-                             <<~#{quote}RUBY2#{quote}
-                               something
-                             RUBY2
-                           end
-                         CORRECTION
-        include_examples 'offense', 'too deep indented', <<~RUBY, <<~CORRECTION
-          <<~#{quote}RUBY2#{quote}
-              something
-          RUBY2
-        RUBY
-          <<~#{quote}RUBY2#{quote}
-            something
-          RUBY2
-        CORRECTION
-        include_examples 'offense', 'not indented, without `~`',
-                         <<~RUBY, <<~CORRECTION
-                           <<#{quote}RUBY2#{quote}
+        RUBY2
+      RUBY
+        <<~#{quote}RUBY2#{quote}
+          something
+        RUBY2
+      CORRECTION
+      include_examples 'offense', 'not indented, without `~`',
+                       <<~RUBY, <<~CORRECTION
+                         <<#{quote}RUBY2#{quote}
+                         foo
+                         RUBY2
+                       RUBY
+                         <<~#{quote}RUBY2#{quote}
                            foo
-                           RUBY2
-                         RUBY
-                           <<~#{quote}RUBY2#{quote}
-                             foo
-                           RUBY2
-                         CORRECTION
+                         RUBY2
+                       CORRECTION
 
-        include_examples 'offense', 'not indented, with `~`',
-                         <<~RUBY, <<~CORRECTION
-                           <<~#{quote}RUBY2#{quote}
+      include_examples 'offense', 'not indented, with `~`',
+                       <<~RUBY, <<~CORRECTION
+                         <<~#{quote}RUBY2#{quote}
+                         foo
+                         RUBY2
+                       RUBY
+                         <<~#{quote}RUBY2#{quote}
                            foo
-                           RUBY2
-                         RUBY
-                           <<~#{quote}RUBY2#{quote}
-                             foo
-                           RUBY2
-                         CORRECTION
+                         RUBY2
+                       CORRECTION
 
-        include_examples 'offense', 'first line minus-level indented, with `-`',
-                         <<~RUBY, <<-CORRECTION
-                                   puts <<-#{quote}RUBY2#{quote}
-                           def foo
-                             bar
-                           end
-                           RUBY2
-                         RUBY
+      include_examples 'offense', 'first line minus-level indented, with `-`',
+                       <<~RUBY, <<-CORRECTION
+                                 puts <<-#{quote}RUBY2#{quote}
+                         def foo
+                           bar
+                         end
+                         RUBY2
+                       RUBY
         puts <<~#{quote}RUBY2#{quote}
           def foo
             bar
           end
         RUBY2
-        CORRECTION
+      CORRECTION
 
-        include_examples 'accept', 'indented, with `~`', <<~RUBY
-          <<~#{quote}RUBY2#{quote}
-            something
+      include_examples 'accept', 'indented, with `~`', <<~RUBY
+        <<~#{quote}RUBY2#{quote}
+          something
+        RUBY2
+      RUBY
+      include_examples 'accept', 'include empty lines', <<~RUBY
+        <<~#{quote}MSG#{quote}
+
+          foo
+
+            bar
+
+        MSG
+      RUBY
+
+      include_examples 'offense', 'not indented enough with empty lines',
+                       <<-RUBY, <<-CORRECTION
+        def baz
+          <<~#{quote}MSG#{quote}
+          foo
+
+            bar
+          MSG
+        end
+      RUBY
+        def baz
+          <<~#{quote}MSG#{quote}
+            foo
+
+              bar
+          MSG
+        end
+      CORRECTION
+
+      it 'displays message to use `<<~` instead of `<<`' do
+        expect_offense(<<~RUBY)
+          <<RUBY2
+          foo
+          ^^^ Use 2 spaces for indentation in a heredoc by using `<<~` instead of `<<`.
           RUBY2
         RUBY
-        include_examples 'accept', 'include empty lines', <<~RUBY
-          <<~#{quote}MSG#{quote}
+      end
 
-            foo
-
-              bar
-
-          MSG
+      it 'displays message to use `<<~` instead of `<<-`' do
+        expect_offense(<<~RUBY)
+          <<-RUBY2
+          foo
+          ^^^ Use 2 spaces for indentation in a heredoc by using `<<~` instead of `<<-`.
+          RUBY2
         RUBY
-
-        include_examples 'offense', 'not indented enough with empty lines',
-                         <<-RUBY, <<-CORRECTION
-          def baz
-            <<~#{quote}MSG#{quote}
-            foo
-
-              bar
-            MSG
-          end
-        RUBY
-          def baz
-            <<~#{quote}MSG#{quote}
-              foo
-
-                bar
-            MSG
-          end
-        CORRECTION
-
-        it 'displays message to use `<<~` instead of `<<`' do
-          expect_offense(<<~RUBY)
-            <<RUBY2
-            foo
-            ^^^ Use 2 spaces for indentation in a heredoc by using `<<~` instead of `<<`.
-            RUBY2
-          RUBY
-        end
-
-        it 'displays message to use `<<~` instead of `<<-`' do
-          expect_offense(<<~RUBY)
-            <<-RUBY2
-            foo
-            ^^^ Use 2 spaces for indentation in a heredoc by using `<<~` instead of `<<-`.
-            RUBY2
-          RUBY
-        end
       end
     end
   end


### PR DESCRIPTION
Since we dropped support for Ruby 2.3 in 58738943eb3f7a41266b4546a829fd0a5a13703d, there’s some cleanup to be done:

- Documentation should not refer to Ruby 2.3.
- Code comments should not refer to Ruby 2.3.
- `Layout/HeredocIndentation` cop should not allow `active_support`, `powerpack` and `unindent` styles, only the `squiggly` style.

Those three issues are fixed by this PR.

Please note that after removing functionality from `Layout/HeredocIndentation` I couldn’t resist cleaning up the remaining code and specs. Those changes _may_ be deemed large enough for a separate pull request. Please let me know.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
