### PR TITLE
Support auto-correction for `Style/IfUnlessModifierOfIfUnless`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#7868](https://github.com/rubocop-hq/rubocop/pull/7868): `Cop::Base` is the new recommended base class for cops. ([@marcandre][])
 * [#8213](https://github.com/rubocop-hq/rubocop/pull/8213): Permit to specify TargetRubyVersion 2.8 (experimental). ([@koic][])
 * [#8164](https://github.com/rubocop-hq/rubocop/pull/8164): Support auto-correction for `Lint/InterpolationCheck`. ([@koic][])
+* [#8223](https://github.com/rubocop-hq/rubocop/pull/8223): Support auto-correction for `Style/IfUnlessModifierOfIfUnless`. ([@koic][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -2997,6 +2997,7 @@ Style/IfUnlessModifierOfIfUnless:
                  Avoid modifier if/unless usage on conditionals.
   Enabled: true
   VersionAdded: '0.39'
+  VersionChanged: '0.87'
 
 Style/IfWithSemicolon:
   Description: 'Do not use if x; .... Use the ternary operator instead.'

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -3683,9 +3683,9 @@ end
 
 | Enabled
 | Yes
-| No
+| Yes
 | 0.39
-| -
+| 0.87
 |===
 
 Checks for if and unless statements used as modifiers of other if or

--- a/lib/rubocop/cop/style/if_unless_modifier_of_if_unless.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier_of_if_unless.rb
@@ -33,6 +33,18 @@ module RuboCop
           add_offense(node, location: :keyword,
                             message: format(MSG, keyword: node.keyword))
         end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            keyword = node.if? ? 'if' : 'unless'
+
+            corrector.replace(node, <<~RUBY.chop)
+              #{keyword} #{node.condition.source}
+              #{node.if_branch.source}
+              end
+            RUBY
+          end
+        end
       end
     end
   end

--- a/spec/rubocop/cop/style/if_unless_modifier_of_if_unless_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_of_if_unless_spec.rb
@@ -10,24 +10,67 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifierOfIfUnless do
       condition ? then_part : else_part unless external_condition
                                         ^^^^^^ Avoid modifier `unless` after another conditional.
     RUBY
+
+    expect_correction(<<~RUBY)
+      unless external_condition
+      condition ? then_part : else_part
+      end
+    RUBY
   end
 
   context 'ternary with modifier' do
-    it 'registers an offense' do
+    it 'registers an offense and corrects' do
       expect_offense(<<~RUBY)
         condition ? then_part : else_part unless external_condition
                                           ^^^^^^ Avoid modifier `unless` after another conditional.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        unless external_condition
+        condition ? then_part : else_part
+        end
       RUBY
     end
   end
 
   context 'conditional with modifier' do
-    it 'registers an offense' do
+    it 'registers an offense and corrects' do
       expect_offense(<<~RUBY)
         unless condition
           then_part
         end if external_condition
             ^^ Avoid modifier `if` after another conditional.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if external_condition
+        unless condition
+          then_part
+        end
+        end
+      RUBY
+    end
+  end
+
+  context '`unless` / `else` with modifier' do
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        unless condition
+          then_part
+        else
+          else_part
+        end if external_condition
+            ^^ Avoid modifier `if` after another conditional.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if external_condition
+        unless condition
+          then_part
+        else
+          else_part
+        end
+        end
       RUBY
     end
   end


### PR DESCRIPTION
This PR supports auto-correction for `Style/IfUnlessModifierOfIfUnless`.

From:

```ruby
condition ? then_part : else_part unless external_condition
```

To:

```ruby
unless external_condition
condition ? then_part : else_part
end
```

Branch indentation is left to `Layout/IndentationWidth` cop to keep the code simple.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
