### PR TITLE
Limit rubocop-ast to pre 1.0

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.7')
   s.add_runtime_dependency('rexml')
-  s.add_runtime_dependency('rubocop-ast', '>= 0.0.3')
+  s.add_runtime_dependency('rubocop-ast', '>= 0.0.3', '< 1.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 2.0')
 


### PR DESCRIPTION
See https://github.com/rubocop-hq/rubocop-ast/pull/26
