### PR TITLE
Support autocorrection for `Lint/SafeNavigationWithEmpty`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#8213](https://github.com/rubocop-hq/rubocop/pull/8213): Permit to specify TargetRubyVersion 2.8 (experimental). ([@koic][])
 * [#8164](https://github.com/rubocop-hq/rubocop/pull/8164): Support auto-correction for `Lint/InterpolationCheck`. ([@koic][])
 * [#8223](https://github.com/rubocop-hq/rubocop/pull/8223): Support auto-correction for `Style/IfUnlessModifierOfIfUnless`. ([@koic][])
+* [#8172](https://github.com/rubocop-hq/rubocop/pull/8172): Support auto-correction for `Lint/SafeNavigationWithEmpty`. ([@koic][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1738,6 +1738,7 @@ Lint/SafeNavigationWithEmpty:
   Description: 'Avoid `foo&.empty?` in conditionals.'
   Enabled: true
   VersionAdded: '0.62'
+  VersionChanged: '0.87'
 
 Lint/ScriptPermission:
   Description: 'Grant script file execute permission.'

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -2826,9 +2826,9 @@ foo&.bar && (foobar.baz || foo&.baz)
 
 | Enabled
 | Yes
-| No
+| Yes
 | 0.62
-| -
+| 0.87
 |===
 
 This cop checks to make sure safe navigation isn't used with `empty?` in

--- a/lib/rubocop/cop/lint/safe_navigation_with_empty.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_with_empty.rb
@@ -32,6 +32,14 @@ module RuboCop
 
           add_offense(node.condition)
         end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            receiver = node.receiver.source
+
+            corrector.replace(node, "#{receiver} && #{receiver}.#{node.method_name}")
+          end
+        end
       end
     end
   end

--- a/spec/rubocop/cop/lint/safe_navigation_with_empty_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_with_empty_spec.rb
@@ -4,10 +4,14 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationWithEmpty do
   subject(:cop) { described_class.new }
 
   context 'in a conditional' do
-    it 'registers an offense on `&.empty?`' do
+    it 'registers an offense and corrects on `&.empty?`' do
       expect_offense(<<~RUBY)
         return unless foo&.empty?
                       ^^^^^^^^^^^ Avoid calling `empty?` with the safe navigation operator in conditionals.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        return unless foo && foo.empty?
       RUBY
     end
 


### PR DESCRIPTION
This PR supports autocorrection for `Lint/SafeNavigationWithEmpty`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
