### PR TITLE
[Fix #8131]: Ignore escapes of delimiters in Style/RedundantRegexpEscape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Bug fixes
 
 * [#8115](https://github.com/rubocop-hq/rubocop/issues/8115): Fix false negative for `Lint::FormatParameterMismatch` when argument contains formatting. ([@andrykonchin][])
-* [#8131](https://github.com/rubocop-hq/rubocop/pull/8131): Fix false positive for Style/RedundantRegexpEscape with escaped delimiters. ([@owst][])
+* [#8131](https://github.com/rubocop-hq/rubocop/pull/8131): Fix false positive for `Style/RedundantRegexpEscape` with escaped delimiters. ([@owst][])
 * [#8124](https://github.com/rubocop-hq/rubocop/issues/8124): Fix a false positive for `Lint/FormatParameterMismatch` when using named parameters with escaped `%`. ([@koic][])
 
 ## 0.85.1 (2020-06-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug fixes
 
 * [#8115](https://github.com/rubocop-hq/rubocop/issues/8115): Fix false negative for `Lint::FormatParameterMismatch` when argument contains formatting. ([@andrykonchin][])
+* [#8131](https://github.com/rubocop-hq/rubocop/pull/8131): Fix false positive for Style/RedundantRegexpEscape with escaped delimiters. ([@owst][])
 * [#8124](https://github.com/rubocop-hq/rubocop/issues/8124): Fix a false positive for `Lint/FormatParameterMismatch` when using named parameters with escaped `%`. ([@koic][])
 
 ## 0.85.1 (2020-06-07)

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -7180,6 +7180,9 @@ This cop checks for redundant escapes inside Regexp literals.
 # good
 %r/foo\/bar/
 
+# good
+%r!foo\!bar!
+
 # bad
 /a\-b/
 

--- a/spec/rubocop/cop/style/redundant_regexp_escape_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_escape_spec.rb
@@ -249,6 +249,18 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpEscape do
       end
     end
 
+    context 'with an escaped { or } outside a character class' do
+      it 'does not register an offense' do
+        expect_no_offenses('foo = %r{\{\}}')
+      end
+    end
+
+    context 'with an escaped { or } inside a character class' do
+      it 'does not register an offense' do
+        expect_no_offenses('foo = %r{[\{\}]}')
+      end
+    end
+
     context 'with redundantly-escaped slashes' do
       it 'registers an offense and corrects' do
         expect_offense(<<~'RUBY')
@@ -260,6 +272,46 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpEscape do
         expect_correction(<<~RUBY)
           foo = %r{/a/}
         RUBY
+      end
+    end
+  end
+
+  [
+    '!',
+    '~',
+    '@',
+    '_',
+    '^',
+    '<>',
+    '()'
+  ].each do |delims|
+    l, r = delims.chars
+    r = l if r.nil?
+    escaped_delims = "\\#{l}\\#{r}"
+
+    context "with a single-line %r#{l}#{r} regexp" do
+      context 'without escapes' do
+        it 'does not register an offense' do
+          expect_no_offenses("foo = %r#{l}a#{r}")
+        end
+      end
+
+      context 'with escaped delimiters and regexp options' do
+        it 'does not register an offense' do
+          expect_no_offenses("foo = %r#{l}#{escaped_delims}#{r}i")
+        end
+      end
+
+      context 'with escaped delimiters outside a character-class' do
+        it 'does not register an offense' do
+          expect_no_offenses("foo = %r#{l}#{escaped_delims}#{r}")
+        end
+      end
+
+      context 'with escaped delimiters inside a character-class' do
+        it 'does not register an offense' do
+          expect_no_offenses("foo = %r#{l}a[#{escaped_delims}]b#{r}")
+        end
       end
     end
   end


### PR DESCRIPTION
We must allow `%r` delimiters to be escaped, e.g. `%r~\~~`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
