### PR TITLE
Reduce memory usage in `ResultCache#rubocop_checksum`

### DIFF
--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -158,6 +158,7 @@ module RuboCop
     end
 
     # The checksum of the rubocop program running the inspection.
+    # rubocop:disable Metrics/AbcSize
     def rubocop_checksum
       ResultCache.source_checksum ||=
         begin
@@ -168,13 +169,16 @@ module RuboCop
           # exe directory. A change to any of them could affect the cop output
           # so we include them in the cache hash.
           source_files = $LOADED_FEATURES + Find.find(exe_root).to_a
-          sources = source_files
-                    .select { |path| File.file?(path) }
-                    .sort
-                    .map { |path| IO.read(path, encoding: Encoding::UTF_8) }
-          Digest::SHA1.hexdigest(sources.join)
+
+          digest = Digest::SHA1.new
+          source_files
+            .select { |path| File.file?(path) }
+            .sort!
+            .each { |path| digest << File.mtime(path).to_s }
+          digest.hexdigest
         end
     end
+    # rubocop:enable Metrics/AbcSize
 
     # Return a hash of the options given at invocation, minus the ones that have
     # no effect on which offenses and disabled line ranges are found, and thus


### PR DESCRIPTION
Profiled with https://github.com/SamSaffron/memory_profiler

```
$ bin/rubocop-profile
```

### Before
```
Total allocated: 103806408 bytes (777343 objects)
Total retained:  5333518 bytes (36291 objects)
.......
allocated memory by file
-----------------------------------
  28757864  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rubocop-ast-0.1.0/lib/rubocop/ast/node_pattern.rb
  14626676  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/result_cache.rb   <========
  11528376  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop.rb
  10214354  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/2.6.0/find.rb
....
```

### After
```
Total allocated: 91409243 bytes (777654 objects)
Total retained:  5333558 bytes (36292 objects)
....
allocated memory by file
-----------------------------------
  28757864  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rubocop-ast-0.1.0/lib/rubocop/ast/node_pattern.rb
  11528494  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop.rb
  10329123  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/2.6.0/find.rb
   8596706  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb
   5195909  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/2.6.0/rubygems/basic_specification.rb
   3155845  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/2.6.0/digest.rb
   2114624  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/result_cache.rb    <========
   1846311  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/2.6.0/erb.rb
   1316992  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/2.6.0/psych/tree_builder.rb
....
```

Memory savings: 
`(103806408.0 - 91409243) / 103806408.0 * 100 = 12%` 
and this is `(103806408.0 - 91409243) / 1024 / 1024 = 12mb`.