### PR TITLE
Add reviewdog tool to docs

### DIFF
--- a/docs/modules/ROOT/pages/automated_code_review.adoc
+++ b/docs/modules/ROOT/pages/automated_code_review.adoc
@@ -30,6 +30,10 @@ It is open source software.
 
 https://github.com/prontolabs/pronto[Pronto] does quick automated code review of your changes. Created to be used on GitHub pull requests, but also works locally and integrates with GitLab and Bitbucket.
 
+== ReviewDog
+
+https://github.com/reviewdog/reviewdog[ReviewDog] is similar to Pronto but with better support for Github Actions.
+
 == Sider
 
 https://sider.review[Sider] improves your team's productivity by automating code analysis.


### PR DESCRIPTION
I recently found a new tool that can run Rubocop on Github PRs: https://github.com/reviewdog/action-rubocop

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
