### PR TITLE
Ffix small typo in spec file

### DIFF
--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'RuboCop Project', type: :feature do
       end
     end
 
-    it 'have a period at EOL of description' do
+    it 'has a period at EOL of description' do
       cop_names.each do |name|
         description = config[name]['Description']
 


### PR DESCRIPTION
I made tiny change in spec/project_spec.rb.
I think "has" is better than "have".

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
