### PR TITLE
Registry improvements

### DIFF
--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -23,7 +23,7 @@ module RuboCop
     #       # Do custom processing
     #     end
     #   end
-    class Cop
+    class Cop # rubocop:disable Metrics/ClassLength
       extend RuboCop::AST::Sexp
       extend NodePattern::Macros
       include RuboCop::AST::Sexp
@@ -46,6 +46,10 @@ module RuboCop
 
       def self.inherited(subclass)
         Registry.global.enlist(subclass)
+      end
+
+      def self.exclude_from_registry
+        Registry.global.dismiss(self)
       end
 
       def self.badge

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -44,22 +44,8 @@ module RuboCop
       attr_reader :config, :offenses, :corrections
       attr_accessor :processed_source # TODO: Bad design.
 
-      @registry = Registry.new
-
-      class << self
-        attr_reader :registry
-      end
-
-      def self.all
-        registry.without_department(:Test).cops
-      end
-
-      def self.qualified_cop_name(name, origin)
-        registry.qualified_cop_name(name, origin)
-      end
-
       def self.inherited(subclass)
-        registry.enlist(subclass)
+        Registry.global.enlist(subclass)
       end
 
       def self.badge
@@ -244,6 +230,23 @@ module RuboCop
       # ie when the ResultCache should be invalidated.
       def external_dependency_checksum
         nil
+      end
+
+      ### Deprecated registry access
+
+      # @deprecated Use Registry.global
+      def self.registry
+        Registry.global
+      end
+
+      # @deprecated Use Registry.all
+      def self.all
+        Registry.all
+      end
+
+      # @deprecated Use Registry.qualified_cop_name
+      def self.qualified_cop_name(name, origin)
+        Registry.qualified_cop_name(name, origin)
       end
 
       private

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -32,7 +32,7 @@ module RuboCop
       end
 
       # @return [Team]
-      def self.new(cop_or_classes, config, options = nil)
+      def self.new(cop_or_classes, config, options = {})
         # Support v0 api:
         return mobilize(cop_or_classes, config, options) if cop_or_classes.first.is_a?(Class)
 

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -321,15 +321,10 @@ RSpec.describe RuboCop::Cop::Generator do
     include FileHelper
 
     around do |example|
-      orig_registry = RuboCop::Cop::Cop.registry
-      RuboCop::Cop::Cop.instance_variable_set(
-        :@registry,
-        RuboCop::Cop::Registry.new(
-          [RuboCop::Cop::InternalAffairs::NodeDestructuring]
-        )
+      new_global = RuboCop::Cop::Registry.new(
+        [RuboCop::Cop::InternalAffairs::NodeDestructuring]
       )
-      example.run
-      RuboCop::Cop::Cop.instance_variable_set(:@registry, orig_registry)
+      RuboCop::Cop::Registry.with_temporary_global(new_global) { example.run }
     end
 
     let(:config) do

--- a/spec/rubocop/cop/registry_spec.rb
+++ b/spec/rubocop/cop/registry_spec.rb
@@ -54,6 +54,29 @@ RSpec.describe RuboCop::Cop::Registry do
     expect(registry.cops).not_to include(klass)
   end
 
+  context 'when dismissing a cop class' do
+    let(:cop_class) { ::RuboCop::Cop::Metrics::AbcSize }
+
+    before { registry.enlist(cop_class) }
+
+    it 'allows it if done rapidly' do
+      registry.dismiss(cop_class)
+      expect(registry.cops).not_to include(cop_class)
+    end
+
+    it 'disallows it if done too late' do
+      expect(registry.cops).to include(cop_class)
+      expect { registry.dismiss(cop_class) }.to raise_error(RuntimeError)
+    end
+
+    it 'allows re-listing' do
+      registry.dismiss(cop_class)
+      expect(registry.cops).not_to include(cop_class)
+      registry.enlist(cop_class)
+      expect(registry.cops).to include(cop_class)
+    end
+  end
+
   it 'exposes cop departments' do
     expect(registry.departments).to eql(%i[Lint Layout Metrics RSpec Test])
   end

--- a/spec/rubocop/cop/registry_spec.rb
+++ b/spec/rubocop/cop/registry_spec.rb
@@ -43,13 +43,15 @@ RSpec.describe RuboCop::Cop::Registry do
   # store. The workaround is to replace the global cop store with a temporary
   # store during these tests
   around do |test|
-    registry        = RuboCop::Cop::Cop.registry
-    temporary_store = described_class.new(registry.cops)
-    RuboCop::Cop::Cop.instance_variable_set(:@registry, temporary_store)
+    described_class.with_temporary_global { test.run }
+  end
 
-    test.run
-
-    RuboCop::Cop::Cop.instance_variable_set(:@registry, registry)
+  it 'can be cloned' do
+    klass = ::RuboCop::Cop::Metrics::AbcSize
+    copy = registry.dup
+    copy.enlist(klass)
+    expect(copy.cops).to include(klass)
+    expect(registry.cops).not_to include(klass)
   end
 
   it 'exposes cop departments' do


### PR DESCRIPTION
This PR:
* moves registry-related globals to Registry (while maintaining compatibility)
* makes `Registry` dupable
* makes `Registry` lazy enough to allow delisting (useful for base classes, see #8023)
* adds `with_temporary_global` for easy testing that won't affect the global registry

Prelude to autocorrect refactor #7868 