### PR TITLE
Let format_offense add variable-width whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#8111](https://github.com/rubocop-hq/rubocop/pull/8111): Add auto-correct for `Style/StructInheritance`. ([@tejasbubane][])
+* [#8113](https://github.com/rubocop-hq/rubocop/pull/8113): Let `expect_offense` templates add variable-length whitespace with `_{foo}`. ([@eugeneius][])
 
 ## 0.85.1 (2020-06-07)
 

--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -72,19 +72,29 @@ module RuboCop
     #
     #   expect_no_corrections
     #
-    # If your code has variables of different lengths, you can use `%{foo}`
-    # and `^{foo}` to format your template:
+    # If your code has variables of different lengths, you can use `%{foo}`,
+    # `^{foo}`, and `_{foo}` to format your template:
     #
     #   %w[raise fail].each do |keyword|
     #     expect_offense(<<~RUBY, keyword: keyword)
     #       %{keyword}(RuntimeError, msg)
     #       ^{keyword}^^^^^^^^^^^^^^^^^^^ Redundant `RuntimeError` argument can be removed.
     #     RUBY
+    #
+    #   %w[has_one has_many].each do |type|
+    #     expect_offense(<<~RUBY, type: type)
+    #       class Book
+    #         %{type} :chapter, foreign_key: 'book_id'
+    #         _{type}           ^^^^^^^^^^^^^^^^^^^^^^ Specifying the default value is redundant.
+    #       end
+    #     RUBY
+    #   end
     module ExpectOffense
       def format_offense(source, **replacements)
         replacements.each do |keyword, value|
           source = source.gsub("%{#{keyword}}", value)
                          .gsub("^{#{keyword}}", '^' * value.size)
+                         .gsub("_{#{keyword}}", ' ' * value.size)
         end
         source
       end


### PR DESCRIPTION
Followup to https://github.com/rubocop-hq/rubocop/pull/8069.

This allows `expect_offense` to be used when the dynamically generated part of the source code is not highlighted by the offense.

I couldn't find a spec in this repo that could be rewritten to use this option, but I have an open PR on RuboCop Rails that would benefit from it: https://github.com/rubocop-hq/rubocop-rails/pull/257/files#diff-d9cf3a5c58c7f3acbad8f9812ca8006bR70

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/