### PR TITLE
[Fix #8132] Fix the problem with Naming/MethodName: EnforcedStyle: camelCase and _ or i variables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug fixes
 
+* [#8132](https://github.com/rubocop-hq/rubocop/issues/8132): Fix the problem with `Naming/MethodName: EnforcedStyle: camelCase` and `_` or `i` variables. ([@avrusanov][])
 * [#8115](https://github.com/rubocop-hq/rubocop/issues/8115): Fix false negative for `Lint::FormatParameterMismatch` when argument contains formatting. ([@andrykonchin][])
 * [#8124](https://github.com/rubocop-hq/rubocop/issues/8124): Fix a false positive for `Lint/FormatParameterMismatch` when using named parameters with escaped `%`. ([@koic][])
 
@@ -4585,3 +4586,4 @@
 [@ric2b]: https://github.com/ric2b
 [@burnettk]: https://github.com/burnettk
 [@andrykonchin]: https://github.com/andrykonchin
+[@avrusanov]: https://github.com/avrusanov

--- a/lib/rubocop/cop/mixin/configurable_naming.rb
+++ b/lib/rubocop/cop/mixin/configurable_naming.rb
@@ -9,7 +9,7 @@ module RuboCop
 
       FORMATS = {
         snake_case: /^@{0,2}[\da-z_]+[!?=]?$/,
-        camelCase:  /^@{0,2}_?[a-z][\da-zA-Z]+[!?=]?$/
+        camelCase:  /^@{0,2}(?:_|_?[a-z][\da-zA-Z]*)[!?=]?$/
       }.freeze
     end
   end

--- a/spec/rubocop/cop/naming/variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/variable_name_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe RuboCop::Cop::Naming::VariableName, :config do
     it 'accepts assignment with indexing of self' do
       expect_no_offenses('self[:a] = b')
     end
+
+    it 'accepts local variables marked as unused' do
+      expect_no_offenses('_ = 1')
+    end
+
+    it 'accepts one symbol size local variables' do
+      expect_no_offenses('i = 1')
+    end
   end
 
   context 'when configured for snake_case' do


### PR DESCRIPTION
Changed regexp for fix the problem with camelCase and one symbol variables.

* [+ ] Wrote [good commit messages][1].
* [ +] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ +] Feature branch is up-to-date with `master` (if not - rebase it).
* [ +] Squashed related commits together.
* [ +] Added tests.
* [ +] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ +] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ +] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
