### PR TITLE
[Fix #8193] Avoid false positive in Style/RedundantRegexpCharacterClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 * [#8195](https://github.com/rubocop-hq/rubocop/issues/8195): Fix an error for `Style/RedundantFetchBlock` when using `#fetch` with empty block. ([@koic][])
+* [#8193](https://github.com/rubocop-hq/rubocop/issues/8193): Fix a false positive for `Style/RedundantRegexpCharacterClass` when using `[\b]`. ([@owst][])
 
 ## 0.86.0 (2020-06-22)
 

--- a/lib/rubocop/cop/style/redundant_regexp_character_class.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_character_class.rb
@@ -34,7 +34,7 @@ module RuboCop
             \[                # Literal [
             (?!\#\{)          # Not (the start of) an interpolation
             (?:               # Either...
-             \\. |            # Any escaped character
+             \\[^b] |         # Any escaped character except b (which would change behaviour)
              [^.*+?{}()|$] |  # or one that doesn't require escaping outside the character class
              \\[upP]\{[^}]+\} # or a unicode code-point or property
             )

--- a/spec/rubocop/cop/style/redundant_regexp_character_class_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_character_class_spec.rb
@@ -121,6 +121,14 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpCharacterClass do
     end
   end
 
+  context 'with a character class containing an escaped-b' do
+    # See https://github.com/rubocop-hq/rubocop/issues/8193 for details - in short \b != [\b] - the
+    # former matches a word boundary, the latter a backspace character.
+    it 'does not register an offense' do
+      expect_no_offenses('foo = /[\b]/')
+    end
+  end
+
   context 'with a character class containing a character requiring escape outside' do
     # Not implemented for now, since we would have to escape on auto-correct, and the cop message
     # would need to be dynamic to not be misleading.


### PR DESCRIPTION
**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
