### PR TITLE
Use `match?` instead of `=~`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ Dir['tasks/**/*.rake'].each { |t| load t }
 desc 'Run RuboCop over itself'
 RuboCop::RakeTask.new(:internal_investigation).tap do |task|
   if RUBY_ENGINE == 'ruby' &&
-     RbConfig::CONFIG['host_os'] !~ /mswin|msys|mingw|cygwin|bccwin|wince|emc/
+     !/mswin|msys|mingw|cygwin|bccwin|wince|emc/.match?(RbConfig::CONFIG['host_os'])
     task.options = %w[--parallel]
   end
 end

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -152,7 +152,7 @@ module RuboCop
       return true if File.extname(file) == '.gemspec'
 
       file_to_include?(file) do |pattern, relative_path, absolute_path|
-        pattern.to_s =~ /[A-Z]/ &&
+        /[A-Z]/.match?(pattern.to_s) &&
           (match_path?(pattern, relative_path) ||
            match_path?(pattern, absolute_path))
       end

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -192,7 +192,7 @@ module RuboCop
 
     def remote_file?(uri)
       regex = URI::DEFAULT_PARSER.make_regexp(%w[http https])
-      uri =~ /\A#{regex}\z/
+      /\A#{regex}\z/.match?(uri)
     end
 
     def handle_disabled_by_default(config, new_default_configuration)

--- a/lib/rubocop/cop/gemspec/required_ruby_version.rb
+++ b/lib/rubocop/cop/gemspec/required_ruby_version.rb
@@ -64,7 +64,7 @@ module RuboCop
         def extract_ruby_version(required_ruby_version)
           if required_ruby_version.array_type?
             required_ruby_version = required_ruby_version.children.detect do |v|
-              v.str_content =~ /[>=]/
+              /[>=]/.match?(v.str_content)
             end
           end
 

--- a/lib/rubocop/cop/generator/configuration_injector.rb
+++ b/lib/rubocop/cop/generator/configuration_injector.rb
@@ -58,7 +58,7 @@ module RuboCop
         end
 
         def cop_name_line?(yaml)
-          yaml !~ /^[\s#]/
+          !/^[\s#]/.match?(yaml)
         end
       end
     end

--- a/lib/rubocop/cop/layout/comment_indentation.rb
+++ b/lib/rubocop/cop/layout/comment_indentation.rb
@@ -109,7 +109,7 @@ module RuboCop
 
         def own_line_comment?(comment)
           own_line = processed_source.lines[comment.loc.line - 1]
-          own_line =~ /\A\s*#/
+          /\A\s*#/.match?(own_line)
         end
 
         def line_after_comment(comment)
@@ -129,11 +129,11 @@ module RuboCop
         end
 
         def less_indented?(line)
-          line =~ /^\s*(end\b|[)}\]])/
+          /^\s*(end\b|[)}\]])/.match?(line)
         end
 
         def two_alternatives?(line)
-          line =~ /^\s*(else|elsif|when|rescue|ensure)\b/
+          /^\s*(else|elsif|when|rescue|ensure)\b/.match?(line)
         end
       end
     end

