### PR TITLE
Support autocorrection for `Style/MultilineTernaryOperator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#8111](https://github.com/rubocop-hq/rubocop/pull/8111): Add auto-correct for `Style/StructInheritance`. ([@tejasbubane][])
 * [#8113](https://github.com/rubocop-hq/rubocop/pull/8113): Let `expect_offense` templates add variable-length whitespace with `_{foo}`. ([@eugeneius][])
+* [#8148](https://github.com/rubocop-hq/rubocop/pull/8148): Support autocorrection for `Style/MultilineTernaryOperator`. ([@koic][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -3239,6 +3239,7 @@ Style/MultilineTernaryOperator:
   StyleGuide: '#no-multiline-ternary'
   Enabled: true
   VersionAdded: '0.9'
+  VersionChanged: '0.86'
 
 Style/MultilineWhenThen:
   Description: 'Do not use then for multi-line when statement.'

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -5170,9 +5170,9 @@ end
 
 | Enabled
 | Yes
-| No
+| Yes
 | 0.9
-| -
+| 0.86
 |===
 
 This cop checks for multi-line ternary op expressions.
@@ -5192,12 +5192,11 @@ a = cond ?
 
 # good
 a = cond ? b : c
-a =
-  if cond
-    b
-  else
-    c
-  end
+a = if cond
+  b
+else
+  c
+end
 ----
 
 === References

--- a/lib/rubocop/cop/style/multiline_ternary_operator.rb
+++ b/lib/rubocop/cop/style/multiline_ternary_operator.rb
@@ -17,12 +17,11 @@ module RuboCop
       #
       #   # good
       #   a = cond ? b : c
-      #   a =
-      #     if cond
-      #       b
-      #     else
-      #       c
-      #     end
+      #   a = if cond
+      #     b
+      #   else
+      #     c
+      #   end
       class MultilineTernaryOperator < Cop
         MSG = 'Avoid multi-line ternary operators, ' \
               'use `if` or `unless` instead.'
@@ -31,6 +30,18 @@ module RuboCop
           return unless node.ternary? && node.multiline?
 
           add_offense(node)
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(node, <<~RUBY.chop)
+              if #{node.condition.source}
+                #{node.if_branch.source}
+              else
+                #{node.else_branch.source}
+              end
+            RUBY
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
@@ -3,29 +3,53 @@
 RSpec.describe RuboCop::Cop::Style::MultilineTernaryOperator do
   subject(:cop) { described_class.new }
 
-  it 'registers offense when the if branch and the else branch are ' \
+  it 'registers offense and corrects when the if branch and the else branch are ' \
      'on a separate line from the condition' do
     expect_offense(<<~RUBY)
       a = cond ?
           ^^^^^^ Avoid multi-line ternary operators, use `if` or `unless` instead.
         b : c
     RUBY
+
+    expect_correction(<<~RUBY)
+      a = if cond
+        b
+      else
+        c
+      end
+    RUBY
   end
 
-  it 'registers an offense when the false branch is on a separate line' do
+  it 'registers an offense and corrects when the false branch is on a separate line' do
     expect_offense(<<~RUBY)
       a = cond ? b :
           ^^^^^^^^^^ Avoid multi-line ternary operators, use `if` or `unless` instead.
           c
     RUBY
+
+    expect_correction(<<~RUBY)
+      a = if cond
+        b
+      else
+        c
+      end
+    RUBY
   end
 
-  it 'registers an offense when everything is on a separate line' do
+  it 'registers an offense and corrects when everything is on a separate line' do
     expect_offense(<<~RUBY)
       a = cond ?
           ^^^^^^ Avoid multi-line ternary operators, use `if` or `unless` instead.
           b :
           c
+    RUBY
+
+    expect_correction(<<~RUBY)
+      a = if cond
+        b
+      else
+        c
+      end
     RUBY
   end
 


### PR DESCRIPTION
This PR supports autocorrection for `Style/MultilineTernaryOperator`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
