### PR TITLE
[Fix #8195] Fix an error for `Style/RedundantFetchBlock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#7868](https://github.com/rubocop-hq/rubocop/pull/7868): `Cop::Base` is the new recommended base class for cops. Extensive refactoring of `Team`, `Commissioner`. ([@marcandre][])
 
+### Bug fixes
+
+* [#8195](https://github.com/rubocop-hq/rubocop/issues/8195): Fix an error for `Style/RedundantFetchBlock` when using `#fetch` with empty block. ([@koic][])
+
 ## 0.86.0 (2020-06-22)
 
 ### New features

--- a/spec/rubocop/cop/style/redundant_fetch_block_spec.rb
+++ b/spec/rubocop/cop/style/redundant_fetch_block_spec.rb
@@ -67,6 +67,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantFetchBlock do
       RUBY
     end
 
+    it 'registers an offense and corrects when using `#fetch` with empty block' do
+      expect_offense(<<~RUBY)
+        hash.fetch(:key) {}
+             ^^^^^^^^^^^^^^ Use `fetch(:key, nil)` instead of `fetch(:key) {}`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        hash.fetch(:key, nil)
+      RUBY
+    end
+
     it 'registers an offense and corrects when using `#fetch` with constant in the block' do
       expect_offense(<<~RUBY)
         hash.fetch(:key) { CONSTANT }


### PR DESCRIPTION
Fixes #8195

This PR fixes an error for `Style/RedundantFetchBlock` when using `#fetch` with empty block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
