### PR TITLE
Update obsolete rubies and add a doc for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,7 @@ RuboCop supports the following Ruby implementations:
 * MRI 2.4+
 * JRuby 9.2+
 
-RuboCop has customarily provided support for about a year after EOL of MRI Ruby version.
-This is done by RuboCop core to provide the community with a margin of transition.
+See [compatibility](https://docs.rubocop.org/rubocop/compatibility.html) for further details.
 
 ## Team
 

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,5 +1,6 @@
 * xref:index.adoc[Home]
 * xref:installation.adoc[Installation]
+* xref:compatibility.adoc[Compatibility]
 * Usage
 ** xref:usage/basic_usage.adoc[Basic Usage]
 ** xref:usage/auto_correct.adoc[Auto-correct]

--- a/docs/modules/ROOT/pages/compatibility.adoc
+++ b/docs/modules/ROOT/pages/compatibility.adoc
@@ -1,0 +1,36 @@
+= Compatibility
+
+RuboCop targets Ruby 2.4+.
+
+RuboCop officially supports MRI and JRuby.
+
+- MRI 2.4+
+- JRuby 9.2+
+
+The supported JRuby version follows to MRI compatible version.
+
+== Support Matrix
+
+RuboCop has customarily provided support for about one year after EOL of MRI version. The following table is the support matrix.
+
+|===
+| Supported target Ruby version | Last supported RuboCop version
+
+| 1.9 | 0.41
+| 2.0 | 0.50
+| 2.1 | 0.57
+| 2.2 | 0.68
+| 2.3 | 0.81
+| 2.4 | -
+| 2.5 | -
+| 2.6 | -
+| 2.7 | -
+|===
+
+One year provides the community with a transition margin. And the final decision to drop support will be made by core maintainers.
+
+NOTE: The compatibility https://docs.rubocop.org/rubocop/configuration.html#setting-the-target-ruby-version[target Ruby version] mentioned here is about analysys, not runtime.
+
+== Forwards Compatibility
+
+Features may be provided for development version of Ruby. These are experimental introductions and may change before the stable version of Ruby will be released.

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -7,7 +7,7 @@ module RuboCop
     DEFAULT_VERSION = KNOWN_RUBIES.first
 
     OBSOLETE_RUBIES = {
-      1.9 => '0.50', 2.0 => '0.50', 2.1 => '0.58', 2.2 => '0.69', 2.3 => '0.81'
+      1.9 => '0.41', 2.0 => '0.50', 2.1 => '0.57', 2.2 => '0.68', 2.3 => '0.81'
     }.freeze
     private_constant :KNOWN_RUBIES, :OBSOLETE_RUBIES
 


### PR DESCRIPTION
Follow up https://github.com/rubocop-hq/rubocop/pull/7943#discussion_r422450919 and https://github.com/rubocop-hq/rubocop/issues/8112#issuecomment-640539334.

This PR updates obsolete rubies, adds a doc for compatibility and  replaces compatibility description with compatibility doc link to keep README.md simple.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
