### PR TITLE
[Fix #8205] Avoid false positive in Style/RedundantRegexpCharacterClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * [#8195](https://github.com/rubocop-hq/rubocop/issues/8195): Fix an error for `Style/RedundantFetchBlock` when using `#fetch` with empty block. ([@koic][])
 * [#8193](https://github.com/rubocop-hq/rubocop/issues/8193): Fix a false positive for `Style/RedundantRegexpCharacterClass` when using `[\b]`. ([@owst][])
+* [#8205](https://github.com/rubocop-hq/rubocop/issues/8205): Fix a false positive for `Style/RedundantRegexpCharacterClass` when using a leading escaped `]`. ([@owst][])
 
 ## 0.86.0 (2020-06-22)
 

--- a/lib/rubocop/cop/style/redundant_regexp_character_class.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_character_class.rb
@@ -38,6 +38,7 @@ module RuboCop
              [^.*+?{}()|$] |  # or one that doesn't require escaping outside the character class
              \\[upP]\{[^}]+\} # or a unicode code-point or property
             )
+            (?<!\\)           # No \-prefix (i.e. not escaped)
             \]                # Literal ]
           )
         /x.freeze

--- a/spec/rubocop/cop/style/redundant_regexp_character_class_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_character_class_spec.rb
@@ -43,6 +43,19 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpCharacterClass do
     end
   end
 
+  context 'with a character class containing an escaped [' do
+    it 'registers an offense and corrects' do
+      expect_offense(<<~'RUBY')
+        foo = /[\[]/
+               ^^^^ Redundant single-element character class, `[\[]` can be replaced with `\[`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        foo = /\[/
+      RUBY
+    end
+  end
+
   context 'with a character class containing a space meta-character' do
     it 'registers an offense and corrects' do
       expect_offense(<<~'RUBY')
@@ -160,6 +173,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpCharacterClass do
       expect_correction(<<~'RUBY')
         foo = /a#{/b/}c/
       RUBY
+    end
+  end
+
+  context 'with a character class with first element an escaped ]' do
+    it 'does not register an offense' do
+      expect_no_offenses('foo = /[\])]/')
     end
   end
 


### PR DESCRIPTION
If the first element of a character class was an escaped-] our pattern
was treating it as a single element classs containing a single backslash
(which is invalid, and incorrect).

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
