### PR TITLE
[Fixes #8273] Fix false positive for Style/WhileUntilModifier.

### DIFF
--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -17,9 +17,9 @@ module RuboCop
       end
 
       def non_eligible_node?(node)
-        node.nonempty_line_count > 3 ||
-          !node.modifier_form? &&
-            processed_source.commented?(node.loc.end)
+        node.modifier_form? ||
+          node.nonempty_line_count > 3 ||
+          processed_source.commented?(node.loc.end)
       end
 
       def non_eligible_body?(body)

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -45,7 +45,7 @@ module RuboCop
                               gvasgn ivasgn masgn].freeze
 
         def on_if(node)
-          msg = if eligible_node?(node)
+          msg = if single_line_as_modifier?(node)
                   MSG_USE_MODIFIER unless named_capture_in_condition?(node)
                 elsif too_long_due_to_modifier?(node)
                   MSG_USE_NORMAL
@@ -125,13 +125,15 @@ module RuboCop
           node.condition.match_with_lvasgn_type?
         end
 
-        def eligible_node?(node)
-          !non_eligible_if?(node) && !node.chained? &&
-            !node.nested_conditional? && single_line_as_modifier?(node)
+        def non_eligible_node?(node)
+          non_simple_if_unless?(node) ||
+            node.chained? ||
+            node.nested_conditional? ||
+            super
         end
 
-        def non_eligible_if?(node)
-          node.ternary? || node.modifier_form? || node.elsif? || node.else?
+        def non_simple_if_unless?(node)
+          node.ternary? || node.elsif? || node.else?
         end
 
         def another_statement_on_same_line?(node)

--- a/spec/rubocop/cop/style/while_until_modifier_spec.rb
+++ b/spec/rubocop/cop/style/while_until_modifier_spec.rb
@@ -3,15 +3,4 @@
 RSpec.describe RuboCop::Cop::Style::WhileUntilModifier, :config do
   it_behaves_like 'condition modifier cop', :while
   it_behaves_like 'condition modifier cop', :until
-
-  # Regression: https://github.com/rubocop-hq/rubocop/issues/4006
-  context 'when the modifier condition is multiline' do
-    it 'registers an offense' do
-      expect_offense(<<~RUBY)
-        foo while bar ||
-            ^^^^^ Favor modifier `while` usage when having a single-line body.
-          baz
-      RUBY
-    end
-  end
 end

--- a/spec/support/condition_modifier_cop.rb
+++ b/spec/support/condition_modifier_cop.rb
@@ -79,5 +79,15 @@ RSpec.shared_examples 'condition modifier cop' do |keyword, extra_message = nil|
         x = 0 #{keyword} true
       RUBY
     end
+
+    # See: https://github.com/rubocop-hq/rubocop/issues/8273
+    context 'accepts multiline condition in modifier form' do
+      it 'registers an offense' do
+        expect_no_offenses(<<~RUBY)
+          foo #{keyword} bar ||
+                         baz
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
While `IfUnless` had the right logic, `WhileUntil` did not.

This contradicts the test for #4010 which I believe was incorrect.