### PR TITLE
Refactor spec use expect_correction in Lint cops

### DIFF
--- a/spec/rubocop/cop/lint/empty_when_spec.rb
+++ b/spec/rubocop/cop/lint/empty_when_spec.rb
@@ -1,164 +1,187 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::EmptyWhen, :config do
-  shared_examples 'code with offense' do |code|
-    context "when checking #{code}" do
-      it 'registers an offense' do
-        expect_offense(code)
-        expect_no_corrections
-      end
-    end
-  end
-
-  shared_examples 'code without offense' do |code|
-    it 'does not register an offense' do
-      expect_no_offenses(code)
-    end
-  end
-
   let(:cop_config) { { 'AllowComments' => false } }
 
   context 'when a `when` body is missing' do
-    it_behaves_like 'code with offense', <<~RUBY
-      case foo
-      when :bar then 1
-      when :baz # nothing
-      ^^^^^^^^^ Avoid `when` branches without a body.
-      end
-    RUBY
+    it 'registers an offense for a missing when body' do
+      expect_offense(<<~RUBY)
+        case foo
+        when :bar then 1
+        when :baz # nothing
+        ^^^^^^^^^ Avoid `when` branches without a body.
+        end
+      RUBY
+      expect_no_corrections
+    end
 
-    it_behaves_like 'code with offense', <<~RUBY
-      case foo
-      when :bar then 1
-      when :baz # nothing
-      ^^^^^^^^^ Avoid `when` branches without a body.
-      else 3
-      end
-    RUBY
+    it 'registers an offense for missing when body followed by else' do
+      expect_offense(<<~RUBY)
+        case foo
+        when :bar then 1
+        when :baz # nothing
+        ^^^^^^^^^ Avoid `when` branches without a body.
+        else 3
+        end
+      RUBY
+      expect_no_corrections
+    end
 
-    it_behaves_like 'code with offense', <<~RUBY
-      case foo
-      when :bar then 1
-      when :baz then # nothing
-      ^^^^^^^^^ Avoid `when` branches without a body.
-      end
-    RUBY
+    it 'registers an offense for missing when ... then body' do
+      expect_offense(<<~RUBY)
+        case foo
+        when :bar then 1
+        when :baz then # nothing
+        ^^^^^^^^^ Avoid `when` branches without a body.
+        end
+      RUBY
+      expect_no_corrections
+    end
 
-    it_behaves_like 'code with offense', <<~RUBY
-      case foo
-      when :bar then 1
-      when :baz then # nothing
-      ^^^^^^^^^ Avoid `when` branches without a body.
-      else 3
-      end
-    RUBY
+    it 'registers an offense for missing when ... then body followed by else' do
+      expect_offense(<<~RUBY)
+        case foo
+        when :bar then 1
+        when :baz then # nothing
+        ^^^^^^^^^ Avoid `when` branches without a body.
+        else 3
+        end
+      RUBY
+      expect_no_corrections
+    end
 
-    it_behaves_like 'code with offense', <<~RUBY
-      case foo
-      when :bar
-        1
-      when :baz
-      ^^^^^^^^^ Avoid `when` branches without a body.
-        # nothing
-      end
-    RUBY
+    it 'registers an offense for missing when body with a comment' do
+      expect_offense(<<~RUBY)
+        case foo
+        when :bar
+          1
+        when :baz
+        ^^^^^^^^^ Avoid `when` branches without a body.
+          # nothing
+        end
+      RUBY
+      expect_no_corrections
+    end
 
-    it_behaves_like 'code with offense', <<~RUBY
-      case foo
-      when :bar
-        1
-      when :baz
-      ^^^^^^^^^ Avoid `when` branches without a body.
-        # nothing
-      else
-        3
-      end
-    RUBY
+    it 'registers an offense for missing when body with a comment ' \
+       'followed by else' do
+      expect_offense(<<~RUBY)
+        case foo
+        when :bar
+          1
+        when :baz
+        ^^^^^^^^^ Avoid `when` branches without a body.
+          # nothing
+        else
+          3
+        end
+      RUBY
+      expect_no_corrections
+    end
 
-    it_behaves_like 'code with offense', <<~RUBY
-      case
-      when :bar
-        1
-      when :baz
-      ^^^^^^^^^ Avoid `when` branches without a body.
-        # nothing
-      else
-        3
-      end
-    RUBY
+    it 'registers an offense when case line has no expression' do
+      expect_offense(<<~RUBY)
+        case
+        when :bar
+          1
+        when :baz
+        ^^^^^^^^^ Avoid `when` branches without a body.
+          # nothing
+        else
+          3
+        end
+      RUBY
+      expect_no_corrections
+    end
   end
 
   context 'when a `when` body is present' do
-    it_behaves_like 'code without offense', <<~RUBY
-      case foo
-      when :bar then 1
-      when :baz then 2
-      end
-    RUBY
+    it 'accepts case with when ... then statements' do
+      expect_no_offenses(<<~RUBY)
+        case foo
+        when :bar then 1
+        when :baz then 2
+        end
+      RUBY
+    end
 
-    it_behaves_like 'code without offense', <<~RUBY
-      case foo
-      when :bar then 1
-      when :baz then 2
-      else 3
-      end
-    RUBY
+    it 'accepts case with when ... then statements and else clause' do
+      expect_no_offenses(<<~RUBY)
+        case foo
+        when :bar then 1
+        when :baz then 2
+        else 3
+        end
+      RUBY
+    end
 
-    it_behaves_like 'code without offense', <<~RUBY
-      case foo
-      when :bar
-        1
-      when :baz
-        2
-      end
-    RUBY
+    it 'accepts case with when bodies' do
+      expect_no_offenses(<<~RUBY)
+        case foo
+        when :bar
+          1
+        when :baz
+          2
+        end
+      RUBY
+    end
 
-    it_behaves_like 'code without offense', <<~RUBY
-      case foo
-      when :bar
-        1
-      when :baz
-        2
-      else
-        3
-      end
-    RUBY
-    it_behaves_like 'code without offense', <<~RUBY
-      case
-      when :bar
-        1
-      when :baz
-        2
-      else
-        3
-      end
-    RUBY
+    it 'accepts case with when bodies and else clause' do
+      expect_no_offenses(<<~RUBY)
+        case foo
+        when :bar
+          1
+        when :baz
+          2
+        else
+          3
+        end
+      RUBY
+    end
+
+    it 'accepts with no case line expression' do
+      expect_no_offenses(<<~RUBY)
+        case
+        when :bar
+          1
+        when :baz
+          2
+        else
+          3
+        end
+      RUBY
+    end
   end
 
   context 'when `AllowComments: true`' do
     let(:cop_config) { { 'AllowComments' => true } }
 
-    it_behaves_like 'code without offense', <<~RUBY
-      case condition
-      when foo
-        do_something
-      when bar
-        # do nothing
-      end
-    RUBY
+    it 'accepts an empty when body with a comment' do
+      expect_no_offenses(<<~RUBY)
+        case condition
+        when foo
+          do_something
+        when bar
+          # do nothing
+        end
+      RUBY
+    end
   end
 
   context 'when `AllowComments: false`' do
     let(:cop_config) { { 'AllowComments' => false } }
 
