### PR TITLE
Bump RuboCop Performance to 1.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'bump', require: false
 gem 'pry'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
-gem 'rubocop-performance', '~> 1.6.0'
+gem 'rubocop-performance', '~> 1.7.0'
 gem 'rubocop-rspec', '~> 1.39.0'
 # Workaround for cc-test-reporter with SimpleCov 0.18.
 # Stop upgrading SimpleCov until the following issue will be resolved.

--- a/lib/rubocop/cop/style/redundant_regexp_escape.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_escape.rb
@@ -83,8 +83,8 @@ module RuboCop
 
         def delimiter?(node, char)
           delimiters = [
-            node.loc.begin.source.chars.last,
-            node.loc.end.source.chars.first
+            node.loc.begin.source[-1],
+            node.loc.end.source[0]
           ]
 
           delimiters.include?(char)


### PR DESCRIPTION
This PR bumps RuboCop Performance to 1.7.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
