### PR TITLE
WIP - Modify --disable-uncorrectable and Style/DoubleCopDisableDirective to append existing disable comments

### DIFF
--- a/lib/rubocop/cop/autocorrect_logic.rb
+++ b/lib/rubocop/cop/autocorrect_logic.rb
@@ -42,7 +42,19 @@ module RuboCop
 
       def disable_offense(node)
         range = node.location.expression
+
+        if range.source_line.match?(/# rubocop:(?:disable|todo)/)
+          eol_comment = ", #{cop_name}"
+          needed_line_length = (range.source_line + eol_comment).length
+
+          if needed_line_length <= max_line_length
+            return disable_offense_at_end_of_line(range_of_first_line(range),
+                                                  eol_comment)
+          end
+        end
+
         eol_comment = " # rubocop:todo #{cop_name}"
+
         needed_line_length = (range.source_line + eol_comment).length
         if needed_line_length <= max_line_length
           disable_offense_at_end_of_line(range_of_first_line(range),

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'uri'
+require 'pry'
 
 module RuboCop
   module Cop

--- a/lib/rubocop/cop/style/double_cop_disable_directive.rb
+++ b/lib/rubocop/cop/style/double_cop_disable_directive.rb
@@ -44,10 +44,9 @@ module RuboCop
                      '# rubocop:todo'
                    end
 
-          lambda do |corrector|
-            corrector.replace(comment,
-                              comment.text[/#{prefix} \S+/])
-          end
+          replacement = "#{prefix} #{comment.text.scan(/#{prefix}\s+(\S+)/).flatten.join(', ')}"
+
+          ->(corrector) { corrector.replace(comment, replacement) }
         end
       end
     end

--- a/spec/rubocop/cop/style/double_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/style/double_cop_disable_directive_spec.rb
@@ -9,8 +9,9 @@ RSpec.describe RuboCop::Cop::Style::DoubleCopDisableDirective do
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ More than one disable comment on one line.
       end
     RUBY
+
     expect_correction(<<~RUBY)
-      def choose_move(who_to_move) # rubocop:disable Metrics/CyclomaticComplexity
+      def choose_move(who_to_move) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength
       end
     RUBY
   end
@@ -21,8 +22,9 @@ RSpec.describe RuboCop::Cop::Style::DoubleCopDisableDirective do
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ More than one disable comment on one line.
       end
     RUBY
+
     expect_correction(<<~RUBY)
-      def choose_move(who_to_move) # rubocop:todo Metrics/CyclomaticComplexity
+      def choose_move(who_to_move) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength
       end
     RUBY
   end


### PR DESCRIPTION
This is related to https://github.com/rubocop-hq/rubocop/issues/8161. This code is not functioning as well as intended.

For example:
```ruby
def f(a, b)
  puts 1 if foo
  puts 2 if bar
  puts 3 if foobar
  puts 4 if baz
  puts 5 if quz
  puts 5 if quz
  puts 5 if quz
  puts 5 if quz
  puts 5 if quz
end
```
is being corrected/disabled to
```ruby
# rubocop:todo Naming/MethodParameterName
# rubocop:todo Metrics/PerceivedComplexity
# rubocop:todo Metrics/AbcSize
def f(_a, _b) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity, Naming/MethodParameterName
  puts 1 if foo
  puts 2 if bar
  puts 3 if foobar
  puts 4 if baz
  puts 5 if quz
  puts 5 if quz
  puts 5 if quz
  puts 5 if quz
  puts 5 if quz
end
# rubocop:enable Metrics/AbcSize
# rubocop:enable Metrics/PerceivedComplexity
# rubocop:enable Naming/MethodParameterName
```

```
rrosenblum@LATLmacK0QUJGH8:~/work/rubocop (double_disables u= origin/double_disables)$ b rubocop test.rb -a --disable-uncorrectable
Inspecting 1 file
W

Offenses:

test.rb:3:1: C: [Todo] Metrics/AbcSize: Assignment Branch Condition size for f is too high. [<0, 18, 9> 20.12/15]
def f(a, b) ...
^^^^^^^^^^^
test.rb:3:1: C: [Todo] Metrics/CyclomaticComplexity: Cyclomatic complexity for f is too high. [10/7]
def f(a, b) ...
^^^^^^^^^^^
test.rb:3:1: C: [Todo] Metrics/PerceivedComplexity: Perceived complexity for f is too high. [10/7]
def f(a, b) ...
^^^^^^^^^^^
test.rb:3:7: W: [Corrected] Lint/UnusedMethodArgument: Unused method argument - a. If it's necessary, use _ or _a as an argument name to indicate that it won't be used. You can also write as f(*) if you want the method to accept any arguments but don't care about them.
def f(a, b)
      ^
test.rb:3:7: C: [Todo] Naming/MethodParameterName: Method parameter must be at least 3 characters long.
def f(a, b)
      ^
test.rb:3:10: W: [Corrected] Lint/UnusedMethodArgument: Unused method argument - b. If it's necessary, use _ or _b as an argument name to indicate that it won't be used. You can also write as f(*) if you want the method to accept any arguments but don't care about them.
def f(a, b)
         ^
test.rb:3:15: C: [Corrected] Style/DoubleCopDisableDirective: More than one disable comment on one line.
def f(_a, _b) # rubocop:todo Metrics/CyclomaticComplexity # rubocop:todo Metrics/AbcSize # rubocop:todo Metrics/PerceivedComplexity # rubocop:todo Naming/MethodParameterName
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```