### PR TITLE
[fix #7902] Unsafe conversion methods as symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#8017](https://github.com/rubocop-hq/rubocop/pull/8017): Fix a false positive for `Lint/SuppressedException` when empty rescue with comment in `def`. ([@koic][])
 * [#7990](https://github.com/rubocop-hq/rubocop/issues/7990): Fix resolving `inherit_gem` in remote configs. ([@CvX][])
 * [#8035](https://github.com/rubocop-hq/rubocop/issues/8035): Fix a false positive for `Lint/DeprecatedOpenSSLConstant` when using double quoted string argument. ([@koic][])
+* [#7902](https://github.com/rubocop-hq/rubocop/issues/7902): Handle unsafe conversion methods as symbols for `map` and `collect` in Lint/NumberConversion. ([@petar-lazarov][])
 
 ## 0.84.0 (2020-05-21)
 
@@ -4542,3 +4543,4 @@
 [@laurmurclar]: https://github.com/laurmurclar
 [@jethrodaniel]: https://github.com/jethrodaniel
 [@CvX]: https://github.com/CvX
+[@petar-lazarov]: https://github.com/petar-lazarov

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -1848,12 +1848,14 @@ fails. Cop prefer parsing with number class instead.
 '10'.to_i
 '10.2'.to_f
 '10'.to_c
+['1', 2, 3, 4].map(&:to_i)
 
 # good
 
 Integer('10', 10)
 Float('10.2')
 Complex('10')
+['1', 2, 3, 4].map { |i| Integer(i, 10) }
 ----
 
 == Lint/OrderedMagicComments

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1445,12 +1445,14 @@ fails. Cop prefer parsing with number class instead.
 '10'.to_i
 '10.2'.to_f
 '10'.to_c
+[1, 2, 3, 4].map(&:to_i)
 
 # good
 
 Integer('10', 10)
 Float('10.2')
 Complex('10')
+[1, 2, 3, 4].map { |i| Integer(i, 10) }
 ```
 
 ## Lint/OrderedMagicComments


### PR DESCRIPTION
Passing `&:to_i`, `&:to_f` or `&:to_c` to `map` and `collect` methods
should be considered offense by NumberConversion cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
