### PR TITLE
[Fixes #8156] CLI options change: auto-correct now safe by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 * [#7868](https://github.com/rubocop-hq/rubocop/pull/7868): **(Breaking)** Extensive refactoring of internal classes `Team`, `Commissioner`, `Corrector`. `Cop::Cop#corrections` not completely compatible. See Upgrade Notes. ([@marcandre][])
+* [#8156](https://github.com/rubocop-hq/rubocop/issues/8156): **(Breaking)** `rubocop -a / --autocorrect` no longer run unsafe corrections; `rubocop -A / --autocorrect-all` run both safe and unsafe corrections. Options `--safe-autocorrect` is deprecated. ([@marcandre][])
 
 ### Bug fixes
 

--- a/docs/modules/ROOT/pages/usage/auto_correct.adoc
+++ b/docs/modules/ROOT/pages/usage/auto_correct.adoc
@@ -4,7 +4,9 @@ In auto-correct mode, RuboCop will try to automatically fix offenses:
 
 [source,sh]
 ----
-$ rubocop -a
+$ rubocop -A
+# or
+$ rubocop --auto-correct-all
 ----
 
 There are a couple of things to keep in mind about auto-correct:
@@ -21,7 +23,9 @@ TIP: You should always run your test suite after using the auto-correct function
 
 [source,sh]
 ----
-$ rubocop --safe-auto-correct
+$ rubocop -a
+# or
+$ rubocop --auto-correct
 ----
 
 In RuboCop 0.60, we began to annotate cops as `Safe` or not safe. The definition of
@@ -36,7 +40,7 @@ design) or not.
 does is safe (equivalent) by design. If a cop is unsafe its auto-correct automatically
 becomes unsafe as well.
 
-If a cop or its auto-correct is annotated as "not safe", it will be omitted when using `--safe-auto-correct`.
+If a cop or its auto-correct is annotated as "not safe", it will be omitted when using `--auto-correct`.
 
 NOTE: Currently there might still be cops that aren't marked as unsafe or
 with unsafe auto-correct.  Eventually, the safety of each cop will be specified
@@ -80,7 +84,7 @@ or
 
 [source,sh]
 ----
-$ rubocop --safe-auto-correct --disable-uncorrectable
+$ rubocop --auto-correct-all --disable-uncorrectable
 ----
 
 You can add the flag `--disable-uncorrectable`, which will generate

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -163,7 +163,7 @@ module RuboCop
       end
     end
 
-    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     def add_boolean_flags(opts)
       option(opts, '-F', '--fail-fast')
       option(opts, '-C', '--cache FLAG')
@@ -171,7 +171,16 @@ module RuboCop
       option(opts, '-D', '--[no-]display-cop-names')
       option(opts, '-E', '--extra-details')
       option(opts, '-S', '--display-style-guide')
-      option(opts, '-a', '--auto-correct')
+      option(opts, '-a', '--auto-correct') do
+        @options[:safe_auto_correct] = true
+      end
+      option(opts, '--safe-autocorrect') do
+        warn '--safe-autocorrect is deprecated; use --autocorrect'
+        @options[:safe_auto_correct] = @options[:auto_correct] = true
+      end
+      option(opts, '-A', '--auto-correct-all') do
+        @options[:auto_correct] = true
+      end
       option(opts, '--disable-pending-cops')
       option(opts, '--enable-pending-cops')
       option(opts, '--ignore-disable-comments')
@@ -184,7 +193,7 @@ module RuboCop
       option(opts, '-V', '--verbose-version')
       option(opts, '-P', '--parallel')
     end
-    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
     def add_aliases(opts)
       option(opts, '-l', '--lint') do
@@ -194,9 +203,6 @@ module RuboCop
       option(opts, '-x', '--fix-layout') do
         @options[:only] ||= []
         @options[:only] << 'Layout'
-        @options[:auto_correct] = true
-      end
-      option(opts, '--safe-auto-correct') do
         @options[:auto_correct] = true
       end
     end
@@ -465,8 +471,9 @@ module RuboCop
       lint:                             'Run only lint cops.',
       safe:                             'Run only safe cops.',
       list_target_files:                'List all files RuboCop will inspect.',
-      auto_correct:                     'Auto-correct offenses.',
-      safe_auto_correct:                'Run auto-correct only when it\'s safe.',
+      auto_correct:                     'Auto-correct offenses (only when it\'s safe).',
+      safe_autocorrect:                 '(same, deprecated)',
+      auto_correct_all:                 'Auto-correct offenses (safe and unsafe)',
       fix_layout:                       'Run only layout cops, with auto-correct on.',
       color:                            'Force color output on or off.',
       version:                          'Display version.',

--- a/lib/rubocop/rake_task.rb
+++ b/lib/rubocop/rake_task.rb
@@ -69,7 +69,7 @@ module RuboCop
         task(:auto_correct, *args) do |_, task_args|
           RakeFileUtils.verbose(verbose) do
             yield(*[self, task_args].slice(0, task_block.arity)) if block_given?
-            options = full_options.unshift('--auto-correct')
+            options = full_options.unshift('--auto-correct-all')
             options.delete('--parallel')
             run_cli(verbose, options)
           end

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       }
     RUBY
     create_file('example.rb', source)
