### PR TITLE
[Fix #8083] Fix an error for `Lint/MixedRegexpCaptureTypes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## 0.85.0 (2020-06-01)
 
+### Bug fixes
+
+* [#8083](https://github.com/rubocop-hq/rubocop/issues/8083): Fix an error for `Lint/MixedRegexpCaptureTypes` cop when using a regular expression that cannot be processed by regexp_parser gem. ([@koic][])
+
 ### New features
 
 * [#6289](https://github.com/rubocop-hq/rubocop/issues/6289): Add new `CheckDefinitionPathHierarchy` option for `Naming/FileName`. ([@jschneid][])

--- a/lib/rubocop/cop/lint/mixed_regexp_capture_types.rb
+++ b/lib/rubocop/cop/lint/mixed_regexp_capture_types.rb
@@ -27,7 +27,14 @@ module RuboCop
         def on_regexp(node)
           return if contain_non_literal?(node)
 
-          tree = Regexp::Parser.parse(node.content)
+          begin
+            tree = Regexp::Parser.parse(node.content)
+          # Returns if a regular expression that cannot be processed by regexp_parser gem.
+          # https://github.com/rubocop-hq/rubocop/issues/8083
+          rescue Regexp::Scanner::ScannerError
+            return
+          end
+
           return unless named_capture?(tree)
           return unless numbered_capture?(tree)
 

--- a/spec/rubocop/cop/lint/mixed_regexp_capture_types_spec.rb
+++ b/spec/rubocop/cop/lint/mixed_regexp_capture_types_spec.rb
@@ -31,6 +31,13 @@ RSpec.describe RuboCop::Cop::Lint::MixedRegexpCaptureTypes do
     RUBY
   end
 
+  # See https://github.com/rubocop-hq/rubocop/issues/8083
+  it 'does not register offense when using a Regexp cannot be processed by regexp_parser gem' do
+    expect_no_offenses(<<~'RUBY')
+      /data = ({"words":.+}}}[^}]*})/m
+    RUBY
+  end
+
   # RuboCop does not know a value of variables that it will contain in the regexp literal.
   # For example, `/(?<foo>#{var}*)` is interpreted as `/(?<foo>*)`.
   # So it does not offense when variables are used in regexp literals.


### PR DESCRIPTION
Fixes #8083.

This PR fixes an error for `Lint/MixedRegexpCaptureTypes` cop when using a regular expression that cannot be processed by regexp_parser gem.
https://github.com/ammar/regexp_parser

Probably false negatives will be made, however false negatives will be reduced when a processing pattern of regexp_parser increases.

So this PR relies on regexp_parser for error resolution.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
