### PR TITLE
Use new cop API in ConfigurableFormatting

### DIFF
--- a/lib/rubocop/cop/mixin/configurable_formatting.rb
+++ b/lib/rubocop/cop/mixin/configurable_formatting.rb
@@ -10,7 +10,7 @@ module RuboCop
         if valid_name?(node, name)
           correct_style_detected
         else
-          add_offense(node, location: name_range, message: message(style)) do
+          add_offense(name_range, message: message(style)) do
             report_opposing_styles(node, name)
           end
         end

--- a/lib/rubocop/cop/naming/method_name.rb
+++ b/lib/rubocop/cop/naming/method_name.rb
@@ -28,7 +28,7 @@ module RuboCop
       #
       #   # good
       #   def fooBar; end
-      class MethodName < Cop
+      class MethodName < Base
         include ConfigurableNaming
         include IgnoredPattern
         include RangeHelp

--- a/lib/rubocop/cop/naming/variable_name.rb
+++ b/lib/rubocop/cop/naming/variable_name.rb
@@ -19,7 +19,7 @@ module RuboCop
       #
       #   # good
       #   fooBar = 1
-      class VariableName < Cop
+      class VariableName < Base
         include ConfigurableNaming
 
         MSG = 'Use %<style>s for variable names.'

--- a/lib/rubocop/cop/naming/variable_number.rb
+++ b/lib/rubocop/cop/naming/variable_number.rb
@@ -37,7 +37,7 @@ module RuboCop
       #   variableone = 1
       #
       #   variable_one = 1
-      class VariableNumber < Cop
+      class VariableNumber < Base
         include ConfigurableNumbering
 
         MSG = 'Use %<style>s for variable numbers.'

--- a/spec/rubocop/cop/naming/variable_number_spec.rb
+++ b/spec/rubocop/cop/naming/variable_number_spec.rb
@@ -2,18 +2,26 @@
 
 RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
   shared_examples 'offense' do |style, variable, style_to_allow_offenses|
-    it "registers an offense for #{Array(variable).first} in #{style}" do
-      inspect_source(Array(variable).map { |v| "#{v} = 1" }.join("\n"))
+    it "registers an offense for #{variable} in #{style}" do
+      expect_offense(<<~RUBY, variable: variable)
+        #{variable} = 1
+        ^{variable} Use #{style} for variable numbers.
+      RUBY
 
-      expect(cop.messages).to eq(["Use #{style} for variable numbers."])
-      expect(cop.highlights).to eq(Array(variable)[0, 1])
-      config_to_allow_offenses =
-        if style_to_allow_offenses
-          { 'EnforcedStyle' => style_to_allow_offenses.to_s }
-        else
-          { 'Enabled' => false }
-        end
-      expect(cop.config_to_allow_offenses).to eq(config_to_allow_offenses)
+      expect(cop.config_to_allow_offenses).to eq(
+        { 'EnforcedStyle' => style_to_allow_offenses.to_s }
+      )
+    end
+  end
+
+  shared_examples 'offense_array' do |style, variables|
+    it "registers an offense for #{variables} in #{style}" do
+      lines = variables.map { |v| "#{v} = 1" }
+      lines.insert(1, "^{first_variable} Use #{style} for variable numbers.")
+
+      expect_offense(lines.join("\n"), first_variable: variables.first)
+
+      expect(cop.config_to_allow_offenses).to eq({ 'Enabled' => false })
     end
   end
 
@@ -33,7 +41,7 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
     it_behaves_like 'offense', 'snake_case', '@camelCase1', :normalcase
     it_behaves_like 'offense', 'snake_case', '_unused1', :normalcase
     it_behaves_like 'offense', 'snake_case', 'aB1', :normalcase
-    it_behaves_like 'offense', 'snake_case', %w[a1 a_2], nil
+    it_behaves_like 'offense_array', 'snake_case', %w[a1 a_2]
 
     it_behaves_like 'accepts', 'snake_case', 'local_1'
     it_behaves_like 'accepts', 'snake_case', 'local_12'
@@ -75,7 +83,7 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
     it_behaves_like 'offense', 'normalcase', '_myLocal_1', :snake_case
     it_behaves_like 'offense', 'normalcase', 'localFOO_1', :snake_case
     it_behaves_like 'offense', 'normalcase', 'local_FOO_1', :snake_case
-    it_behaves_like 'offense', 'normalcase', %w[a_1 a2], nil
+    it_behaves_like 'offense_array', 'normalcase', %w[a_1 a2]
 
     it_behaves_like 'accepts', 'normalcase', 'local1'
     it_behaves_like 'accepts', 'normalcase', 'local_'
@@ -120,7 +128,7 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
     it_behaves_like 'offense', 'non_integer', '@myAttribute1', :normalcase
     it_behaves_like 'offense', 'non_integer', '_myLocal_1', :snake_case
     it_behaves_like 'offense', 'non_integer', '_myLocal1', :normalcase
-    it_behaves_like 'offense', 'non_integer', %w[a_1 aone], nil
+    it_behaves_like 'offense_array', 'non_integer', %w[a_1 aone]
 
     it_behaves_like 'accepts', 'non_integer', 'localone'
     it_behaves_like 'accepts', 'non_integer', 'local_one'


### PR DESCRIPTION
In order to use the new autocorrection API in rubocop-rspec, I need `ConfigurableFormatting` to call `add_offense` using the new API. This was also mentioned in https://github.com/rubocop-hq/rubocop/pull/7868#issuecomment-641595191

I had to change spec/rubocop/cop/naming/variable_number_spec.rb – the example introduced in #3728 was impossible to change to use `expect_offense` without splitting the shared example in two. I am still not sure what the example _does_, but at least it works the same way as before.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
