### PR TITLE
Mark unsafe for `Lint/RaiseException` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 * [#8146](https://github.com/rubocop-hq/rubocop/pull/8146): Use UTC in RuboCop todo file generation. ([@mauro-oto][])
 * [#8149](https://github.com/rubocop-hq/rubocop/pull/8149): Cop `Metrics/CyclomaticComplexity` now counts `&.`, `||=`, `&&=` and blocks known to iterate. Default bumped from 6 to 7. ([@marcandre][])
+* [#8178](https://github.com/rubocop-hq/rubocop/pull/8178): Mark unsafe for `Lint/RaiseException`. ([@koic][])
 
 ## 0.85.1 (2020-06-07)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1620,6 +1620,7 @@ Lint/RaiseException:
   Description: Checks for `raise` or `fail` statements which are raising `Exception` class.
   StyleGuide: '#raise-exception'
   Enabled: pending
+  Safe: false
   VersionAdded: '0.81'
   AllowedImplicitNamespaces:
     - 'Gem'

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -2138,7 +2138,7 @@ rather than meant to be part of the resulting symbols.
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
 | Pending
-| Yes
+| No
 | No
 | 0.81
 | -


### PR DESCRIPTION
Follow up https://github.com/rubocop-hq/rubocop/pull/8169#issuecomment-647012793.

`Lint/RaiseException` cop is unsafe due to incompatibility between bad and good cases. The following is an example.

## bad case

```console
% cat /tmp/example_for_exception.rb
begin
  raise Exception
rescue
  puts 'Handle exception'
end

% ruby example_for_exception.rb
example_for_exception.rb:2:in `<main>': Exception (Exception)
```

## good case

```console
% cat example_for_starndard_error.rb
begin
  raise StandardError
rescue
  puts 'Handle exception'
end

% ruby /tmp/example_for_starndard_error.rb
Handle exception
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
