### PR TITLE
Tweaks to Metrics/PerceivedComplexity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [#8338](https://github.com/rubocop-hq/rubocop/pull/8338): **potentially breaking**. Config#for_department now returns only the config specified for that department; the 'Enabled' attribute is no longer calculated. ([@marcandre][])
 * [#8037](https://github.com/rubocop-hq/rubocop/pull/8037): **(Breaking)** Cop `Metrics/AbcSize` now counts ||=, &&=, multiple assignments, for, yield, iterating blocks. `&.` now count as conditions too (unless repeated on the same variable). Default bumped from 15 to 17. Consider using `rubocop -a --disable-uncorrectable` to ease transition. ([@marcandre][])
 * [#8276](https://github.com/rubocop-hq/rubocop/issues/8276): Cop `Metrics/CyclomaticComplexity` not longer counts `&.` when repeated on the same variable. ([@marcandre][])
+* [#8204](https://github.com/rubocop-hq/rubocop/pull/8204): **(Breaking)** Cop `Metrics/PerceivedComplexity` now counts `else` in `case` statements, `&.`, `||=`, `&&=` and blocks known to iterate. Default bumped from 7 to 8. Consider using `rubocop -a --disable-uncorrectable` to ease transition. ([@marcandre][])
 
 ## 0.88.0 (2020-07-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 * [#8376](https://github.com/rubocop-hq/rubocop/pull/8376): `Style/MethodMissingSuper` cop is removed in favor of new `Lint/MissingSuper` cop. ([@fatkodima][])
 * [#8350](https://github.com/rubocop-hq/rubocop/pull/8350): Set default max line length to 120 for `Style/MultilineMethodSignature`. ([@koic][])
 * [#8338](https://github.com/rubocop-hq/rubocop/pull/8338): **potentially breaking**. Config#for_department now returns only the config specified for that department; the 'Enabled' attribute is no longer calculated. ([@marcandre][])
-* [#8037](https://github.com/rubocop-hq/rubocop/pull/8037): **(Breaking)** Cop `Metrics/AbcSize` now counts ||=, &&=, multiple assignments, for, yield, iterating blocks. `&.` now count as conditions too (unless repeated on the same variable). Default bumped from 15 to 16.5. ([@marcandre][])
+* [#8037](https://github.com/rubocop-hq/rubocop/pull/8037): **(Breaking)** Cop `Metrics/AbcSize` now counts ||=, &&=, multiple assignments, for, yield, iterating blocks. `&.` now count as conditions too (unless repeated on the same variable). Default bumped from 15 to 17. Consider using `rubocop -a --disable-uncorrectable` to ease transition. ([@marcandre][])
 * [#8276](https://github.com/rubocop-hq/rubocop/issues/8276): Cop `Metrics/CyclomaticComplexity` not longer counts `&.` when repeated on the same variable. ([@marcandre][])
 
 ## 0.88.0 (2020-07-13)

--- a/config/default.yml
+++ b/config/default.yml
@@ -2015,7 +2015,7 @@ Metrics/PerceivedComplexity:
   VersionAdded: '0.25'
   VersionChanged: '0.81'
   IgnoredMethods: []
-  Max: 7
+  Max: 8
 
 ################## Migration #############################
 

--- a/docs/modules/ROOT/pages/cops_metrics.adoc
+++ b/docs/modules/ROOT/pages/cops_metrics.adoc
@@ -472,6 +472,6 @@ end                             # 7 complexity points
 | Array
 
 | Max
-| `7`
+| `8`
 | Integer
 |===

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -135,7 +135,7 @@ module RuboCop
           end
         end
 
-        # rubocop:todo Metrics/CyclomaticComplexity
+        # rubocop:todo Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def find_redundant(comment, offenses, cop, line_range, next_line_range)
           if all_disabled?(comment)
             # If there's a disable all comment followed by a comment
@@ -153,7 +153,7 @@ module RuboCop
             cop if cop_offenses.none? { |o| line_range.cover?(o.line) }
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def all_disabled?(comment)
           /rubocop\s*:\s*(?:disable|todo)\s+all\b/.match?(comment.text)

--- a/lib/rubocop/cop/metrics/perceived_complexity.rb
+++ b/lib/rubocop/cop/metrics/perceived_complexity.rb
@@ -26,13 +26,11 @@ module RuboCop
       #       do_something until a && b   # 2
       #     end                           # ===
       #   end                             # 7 complexity points
-      class PerceivedComplexity < Base
-        include MethodComplexity
-
+      class PerceivedComplexity < CyclomaticComplexity
         MSG = 'Perceived complexity for %<method>s is too high. ' \
               '[%<complexity>d/%<max>d]'
-        COUNTED_NODES = %i[if case while until
-                           for rescue and or].freeze
+
+        COUNTED_NODES = (CyclomaticComplexity::COUNTED_NODES - [:when] + [:case]).freeze
 
         private
 
@@ -53,7 +51,7 @@ module RuboCop
           when :if
             node.else? && !node.elsif? ? 2 : 1
           else
-            1
+            super
           end
         end
       end

--- a/lib/rubocop/cop/metrics/perceived_complexity.rb
+++ b/lib/rubocop/cop/metrics/perceived_complexity.rb
@@ -42,12 +42,13 @@ module RuboCop
             # If cond is nil, that means each when has an expression that
             # evaluates to true or false. It's just an alternative to
             # if/elsif/elsif... so the when nodes count.
+            nb_branches = node.when_branches.length + (node.else_branch ? 1 : 0)
             if node.condition.nil?
-              node.when_branches.length
+              nb_branches
             else
               # Otherwise, the case node gets 0.8 complexity points and each
               # when gets 0.2.
-              (0.8 + 0.2 * node.when_branches.length).round
+              (0.8 + 0.2 * nb_branches).round
             end
           when :if
             node.else? && !node.elsif? ? 2 : 1

--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -81,7 +81,7 @@ module RuboCop
 
         private
 
-        def check_branches(branches) # rubocop:todo Metrics/CyclomaticComplexity
+        def check_branches(branches) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
           # return if any branch is empty. An empty branch can be an `if`
           # without an `else` or a branch that contains only comments.
           return if branches.any?(&:nil?)

--- a/lib/rubocop/cop/variable_force/variable.rb
+++ b/lib/rubocop/cop/variable_force/variable.rb
@@ -38,7 +38,7 @@ module RuboCop
           !@references.empty?
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def reference!(node)
           reference = Reference.new(node, @scope)
           @references << reference
@@ -63,7 +63,7 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def in_modifier_if?(assignment)
           parent = assignment.node.parent

--- a/spec/rubocop/cop/metrics/perceived_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/perceived_complexity_spec.rb
@@ -156,6 +156,22 @@ RSpec.describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
       RUBY
     end
 
+    it 'counts else in a case with no argument' do
+      expect_offense(<<~RUBY)
+        def method_name
+        ^^^^^^^^^^^^^^^ Perceived complexity for method_name is too high. [4/1]
+          case
+          when value == 1
+            call_foo
+          when value == 2
+            call_bar
+          else
+            call_baz
+          end
+        end
+      RUBY
+    end
+
     it 'registers an offense for &&' do
       expect_offense(<<~RUBY)
         def method_name

--- a/spec/rubocop/cop/metrics/perceived_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/perceived_complexity_spec.rb
@@ -242,6 +242,27 @@ RSpec.describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
         end
       RUBY
     end
+
+    it 'does not count unknown block calls' do
+      expect_no_offenses(<<~RUBY)
+        def method_name
+          bar.baz(:qux) do |x|
+            raise x
+          end
+        end
+      RUBY
+    end
+
+    it 'counts known iterating block' do
+      expect_offense(<<~RUBY)
+        def method_name
+        ^^^^^^^^^^^^^^^ Perceived complexity for method_name is too high. [2/1]
+          ary.each do |x|
+            foo(x)
+          end
+        end
+      RUBY
+    end
   end
 
   context 'when method is in list of ignored methods' do


### PR DESCRIPTION
`Metrics/PerceivedComplexity` currently ignores `else` branches in `case` statement which seems like a clear bug, considering the weight if gives to `else` in if statements:

```ruby
if foo
  bar
else
  baz
end
# counts for more than the equivalent:
case
when foo
  bar
else
  baz
end
```

For the rest, there's no clear definition of what `PerceivedComplexity` is  supposed to do, but it sounds like it's the same thing as `CyclomaticComplexity` with a twist for `case` and `if` with `else`.

This PR fixes the `else` issue and makes the same changes that #8149 made for CyclomaticComplexity (`||=`, iterating methods, etc.) Default bumped also from 7 to 8. 3 new todos all of which are already CyclomaticComplexity todos.

If we're ok with these fixes, it would be best for v1 as it is breaking.