### PR TITLE
[Fix #8179] Fix an infinite correction loop for `Layout/MultilineBlockLayout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#7979](https://github.com/rubocop-hq/rubocop/issues/7979): Fix "uninitialized constant DidYouMean::SpellChecker" exception. ([@bquorning][])
 * [#8098](https://github.com/rubocop-hq/rubocop/issues/8098): Fix a false positive for `Style/RedundantRegexpCharacterClass` when using interpolations. ([@owst][])
 * [#8150](https://github.com/rubocop-hq/rubocop/pull/8150): Fix a false positive for `Layout/EmptyLinesAroundAttributeAccessor` when using attribute accessors in `if` ... `else` branches. ([@koic][])
+* [#8179](https://github.com/rubocop-hq/rubocop/issues/8179): Fix an infinite correction loop error for `Layout/MultilineBlockLayout` when missing newline before opening parenthesis `(` for block body. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/multiline_block_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_block_layout.rb
@@ -121,7 +121,7 @@ module RuboCop
         end
 
         def autocorrect_body(corrector, node, block_body)
-          first_node = if block_body.begin_type?
+          first_node = if block_body.begin_type? && !block_body.source.start_with?('(')
                          block_body.children.first
                        else
                          block_body

--- a/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
@@ -216,6 +216,24 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
     RUBY
   end
 
+  it 'registers an offense and corrects for missing newline before opening parenthesis `(` for block body' do
+    expect_offense(<<~RUBY)
+      foo do |o| (
+                 ^ Block body expression is on the same line as the block start.
+          bar
+        )
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo do |o| 
+        (
+          bar
+        )
+      end
+    RUBY
+  end
+
   it 'registers an offense and corrects a line-break within arguments' do
     expect_offense(<<~RUBY)
       test do |x,


### PR DESCRIPTION
Fixes #8179.

This PR fixes an infinite correction loop error for `Layout/MultilineBlockLayout` when missing newline before opening parenthesis `(` for block body.

```ruby
# frozen_string_literal: true

foo do |o| (
    bar
  )
end
```

```console
% rubocop -a --only Layout/MultilineBlockLayout
Inspecting 1 file
C

Offenses:

example.rb:3:12: C: [Corrected] Layout/MultilineBlockLayout: Block body
expression is on the same line as the block start.
foo do |o| ( ...
           ^

0 files inspected, 1 offense detected, 1 offense corrected
Infinite loop detected in /Users/koic/src/github.com/koic/rubocop-issues/8179/example.rb.
/Users/koic/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rubocop-0.85.1/lib/rubocop/runner.rb:276:in
`block in iterate_until_no_changes'
/Users/koic/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rubocop-0.85.1/lib/rubocop/runner.rb:272:in
`loop'
/Users/koic/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rubocop-0.85.1/lib/rubocop/runner.rb:272:in
`iterate_until_no_changes'
/Users/koic/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rubocop-0.85.1/lib/rubocop/runner.rb:243:in
`do_inspection_loop'
/Users/koic/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rubocop-0.85.1/lib/rubocop/runner.rb:122:in
`block in file_offenses'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
