### PR TITLE
Ignore bundle binstubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ TAGS
 
 # For rubinius:
 #*.rbc
+
+# For bundle binstubs
+bin/*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ AllCops:
     - 'spec/fixtures/**/*'
     - 'tmp/**/*'
     - '.git/**/*'
+    - 'bin/*'
   TargetRubyVersion: 2.4
 
 Naming/PredicateName:


### PR DESCRIPTION
Those who want to avoid typing `bundle exec` before each command that is provided by a dependent gem, e.g. `rake`, `yard`, `rspec`, `rubocop` itself, Bundler provides a convenient way of creating binstubs in `bin` directory.
Commands can be run like `bin/rake`, `bin/yard`, `bin/rspec` etc then.

This can further simplify the usage by employing [`direnv`](https://github.com/direnv/direnv) that has a nice option in its `.envrc` file:

    PATH_add bin

After that (and approving `.envrc` changes with `direnv allow`) it's possible to run `yard`, `rspec` and `rubocop` with no prefixes. I stick to this in every repository I contribute to even if I have to deal with unstaged changes in my `bin`.

Not prefixing with `bundle exec` may cause you trouble if you have several versions of a gem installed and its binary will pick up the wrong one. This happens even if you use RVM gemsets or comparable.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/