-    it_behaves_like 'code with offense', <<~RUBY
-      case condition
-      when foo
-        do_something
-      when bar
-      ^^^^^^^^ Avoid `when` branches without a body.
-        # do nothing
-      end
-    RUBY
+    it 'registers an offense for empty when body with a comment' do
+      expect_offense(<<~RUBY)
+        case condition
+        when foo
+          do_something
+        when bar
+        ^^^^^^^^ Avoid `when` branches without a body.
+          # do nothing
+        end
+      RUBY
+      expect_no_corrections
+    end
   end
 end

--- a/spec/rubocop/cop/lint/empty_when_spec.rb
+++ b/spec/rubocop/cop/lint/empty_when_spec.rb
@@ -1,48 +1,29 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::EmptyWhen, :config do
-  before do
-    inspect_source(source)
-  end
-
-  shared_examples 'code with offense' do |code, expected = nil|
+  shared_examples 'code with offense' do |code|
     context "when checking #{code}" do
-      let(:source) { code }
-
       it 'registers an offense' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages).to eq([message])
-      end
-
-      if expected
-        it 'auto-corrects' do
-          expect(autocorrect_source(code)).to eq(expected)
-        end
-      else
-        it 'does not auto-correct' do
-          expect(autocorrect_source(code)).to eq(code)
-        end
+        expect_offense(code)
+        expect_no_corrections
       end
     end
   end
 
   shared_examples 'code without offense' do |code|
-    let(:source) { code }
-
     it 'does not register an offense' do
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses(code)
     end
   end
 
   let(:cop_config) { { 'AllowComments' => false } }
-
-  let(:message) { 'Avoid `when` branches without a body.' }
 
   context 'when a `when` body is missing' do
     it_behaves_like 'code with offense', <<~RUBY
       case foo
       when :bar then 1
       when :baz # nothing
+      ^^^^^^^^^ Avoid `when` branches without a body.
       end
     RUBY
 
@@ -50,6 +31,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyWhen, :config do
       case foo
       when :bar then 1
       when :baz # nothing
+      ^^^^^^^^^ Avoid `when` branches without a body.
       else 3
       end
     RUBY
@@ -58,6 +40,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyWhen, :config do
       case foo
       when :bar then 1
       when :baz then # nothing
+      ^^^^^^^^^ Avoid `when` branches without a body.
       end
     RUBY
 
@@ -65,6 +48,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyWhen, :config do
       case foo
       when :bar then 1
       when :baz then # nothing
+      ^^^^^^^^^ Avoid `when` branches without a body.
       else 3
       end
     RUBY
@@ -74,6 +58,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyWhen, :config do
       when :bar
         1
       when :baz
+      ^^^^^^^^^ Avoid `when` branches without a body.
         # nothing
       end
     RUBY
@@ -83,6 +68,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyWhen, :config do
       when :bar
         1
       when :baz
+      ^^^^^^^^^ Avoid `when` branches without a body.
         # nothing
       else
         3
@@ -94,6 +80,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyWhen, :config do
       when :bar
         1
       when :baz
+      ^^^^^^^^^ Avoid `when` branches without a body.
         # nothing
       else
         3
@@ -169,6 +156,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyWhen, :config do
       when foo
         do_something
       when bar
+      ^^^^^^^^ Avoid `when` branches without a body.
         # do nothing
       end
     RUBY

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -20,54 +20,69 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
   end
 
   shared_examples 'literal interpolation' do |literal, expected = literal|
-    it "registers an offense for #{literal} in interpolation" do
-      inspect_source(%("this is the \#{#{literal}}"))
-      expect(cop.offenses.size).to eq(1)
-    end
-
-    it "has #{literal} as the message highlight" do
-      inspect_source(%("this is the \#{#{literal}}"))
-      expect(cop.highlights).to eq([literal.to_s])
-    end
-
-    it "removes interpolation around #{literal}" do
-      corrected = autocorrect_source(%("this is the \#{#{literal}}"))
-      expect(corrected).to eq(%("this is the #{expected}"))
+    it "registers an offense for #{literal} in interpolation " \
+       'and removes interpolation around it' do
+      expect_offense(<<~'RUBY', literal: literal)
+        "this is the #{%{literal}}"
+                       ^{literal} Literal interpolation detected.
+      RUBY
+      expect_correction(<<~RUBY)
+        "this is the #{expected}"
+      RUBY
     end
 
     it "removes interpolation around #{literal} when there is more text" do
-      corrected =
-        autocorrect_source(%("this is the \#{#{literal}} literally"))
-      expect(corrected).to eq(%("this is the #{expected} literally"))
+      expect_offense(<<~'RUBY', literal: literal)
+        "this is the #{%{literal}} literally"
+                       ^{literal} Literal interpolation detected.
+      RUBY
+      expect_correction(<<~RUBY)
+        "this is the #{expected} literally"
+      RUBY
     end
 
     it "removes interpolation around multiple #{literal}" do
-      corrected =
-        autocorrect_source(%("some \#{#{literal}} with \#{#{literal}} too"))
-      expect(corrected).to eq(%("some #{expected} with #{expected} too"))
+      expect_offense(<<~'RUBY', literal: literal)
+        "some #{%{literal}} with #{%{literal}} too"
+                ^{literal} Literal interpolation detected.
+                _{literal}         ^{literal} Literal interpolation detected.
+      RUBY
+      expect_correction(<<~RUBY)
+        "some #{expected} with #{expected} too"
+      RUBY
     end
 
     context 'when there is non-literal and literal interpolation' do
       context 'when literal interpolation is before non-literal' do
-        it 'only remove interpolation around literal' do
-          corrected =
-            autocorrect_source(%("this is \#{#{literal}} with \#{a} now"))
-          expect(corrected).to eq(%("this is #{expected} with \#{a} now"))
+        it 'only removes interpolation around literal' do
+          expect_offense(<<~'RUBY', literal: literal)
+            "this is #{%{literal}} with #{a} now"
+                       ^{literal} Literal interpolation detected.
+          RUBY
+          expect_correction(<<~RUBY)
+            "this is #{expected} with \#{a} now"
+          RUBY
         end
       end
 
       context 'when literal interpolation is after non-literal' do
-        it 'only remove interpolation around literal' do
-          corrected =
-            autocorrect_source(%("this is \#{a} with \#{#{literal}} now"))
-          expect(corrected).to eq(%("this is \#{a} with #{expected} now"))
+        it 'only removes interpolation around literal' do
+          expect_offense(<<~'RUBY', literal: literal)
+            "this is #{a} with #{%{literal}} now"
+                                 ^{literal} Literal interpolation detected.
+          RUBY
+          expect_correction(<<~RUBY)
+            "this is \#{a} with #{expected} now"
+          RUBY
         end
       end
     end
 
     it "registers an offense only for final #{literal} in interpolation" do
-      inspect_source(%("this is the \#{#{literal};#{literal}}"))
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<~'RUBY', literal: literal)
+        "this is the #{%{literal};%{literal}}"
+                       _{literal} ^{literal} Literal interpolation detected.
+      RUBY
     end
   end
 
