### PR TITLE
[Fix #8098]: Fix false-positive in Style/RedundantRegexpCharacterClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * [#8115](https://github.com/rubocop-hq/rubocop/issues/8115): Fix false negative for `Lint::FormatParameterMismatch` when argument contains formatting. ([@andrykonchin][])
 * [#8124](https://github.com/rubocop-hq/rubocop/issues/8124): Fix a false positive for `Lint/FormatParameterMismatch` when using named parameters with escaped `%`. ([@koic][])
+* [#8098](https://github.com/rubocop-hq/rubocop/issues/8098): Fix a false positive for `Style/RedundantRegexpCharacterClass` when using interpolations. ([@owst][])
 
 ## 0.85.1 (2020-06-07)
 

--- a/lib/rubocop/cop/mixin/regexp_literal_help.rb
+++ b/lib/rubocop/cop/mixin/regexp_literal_help.rb
@@ -11,6 +11,33 @@ module RuboCop
 
         regopt.children.include?(:x)
       end
+
+      def pattern_source(node)
+        freespace_mode = freespace_mode_regexp?(node)
+
+        node.children.reject(&:regopt_type?).map do |child|
+          source_with_comments_and_interpolations_blanked(child, freespace_mode)
+        end.join
+      end
+
+      def source_with_comments_and_interpolations_blanked(child, freespace_mode)
+        source = child.source
+
+        # We don't want to consider the contents of interpolations or free-space mode comments as
+        # part of the pattern source, but need to preserve their width, to allow offsets to
+        # correctly line up with the original source: spaces have no effect, and preserve width.
+        if child.begin_type?
+          replace_match_with_spaces(source, /.*/) # replace all content
+        elsif freespace_mode
+          replace_match_with_spaces(source, /(?<!\\)#.*/) # replace any comments
+        else
+          source
+        end
+      end
+
+      def replace_match_with_spaces(source, pattern)
+        source.sub(pattern) { ' ' * Regexp.last_match[0].length }
+      end
     end
   end
 end

--- a/lib/rubocop/cop/style/redundant_regexp_character_class.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_character_class.rb
@@ -67,8 +67,8 @@ module RuboCop
         end
 
         def each_redundant_character_class(node)
-          each_match_range(node.loc.expression, PATTERN) do |loc|
-            yield loc
+          pattern_source(node).scan(PATTERN) do
+            yield match_range(node.loc.begin.end, Regexp.last_match)
           end
         end
 

--- a/lib/rubocop/cop/style/redundant_regexp_escape.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_escape.rb
@@ -109,21 +109,6 @@ module RuboCop
 
           range_between(start, start + 2)
         end
-
-        def pattern_source(node)
-          freespace_mode = freespace_mode_regexp?(node)
-
-          node.children.reject(&:regopt_type?).map do |child|
-            source = child.source
-
-            if freespace_mode
-              # Remove comments to avoid misleading results
-              source.sub(/(?<!\\)#.*/, '')
-            else
-              source
-            end
-          end.join
-        end
       end
     end
   end

--- a/spec/rubocop/cop/style/redundant_regexp_escape_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_escape_spec.rb
@@ -91,6 +91,25 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpEscape do
       end
     end
 
+    context 'with an interpolated unnecessary-escape regexp' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~'RUBY')
+          foo = /a#{/\-/}c/
+                     ^^ Redundant escape inside regexp literal
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          foo = /a#{/-/}c/
+        RUBY
+      end
+    end
+
+    context 'with an escape inside an interpolated string' do
+      it 'does not register an offense' do
+        expect_no_offenses('foo = /#{"\""}/')
+      end
+    end
+
     context 'with an escaped interpolation outside a character class' do
       it 'does not register an offense' do
         expect_no_offenses('foo = /\#\{[a-z_]+\}/')
@@ -305,6 +324,25 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpEscape do
           foo = %r{
             /a
             b/
+          }x
+        RUBY
+      end
+    end
+
+    context 'with a redundant escape after a line with comment' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~'RUBY')
+          foo = %r{
+            foo # this should not affect the position of the escape below
+            \-
+            ^^ Redundant escape inside regexp literal
+          }x
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo = %r{
+            foo # this should not affect the position of the escape below
+            -
           }x
         RUBY
       end


### PR DESCRIPTION
Also correct the handling of interpolations and comments - we need to
preserve their width in the checked pattern source without their
contents triggering the cop in question, so that we can correctly
highlight following offenses based on the offset in the pattern_source.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
