### PR TITLE
[Fixes #8207] Don't consider underscores and dashes when sorting gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 * [#8223](https://github.com/rubocop-hq/rubocop/pull/8223): Support auto-correction for `Style/IfUnlessModifierOfIfUnless`. ([@koic][])
 * [#8172](https://github.com/rubocop-hq/rubocop/pull/8172): Support auto-correction for `Lint/SafeNavigationWithEmpty`. ([@koic][])
 
+### Changes
+
+* [#7868](https://github.com/rubocop-hq/rubocop/pull/7868): **(Breaking)** Extensive refactoring of internal classes `Team`, `Commissioner`, `Corrector`. `Cop::Cop#corrections` not completely compatible. See Upgrade Notes. ([@marcandre][])
+* [#8207](https://github.com/rubocop-hq/rubocop/pull/8207): **(Breaking)** Order for gems names now disregards underscores and dashes unless `ConsiderPunctuation` setting is set to `true`. ([@marcandre][])
+
 ### Bug fixes
 
 * [#8196](https://github.com/rubocop-hq/rubocop/issues/8196): Fix a false positive for `Style/RedundantFetchBlock` when using with `Rails.cache`. ([@fatkodima][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -180,6 +180,9 @@ Bundler/OrderedGems:
   VersionAdded: '0.46'
   VersionChanged: '0.47'
   TreatCommentsAsGroupSeparators: true
+  # By default, "-" and "_" are ignored for order purposes.
+  # This can be overriden by setting this parameter to true.
+  ConsiderPunctuation: false
   Include:
     - '**/*.gemfile'
     - '**/Gemfile'
@@ -200,6 +203,9 @@ Gemspec/OrderedDependencies:
   Enabled: true
   VersionAdded: '0.51'
   TreatCommentsAsGroupSeparators: true
+  # By default, "-" and "_" are ignored for order purposes.
+  # This can be overriden by setting this parameter to true.
+  ConsiderPunctuation: false
   Include:
     - '**/*.gemspec'
 

--- a/docs/modules/ROOT/pages/cops_bundler.adoc
+++ b/docs/modules/ROOT/pages/cops_bundler.adoc
@@ -245,6 +245,10 @@ gem 'rspec'
 | `true`
 | Boolean
 
+| ConsiderPunctuation
+| `false`
+| Boolean
+
 | Include
 | `+**/*.gemfile+`, `+**/Gemfile+`, `+**/gems.rb+`
 | Array

--- a/docs/modules/ROOT/pages/cops_gemspec.adoc
+++ b/docs/modules/ROOT/pages/cops_gemspec.adoc
@@ -131,6 +131,10 @@ spec.add_dependency 'rspec'
 | `true`
 | Boolean
 
+| ConsiderPunctuation
+| `false`
+| Boolean
+
 | Include
 | `+**/*.gemspec+`
 | Array

--- a/lib/rubocop/cop/mixin/ordered_gem_node.rb
+++ b/lib/rubocop/cop/mixin/ordered_gem_node.rb
@@ -15,8 +15,13 @@ module RuboCop
         node.source_range
       end
 
+      def gem_canonical_name(name)
+        name = name.tr('-_', '') unless cop_config['ConsiderPunctuation']
+        name.downcase
+      end
+
       def case_insensitive_out_of_order?(string_a, string_b)
-        string_a.downcase < string_b.downcase
+        gem_canonical_name(string_a) < gem_canonical_name(string_b)
       end
 
       def consecutive_lines(previous, current)

--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -175,11 +175,11 @@ RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
     end
   end
 
-  context 'When gems are asciibetically sorted' do
+  context 'When gems are asciibetically sorted irrespective of _' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)
-        gem 'paper_trail'
         gem 'paperclip'
+        gem 'paper_trail'
       RUBY
     end
   end
@@ -205,6 +205,38 @@ RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
         gem 'a'
         gem 'Z'
       RUBY
+    end
+  end
+
+  context 'When a gem is sorted but not so when disregarding _-' do
+    context 'by default' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          gem 'active-admin-some_plugin'
+          gem 'active_admin_other_plugin'
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem `active_admin_other_plugin` should appear before `active-admin-some_plugin`.
+          gem 'activeadmin'
+          ^^^^^^^^^^^^^^^^^ Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem `activeadmin` should appear before `active_admin_other_plugin`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          gem 'activeadmin'
+          gem 'active_admin_other_plugin'
+          gem 'active-admin-some_plugin'
+        RUBY
+      end
+    end
+
+    context 'when ConsiderPunctuation is true' do
+      let(:cop_config) { super().merge({ 'ConsiderPunctuation' => true }) }
+
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          gem 'active-admin-some_plugin'
+          gem 'active_admin_other_plugin'
+          gem 'activeadmin'
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
I think it is a small improvement if `activeadmin` is sorted before `active_admin-sortable_tree`.

It is a breaking change though, with a frequent real world example: `paper_trail` vs `paperclip`. v1 might be the perfect timing, or it might not be worth it...