### PR TITLE
Fix link to documentation about configuration in .rubocop.yml

### DIFF
--- a/docs/modules/ROOT/pages/usage/basic_usage.adoc
+++ b/docs/modules/ROOT/pages/usage/basic_usage.adoc
@@ -167,7 +167,7 @@ $ rubocop -h
 | Inspect files in order of modification time and stops after first file with offenses.
 
 | `--fail-level`
-| Minimum link:configuration.md#severity[severity] for exit with error code. Full severity name or upper case initial can be given. Normally, auto-corrected offenses are ignored. Use `A` or `autocorrect` if you'd like them to trigger failure.
+| Minimum xref:configuration.adoc#severity[severity] for exit with error code. Full severity name or upper case initial can be given. Normally, auto-corrected offenses are ignored. Use `A` or `autocorrect` if you'd like them to trigger failure.
 
 | `--force-exclusion`
 | Force excluding files specified in the configuration `Exclude` even if they are explicitly passed as arguments.

--- a/lib/rubocop/cli/command/init_dotfile.rb
+++ b/lib/rubocop/cli/command/init_dotfile.rb
@@ -27,7 +27,7 @@ module RuboCop
               # RuboCop will start looking for the configuration file in the directory
               # where the inspected file is and continue its way up to the root directory.
               #
-              # See https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md
+              # See https://docs.rubocop.org/rubocop/configuration
             DESC
 
             File.open(DOTFILE, 'w') do |f|

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             # RuboCop will start looking for the configuration file in the directory
             # where the inspected file is and continue its way up to the root directory.
             #
-            # See https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md
+            # See https://docs.rubocop.org/rubocop/configuration
           YAML
         end
       end


### PR DESCRIPTION
The link in the generated .rubocop.yml is outdated.

- I updated it.
- I updated the spec that controls the content of .rubocop.yml.
- I also updated the link to the same page where it appears in the docs.


**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/