### PR TITLE
expect_correction with loop

### DIFF
--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -48,21 +48,6 @@ module CopHelper
     corrector.rewrite
   end
 
-  def autocorrect_source_with_loop(source, file = nil)
-    cnt = 0
-    loop do
-      cop.instance_variable_set(:@corrections, [])
-      new_source = autocorrect_source(source, file)
-      return new_source if new_source == source
-
-      source = new_source
-      cnt += 1
-      if cnt > RuboCop::Runner::MAX_ITERATIONS
-        raise RuboCop::Runner::InfiniteCorrectionLoop.new(file, [])
-      end
-    end
-  end
-
   def _investigate(cop, processed_source)
     team = RuboCop::Cop::Team.new([cop], nil, raise_error: true)
     team.inspect_file(processed_source)

--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -96,17 +96,35 @@ module RuboCop
 
         expect(actual_annotations.to_s).to eq(expected_annotations.to_s)
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
-      def expect_correction(correction)
+      def expect_correction(correction, loop: false)
         raise '`expect_correction` must follow `expect_offense`' unless @processed_source
 
-        corrector =
-          RuboCop::Cop::Corrector.new(@processed_source.buffer, cop.corrections)
-        new_source = corrector.rewrite
+        iteration = 0
+        new_source = loop do
+          iteration += 1
+
+          corrector =
+            RuboCop::Cop::Corrector.new(@processed_source.buffer, cop.corrections)
+          corrected_source = corrector.rewrite
+
+          break corrected_source unless loop
+          break corrected_source if cop.corrections.empty?
+
+          if iteration > RuboCop::Runner::MAX_ITERATIONS
+            raise RuboCop::Runner::InfiniteCorrectionLoop.new(@processed_source.path, [])
+          end
+
+          # Prepare for next loop
+          cop.instance_variable_set(:@corrections, [])
+          @processed_source = parse_source(corrected_source,
+                                           @processed_source.path)
+          _investigate(cop, @processed_source)
+        end
 
         expect(new_source).to eq(correction)
       end
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
       def expect_no_corrections
         raise '`expect_no_corrections` must follow `expect_offense`' unless @processed_source

--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -86,20 +86,6 @@ RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
   end
 
   context 'When each individual group of line is not sorted' do
-    let(:source) { <<~RUBY }
-      gem "d"
-      gem "b"
-      gem "e"
-      gem "a"
-      gem "c"
-
-      gem "h"
-      gem "g"
-      gem "j"
-      gem "f"
-      gem "i"
-    RUBY
-
     it 'registers some offenses' do
       expect_offense(<<~RUBY)
         gem "d"
@@ -118,11 +104,8 @@ RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
         ^^^^^^^ Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem `f` should appear before `j`.
         gem "i"
       RUBY
-    end
 
-    it 'autocorrects' do
-      new_source = autocorrect_source_with_loop(source)
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY, loop: true)
         gem "a"
         gem "b"
         gem "c"
@@ -176,12 +159,6 @@ RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
   end
 
   context 'When gems have an inline comment, and not sorted' do
-    let(:source) { <<~RUBY }
-      gem 'rubocop' # For code quality
-      gem 'pry'
-      gem 'rspec'   # For test
-    RUBY
-
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         gem 'rubocop' # For code quality
@@ -189,11 +166,8 @@ RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
         ^^^^^^^^^ Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem `pry` should appear before `rubocop`.
         gem 'rspec'   # For test
       RUBY
-    end
 
-    it 'autocorrects' do
-      new_source = autocorrect_source_with_loop(source)
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY, loop: true)
         gem 'pry'
         gem 'rspec'   # For test
         gem 'rubocop' # For code quality

--- a/spec/rubocop/cop/gemspec/ordered_dependencies_spec.rb
+++ b/spec/rubocop/cop/gemspec/ordered_dependencies_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Cop::Gemspec::OrderedDependencies, :config do
         end
 
         it 'autocorrects' do
-          new_source = autocorrect_source_with_loop(source)
+          new_source = autocorrect_source(source)
           expect(new_source).to eq(<<~RUBY)
             Gem::Specification.new do |spec|
               spec.#{add_dependency} 'rspec'
@@ -95,7 +95,7 @@ RSpec.describe RuboCop::Cop::Gemspec::OrderedDependencies, :config do
           end
 
           it 'autocorrects' do
