### PR TITLE
[Fix #8081] Fix an error for `Lint/SuppressedException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#8083](https://github.com/rubocop-hq/rubocop/issues/8083): Fix an error for `Lint/MixedRegexpCaptureTypes` cop when using a regular expression that cannot be processed by regexp_parser gem. ([@koic][])
+* [#8081](https://github.com/rubocop-hq/rubocop/issues/8081): Fix an error for `Lint/SuppressedException` when empty rescue block in `do` block. ([@koic][])
 
 ## 0.85.0 (2020-06-01)
 

--- a/lib/rubocop/cop/lint/suppressed_exception.rb
+++ b/lib/rubocop/cop/lint/suppressed_exception.rb
@@ -78,7 +78,7 @@ module RuboCop
 
         def comment_between_rescue_and_end?(node)
           end_line = nil
-          node.each_ancestor(:kwbegin, :def) do |ancestor|
+          node.each_ancestor(:kwbegin, :def, :block) do |ancestor|
             end_line = ancestor.loc.end.line
             break
           end

--- a/spec/rubocop/cop/lint/suppressed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/suppressed_exception_spec.rb
@@ -48,6 +48,30 @@ RSpec.describe RuboCop::Cop::Lint::SuppressedException, :config do
         RUBY
       end
     end
+
+    context 'Ruby 2.5 or higher', :ruby25 do
+      context 'when empty rescue for `do` block' do
+        it 'registers an offense for empty rescue without comment' do
+          expect_offense(<<~RUBY)
+            foo do
+              do_something
+            rescue
+            ^^^^^^ Do not suppress exceptions.
+            end
+          RUBY
+        end
+
+        it 'registers an offense for empty rescue with comment' do
+          expect_offense(<<~RUBY)
+            foo do
+            rescue
+            ^^^^^^ Do not suppress exceptions.
+              # do nothing
+            end
+          RUBY
+        end
+      end
+    end
   end
 
   context 'with AllowComments set to true' do
@@ -83,6 +107,29 @@ RSpec.describe RuboCop::Cop::Lint::SuppressedException, :config do
             # do nothing
           end
         RUBY
+      end
+    end
+
+    context 'Ruby 2.5 or higher', :ruby25 do
+      context 'when empty rescue for `do` block' do
+        it 'registers an offense for empty rescue without comment' do
+          expect_offense(<<~RUBY)
+            foo do
+              do_something
+            rescue
+            ^^^^^^ Do not suppress exceptions.
+            end
+          RUBY
+        end
+
+        it 'does not register an offense for empty rescue with comment' do
+          expect_no_offenses(<<~RUBY)
+            foo do
+            rescue
+              # do nothing
+            end
+          RUBY
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #8081.

This PR fixes an error for `Lint/SuppressedException` when empty rescue block in `do` block.

```console
% cat example.rb
foo do
rescue Foo
  # ok
end

% bundle exec rubocop --only Lint/SuppressedException
(snip)

Inspecting 1 file
W

Offenses:

example.rb:2:1: W: Lint/SuppressedException: Do not suppress exceptions.
rescue Foo
^^^^^^^^^^

1 file inspected, 1 offense detected
```

`do` block rescue is a syntax introduced in Ruby 2.5.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
