### PR TITLE
Add rubocop-packaging as a known extension in the docs

### DIFF
--- a/docs/modules/ROOT/pages/extensions.adoc
+++ b/docs/modules/ROOT/pages/extensions.adoc
@@ -51,6 +51,8 @@ Code style checking for Sequel gem
 Custom cops and config defaults for Chef Infra Cookbooks
 * https://github.com/rubocop-hq/rubocop-rake[rubocop-rake] -
 Rake-specific analysis
+* https://github.com/utkarsh2102/rubocop-packaging[rubocop-packaging] -
+Upstream best practices and coding conventions for downstream compatibility.
 
 Any extensions missing? Send us a Pull Request!
 


### PR DESCRIPTION
This PR adds another known extension, [rubocop-packaging](https://github.com/utkarsh2102/rubocop-packaging) to the [extension docs](https://docs.rubocop.org/rubocop/0.85/extensions.html).

And lastly, thanks @bbatsov, for this wonderful tool! :heart: 

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
