### PR TITLE
Add expect_offense mark for offense on empty line

### DIFF
--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -89,6 +89,16 @@ module RuboCop
     #       end
     #     RUBY
     #   end
+    #
+    # If you need to specify an offense on a blank line, use the empty `^{}` marker:
+    #
+    # @example `^{}` empty line offense
+    #
+    #   expect_offense(<<~RUBY)
+    #
+    #     ^{} Missing frozen string literal comment.
+    #     puts 1
+    #   RUBY
     module ExpectOffense
       def format_offense(source, **replacements)
         replacements.each do |keyword, value|
@@ -177,7 +187,7 @@ module RuboCop
 
       # Parsed representation of code annotated with the `^^^ Message` style
       class AnnotatedSource
-        ANNOTATION_PATTERN = /\A\s*\^+ /.freeze
+        ANNOTATION_PATTERN = /\A\s*(\^+|\^{}) /.freeze
 
         # @param annotated_source [String] string passed to the matchers
         #
@@ -261,6 +271,7 @@ module RuboCop
             offenses.map do |offense|
               indent     = ' ' * offense.column
               carets     = '^' * offense.column_length
+              carets     = '^{}' if offense.column_length.zero?
 
               [offense.line, "#{indent}#{carets} #{offense.message}\n"]
             end

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -273,12 +273,9 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
     end
 
     it 'registers an offense for an extra first empty line' do
-      pending 'There is a flaw that skips adding caret symbol in this case, ' \
-              'making it impossible to use `expect_offense` matcher'
-
       expect_offense(<<~RUBY)
 
-        ^ Missing magic comment `# frozen_string_literal: true`.
+        ^{} Missing frozen string literal comment.
         puts 1
       RUBY
 
@@ -580,12 +577,9 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
     end
 
     it 'registers an offense for an extra first empty line' do
-      pending 'There is a flaw that skips adding caret symbol in this case, ' \
-              'making it impossible to use `expect_offense` matcher'
-
       expect_offense(<<~RUBY)
 
-        ^ Missing magic comment `# frozen_string_literal: true`.
+        ^{} Missing magic comment `# frozen_string_literal: true`.
         puts 1
       RUBY
 
@@ -854,14 +848,11 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for not having a frozen string literal comment ' \
        'under a shebang, an encoding comment, and extra space' do
-      pending 'There is a flaw that skips adding caret symbol in this case, ' \
-              'making it impossible to use `expect_offense` matcher'
-
       expect_offense(<<~RUBY)
         #!/usr/bin/env ruby
+        ^ Missing magic comment `# frozen_string_literal: true`.
         # encoding: utf-8
 
-        ^ Missing magic comment `# frozen_string_literal: true`.
         puts 1
       RUBY
 
@@ -927,13 +918,10 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for not having a frozen string literal comment ' \
        'under an encoding comment and extra space' do
-      pending 'There is a flaw that skips adding caret symbol in this case, ' \
-              'making it impossible to use `expect_offense` matcher'
-
       expect_offense(<<~RUBY)
         # encoding: utf-8
-
         ^ Missing magic comment `# frozen_string_literal: true`.
+
         puts 1
       RUBY
 


### PR DESCRIPTION
Part of #8003

Use `^{}` to denote an offense at an empty line in `expect_offense`. This format was suggested by @marcandre in [Issue 8003 comment](https://github.com/rubocop-hq/rubocop/issues/8003#issuecomment-641567272). I think it has the advantage of familiarity with existing `^` and `^{name}` syntax.

Example:

```ruby
expect_offense(<<~RUBY)

  ^{} Missing frozen string literal comment.
  puts 1
RUBY
```

I have enabled pending frozen string literal specs as coverage for this change.

Also corrected which line the offense is added to in the frozen string literal
specs (always the first line). As the first line is non-empty in some of these
cases, a normal caret `^` is used to mark the offense.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/