### PR TITLE
Add new `AsciiConstants` option for `Naming/AsciiIdentifiers`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#7868](https://github.com/rubocop-hq/rubocop/pull/7868): `Cop::Base` is the new recommended base class for cops. ([@marcandre][])
+* [#7458](https://github.com/rubocop-hq/rubocop/issues/7458): Add new `AsciiConstants` option for `Naming/AsciiIdentifiers`. ([@fatkodima][])
 * [#8213](https://github.com/rubocop-hq/rubocop/pull/8213): Permit to specify TargetRubyVersion 2.8 (experimental). ([@koic][])
 * [#8164](https://github.com/rubocop-hq/rubocop/pull/8164): Support auto-correction for `Lint/InterpolationCheck`. ([@koic][])
 * [#8223](https://github.com/rubocop-hq/rubocop/pull/8223): Support auto-correction for `Style/IfUnlessModifierOfIfUnless`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2001,10 +2001,12 @@ Naming/AccessorMethodName:
   VersionAdded: '0.50'
 
 Naming/AsciiIdentifiers:
-  Description: 'Use only ascii symbols in identifiers.'
+  Description: 'Use only ascii symbols in identifiers and constants.'
   StyleGuide: '#english-identifiers'
   Enabled: true
   VersionAdded: '0.50'
+  VersionChanged: '0.87'
+  AsciiConstants: true
 
 Naming/BinaryOperatorParameterName:
   Description: 'When defining binary operators, name the argument other.'

--- a/docs/modules/ROOT/pages/cops_naming.adoc
+++ b/docs/modules/ROOT/pages/cops_naming.adoc
@@ -48,10 +48,12 @@ end
 | Yes
 | No
 | 0.50
-| -
+| 0.87
 |===
 
-This cop checks for non-ascii characters in identifier names.
+This cop checks for non-ascii characters in identifier and constant names.
+Identifiers are always checked and whether constants are checked
+can be controlled using AsciiConstants config.
 
 === Examples
 
@@ -85,6 +87,38 @@ params[:عرض_gteq] # Arabic character (non-ascii)
 # good
 params[:width_gteq]
 ----
+
+==== AsciiConstants: true (default)
+
+[source,ruby]
+----
+# bad
+class Foö
+end
+
+FOÖ = "foo"
+----
+
+==== AsciiConstants: false
+
+[source,ruby]
+----
+# good
+class Foö
+end
+
+FOÖ = "foo"
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AsciiConstants
+| `true`
+| Boolean
+|===
 
 === References
 

--- a/spec/rubocop/cop/naming/ascii_identifiers_spec.rb
+++ b/spec/rubocop/cop/naming/ascii_identifiers_spec.rb
@@ -1,34 +1,67 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Naming::AsciiIdentifiers do
-  subject(:cop) { described_class.new }
+RSpec.describe RuboCop::Cop::Naming::AsciiIdentifiers, :config do
+  subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense for a variable name with non-ascii chars' do
-    expect_offense(<<~RUBY)
-      älg = 1
-      ^ Use only ascii symbols in identifiers.
-    RUBY
+  shared_examples 'checks identifiers' do
+    it 'registers an offense for a variable name with non-ascii chars' do
+      expect_offense(<<~RUBY)
+        älg = 1
+        ^ Use only ascii symbols in identifiers.
+      RUBY
+    end
+
+    it 'registers an offense for a variable name with mixed chars' do
+      expect_offense(<<~RUBY)
+        foo∂∂bar = baz
+           ^^ Use only ascii symbols in identifiers.
+      RUBY
+    end
+
+    it 'accepts identifiers with only ascii chars' do
+      expect_no_offenses('x.empty?')
+    end
+
+    it 'does not get confused by a byte order mark' do
+      expect_no_offenses(<<~RUBY)
+        ﻿
+        puts 'foo'
+      RUBY
+    end
+
+    it 'does not get confused by an empty file' do
+      expect_no_offenses('')
+    end
   end
 
-  it 'registers an offense for a variable name with mixed chars' do
-    expect_offense(<<~RUBY)
-      foo∂∂bar = baz
-         ^^ Use only ascii symbols in identifiers.
-    RUBY
+  context 'when AsciiConstants is true' do
+    let(:cop_config) do
+      { 'AsciiConstants' => true }
+    end
+
+    include_examples 'checks identifiers'
+
+    it 'registers an offense for a constant name with non-ascii chars' do
+      expect_offense(<<~RUBY)
+        class Foö
+                ^ Use only ascii symbols in constants.
+        end
+      RUBY
+    end
   end
 
-  it 'accepts identifiers with only ascii chars' do
-    expect_no_offenses('x.empty?')
-  end
+  context 'when AsciiConstants is false' do
+    let(:cop_config) do
+      { 'AsciiConstants' => false }
+    end
 
-  it 'does not get confused by a byte order mark' do
-    expect_no_offenses(<<~RUBY)
-      ﻿
-      puts 'foo'
-    RUBY
-  end
+    include_examples 'checks identifiers'
 
-  it 'does not get confused by an empty file' do
-    expect_no_offenses('')
+    it 'accepts constants with only ascii chars' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Closes #7458 

Implementation as suggested in https://github.com/rubocop-hq/rubocop/pull/7459#issuecomment-546032027