### PR TITLE
[Fix #8173] Fix an error for `Style/NestedTernaryOperator`

### DIFF
--- a/lib/rubocop/cop/style/nested_ternary_operator.rb
+++ b/lib/rubocop/cop/style/nested_ternary_operator.rb
@@ -28,20 +28,27 @@ module RuboCop
         end
 
         def autocorrect(node)
-          node = node.parent.parent
+          if_node = if_node(node)
 
           lambda do |corrector|
-            corrector.replace(node, <<~RUBY.chop)
-              if #{node.condition.source}
-                #{remove_parentheses(node.if_branch.source)}
+            corrector.replace(if_node, <<~RUBY.chop)
+              if #{if_node.condition.source}
+                #{remove_parentheses(if_node.if_branch.source)}
               else
-                #{node.else_branch.source}
+                #{if_node.else_branch.source}
               end
             RUBY
           end
         end
 
         private
+
+        def if_node(node)
+          node = node.parent
+          return node if node.if_type?
+
+          if_node(node)
+        end
 
         def remove_parentheses(source)
           source.gsub(/\A\(/, '').gsub(/\)\z/, '')

--- a/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
@@ -18,6 +18,22 @@ RSpec.describe RuboCop::Cop::Style::NestedTernaryOperator do
     RUBY
   end
 
+  it 'registers an offense and corrects for a nested ternary operator expression with block' do
+    expect_offense(<<~RUBY)
+      cond ? foo : bar(foo.a ? foo.b : foo) { |e, k| e.nil? ? nil : e[k] }
+                                                     ^^^^^^^^^^^^^^^^^^^ Ternary operators must not be nested. Prefer `if` or `else` constructs instead.
+                       ^^^^^^^^^^^^^^^^^^^ Ternary operators must not be nested. Prefer `if` or `else` constructs instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if cond
+        foo
+      else
+        bar(foo.a ? foo.b : foo) { |e, k| e.nil? ? nil : e[k] }
+      end
+    RUBY
+  end
+
   it 'accepts a non-nested ternary operator within an if' do
     expect_no_offenses(<<~RUBY)
       a = if x


### PR DESCRIPTION
Fixes #8173.

This PR fixes an error for `Style/NestedTernaryOperator` when a nested ternary operator expression with block.

No changelog has been added due to the bug fix for an unreleased feature.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
