### PR TITLE
Remove Rails/DefaultScope from ConfigObsoletion

### DIFF
--- a/lib/rubocop/config_obsoletion.rb
+++ b/lib/rubocop/config_obsoletion.rb
@@ -63,7 +63,6 @@ module RuboCop
       'Layout/SpaceAfterControlKeyword' => 'Layout/SpaceAroundKeyword',
       'Layout/SpaceBeforeModifierKeyword' => 'Layout/SpaceAroundKeyword',
       'Lint/RescueWithoutErrorClass' => 'Style/RescueStandardError',
-      'Rails/DefaultScope' => nil,
       'Style/SpaceAfterControlKeyword' => 'Layout/SpaceAroundKeyword',
       'Style/SpaceBeforeModifierKeyword' => 'Layout/SpaceAroundKeyword',
       'Style/TrailingComma' => 'Style/TrailingCommaInArguments, ' \

--- a/spec/rubocop/config_obsoletion_spec.rb
+++ b/spec/rubocop/config_obsoletion_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe RuboCop::ConfigObsoletion do
           'Lint/InvalidCharacterLiteral' => { 'Enabled': true },
           'Lint/RescueWithoutErrorClass' => { 'Enabled': true },
           'Lint/SpaceBeforeFirstArg' => { 'Enabled': true },
-          'Rails/DefaultScope' => { 'Enabled': true },
           'Style/SpaceAfterControlKeyword' => { 'Enabled': true },
           'Style/SpaceBeforeModifierKeyword' => { 'Enabled': true },
           'Style/TrailingComma' => { 'Enabled': true },
@@ -184,8 +183,6 @@ RSpec.describe RuboCop::ConfigObsoletion do
           The `Layout/SpaceBeforeModifierKeyword` cop has been removed. Please use `Layout/SpaceAroundKeyword` instead.
           (obsolete configuration found in example/.rubocop.yml, please update it)
           The `Lint/RescueWithoutErrorClass` cop has been removed. Please use `Style/RescueStandardError` instead.
-          (obsolete configuration found in example/.rubocop.yml, please update it)
-          The `Rails/DefaultScope` cop has been removed.
           (obsolete configuration found in example/.rubocop.yml, please update it)
           The `Style/SpaceAfterControlKeyword` cop has been removed. Please use `Layout/SpaceAroundKeyword` instead.
           (obsolete configuration found in example/.rubocop.yml, please update it)


### PR DESCRIPTION
For context:
https://github.com/rubocop-hq/rubocop-rails/pull/267 description 
and https://github.com/rubocop-hq/rubocop-rails/pull/267#issuecomment-649744622