### PR TITLE
Rewrite `Layout/SpaceAroundMethodCallOperator` cop to make it faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Changes
 
+* [#8021](https://github.com/rubocop-hq/rubocop/issues/8021): Rewrite `Layout/SpaceAroundMethodCallOperator` cop to make it faster. ([@fatkodima][])
 * [#8294](https://github.com/rubocop-hq/rubocop/pull/8294): Add `of` to `AllowedNames` of `MethodParameterName` cop. ([@AlexWayfer][])
 
 ## 0.87.1 (2020-07-07)


### PR DESCRIPTION
Closes #8021 

### Before
```
Finished in 44.9 seconds

$ rake prof:slow_cops

stackprof tmp/stackprof.dump --text --method 'RuboCop::Cop::Commissioner#trigger_responding_cops'
    4065  (   18.0%)  RuboCop::Cop::Layout::SpaceAroundMethodCallOperator#on_send   <========== 1
     509  (    2.3%)  RuboCop::Cop::Style::TrailingMethodEndStatement#on_def
     386  (    1.7%)  RuboCop::Cop::Layout::IndentationConsistency#on_begin
     369  (    1.6%)  RuboCop::Cop::Style::NumericPredicate#on_send
     337  (    1.5%)  RuboCop::Cop::MultilineExpressionIndentation#on_send
     299  (    1.3%)  RuboCop::Cop::Layout::FirstArgumentIndentation#on_send
     285  (    1.3%)  RuboCop::Cop::Lint::DuplicateMethods#on_def
     274  (    1.2%)  RuboCop::Cop::Metrics::ModuleLength#on_module
     269  (    1.2%)  RuboCop::Cop::Layout::DefEndAlignment#on_send
     264  (    1.2%)  RuboCop::Cop::Performance::FixedSize#on_send
     243  (    1.1%)  RuboCop::Cop::Lint::NestedMethodDefinition#on_def
     238  (    1.1%)  RuboCop::Cop::Layout::DotPosition#on_send
     235  (    1.0%)  RuboCop::Cop::Layout::SpaceInsideReferenceBrackets#on_send
     216  (    1.0%)  RuboCop::Cop::Metrics::MethodLength#on_def
     212  (    0.9%)  RuboCop::Cop::Layout::ArgumentAlignment#on_send
     211  (    0.9%)  RuboCop::Cop::MethodComplexity#on_def
     194  (    0.9%)  RuboCop::Cop::Layout::LineLength#on_potential_breakable_node
     188  (    0.8%)  RuboCop::Cop::Lint::DeprecatedClassMethods#on_send
     175  (    0.8%)  RuboCop::Cop::Lint::MixedRegexpCaptureTypes#on_regexp
     173  (    0.8%)  RuboCop::Cop::Layout::SpaceAroundMethodCallOperator#on_const    <========== 2
     171  (    0.8%)  RuboCop::Cop::Naming::VariableName#on_lvasgn
     170  (    0.8%)  RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces#on_hash
```

### After
```
Finished in 37.1 seconds

stackprof tmp/stackprof.dump --text --method 'RuboCop::Cop::Commissioner#trigger_responding_cops'
     440  (    2.8%)  RuboCop::Cop::Style::TrailingMethodEndStatement#on_def
     342  (    2.2%)  RuboCop::Cop::Layout::IndentationConsistency#on_begin
     286  (    1.8%)  RuboCop::Cop::MultilineExpressionIndentation#on_send
     285  (    1.8%)  RuboCop::Cop::Style::NumericPredicate#on_send
     262  (    1.7%)  RuboCop::Cop::Metrics::ModuleLength#on_module
```

Both lines disappeared from the profile and gave 20% speedup overall.