### PR TITLE
Memoize `Badge#to_s` to reduce memory allocations

### DIFF
--- a/lib/rubocop/cop/badge.rb
+++ b/lib/rubocop/cop/badge.rb
@@ -58,7 +58,7 @@ module RuboCop
       end
 
       def to_s
-        qualified? ? "#{department}/#{cop_name}" : cop_name
+        @to_s ||= qualified? ? "#{department}/#{cop_name}" : cop_name
       end
 
       def qualified?


### PR DESCRIPTION
Profiled with `memory_profiler`.

```
$ bin/rubocop-profile lib/rubocop/cop/style
```

### Before
```
Total allocated: 682975704 bytes (8263326 objects)
Total retained:  6103832 bytes (39018 objects)
....
allocated memory by file
-----------------------------------
  62890239  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/2.6.0/set.rb
  43983225  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/parser-2.7.1.4/lib/parser/source/tree_rewriter.rb
  43851800  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/base.rb
  43461557  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rubocop-ast-0.1.0/lib/rubocop/ast/node.rb
  39761197  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/style/commented_keyword.rb
  28841125  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rubocop-ast-0.1.0/lib/rubocop/ast/node_pattern.rb
  26456590  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/badge.rb     <==========
  23182282  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/parser-2.7.1.4/lib/parser/source/buffer.rb
  22439585  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/util.rb
......
```

### After
```
Total allocated: 657230941 bytes (7767964 objects)
Total retained:  6102216 bytes (38992 objects)
......
allocated memory by file
-----------------------------------
  62890239  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/2.6.0/set.rb
  43983225  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/parser-2.7.1.4/lib/parser/source/tree_rewriter.rb
  43851800  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/base.rb
  43461557  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rubocop-ast-0.1.0/lib/rubocop/ast/node.rb
  39761197  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/style/commented_keyword.rb
  28841125  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rubocop-ast-0.1.0/lib/rubocop/ast/node_pattern.rb
  23182282  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/parser-2.7.1.4/lib/parser/source/buffer.rb
  22439585  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/util.rb
  21007465  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/parser-2.7.1.4/lib/parser/lexer.rb
  17836125  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
  16530814  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/commissioner.rb
.......
```
That line disappeared from the profile 😄 

Memory savings: `(682975704.0 - 657230941) / 682975704.0 * 100 = 4%`
and in megabytes: `(682975704.0 - 657230941) / 1024 / 1024 = 25mb`.