-            new_source = autocorrect_source_with_loop(source)
+            new_source = autocorrect_source(source)
             expect(new_source).to eq(<<~RUBY)
               Gem::Specification.new do |spec|
                 # For

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -106,22 +106,13 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
           extend SomeModule
         end
       RUBY
-    end
 
-    specify do
-      expect(autocorrect_source_with_loop(<<~RUBY))
-        class Example
-          CONST = 1
+      expect_correction(<<~RUBY, loop: true)
+        class Person
           include AnotherModule
           extend SomeModule
+          CONST = 'wrong place'
         end
-      RUBY
-        .to eq(<<~RUBY)
-          class Example
-            include AnotherModule
-            extend SomeModule
-            CONST = 1
-          end
       RUBY
     end
   end

--- a/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
@@ -121,17 +121,14 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
       end
 
       it 'registers an offense for not indented, without `~`' do
-        annotated_source = <<~RUBY
+        expect_offense(<<~RUBY)
           <<#{quote}RUBY2#{quote}
           foo
           ^^^ Use 2 spaces for indentation in a heredoc by using `<<~` instead of `<<`.
           RUBY2
         RUBY
 
-        expect_offense(annotated_source)
-
-        corrected = looped_autocorrect_from_annotated_source(annotated_source)
-        expect(corrected).to eq(<<~CORRECTION)
+        expect_correction(<<~CORRECTION, loop: true)
           <<~#{quote}RUBY2#{quote}
             foo
           RUBY2
@@ -154,7 +151,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
       end
 
       it 'registers an offense for first line minus-level indented, with `-`' do
-        annotated_source = <<~RUBY
+        expect_offense(<<~RUBY)
                   puts <<-#{quote}RUBY2#{quote}
           def foo
           ^^^^^^^ Use 2 spaces for indentation in a heredoc by using `<<~` instead of `<<-`.
@@ -163,10 +160,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
           RUBY2
         RUBY
 
-        expect_offense(annotated_source)
-
-        corrected = looped_autocorrect_from_annotated_source(annotated_source)
-        expect(corrected).to eq(<<-CORRECTION)
+        expect_correction(<<-CORRECTION, loop: true)
         puts <<~#{quote}RUBY2#{quote}
           def foo
             bar
@@ -242,11 +236,5 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
 
   [nil, "'", '"', '`'].each do |quote|
     include_examples 'all heredoc type', quote
-  end
-
-  def looped_autocorrect_from_annotated_source(annotated_source)
-    source =
-      annotated_source.lines.reject { |line| line =~ /^ *\^/ }.join
-    autocorrect_source_with_loop(source)
   end
 end

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -80,11 +80,9 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
     end
 
     it 'autocorrects the outer offense later' do
-      source =
-        annotated_source.lines.reject { |line| line =~ /^ *\^/ }.join
-      corrected = autocorrect_source_with_loop(source)
+      expect_offense(annotated_source)
 
-      expect(corrected).to eq(<<~RUBY)
+      expect_correction(<<~RUBY, loop: true)
         @errors << if var.any?(:prob_a_check)
           'Problem A'
         elsif var.any?(:prob_a_check)
@@ -2228,11 +2226,9 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
     end
 
     it 'eventually autocorrects all branches' do
-      source =
-        annotated_source.lines.reject { |line| line =~ /^ *\^/ }.join
-      corrected = autocorrect_source_with_loop(source)
+      expect_offense(annotated_source)
 
-      expect(corrected).to eq(<<~RUBY)
+      expect_correction(<<~RUBY, loop: true)
         bar = if outer
           1
         else

--- a/spec/rubocop/cop/style/rescue_modifier_spec.rb
+++ b/spec/rubocop/cop/style/rescue_modifier_spec.rb
@@ -204,11 +204,13 @@ RSpec.describe RuboCop::Cop::Style::RescueModifier do
     end
 
     it 'corrects doubled rescue modifiers' do
-      new_source = autocorrect_source_with_loop(<<~RUBY)
+      expect_offense(<<~RUBY)
         blah rescue 1 rescue 2
+        ^^^^^^^^^^^^^ Avoid using `rescue` in its modifier form.
+        ^^^^^^^^^^^^^^^^^^^^^^ Avoid using `rescue` in its modifier form.
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY, loop: true)
         begin
           begin
             blah


### PR DESCRIPTION
In some places, we spec what happens after `one` auto-correct iteration, and in some places we spec what happens after _many_ auto-correct iterations.

As mentioned in #8003, there is no longer any reason to use helpers like `autocorrect_source_with_loop`. This PR removes that method and all our uses of it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
