### PR TITLE
Disable uncorrectable unsafe cops when using --safe-auto-correct --disable-uncorrectable

### DIFF
--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -138,7 +138,14 @@ module RuboCop
 
       def correct(node) # rubocop:disable Metrics/PerceivedComplexity, Metrics/MethodLength
         reason = reason_to_not_correct(node)
-        return reason if reason
+        if reason
+          if disable_uncorrectable? && reason != :already_corrected
+            disable_uncorrectable(node)
+            return :corrected_with_todo
+          else
+            return reason
+          end
+        end
 
         @corrected_nodes[node] = true
 


### PR DESCRIPTION
…sable-uncorrectable

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
