### PR TITLE
[Fix #8240] Improve documentation on path relativity

### DIFF
--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -330,6 +330,11 @@ configuration file is. In configuration files that don't begin with `.rubocop`,
 e.g. `our_company_defaults.yml`, paths are relative to the directory where
 `rubocop` is run.
 
+This affects cops that have customisable paths: if the default is `db/migrate/*.rb`,
+and the cop is enabled in `db/migrate/.rubocop.yml`, the path will need to be
+explicitly set as `*.rb`, as the default will look for `db/migrate/db/migrate/*.rb`.
+This is unlikely to be what you wanted.
+
 === Unusual files, that would not be included by default
 
 RuboCop comes with a comprehensive list of common ruby file names and


### PR DESCRIPTION
Clarify path relativity's effect on cops with customisable paths.

As shown in https://github.com/rubocop-hq/rubocop/issues/8240, cops that specify paths do not do what's initially expected when configured in subdirectories. Hopefully this will save somebody else a bit of time.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation. *(not sure if I need to do this for a doc change — sorry if I should have!)*

[1]: https://chris.beams.io/posts/git-commit/
