### PR TITLE
Add Ruby EOL support policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ RuboCop supports the following Ruby implementations:
 * MRI 2.4+
 * JRuby 9.2+
 
+RuboCop has customarily provided support for about a year after EOL of MRI Ruby version.
+This is done by RuboCop core to provide the community with a margin of transition.
+
 ## Team
 
 Here's a list of RuboCop's core developers:


### PR DESCRIPTION
Contributors came to a common conclusion in #8112

Closes #8112 since we will support 2.4 for a year.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/