### PR TITLE
[Fix #8106] Add missing config documentation for `Layout/SpaceBeforeBlockBraces`

### DIFF
--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -5269,6 +5269,28 @@ foo.map{ |a|
 }
 ----
 
+==== EnforcedStyleForEmptyBraces: space (default)
+
+[source,ruby]
+----
+# bad
+7.times{}
+
+# good
+7.times {}
+----
+
+==== EnforcedStyleForEmptyBraces: no_space
+
+[source,ruby]
+----
+# bad
+7.times {}
+
+# good
+7.times{}
+----
+
 === Configurable attributes
 
 |===

--- a/lib/rubocop/cop/layout/space_before_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_before_block_braces.rb
@@ -27,6 +27,20 @@ module RuboCop
       #   foo.map{ |a|
       #     a.bar.to_s
       #   }
+      #
+      # @example EnforcedStyleForEmptyBraces: space (default)
+      #   # bad
+      #   7.times{}
+      #
+      #   # good
+      #   7.times {}
+      #
+      # @example EnforcedStyleForEmptyBraces: no_space
+      #   # bad
+      #   7.times {}
+      #
+      #   # good
+      #   7.times{}
       class SpaceBeforeBlockBraces < Cop
         include ConfigurableEnforcedStyle
         include RangeHelp


### PR DESCRIPTION
For `EnforcedStyleForEmptyBraces` option

Closes #8106

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/