### PR TITLE
Fix Lint/DeprecatedOpenSSLConstant auto-correction of OpenSSL::Cipher to use lower case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#8257](https://github.com/rubocop-hq/rubocop/issues/8257): Fix an error for `Style/BisectedAttrAccessor` when using `attr_reader` and `attr_writer` with splat arguments. ([@fatkodima][])
 * [#8239](https://github.com/rubocop-hq/rubocop/pull/8239): Don't load `.rubocop.yml` from personal folders to check for exclusions if given a custom configuration file. ([@deivid-rodriguez][])
 * [#8256](https://github.com/rubocop-hq/rubocop/issues/8256): Fix an error for `--auto-gen-config` when running a cop who do not support auto-correction. ([@koic][])
+* [#8262](https://github.com/rubocop-hq/rubocop/pull/8262): Fix `Lint/DeprecatedOpenSSLConstant` auto-correction of `OpenSSL::Cipher` to use lower case, as some Linux-based systems do not accept upper cased cipher names. ([@bdewater][])
 
 ## 0.87.0 (2020-07-06)
 

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -507,7 +507,7 @@ instead.
 OpenSSL::Cipher::AES.new(128, :GCM)
 
 # good
-OpenSSL::Cipher.new('AES-128-GCM')
+OpenSSL::Cipher.new('aes-128-gcm')
 ----
 
 [source,ruby]

--- a/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
+++ b/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
@@ -15,7 +15,7 @@ module RuboCop
       #   OpenSSL::Cipher::AES.new(128, :GCM)
       #
       #   # good
-      #   OpenSSL::Cipher.new('AES-128-GCM')
+      #   OpenSSL::Cipher.new('aes-128-gcm')
       #
       # @example
       #
@@ -127,9 +127,9 @@ module RuboCop
         end
 
         def build_cipher_arguments(node, algorithm_name)
-          algorithm_parts = algorithm_name.split('-')
-          size_and_mode = sanitize_arguments(node.arguments)
-          "'#{(algorithm_parts + size_and_mode + ['CBC']).take(3).join('-')}'"
+          algorithm_parts = algorithm_name.downcase.split('-')
+          size_and_mode = sanitize_arguments(node.arguments).map(&:downcase)
+          "'#{(algorithm_parts + size_and_mode + ['cbc']).take(3).join('-')}'"
         end
       end
     end

--- a/spec/rubocop/cop/lint/deprecated_open_ssl_constant_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_open_ssl_constant_spec.rb
@@ -8,61 +8,61 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedOpenSSLConstant do
   it 'registers an offense with cipher constant and two arguments and corrects' do
     expect_offense(<<~RUBY)
       OpenSSL::Cipher::AES.new(128, :GCM)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `OpenSSL::Cipher.new('AES-128-GCM')` instead of `OpenSSL::Cipher::AES.new(128, :GCM)`.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `OpenSSL::Cipher.new('aes-128-gcm')` instead of `OpenSSL::Cipher::AES.new(128, :GCM)`.
     RUBY
 
     expect_correction(<<~RUBY)
-      OpenSSL::Cipher.new('AES-128-GCM')
+      OpenSSL::Cipher.new('aes-128-gcm')
     RUBY
   end
 
   it 'registers an offense with cipher constant and one argument and corrects' do
     expect_offense(<<~RUBY)
       OpenSSL::Cipher::AES.new('128-GCM')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `OpenSSL::Cipher.new('AES-128-GCM')` instead of `OpenSSL::Cipher::AES.new('128-GCM')`.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `OpenSSL::Cipher.new('aes-128-gcm')` instead of `OpenSSL::Cipher::AES.new('128-GCM')`.
     RUBY
 
     expect_correction(<<~RUBY)
-      OpenSSL::Cipher.new('AES-128-GCM')
+      OpenSSL::Cipher.new('aes-128-gcm')
     RUBY
   end
 
   it 'registers an offense with cipher constant and double quoted string argument and corrects' do
     expect_offense(<<~RUBY)
       OpenSSL::Cipher::AES128.new("GCM")
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `OpenSSL::Cipher.new('AES-128-GCM')` instead of `OpenSSL::Cipher::AES128.new("GCM")`.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `OpenSSL::Cipher.new('aes-128-gcm')` instead of `OpenSSL::Cipher::AES128.new("GCM")`.
     RUBY
 
     expect_correction(<<~RUBY)
-      OpenSSL::Cipher.new('AES-128-GCM')
+      OpenSSL::Cipher.new('aes-128-gcm')
     RUBY
   end
 
   it 'registers an offense with AES + blocksize constant and mode argument and corrects' do
     expect_offense(<<~RUBY)
       OpenSSL::Cipher::AES128.new(:GCM)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `OpenSSL::Cipher.new('AES-128-GCM')` instead of `OpenSSL::Cipher::AES128.new(:GCM)`.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `OpenSSL::Cipher.new('aes-128-gcm')` instead of `OpenSSL::Cipher::AES128.new(:GCM)`.
     RUBY
 
     expect_correction(<<~RUBY)
-      OpenSSL::Cipher.new('AES-128-GCM')
+      OpenSSL::Cipher.new('aes-128-gcm')
     RUBY
   end
 
   it 'registers an offense with AES + blocksize constant and corrects' do
     expect_offense(<<~RUBY)
       OpenSSL::Cipher::AES128.new
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `OpenSSL::Cipher.new('AES-128-CBC')` instead of `OpenSSL::Cipher::AES128.new`.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `OpenSSL::Cipher.new('aes-128-cbc')` instead of `OpenSSL::Cipher::AES128.new`.
     RUBY
 
     expect_correction(<<~RUBY)
-      OpenSSL::Cipher.new('AES-128-CBC')
+      OpenSSL::Cipher.new('aes-128-cbc')
     RUBY
   end
 
   it 'does not register an offense when using cipher with a string' do
     expect_no_offenses(<<~RUBY)
-      OpenSSL::Cipher.new('AES-128-GCM')
+      OpenSSL::Cipher.new('aes-128-gcm')
     RUBY
   end
 


### PR DESCRIPTION
Testing on some Linux-based CI systems revealed the upper case cipher name is not always accepted, but lower case always is. I didn't ran into this when developing https://github.com/rubocop-hq/rubocop/pull/7950 

Example output on a random VM:
```
user@app1:~$ cat /etc/issue
Ubuntu 16.04.3 LTS \n \l
user@app1:~$ ruby --version
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-linux]
user@app1:~$ irb
irb(main):001:0> require 'openssl'
=> true
irb(main):002:0> OpenSSL::Cipher.new('AES-256-GCM')
RuntimeError: unsupported cipher algorithm (AES-256-GCM)
	from (irb):2:in `initialize'
	from (irb):2:in `new'
	from (irb):2
	from /home/deploy/.rbenv/versions/2.3.1/bin/irb:11:in `<main>'
irb(main):003:0> OpenSSL::Cipher.new('aes-256-gcm')
=> #<OpenSSL::Cipher:0x00560ce9b75470>
```



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
