### PR TITLE
[Fix #8232] Fix a false positive for `Layout/EmptyLinesAroundAccessModifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#8242](https://github.com/rubocop-hq/rubocop/pull/8242): Internal profiling available with `bin/rubocop-profile` and rake tasks. ([@marcandre][])
 
+### Bug fixes
+
+* [#8232](https://github.com/rubocop-hq/rubocop/issues/8232): Fix a false positive for `Layout/EmptyLinesAroundAccessModifier` when `end` immediately after access modifier. ([@koic][])
+
 ## 0.87.1 (2020-07-07)
 
 ### Bug fixes

--- a/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
@@ -109,6 +109,7 @@ module RuboCop
 
         def allowed_only_before_style?(node)
           if node.special_modifier?
+            return true if processed_source[node.last_line] == 'end'
             return false if next_line_empty?(node.last_line)
           end
 

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -397,6 +397,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
           end
         RUBY
       end
+
+      it "does not register an offense when `end` immediately after #{access_modifier}" do
+        expect_no_offenses(<<~RUBY)
+          class Test
+            #{access_modifier}
+          end
+        RUBY
+      end
     end
 
     %w[public module_function].each do |access_modifier|


### PR DESCRIPTION
Fixes #8232.

This PR fixes a false positive and an incorrect auto-correct for `Layout/EmptyLinesAroundAccessModifier` when `end` immediately after access modifier.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
