### PR TITLE
Failing spec for Layout/SpaceInsideArrayLiteralBrackets

### DIFF
--- a/spec/rubocop/cop/layout/space_inside_array_literal_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_array_literal_brackets_spec.rb
@@ -524,8 +524,21 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       RUBY
     end
 
-    context 'multiline array does not collapse successive right-brackets' do
-      it 'registers an offense and corrects' do
+    context 'multiline, 2-dimensional array with spaces' do
+      pending 'registers an offense and corrects at the beginning of array' do
+        expect_offense(<<~RUBY)
+          multiline = [ [ 1, 2, 3, 4 ],
+                       ^ #{no_space_message}
+            [ 3, 4, 5, 6 ]]
+        RUBY
+
+        expect_correction(<<~RUBY, loop: false)
+          multiline = [[ 1, 2, 3, 4 ],
+            [ 3, 4, 5, 6 ]]
+        RUBY
+      end
+
+      pending 'registers an offense and corrects at the end of array' do
         expect_offense(<<~RUBY)
           multiline = [[ 1, 2, 3, 4 ],
             [ 3, 4, 5, 6 ] ]
@@ -533,7 +546,37 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
         RUBY
 
         expect_correction(<<~RUBY, loop: false)
-          multiline = [ [ 1, 2, 3, 4 ],
+          multiline = [[ 1, 2, 3, 4 ],
+            [ 3, 4, 5, 6 ]]
+        RUBY
+      end
+    end
+
+    context 'multiline, 2-dimensional array with newlines' do
+      pending 'registers an offense and corrects at the beginning of array' do
+        expect_offense(<<~RUBY)
+          multiline = [
+                       ^{} #{no_space_message}
+            [ 1, 2, 3, 4 ],
+            [ 3, 4, 5, 6 ]]
+        RUBY
+
+        expect_correction(<<~RUBY, loop: false)
+          multiline = [[ 1, 2, 3, 4 ],
+            [ 3, 4, 5, 6 ]]
+        RUBY
+      end
+
+      pending 'registers an offense and corrects at the end of array' do
+        expect_offense(<<~RUBY)
+          multiline = [[ 1, 2, 3, 4 ],
+            [ 3, 4, 5, 6 ]
+                          ^{} #{no_space_message}
+          ]
+        RUBY
+
+        expect_correction(<<~RUBY, loop: false)
+          multiline = [[ 1, 2, 3, 4 ],
             [ 3, 4, 5, 6 ]]
         RUBY
       end
@@ -568,37 +611,6 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       expect_correction(<<~RUBY)
         [[ a, b ], [ foo, [ bar, baz ]]]
       RUBY
-    end
-
-    context 'multiline array does not collapse successive left-brackets' do
-      it 'registers an offense, and auto-corrects' do
-        expect_offense(<<~RUBY)
-          multiline = [
-                       ^{} #{no_space_message}
-            [ 1, 2, 3, 4 ],
-            [ 3, 4, 5, 6 ]]
-        RUBY
-
-        expect_correction(<<~RUBY, loop: false)
-          multiline = [
-            [ 1, 2, 3, 4 ],
-            [ 3, 4, 5, 6 ] ]
-        RUBY
-      end
-    end
-
-    context 'multiline array does not collapse any successive brackets' do
-      it 'registers an offense, but does not autocorrect' do
-        expect_offense(<<~RUBY)
-          array = [
-                   ^{} #{no_space_message}
-            [ a ],
-            [ b, c ]
-          ]
-        RUBY
-
-        expect_no_corrections
-      end
     end
   end
 end


### PR DESCRIPTION
These specs were added in #6585 which very honestly says:

> Adds tests and docs for multiline arrays in the `compact` style.
>
> My goal here is just to document current behavior, or, if this is not the desired behavior, to draw maintainer attention to the problem.

I believe that the specs should document the _desired_ behavior. If that means marking some of our existing specs as `pending`, well, so be it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/