### PR TITLE
Fix an error for `Style/BisectedAttrAccessor` when using `attr_reader` and `attr_writer` with splat arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#8252](https://github.com/rubocop-hq/rubocop/issues/8252): Fix a command line option name from `--safe-autocorrect` to `--safe-auto-correct`, which is compatible with RuboCop 0.86 and lower. ([@koic][])
+* [#8257](https://github.com/rubocop-hq/rubocop/issues/8257): Fix an error for `Style/BisectedAttrAccessor` when using `attr_reader` and `attr_writer` with splat arguments. ([@fatkodima][])
 * [#8239](https://github.com/rubocop-hq/rubocop/pull/8239): Don't load `.rubocop.yml` from personal folders to check for exclusions if given a custom configuration file. ([@deivid-rodriguez][])
 * [#8256](https://github.com/rubocop-hq/rubocop/issues/8256): Fix an error for `--auto-gen-config` when running a cop who do not support auto-correction. ([@koic][])
 

--- a/spec/rubocop/cop/style/bisected_attr_accessor_spec.rb
+++ b/spec/rubocop/cop/style/bisected_attr_accessor_spec.rb
@@ -43,12 +43,34 @@ RSpec.describe RuboCop::Cop::Style::BisectedAttrAccessor do
     RUBY
   end
 
+  it 'registers an offense and corrects when both accessors of the splat exists' do
+    expect_offense(<<~RUBY)
+      class Foo
+        ATTRIBUTES = %i[foo bar]
+        attr_reader *ATTRIBUTES
+                    ^^^^^^^^^^^ Combine both accessors into `attr_accessor *ATTRIBUTES`.
+        attr_writer *ATTRIBUTES
+                    ^^^^^^^^^^^ Combine both accessors into `attr_accessor *ATTRIBUTES`.
+        other_macro :something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo
+        ATTRIBUTES = %i[foo bar]
+        attr_accessor *ATTRIBUTES
+        
+        other_macro :something
+      end
+    RUBY
+  end
+
   it 'registers an offense and corrects when both accessors of the name exists and accessor contains multiple names' do
     expect_offense(<<~RUBY)
       class Foo
         attr_reader :baz, :bar, :quux
                           ^^^^ Combine both accessors into `attr_accessor :bar`.
-        attr_writer :bar
+        attr_writer :bar, :zoo
                     ^^^^ Combine both accessors into `attr_accessor :bar`.
         other_macro :something
       end
@@ -58,7 +80,7 @@ RSpec.describe RuboCop::Cop::Style::BisectedAttrAccessor do
       class Foo
         attr_accessor :bar
         attr_reader :baz, :quux
-        
+        attr_writer :zoo
         other_macro :something
       end
     RUBY


### PR DESCRIPTION
Closes #8257 