-    expect(cli.run(['--auto-correct'])).to eq(1)
+    expect(cli.run(['--auto-correct-all'])).to eq(1)
     expect(IO.read('example.rb')).to eq(source)
   end
 
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     RUBY
 
     create_file('example.rb', source)
-    expect(cli.run(['--auto-correct'])).to eq(1)
+    expect(cli.run(['--auto-correct-all'])).to eq(1)
 
     expect(IO.read('example.rb')).to eq(<<~RUBY)
       # frozen_string_literal: true
@@ -119,7 +119,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       test1_test2_test3_test4_12 =nil
     RUBY
 
-    expect(cli.run(['--auto-correct'])).to eq(1)
+    expect(cli.run(['--auto-correct-all'])).to eq(1)
 
     expect(IO.read('example.rb')).to eq(<<~RUBY)
       # frozen_string_literal: true
@@ -153,7 +153,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       }
     RUBY
     create_file('example.rb', source)
-    expect(cli.run(['--auto-correct'])).to eq(1)
+    expect(cli.run(['--auto-correct-all'])).to eq(1)
 
     # 1=>2 is changed to 1 => 2. The rest is unchanged.
     # SpaceAroundOperators leaves it to HashAlignment when the style is table.
@@ -217,7 +217,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     shared_examples 'corrects offenses without producing a double comma' do
       it 'corrects TrailingCommaInLiteral and TrailingCommaInArguments ' \
          'without producing a double comma' do
-        cli.run(['--auto-correct'])
+        cli.run(['--auto-correct-all'])
 
         expect(IO.read('example.rb'))
           .to eq(expected_corrected_source)
@@ -312,7 +312,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     shared_examples 'corrects offenses' do
       it 'corrects SpaceInsideArrayLiteralBrackets and ' \
          'SpaceInsideReferenceBrackets' do
-        cli.run(['--auto-correct'])
+        cli.run(['--auto-correct-all'])
 
         expect(IO.read('example.rb'))
           .to eq(corrected_source)
@@ -398,7 +398,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
     RUBY
     create_file('example.rb', source)
-    expect(cli.run(['--auto-correct'])).to eq(0)
+    expect(cli.run(['--auto-correct-all'])).to eq(0)
     corrected = <<~RUBY
       # frozen_string_literal: true
 
@@ -423,7 +423,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       "#{c}"
     RUBY
     create_file('example.rb', source)
