### PR TITLE
Small file finding refactor

### DIFF
--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -118,14 +118,14 @@ module RuboCop
       end
 
       def add_excludes_from_files(config, config_file)
-        found_files = find_files_upwards(DOTFILE, config_file)
+        exclusion_file = find_last_file_upwards(DOTFILE, config_file)
 
-        return if found_files.empty?
-        return if PathUtil.relative_path(found_files.last) ==
+        return if exclusion_file.nil?
+        return if PathUtil.relative_path(exclusion_file) ==
                   PathUtil.relative_path(config_file)
 
         print 'AllCops/Exclude ' if debug?
-        config.add_excludes_from_higher_level(load_file(found_files.last))
+        config.add_excludes_from_higher_level(load_file(exclusion_file))
       end
 
       def default_configuration

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -121,8 +121,7 @@ module RuboCop
         exclusion_file = find_last_file_upwards(DOTFILE, config_file)
 
         return unless exclusion_file
-        return if PathUtil.relative_path(exclusion_file) ==
-                  PathUtil.relative_path(config_file)
+        return if PathUtil.relative_path(exclusion_file) == PathUtil.relative_path(config_file)
 
         print 'AllCops/Exclude ' if debug?
         config.add_excludes_from_higher_level(load_file(exclusion_file))

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -120,7 +120,7 @@ module RuboCop
       def add_excludes_from_files(config, config_file)
         exclusion_file = find_last_file_upwards(DOTFILE, config_file)
 
-        return if exclusion_file.nil?
+        return unless exclusion_file
         return if PathUtil.relative_path(exclusion_file) ==
                   PathUtil.relative_path(config_file)
 

--- a/lib/rubocop/file_finder.rb
+++ b/lib/rubocop/file_finder.rb
@@ -20,12 +20,12 @@ module RuboCop
       end
     end
 
-    def find_files_upwards(filename, start_dir)
+    def find_last_file_upwards(filename, start_dir)
       files = []
       traverse_files_upwards(filename, start_dir) do |file|
         files << file
       end
-      files
+      files.last
     end
 
     private

--- a/lib/rubocop/file_finder.rb
+++ b/lib/rubocop/file_finder.rb
@@ -21,11 +21,11 @@ module RuboCop
     end
 
     def find_last_file_upwards(filename, start_dir)
-      files = []
+      last_file = nil
       traverse_files_upwards(filename, start_dir) do |file|
-        files << file
+        last_file = file
       end
-      files.last
+      last_file
     end
 
     private

--- a/spec/rubocop/file_finder_spec.rb
+++ b/spec/rubocop/file_finder_spec.rb
@@ -23,15 +23,14 @@ RSpec.describe RuboCop::FileFinder, :isolated_environment do
     end
   end
 
-  describe '#find_files_upwards' do
-    it 'returns an array of files to be found upwards' do
-      expect(finder.find_files_upwards('file', 'dir'))
-        .to eq([File.expand_path('file', 'dir'),
-                File.expand_path('file')])
+  describe '#find_last_file_upwards' do
+    it 'returns the last file found upwards' do
+      expect(finder.find_last_file_upwards('file', 'dir'))
+        .to eq(File.expand_path('file'))
     end
 
-    it 'returns an empty array when file is not found' do
-      expect(finder.find_files_upwards('xyz', 'dir')).to eq([])
+    it 'returns nil when file is not found' do
+      expect(finder.find_last_file_upwards('xyz', 'dir')).to be(nil)
     end
   end
 end


### PR DESCRIPTION
The `find_files_upwards` is only used to find the _last_ file upwards. So I replaced it with `find_last_file_upwards`.

It makes the code easier to understand and the new method will be useful for fixing a bug I plan to get to later.

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
