### PR TITLE
Fix spec from symlink: remove bundle env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#8156](https://github.com/rubocop-hq/rubocop/issues/8156): **(Breaking)** `rubocop -a / --autocorrect` no longer run unsafe corrections; `rubocop -A / --autocorrect-all` run both safe and unsafe corrections. Options `--safe-autocorrect` is deprecated. ([@marcandre][])
 * [#8207](https://github.com/rubocop-hq/rubocop/pull/8207): **(Breaking)** Order for gems names now disregards underscores and dashes unless `ConsiderPunctuation` setting is set to `true`. ([@marcandre][])
 * [#8211](https://github.com/rubocop-hq/rubocop/pull/8211): `Style/ClassVars` cop now detects `class_variable_set`. ([@biinari][])
+* [#8212](https://github.com/rubocop-hq/rubocop/pull/8212): Fix running specs from a symlinked directory. ([@biinari][])
 
 ## 0.86.0 (2020-06-22)
 

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe 'RuboCop Project', type: :feature do
   end
 
   describe 'requiring all of `lib` with verbose warnings enabled' do
-    it 'emits no warnings' do
+    it 'emits no warnings', :unbundle do
       warnings = `ruby -Ilib -w -W2 lib/rubocop.rb 2>&1`
                  .lines
                  .grep(%r{/lib/rubocop}) # ignore warnings from dependencies

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::CLI, :isolated_environment do
+RSpec.describe RuboCop::CLI, :isolated_environment, :unbundle do
   include_context 'cli spec behavior'
 
   subject(:cli) { described_class.new }
@@ -250,7 +250,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         # Since we define a new cop class, we have to do this in a separate
         # process. Otherwise, the extra cop will affect other specs.
         output =
-          `ruby -I . "#{rubocop}" --require redirect.rb --only Style/SomeCop`
+          `#{ruby} -I . "#{rubocop}" --require redirect.rb --only Style/SomeCop`
         # Excludes a warning when new `Enabled: pending` status cop is specified
         # in config/default.yml.
         output_excluding_warn_for_pending_cops =
@@ -268,7 +268,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         # Since we define a new cop class, we have to do this in a separate
         # process. Otherwise, the extra cop will affect other specs.
         let(:output) do
-          `ruby -I . "#{rubocop}" --require redirect.rb --only Style/SomeCop`
+          `#{ruby} -I . "#{rubocop}" --require redirect.rb --only Style/SomeCop`
         end
 
         let(:pending_cop_warning) { <<~PENDING_COP_WARNING }
@@ -360,7 +360,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             let(:option) { '--disable-pending-cops' }
 
             let(:output) do
-              `ruby -I . "#{rubocop}" --require redirect.rb #{option}`
+              `#{ruby} -I . "#{rubocop}" --require redirect.rb #{option}`
             end
 
             it 'does not display a pending cop warning' do
@@ -372,7 +372,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             let(:option) { '--enable-pending-cops' }
 
             let(:output) do
-              `ruby -I . "#{rubocop}" --require redirect.rb #{option}`
+              `#{ruby} -I . "#{rubocop}" --require redirect.rb #{option}`
             end
 
             it 'does not display a pending cop warning' do
@@ -384,7 +384,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             let(:new_cops_option) { 'NewCops: pending' }
 
             let(:output) do
-              `ruby -I . "#{rubocop}" --require redirect.rb`
+              `#{ruby} -I . "#{rubocop}" --require redirect.rb`
             end
 
             it 'displays a pending cop warning' do
@@ -396,7 +396,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             let(:new_cops_option) { 'NewCops: disable' }
 
             let(:output) do
-              `ruby -I . "#{rubocop}" --require redirect.rb`
+              `#{ruby} -I . "#{rubocop}" --require redirect.rb`
             end
 
             it 'does not display a pending cop warning' do
@@ -408,7 +408,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             let(:new_cops_option) { 'NewCops: enable' }
 
             let(:output) do
-              `ruby -I . "#{rubocop}" --require redirect.rb`
+              `#{ruby} -I . "#{rubocop}" --require redirect.rb`
             end
 
             it 'does not display a pending cop warning' do

--- a/spec/support/unbundle.rb
+++ b/spec/support/unbundle.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'unbundle', :unbundle do
+  let(:ruby) do
+    "BUNDLE_GEMFILE=#{RuboCop::ConfigLoader::RUBOCOP_HOME}/Gemfile " \
+      'bundle exec ruby'
+  end
+
+  around do |example|
+    if Bundler.respond_to?(:with_unbundled_env)
+      Bundler.with_unbundled_env(&example)
+    else
+      Bundler.with_clean_env(&example)
+    end
+  end
+end


### PR DESCRIPTION
I have checked out rubocop to a directory under a symlink. When I try to
run the specs from the symlink instead of the original directory, odd
behaviour ensues.

Ruby resolves the directory for `'rubocop/version'` to different
locations. When ruby first starts, the symlink location is loaded. After
`require 'rubocop'`, ruby loads the original directory.

Presumably, this has to do with the gemspec requiring `rubocop/version`
and require_relative being used in `lib/rubocop.rb` but that is common
practice.

To fix this for the specs, I call upon bundler's
`with_unbundled_env` (which used to be `with_clean_env`). Then for ruby
commands in `:isolated_environment`, use `bundle exec` with this project's
`Gemfile`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/