### PR TITLE
Optimize `Style/CommentedKeyword` to reduce memory usage

### DIFF
--- a/lib/rubocop/cop/style/commented_keyword.rb
+++ b/lib/rubocop/cop/style/commented_keyword.rb
@@ -46,17 +46,20 @@ module RuboCop
         private
 
         KEYWORDS = %w[begin class def end module].freeze
+        KEYWORD_REGEXES = KEYWORDS.map { |w| /^\s*#{w}\s/ }.freeze
+
         ALLOWED_COMMENTS = %w[
           :nodoc:
           :yields:
           rubocop:disable
           rubocop:todo
         ].freeze
+        ALLOWED_COMMENT_REGEXES = ALLOWED_COMMENTS.map { |c| /#\s*#{c}/ }.freeze
 
         def offensive?(comment)
           line = line(comment)
-          KEYWORDS.any? { |word| /^\s*#{word}\s/.match?(line) } &&
-            ALLOWED_COMMENTS.none? { |c| /#\s*#{c}/.match?(line) }
+          KEYWORD_REGEXES.any? { |r| r.match?(line) } &&
+            ALLOWED_COMMENT_REGEXES.none? { |r| r.match?(line) }
         end
 
         def message(comment)


### PR DESCRIPTION
Profiled with `memory_profiler`.

```
bin/rubocop-profile lib/rubocop/cop/style
```

### Before
```
Total allocated: 681427009 bytes (8246313 objects)
Total retained:  6103832 bytes (39018 objects)
.....
allocated memory by file
-----------------------------------
  62890239  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/2.6.0/set.rb
  43983225  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/parser-2.7.1.4/lib/parser/source/tree_rewriter.rb
  43851800  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/base.rb
  43461557  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rubocop-ast-0.1.0/lib/rubocop/ast/node.rb
  39761197  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/style/commented_keyword.rb       <=======
  28841125  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rubocop-ast-0.1.0/lib/rubocop/ast/node_pattern.rb
  26456590  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/badge.rb
.....
```

### After
```
Total allocated: 642051791 bytes (8046300 objects)
Total retained:  6110058 bytes (39039 objects)
.....
allocated memory by file
-----------------------------------
  62891631  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/2.6.0/set.rb
  43983225  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/parser-2.7.1.4/lib/parser/source/tree_rewriter.rb
  43851880  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/base.rb
  43500709  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rubocop-ast-0.1.0/lib/rubocop/ast/node.rb
  28841125  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rubocop-ast-0.1.0/lib/rubocop/ast/node_pattern.rb
  26456590  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/badge.rb
  23206228  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/parser-2.7.1.4/lib/parser/source/buffer.rb
  22456704  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/util.rb
  21016745  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/parser-2.7.1.4/lib/parser/lexer.rb
  17848959  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
......
```

It disappeared from profile 😄 .

Memory savings:
`(681427009.0 - 642051791) / 681427009.0 * 100 = 6%`
and in megabytes: `(681427009.0 - 642051791) / 1024 / 1024 = 38mb`