### PR TITLE
[Fix #8118] fix autocorrect for redundant cop enable directive

### DIFF
--- a/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
@@ -96,9 +96,7 @@ module RuboCop
 
           # If the list of cops is comma-separated, but without a white-space after the comma,
           # we should **not** remove the prepending white-space, thus begin_pos += 1
-          if comma_pos == :after && source[end_pos + 1] != ' '
-            begin_pos += 1
-          end
+          begin_pos += 1 if comma_pos == :after && source[end_pos + 1] != ' '
 
           range_to_remove(begin_pos, end_pos, comma_pos, comment)
         end

--- a/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
@@ -74,6 +74,16 @@ module RuboCop
           comment.text.index(name)
         end
 
+        def find_comma_position(source, begin_pos, end_pos)
+          if source[begin_pos - 1] == ','
+            :before
+          elsif source[end_pos] == ','
+            :after
+          else
+            :none
+          end
+        end
+
         def range_with_comma(comment, name)
           source = comment.loc.expression.source
 
@@ -82,14 +92,7 @@ module RuboCop
           begin_pos = reposition(source, begin_pos, -1)
           end_pos = reposition(source, end_pos, 1)
 
-          comma_pos =
-            if source[begin_pos - 1] == ','
-              :before
-            elsif source[end_pos] == ','
-              :after
-            else
-              :none
-            end
+          comma_pos = find_comma_position(source, begin_pos, end_pos)
 
           # If the list of cops is comma-separated, but without a white-space after the comma,
           # we should **not** remove the prepending white-space, thus begin_pos += 1

--- a/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
@@ -91,6 +91,12 @@ module RuboCop
               :none
             end
 
+          # If the list of cops is comma-separated, but without a white-space after the comma,
+          # we should **not** remove the prepending white-space, thus begin_pos += 1
+          if comma_pos == :after && source[end_pos + 1] != ' '
+            begin_pos += 1
+          end
+
           range_to_remove(begin_pos, end_pos, comma_pos, comment)
         end
 

--- a/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
@@ -104,14 +104,18 @@ module RuboCop
           when :before
             range_between(start + begin_pos - 1, start + end_pos)
           when :after
-            # If the list of cops is comma-separated, but without a white-space after the comma,
-            # we should **not** remove the prepending white-space, thus begin_pos += 1
-            begin_pos += 1 if comment.loc.expression.source[end_pos + 1] != ' '
-
-            range_between(start + begin_pos, start + end_pos + 1)
+            range_between_for_after(start, begin_pos, end_pos, comment)
           else
             range_between(start, comment.loc.expression.end_pos)
           end
+        end
+
+        # If the list of cops is comma-separated, but without a empty space after the comma,
+        # we should **not** remove the prepending empty space, thus begin_pos += 1
+        def range_between_for_after(start, begin_pos, end_pos, comment)
+          begin_pos += 1 if comment.loc.expression.source[end_pos + 1] != ' '
+
+          range_between(start + begin_pos, start + end_pos + 1)
         end
 
         def all_or_name(name)

--- a/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
@@ -94,10 +94,6 @@ module RuboCop
 
           comma_pos = find_comma_position(source, begin_pos, end_pos)
 
-          # If the list of cops is comma-separated, but without a white-space after the comma,
-          # we should **not** remove the prepending white-space, thus begin_pos += 1
-          begin_pos += 1 if comma_pos == :after && source[end_pos + 1] != ' '
-
           range_to_remove(begin_pos, end_pos, comma_pos, comment)
         end
 
@@ -108,6 +104,10 @@ module RuboCop
           when :before
             range_between(start + begin_pos - 1, start + end_pos)
           when :after
+            # If the list of cops is comma-separated, but without a white-space after the comma,
+            # we should **not** remove the prepending white-space, thus begin_pos += 1
+            begin_pos += 1 if comment.loc.expression.source[end_pos + 1] != ' '
+
             range_between(start + begin_pos, start + end_pos + 1)
           else
             range_between(start, comment.loc.expression.end_pos)

--- a/spec/rubocop/cop/lint/redundant_cop_enable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_enable_directive_spec.rb
@@ -65,6 +65,23 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopEnableDirective do
     RUBY
   end
 
+  it 'registers correct offense when combined with necessary enable, no white-space after comma' do
+    expect_offense(<<~RUBY)
+      # rubocop:disable Layout/LineLength
+      fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo = barrrrrrrrrrrrrrrrrrrrrrrrrr
+      # rubocop:enable Metrics/AbcSize,Layout/LineLength
+                       ^^^^^^^^^^^^^^^ Unnecessary enabling of Metrics/AbcSize.
+      bar
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # rubocop:disable Layout/LineLength
+      fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo = barrrrrrrrrrrrrrrrrrrrrrrrrr
+      # rubocop:enable Layout/LineLength
+      bar
+    RUBY
+  end
+
   it 'registers offense and corrects redundant enabling of same cop' do
     expect_offense(<<~RUBY)
       # rubocop:disable Layout/LineLength


### PR DESCRIPTION
If the redundant cop enable directive contains a list of cops, and that list is comma separated without a white-space after the commas, the autocorrection returned a wrong output.

Before

```ruby
# rubocop:enable NotActually/Needed,IAm/Needed

# gets corrected to

# rubocop:enableIAm/Needed
```

This commit fixes that behaviour and adds a corresponding test.

After

```ruby
# rubocop:enable NotActually/Needed,IAm/Needed

# gets corrected to

# rubocop:enable IAm/Needed
```

---

Hello RuboCop Team 👋 

This is the simplest way I could come up with to fix that issue (#8118) without breaking other tests. I'm open to suggestions and/or changes.
