### PR TITLE
Fix Style/RedundantParentheses with hash literal as first argument to yield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#8195](https://github.com/rubocop-hq/rubocop/issues/8195): Fix an error for `Style/RedundantFetchBlock` when using `#fetch` with empty block. ([@koic][])
 * [#8193](https://github.com/rubocop-hq/rubocop/issues/8193): Fix a false positive for `Style/RedundantRegexpCharacterClass` when using `[\b]`. ([@owst][])
 * [#8205](https://github.com/rubocop-hq/rubocop/issues/8205): Fix a false positive for `Style/RedundantRegexpCharacterClass` when using a leading escaped `]`. ([@owst][])
+* [#8208](https://github.com/rubocop-hq/rubocop/issues/8208): Fix `Style/RedundantParentheses` with hash literal as first argument to `yield`. ([@karlwithak][])
 
 ### Changes
 
@@ -4631,3 +4632,4 @@
 [@avrusanov]: https://github.com/avrusanov
 [@mauro-oto]: https://github.com/mauro-oto
 [@fatkodima]: https://github.com/fatkodima
+[@karlwithak]: https://github.com/karlwithak

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -205,7 +205,9 @@ module RuboCop
         end
 
         def first_argument?(node)
-          first_send_argument?(node) || first_super_argument?(node)
+          first_send_argument?(node) ||
+            first_super_argument?(node) ||
+            first_yield_argument?(node)
         end
 
         def_node_matcher :first_send_argument?, <<~PATTERN
@@ -214,6 +216,10 @@ module RuboCop
 
         def_node_matcher :first_super_argument?, <<~PATTERN
           ^(super equal?(%0) ...)
+        PATTERN
+
+        def_node_matcher :first_yield_argument?, <<~PATTERN
+          ^(yield equal?(%0) ...)
         PATTERN
 
         def call_chain_starts_with_int?(begin_node, send_node)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -278,4 +278,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses do
       })
     RUBY
   end
+
+  it 'accepts parentheses in yield call with hash' do
+    expect_no_offenses(<<~RUBY)
+      yield ({
+        foo: bar,
+      })
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/rubocop-hq/rubocop/issues/8208

Do not consider the parentheses around a yielded hash literal as redundant.