### PR TITLE
[Fix #8189] Consider spaces for Layout/MultilineBlockLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Bug fixes
 
+* [#8189](https://github.com/rubocop-hq/rubocop/issues/8189): Fix an error for `Layout/MultilineBlockLayout` where spaces for a new line where not considered. ([@knejad][])
 * [#8252](https://github.com/rubocop-hq/rubocop/issues/8252): Fix a command line option name from `--safe-autocorrect` to `--safe-auto-correct`, which is compatible with RuboCop 0.86 and lower. ([@koic][])
 * [#8259](https://github.com/rubocop-hq/rubocop/issues/8259): Fix false positives for `Style/BisectedAttrAccessor` when accessors have different access modifiers. ([@fatkodima][])
 * [#8253](https://github.com/rubocop-hq/rubocop/issues/8253): Fix false positives for `Style/AccessorGrouping` when accessors have different access modifiers. ([@fatkodima][])
@@ -4672,3 +4673,4 @@
 [@karlwithak]: https://github.com/karlwithak
 [@CamilleDrapier]: https://github.com/CamilleDrapier
 [@shekhar-patil]: https://github.com/shekhar-patil
+[@knejad]: https://github.com/knejad

--- a/lib/rubocop/cop/autocorrect_logic.rb
+++ b/lib/rubocop/cop/autocorrect_logic.rb
@@ -73,7 +73,7 @@ module RuboCop
       end
 
       def max_line_length
-        config.for_cop('Layout/LineLength')['Max'] || 80
+        config.for_cop('Layout/LineLength')['Max'] || 120
       end
 
       def disable_offense_at_end_of_line(range, eol_comment)

--- a/lib/rubocop/cop/layout/multiline_block_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_block_layout.rb
@@ -95,11 +95,22 @@ module RuboCop
         end
 
         def line_break_necessary_in_args?(node)
-          needed_length = node.source_range.column +
-                          node.source.lines.first.length +
-                          block_arg_string(node, node.arguments).length +
-                          PIPE_SIZE
-          needed_length > max_line_length
+          needed_length_for_args(node) > max_line_length
+        end
+
+        def needed_length_for_args(node)
+          node.source_range.column +
+            characters_needed_for_space_and_pipes(node) +
+            node.source.lines.first.chomp.length +
+            block_arg_string(node, node.arguments).length
+        end
+
+        def characters_needed_for_space_and_pipes(node)
+          if node.source.lines.first.end_with?("|\n")
+            PIPE_SIZE
+          else
+            1 + PIPE_SIZE * 2
+          end
         end
 
         def add_offense_for_expression(node, expr, msg)

--- a/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
@@ -78,15 +78,49 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
     RUBY
   end
 
-  it 'does not register offenses when there are too many parameters to fit ' \
-     'on one line' do
+  it 'does not register offenses when there are too many parameters to fit on one line' do
     expect_no_offenses(<<~RUBY)
       some_result = lambda do |
         so_many,
         parameters,
         it_will,
         be_too_long,
-        for_one_line|
+        for_one_line,
+        line_length,
+        has_increased,
+        add_3_more|
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers offenses when there are not too many parameters to fit on one line' do
+    expect_offense(<<~RUBY)
+      some_result = lambda do |
+                              ^ Block argument expression is not on the same line as the block start.
+        so_many,
+        parameters,
+        it_will,
+        be_too_long,
+        for_one_line,
+        line_length,
+        has_increased,
+        add_3_mor|
+        do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      some_result = lambda do |so_many, parameters, it_will, be_too_long, for_one_line, line_length, has_increased, add_3_mor|
+        do_something
+      end
+    RUBY
+  end
+
+  it 'considers the extra space required to join the lines together' do
+    expect_no_offenses(<<~RUBY)
+      some_result = lambda do
+        |so_many, parameters, it_will, be_too_long, for_one_line, line_length, has_increased, add_3_more|
         do_something
       end
     RUBY


### PR DESCRIPTION
Before this commit when deciding whether to trigger a Layout/MultilineBlockLayout it would not consider any extra spaces required to join the lines. This commit fixes that issue.

For example the below would trigger a LayoutMultilineBlockLayout warning before but not anymore:

```
some_result = lambda do
  |so_many, parameters, it_will, be_too_long, for_one_line, line_length, has_increased, add_3_more|
  do_something
end
```

~I had to disable the AbcSize metric for the method I was extending, as much as I tried I couldn't get a nice method with an Abc < 15. The best I got was 15.07 :unamused:. I could get it < 15 but IMHO it looked worse and seemed to go against the spirit of the cop.~ (Thanks to @jonas054 I fixed this issue)

**Note:** I also updated the max_line_length to default to the new 120 value if nothing is defined

Resolves https://github.com/rubocop-hq/rubocop/issues/8189

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
