### PR TITLE
Fix a false positive for `Layout/EmptyLinesAroundAttributeAccessor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#8124](https://github.com/rubocop-hq/rubocop/issues/8124): Fix a false positive for `Lint/FormatParameterMismatch` when using named parameters with escaped `%`. ([@koic][])
 * [#7979](https://github.com/rubocop-hq/rubocop/issues/7979): Fix "uninitialized constant DidYouMean::SpellChecker" exception. ([@bquorning][])
 * [#8098](https://github.com/rubocop-hq/rubocop/issues/8098): Fix a false positive for `Style/RedundantRegexpCharacterClass` when using interpolations. ([@owst][])
+* [#8150](https://github.com/rubocop-hq/rubocop/pull/8150): Fix a false positive for `Layout/EmptyLinesAroundAttributeAccessor` when using attribute accessors in `if` ... `else` branches. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/empty_lines_around_attribute_accessor.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_attribute_accessor.rb
@@ -96,6 +96,8 @@ module RuboCop
         end
 
         def next_line_node(node)
+          return if node.parent.if_type?
+
           node.parent.children[node.sibling_index + 1]
         end
 

--- a/spec/rubocop/cop/layout/empty_lines_around_attribute_accessor_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_attribute_accessor_spec.rb
@@ -75,6 +75,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAttributeAccessor, :config 
     RUBY
   end
 
+  it 'does not registers an offense and corrects when using `if` ... `else` branches' do
+    expect_no_offenses(<<~RUBY)
+      if condition
+        attr_reader :foo
+      else
+        do_something
+      end
+    RUBY
+  end
+
   context 'when `AllowAliasSyntax: true`' do
     let(:cop_config) do
       { 'AllowAliasSyntax' => true }


### PR DESCRIPTION
This PR fixes the following false positive for `Layout/EmptyLinesAroundAttributeAccessor` when using attribute accessors in `if` ... `else` branches.

```ruby
if condition
  attr_reader :foo
else
  do_something
end
```

```console
% bundle exec rubocop --only Layout/EmptyLinesAroundAttributeAccessor
(snip)
Inspecting 1 file
C

Offenses:

example.rb:2:3: C: Layout/EmptyLinesAroundAttributeAccessor: Add an
empty line after attribute accessor.
  attr_reader :foo
  ^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
