### PR TITLE
[Fix #8057] Update document links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ $ rubocop -V
 
 * Read [how to properly contribute to open source projects on GitHub][2].
 * Fork the project.
-* If you're adding or making changes to cops, read the [Development docs](https://docs.rubocop.org/en/latest/development/)
+* If you're adding or making changes to cops, read the [Development docs](https://docs.rubocop.org/rubocop/development.html)
 * Use a topic/feature branch to easily amend a pull request later, if necessary.
 * Write [good commit messages][3].
 * Use the same coding conventions as the rest of the project.

--- a/docs/modules/ROOT/pages/versioning.adoc
+++ b/docs/modules/ROOT/pages/versioning.adoc
@@ -47,7 +47,7 @@ set Enabled to either `true` or `false` in your `.rubocop.yml` file:
  - Style/HashEachMethods (0.80)
  - Style/HashTransformKeys (0.80)
  - Style/HashTransformValues (0.80)
-For more information: https://docs.rubocop.org/en/latest/versioning/
+For more information: https://docs.rubocop.org/rubocop/versioning.html
 ----
 
 You can see that 3 new cops were added in RuboCop 0.80 and it's up to you

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -136,7 +136,7 @@ module RuboCop
           warn Rainbow(" - #{cop.name} (#{version})").yellow
         end
 
-        warn Rainbow('For more information: https://docs.rubocop.org/en/latest/versioning/').yellow
+        warn Rainbow('For more information: https://docs.rubocop.org/rubocop/versioning.html').yellow
       end
 
       # Merges the given configuration with the default one. If

--- a/manual/versioning.md
+++ b/manual/versioning.md
@@ -49,7 +49,7 @@ set Enabled to either `true` or `false` in your `.rubocop.yml` file:
  - Style/HashEachMethods (0.80)
  - Style/HashTransformKeys (0.80)
  - Style/HashTransformValues (0.80)
-For more information: https://docs.rubocop.org/en/latest/versioning/
+For more information: https://docs.rubocop.org/rubocop/versioning.html
 ```
 
 You can see that 3 new cops were added in RuboCop 0.80 and it's up to you

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         INSPECTED_OUTPUT
 
         let(:versioning_manual_url) { <<~VERSIONING_MANUAL_URL.chop }
-          For more information: https://docs.rubocop.org/en/latest/versioning/
+          For more information: https://docs.rubocop.org/rubocop/versioning.html
         VERSIONING_MANUAL_URL
 
         before do


### PR DESCRIPTION
Fixes #8057.

This PR updates the following document links.

- https://docs.rubocop.org/en/latest/versioning/  -> https://docs.rubocop.org/rubocop/versioning.html
- https://docs.rubocop.org/en/latest/development/ -> https://docs.rubocop.org/rubocop/development.html

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
