### PR TITLE
[Fix #8299] Fix an incorrect auto-correct for `Style/RedundantCondition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#8324](https://github.com/rubocop-hq/rubocop/issues/8324): Fix crash for `Layout/SpaceAroundMethodCallOperator` when using `Proc#call` shorthand syntax. ([@fatkodima][])
 * [#8323](https://github.com/rubocop-hq/rubocop/issues/8323): Fix a false positive for `Style/HashAsLastArrayItem` when hash is not a last array item. ([@fatkodima][])
+* [#8299](https://github.com/rubocop-hq/rubocop/issues/8299): Fix an incorrect auto-correct for `Style/RedundantCondition` when using `raise`, `rescue`, or `and` without argument parentheses in `else`. ([@koic][])
 
 ## 0.88.0 (2020-07-13)
 

--- a/lib/rubocop/cop/style/redundant_condition.rb
+++ b/lib/rubocop/cop/style/redundant_condition.rb
@@ -90,10 +90,10 @@ module RuboCop
         end
 
         def else_source(else_branch)
-          if else_branch.basic_conditional? &&
-             else_branch.modifier_form? ||
-             else_branch.range_type?
+          if require_parentheses?(else_branch)
             "(#{else_branch.source})"
+          elsif without_argument_parentheses_method?(else_branch)
+            "#{else_branch.method_name}(#{else_branch.arguments.map(&:source).join(', ')})"
           else
             else_branch.source
           end
@@ -117,6 +117,18 @@ module RuboCop
           return unless node.else_branch.range_type?
 
           corrector.wrap(node.else_branch, '(', ')')
+        end
+
+        def require_parentheses?(node)
+          node.basic_conditional? &&
+            node.modifier_form? ||
+            node.range_type? ||
+            node.rescue_type? ||
+            node.respond_to?(:semantic_operator?) && node.semantic_operator?
+        end
+
+        def without_argument_parentheses_method?(node)
+          node.send_type? && !node.arguments.empty? && !node.parenthesized?
         end
       end
     end

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -42,6 +42,36 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition do
         RUBY
       end
 
+      it 'registers an offense and corrects when `raise` without argument parentheses in `else`' do
+        expect_offense(<<~RUBY)
+          if b
+          ^^^^ Use double pipes `||` instead.
+            b
+          else
+            raise 'foo'
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          b || raise('foo')
+        RUBY
+      end
+
+      it 'registers an offense and corrects when a method without argument parentheses in `else`' do
+        expect_offense(<<~RUBY)
+          if b
+          ^^^^ Use double pipes `||` instead.
+            b
+          else
+            do_something foo, bar, key: :value
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          b || do_something(foo, bar, key: :value)
+        RUBY
+      end
+
       it 'registers an offense and corrects complex one liners' do
         expect_offense(<<~RUBY)
           if b
@@ -250,6 +280,36 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition do
 
         expect_correction(<<~RUBY)
           time_period = updated_during || (2.days.ago...Time.now)
+        RUBY
+      end
+
+      it 'registers an offense and corrects when the else branch contains `rescue`' do
+        expect_offense(<<~RUBY)
+          if a
+          ^^^^ Use double pipes `||` instead.
+            a
+          else
+            b rescue c
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a || (b rescue c)
+        RUBY
+      end
+
+      it 'registers an offense and corrects when the else branch contains `and`' do
+        expect_offense(<<~RUBY)
+          if a
+          ^^^^ Use double pipes `||` instead.
+            a
+          else
+            b and c
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a || (b and c)
         RUBY
       end
     end


### PR DESCRIPTION
Fixes #8299

This PR fixes an incorrect auto-correct for `Style/RedundantCondition` when using `raise` without argument parentheses in `else`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
