### PR TITLE
[Fix #8185] Fix a false positive for `Style/YodaCondition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#8098](https://github.com/rubocop-hq/rubocop/issues/8098): Fix a false positive for `Style/RedundantRegexpCharacterClass` when using interpolations. ([@owst][])
 * [#8150](https://github.com/rubocop-hq/rubocop/pull/8150): Fix a false positive for `Layout/EmptyLinesAroundAttributeAccessor` when using attribute accessors in `if` ... `else` branches. ([@koic][])
 * [#8179](https://github.com/rubocop-hq/rubocop/issues/8179): Fix an infinite correction loop error for `Layout/MultilineBlockLayout` when missing newline before opening parenthesis `(` for block body. ([@koic][])
+* [#8185](https://github.com/rubocop-hq/rubocop/issues/8185): Fix a false positive for `Style/YodaCondition` when interpolation is used on the left hand side. ([@koic][])
 
 ### Changes
 

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -10018,6 +10018,8 @@ foo == 99
 foo == "bar"
 foo <= 42
 bar > 10
+"#{interpolation}" == foo
+/#{interpolation}/ == foo
 ----
 
 ==== EnforcedStyle: forbid_for_equality_operators_only

--- a/spec/rubocop/cop/style/yoda_condition_spec.rb
+++ b/spec/rubocop/cop/style/yoda_condition_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe RuboCop::Cop::Style::YodaCondition, :config do
     it_behaves_like 'accepts', 'b = 1; b == 2'
     it_behaves_like 'accepts', '$var == 5'
     it_behaves_like 'accepts', 'foo == "bar"'
+    it_behaves_like 'accepts', '"#{interpolation}" == foo'
+    it_behaves_like 'accepts', '/#{interpolation}/ == foo'
     it_behaves_like 'accepts', 'foo[0] > "bar" || baz != "baz"'
     it_behaves_like 'accepts', 'node = last_node.parent'
     it_behaves_like 'accepts', '(first_line - second_line) > 0'


### PR DESCRIPTION
Fixes #8185.

This PR fixes a false positive for `Style/YodaCondition` when interpolation is used on the left side.

String interpolation (and Regexp interpolation) contains variables, I think it's acceptable to use it on the left hand side.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
