### PR TITLE
Don't load exclusions from personal files when passing a config with a custom name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#8252](https://github.com/rubocop-hq/rubocop/issues/8252): Fix a command line option name from `--safe-autocorrect` to `--safe-auto-correct`, which is compatible with RuboCop 0.86 and lower. ([@koic][])
+* [#8239](https://github.com/rubocop-hq/rubocop/pull/8239): Don't load `.rubocop.yml` from personal folders to check for exclusions if given a custom configuration file. ([@deivid-rodriguez][])
 
 ## 0.87.0 (2020-07-06)
 

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -51,6 +51,10 @@ files:
 * `~/.config/rubocop/config.yml`
 * https://github.com/rubocop-hq/rubocop/blob/master/config/default.yml[RuboCop's default configuration]
 
+All the previous logic does not apply if a specific configuration file is passed
+on the command line through the `--config` flag. In that case, the resolved
+configuration file will be the one passed to the CLI.
+
 == Inheritance
 
 All configuration inherits from https://github.com/rubocop-hq/rubocop/blob/master/config/default.yml[RuboCop's default configuration] (See

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -119,7 +119,6 @@ module RuboCop
 
       def add_excludes_from_files(config, config_file)
         found_files = find_files_upwards(DOTFILE, config_file)
-        found_files = [find_user_dotfile, find_user_xdg_config].compact if found_files.empty?
 
         return if found_files.empty?
         return if PathUtil.relative_path(found_files.last) ==

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -170,6 +170,33 @@ RSpec.describe RuboCop::ConfigLoader do
       end
     end
 
+    context 'when configuration has a custom name' do
+      let(:file_path) { '.custom_rubocop.yml' }
+
+      before do
+        create_file(file_path, <<~YAML)
+          AllCops:
+            Exclude:
+              - vendor/**
+        YAML
+      end
+
+      context 'and there is a personal config file in the home folder' do
+        before do
+          create_file('~/.rubocop.yml', <<~YAML)
+            AllCops:
+              Exclude:
+                - tmp/**
+          YAML
+        end
+
+        it 'ignores personal AllCops/Exclude' do
+          excludes = configuration_from_file['AllCops']['Exclude']
+          expect(excludes).to eq([File.expand_path('vendor/**')])
+        end
+      end
+    end
+
     context 'when a parent file specifies DisabledByDefault: true' do
       let(:file_path) { '.rubocop.yml' }
 
@@ -965,7 +992,7 @@ RSpec.describe RuboCop::ConfigLoader do
     end
 
     context 'when a file inherits from a url inheriting from another file' do
-      let(:file_path) { '.robocop.yml' }
+      let(:file_path) { '.rubocop.yml' }
       let(:cache_file) { '.rubocop-http---example-com-rubocop-yml' }
       let(:cache_file_2) { '.rubocop-http---example-com-inherit-yml' }
 


### PR DESCRIPTION
If passing a configuration with a custom name, like `rubocop --config .my_custom_project_config.yml`, that configuration should act as the project configuration and we want personal configuration files disregarded.

That's actually the only case where `find_files_upwards` can return an empty list, because when given an existing `.rubocop.yml` as the starting point, it will at least return that file, and the fallback to personal config files will not be applied.

Well, there's another case where `find_files_upwards` could return an empty list, which is when giving it a non existent file as the starting point. However, I don't think that ever happens in real life, and in tests it was only happening once, and due to a typo I believe.

So, we can completely remove the explicit fallback to look for exclusions in personal configuration files.

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
