### PR TITLE
Fix Layout/SpaceAroundBlockParameters bug related to trailing commas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#8912](https://github.com/rubocop-hq/rubocop/pull/8912): Fix `Layout/ElseAlignment` for `rescue/else/ensure` inside `do/end` blocks with assignment. ([@miry][])
 * [#8971](https://github.com/rubocop-hq/rubocop/issues/8971): Fix a false alarm for `# rubocop:disable Lint/EmptyBlock` inline comment with `Lint/RedundantCopDisableDirective`. ([@koic][])
 * [#8976](https://github.com/rubocop-hq/rubocop/issues/8976): Fix an incorrect auto-correct for `Style/KeywordParametersOrder` when when `kwoptarg` is before `kwarg` and argument parentheses omitted. ([@koic][])
+* [#8084](https://github.com/rubocop-hq/rubocop/pull/8084): Fix a bug in how `Layout/SpaceAroundBlockParameters` handles block parameters with a trailing comma. ([@bquorning][])
 
 ## 1.1.0 (2020-10-29)
 

--- a/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
@@ -154,8 +154,15 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
         RUBY
       end
 
-      it 'accepts no space after the last comma' do
-        expect_no_offenses('{}.each { |x,| puts x }')
+      it 'registers an offense for space before and after the last comma' do
+        expect_offense(<<~RUBY)
+          {}.each { |x , | puts x }
+                        ^ Space after last block parameter detected.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {}.each { |x ,| puts x }
+        RUBY
       end
     end
 
@@ -351,6 +358,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
     context 'trailing comma' do
       it 'accepts space after the last comma' do
         expect_no_offenses('{}.each { | x, | puts x }')
+      end
+
+      it 'accepts space both before and after the last comma' do
+        expect_no_offenses('{}.each { | x , | puts x }')
       end
 
       it 'registers an offense and corrects no space after the last comma' do


### PR DESCRIPTION
There was a bug in how Layout/SpaceAroundBlockParameters autocorrected block parameters with a trailing comma with both leading and trailing whitespace.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/