### PR TITLE
Support autocorrection for `Lint/InterpolationCheck`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#7868](https://github.com/rubocop-hq/rubocop/pull/7868): `Cop::Base` is the new recommended base class for cops. ([@marcandre][])
 * [#8213](https://github.com/rubocop-hq/rubocop/pull/8213): Permit to specify TargetRubyVersion 2.8 (experimental). ([@koic][])
+* [#8164](https://github.com/rubocop-hq/rubocop/pull/8164): Support auto-correction for `Lint/InterpolationCheck`. ([@koic][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1508,7 +1508,9 @@ Lint/InheritException:
 Lint/InterpolationCheck:
   Description: 'Raise warning for interpolation in single q strs.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.50'
+  VersionChanged: '0.87'
 
 Lint/LiteralAsCondition:
   Description: 'Checks of literals used in conditions.'

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -1437,9 +1437,9 @@ C = Class.new(StandardError)
 
 | Enabled
 | Yes
-| No
+| Yes (Unsafe)
 | 0.50
-| -
+| 0.87
 |===
 
 This cop checks for interpolation in a single quoted string.

--- a/lib/rubocop/cop/lint/interpolation_check.rb
+++ b/lib/rubocop/cop/lint/interpolation_check.rb
@@ -30,6 +30,19 @@ module RuboCop
           add_offense(node)
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            starting_token, ending_token = if node.source.include?('"')
+                                             ['%{', '}']
+                                           else
+                                             ['"', '"']
+                                           end
+
+            corrector.replace(node.loc.begin, starting_token)
+            corrector.replace(node.loc.end, ending_token)
+          end
+        end
+
         def heredoc?(node)
           node.loc.is_a?(Parser::Source::Map::Heredoc) ||
             (node.parent && heredoc?(node.parent))

--- a/spec/rubocop/cop/lint/interpolation_check_spec.rb
+++ b/spec/rubocop/cop/lint/interpolation_check_spec.rb
@@ -3,10 +3,25 @@
 RSpec.describe RuboCop::Cop::Lint::InterpolationCheck do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for interpolation in single quoted string' do
+  it 'registers an offense and corrects for interpolation in single quoted string' do
     expect_offense(<<~'RUBY')
       'foo #{bar}'
       ^^^^^^^^^^^^ Interpolation in single quoted string detected. Use double quoted strings if you need interpolation.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      "foo #{bar}"
+    RUBY
+  end
+
+  it 'registers an offense and corrects when including interpolation and double quoted string in single quoted string' do
+    expect_offense(<<~'RUBY')
+      'foo "#{bar}"'
+      ^^^^^^^^^^^^^^ Interpolation in single quoted string detected. Use double quoted strings if you need interpolation.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      %{foo "#{bar}"}
     RUBY
   end
 


### PR DESCRIPTION
This PR supports autocorrection for `Lint/InterpolationCheck` and marks it unsafe because autocorrected code is incompatible.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
