### PR TITLE
[Fix #8124] Fix a false positive for `Lint/FormatParameterMismatch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug fixes
 
 * [#8115](https://github.com/rubocop-hq/rubocop/issues/8115): Fix false negative for `Lint::FormatParameterMismatch` when argument contains formatting. ([@andrykonchin][])
+* [#8124](https://github.com/rubocop-hq/rubocop/issues/8124): Fix a false positive for `Lint/FormatParameterMismatch` when using named parameters with escaped `%`. ([@koic][])
 
 ## 0.85.1 (2020-06-07)
 

--- a/lib/rubocop/cop/utils/format_string.rb
+++ b/lib/rubocop/cop/utils/format_string.rb
@@ -120,7 +120,7 @@ module RuboCop
         end
 
         def mixed_formats?
-          formats = format_sequences.map do |seq|
+          formats = format_sequences.reject(&:percent?).map do |seq|
             if seq.name
               :named
             elsif seq.max_digit_dollar_num

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -222,6 +222,10 @@ RSpec.describe RuboCop::Cop::Lint::FormatParameterMismatch do
     expect_no_offenses('"foo %{bar} baz" % { bar: 42 }')
   end
 
+  it 'does not register an offense when using named parameters with escaped `%`' do
+    expect_no_offenses('format("%%%<hex>02X", hex: 10)')
+  end
+
   it 'identifies correctly digits for spacing in format' do
     expect_no_offenses('"duration: %10.fms" % 42')
   end

--- a/spec/rubocop/cop/utils/format_string_spec.rb
+++ b/spec/rubocop/cop/utils/format_string_spec.rb
@@ -97,6 +97,11 @@ RSpec.describe RuboCop::Cop::Utils::FormatString do
       expect(fs.valid?).to eq true
     end
 
+    it 'returns true when there are only named with escaped `%` formats' do
+      fs = described_class.new('%%%{foo}d')
+      expect(fs.valid?).to eq true
+    end
+
     it 'returns false when there are unnumbered and numbered formats' do
       fs = described_class.new('%s %1$d')
       expect(fs.valid?).to eq false


### PR DESCRIPTION
Fixes #8124.

This PR fixes a false positive for `Lint/FormatParameterMismatch` using named parameters with escaped `%`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
