### PR TITLE
Refine offense range for `Lint/SafeNavigationWithEmpty`

### DIFF
--- a/lib/rubocop/cop/lint/safe_navigation_with_empty.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_with_empty.rb
@@ -30,7 +30,7 @@ module RuboCop
         def on_if(node)
           return unless safe_navigation_empty_in_conditional?(node)
 
-          add_offense(node)
+          add_offense(node.condition)
         end
       end
     end

--- a/spec/rubocop/cop/lint/safe_navigation_with_empty_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_with_empty_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationWithEmpty do
     it 'registers an offense on `&.empty?`' do
       expect_offense(<<~RUBY)
         return unless foo&.empty?
-        ^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid calling `empty?` with the safe navigation operator in conditionals.
+                      ^^^^^^^^^^^ Avoid calling `empty?` with the safe navigation operator in conditionals.
       RUBY
     end
 


### PR DESCRIPTION
This PR refines offense range for `Lint/SafeNavigationWithEmpty`.

The following is an example.

```ruby
return unless foo&.empty?
```

## Before

```console
% bundle exec rubocop example.rb --only Lint/SafeNavigationWithEmpty
(snip)

Offenses:

example.rb:1:1: W: Lint/SafeNavigationWithEmpty: Avoid calling empty?
with the safe navigation operator in conditionals.
return unless foo&.empty?
^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```

## After

```console
% bundle exec rubocop example.rb --only Lint/SafeNavigationWithEmpty
(snip)

Offenses:

example.rb:1:15: W: Lint/SafeNavigationWithEmpty: Avoid calling empty?
with the safe navigation operator in conditionals.
return unless foo&.empty?
              ^^^^^^^^^^^

1 file inspected, 1 offense detected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