@@ -99,9 +114,14 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
   it_behaves_like('literal interpolation', '%i[ s1   s2 ]', '[\"s1\", \"s2\"]')
 
   it 'handles nested interpolations when auto-correction' do
-    corrected = autocorrect_source(%("this is \#{"\#{1}"} silly"))
+    expect_offense(<<~'RUBY')
+      "this is #{"#{1}"} silly"
+                    ^ Literal interpolation detected.
+    RUBY
     # next iteration fixes this
-    expect(corrected).to eq %("this is \#{"1"} silly")
+    expect_correction(<<~'RUBY', loop: false)
+      "this is #{"1"} silly"
+    RUBY
   end
 
   shared_examples 'special keywords' do |keyword|
@@ -111,20 +131,14 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
       RUBY
     end
 
-    it "does not try to autocorrect strings like #{keyword}" do
-      corrected = autocorrect_source(%("this is the \#{#{keyword}} silly"))
-
-      expect(corrected).to eq(%("this is the \#{#{keyword}} silly"))
-    end
-
-    it "registers an offense for interpolation after #{keyword}" do
-      inspect_source(%("this is the \#{#{keyword}} \#{1}"))
-      expect(cop.offenses.size).to eq(1)
-    end
-
-    it "auto-corrects literal interpolation after #{keyword}" do
-      corrected = autocorrect_source(%("this is the \#{#{keyword}} \#{1}"))
-      expect(corrected).to eq(%("this is the \#{#{keyword}} 1"))
+    it "registers an offense and autocorrects interpolation after #{keyword}" do
+      expect_offense(<<~'RUBY', keyword: keyword)
+        "this is the #{%{keyword}} #{1}"
+                       _{keyword}    ^ Literal interpolation detected.
+      RUBY
+      expect_correction(<<~RUBY)
+        "this is the \#{#{keyword}} 1"
+      RUBY
     end
   end
 
@@ -134,19 +148,16 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
   it_behaves_like('special keywords', '__ENCODING__')
 
   shared_examples 'non-special string literal interpolation' do |string|
-    it "registers an offense for #{string}" do
-      inspect_source(%("this is the \#{#{string}}"))
-      expect(cop.offenses.size).to eq(1)
-    end
+    it "registers an offense for #{string} and removes the interpolation " \
+       "and quotes around #{string}" do
+      expect_offense(<<~'RUBY', string: string)
+        "this is the #{%{string}}"
+                       ^{string} Literal interpolation detected.
+      RUBY
 
-    it "has #{string} in the message highlight" do
-      inspect_source(%("this is the \#{#{string}}"))
-      expect(cop.highlights).to eq([string])
-    end
-
-    it "removes the interpolation and quotes around #{string}" do
-      corrected = autocorrect_source(%("this is the \#{#{string}}"))
-      expect(corrected).to eq(%("this is the #{string.gsub(/'|"/, '')}"))
+      expect_correction(<<~RUBY)
+        "this is the #{string.gsub(/'|"/, '')}"
+      RUBY
     end
   end
 
@@ -206,18 +217,33 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
     let(:expected) { '42' }
 
     it 'removes interpolation in symbols' do
-      corrected = autocorrect_source(%(:"this is the \#{#{literal}}"))
-      expect(corrected).to eq(%(:"this is the #{expected}"))
+      expect_offense(<<~'RUBY', literal: literal)
+        :"this is the #{%{literal}}"
+                        ^{literal} Literal interpolation detected.
+      RUBY
+      expect_correction(<<~RUBY)
+        :"this is the #{expected}"
+      RUBY
     end
 
     it 'removes interpolation in backticks' do
