### PR TITLE
Simplify logic for UncommunicativeName. 

### DIFF
--- a/lib/rubocop/cop/mixin/uncommunicative_name.rb
+++ b/lib/rubocop/cop/mixin/uncommunicative_name.rb
@@ -15,11 +15,13 @@ module RuboCop
         args.each do |arg|
           # Argument names might be "_" or prefixed with "_" to indicate they
           # are unused. Trim away this prefix and only analyse the basename.
-          full_name = arg.children.first.to_s
+          name_child = arg.children.first
+          next if name_child.nil?
+
+          full_name = name_child.to_s
           next if full_name == '_'
 
           name = full_name.gsub(/\A(_+)/, '')
-          next if (arg.restarg_type? || arg.kwrestarg_type?) && name.empty?
           next if allowed_names.include?(name)
 
           range = arg_range(arg, name.size)

--- a/lib/rubocop/cop/naming/method_parameter_name.rb
+++ b/lib/rubocop/cop/naming/method_parameter_name.rb
@@ -49,7 +49,7 @@ module RuboCop
         def on_def(node)
           return unless node.arguments?
 
-          check(node, node.arguments.reject(&:forward_args_type?))
+          check(node, node.arguments)
         end
         alias on_defs on_def
       end


### PR DESCRIPTION
If not having a name is a possible syntax, it is acceptable

Needed for https://github.com/rubocop-hq/rubocop-ast/pull/52