### PR TITLE
[Fix #8252] Fix a typo for `--safe-auto-correct` command line option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#8252](https://github.com/rubocop-hq/rubocop/issues/8252): Fix a command line option name from `--safe-autocorrect` to `--safe-auto-correct`, which is compatible with RuboCop 0.66 and lower. ([@koic][])
+
 ## 0.87.0 (2020-07-06)
 
 ### New features

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -174,8 +174,8 @@ module RuboCop
       option(opts, '-a', '--auto-correct') do
         @options[:safe_auto_correct] = true
       end
-      option(opts, '--safe-autocorrect') do
-        warn '--safe-autocorrect is deprecated; use --autocorrect'
+      option(opts, '--safe-auto-correct') do
+        warn '--safe-auto-correct is deprecated; use --auto-correct'
         @options[:safe_auto_correct] = @options[:auto_correct] = true
       end
       option(opts, '-A', '--auto-correct-all') do
@@ -472,7 +472,7 @@ module RuboCop
       safe:                             'Run only safe cops.',
       list_target_files:                'List all files RuboCop will inspect.',
       auto_correct:                     'Auto-correct offenses (only when it\'s safe).',
-      safe_autocorrect:                 '(same, deprecated)',
+      safe_auto_correct:                '(same, deprecated)',
       auto_correct_all:                 'Auto-correct offenses (safe and unsafe)',
       fix_layout:                       'Run only layout cops, with auto-correct on.',
       color:                            'Force color output on or off.',

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
               -E, --extra-details              Display extra details in offense messages.
               -S, --display-style-guide        Display style guide URLs in offense messages.
               -a, --auto-correct               Auto-correct offenses (only when it's safe).
-                  --safe-autocorrect           (same, deprecated)
+                  --safe-auto-correct          (same, deprecated)
               -A, --auto-correct-all           Auto-correct offenses (safe and unsafe)
                   --disable-pending-cops       Run without pending cops.
                   --enable-pending-cops        Run with pending cops.
@@ -372,9 +372,9 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       end
     end
 
-    describe '--safe-autocorrect' do
+    describe '--safe-auto-correct' do
       it 'is a deprecated alias' do
-        expect { options.parse %w[--safe-autocorrect] }
+        expect { options.parse %w[--safe-auto-correct] }
           .to output(/deprecated/).to_stderr
       end
     end


### PR DESCRIPTION
Fixes #8252.

This PR fixes a command line option name from `--safe-autocorrect` to `--safe-auto-correct`, which is compatible with RuboCop 0.66 and lower.

Before:

```console
% bundle exec ./exe/rubocop --safe-auto-correct
invalid option: --safe-auto-correct
Did you mean?  safe-autocorrect
For usage information, use --help
```

After:

```console
% bundle exec ./exe/rubocop --safe-auto-correct
--safe-auto-correct is deprecated; use --auto-correct
Inspecting 1082 files
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
