### PR TITLE
Fix `Style/AccessorGrouping` to not register offense for accessor with comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#7777](https://github.com/rubocop-hq/rubocop/issues/7777): Fix crash for `Layout/MultilineArrayBraceLayout` when comment is present after last element. ([@shekhar-patil][])
 * [#7776](https://github.com/rubocop-hq/rubocop/issues/7776): Fix crash for `Layout/MultilineMethodCallBraceLayout` when comment is present before closing braces. ([@shekhar-patil][])
 * [#8282](https://github.com/rubocop-hq/rubocop/issues/8282): Fix `Style/IfUnlessModifier` bad precedence detection. ([@tejasbubane][])
+* [#8289](https://github.com/rubocop-hq/rubocop/issues/8289): Fix `Style/AccessorGrouping` to not register offense for accessor with comment. ([@tejasbubane][])
 
 ## 0.87.1 (2020-07-07)
 

--- a/lib/rubocop/cop/style/accessor_grouping.rb
+++ b/lib/rubocop/cop/style/accessor_grouping.rb
@@ -58,6 +58,10 @@ module RuboCop
 
         private
 
+        def previous_line_comment?(node)
+          comment_line?(processed_source[node.first_line - 2])
+        end
+
         def class_send_elements(class_node)
           class_def = class_node.body
 
@@ -75,6 +79,8 @@ module RuboCop
         end
 
         def check(send_node)
+          return if previous_line_comment?(send_node)
+
           if grouped_style? && sibling_accessors(send_node).size > 1
             add_offense(send_node)
           elsif separated_style? && send_node.arguments.size > 1
@@ -94,7 +100,8 @@ module RuboCop
           send_node.parent.each_child_node(:send).select do |sibling|
             accessor?(sibling) &&
               sibling.method?(send_node.method_name) &&
-              node_visibility(sibling) == node_visibility(send_node)
+              node_visibility(sibling) == node_visibility(send_node) &&
+              !previous_line_comment?(sibling)
           end
         end
 

--- a/spec/rubocop/cop/style/accessor_grouping_spec.rb
+++ b/spec/rubocop/cop/style/accessor_grouping_spec.rb
@@ -123,6 +123,47 @@ RSpec.describe RuboCop::Cop::Style::AccessorGrouping, :config do
         end
       RUBY
     end
+
+    it 'does not register offense for accessors with comments' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          # @return [String] value of foo
+          attr_reader :one, :two
+
+          attr_reader :four
+        end
+      RUBY
+    end
+
+    it 'registers offense and corrects if atleast two separate accessors without comments' do
+      expect_offense(<<~RUBY)
+        class Foo
+          # @return [String] value of foo
+          attr_reader :one, :two
+
+          # [String] Some bar value return
+          attr_reader :three
+
+          attr_reader :four
+          ^^^^^^^^^^^^^^^^^ Group together all `attr_reader` attributes.
+          attr_reader :five
+          ^^^^^^^^^^^^^^^^^ Group together all `attr_reader` attributes.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo
+          # @return [String] value of foo
+          attr_reader :one, :two
+
+          # [String] Some bar value return
+          attr_reader :three
+
+          attr_reader :four, :five
+          
+        end
+      RUBY
+    end
   end
 
   context 'when EnforcedStyle is separated' do
@@ -233,6 +274,15 @@ RSpec.describe RuboCop::Cop::Style::AccessorGrouping, :config do
         class Foo
           attr_reader :bar
           attr_reader :baz
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for grouped accessors with comments' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          # Some comment
+          attr_reader :one, :two
         end
       RUBY
     end


### PR DESCRIPTION
Closes #8289 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/