### PR TITLE
Fix leaky constant declarations

### DIFF
--- a/spec/rubocop/cop/registry_spec.rb
+++ b/spec/rubocop/cop/registry_spec.rb
@@ -4,27 +4,6 @@ RSpec.describe RuboCop::Cop::Registry do
   subject(:registry) { described_class.new(cops, options) }
 
   let(:cops) do
-    stub_const('RuboCop::Cop::Test', Module.new)
-    stub_const('RuboCop::Cop::RSpec', Module.new)
-
-    # rubocop:disable RSpec/LeakyConstantDeclaration
-    module RuboCop
-      module Cop
-        module Test
-          # Create another cop with a different namespace
-          class FirstArrayElementIndentation < Cop
-          end
-        end
-
-        module RSpec
-          # Define a dummy rspec cop which has special namespace inflection
-          class Foo < Cop
-          end
-        end
-      end
-    end
-    # rubocop:enable RSpec/LeakyConstantDeclaration
-
     [
       RuboCop::Cop::Lint::BooleanSymbol,
       RuboCop::Cop::Lint::DuplicateMethods,
@@ -36,6 +15,11 @@ RSpec.describe RuboCop::Cop::Registry do
   end
 
   let(:options) { {} }
+
+  before do
+    stub_const('RuboCop::Cop::Test::FirstArrayElementIndentation', Class.new(RuboCop::Cop::Cop))
+    stub_const('RuboCop::Cop::RSpec::Foo', Class.new(RuboCop::Cop::Cop))
+  end
 
   # `RuboCop::Cop::Cop` mutates its `registry` when inherited from.
   # This can introduce nondeterministic failures in other parts of the

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -341,15 +341,12 @@ RSpec.describe RuboCop::Cop::Team do
 
     context 'when cop with different checksum joins' do
       before do
-        # rubocop:disable RSpec/LeakyConstantDeclaration
-        module Test
-          class CopWithExternalDeps < ::RuboCop::Cop::Cop
-            def external_dependency_checksum
-              'something other than nil'
-            end
-          end
-        end
-        # rubocop:enable RSpec/LeakyConstantDeclaration
+        stub_const('Test::CopWithExternalDeps',
+                   Class.new(::RuboCop::Cop::Cop) do
+                     def external_dependency_checksum
+                       'something other than nil'
+                     end
+                   end)
       end
 
       let(:new_cop_classes) do

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -251,15 +251,12 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
 
   context 'with auto-correct supported cop' do
     before do
-      # rubocop:disable RSpec/LeakyConstantDeclaration
-      module Test
-        class Cop3 < ::RuboCop::Cop::Cop
-          def autocorrect
-            # Dummy method to respond to #support_autocorrect?
-          end
-        end
-      end
-      # rubocop:enable RSpec/LeakyConstantDeclaration
+      stub_const('Test::Cop3',
+                 Class.new(::RuboCop::Cop::Cop) do
+                   def autocorrect
+                     # Dummy method to respond to #support_autocorrect?
+                   end
+                 end)
 
       formatter.started(['test_auto_correct.rb'])
       formatter.file_started('test_auto_correct.rb', {})


### PR DESCRIPTION
Got rid of class declarations in specs that littered the root namespace.

#8095 allowed to dynamically declare cops with `Class.new`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/