### PR TITLE
Lint/FormatParameterMismatch. Fix bug with formating in argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * [#8111](https://github.com/rubocop-hq/rubocop/pull/8111): Add auto-correct for `Style/StructInheritance`. ([@tejasbubane][])
 * [#8113](https://github.com/rubocop-hq/rubocop/pull/8113): Let `expect_offense` templates add variable-length whitespace with `_{foo}`. ([@eugeneius][])
 
+### Bug fixes
+
+* [#8115](https://github.com/rubocop-hq/rubocop/issues/8115): Fix false negative for `Lint::FormatParameterMismatch` when argument contains formatting. ([@andrykonchin][])
+
 ## 0.85.1 (2020-06-07)
 
 ### Bug fixes

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -65,7 +65,12 @@ module RuboCop
         end
 
         def invalid_format_string?(node)
-          !RuboCop::Cop::Utils::FormatString.new(node.source).valid?
+          string = if sprintf?(node) || format?(node)
+                     node.first_argument.source
+                   else
+                     node.receiver.source
+                   end
+          !RuboCop::Cop::Utils::FormatString.new(string).valid?
         end
 
         def offending_node?(node)

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -187,6 +187,14 @@ RSpec.describe RuboCop::Cop::Lint::FormatParameterMismatch do
     end
   end
 
+  # Regression: https://github.com/rubocop-hq/rubocop/issues/8115
+  context 'when argument itself contains format characters and ' \
+          'formats in format string and argument are not equal' do
+    it 'ignores argument formatting' do
+      expect_no_offenses(%{format('%<t>s', t: '%d')})
+    end
+  end
+
   it 'ignores percent right next to format string' do
     expect_no_offenses('format("%0.1f%% percent", 22.5)')
   end


### PR DESCRIPTION
Fix a bug introduced in https://github.com/rubocop-hq/rubocop/pull/8042

Closes https://github.com/rubocop-hq/rubocop/issues/8115.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
