### PR TITLE
Detect class_variable_set in Style/ClassVars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#7868](https://github.com/rubocop-hq/rubocop/pull/7868): **(Breaking)** Extensive refactoring of internal classes `Team`, `Commissioner`, `Corrector`. `Cop::Cop#corrections` not completely compatible. See Upgrade Notes. ([@marcandre][])
 * [#8156](https://github.com/rubocop-hq/rubocop/issues/8156): **(Breaking)** `rubocop -a / --autocorrect` no longer run unsafe corrections; `rubocop -A / --autocorrect-all` run both safe and unsafe corrections. Options `--safe-autocorrect` is deprecated. ([@marcandre][])
 * [#8207](https://github.com/rubocop-hq/rubocop/pull/8207): **(Breaking)** Order for gems names now disregards underscores and dashes unless `ConsiderPunctuation` setting is set to `true`. ([@marcandre][])
+* [#8211](https://github.com/rubocop-hq/rubocop/pull/8211): `Style/ClassVars` cop now detects `class_variable_set`. ([@biinari][])
 
 ## 0.86.0 (2020-06-22)
 

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -951,6 +951,15 @@ class A
   @@test = 10
 end
 
+class A
+  def self.test(name, value)
+    class_variable_set("@@#{name}", value)
+  end
+end
+
+class A; end
+A.class_variable_set(:@@test, 10)
+
 # good
 class A
   @test = 10
@@ -959,6 +968,12 @@ end
 class A
   def test
     @@test # you can access class variable without offense
+  end
+end
+
+class A
+  def self.test(name)
+    class_variable_get("@@#{name}") # you can access without offense
   end
 end
 ----

--- a/lib/rubocop/cop/style/class_vars.rb
+++ b/lib/rubocop/cop/style/class_vars.rb
@@ -19,6 +19,15 @@ module RuboCop
       #     @@test = 10
       #   end
       #
+      #   class A
+      #     def self.test(name, value)
+      #       class_variable_set("@@#{name}", value)
+      #     end
+      #   end
+      #
+      #   class A; end
+      #   A.class_variable_set(:@@test, 10)
+      #
       #   # good
       #   class A
       #     @test = 10
@@ -30,12 +39,24 @@ module RuboCop
       #     end
       #   end
       #
+      #   class A
+      #     def self.test(name)
+      #       class_variable_get("@@#{name}") # you can access without offense
+      #     end
+      #   end
+      #
       class ClassVars < Cop
         MSG = 'Replace class var %<class_var>s with a class ' \
               'instance var.'
 
         def on_cvasgn(node)
           add_offense(node, location: :name)
+        end
+
+        def on_send(node)
+          return unless node.method?(:class_variable_set)
+
+          add_offense(node.first_argument)
         end
 
         def message(node)

--- a/spec/rubocop/cop/style/class_vars_spec.rb
+++ b/spec/rubocop/cop/style/class_vars_spec.rb
@@ -10,6 +10,23 @@ RSpec.describe RuboCop::Cop::Style::ClassVars do
     RUBY
   end
 
+  it 'registers an offense for class variable set in class' do
+    expect_offense(<<~RUBY)
+      class TestClass
+        class_variable_set(:@@test, 2)
+                           ^^^^^^^ Replace class var @@test with a class instance var.
+      end
+    RUBY
+  end
+
+  it 'registers an offense for class variable set on class receiver' do
+    expect_offense(<<~RUBY)
+      class TestClass; end
+      TestClass.class_variable_set(:@@test, 42)
+                                   ^^^^^^^ Replace class var @@test with a class instance var.
+    RUBY
+  end
+
   it 'does not register an offense for class variable usage' do
     expect_no_offenses('@@test.test(20)')
   end


### PR DESCRIPTION
`class_variable_set(:@@name, 2)` has the same effect as `@@name = 2`

This variation can be within the class definition:

```ruby
class A
  class_variable_set(:@@name, 2)
end
```

Or it could be called elsewhere, with the class as receiver:

```ruby
class A; end

class B
  def change(name, value)
    A.class_variable_set(":@@#{name}", value)
  end
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/