### PR TITLE
Update assertion to docs synchronized

### DIFF
--- a/docs/modules/ROOT/pages/cops_naming.adoc
+++ b/docs/modules/ROOT/pages/cops_naming.adoc
@@ -311,6 +311,10 @@ anything/using_snake_case.rake
 | `false`
 | Boolean
 
+| CheckDefinitionPathHierarchy
+| `true`
+| Boolean
+
 | Regex
 | `<none>`
 | 

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -266,15 +266,15 @@ task generate_cops_documentation: :yard_for_generate_documentation do
     status == 'pending' ? 'Pending' : 'Enabled'
   end
 
-  def assert_manual_synchronized
+  def assert_docs_synchronized
     # Do not print diff and yield whether exit code was zero
-    sh('git diff --quiet manual') do |outcome, _|
+    sh('git diff --quiet docs') do |outcome, _|
       return if outcome
 
       # Output diff before raising error
-      sh('GIT_PAGER=cat git diff manual')
+      sh('GIT_PAGER=cat git diff docs')
 
-      warn 'The manual directory is out of sync. ' \
+      warn 'The docs directory is out of sync. ' \
         'Run `rake generate_cops_documentation` and commit the results.'
       exit!
     end
@@ -291,7 +291,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
 
     print_table_of_contents(cops)
 
-    assert_manual_synchronized if ENV['CI'] == 'true'
+    assert_docs_synchronized if ENV['CI'] == 'true'
   ensure
     RuboCop::ConfigLoader.default_configuration = nil
   end


### PR DESCRIPTION
Follow up to #8047.

This PR fixes the following error.

```console
% CI=true bundle exec rake generate_cops_documentation
Files:         485
Modules:        84 (   12 undocumented)
Classes:       450 (    3 undocumented)
Constants:     643 (  632 undocumented)
Attributes:     31 (    0 undocumented)
Methods:      1121 (  995 undocumented)
 29.50% documented
* generated
  /Users/koic/src/github.com/rubocop-hq/rubocop/docs/modules/ROOT/pages/cops_bundler.adoc
* generated
  /Users/koic/src/github.com/rubocop-hq/rubocop/docs/modules/ROOT/pages/cops_gemspec.adoc
* generated
  /Users/koic/src/github.com/rubocop-hq/rubocop/docs/modules/ROOT/pages/cops_layout.adoc
* generated
  /Users/koic/src/github.com/rubocop-hq/rubocop/docs/modules/ROOT/pages/cops_lint.adoc
* generated
  /Users/koic/src/github.com/rubocop-hq/rubocop/docs/modules/ROOT/pages/cops_metrics.adoc
* generated
  /Users/koic/src/github.com/rubocop-hq/rubocop/docs/modules/ROOT/pages/cops_migration.adoc
* generated
  /Users/koic/src/github.com/rubocop-hq/rubocop/docs/modules/ROOT/pages/cops_naming.adoc
* generated
  /Users/koic/src/github.com/rubocop-hq/rubocop/docs/modules/ROOT/pages/cops_security.adoc
* generated
  /Users/koic/src/github.com/rubocop-hq/rubocop/docs/modules/ROOT/pages/cops_style.adoc
git diff --quiet manual
fatal: ambiguous argument 'manual': unknown revision or path not in the
  working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
GIT_PAGER=cat git diff manual
fatal: ambiguous argument 'manual': unknown revision or path not in the
  working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
rake aborted!
Command failed with status (128): [GIT_PAGER=cat git diff manual...]
tasks/cops_documentation.rake:275:in `block in
  assert_manual_synchronized'
tasks/cops_documentation.rake:271:in `assert_manual_synchronized'
tasks/cops_documentation.rake:294:in `main'
tasks/cops_documentation.rake:299:in `block in <top (required)>'
/Users/koic/.rbenv/versions/2.6.6/bin/bundle:23:in `load'
/Users/koic/.rbenv/versions/2.6.6/bin/bundle:23:in `<main>'
Tasks: TOP => generate_cops_documentation
(See full trace by running task with --trace)
```

https://circleci.com/gh/rubocop-hq/rubocop/104732

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
