### PR TITLE
Refine offense range for `Lint/RaiseException`

### DIFF
--- a/lib/rubocop/cop/lint/raise_exception.rb
+++ b/lib/rubocop/cop/lint/raise_exception.rb
@@ -31,12 +31,12 @@ module RuboCop
         MSG = 'Use `StandardError` over `Exception`.'
 
         def_node_matcher :exception?, <<~PATTERN
-          (send nil? {:raise :fail} (const ${cbase nil?} :Exception) ... )
+          (send nil? {:raise :fail} $(const ${cbase nil?} :Exception) ... )
         PATTERN
 
         def_node_matcher :exception_new_with_message?, <<~PATTERN
           (send nil? {:raise :fail}
-            (send (const ${cbase nil?} :Exception) :new ... ))
+            (send $(const ${cbase nil?} :Exception) :new ... ))
         PATTERN
 
         def on_send(node)
@@ -47,10 +47,10 @@ module RuboCop
         private
 
         def check(node)
-          lambda do |cbase|
+          lambda do |exception_class, cbase|
             return if cbase.nil? && implicit_namespace?(node)
 
-            add_offense(node)
+            add_offense(exception_class)
           end
         end
 

--- a/spec/rubocop/cop/lint/raise_exception_spec.rb
+++ b/spec/rubocop/cop/lint/raise_exception_spec.rb
@@ -6,70 +6,70 @@ RSpec.describe RuboCop::Cop::Lint::RaiseException, :config do
   it 'registers an offense for `raise` with `::Exception`' do
     expect_offense(<<~RUBY)
       raise ::Exception
-      ^^^^^^^^^^^^^^^^^ Use `StandardError` over `Exception`.
+            ^^^^^^^^^^^ Use `StandardError` over `Exception`.
     RUBY
   end
 
   it 'registers an offense for `raise` with `::Exception.new`' do
     expect_offense(<<~RUBY)
       raise ::Exception.new 'Error with exception'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `StandardError` over `Exception`.
+            ^^^^^^^^^^^ Use `StandardError` over `Exception`.
     RUBY
   end
 
   it 'registers an offense for `raise` with `::Exception` and message' do
     expect_offense(<<~RUBY)
       raise ::Exception, 'Error with exception'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `StandardError` over `Exception`.
+            ^^^^^^^^^^^ Use `StandardError` over `Exception`.
     RUBY
   end
 
   it 'registers an offense for `raise` with `Exception`' do
     expect_offense(<<~RUBY)
       raise Exception
-      ^^^^^^^^^^^^^^^ Use `StandardError` over `Exception`.
+            ^^^^^^^^^ Use `StandardError` over `Exception`.
     RUBY
   end
 
   it 'registers an offense for `raise` with `Exception` and message' do
     expect_offense(<<~RUBY)
       raise Exception, 'Error with exception'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `StandardError` over `Exception`.
+            ^^^^^^^^^ Use `StandardError` over `Exception`.
     RUBY
   end
 
   it 'registers an offense for `raise` with `Exception.new` and message' do
     expect_offense(<<~RUBY)
       raise Exception.new 'Error with exception'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `StandardError` over `Exception`.
+            ^^^^^^^^^ Use `StandardError` over `Exception`.
     RUBY
   end
 
   it 'registers an offense for `raise` with `Exception.new(args*)` ' do
     expect_offense(<<~RUBY)
       raise Exception.new('arg1', 'arg2')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `StandardError` over `Exception`.
+            ^^^^^^^^^ Use `StandardError` over `Exception`.
     RUBY
   end
 
   it 'registers an offense for `fail` with `Exception`' do
     expect_offense(<<~RUBY)
       fail Exception
-      ^^^^^^^^^^^^^^ Use `StandardError` over `Exception`.
+           ^^^^^^^^^ Use `StandardError` over `Exception`.
     RUBY
   end
 
   it 'registers an offense for `fail` with `Exception` and message' do
     expect_offense(<<~RUBY)
       fail Exception, 'Error with exception'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `StandardError` over `Exception`.
+           ^^^^^^^^^ Use `StandardError` over `Exception`.
     RUBY
   end
 
   it 'registers an offense for `fail` with `Exception.new` and message' do
     expect_offense(<<~RUBY)
       fail Exception.new 'Error with exception'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `StandardError` over `Exception`.
+           ^^^^^^^^^ Use `StandardError` over `Exception`.
     RUBY
   end
 
@@ -104,7 +104,7 @@ RSpec.describe RuboCop::Cop::Lint::RaiseException, :config do
         module Gem
           def self.foo
             raise ::Exception
-            ^^^^^^^^^^^^^^^^^ Use `StandardError` over `Exception`.
+                  ^^^^^^^^^^^ Use `StandardError` over `Exception`.
           end
         end
       RUBY


### PR DESCRIPTION
This PR refines offense range for `Lint/RaiseException`.

The following is an example.

```ruby
raise Exception.new('Message')
```

## Before

```console
% bundle exec rubocop example.rb --only Lint/RaiseException
(snip)

Offenses:

example.rb:1:1: W: Lint/RaiseException: Use StandardError over
Exception.
raise Exception.new('Message')
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```

## After

```console
% bundle exec rubocop example.rb --only Lint/RaiseException
(snip)

Offenses:

example.rb:1:7: W: Lint/RaiseException: Use StandardError over
Exception.
raise Exception.new('Message')
      ^^^^^^^^^

1 file inspected, 1 offense detected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
