### PR TITLE
Support autocorrection for `Style/NestedTernaryOperator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#8111](https://github.com/rubocop-hq/rubocop/pull/8111): Add auto-correct for `Style/StructInheritance`. ([@tejasbubane][])
 * [#8113](https://github.com/rubocop-hq/rubocop/pull/8113): Let `expect_offense` templates add variable-length whitespace with `_{foo}`. ([@eugeneius][])
 * [#8148](https://github.com/rubocop-hq/rubocop/pull/8148): Support autocorrection for `Style/MultilineTernaryOperator`. ([@koic][])
+* [#8151](https://github.com/rubocop-hq/rubocop/pull/8151): Support autocorrection for `Style/NestedTernaryOperator`. ([@koic][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -3344,6 +3344,7 @@ Style/NestedTernaryOperator:
   StyleGuide: '#no-nested-ternary'
   Enabled: true
   VersionAdded: '0.9'
+  VersionChanged: '0.86'
 
 Style/Next:
   Description: 'Use `next` to skip iteration instead of a condition at the end.'

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -5670,9 +5670,9 @@ method1(method2 arg)
 
 | Enabled
 | Yes
-| No
+| Yes
 | 0.9
-| -
+| 0.86
 |===
 
 This cop checks for nested ternary op expressions.

--- a/lib/rubocop/cop/style/nested_ternary_operator.rb
+++ b/lib/rubocop/cop/style/nested_ternary_operator.rb
@@ -26,6 +26,26 @@ module RuboCop
             add_offense(nested_ternary)
           end
         end
+
+        def autocorrect(node)
+          node = node.parent.parent
+
+          lambda do |corrector|
+            corrector.replace(node, <<~RUBY.chop)
+              if #{node.condition.source}
+                #{remove_parentheses(node.if_branch.source)}
+              else
+                #{node.else_branch.source}
+              end
+            RUBY
+          end
+        end
+
+        private
+
+        def remove_parentheses(source)
+          source.gsub(/\A\(/, '').gsub(/\)\z/, '')
+        end
       end
     end
   end

--- a/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
@@ -3,10 +3,18 @@
 RSpec.describe RuboCop::Cop::Style::NestedTernaryOperator do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for a nested ternary operator expression' do
+  it 'registers an offense and corrects for a nested ternary operator expression' do
     expect_offense(<<~RUBY)
       a ? (b ? b1 : b2) : a2
            ^^^^^^^^^^^ Ternary operators must not be nested. Prefer `if` or `else` constructs instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if a
+        b ? b1 : b2
+      else
+        a2
+      end
     RUBY
   end
 


### PR DESCRIPTION
This PR supports autocorrection for `Style/NestedTernaryOperator`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