--- a/lib/rubocop/cop/layout/empty_comment.rb
+++ b/lib/rubocop/cop/layout/empty_comment.rb
@@ -119,7 +119,7 @@ module RuboCop
                                     /\A(#+\n)+\z/
                                   end
 
-          !(comment_text =~ empty_comment_pattern).nil?
+          empty_comment_pattern.match?(comment_text)
         end
 
         def comment_text(comment)

--- a/lib/rubocop/cop/layout/end_of_line.rb
+++ b/lib/rubocop/cop/layout/end_of_line.rb
@@ -65,7 +65,7 @@ module RuboCop
 
         # If there is no LF on the last line, we don't care if there's no CR.
         def unimportant_missing_cr?(index, last_line, line)
-          style == :crlf && index == last_line - 1 && line !~ /\n$/
+          style == :crlf && index == last_line - 1 && !/\n$/.match?(line)
         end
 
         def offense_message(line)

--- a/lib/rubocop/cop/layout/first_argument_indentation.rb
+++ b/lib/rubocop/cop/layout/first_argument_indentation.rb
@@ -168,7 +168,7 @@ module RuboCop
 
           send_node = arg_node.parent
           text = base_range(send_node, arg_node).source.strip
-          base = if text !~ /\n/ && special_inner_call_indentation?(send_node)
+          base = if !/\n/.match?(text) && special_inner_call_indentation?(send_node)
                    "`#{text}`"
                  elsif comment_line?(text.lines.reverse_each.first)
                    'the start of the previous line (not counting the comment)'

--- a/lib/rubocop/cop/layout/first_array_element_line_break.rb
+++ b/lib/rubocop/cop/layout/first_array_element_line_break.rb
@@ -37,7 +37,7 @@ module RuboCop
 
         def assignment_on_same_line?(node)
           source = node.source_range.source_line[0...node.loc.column]
-          source =~ /\s*=\s*$/
+          /\s*=\s*$/.match?(source)
         end
       end
     end

--- a/lib/rubocop/cop/layout/space_after_colon.rb
+++ b/lib/rubocop/cop/layout/space_after_colon.rb
@@ -39,7 +39,7 @@ module RuboCop
         private
 
         def followed_by_space?(colon)
-          colon.source_buffer.source[colon.end_pos] =~ /\s/
+          /\s/.match?(colon.source_buffer.source[colon.end_pos])
         end
       end
     end

--- a/lib/rubocop/cop/layout/space_around_keyword.rb
+++ b/lib/rubocop/cop/layout/space_around_keyword.rb
@@ -186,7 +186,7 @@ module RuboCop
           pos = range.begin_pos - 1
           return false if pos.negative?
 
-          range.source_buffer.source[pos] !~ /[\s(|{\[;,*=]/
+          !/[\s(|{\[;,*=]/.match?(range.source_buffer.source[pos])
         end
 
         def space_after_missing?(range)
@@ -198,7 +198,7 @@ module RuboCop
           return false if accept_namespace_operator?(range) &&
                           namespace_operator?(range, pos)
 
-          char !~ /[\s;,#\\)}\].]/
+          !/[\s;,#\\)}\].]/.match?(char)
         end
 
         def accepted_opening_delimiter?(range, char)

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -134,7 +134,7 @@ module RuboCop
 
         def autocorrect(range)
           lambda do |corrector|
-            if range.source =~ /\*\*/ && !space_around_exponent_operator?
+            if /\*\*/.match?(range.source) && !space_around_exponent_operator?
               corrector.replace(range, '**')
             elsif range.source.end_with?("\n")
               corrector.replace(range, " #{range.source.strip}\n")

--- a/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
@@ -130,7 +130,7 @@ module RuboCop
           line, col = line_and_column_for(token)
           return true if col == -1
 
-          processed_source.lines[line][0..col] !~ /\S/
+          !/\S/.match?(processed_source.lines[line][0..col])
         end
 
         def index_for(node, token)

--- a/lib/rubocop/cop/layout/space_inside_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_block_braces.rb
@@ -150,7 +150,7 @@ module RuboCop
         end
 
         def check_right_brace(inner, left_brace, right_brace, single_line)
-          if single_line && inner =~ /\S$/
+          if single_line && /\S$/.match?(inner)
             no_space(right_brace.begin_pos, right_brace.end_pos,
                      'Space missing inside }.')
           else

--- a/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
@@ -182,7 +182,7 @@ module RuboCop
         def range_of_space_to_the_right(range)
           src = range.source_buffer.source
           end_pos = range.end_pos
-          end_pos += 1 while src[end_pos] =~ /[ \t]/
+          end_pos += 1 while /[ \t]/.match?(src[end_pos])
 
           range_between(range.begin_pos + 1, end_pos)
         end
@@ -190,7 +190,7 @@ module RuboCop
         def range_of_space_to_the_left(range)
           src = range.source_buffer.source
           begin_pos = range.begin_pos
-          begin_pos -= 1 while src[begin_pos - 1] =~ /[ \t]/
+          begin_pos -= 1 while /[ \t]/.match?(src[begin_pos - 1])
 
           range_between(begin_pos, range.end_pos - 1)
         end

--- a/lib/rubocop/cop/lint/float_out_of_range.rb
+++ b/lib/rubocop/cop/lint/float_out_of_range.rb
@@ -25,7 +25,7 @@ module RuboCop
           value, = *node
 
           return unless value.infinite? ||
-                        value.zero? && node.source =~ /[1-9]/
+                        value.zero? && /[1-9]/.match?(node.source)
 
           add_offense(node)
         end

--- a/lib/rubocop/cop/lint/percent_string_array.rb
+++ b/lib/rubocop/cop/lint/percent_string_array.rb
@@ -62,7 +62,7 @@ module RuboCop
             # To avoid likely false positives (e.g. a single ' or ")
             next if literal.gsub(/[^[[:alnum:]]]/, '').empty?
 
-            QUOTES_AND_COMMAS.any? { |pat| literal =~ pat }
+            QUOTES_AND_COMMAS.any? { |pat| literal.match?(pat) }
           end
         end
       end

--- a/lib/rubocop/cop/lint/percent_symbol_array.rb
+++ b/lib/rubocop/cop/lint/percent_symbol_array.rb
@@ -61,7 +61,7 @@ module RuboCop
         end
 
         def non_alphanumeric_literal?(literal)
-          literal !~ /[[:alnum:]]/
+          !/[[:alnum:]]/.match?(literal)
         end
       end
     end

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -154,7 +154,7 @@ module RuboCop
         end
 
         def all_disabled?(comment)
-          comment.text =~ /rubocop\s*:\s*(?:disable|todo)\s+all\b/
+          /rubocop\s*:\s*(?:disable|todo)\s+all\b/.match?(comment.text)
         end
 
         def ignore_offense?(disabled_ranges, line_range)
@@ -225,7 +225,7 @@ module RuboCop
             .drop_while { |r| !r.equal?(range) }
             .each_cons(2)
             .map { |range1, range2| range1.end.join(range2.begin).source }
-            .all? { |intervening| intervening =~ /\A\s*,\s*\Z/ }
+            .all? { |intervening| /\A\s*,\s*\Z/.match?(intervening) }
         end
 
         def describe(cop)

--- a/lib/rubocop/cop/mixin/documentation_comment.rb
+++ b/lib/rubocop/cop/mixin/documentation_comment.rb
@@ -41,11 +41,11 @@ module RuboCop
       end
 
       def interpreter_directive_comment?(comment)
-        comment.text =~ /^#\s*(frozen_string_literal|encoding):/
+        /^#\s*(frozen_string_literal|encoding):/.match?(comment.text)
       end
 
       def rubocop_directive_comment?(comment)
-        comment.text =~ CommentConfig::COMMENT_DIRECTIVE_REGEXP
+        CommentConfig::COMMENT_DIRECTIVE_REGEXP.match?(comment.text)
       end
     end
   end

--- a/lib/rubocop/cop/mixin/end_keyword_alignment.rb
+++ b/lib/rubocop/cop/mixin/end_keyword_alignment.rb
@@ -51,7 +51,7 @@ module RuboCop
 
       def accept_end_kw_alignment?(end_loc)
         end_loc.nil? || # Discard modifier forms of if/while/until.
-          processed_source.lines[end_loc.line - 1] !~ /\A[ \t]*end/
+          !/\A[ \t]*end/.match?(processed_source.lines[end_loc.line - 1])
       end
 
       def style_parameter_name

--- a/lib/rubocop/cop/mixin/first_element_line_break.rb
+++ b/lib/rubocop/cop/mixin/first_element_line_break.rb
@@ -17,7 +17,7 @@ module RuboCop
 
       def method_uses_parens?(node, limit)
         source = node.source_range.source_line[0...limit.loc.column]
-        source =~ /\s*\(\s*$/
+        /\s*\(\s*$/.match?(source)
       end
 
       def check_children_line_break(node, children, start = node)

--- a/lib/rubocop/cop/mixin/parentheses.rb
+++ b/lib/rubocop/cop/mixin/parentheses.rb
@@ -9,8 +9,7 @@ module RuboCop
       def parens_required?(node)
         range  = node.source_range
         source = range.source_buffer.source
-        source[range.begin_pos - 1] =~ /[a-z]/ ||
-          source[range.end_pos] =~ /[a-z]/
+        /[a-z]/.match?(source[range.begin_pos - 1]) || /[a-z]/.match?(source[range.end_pos])
       end
     end
   end

--- a/lib/rubocop/cop/mixin/preceding_following_alignment.rb
+++ b/lib/rubocop/cop/mixin/preceding_following_alignment.rb
@@ -87,7 +87,7 @@ module RuboCop
       end
 
       def aligned_words?(range, line)
-        line[range.column - 1, 2] =~ /\s\S/
+        /\s\S/.match?(line[range.column - 1, 2])
       end
 
       def aligned_char?(range, line)

--- a/lib/rubocop/cop/mixin/range_help.rb
+++ b/lib/rubocop/cop/mixin/range_help.rb
@@ -109,7 +109,7 @@ module RuboCop
 
       def move_pos(src, pos, step, condition, regexp)
         offset = step == -1 ? -1 : 0
-        pos += step while condition && src[pos + offset] =~ regexp
+        pos += step while condition && regexp.match?(src[pos + offset])
         pos.negative? ? 0 : pos
       end
     end

--- a/lib/rubocop/cop/mixin/string_literals_help.rb
+++ b/lib/rubocop/cop/mixin/string_literals_help.rb
@@ -15,7 +15,7 @@ module RuboCop
         if style == :single_quotes
           !double_quotes_required?(src)
         else
-          src !~ /" | \\[^'] | \#(@|\{)/x
+          !/" | \\[^'] | \#(@|\{)/x.match?(src)
         end
       end
     end

--- a/lib/rubocop/cop/mixin/surrounding_space.rb
+++ b/lib/rubocop/cop/mixin/surrounding_space.rb
@@ -87,15 +87,15 @@ module RuboCop
         return false unless token
 
         if side == :left
-          String(token.space_after?) =~ SINGLE_SPACE_REGEXP
+          SINGLE_SPACE_REGEXP.match?(String(token.space_after?))
         else
-          String(token.space_before?) =~ SINGLE_SPACE_REGEXP
+          SINGLE_SPACE_REGEXP.match?(String(token.space_before?))
         end
       end
 
       def reposition(src, pos, step)
         offset = step == -1 ? -1 : 0
-        pos += step while src[pos + offset] =~ SINGLE_SPACE_REGEXP
+        pos += step while SINGLE_SPACE_REGEXP.match?(src[pos + offset])
         pos.negative? ? 0 : pos
       end
 

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -31,7 +31,7 @@ module RuboCop
         # If there is any heredoc in items, then match the comma succeeding
         # any whitespace (except newlines), otherwise allow for newlines
         comma_regex = any_heredoc?(items) ? /\A[^\S\n]*,/ : /\A\s*,/
-        range.source =~ comma_regex && range.source.index(',')
+        comma_regex.match?(range.source) && range.source.index(',')
       end
 
       def check_comma(node, kind, comma_pos)

--- a/lib/rubocop/cop/mixin/uncommunicative_name.rb
+++ b/lib/rubocop/cop/mixin/uncommunicative_name.rb
@@ -44,7 +44,7 @@ module RuboCop
       end
 
       def uppercase?(name)
-        name =~ /[[:upper:]]/
+        /[[:upper:]]/.match?(name)
       end
 
       def name_type(node)
@@ -62,7 +62,7 @@ module RuboCop
       end
 
       def ends_with_num?(name)
-        name[-1] =~ /\d/
+        /\d/.match?(name[-1])
       end
 
       def length_offense(node, range)

--- a/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
+++ b/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
@@ -35,7 +35,7 @@ module RuboCop
         def op_method?(name)
           return false if BLACKLISTED.include?(name)
 
-          name !~ /\A\w/ || OP_LIKE_METHODS.include?(name)
+          !/\A\w/.match?(name) || OP_LIKE_METHODS.include?(name)
         end
       end
     end

--- a/lib/rubocop/cop/naming/file_name.rb
+++ b/lib/rubocop/cop/naming/file_name.rb
@@ -123,7 +123,7 @@ module RuboCop
           # special handling for Action Pack Variants file names like
           # some_file.xlsx+mobile.axlsx
           basename = basename.sub('+', '_')
-          basename =~ (regex || SNAKE_CASE)
+          basename.match?(regex || SNAKE_CASE)
         end
 
         # rubocop:disable Metrics/CyclomaticComplexity

--- a/lib/rubocop/cop/naming/heredoc_delimiter_naming.rb
+++ b/lib/rubocop/cop/naming/heredoc_delimiter_naming.rb
@@ -42,7 +42,7 @@ module RuboCop
           return false unless /\w/.match?(delimiters)
 
           forbidden_delimiters.none? do |forbidden_delimiter|
-            delimiters =~ Regexp.new(forbidden_delimiter)
+            Regexp.new(forbidden_delimiter).match?(delimiters)
           end
         end
 

--- a/lib/rubocop/cop/style/bare_percent_literals.rb
+++ b/lib/rubocop/cop/style/bare_percent_literals.rb
@@ -60,7 +60,7 @@ module RuboCop
         end
 
         def requires_percent_q?(source)
-          style == :percent_q && source =~ /^%[^\w]/
+          style == :percent_q && /^%[^\w]/.match?(source)
         end
 
         def requires_bare_percent?(source)

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -245,11 +245,11 @@ module RuboCop
         end
 
         def whitespace_before?(range)
-          range.source_buffer.source[range.begin_pos - 1, 1] =~ /\s/
+          /\s/.match?(range.source_buffer.source[range.begin_pos - 1, 1])
         end
 
         def whitespace_after?(range, length = 1)
-          range.source_buffer.source[range.begin_pos + length, 1] =~ /\s/
+          /\s/.match?(range.source_buffer.source[range.begin_pos + length, 1])
         end
 
         # rubocop:disable Metrics/CyclomaticComplexity

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -143,7 +143,7 @@ module RuboCop
         end
 
         def compact_node_name?(node)
-          node.loc.name.source =~ /::/
+          /::/.match?(node.loc.name.source)
         end
       end
     end

--- a/lib/rubocop/cop/style/command_literal.rb
+++ b/lib/rubocop/cop/style/command_literal.rb
@@ -153,7 +153,7 @@ module RuboCop
         end
 
         def contains_backtick?(node)
-          node_body(node) =~ /`/
+          /`/.match?(node_body(node))
         end
 
         def node_body(node)

--- a/lib/rubocop/cop/style/commented_keyword.rb
+++ b/lib/rubocop/cop/style/commented_keyword.rb
@@ -55,8 +55,8 @@ module RuboCop
 
         def offensive?(comment)
           line = line(comment)
-          KEYWORDS.any? { |word| line =~ /^\s*#{word}\s/ } &&
-            ALLOWED_COMMENTS.none? { |c| line =~ /#\s*#{c}/ }
+          KEYWORDS.any? { |word| /^\s*#{word}\s/.match?(line) } &&
+            ALLOWED_COMMENTS.none? { |c| /#\s*#{c}/.match?(line) }
         end
 
         def message(comment)

--- a/lib/rubocop/cop/style/copyright.rb
+++ b/lib/rubocop/cop/style/copyright.rb
@@ -72,14 +72,14 @@ module RuboCop
           return false if token_index >= processed_source.tokens.size
 
           token = processed_source.tokens[token_index]
-          token.comment? && token.text =~ /^#!.*$/
+          token.comment? && /^#!.*$/.match?(token.text)
         end
 
         def encoding_token?(processed_source, token_index)
           return false if token_index >= processed_source.tokens.size
 
           token = processed_source.tokens[token_index]
-          token.comment? && token.text =~ /^#.*coding\s?[:=]\s?(?:UTF|utf)-8/
+          token.comment? && /^#.*coding\s?[:=]\s?(?:UTF|utf)-8/.match?(token.text)
         end
 
         def notice_found?(processed_source)
@@ -88,7 +88,7 @@ module RuboCop
           processed_source.each_token do |token|
             break unless token.comment?
 
-            notice_found = !(token.text =~ notice_regexp).nil?
+            notice_found = notice_regexp.match?(token.text)
             break if notice_found
           end
           notice_found

--- a/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
+++ b/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
@@ -41,7 +41,7 @@ module RuboCop
         private
 
         def rubocop_directive_comment?(comment)
-          comment.text =~ CommentConfig::COMMENT_DIRECTIVE_REGEXP
+          CommentConfig::COMMENT_DIRECTIVE_REGEXP.match?(comment.text)
         end
       end
     end

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -104,7 +104,7 @@ module RuboCop
         end
 
         def compact_namespace?(node)
-          node.loc.name.source =~ /::/
+          /::/.match?(node.loc.name.source)
         end
 
         # First checks if the :nodoc: comment is associated with the
@@ -123,7 +123,7 @@ module RuboCop
         end
 
         def nodoc?(comment, require_all = false)
-          comment.text =~ /^#\s*:nodoc:#{"\s+all\s*$" if require_all}/
+          /^#\s*:nodoc:#{"\s+all\s*$" if require_all}/.match?(comment.text)
         end
 
         def nodoc(node)

--- a/lib/rubocop/cop/style/encoding.rb
+++ b/lib/rubocop/cop/style/encoding.rb
@@ -42,7 +42,7 @@ module RuboCop
         end
 
         def encoding_omitable?(line)
-          line =~ ENCODING_PATTERN
+          ENCODING_PATTERN.match?(line)
         end
 
         def encoding_line_number(processed_source)

--- a/lib/rubocop/cop/style/exponential_notation.rb
+++ b/lib/rubocop/cop/style/exponential_notation.rb
@@ -69,7 +69,7 @@ module RuboCop
 
         def scientific?(node)
           mantissa, = node.source.split('e')
-          mantissa =~ /^-?[1-9](\.\d*[0-9])?$/
+          /^-?[1-9](\.\d*[0-9])?$/.match?(mantissa)
         end
 
         def engineering?(node)
@@ -85,7 +85,7 @@ module RuboCop
 
         def integral(node)
           mantissa, = node.source.split('e')
-          mantissa =~ /^-?[1-9](\d*[1-9])?$/
+          /^-?[1-9](\d*[1-9])?$/.match?(mantissa)
         end
 
         def offense?(node)

--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -148,7 +148,7 @@ module RuboCop
           end
 
           next_token = processed_source.tokens[token_number]
-          token = next_token if next_token && next_token.text =~ Encoding::ENCODING_PATTERN
+          token = next_token if Encoding::ENCODING_PATTERN.match?(next_token&.text)
 
           token
         end

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -178,7 +178,7 @@ module RuboCop
         end
 
         def camel_case_constant?(node)
-          node.const_type? && node.source =~ CAMEL_CASE
+          node.const_type? && CAMEL_CASE.match?(node.source)
         end
 
         def dot_range(loc)

--- a/lib/rubocop/cop/style/ip_addresses.rb
+++ b/lib/rubocop/cop/style/ip_addresses.rb
@@ -34,7 +34,7 @@ module RuboCop
           # shortcut out if the string does not look like an IP address
           return false unless could_be_ip?(contents)
 
-          contents =~ ::Resolv::IPv4::Regex || contents =~ ::Resolv::IPv6::Regex
+          ::Resolv::IPv4::Regex.match?(contents) || ::Resolv::IPv6::Regex.match?(contents)
         end
 
         # Dummy implementation of method in ConfigurableEnforcedStyle that is

--- a/lib/rubocop/cop/style/multiline_if_then.rb
+++ b/lib/rubocop/cop/style/multiline_if_then.rb
@@ -42,7 +42,7 @@ module RuboCop
         private
 
         def non_modifier_then?(node)
-          node.loc.begin && node.loc.begin.source_line =~ NON_MODIFIER_THEN
+          NON_MODIFIER_THEN.match?(node.loc.begin&.source_line)
         end
       end
     end

--- a/lib/rubocop/cop/style/next.rb
+++ b/lib/rubocop/cop/style/next.rb
@@ -191,7 +191,7 @@ module RuboCop
         end
 
         def end_followed_by_whitespace_only?(source_buffer, end_pos)
-          source_buffer.source[end_pos..-1] =~ /\A\s*$/
+          /\A\s*$/.match?(source_buffer.source[end_pos..-1])
         end
 
         def reindentable_lines(node)
@@ -201,7 +201,7 @@ module RuboCop
           lines = (node.source_range.line + 1)...node.loc.end.line
           lines = lines.to_a - heredoc_lines(node)
           # Skip blank lines
-          lines.reject { |lineno| buffer.source_line(lineno) =~ /\A\s*\z/ }
+          lines.reject { |lineno| /\A\s*\z/.match?(buffer.source_line(lineno)) }
         end
 
         # Adjust indentation of `lines` to match `node`

--- a/lib/rubocop/cop/style/numeric_literal_prefix.rb
+++ b/lib/rubocop/cop/style/numeric_literal_prefix.rb
@@ -77,9 +77,9 @@ module RuboCop
         end
 
         def octal_literal_type(literal)
-          if literal =~ OCTAL_ZERO_ONLY_REGEX && octal_zero_only?
+          if OCTAL_ZERO_ONLY_REGEX.match?(literal) && octal_zero_only?
             :octal_zero_only
-          elsif literal =~ OCTAL_REGEX && !octal_zero_only?
+          elsif OCTAL_REGEX.match?(literal) && !octal_zero_only?
             :octal
           end
         end

--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -102,7 +102,7 @@ module RuboCop
           delimiters_regexp = Regexp.union(delimiters)
           node
             .children.map { |n| string_source(n) }.compact
-            .any? { |s| delimiters_regexp =~ s }
+            .any? { |s| delimiters_regexp.match?(s) }
         end
 
         def string_source(node)

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -156,7 +156,7 @@ module RuboCop
           source_buffer = node.source_range.source_buffer
           line_range = source_buffer.line_range(node.loc.end.line)
 
-          line_range.source =~ /^\s*\)\s*,/
+          /^\s*\)\s*,/.match?(line_range.source)
         end
 
         def disallowed_literal?(begin_node, node)

--- a/lib/rubocop/cop/style/redundant_percent_q.rb
+++ b/lib/rubocop/cop/style/redundant_percent_q.rb
@@ -97,13 +97,13 @@ module RuboCop
 
           return true if STRING_INTERPOLATION_REGEXP.match?(src)
 
-          src.scan(/\\./).any? { |s| s =~ ESCAPED_NON_BACKSLASH }
+          src.scan(/\\./).any? { |s| ESCAPED_NON_BACKSLASH.match?(s) }
         end
 
         def acceptable_capital_q?(node)
           src = node.source
           src.include?(QUOTE) &&
-            (src =~ STRING_INTERPOLATION_REGEXP ||
+            (STRING_INTERPOLATION_REGEXP.match?(src) ||
             (node.str_type? && double_quotes_required?(src)))
         end
       end

--- a/lib/rubocop/cop/style/symbol_array.rb
+++ b/lib/rubocop/cop/style/symbol_array.rb
@@ -65,7 +65,7 @@ module RuboCop
         def symbols_contain_spaces?(node)
           node.children.any? do |sym|
             content, = *sym
-            content =~ / /
+            / /.match?(content)
           end
         end
 
@@ -104,12 +104,12 @@ module RuboCop
           )
 
           # method name
-          string =~ /\A[a-zA-Z_]\w*[!?]?\z/ ||
+          /\A[a-zA-Z_]\w*[!?]?\z/.match?(string) ||
             # instance / class variable
-            string =~ /\A@@?[a-zA-Z_]\w*\z/ ||
+            /\A@@?[a-zA-Z_]\w*\z/.match?(string) ||
             # global variable
-            string =~ /\A\$[1-9]\d*\z/ ||
-            string =~ /\A\$[a-zA-Z_]\w*\z/ ||
+            /\A\$[1-9]\d*\z/.match?(string) ||
+            /\A\$[a-zA-Z_]\w*\z/.match?(string) ||
             special_gvars.include?(string) ||
             redefinable_operators.include?(string)
         end

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -174,7 +174,7 @@ module RuboCop
         end
 
         def unparenthesized_method_call?(child)
-          method_name(child) =~ /^[a-z]/i && !child.parenthesized?
+          /^[a-z]/i.match?(method_name(child)) && !child.parenthesized?
         end
 
         def below_ternary_precedence?(child)

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -73,7 +73,7 @@ module RuboCop
           strings.any? do |s|
             string = s.str_content.dup.force_encoding(::Encoding::UTF_8)
             !string.valid_encoding? ||
-              string !~ word_regex || string =~ / /
+              !word_regex.match?(string) || / /.match?(string)
           end
         end
 

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -14,7 +14,7 @@ module RuboCop
       module_function
 
       def comment_line?(line_source)
-        line_source =~ /^\s*#/
+        /^\s*#/.match?(line_source)
       end
 
       def comment_lines?(node)
@@ -88,7 +88,7 @@ module RuboCop
 
         # Regex matches IF there is a ' or there is a \\ in the string that is
         # not preceded/followed by another \\ (e.g. "\\x34") but not "\\\\".
-        string =~ /'|(?<! \\) \\{2}* \\ (?![\\"])/x
+        /'|(?<! \\) \\{2}* \\ (?![\\"])/x.match?(string)
       end
 
       def needs_escaping?(string)

--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -82,7 +82,7 @@ module RuboCop
 
       def builtin_formatter_class(specified_key)
         matching_keys = BUILTIN_FORMATTERS_FOR_KEYS.keys.select do |key|
-          key =~ /^\[#{specified_key}\]/ || specified_key == key.delete('[]')
+          /^\[#{specified_key}\]/.match?(key) || specified_key == key.delete('[]')
         end
 
         raise %(No formatter for "#{specified_key}") if matching_keys.empty?

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -40,7 +40,7 @@ module RuboCop
           hidden_file_in_not_hidden_dir?(pattern, path)
       when Regexp
         begin
-          path =~ pattern
+          pattern.match?(path)
         rescue ArgumentError => e
           return false if e.message.start_with?('invalid byte sequence')
 
@@ -51,7 +51,7 @@ module RuboCop
 
     # Returns true for an absolute Unix or Windows path.
     def absolute?(path)
-      path =~ %r{\A([A-Z]:)?/}i
+      %r{\A([A-Z]:)?/}i.match?(path)
     end
 
     def self.pwd

--- a/lib/rubocop/platform.rb
+++ b/lib/rubocop/platform.rb
@@ -5,7 +5,7 @@ module RuboCop
   # on.
   module Platform
     def self.windows?
-      RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/
+      /cygwin|mswin|mingw|bccwin|wince|emx/.match?(RbConfig::CONFIG['host_os'])
     end
   end
 end

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -139,7 +139,7 @@ module RuboCop
       return false unless File.extname(file).empty? && File.exist?(file)
 
       first_line = File.open(file, &:readline)
-      !(first_line =~ /#!.*(#{ruby_interpreters(file).join('|')})/).nil?
+      /#!.*(#{ruby_interpreters(file).join('|')})/.match?(first_line)
     rescue EOFError, ArgumentError => e
       warn("Unprocessable file #{file}: #{e.class}, #{e.message}") if debug?
 

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
         option_sections = $stdout.string.lines.slice_before(/^\s*-/)
 
         format_section = option_sections.find do |lines|
-          lines.first =~ /^\s*-f/
+          /^\s*-f/.match?(lines.first)
         end
 
         formatter_keys = format_section.reduce([]) do |keys, line|

--- a/spec/rubocop/path_util_spec.rb
+++ b/spec/rubocop/path_util_spec.rb
@@ -110,8 +110,8 @@ RSpec.describe RuboCop::PathUtil do
     end
 
     it 'matches regexps' do
-      expect(described_class.match_path?(/^d.*e$/, 'dir/file')).to be(0)
-      expect(described_class.match_path?(/^d.*e$/, 'dir/filez')).to be(nil)
+      expect(described_class.match_path?(/^d.*e$/, 'dir/file')).to be(true)
+      expect(described_class.match_path?(/^d.*e$/, 'dir/filez')).to be(false)
     end
 
     it 'does not match invalid UTF-8 paths' do

--- a/spec/support/alignment_examples.rb
+++ b/spec/support/alignment_examples.rb
@@ -10,7 +10,7 @@ shared_examples_for 'misaligned' do |annotated_source, used_style|
                              end
   annotated_source.split(/\n\n/).each do |chunk|
     chunk << "\n" unless chunk.end_with?("\n")
-    source = chunk.lines.reject { |line| line =~ /^ *\^/ }.join
+    source = chunk.lines.reject { |line| /^ *\^/.match?(line) }.join
     name = source.gsub(/\n(?=[a-z ])/, ' <newline> ').gsub(/\s+/, ' ')
 
     it "registers an offense for mismatched #{name}" do


### PR DESCRIPTION
This PR uses `match?` instead of `=~`.

In future this change would be better if it could be detected by the extended `Performance/RegexpMatch`. So far, it is detected and corrected by handcraft.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
