### PR TITLE
DidYouMean::SpellChecker may not be available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * [#8115](https://github.com/rubocop-hq/rubocop/issues/8115): Fix false negative for `Lint::FormatParameterMismatch` when argument contains formatting. ([@andrykonchin][])
 * [#8124](https://github.com/rubocop-hq/rubocop/issues/8124): Fix a false positive for `Lint/FormatParameterMismatch` when using named parameters with escaped `%`. ([@koic][])
+* [#7979](https://github.com/rubocop-hq/rubocop/issues/7979): Fix "uninitialized constant DidYouMean::SpellChecker" exception. ([@bquorning][])
 
 ## 0.85.1 (2020-06-07)
 

--- a/lib/rubocop/name_similarity.rb
+++ b/lib/rubocop/name_similarity.rb
@@ -12,6 +12,12 @@ module RuboCop
     end
 
     def find_similar_names(target_name, names)
+      # DidYouMean::SpellChecker is not available in all versions of Ruby, and
+      # even on versions where it *is* available (>= 2.3), it is not always
+      # required correctly. So we do a feature check first.
+      # See: https://github.com/rubocop-hq/rubocop/issues/7979
+      return [] unless defined?(DidYouMean::SpellChecker)
+
       names = names.dup
       names.delete(target_name)
 


### PR DESCRIPTION
Fixes #7979 

In #7979 it was reported that `DidYouMean::SpellChecker` may not always be available. We can work around that by doing a feature check before using the `SpellChecker` class.

I did not add any tests.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
