### PR TITLE
[Fix #8108] Disregard whitespace lines in HeredocIndentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#8083](https://github.com/rubocop-hq/rubocop/issues/8083): Fix an error for `Lint/MixedRegexpCaptureTypes` cop when using a regular expression that cannot be processed by regexp_parser gem. ([@koic][])
 * [#8081](https://github.com/rubocop-hq/rubocop/issues/8081): Fix a false positive for `Lint/SuppressedException` when empty rescue block in `do` block. ([@koic][])
 * [#8096](https://github.com/rubocop-hq/rubocop/issues/8096): Fix a false positive for `Lint/SuppressedException` when empty rescue block in defs. ([@koic][])
+* [#8108](https://github.com/rubocop-hq/rubocop/issues/8108): Fix infinite loop in `Layout/HeredocIndentation` auto-correct. ([@jonas054][])
 
 ## 0.85.0 (2020-06-01)
 

--- a/lib/rubocop/cop/layout/heredoc_indentation.rb
+++ b/lib/rubocop/cop/layout/heredoc_indentation.rb
@@ -147,7 +147,7 @@ module RuboCop
         def indent_level(str)
           indentations = str.lines
                             .map { |line| line[/^\s*/] }
-                            .reject { |line| line == "\n" }
+                            .reject { |line| line.end_with?("\n") }
           indentations.empty? ? 0 : indentations.min_by(&:size).size
         end
 

--- a/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
@@ -189,29 +189,51 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
         RUBY
       end
 
-      it 'registers an offense for not indented enough with empty lines' do
-        # rubocop:disable Layout/HeredocIndentation
-        expect_offense(<<-RUBY)
-          def baz
-            <<~#{quote}MSG#{quote}
-            foo
-^^^^^^^^^^^^^^^ Use 2 spaces for indentation in a heredoc.
-
-              bar
-            MSG
-          end
-        RUBY
-        # rubocop:enable Layout/HeredocIndentation
-
-        expect_correction(<<-CORRECTION)
-          def baz
-            <<~#{quote}MSG#{quote}
+      { empty: '', whitespace: '    ' }.each do |description, line|
+        it "registers an offense for not indented enough with #{description} line" do
+          # Using <<- in this section makes the code more readable.
+          # rubocop:disable Layout/HeredocIndentation
+          expect_offense(<<-RUBY)
+            def baz
+              <<~#{quote}MSG#{quote}
               foo
-
+^^^^^^^^^^^^^^^^^ Use 2 spaces for indentation in a heredoc.
+#{line}
                 bar
-            MSG
-          end
-        CORRECTION
+              MSG
+            end
+          RUBY
+
+          expect_correction(<<-CORRECTION)
+            def baz
+              <<~#{quote}MSG#{quote}
+                foo
+#{line}
+                  bar
+              MSG
+            end
+          CORRECTION
+        end
+
+        it "registers an offense for too deep indented with #{description} line" do
+          expect_offense(<<-RUBY)
+            <<~#{quote}RUBY2#{quote}
+                  foo
+^^^^^^^^^^^^^^^^^^^^^ Use 2 spaces for indentation in a heredoc.
+#{line}
+                bar
+            RUBY2
+          RUBY
+
+          expect_correction(<<-CORRECTION)
+            <<~#{quote}RUBY2#{quote}
+                foo
+#{line}
+              bar
+            RUBY2
+          CORRECTION
+        end
+        # rubocop:enable Layout/HeredocIndentation
       end
 
       it 'displays message to use `<<~` instead of `<<`' do


### PR DESCRIPTION
Empty lines were already excluded for calculation of indentation in `Layout/HeredocIndentation`. We need to do the same thing for lines consisting only of whitespace.