-    expect(cli.run(['--auto-correct'])).to eq(0)
+    expect(cli.run(['--auto-correct-all'])).to eq(0)
     corrected = ['# frozen_string_literal: true',
                  '',
                  "puts 'foo' \\",
@@ -443,7 +443,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     RUBY
     create_file('example.rb', source)
     expect(cli.run([
-                     '--auto-correct',
+                     '--auto-correct-all',
                      '--only', 'Style/InverseMethods,Style/Not'
                    ])).to eq(0)
     corrected = <<~'RUBY'
@@ -468,7 +468,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     RUBY
     create_file('example.rb', source)
     expect(cli.run([
-                     '--auto-correct',
+                     '--auto-correct-all',
                      '--only', 'Style/Next,Style/SafeNavigation'
                    ])).to eq(0)
     corrected = <<~'RUBY'
@@ -490,7 +490,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     RUBY
     create_file('example.rb', source)
     expect(cli.run([
-                     '--auto-correct',
+                     '--auto-correct-all',
                      '--only', 'Lint/Lambda,Lint/UnusedBlockArgument'
                    ])).to eq(0)
     corrected = <<~'RUBY'
@@ -517,7 +517,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       let(:cached_offenses) { [] }
 
       it "doesn't correct offenses" do
-        expect(cli.run(['--auto-correct'])).to eq(0)
+        expect(cli.run(['--auto-correct-all'])).to eq(0)
         expect(IO.read('example.rb')).to eq(source)
       end
     end
@@ -527,7 +527,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
       it 'corrects offenses' do
         allow(cache).to receive(:save)
-        expect(cli.run(['--auto-correct'])).to eq(0)
+        expect(cli.run(['--auto-correct-all'])).to eq(0)
         expect(IO.read('example.rb')).to eq(<<~RUBY)
           # frozen_string_literal: true
 
@@ -553,7 +553,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           Style/BlockDelimiters:
             EnforcedStyle: #{style}
         YAML
-        expect(cli.run(['--auto-correct'])).to eq(1)
+        expect(cli.run(['--auto-correct-all'])).to eq(1)
         corrected = case style
                     when :semantic
                       <<~RUBY
@@ -614,7 +614,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       Layout/DefEndAlignment:
         AutoCorrect: true
     YAML
-    expect(cli.run(['--auto-correct'])).to eq(0)
+    expect(cli.run(['--auto-correct-all'])).to eq(0)
     corrected = <<~RUBY
       # frozen_string_literal: true
 
@@ -646,7 +646,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
     RUBY
     create_file('example.rb', source)
-    expect(cli.run(%w[--auto-correct --format simple])).to eq(1)
+    expect(cli.run(%w[--auto-correct-all --format simple])).to eq(1)
     expect($stdout.string).to eq(<<~RESULT)
       == example.rb ==
       C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
@@ -712,7 +712,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
     RUBY
     create_file('example.rb', source)
-    expect(cli.run(['--auto-correct'])).to eq(1)
+    expect(cli.run(['--auto-correct-all'])).to eq(1)
     corrected = <<~RUBY
       # frozen_string_literal: true
 
@@ -762,7 +762,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           end
     RUBY
     create_file('example.rb', source)
-    expect(cli.run(['--auto-correct'])).to eq(0)
+    expect(cli.run(['--auto-correct-all'])).to eq(0)
     corrected = <<~RUBY
       # frozen_string_literal: true
 
@@ -795,7 +795,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
     RUBY
     create_file('example.rb', source)
-    expect(cli.run(['--auto-correct'])).to eq(0)
+    expect(cli.run(['--auto-correct-all'])).to eq(0)
     corrected = <<~RUBY
       # frozen_string_literal: true
 
@@ -837,7 +837,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     create_file('example.rb', source)
 
     expect(cli.run([
-                     '--auto-correct',
+                     '--auto-correct-all',
                      '--only',
                      [
                        'Layout/AccessModifierIndentation',
@@ -861,7 +861,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
   it 'corrects SymbolProc and SpaceBeforeBlockBraces offenses' do
     source = ['foo.map{ |a| a.nil? }']
     create_file('example.rb', source)
-    expect(cli.run(['-D', '--auto-correct'])).to eq(0)
+    expect(cli.run(['-D', '--auto-correct-all'])).to eq(0)
     corrected = "# frozen_string_literal: true\n\nfoo.map(&:nil?)\n"
     expect(IO.read('example.rb')).to eq(corrected)
     uncorrected = $stdout.string.split($RS).select do |line|
@@ -881,7 +881,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
     RUBY
     create_file('example.rb', source)
-    expect(cli.run(%w[--only IndentationWidth --auto-correct])).to eq(0)
+    expect(cli.run(%w[--only IndentationWidth --auto-correct-all])).to eq(0)
     corrected = <<~RUBY
       foo = if bar
               something
@@ -904,7 +904,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       Style/FrozenStringLiteralComment:
         Enabled: false
     YAML
-    expect(cli.run(['--auto-correct'])).to eq(0)
+    expect(cli.run(['--auto-correct-all'])).to eq(0)
     expect($stdout.string).to include('no offenses detected')
     expect(IO.read('example.rb')).to eq("#{source}\n")
   end
@@ -938,7 +938,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
       end
     RUBY
-    expect(cli.run(['--auto-correct'])).to eq(1)
+    expect(cli.run(['--auto-correct-all'])).to eq(1)
     expect(IO.read('example.rb'))
       .to eq(<<~RUBY)
         # frozen_string_literal: true
@@ -984,7 +984,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
       end
     RUBY
-    expect(cli.run(['--auto-correct'])).to eq(1)
+    expect(cli.run(['--auto-correct-all'])).to eq(1)
     expect(IO.read('example.rb'))
       .to eq(<<~RUBY)
         # frozen_string_literal: true
@@ -1009,7 +1009,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         puts i
       }
     RUBY
-    expect(cli.run(['--auto-correct'])).to eq(0)
+    expect(cli.run(['--auto-correct-all'])).to eq(0)
     expect(IO.read('example.rb'))
       .to eq(<<~RUBY)
         # frozen_string_literal: true
@@ -1031,7 +1031,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
       end
     RUBY
-    expect(cli.run(['--auto-correct'])).to eq(1)
+    expect(cli.run(['--auto-correct-all'])).to eq(1)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq(<<~RUBY)
       # frozen_string_literal: true
@@ -1052,7 +1052,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
     RUBY
     exit_status = cli.run(
-      %w[--auto-correct --format emacs --only] << %w[
+      %w[--auto-correct-all --format emacs --only] << %w[
         WordArray AccessModifierIndentation
         Documentation TrailingCommaInArrayLiteral
       ].join(',')
@@ -1081,7 +1081,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
       end end
     RUBY
-    expect(cli.run(['--auto-correct'])).to eq(1)
+    expect(cli.run(['--auto-correct-all'])).to eq(1)
     expect(IO.read('example.rb')).to eq(<<~RUBY)
       # frozen_string_literal: true
 
@@ -1101,7 +1101,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       def func2() do_1; do_2; end
     RUBY
     exit_status = cli.run(
-      %w[--auto-correct --format offenses --only] << %w[
+      %w[--auto-correct-all --format offenses --only] << %w[
         SingleLineMethods Semicolon EmptyLineBetweenDefs
         DefWithParentheses TrailingWhitespace
       ].join(',')
@@ -1139,7 +1139,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       fail NotImplementedError,
            'Method should be overridden in child classes'
     RUBY
-    expect(cli.run(['--auto-correct', '--only',
+    expect(cli.run(['--auto-correct-all', '--only',
                     'SignalException,ArgumentAlignment'])).to eq(0)
     expect(IO.read('example.rb'))
       .to eq(<<~RUBY)
@@ -1172,7 +1172,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                  '  ',
                  '  def f; end',
                  'end'])
-    expect(cli.run(['--auto-correct', '--only',
+    expect(cli.run(['--auto-correct-all', '--only',
                     'Layout/TrailingWhitespace,' \
                     'Layout/EmptyLinesAroundClassBody'])).to eq(0)
     expect(IO.read('example.rb'))
@@ -1202,7 +1202,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         1.upto(limit).select { |i| i.even? }
       end
     RUBY
-    expect(cli.run(%w[-D --auto-correct
+    expect(cli.run(%w[-D --auto-correct-all
                       --only Style/MethodDefParentheses,Style/SymbolProc]))
       .to eq(0)
     expect($stderr.string).to eq('')
@@ -1233,7 +1233,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       f(type: ['offline','offline_payment'],
         bar_colors: ['958c12','953579','ff5800','0085cc'])
     RUBY
-    expect(cli.run(%w[-D --auto-correct --format o
+    expect(cli.run(%w[-D --auto-correct-all --format o
                       --only WordArray,SpaceAfterComma])).to eq(0)
     expect($stdout.string)
       .to eq(<<~RESULT)
@@ -1254,7 +1254,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
   it 'can correct SpaceAfterComma and HashSyntax offenses' do
     create_file('example.rb',
                 "I18n.t('description',:property_name => property.name)")
-    expect(cli.run(%w[-D --auto-correct --format emacs
+    expect(cli.run(%w[-D --auto-correct-all --format emacs
                       --only SpaceAfterComma,HashSyntax])).to eq(0)
     expect($stdout.string)
       .to eq(["#{abs('example.rb')}:1:21: C: [Corrected] " \
@@ -1269,7 +1269,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
   it 'can correct HashSyntax and SpaceAroundOperators offenses' do
     create_file('example.rb', '{ :b=>1 }')
-    expect(cli.run(%w[-D --auto-correct --format emacs
+    expect(cli.run(%w[-D --auto-correct-all --format emacs
                       --only HashSyntax,SpaceAroundOperators])).to eq(0)
     expect(IO.read('example.rb')).to eq(<<~RUBY)
       { b: 1 }
@@ -1283,7 +1283,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
   it 'can correct HashSyntax when --only is used' do
     create_file('example.rb', '{ :b=>1 }')
-    expect(cli.run(%w[--auto-correct -f emacs
+    expect(cli.run(%w[--auto-correct-all -f emacs
                       --only Style/HashSyntax])).to eq(0)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq("{ b: 1 }\n")
@@ -1299,7 +1299,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                  '  ',
                  '',
                  ''])
-    expect(cli.run(%w[--auto-correct --format emacs])).to eq(0)
+    expect(cli.run(%w[--auto-correct-all --format emacs])).to eq(0)
     expect(IO.read('example.rb')).to eq(<<~RUBY)
       # frozen_string_literal: true
     RUBY
@@ -1312,7 +1312,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
   it 'can correct MethodCallWithoutArgsParentheses and EmptyLiteral offenses' do
     create_file('example.rb', 'Hash.new()')
     exit_status = cli.run(
-      %w[--auto-correct --format emacs
+      %w[--auto-correct-all --format emacs
          --only Style/MethodCallWithoutArgsParentheses,Style/EmptyLiteral]
     )
     expect(exit_status).to eq(0)
@@ -1339,7 +1339,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       Layout/HashAlignment:
         EnforcedColonStyle: separator
     YAML
-    expect(cli.run(%w[--auto-correct])).to eq(0)
+    expect(cli.run(%w[--auto-correct-all])).to eq(0)
     expect(IO.read('example.rb'))
       .to eq(<<~RUBY)
         # frozen_string_literal: true
@@ -1393,7 +1393,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
   it 'does not hang SpaceAfterPunctuation and SpaceInsideParens' do
     create_file('example.rb', 'some_method(a, )')
     Timeout.timeout(10) do
-      expect(cli.run(%w[--auto-correct])).to eq(0)
+      expect(cli.run(%w[--auto-correct-all])).to eq(0)
     end
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq(<<~RUBY)
@@ -1407,7 +1407,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
      'SpaceInsideArrayLiteralBrackets' do
     create_file('example.rb', 'puts [1, ]')
     Timeout.timeout(10) do
-      expect(cli.run(%w[--auto-correct])).to eq(0)
+      expect(cli.run(%w[--auto-correct-all])).to eq(0)
     end
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq(<<~RUBY)
@@ -1423,7 +1423,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       Style/StringLiterals:
         AutoCorrect: false
     YAML
-    expect(cli.run(%w[--auto-correct])).to eq(1)
+    expect(cli.run(%w[--auto-correct-all])).to eq(1)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq(<<~RUBY)
       # frozen_string_literal: true
@@ -1447,7 +1447,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       Style/TrailingCommaInHashLiteral:
         EnforcedStyleForMultiline: consistent_comma
     YAML
-    expect(cli.run(%w[--auto-correct])).to eq(1)
+    expect(cli.run(%w[--auto-correct-all])).to eq(1)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq(<<~RUBY)
       # frozen_string_literal: true
@@ -1472,7 +1472,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         EnforcedStyle: line_count_based
     YAML
 
-    expect(cli.run(%w[--auto-correct])).to eq(0)
+    expect(cli.run(%w[--auto-correct-all])).to eq(0)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq(<<~RUBY)
       # frozen_string_literal: true
@@ -1496,7 +1496,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     YAML
 
     expect(cli.run([
-                     '--auto-correct',
+                     '--auto-correct-all',
                      '--only',
                      'Style/BlockDelimiters,Layout/SpaceBeforeBlockBraces'
                    ])).to eq(0)
@@ -1526,7 +1526,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         EnforcedStyleForMultiline: comma
     YAML
 
-    expect(cli.run(%w[--auto-correct])).to eq(1)
+    expect(cli.run(%w[--auto-correct-all])).to eq(1)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq(<<~RUBY)
       # frozen_string_literal: true
@@ -1562,7 +1562,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
     status = cli.run(
       [
-        '--auto-correct',
+        '--auto-correct-all',
         '--only',
         [
           'Style/TrailingCommaInArrayLiteral',

--- a/spec/rubocop/cli/cli_disable_uncorrectable_spec.rb
+++ b/spec/rubocop/cli/cli_disable_uncorrectable_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
   describe '--disable-uncorrectable' do
     let(:exit_code) do
-      cli.run(%w[--auto-correct --format simple --disable-uncorrectable])
+      cli.run(%w[--auto-correct-all --format simple --disable-uncorrectable])
     end
 
     let(:setup_long_line) do

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -1447,7 +1447,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
     end
 
-    context 'with --auto-correct' do
+    context 'with --auto-correct-all' do
       def expect_auto_corrected
         expect_offense_detected
         expect($stdout.string.lines.to_a.last)
@@ -1457,7 +1457,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
       it 'fails when option is autocorrect and all offenses are ' \
          'autocorrected' do
-        expect(cli.run(['--auto-correct', '--format', 'simple',
+        expect(cli.run(['--auto-correct-all', '--format', 'simple',
                         '--fail-level', 'autocorrect',
                         '--only', 'Layout/IndentationWidth',
                         target_file])).to eq(1)
@@ -1465,7 +1465,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
 
       it 'fails when option is A and all offenses are autocorrected' do
-        expect(cli.run(['--auto-correct', '--format', 'simple',
+        expect(cli.run(['--auto-correct-all', '--format', 'simple',
                         '--fail-level', 'A',
                         '--only', 'Layout/IndentationWidth',
                         target_file])).to eq(1)
@@ -1474,7 +1474,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
       it 'succeeds when option is not given and all offenses are ' \
          'autocorrected' do
-        expect(cli.run(['--auto-correct', '--format', 'simple',
+        expect(cli.run(['--auto-correct-all', '--format', 'simple',
                         '--only', 'Layout/IndentationWidth',
                         target_file])).to eq(0)
         expect_auto_corrected
@@ -1482,7 +1482,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
       it 'succeeds when option is refactor and all offenses are ' \
          'autocorrected' do
-        expect(cli.run(['--auto-correct', '--format', 'simple',
+        expect(cli.run(['--auto-correct-all', '--format', 'simple',
                         '--fail-level', 'refactor',
                         '--only', 'Layout/IndentationWidth',
                         target_file])).to eq(0)
@@ -1491,7 +1491,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     end
   end
 
-  describe 'with --auto-correct and disabled offense' do
+  describe 'with --auto-correct-all and disabled offense' do
     let(:target_file) { 'example.rb' }
 
     before do
@@ -1508,7 +1508,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         end
       RUBY
 
-      expect(cli.run(['--auto-correct', '--format', 'simple',
+      expect(cli.run(['--auto-correct-all', '--format', 'simple',
                       '--fail-level', 'autocorrect',
                       target_file])).to eq(0)
 
@@ -1637,10 +1637,10 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
     end
 
-    it 'prints corrected code to stdout if --auto-correct is used' do
+    it 'prints corrected code to stdout if --auto-correct-all is used' do
       begin
         $stdin = StringIO.new('p $/')
-        argv   = ['--auto-correct',
+        argv   = ['--auto-correct-all',
                   '--only=Style/SpecialGlobalVars',
                   '--format=simple',
                   '--stdin',

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
     end
 
-    context 'when --auto-correct is given' do
+    context 'when --auto-correct-all is given' do
       it 'does not trigger RedundantCopDisableDirective due to ' \
          'lines moving around' do
         src = ['a = 1 # rubocop:disable Lint/UselessAssignment']
@@ -272,7 +272,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           Layout/EmptyLineAfterMagicComment:
             Enabled: false
         YAML
-        expect(cli.run(['--format', 'offenses', '-a', 'example.rb'])).to eq(0)
+        expect(cli.run(['--format', 'offenses', '-A', 'example.rb'])).to eq(0)
         expect($stdout.string).to eq(<<~RESULT)
 
           1  Style/FrozenStringLiteralComment

--- a/spec/rubocop/cop/lint/syntax_spec.rb
+++ b/spec/rubocop/cop/lint/syntax_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::Lint::Syntax, :config do
         end
       end
 
-      context 'with --auto-correct --disable-uncorrectable options' do
+      context 'with --auto-correct-all --disable-uncorrectable options' do
         let(:cop_options) { { auto_correct: true, disable_uncorrectable: true } }
 
         it 'returns an offense' do

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -114,7 +114,9 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                                                Default is true.
               -E, --extra-details              Display extra details in offense messages.
               -S, --display-style-guide        Display style guide URLs in offense messages.
-              -a, --auto-correct               Auto-correct offenses.
+              -a, --auto-correct               Auto-correct offenses (only when it's safe).
+                  --safe-autocorrect           (same, deprecated)
+              -A, --auto-correct-all           Auto-correct offenses (safe and unsafe)
                   --disable-pending-cops       Run without pending cops.
                   --enable-pending-cops        Run with pending cops.
                   --ignore-disable-comments    Run cops even when they are disabled locally
@@ -127,7 +129,6 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                                                parallel.
               -l, --lint                       Run only lint cops.
               -x, --fix-layout                 Run only layout cops, with auto-correct on.
-                  --safe-auto-correct          Run auto-correct only when it's safe.
               -s, --stdin FILE                 Pipe source from STDIN, using FILE in offense
                                                reports. This is useful for editor integration.
         OUTPUT
@@ -302,8 +303,8 @@ RSpec.describe RuboCop::Options, :isolated_environment do
           .not_to raise_error
       end
 
-      it 'accepts together with --safe-auto-correct' do
-        expect { options.parse %w[--safe-auto-correct --disable-uncorrectable] }
+      it 'accepts together with --auto-correct-all' do
+        expect { options.parse %w[--auto-correct-all --disable-uncorrectable] }
           .not_to raise_error
       end
 
@@ -368,6 +369,13 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       it 'fails if more than one path is given' do
         expect { options.parse %w[--stdin foo bar] }
           .to raise_error(RuboCop::OptionArgumentError)
+      end
+    end
+
+    describe '--safe-autocorrect' do
+      it 'is a deprecated alias' do
+        expect { options.parse %w[--safe-autocorrect] }
+          .to output(/deprecated/).to_stderr
       end
     end
   end

--- a/spec/rubocop/rake_task_spec.rb
+++ b/spec/rubocop/rake_task_spec.rb
@@ -134,12 +134,12 @@ RSpec.describe RuboCop::RakeTask do
     end
 
     context 'auto_correct' do
-      it 'runs with --auto-correct' do
+      it 'runs with --auto-correct-all' do
         described_class.new
 
         cli = instance_double(RuboCop::CLI, run: 0)
         allow(RuboCop::CLI).to receive(:new).and_return(cli)
-        options = ['--auto-correct']
+        options = ['--auto-correct-all']
 
         expect(cli).to receive(:run).with(options)
 
@@ -157,7 +157,7 @@ RSpec.describe RuboCop::RakeTask do
 
         cli = instance_double(RuboCop::CLI, run: 0)
         allow(RuboCop::CLI).to receive(:new).and_return(cli)
-        options = ['--auto-correct', '--format', 'files', '-D', 'lib/**/*.rb']
+        options = ['--auto-correct-all', '--format', 'files', '-D', 'lib/**/*.rb']
 
         expect(cli).to receive(:run).with(options)
 


### PR DESCRIPTION
I'm proposing slightly different options than in #8156:

`-a` / `--auto-correct` are now safe only, replacing `--safe-auto-correct`
`-A` / `--auto-correct-all` apply safe and unsafe corrections

Help reads:
```
...
-a, --auto-correct               Auto-correct offenses (only when it's safe).
-A, --auto-correct-all           Auto-correct offenses (safe and unsafe)
...
```