### PR TITLE
Remove `PathUtil.pwd` and `PathUtil.chdir`

### DIFF
--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -5,7 +5,7 @@ module RuboCop
   module PathUtil
     module_function
 
-    def relative_path(path, base_dir = PathUtil.pwd)
+    def relative_path(path, base_dir = Dir.pwd)
       # Optimization for the common case where path begins with the base
       # dir. Just cut off the first part.
       if path.start_with?(base_dir)
@@ -24,7 +24,7 @@ module RuboCop
 
     def smart_path(path)
       # Ideally, we calculate this relative to the project root.
-      base_dir = PathUtil.pwd
+      base_dir = Dir.pwd
 
       if path.start_with? base_dir
         relative_path(path, base_dir)
@@ -52,21 +52,6 @@ module RuboCop
     # Returns true for an absolute Unix or Windows path.
     def absolute?(path)
       %r{\A([A-Z]:)?/}i.match?(path)
-    end
-
-    def self.pwd
-      @pwd ||= Dir.pwd
-    end
-
-    def self.reset_pwd
-      @pwd = nil
-    end
-
-    def self.chdir(dir, &block)
-      reset_pwd
-      Dir.chdir(dir, &block)
-    ensure
-      reset_pwd
     end
 
     def hidden_file_in_not_hidden_dir?(pattern, path)

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -24,7 +24,7 @@ RSpec.shared_context 'isolated environment', :isolated_environment do
         working_dir = File.join(tmpdir, 'work')
         Dir.mkdir(working_dir)
 
-        RuboCop::PathUtil.chdir(working_dir) do
+        Dir.chdir(working_dir) do
           example.run
         end
       ensure

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -497,7 +497,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           Layout/LineLength:
             Max: 95
         YAML
-        RuboCop::PathUtil.chdir('dir') do
+        Dir.chdir('dir') do
           expect(cli.run(%w[--auto-gen-config])).to eq(0)
         end
         expect($stderr.string).to eq('')

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           x = 1
         RUBY
         create_empty_file('other/empty')
-        RuboCop::PathUtil.chdir('other') do
+        Dir.chdir('other') do
           expect(cli.run(['--format', 'simple', checked_path])).to eq(1)
         end
         expect($stdout.string).to eq(<<~RESULT)

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1463,7 +1463,7 @@ RSpec.describe RuboCop::ConfigLoader do
 
     it 'uses paths relative to the .rubocop.yml, not cwd' do
       config_path = described_class.configuration_file_for('.')
-      RuboCop::PathUtil.chdir '..' do
+      Dir.chdir '..' do
         described_class.configuration_from_file(config_path)
         expect(defined?(MyClass)).to be_truthy
       end
@@ -1481,7 +1481,7 @@ RSpec.describe RuboCop::ConfigLoader do
     it 'works without a starting .' do
       config_path = described_class.configuration_file_for('.')
       $LOAD_PATH.unshift(File.dirname(config_path))
-      RuboCop::PathUtil.chdir '..' do
+      Dir.chdir '..' do
         described_class.configuration_from_file(config_path)
         expect(defined?(MyClass)).to be_truthy
       end

--- a/spec/rubocop/cop/generator/require_file_injector_spec.rb
+++ b/spec/rubocop/cop/generator/require_file_injector_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RuboCop::Cop::Generator::RequireFileInjector do
 
   around do |example|
     Dir.mktmpdir('rubocop-require_file_injector_spec-') do |dir|
-      RuboCop::PathUtil.chdir(dir) do
+      Dir.chdir(dir) do
         Dir.mkdir('lib')
         example.run
       end

--- a/spec/rubocop/formatter/html_formatter_spec.rb
+++ b/spec/rubocop/formatter/html_formatter_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Formatter::HTMLFormatter, :isolated_environment do
     project_path = File.join(spec_root, 'fixtures/html_formatter/project')
     FileUtils.cp_r(project_path, '.')
 
-    RuboCop::PathUtil.chdir(File.basename(project_path)) do
+    Dir.chdir(File.basename(project_path)) do
       example.run
     end
   end

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       let(:args) { [] }
 
       it 'finds files under the current directory' do
-        RuboCop::PathUtil.chdir('dir1') do
+        Dir.chdir('dir1') do
           expect(found_files.empty?).to be(false)
           found_files.each do |file|
             expect(file).to include('/dir1/')
@@ -186,7 +186,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       let(:args) { ['../dir2'] }
 
       it 'finds files under the specified directory' do
-        RuboCop::PathUtil.chdir('dir1') do
+        Dir.chdir('dir1') do
           expect(found_files.empty?).to be(false)
           found_files.each do |file|
             expect(file).to include('/dir2/')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,8 +51,4 @@ RSpec.configure do |config|
   if %w[ruby-head-ascii_spec ruby-head-spec].include? ENV['CIRCLE_STAGE']
     config.filter_run_excluding broken_on: :ruby_head
   end
-
-  config.after do
-    RuboCop::PathUtil.reset_pwd
-  end
 end


### PR DESCRIPTION
Current code used `Dir.pwd` everywhere except for inside the `PathUtil` module itself. It also used `Dir.chdir` vs `PathUtil.chdir` inconsistently across the board.

Since the wrappers don't seem to provide anything on top of the raw functionality, I figured it'd be best to remove them?

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/