### PR TITLE
Always loop when testing autocorrection

### DIFF
--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -115,7 +115,7 @@ module RuboCop
         expect(actual_annotations.to_s).to eq(expected_annotations.to_s)
       end
 
-      def expect_correction(correction, loop: false)
+      def expect_correction(correction, loop: true)
         raise '`expect_correction` must follow `expect_offense`' unless @processed_source
 
         iteration = 0

--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -128,6 +128,7 @@ module RuboCop
 
           break corrected_source unless loop
           break corrected_source if cop.corrections.empty?
+          break corrected_source if corrected_source == @processed_source.buffer.source
 
           if iteration > RuboCop::Runner::MAX_ITERATIONS
             raise RuboCop::Runner::InfiniteCorrectionLoop.new(@processed_source.path, [])
@@ -135,6 +136,8 @@ module RuboCop
 
           # Prepare for next loop
           cop.instance_variable_set(:@corrections, [])
+          # Cache invalidation. This is bad!
+          cop.instance_variable_set(:@token_table, nil)
           @processed_source = parse_source(corrected_source,
                                            @processed_source.path)
           _investigate(cop, @processed_source)

--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
         gem "i"
       RUBY
 
-      expect_correction(<<~RUBY, loop: true)
+      expect_correction(<<~RUBY)
         gem "a"
         gem "b"
         gem "c"
@@ -167,7 +167,7 @@ RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
         gem 'rspec'   # For test
       RUBY
 
-      expect_correction(<<~RUBY, loop: true)
+      expect_correction(<<~RUBY)
         gem 'pry'
         gem 'rspec'   # For test
         gem 'rubocop' # For code quality

--- a/spec/rubocop/cop/layout/array_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/array_alignment_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe RuboCop::Cop::Layout::ArrayAlignment do
            [:l4]]]]
       RUBY
 
-      expect_correction(<<~RUBY)
+      expect_correction(<<~RUBY, loop: false)
         [:l1,
          [:l2,
            [:l3,
@@ -251,7 +251,7 @@ RSpec.describe RuboCop::Cop::Layout::ArrayAlignment do
             [:l4]]]]
       RUBY
 
-      expect_correction(<<~RUBY)
+      expect_correction(<<~RUBY, loop: false)
         [:l1,
           [:l2,
            [:l3,

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
         end
       RUBY
 
-      expect_correction(<<~RUBY, loop: true)
+      expect_correction(<<~RUBY)
         class Person
           include AnotherModule
           extend SomeModule

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -529,7 +529,7 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
         end
       RUBY
 
-      expect_correction(<<~RUBY)
+      expect_correction(<<~RUBY, loop: false)
         def batch
           @areas   = params[:param].map {
                        var_1      = 123_456

--- a/spec/rubocop/cop/layout/heredoc_argument_closing_parenthesis_spec.rb
+++ b/spec/rubocop/cop/layout/heredoc_argument_closing_parenthesis_spec.rb
@@ -395,7 +395,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
           )
         RUBY
 
-        expect_correction(<<~RUBY)
+        expect_correction(<<~RUBY, loop: false)
           bar(
             foo(123, <<-SQL),
               foo
@@ -503,7 +503,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
                               ^ Put the closing parenthesis for a method call with a HEREDOC parameter on the same line as the HEREDOC opening.
         RUBY
 
-        expect_correction(<<~RUBY)
+        expect_correction(<<~RUBY, loop: false)
           query.order(Arel.sql(<<-SQL)
             foo
           SQL

--- a/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
           RUBY2
         RUBY
 
-        expect_correction(<<~CORRECTION, loop: true)
+        expect_correction(<<~CORRECTION)
           <<~#{quote}RUBY2#{quote}
             foo
           RUBY2
@@ -160,7 +160,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
           RUBY2
         RUBY
 
-        expect_correction(<<-CORRECTION, loop: true)
+        expect_correction(<<-CORRECTION)
         puts <<~#{quote}RUBY2#{quote}
           def foo
             bar

--- a/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
@@ -359,7 +359,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
                       ^ Space after last block parameter missing.
         RUBY
 
-        expect_correction(<<~RUBY)
+        expect_correction(<<~RUBY, loop: false)
           {}.each { | x ,| puts x }
         RUBY
       end

--- a/spec/rubocop/cop/layout/space_inside_array_literal_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_array_literal_brackets_spec.rb
@@ -527,7 +527,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
                           ^ Do not use space inside array brackets.
         RUBY
 
-        expect_correction(<<~RUBY)
+        expect_correction(<<~RUBY, loop: false)
           multiline = [ [ 1, 2, 3, 4 ],
             [ 3, 4, 5, 6 ]]
         RUBY

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -634,7 +634,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier do
         end
       RUBY
 
-      expect_correction(<<~RUBY)
+      expect_correction(<<~RUBY, loop: false)
         #{keyword} A
           private
           def method1

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
     it 'autocorrects the inner offense first' do
       expect_offense(annotated_source)
 
-      expect_correction(<<~RUBY)
+      expect_correction(<<~RUBY, loop: false)
         if var.any?(:prob_a_check)
           @errors << 'Problem A'
         elsif var.any?(:prob_a_check)
@@ -2079,7 +2079,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
           end
         RUBY
 
-        expect_correction(<<~RUBY)
+        expect_correction(<<~RUBY, loop: false)
           unless foo
             baz = if foobar
               1
@@ -2212,7 +2212,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
     it 'does not consider branches of nested ifs' do
       expect_offense(annotated_source)
 
-      expect_correction(<<~RUBY)
+      expect_correction(<<~RUBY, loop: false)
         if outer
           bar = 1
         else

--- a/spec/rubocop/cop/style/rescue_modifier_spec.rb
+++ b/spec/rubocop/cop/style/rescue_modifier_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe RuboCop::Cop::Style::RescueModifier do
         ^^^^^^^^^^^^^^^^^^^^^^ Avoid using `rescue` in its modifier form.
       RUBY
 
-      expect_correction(<<~RUBY, loop: true)
+      expect_correction(<<~RUBY)
         begin
           begin
             blah


### PR DESCRIPTION
Related to #8062, #8075 and #8076, this PR changes `#expect_correction` to always do looped autocorrection.

For most cops and specs, this won't change anything. The offense is corrected in one go, and the second iteration doesn't change anything.

For a few specs, something will change. A few specs have to explicitly pass `loop: false` to test the result of the first round of autocorrect, and another few specs need to pass it to avoid exceptions such as `InfiniteCorrectionLoop`. And that's the real value of using looped autocorrection in the specs – we will find more errors before releasing them to our users.

(Also in this PR: Fixing two bugs in `#expect_correction`, discovered when enabling the looping)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [-] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [-] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
