### PR TITLE
Add AllowedCompactTypes option for Style/RaiseArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#8983](https://github.com/rubocop-hq/rubocop/pull/8983): Support auto-correction for `Naming/HeredocDelimiterCase`. ([@koic][])
 * [#8004](https://github.com/rubocop-hq/rubocop/issues/8004): Add new `GitHubActionsFormatter` formatter. ([@lautis][])
+* [#8175](https://github.com/rubocop-hq/rubocop/pull/8175): Add new `AllowedCompactTypes` option for `Style/RaiseArgs`. ([@pdobb][])
 
 ### Bug fixes
 
@@ -5058,3 +5059,4 @@
 [@matthieugendreau]: https://github.com/matthieugendreau
 [@miry]: https://github.com/miry
 [@lautis]: https://github.com/lautis
+[@pdobb]: https://github.com/pdobb

--- a/config/default.yml
+++ b/config/default.yml
@@ -3912,11 +3912,12 @@ Style/RaiseArgs:
   StyleGuide: '#exception-class-messages'
   Enabled: true
   VersionAdded: '0.14'
-  VersionChanged: '0.40'
+  VersionChanged: '1.2'
   EnforcedStyle: exploded
   SupportedStyles:
     - compact # raise Exception.new(msg)
     - exploded # raise Exception, msg
+  AllowedCompactTypes: []
 
 Style/RandomWithOffset:
   Description: >-

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -7686,7 +7686,7 @@ p = proc { |n| puts n }
 | Yes
 | Yes
 | 0.14
-| 0.40
+| 1.2
 |===
 
 This cop checks the args passed to `fail` and `raise`. For exploded
@@ -7699,6 +7699,9 @@ The exploded style works identically, but with the addition that it
 will also suggest constructing error objects when the exception is
 passed multiple arguments.
 
+The exploded style has an `AllowedCompactTypes` configuration
+option that takes an Array of exception name Strings.
+
 === Examples
 
 ==== EnforcedStyle: exploded (default)
@@ -7706,13 +7709,17 @@ passed multiple arguments.
 [source,ruby]
 ----
 # bad
-raise StandardError.new("message")
+raise StandardError.new('message')
 
 # good
-raise StandardError, "message"
-fail "message"
+raise StandardError, 'message'
+fail 'message'
 raise MyCustomError.new(arg1, arg2, arg3)
 raise MyKwArgError.new(key1: val1, key2: val2)
+
+# With `AllowedCompactTypes` set to ['MyWrappedError']
+raise MyWrappedError.new(obj)
+raise MyWrappedError.new(obj), 'message'
 ----
 
 ==== EnforcedStyle: compact
@@ -7720,13 +7727,13 @@ raise MyKwArgError.new(key1: val1, key2: val2)
 [source,ruby]
 ----
 # bad
-raise StandardError, "message"
+raise StandardError, 'message'
 raise RuntimeError, arg1, arg2, arg3
 
 # good
-raise StandardError.new("message")
+raise StandardError.new('message')
 raise MyCustomError.new(arg1, arg2, arg3)
-fail "message"
+fail 'message'
 ----
 
 === Configurable attributes
@@ -7737,6 +7744,10 @@ fail "message"
 | EnforcedStyle
 | `exploded`
 | `compact`, `exploded`
+
+| AllowedCompactTypes
+| `[]`
+| Array
 |===
 
 === References

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -255,6 +255,36 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
       end
     end
 
+    context 'when exception type is in AllowedCompactTypes' do
+      before do
+        stub_const('Ex1', StandardError)
+        stub_const('Ex2', StandardError)
+      end
+
+      let(:cop_config) do
+        {
+          'EnforcedStyle' => 'exploded',
+          'AllowedCompactTypes' => ['Ex1']
+        }
+      end
+
+      it 'accepts exception constructor with no arguments' do
+        expect_no_offenses('raise Ex1.new')
+      end
+
+      context 'with one argument' do
+        it 'accepts exception constructor' do
+          expect_no_offenses('raise Ex1.new(msg)')
+        end
+      end
+
+      context 'with more than one argument' do
+        it 'accepts exception constructor' do
+          expect_no_offenses('raise Ex1.new(arg1, arg2)')
+        end
+      end
+    end
+
     it 'accepts exception constructor with more than 1 argument' do
       expect_no_offenses('raise MyCustomError.new(a1, a2, a3)')
     end


### PR DESCRIPTION
## Style/RaiseArgs -- Add `AllowedCompactTypes` Option
```yaml
Style/RaiseArgs
  AllowedCompactTypes: [] # default
```

Add custom exception names that should be ignored when
Style/RaiseArgs investigates code with `EnforcedStyle: exploded`.
This is useful for certain exception types where we really do want an
instance of an exception to be raised. e.g. in Rails:

```ruby
raise ActiveRecord::RecordInvalid.new(my_model)
```

Or to raise a custom error type that wraps an object.

To allow the above to pass even while `EnforcedStyle: exploded` is set
while still not allowing other Exception types:

```yaml
Style/RaiseArgs
  AllowedCompactTypes:
    - 'ActiveRecord::RecordInvalid'
    - 'MyCustomWrappedError'
```

---

![Image 2020-06-27 16-26-48](https://user-images.githubusercontent.com/64674/85932616-2ba29500-b893-11ea-9d35-8808d86941f9.png)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
