### PR TITLE
Support autocorrection for `Lint/RaiseException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#8151](https://github.com/rubocop-hq/rubocop/pull/8151): Support autocorrection for `Style/NestedTernaryOperator`. ([@koic][])
 * [#8142](https://github.com/rubocop-hq/rubocop/pull/8142): Add `Lint/ConstantResolution` cop. ([@robotdana][])
 * [#8170](https://github.com/rubocop-hq/rubocop/pull/8170): Support autocorrection for `Lint/RegexpAsCondition`. ([@koic][])
+* [#8169](https://github.com/rubocop-hq/rubocop/pull/8169): Support autocorrection for `Lint/RaiseException`. ([@koic][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1622,6 +1622,7 @@ Lint/RaiseException:
   Enabled: pending
   Safe: false
   VersionAdded: '0.81'
+  VersionChanged: '0.86'
   AllowedImplicitNamespaces:
     - 'Gem'
 

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -2139,9 +2139,9 @@ rather than meant to be part of the resulting symbols.
 
 | Pending
 | No
-| No
+| Yes (Unsafe)
 | 0.81
-| -
+| 0.86
 |===
 
 This cop checks for `raise` or `fail` statements which are

--- a/lib/rubocop/cop/lint/raise_exception.rb
+++ b/lib/rubocop/cop/lint/raise_exception.rb
@@ -44,6 +44,14 @@ module RuboCop
             exception_new_with_message?(node, &check(node))
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            exception_class = node.children.first&.cbase_type? ? '::StandardError' : 'StandardError'
+
+            corrector.replace(node, exception_class)
+          end
+        end
+
         private
 
         def check(node)

--- a/spec/rubocop/cop/lint/raise_exception_spec.rb
+++ b/spec/rubocop/cop/lint/raise_exception_spec.rb
@@ -3,73 +3,113 @@
 RSpec.describe RuboCop::Cop::Lint::RaiseException, :config do
   let(:cop_config) { { 'AllowedImplicitNamespaces' => ['Gem'] } }
 
-  it 'registers an offense for `raise` with `::Exception`' do
+  it 'registers an offense and corrects for `raise` with `::Exception`' do
     expect_offense(<<~RUBY)
       raise ::Exception
             ^^^^^^^^^^^ Use `StandardError` over `Exception`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      raise ::StandardError
+    RUBY
   end
 
-  it 'registers an offense for `raise` with `::Exception.new`' do
+  it 'registers an offense and corrects for `raise` with `::Exception.new`' do
     expect_offense(<<~RUBY)
       raise ::Exception.new 'Error with exception'
             ^^^^^^^^^^^ Use `StandardError` over `Exception`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      raise ::StandardError.new 'Error with exception'
+    RUBY
   end
 
-  it 'registers an offense for `raise` with `::Exception` and message' do
+  it 'registers an offense and corrects for `raise` with `::Exception` and message' do
     expect_offense(<<~RUBY)
       raise ::Exception, 'Error with exception'
             ^^^^^^^^^^^ Use `StandardError` over `Exception`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      raise ::StandardError, 'Error with exception'
+    RUBY
   end
 
-  it 'registers an offense for `raise` with `Exception`' do
+  it 'registers an offense and corrects for `raise` with `Exception`' do
     expect_offense(<<~RUBY)
       raise Exception
             ^^^^^^^^^ Use `StandardError` over `Exception`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      raise StandardError
+    RUBY
   end
 
-  it 'registers an offense for `raise` with `Exception` and message' do
+  it 'registers an offense and corrects for `raise` with `Exception` and message' do
     expect_offense(<<~RUBY)
       raise Exception, 'Error with exception'
             ^^^^^^^^^ Use `StandardError` over `Exception`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      raise StandardError, 'Error with exception'
+    RUBY
   end
 
-  it 'registers an offense for `raise` with `Exception.new` and message' do
+  it 'registers an offense and corrects for `raise` with `Exception.new` and message' do
     expect_offense(<<~RUBY)
       raise Exception.new 'Error with exception'
             ^^^^^^^^^ Use `StandardError` over `Exception`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      raise StandardError.new 'Error with exception'
+    RUBY
   end
 
-  it 'registers an offense for `raise` with `Exception.new(args*)` ' do
+  it 'registers an offense and corrects for `raise` with `Exception.new(args*)` ' do
     expect_offense(<<~RUBY)
       raise Exception.new('arg1', 'arg2')
             ^^^^^^^^^ Use `StandardError` over `Exception`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      raise StandardError.new('arg1', 'arg2')
+    RUBY
   end
 
-  it 'registers an offense for `fail` with `Exception`' do
+  it 'registers an offense and corrects for `fail` with `Exception`' do
     expect_offense(<<~RUBY)
       fail Exception
            ^^^^^^^^^ Use `StandardError` over `Exception`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      fail StandardError
+    RUBY
   end
 
-  it 'registers an offense for `fail` with `Exception` and message' do
+  it 'registers an offense and corrects for `fail` with `Exception` and message' do
     expect_offense(<<~RUBY)
       fail Exception, 'Error with exception'
            ^^^^^^^^^ Use `StandardError` over `Exception`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      fail StandardError, 'Error with exception'
+    RUBY
   end
 
-  it 'registers an offense for `fail` with `Exception.new` and message' do
+  it 'registers an offense and corrects for `fail` with `Exception.new` and message' do
     expect_offense(<<~RUBY)
       fail Exception.new 'Error with exception'
            ^^^^^^^^^ Use `StandardError` over `Exception`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      fail StandardError.new 'Error with exception'
     RUBY
   end
 
@@ -99,12 +139,20 @@ RSpec.describe RuboCop::Cop::Lint::RaiseException, :config do
       RUBY
     end
 
-    it 'does not register an offense when Exception with cbase specified' do
+    it 'registers an offense and corrects when Exception with cbase specified' do
       expect_offense(<<~RUBY)
         module Gem
           def self.foo
             raise ::Exception
                   ^^^^^^^^^^^ Use `StandardError` over `Exception`.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module Gem
+          def self.foo
+            raise ::StandardError
           end
         end
       RUBY


### PR DESCRIPTION
This PR supports autocorrection for `Lint/RaiseException`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
