### PR TITLE
Support autocorrection for `Lint/RegexpAsCondition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#8148](https://github.com/rubocop-hq/rubocop/pull/8148): Support autocorrection for `Style/MultilineTernaryOperator`. ([@koic][])
 * [#8151](https://github.com/rubocop-hq/rubocop/pull/8151): Support autocorrection for `Style/NestedTernaryOperator`. ([@koic][])
 * [#8142](https://github.com/rubocop-hq/rubocop/pull/8142): Add `Lint/ConstantResolution` cop. ([@robotdana][])
+* [#8170](https://github.com/rubocop-hq/rubocop/pull/8170): Support autocorrection for `Lint/RegexpAsCondition`. ([@koic][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1677,6 +1677,7 @@ Lint/RegexpAsCondition:
                  The regexp literal matches `$_` implicitly.
   Enabled: true
   VersionAdded: '0.51'
+  VersionChanged: '0.86'
 
 Lint/RequireParentheses:
   Description: >-

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -2524,9 +2524,9 @@ end
 
 | Enabled
 | Yes
-| No
+| Yes
 | 0.51
-| -
+| 0.86
 |===
 
 This cop checks for regexp literals used as `match-current-line`.

--- a/lib/rubocop/cop/lint/regexp_as_condition.rb
+++ b/lib/rubocop/cop/lint/regexp_as_condition.rb
@@ -23,6 +23,12 @@ module RuboCop
         def on_match_current_line(node)
           add_offense(node)
         end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(node, "#{node.source} =~ $_")
+          end
+        end
       end
     end
   end

--- a/spec/rubocop/cop/lint/regexp_as_condition_spec.rb
+++ b/spec/rubocop/cop/lint/regexp_as_condition_spec.rb
@@ -5,10 +5,15 @@ RSpec.describe RuboCop::Cop::Lint::RegexpAsCondition do
 
   let(:config) { RuboCop::Config.new }
 
-  it 'registers an offense for a regexp literal in `if` condition' do
+  it 'registers an offense and corrects for a regexp literal in `if` condition' do
     expect_offense(<<~RUBY)
       if /foo/
          ^^^^^ Do not use regexp literal as a condition. The regexp literal matches `$_` implicitly.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if /foo/ =~ $_
       end
     RUBY
   end


### PR DESCRIPTION
This PR supports autocorrection for `Lint/RegexpAsCondition`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