-      corrected = autocorrect_source(%(\`this is the \#{#{literal}}\`))
-      expect(corrected).to eq(%(\`this is the #{expected}\`))
+      expect_offense(<<~'RUBY', literal: literal)
+        `this is the #{%{literal}}`
+                       ^{literal} Literal interpolation detected.
+      RUBY
+      expect_correction(<<~RUBY)
+        \`this is the #{expected}\`
+      RUBY
     end
 
     it 'removes interpolation in regular expressions' do
-      corrected = autocorrect_source(%(/this is the \#{#{literal}}/))
-      expect(corrected).to eq(%(/this is the #{expected}/))
+      expect_offense(<<~'RUBY', literal: literal)
+        /this is the #{%{literal}}/
+                       ^{literal} Literal interpolation detected.
+      RUBY
+      expect_correction(<<~RUBY)
+        /this is the #{expected}/
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/lint/multiple_comparison_spec.rb
+++ b/spec/rubocop/cop/lint/multiple_comparison_spec.rb
@@ -6,23 +6,21 @@ RSpec.describe RuboCop::Cop::Lint::MultipleComparison do
   let(:config) { RuboCop::Config.new }
 
   shared_examples 'Check to use two comparison operator' do |operator1, operator2|
-    bad_source = "x #{operator1} y #{operator2} z"
-    good_source = "x #{operator1} y && y #{operator2} z"
+    it "registers an offense for x #{operator1} y #{operator2} z" do
+      expect_offense(<<~RUBY, operator1: operator1, operator2: operator2)
+        x %{operator1} y %{operator2} z
+        ^^^{operator1}^^^^{operator2}^^ Use the `&&` operator to compare multiple values.
+      RUBY
 
-    it "registers an offense for #{bad_source}" do
-      inspect_source(bad_source)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Use the `&&` operator to compare multiple values.'])
+      expect_correction(<<~RUBY)
+        x #{operator1} y && y #{operator2} z
+      RUBY
     end
 
-    it 'autocorrects' do
-      new_source = autocorrect_source(bad_source)
-      expect(new_source).to eq(good_source)
-    end
-
-    it "accepts for #{good_source}" do
-      expect_no_offenses(good_source)
+    it "accepts for x #{operator1} y && y #{operator2} z" do
+      expect_no_offenses(<<~RUBY)
+        x #{operator1} y && y #{operator2} z
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/lint/multiple_comparison_spec.rb
+++ b/spec/rubocop/cop/lint/multiple_comparison_spec.rb
@@ -16,12 +16,6 @@ RSpec.describe RuboCop::Cop::Lint::MultipleComparison do
         x #{operator1} y && y #{operator2} z
       RUBY
     end
-
-    it "accepts for x #{operator1} y && y #{operator2} z" do
-      expect_no_offenses(<<~RUBY)
-        x #{operator1} y && y #{operator2} z
-      RUBY
-    end
   end
 
   %w[< > <= >=].repeated_permutation(2) do |operator1, operator2|

--- a/spec/rubocop/cop/lint/redundant_splat_expansion_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_splat_expansion_spec.rb
@@ -3,8 +3,6 @@
 RSpec.describe RuboCop::Cop::Lint::RedundantSplatExpansion do
   subject(:cop) { described_class.new }
 
-  let(:message) { 'Replace splat expansion with comma separated values.' }
-
   it 'allows assigning to a splat' do
     expect_no_offenses('*, rhs = *node')
   end
@@ -32,49 +30,61 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSplatExpansion do
     RUBY
   end
 
-  shared_examples 'splat literal assignment' do |literal|
-    it 'registers an offense for ' do
-      inspect_source("a = *#{literal}")
-
-      expect(cop.messages).to eq([message])
-      expect(cop.highlights).to eq(["*#{literal}"])
+  shared_examples 'splat literal assignment' do |literal, corrects, as_array: literal|
+    it "registers an offense and #{corrects}" do
+      expect_offense(<<~RUBY, literal: literal)
+        a = *%{literal}
+            ^^{literal} Replace splat expansion with comma separated values.
+      RUBY
+      expect_correction(<<~RUBY)
+        a = #{as_array}
+      RUBY
     end
   end
 
-  shared_examples 'array splat expansion' do |literal|
+  shared_examples 'array splat expansion' do |literal, as_args: nil|
     context 'method parameters' do
-      it 'registers an offense' do
-        inspect_source("array.push(*#{literal})")
-
-        expect(cop.messages)
-          .to eq(['Pass array contents as separate arguments.'])
-        expect(cop.highlights).to eq(["*#{literal}"])
+      it 'registers an offense and converts to a list of arguments' do
+        expect_offense(<<~RUBY, literal: literal)
+          array.push(*%{literal})
+                     ^^{literal} Pass array contents as separate arguments.
+        RUBY
+        expect_correction(<<~RUBY)
+          array.push(#{as_args})
+        RUBY
       end
     end
 
-    it_behaves_like 'splat literal assignment', literal
+    it_behaves_like 'splat literal assignment', literal,
+                    'removes the splat from array', as_array: literal
   end
 
-  shared_examples 'splat expansion' do |literal|
+  shared_examples 'splat expansion' do |literal, as_array: literal|
     context 'method parameters' do
-      it 'registers an offense' do
-        inspect_source("array.push(*#{literal})")
-
-        expect(cop.messages).to eq([message])
-        expect(cop.highlights).to eq(["*#{literal}"])
+      it 'registers an offense and converts to an array' do
+        expect_offense(<<~RUBY, literal: literal)
+          array.push(*%{literal})
+                     ^^{literal} Replace splat expansion with comma separated values.
+        RUBY
+        expect_correction(<<~RUBY)
+          array.push(#{as_array})
+        RUBY
       end
     end
 
-    it_behaves_like 'splat literal assignment', literal
+    it_behaves_like 'splat literal assignment', literal,
+                    'converts to an array', as_array: as_array
   end
 
-  it_behaves_like 'array splat expansion', '[1, 2, 3]'
-  it_behaves_like 'array splat expansion', '%w(one two three)'
-  it_behaves_like 'array splat expansion', '%W(one #{two} three)'
-  it_behaves_like 'splat expansion', "'a'"
-  it_behaves_like 'splat expansion', '"#{a}"'
-  it_behaves_like 'splat expansion', '1'
-  it_behaves_like 'splat expansion', '1.1'
+  it_behaves_like 'array splat expansion', '[1, 2, 3]', as_args: '1, 2, 3'
+  it_behaves_like 'array splat expansion', '%w(one two three)',
+                  as_args: "'one', 'two', 'three'"
+  it_behaves_like 'array splat expansion', '%W(one #{two} three)',
+                  as_args: '"one", "#{two}", "three"'
+  it_behaves_like 'splat expansion', "'a'", as_array: "['a']"
+  it_behaves_like 'splat expansion', '"#{a}"', as_array: '["#{a}"]'
+  it_behaves_like 'splat expansion', '1', as_array: '[1]'
+  it_behaves_like 'splat expansion', '1.1', as_array: '[1.1]'
 
   context 'assignment to splat expansion' do
     it 'registers an offense and corrects an array using a constructor' do
@@ -323,74 +333,10 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSplatExpansion do
     end
   end
 
-  context 'autocorrect' do
-    context 'assignment to a splat expanded variable' do
-      it 'removes the splat from an array using []' do
-        new_source = autocorrect_source('a = *[1, 2, 3]')
-
-        expect(new_source).to eq('a = [1, 2, 3]')
-      end
-
-      it 'removes the splat from an array using %w' do
-        new_source = autocorrect_source('a = *%w(one two three)')
-
-        expect(new_source).to eq('a = %w(one two three)')
-      end
-
-      it 'removes the splat from an array using %W' do
-        new_source = autocorrect_source('a = *%W(one two three)')
-
-        expect(new_source).to eq('a = %W(one two three)')
-      end
-
-      it 'converts an expanded string to an array' do
-        new_source = autocorrect_source("a = *'a'")
-
-        expect(new_source).to eq("a = ['a']")
-      end
-
-      it 'converts an expanded string with interpolation to an array' do
-        new_source = autocorrect_source('a = *"#{a}"')
-
-        expect(new_source).to eq('a = ["#{a}"]')
-      end
-
-      it 'converts an expanded integer to an array' do
-        new_source = autocorrect_source('a = *1')
-
-        expect(new_source).to eq('a = [1]')
-      end
-
-      it 'converts an expanded float to an array' do
-        new_source = autocorrect_source('a = *1.1')
-
-        expect(new_source).to eq('a = [1.1]')
-      end
-    end
-
-    context 'splat expansion of method parameters' do
-      it 'removes the splat and brackets from []' do
-        new_source = autocorrect_source('foo(*[1, 2, 3])')
-
-        expect(new_source).to eq('foo(1, 2, 3)')
-      end
-
-      it 'changes %w to a list of words' do
-        new_source = autocorrect_source('foo(*%w(one two three))')
-
-        expect(new_source).to eq("foo('one', 'two', 'three')")
-      end
-
-      it 'changes %W to a list of words' do
-        new_source = autocorrect_source('foo(*%W(#{one} two three))')
-
-        expect(new_source).to eq('foo("#{one}", "two", "three")')
-      end
-    end
-  end
-
-  it_behaves_like 'array splat expansion', '%i(first second)'
-  it_behaves_like 'array splat expansion', '%I(first second #{third})'
+  it_behaves_like 'array splat expansion', '%i(first second)',
+                  as_args: ':first, :second'
+  it_behaves_like 'array splat expansion', '%I(first second #{third})',
+                  as_args: ':"first", :"second", :"#{third}"'
 
   context 'arrays being expanded with %i variants using splat expansion' do
     context 'splat expansion of method parameters' do

--- a/spec/rubocop/cop/lint/rescue_type_spec.rb
+++ b/spec/rubocop/cop/lint/rescue_type_spec.rb
@@ -42,29 +42,17 @@ RSpec.describe RuboCop::Cop::Lint::RescueType do
   shared_examples 'offenses' do |rescues|
     context 'begin rescue' do
       context "rescuing from #{rescues}" do
-        let(:source) do
-          <<-RUBY
+        it 'registers an offense and auto-corrects' do
+          expect_offense(<<~RUBY, rescues: rescues)
             begin
               foo
-            rescue #{rescues}
+            rescue %{rescues}
+            ^^^^^^^^{rescues} Rescuing from `#{rescues}` will raise a `TypeError` instead of catching the actual exception.
               bar
             end
           RUBY
-        end
 
-        it 'registers an offense' do
-          inspect_source(source)
-
-          expect(cop.highlights).to eq(["rescue #{rescues}"])
-          expect(cop.messages)
-            .to eq(["Rescuing from `#{rescues}` will raise a `TypeError` " \
-                    'instead of catching the actual exception.'])
-        end
-
-        it 'auto-corrects' do
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq(<<-RUBY)
+          expect_correction(<<~RUBY)
             begin
               foo
             rescue
@@ -75,29 +63,17 @@ RSpec.describe RuboCop::Cop::Lint::RescueType do
       end
 
       context "rescuing from #{rescues} before another exception" do
-        let(:source) do
-          <<-RUBY
+        it 'registers an offense and auto-corrects' do
+          expect_offense(<<~RUBY, rescues: rescues)
             begin
               foo
-            rescue #{rescues}, StandardError
+            rescue %{rescues}, StandardError
+            ^^^^^^^^{rescues}^^^^^^^^^^^^^^^ Rescuing from `#{rescues}` will raise a `TypeError` instead of catching the actual exception.
               bar
             end
           RUBY
-        end
 
-        it 'registers an offense' do
-          inspect_source(source)
-
-          expect(cop.highlights).to eq(["rescue #{rescues}, StandardError"])
-          expect(cop.messages)
-            .to eq(["Rescuing from `#{rescues}` will raise a `TypeError` " \
-                    'instead of catching the actual exception.'])
-        end
-
-        it 'auto-corrects' do
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq(<<-RUBY)
+          expect_correction(<<~RUBY)
             begin
               foo
             rescue StandardError
@@ -108,29 +84,17 @@ RSpec.describe RuboCop::Cop::Lint::RescueType do
       end
 
       context "rescuing from #{rescues} after another exception" do
-        let(:source) do
-          <<-RUBY
+        it 'registers an offense and auto-corrects' do
+          expect_offense(<<~RUBY, rescues: rescues)
             begin
               foo
-            rescue StandardError, #{rescues}
+            rescue StandardError, %{rescues}
+            ^^^^^^^^^^^^^^^^^^^^^^^{rescues} Rescuing from `#{rescues}` will raise a `TypeError` instead of catching the actual exception.
               bar
             end
           RUBY
-        end
 
-        it 'registers an offense' do
-          inspect_source(source)
-
-          expect(cop.highlights).to eq(["rescue StandardError, #{rescues}"])
-          expect(cop.messages)
-            .to eq(["Rescuing from `#{rescues}` will raise a `TypeError` " \
-                    'instead of catching the actual exception.'])
-        end
-
-        it 'auto-corrects' do
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq(<<-RUBY)
+          expect_correction(<<~RUBY)
             begin
               foo
             rescue StandardError
@@ -143,31 +107,19 @@ RSpec.describe RuboCop::Cop::Lint::RescueType do
 
     context 'begin rescue ensure' do
       context "rescuing from #{rescues}" do
-        let(:source) do
-          <<-RUBY
+        it 'registers an offense and auto-corrects' do
+          expect_offense(<<~RUBY, rescues: rescues)
             begin
               foo
-            rescue #{rescues}
+            rescue %{rescues}
+            ^^^^^^^^{rescues} Rescuing from `#{rescues}` will raise a `TypeError` instead of catching the actual exception.
               bar
             ensure
               baz
             end
           RUBY
-        end
 
-        it 'registers an offense' do
-          inspect_source(source)
-
-          expect(cop.highlights).to eq(["rescue #{rescues}"])
-          expect(cop.messages)
-            .to eq(["Rescuing from `#{rescues}` will raise a `TypeError` " \
-                    'instead of catching the actual exception.'])
-        end
-
-        it 'auto-corrects' do
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq(<<-RUBY)
+          expect_correction(<<~RUBY)
             begin
               foo
             rescue
@@ -182,29 +134,17 @@ RSpec.describe RuboCop::Cop::Lint::RescueType do
 
     context 'def rescue' do
       context "rescuing from #{rescues}" do
-        let(:source) do
-          <<-RUBY
+        it 'registers an offense and auto-corrects' do
+          expect_offense(<<~RUBY, rescues: rescues)
             def foobar
               foo
-            rescue #{rescues}
+            rescue %{rescues}
+            ^^^^^^^^{rescues} Rescuing from `#{rescues}` will raise a `TypeError` instead of catching the actual exception.
               bar
             end
           RUBY
-        end
 
-        it 'registers an offense' do
-          inspect_source(source)
-
-          expect(cop.highlights).to eq(["rescue #{rescues}"])
-          expect(cop.messages)
-            .to eq(["Rescuing from `#{rescues}` will raise a `TypeError` " \
-                    'instead of catching the actual exception.'])
-        end
-
-        it 'auto-corrects' do
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq(<<-RUBY)
+          expect_correction(<<~RUBY)
             def foobar
               foo
             rescue
@@ -217,31 +157,19 @@ RSpec.describe RuboCop::Cop::Lint::RescueType do
 
     context 'def rescue ensure' do
       context "rescuing from #{rescues}" do
-        let(:source) do
-          <<-RUBY
+        it 'registers an offense and auto-corrects' do
+          expect_offense(<<~RUBY, rescues: rescues)
             def foobar
               foo
-            rescue #{rescues}
+            rescue %{rescues}
+            ^^^^^^^^{rescues} Rescuing from `#{rescues}` will raise a `TypeError` instead of catching the actual exception.
               bar
             ensure
               baz
             end
           RUBY
-        end
 
-        it 'registers an offense' do
-          inspect_source(source)
-
-          expect(cop.highlights).to eq(["rescue #{rescues}"])
-          expect(cop.messages)
-            .to eq(["Rescuing from `#{rescues}` will raise a `TypeError` " \
-                    'instead of catching the actual exception.'])
-        end
-
-        it 'auto-corrects' do
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq(<<-RUBY)
+          expect_correction(<<~RUBY)
             def foobar
               foo
             rescue

--- a/spec/rubocop/cop/lint/unified_integer_spec.rb
+++ b/spec/rubocop/cop/lint/unified_integer_spec.rb
@@ -4,32 +4,28 @@ RSpec.describe RuboCop::Cop::Lint::UnifiedInteger, :config do
   shared_examples 'registers an offense' do |klass|
     context "when #{klass}" do
       context 'without any decorations' do
-        let(:source) { "1.is_a?(#{klass})" }
+        it 'registers an offense and autocorrects' do
+          expect_offense(<<~RUBY, klass: klass)
+            1.is_a?(%{klass})
+                    ^{klass} Use `Integer` instead of `#{klass}`.
+          RUBY
 
-        it 'registers an offense' do
-          inspect_source(source)
-          expect(cop.offenses.size).to eq(1)
-          expect(cop.messages).to eq(["Use `Integer` instead of `#{klass}`."])
-        end
-
-        it 'autocorrects' do
-          new_source = autocorrect_source(source)
-          expect(new_source).to eq('1.is_a?(Integer)')
+          expect_correction(<<~RUBY)
+            1.is_a?(Integer)
+          RUBY
         end
       end
 
       context 'when explicitly specified as toplevel constant' do
-        let(:source) { "1.is_a?(::#{klass})" }
-
         it 'registers an offense' do
-          inspect_source(source)
-          expect(cop.offenses.size).to eq(1)
-          expect(cop.messages).to eq(["Use `Integer` instead of `#{klass}`."])
-        end
+          expect_offense(<<~RUBY, klass: klass)
+            1.is_a?(::%{klass})
+                    ^^^{klass} Use `Integer` instead of `#{klass}`.
+          RUBY
 
-        it 'autocorrects' do
-          new_source = autocorrect_source(source)
-          expect(new_source).to eq('1.is_a?(::Integer)')
+          expect_correction(<<~RUBY)
+            1.is_a?(::Integer)
+          RUBY
         end
       end
 

--- a/spec/rubocop/cop/lint/unused_block_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_block_argument_spec.rb
@@ -25,6 +25,19 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
               puts key
             end
           RUBY
+          expect_correction(<<~RUBY)
+            hash.each do |key, _value|
+              puts key
+            end
+          RUBY
+        end
+      end
+
+      context 'and all arguments are used' do
+        it 'accepts' do
+          expect_no_offenses(<<~RUBY)
+            obj.method { |foo, bar| stuff(foo, bar) }
+          RUBY
         end
       end
 
@@ -51,6 +64,39 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
               key, value = value, 42
             end
           RUBY
+          expect_correction(<<~RUBY)
+            hash.each do |_key, value|
+              key, value = value, 42
+            end
+          RUBY
+        end
+      end
+
+      context 'and a splat argument is unused' do
+        it 'registers an offense and preserves splat' do
+          expect_offense(<<~RUBY)
+            obj.method { |foo, *bars, baz| stuff(foo, baz) }
+                                ^^^^ Unused block argument - `bars`. If it's necessary, use `_` or `_bars` as an argument name to indicate that it won't be used.
+          RUBY
+          expect_correction(<<~RUBY)
+            obj.method { |foo, *_bars, baz| stuff(foo, baz) }
+          RUBY
+        end
+      end
+
+      context 'and an argument with default value is unused' do
+        it 'registers an offense and preserves default value' do
+          expect_offense(<<~RUBY)
+            obj.method do |foo, bar = baz|
+                                ^^^ Unused block argument - `bar`. If it's necessary, use `_` or `_bar` as an argument name to indicate that it won't be used.
+              stuff(foo)
+            end
+          RUBY
+          expect_correction(<<~RUBY)
+            obj.method do |foo, _bar = baz|
+              stuff(foo)
+            end
+          RUBY
         end
       end
 
@@ -69,6 +115,36 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
               puts :something
             end
           RUBY
+          expect_correction(<<~RUBY)
+            hash = { foo: 'FOO', bar: 'BAR' }
+            hash.each do |_key, _value|
+              puts :something
+            end
+          RUBY
+        end
+
+        context 'and unused arguments span multiple lines' do
+          it 'registers offenses and suggests omitting them' do
+            key_message, value_message = %w[key value].map do |arg|
+              "Unused block argument - `#{arg}`. You can omit all the " \
+                "arguments if you don't care about them."
+            end
+
+            expect_offense(<<~RUBY)
+              hash.each do |key,
+                            ^^^ #{key_message}
+                            value|
+                            ^^^^^ #{value_message}
+                puts :something
+              end
+            RUBY
+            expect_correction(<<~RUBY)
+              hash.each do |_key,
+                            _value|
+                puts :something
+              end
+            RUBY
+          end
         end
       end
     end
@@ -82,6 +158,11 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
           expect_offense(<<~RUBY)
             1.times do |index|
                         ^^^^^ #{message}
+              puts :something
+            end
+          RUBY
+          expect_correction(<<~RUBY)
+            1.times do |_index|
               puts :something
             end
           RUBY
@@ -100,6 +181,11 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
               puts 'baz'
             end
           RUBY
+          expect_correction(<<~RUBY)
+            define_method(:foo) do |_bar|
+              puts 'baz'
+            end
+          RUBY
         end
       end
     end
@@ -110,6 +196,11 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
           expect_offense(<<~RUBY)
             1.times do |index; block_local_variable|
                                ^^^^^^^^^^^^^^^^^^^^ Unused block local variable - `block_local_variable`.
+              puts index
+            end
+          RUBY
+          expect_correction(<<~RUBY)
+            1.times do |index; _block_local_variable|
               puts index
             end
           RUBY
@@ -134,6 +225,9 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
                      ^^^ #{bar_message}
                 ^^^ #{foo_message}
           RUBY
+          expect_correction(<<~RUBY)
+            -> (_foo, _bar) { do_something }
+          RUBY
         end
       end
 
@@ -146,6 +240,9 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
           expect_offense(<<~RUBY)
             -> (foo, bar) { puts bar }
                 ^^^ #{message}
+          RUBY
+          expect_correction(<<~RUBY)
+            -> (_foo, bar) { puts bar }
           RUBY
         end
       end
@@ -174,6 +271,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
               puts 'bar'
             end
           RUBY
+          expect_no_corrections
         end
 
         context 'when AllowUnusedKeywordArguments set' do
@@ -200,6 +298,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
               puts 'bar'
             end
           RUBY
+          expect_no_corrections
         end
 
         context 'when AllowUnusedKeywordArguments set' do
@@ -260,6 +359,13 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
               end
             end
           RUBY
+          expect_correction(<<~RUBY)
+            test do |_key, _value|
+              def other(a)
+                puts something(binding)
+              end
+            end
+          RUBY
         end
       end
     end
@@ -279,6 +385,11 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
               puts something(binding(:other))
             end
           RUBY
+          expect_correction(<<~RUBY)
+            test do |_key, _value|
+              puts something(binding(:other))
+            end
+          RUBY
         end
       end
     end
@@ -295,6 +406,9 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
             super { |bar| }
                      ^^^ #{message}
           RUBY
+          expect_correction(<<~RUBY)
+            super { |_bar| }
+          RUBY
         end
       end
 
@@ -305,55 +419,6 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
           expect_no_offenses('super { |bar| }')
         end
       end
-    end
-  end
-
-  context 'auto-correct' do
-    it_behaves_like(
-      'auto-correction',
-      'fixes single',
-      'arr.map { |foo| stuff }',
-      'arr.map { |_foo| stuff }'
-    )
-
-    it_behaves_like(
-      'auto-correction',
-      'fixes multiple',
-      'hash.map { |key, val| stuff }',
-      'hash.map { |_key, _val| stuff }'
-    )
-
-    it_behaves_like(
-      'auto-correction',
-      'preserves whitespace',
-      <<-SOURCE,
-        hash.map { |key,
-                    val| stuff }
-      SOURCE
-      <<-CORRECTED_SOURCE
-        hash.map { |_key,
-                    _val| stuff }
-      CORRECTED_SOURCE
-    )
-
-    it_behaves_like(
-      'auto-correction',
-      'preserves splat',
-      'obj.method { |foo, *bars, baz| stuff(foo, baz) }',
-      'obj.method { |foo, *_bars, baz| stuff(foo, baz) }'
-    )
-
-    it_behaves_like(
-      'auto-correction',
-      'preserves default',
-      'obj.method { |foo, bar = baz| stuff(foo) }',
-      'obj.method { |foo, _bar = baz| stuff(foo) }'
-    )
-
-    it 'ignores used arguments' do
-      original_source = 'obj.method { |foo, baz| stuff(foo, baz) }'
-
-      expect(autocorrect_source(original_source)).to eq(original_source)
     end
   end
 
@@ -375,6 +440,9 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
         ->(arg) { 1 }
            ^^^ #{message}
       RUBY
+      expect_correction(<<~RUBY)
+        ->(_arg) { 1 }
+      RUBY
     end
 
     it 'accepts an empty block with multiple unused parameters' do
@@ -395,6 +463,9 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
                         ^^^^^^ #{others_message}
                  ^^^^ #{arg2_message}
            ^^^^ #{arg1_message}
+      RUBY
+      expect_correction(<<~RUBY)
+        ->(_arg1, _arg2, *_others) { 1 }
       RUBY
     end
   end

--- a/spec/rubocop/cop/lint/unused_block_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_block_argument_spec.rb
@@ -74,9 +74,13 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
 
       context 'and a splat argument is unused' do
         it 'registers an offense and preserves splat' do
+          message = 'Unused block argument - `bars`. ' \
+                    "If it's necessary, use `_` or `_bars` as an argument " \
+                    "name to indicate that it won't be used."
+
           expect_offense(<<~RUBY)
             obj.method { |foo, *bars, baz| stuff(foo, baz) }
-                                ^^^^ Unused block argument - `bars`. If it's necessary, use `_` or `_bars` as an argument name to indicate that it won't be used.
+                                ^^^^ #{message}
           RUBY
           expect_correction(<<~RUBY)
             obj.method { |foo, *_bars, baz| stuff(foo, baz) }
@@ -86,9 +90,13 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
 
       context 'and an argument with default value is unused' do
         it 'registers an offense and preserves default value' do
+          message = 'Unused block argument - `bar`. ' \
+                    "If it's necessary, use `_` or `_bar` as an argument " \
+                    "name to indicate that it won't be used."
+
           expect_offense(<<~RUBY)
             obj.method do |foo, bar = baz|
-                                ^^^ Unused block argument - `bar`. If it's necessary, use `_` or `_bar` as an argument name to indicate that it won't be used.
+                                ^^^ #{message}
               stuff(foo)
             end
           RUBY

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -32,10 +32,14 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
 
         context 'and there is some whitespace around the unused argument' do
           it 'registers an offense and preserves whitespace' do
+            message = 'Unused method argument - `bar`. ' \
+                        "If it's necessary, use `_` or `_bar` " \
+                        "as an argument name to indicate that it won't be used."
+
             expect_offense(<<~RUBY)
               def some_method(foo,
                   bar)
-                  ^^^ Unused method argument - `bar`. If it's necessary, use `_` or `_bar` as an argument name to indicate that it won't be used.
+                  ^^^ #{message}
                 puts foo
               end
             RUBY
@@ -108,9 +112,13 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
 
     context 'when a splat argument is unused' do
       it 'registers an offense and preserves the splat' do
+        message = 'Unused method argument - `bar`. ' \
+                    "If it's necessary, use `_` or `_bar` " \
+                    "as an argument name to indicate that it won't be used."
+
         expect_offense(<<~RUBY)
           def some_method(foo, *bar)
-                                ^^^ Unused method argument - `bar`. If it's necessary, use `_` or `_bar` as an argument name to indicate that it won't be used.
+                                ^^^ #{message}
             puts foo
           end
         RUBY
@@ -124,9 +132,13 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
 
     context 'when an argument with a default value is unused' do
       it 'registers an offense and preserves the default value' do
+        message = 'Unused method argument - `bar`. ' \
+                    "If it's necessary, use `_` or `_bar` " \
+                    "as an argument name to indicate that it won't be used."
+
         expect_offense(<<~RUBY)
           def some_method(foo, bar = 1)
-                               ^^^ Unused method argument - `bar`. If it's necessary, use `_` or `_bar` as an argument name to indicate that it won't be used.
+                               ^^^ #{message}
             puts foo
           end
         RUBY
@@ -176,9 +188,13 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
 
     context 'when a trailing block argument is unused' do
       it 'registers an offense and removes the unused block arg' do
+        message = 'Unused method argument - `block`. ' \
+                    "If it's necessary, use `_` or `_block` " \
+                    "as an argument name to indicate that it won't be used."
+
         expect_offense(<<~RUBY)
           def some_method(foo, bar, &block)
-                                     ^^^^^ Unused method argument - `block`. If it's necessary, use `_` or `_block` as an argument name to indicate that it won't be used.
+                                     ^^^^^ #{message}
             foo + bar
           end
         RUBY

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
   describe 'inspection' do
     context 'when a method takes multiple arguments' do
       context 'and an argument is unused' do
-        it 'registers an offense' do
+        it 'registers an offense and adds underscore-prefix' do
           message = 'Unused method argument - `foo`. ' \
                       "If it's necessary, use `_` or `_foo` " \
                       "as an argument name to indicate that it won't be used."
@@ -23,6 +23,29 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
               puts bar
             end
           RUBY
+          expect_correction(<<~RUBY)
+            def some_method(_foo, bar)
+              puts bar
+            end
+          RUBY
+        end
+
+        context 'and there is some whitespace around the unused argument' do
+          it 'registers an offense and preserves whitespace' do
+            expect_offense(<<~RUBY)
+              def some_method(foo,
+                  bar)
+                  ^^^ Unused method argument - `bar`. If it's necessary, use `_` or `_bar` as an argument name to indicate that it won't be used.
+                puts foo
+              end
+            RUBY
+            expect_correction(<<~RUBY)
+              def some_method(foo,
+                  _bar)
+                puts foo
+              end
+            RUBY
+          end
         end
 
         context 'and arguments are swap-assigned' do
@@ -48,12 +71,18 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
                 a, b = b, 42
               end
             RUBY
+            expect_correction(<<~RUBY)
+              def foo(_a, b)
+                a, b = b, 42
+              end
+            RUBY
           end
         end
       end
 
       context 'and all the arguments are unused' do
-        it 'registers offenses and suggests the use of `*`' do
+        it 'registers offenses and suggests the use of `*` and ' \
+           'auto-corrects to add underscore-prefix to all arguments' do
           (foo_message, bar_message) = %w[foo bar].map do |arg|
             "Unused method argument - `#{arg}`. " \
             "If it's necessary, use `_` or `_#{arg}` " \
@@ -68,7 +97,44 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
                             ^^^ #{foo_message}
             end
           RUBY
+
+          expect_correction(<<~RUBY)
+            def some_method(_foo, _bar)
+            end
+          RUBY
         end
+      end
+    end
+
+    context 'when a splat argument is unused' do
+      it 'registers an offense and preserves the splat' do
+        expect_offense(<<~RUBY)
+          def some_method(foo, *bar)
+                                ^^^ Unused method argument - `bar`. If it's necessary, use `_` or `_bar` as an argument name to indicate that it won't be used.
+            puts foo
+          end
+        RUBY
+        expect_correction(<<~RUBY)
+          def some_method(foo, *_bar)
+            puts foo
+          end
+        RUBY
+      end
+    end
+
+    context 'when an argument with a default value is unused' do
+      it 'registers an offense and preserves the default value' do
+        expect_offense(<<~RUBY)
+          def some_method(foo, bar = 1)
+                               ^^^ Unused method argument - `bar`. If it's necessary, use `_` or `_bar` as an argument name to indicate that it won't be used.
+            puts foo
+          end
+        RUBY
+        expect_correction(<<~RUBY)
+          def some_method(foo, _bar = 1)
+            puts foo
+          end
+        RUBY
       end
     end
 
@@ -80,6 +146,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
             puts foo
           end
         RUBY
+        expect_no_corrections
       end
     end
 
@@ -91,6 +158,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
             puts foo
           end
         RUBY
+        expect_no_corrections
       end
 
       context 'and AllowUnusedKeywordArguments set' do
@@ -106,6 +174,22 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
       end
     end
 
+    context 'when a trailing block argument is unused' do
+      it 'registers an offense and removes the unused block arg' do
+        expect_offense(<<~RUBY)
+          def some_method(foo, bar, &block)
+                                     ^^^^^ Unused method argument - `block`. If it's necessary, use `_` or `_block` as an argument name to indicate that it won't be used.
+            foo + bar
+          end
+        RUBY
+        expect_correction(<<~RUBY)
+          def some_method(foo, bar)
+            foo + bar
+          end
+        RUBY
+      end
+    end
+
     context 'when a singleton method argument is unused' do
       it 'registers an offense' do
         message = "Unused method argument - `foo`. If it's necessary, use " \
@@ -117,6 +201,10 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
         expect_offense(<<~RUBY)
           def self.some_method(foo)
                                ^^^ #{message}
+          end
+        RUBY
+        expect_correction(<<~RUBY)
+          def self.some_method(_foo)
           end
         RUBY
       end
@@ -196,6 +284,11 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
               super(:something)
             end
           RUBY
+          expect_correction(<<~RUBY)
+            def some_method(_foo)
+              super(:something)
+            end
+          RUBY
         end
       end
     end
@@ -229,6 +322,13 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
               end
             end
           RUBY
+          expect_correction(<<~RUBY)
+            def some_method(_foo, _bar)
+              def other(a)
+                puts something(binding)
+              end
+            end
+          RUBY
         end
       end
     end
@@ -248,131 +348,12 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
               binding(:something)
             end
           RUBY
+          expect_correction(<<~RUBY)
+            def some_method(_foo)
+              binding(:something)
+            end
+          RUBY
         end
-      end
-    end
-  end
-
-  describe 'auto-correction' do
-    let(:corrected_source) { autocorrect_source(source) }
-
-    context 'when multiple arguments are unused' do
-      let(:source) { <<-RUBY }
-        def some_method(foo, bar)
-        end
-      RUBY
-
-      let(:expected_source) { <<-RUBY }
-        def some_method(_foo, _bar)
-        end
-      RUBY
-
-      it 'adds underscore-prefix to them' do
-        expect(corrected_source).to eq(expected_source)
-      end
-    end
-
-    context 'when only a part of arguments is unused' do
-      let(:source) { <<-RUBY }
-        def some_method(foo, bar)
-          puts foo
-        end
-      RUBY
-
-      let(:expected_source) { <<-RUBY }
-        def some_method(foo, _bar)
-          puts foo
-        end
-      RUBY
-
-      it 'modifies only the unused one' do
-        expect(corrected_source).to eq(expected_source)
-      end
-    end
-
-    context 'when there is some whitespace around the argument' do
-      let(:source) { <<-RUBY }
-        def some_method(foo,
-            bar)
-          puts foo
-        end
-      RUBY
-
-      let(:expected_source) { <<-RUBY }
-        def some_method(foo,
-            _bar)
-          puts foo
-        end
-      RUBY
-
-      it 'preserves the whitespace' do
-        expect(corrected_source).to eq(expected_source)
-      end
-    end
-
-    context 'when a splat argument is unused' do
-      let(:source) { <<-RUBY }
-        def some_method(foo, *bar)
-          puts foo
-        end
-      RUBY
-
-      let(:expected_source) { <<-RUBY }
-        def some_method(foo, *_bar)
-          puts foo
-        end
-      RUBY
-
-      it 'preserves the splat' do
-        expect(corrected_source).to eq(expected_source)
-      end
-    end
-
-    context 'when an unused argument has default value' do
-      let(:source) { <<-RUBY }
-        def some_method(foo, bar = 1)
-          puts foo
-        end
-      RUBY
-
-      let(:expected_source) { <<-RUBY }
-        def some_method(foo, _bar = 1)
-          puts foo
-        end
-      RUBY
-
-      it 'preserves the default value' do
-        expect(corrected_source).to eq(expected_source)
-      end
-    end
-
-    context 'when a keyword argument is unused' do
-      let(:source) { <<-RUBY }
-        def some_method(foo, bar: 1)
-          puts foo
-        end
-      RUBY
-
-      it 'ignores that since modifying the name changes the method interface' do
-        expect(corrected_source).to eq(source)
-      end
-    end
-
-    context 'when a trailing block argument is unused' do
-      let(:source) { <<-RUBY }
-        def some_method(foo, bar, &block)
-          foo + bar
-        end
-      RUBY
-
-      let(:expected_source) { <<-RUBY }
-        def some_method(foo, bar)
-          foo + bar
-        end
-      RUBY
-
-      it 'removes the unused block arg' do
-        expect(corrected_source).to eq(expected_source)
       end
     end
   end
@@ -408,6 +389,11 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
           1
         end
       RUBY
+      expect_correction(<<~RUBY)
+        def method(_arg)
+          1
+        end
+      RUBY
     end
 
     it 'accepts an empty method with multiple unused parameters' do
@@ -431,6 +417,11 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
                           ^^^^^^ #{others_message}
                       ^ #{b_message}
                    ^ #{a_message}
+          1
+        end
+      RUBY
+      expect_correction(<<~RUBY)
+        def method(_a, _b, *_others)
           1
         end
       RUBY
@@ -499,6 +490,11 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
           1
         end
       RUBY
+      expect_correction(<<~RUBY)
+        def method(_arg)
+          1
+        end
+      RUBY
     end
 
     it 'accepts an empty method with multiple unused parameters' do
@@ -523,6 +519,11 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
                           ^^^^^^ #{others_message}
                       ^ #{b_message}
                    ^ #{a_message}
+          1
+        end
+      RUBY
+      expect_correction(<<~RUBY)
+        def method(_a, _b, *_others)
           1
         end
       RUBY


### PR DESCRIPTION
Part of #8127

Use newer expect_correction API in Lint namespace cops.

Move expected corrections to directly follow expected offenses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/