### PR TITLE
Remove unnecessary logic from MissingElse

### DIFF
--- a/lib/rubocop/cop/style/missing_else.rb
+++ b/lib/rubocop/cop/style/missing_else.rb
@@ -119,17 +119,7 @@ module RuboCop
         private
 
         def check(node)
-          return if node.else?
-
-          if empty_else_cop_enabled?
-            if empty_else_style == :empty
-              add_offense(node)
-            elsif empty_else_style == :nil
-              add_offense(node)
-            end
-          end
-
-          add_offense(node)
+          add_offense(node) unless node.else?
         end
 
         def message(node)


### PR DESCRIPTION
Some years ago, the logic for generating the `message` was extracted to a method, leaving a couple of unnecessary lines behind. See b11ef7741f38b7c23761695f5b3bcb7a0219dfeb.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
