### PR TITLE
Don't show pending cops warning when using --only flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Changes
 
 * [#8294](https://github.com/rubocop-hq/rubocop/pull/8294): Add `of` to `AllowedNames` of `MethodParameterName` cop. ([@AlexWayfer][])
+* [#8265](https://github.com/rubocop-hq/rubocop/issues/8265): Don't show pending cops warning when using --only flag. ([@tejasbubane][])
 
 ## 0.87.1 (2020-07-07)
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -101,7 +101,7 @@ module RuboCop
 
     def set_options_to_config_loader
       ConfigLoader.debug = @options[:debug]
-      ConfigLoader.disable_pending_cops = @options[:disable_pending_cops]
+      ConfigLoader.disable_pending_cops = @options[:disable_pending_cops] || @options[:only]
       ConfigLoader.enable_pending_cops = @options[:enable_pending_cops]
       ConfigLoader.ignore_parent_exclusion = @options[:ignore_parent_exclusion]
     end

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         # Since we define a new cop class, we have to do this in a separate
         # process. Otherwise, the extra cop will affect other specs.
         let(:output) do
-          `ruby -I . "#{rubocop}" --require redirect.rb --only Style/SomeCop`
+          `ruby -I . "#{rubocop}" --require redirect.rb`
         end
 
         let(:pending_cop_warning) { <<~PENDING_COP_WARNING }
@@ -313,6 +313,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                 DefaultFormatter: progress
                 #{new_cops_option}
 
+              Style/FrozenStringLiteralComment:
+                Enabled: false
+
               Style/SomeCop:
                 Description: Something
                 Enabled: pending
@@ -330,10 +333,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
               pending_cops = output[remaining_range].split("\n")
 
               expect(pending_cops).to include(' - Style/SomeCop (0.80)')
-
-              manual_url = output[remaining_range].split("\n").last
-
-              expect(manual_url).to eq(versioning_manual_url)
+              expect(pending_cops).to include(versioning_manual_url)
             end
           end
 
@@ -370,6 +370,18 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
           context 'when using `--enable-pending-cops` command-line option' do
             let(:option) { '--enable-pending-cops' }
+
+            let(:output) do
+              `ruby -I . "#{rubocop}" --require redirect.rb #{option}`
+            end
+
+            it 'does not display a pending cop warning' do
+              expect(output).not_to start_with(pending_cop_warning)
+            end
+          end
+
+          context 'when using `--only` command-line option' do
+            let(:option) { '--only Style/RedundantAssignment' }
 
             let(:output) do
               `ruby -I . "#{rubocop}" --require redirect.rb #{option}`


### PR DESCRIPTION
Closes #8265

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/