### PR TITLE
Refactor Lint cops to use expect_offense

### DIFF
--- a/lib/rubocop/cop/lint/literal_as_condition.rb
+++ b/lib/rubocop/cop/lint/literal_as_condition.rb
@@ -30,6 +30,8 @@ module RuboCop
       #     break if condition
       #   end
       class LiteralAsCondition < Cop
+        include RangeHelp
+
         MSG = 'Literal `%<literal>s` appeared as a condition.'
 
         def on_if(node)
@@ -57,7 +59,8 @@ module RuboCop
             case_node.each_when do |when_node|
               next unless when_node.conditions.all?(&:literal?)
 
-              add_offense(when_node)
+              range = when_conditions_range(when_node)
+              add_offense(when_node, location: range, message: message(range))
             end
           end
         end
@@ -128,6 +131,13 @@ module RuboCop
           else
             node.condition
           end
+        end
+
+        def when_conditions_range(when_node)
+          range_between(
+            when_node.conditions.first.source_range.begin_pos,
+            when_node.conditions.last.source_range.end_pos
+          )
         end
       end
     end

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -1,64 +1,160 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
-  shared_examples_for 'debugger' do |name, src|
-    it "reports an offense for a #{name} call" do
-      inspect_source(src)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(["Remove debugger entry point `#{src}`."])
-      expect(cop.highlights).to eq([src])
+  it 'reports an offense for a debugger call' do
+    expect_offense(<<~RUBY)
+      debugger
+      ^^^^^^^^ Remove debugger entry point `debugger`.
+    RUBY
+  end
+
+  it 'reports an offense for a byebug call' do
+    expect_offense(<<~RUBY)
+      byebug
+      ^^^^^^ Remove debugger entry point `byebug`.
+    RUBY
+  end
+
+  it 'reports an offense for a pry binding call' do
+    expect_offense(<<~RUBY)
+      binding.pry
+      ^^^^^^^^^^^ Remove debugger entry point `binding.pry`.
+    RUBY
+  end
+
+  it 'reports an offense for a remote_pry binding call' do
+    expect_offense(<<~RUBY)
+      binding.remote_pry
+      ^^^^^^^^^^^^^^^^^^ Remove debugger entry point `binding.remote_pry`.
+    RUBY
+  end
+
+  it 'reports an offense for a pry_remote binding call' do
+    expect_offense(<<~RUBY)
+      binding.pry_remote
+      ^^^^^^^^^^^^^^^^^^ Remove debugger entry point `binding.pry_remote`.
+    RUBY
+  end
+
+  context 'with capybara debug method call' do
+    it 'reports an offense for save_and_open_page' do
+      expect_offense(<<~RUBY)
+        save_and_open_page
+        ^^^^^^^^^^^^^^^^^^ Remove debugger entry point `save_and_open_page`.
+      RUBY
+    end
+
+    it 'reports an offense for save_and_open_screenshot' do
+      expect_offense(<<~RUBY)
+        save_and_open_screenshot
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Remove debugger entry point `save_and_open_screenshot`.
+      RUBY
+    end
+
+    it 'reports an offense for save_screenshot' do
+      expect_offense(<<~RUBY)
+        save_screenshot
+        ^^^^^^^^^^^^^^^ Remove debugger entry point `save_screenshot`.
+      RUBY
+    end
+
+    context 'with an argument' do
+      it 'reports an offense for save_and_open_page' do
+        expect_offense(<<~RUBY)
+          save_and_open_page foo
+          ^^^^^^^^^^^^^^^^^^^^^^ Remove debugger entry point `save_and_open_page foo`.
+        RUBY
+      end
+
+      it 'reports an offense for save_and_open_screenshot' do
+        expect_offense(<<~RUBY)
+          save_and_open_screenshot foo
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove debugger entry point `save_and_open_screenshot foo`.
+        RUBY
+      end
+
+      it 'reports an offense for save_screenshot' do
+        expect_offense(<<~RUBY)
+          save_screenshot foo
+          ^^^^^^^^^^^^^^^^^^^ Remove debugger entry point `save_screenshot foo`.
+        RUBY
+      end
     end
   end
 
-  include_examples 'debugger', 'debugger', 'debugger'
-  include_examples 'debugger', 'byebug', 'byebug'
-  include_examples 'debugger', 'pry binding',
-                   'binding.pry'
-  include_examples 'debugger', 'pry binding',
-                   'binding.remote_pry'
-  include_examples 'debugger', 'pry binding',
-                   'binding.pry_remote'
-  include_examples 'debugger',
-                   'capybara debug method',
-                   'save_and_open_page'
-  include_examples 'debugger',
-                   'capybara debug method',
-                   'save_and_open_screenshot'
-  include_examples 'debugger',
-                   'capybara debug method',
-                   'save_screenshot'
-  include_examples 'debugger', 'debugger with an argument', 'debugger foo'
-  include_examples 'debugger', 'byebug with an argument', 'byebug foo'
-  include_examples 'debugger',
-                   'pry binding with an argument',
-                   'binding.pry foo'
-  include_examples 'debugger',
-                   'pry binding with an argument',
-                   'binding.remote_pry foo'
-  include_examples 'debugger',
-                   'pry binding with an argument',
-                   'binding.pry_remote foo'
-  include_examples 'debugger',
-                   'capybara debug method with an argument',
-                   'save_and_open_page foo'
-  include_examples 'debugger',
-                   'capybara debug method with an argument',
-                   'save_and_open_screenshot foo'
-  include_examples 'debugger',
-                   'capybara debug method with an argument',
-                   'save_screenshot foo'
+  it 'reports an offense for a debugger with an argument call' do
+    expect_offense(<<~RUBY)
+      debugger foo
+      ^^^^^^^^^^^^ Remove debugger entry point `debugger foo`.
+    RUBY
+  end
 
-  include_examples 'debugger', 'remote_byebug', 'remote_byebug'
-  include_examples 'debugger', 'web console binding', 'binding.console'
+  it 'reports an offense for a byebug with an argument call' do
+    expect_offense(<<~RUBY)
+      byebug foo
+      ^^^^^^^^^^ Remove debugger entry point `byebug foo`.
+    RUBY
+  end
+
+  it 'reports an offense for a pry binding with an argument call' do
+    expect_offense(<<~RUBY)
+      binding.pry foo
+      ^^^^^^^^^^^^^^^ Remove debugger entry point `binding.pry foo`.
+    RUBY
+  end
+
+  it 'reports an offense for a remote_pry binding with an argument call' do
+    expect_offense(<<~RUBY)
+      binding.remote_pry foo
+      ^^^^^^^^^^^^^^^^^^^^^^ Remove debugger entry point `binding.remote_pry foo`.
+    RUBY
+  end
+
+  it 'reports an offense for a pry_remote binding with an argument call' do
+    expect_offense(<<~RUBY)
+      binding.pry_remote foo
+      ^^^^^^^^^^^^^^^^^^^^^^ Remove debugger entry point `binding.pry_remote foo`.
+    RUBY
+  end
+
+  it 'reports an offense for a remote_byebug call' do
+    expect_offense(<<~RUBY)
+      remote_byebug
+      ^^^^^^^^^^^^^ Remove debugger entry point `remote_byebug`.
+    RUBY
+  end
+
+  it 'reports an offense for a web console binding call' do
+    expect_offense(<<~RUBY)
+      binding.console
+      ^^^^^^^^^^^^^^^ Remove debugger entry point `binding.console`.
+    RUBY
+  end
 
   it 'does not report an offense for a non-pry binding' do
     expect_no_offenses('binding.pirate')
   end
 
-  include_examples 'debugger', 'debugger with Kernel', 'Kernel.debugger'
-  include_examples 'debugger', 'debugger with ::Kernel', '::Kernel.debugger'
-  include_examples 'debugger', 'binding.pry with Kernel', 'Kernel.binding.pry'
+  it 'reports an offense for a debugger with Kernel call' do
+    expect_offense(<<~RUBY)
+      Kernel.debugger
+      ^^^^^^^^^^^^^^^ Remove debugger entry point `Kernel.debugger`.
+    RUBY
+  end
+
+  it 'reports an offense for a debugger with ::Kernel call' do
+    expect_offense(<<~RUBY)
+      ::Kernel.debugger
+      ^^^^^^^^^^^^^^^^^ Remove debugger entry point `::Kernel.debugger`.
+    RUBY
+  end
+
+  it 'reports an offense for a binding.pry with Kernel call' do
+    expect_offense(<<~RUBY)
+      Kernel.binding.pry
+      ^^^^^^^^^^^^^^^^^^ Remove debugger entry point `Kernel.binding.pry`.
+    RUBY
+  end
 
   it 'does not report an offense for save_and_open_page with Kernel' do
     expect_no_offenses('Kernel.save_and_open_page')
@@ -86,6 +182,17 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
     RUBY
   end
 
-  include_examples 'debugger', 'irb binding', 'binding.irb'
-  include_examples 'debugger', 'binding.irb with Kernel', 'Kernel.binding.irb'
+  it 'reports an offense for a irb binding call' do
+    expect_offense(<<~RUBY)
+      binding.irb
+      ^^^^^^^^^^^ Remove debugger entry point `binding.irb`.
+    RUBY
+  end
+
+  it 'reports an offense for a binding.irb with Kernel call' do
+    expect_offense(<<~RUBY)
+      Kernel.binding.irb
+      ^^^^^^^^^^^^^^^^^^ Remove debugger entry point `Kernel.binding.irb`.
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/lint/duplicate_hash_key_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_hash_key_spec.rb
@@ -42,11 +42,10 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateHashKey do
 
   shared_examples 'duplicated literal key' do |key|
     it "registers an offense for duplicated `#{key}` hash keys" do
-      inspect_source("hash = { #{key} => 1, #{key} => 4}")
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.message)
-        .to eq('Duplicated key in hash literal.')
-      expect(cop.highlights).to eq [key]
+      expect_offense(<<~RUBY, key: key)
+        hash = { %{key} => 1, %{key} => 4}
+                 _{key}       ^{key} Duplicated key in hash literal.
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods do
 
     it 'registers an offense for a duplicate class method in separate ' \
        "#{type} blocks" do
-      inspect_source(<<~RUBY)
+      expect_offense(<<~RUBY, 'test.rb')
         #{opening_line}
           def self.some_method
             implement 1
@@ -176,15 +176,15 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods do
         end
         #{opening_line}
           def self.some_method
+          ^^^^^^^^^^^^^^^^^^^^ Method `A.some_method` is defined at both test.rb:2 and test.rb:7.
             implement 2
           end
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
 
     it 'registers offense for a duplicate instance method in separate files' do
-      inspect_source(<<~RUBY, 'first.rb')
+      expect_no_offenses(<<~RUBY, 'first.rb')
         #{opening_line}
           def some_method
             implement 1
@@ -240,19 +240,19 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods do
 
     it 'registers an offense when class << exp is used' do
       pending
-      inspect_source(<<~RUBY, 'test.rb')
+      expect_offense(<<~RUBY, 'test.rb')
         #{opening_line}
           class << blah
             def some_method
               implement 1
             end
             def some_method
+            ^^^^^^^^^^^^^^^ Method `A#some_method` is defined at both test.rb:3 and test.rb:6.
               implement 2
             end
           end
         end
       RUBY
-      expect(cop.offenses.empty?).to be(false)
     end
 
     it "registers an offense for duplicate alias in #{type}" do

--- a/spec/rubocop/cop/lint/implicit_string_concatenation_spec.rb
+++ b/spec/rubocop/cop/lint/implicit_string_concatenation_spec.rb
@@ -33,11 +33,21 @@ RSpec.describe RuboCop::Cop::Lint::ImplicitStringConcatenation do
 
   context 'when the string literals contain newlines' do
     it 'registers an offense' do
-      inspect_source(<<~RUBY)
-        def method; "ab\nc" "de\nf"; end
+      expect_offense(<<~'RUBY')
+        def method
+          "ab
+          ^^^ Combine "ab\nc" and "de\nf" into a single string literal, [...]
+        c" "de
+        f"
+        end
       RUBY
+    end
 
-      expect(cop.offenses.size).to eq(1)
+    it 'does not register an offense for a single string' do
+      expect_no_offenses(<<~RUBY)
+        'abc
+        def'
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/lint/literal_as_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_as_condition_spec.rb
@@ -5,67 +5,69 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition do
 
   %w(1 2.0 [1] {} :sym :"#{a}").each do |lit|
     it "registers an offense for literal #{lit} in if" do
-      inspect_source(<<~RUBY)
-        if #{lit}
+      expect_offense(<<~RUBY, lit: lit)
+        if %{lit}
+           ^{lit} Literal `#{lit}` appeared as a condition.
           top
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for literal #{lit} in while" do
-      inspect_source(<<~RUBY)
-        while #{lit}
+      expect_offense(<<~RUBY, lit: lit)
+        while %{lit}
+              ^{lit} Literal `#{lit}` appeared as a condition.
           top
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for literal #{lit} in post-loop while" do
-      inspect_source(<<~RUBY)
+      expect_offense(<<~RUBY, lit: lit)
         begin
           top
-        end while(#{lit})
+        end while(%{lit})
+                  ^{lit} Literal `#{lit}` appeared as a condition.
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for literal #{lit} in until" do
-      inspect_source(<<~RUBY)
-        until #{lit}
+      expect_offense(<<~RUBY, lit: lit)
+        until %{lit}
+              ^{lit} Literal `#{lit}` appeared as a condition.
           top
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for literal #{lit} in post-loop until" do
-      inspect_source(<<~RUBY)
+      expect_offense(<<~RUBY, lit: lit)
         begin
           top
-        end until #{lit}
+        end until %{lit}
+                  ^{lit} Literal `#{lit}` appeared as a condition.
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for literal #{lit} in case" do
-      inspect_source(<<~RUBY)
-        case #{lit}
+      expect_offense(<<~RUBY, lit: lit)
+        case %{lit}
+             ^{lit} Literal `#{lit}` appeared as a condition.
         when x then top
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for literal #{lit} in a when " \
        'of a case without anything after case keyword' do
-      inspect_source(<<~RUBY)
+      pending 'Offense should be just the literal condition rather than ' \
+        'the whole when line.'
+      expect_offense(<<~RUBY, lit: lit)
         case
-        when #{lit} then top
+        when %{lit} then top
+             ^{lit} Literal `#{lit}` appeared as a condition.
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
 
     it "accepts literal #{lit} in a when of a case with " \
@@ -78,39 +80,39 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition do
     end
 
     it "registers an offense for literal #{lit} in &&" do
-      inspect_source(<<~RUBY)
-        if x && #{lit}
+      expect_offense(<<~RUBY, lit: lit)
+        if x && %{lit}
+                ^{lit} Literal `#{lit}` appeared as a condition.
           top
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for literal #{lit} in complex cond" do
-      inspect_source(<<~RUBY)
-        if x && !(a && #{lit}) && y && z
+      expect_offense(<<~RUBY, lit: lit)
+        if x && !(a && %{lit}) && y && z
+                       ^{lit} Literal `#{lit}` appeared as a condition.
           top
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for literal #{lit} in !" do
-      inspect_source(<<~RUBY)
-        if !#{lit}
+      expect_offense(<<~RUBY, lit: lit)
+        if !%{lit}
+            ^{lit} Literal `#{lit}` appeared as a condition.
           top
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for literal #{lit} in complex !" do
-      inspect_source(<<~RUBY)
-        if !(x && (y && #{lit}))
+      expect_offense(<<~RUBY, lit: lit)
+        if !(x && (y && %{lit}))
+                        ^{lit} Literal `#{lit}` appeared as a condition.
           top
         end
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
 
     it "accepts literal #{lit} if it's not an and/or operand" do
@@ -130,17 +132,17 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition do
     end
 
     it "registers an offense for `!#{lit}`" do
-      inspect_source(<<~RUBY)
-        !#{lit}
+      expect_offense(<<~RUBY, lit: lit)
+        !%{lit}
+         ^{lit} Literal `#{lit}` appeared as a condition.
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for `not #{lit}`" do
-      inspect_source(<<~RUBY)
-        not(#{lit})
+      expect_offense(<<~RUBY, lit: lit)
+        not(%{lit})
+            ^{lit} Literal `#{lit}` appeared as a condition.
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
   end
 

--- a/spec/rubocop/cop/lint/literal_as_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_as_condition_spec.rb
@@ -60,8 +60,6 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition do
 
     it "registers an offense for literal #{lit} in a when " \
        'of a case without anything after case keyword' do
-      pending 'Offense should be just the literal condition rather than ' \
-        'the whole when line.'
       expect_offense(<<~RUBY, lit: lit)
         case
         when %{lit} then top

--- a/spec/rubocop/cop/lint/next_without_accumulator_spec.rb
+++ b/spec/rubocop/cop/lint/next_without_accumulator_spec.rb
@@ -3,50 +3,37 @@
 RSpec.describe RuboCop::Cop::Lint::NextWithoutAccumulator do
   subject(:cop) { described_class.new }
 
-  def code_without_accumulator(method_name)
-    <<-RUBY
-      (1..4).#{method_name}(0) do |acc, i|
-        next if i.odd?
-        acc + i
-      end
-    RUBY
-  end
-
-  def code_with_accumulator(method_name)
-    <<-RUBY
-      (1..4).#{method_name}(0) do |acc, i|
-        next acc if i.odd?
-        acc + i
-      end
-    RUBY
-  end
-
-  def code_with_nested_block(method_name)
-    <<-RUBY
-      [(1..3), (4..6)].#{method_name}(0) do |acc, elems|
-        elems.each_with_index do |elem, i|
-          next if i == 1
-          acc << elem
-        end
-        acc
-      end
-    RUBY
-  end
-
   shared_examples 'reduce/inject' do |reduce_alias|
     context "given a #{reduce_alias} block" do
       it 'registers an offense for a bare next' do
-        inspect_source(code_without_accumulator(reduce_alias))
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.highlights).to eq(['next'])
+        expect_offense(<<~RUBY)
+          (1..4).#{reduce_alias}(0) do |acc, i|
+            next if i.odd?
+            ^^^^ Use `next` with an accumulator argument in a `reduce`.
+            acc + i
+          end
+        RUBY
       end
 
       it 'accepts next with a value' do
-        expect_no_offenses(code_with_accumulator(reduce_alias))
+        expect_no_offenses(<<~RUBY)
+          (1..4).#{reduce_alias}(0) do |acc, i|
+            next acc if i.odd?
+            acc + i
+          end
+        RUBY
       end
 
       it 'accepts next within a nested block' do
-        expect_no_offenses(code_with_nested_block(reduce_alias))
+        expect_no_offenses(<<~RUBY)
+          [(1..3), (4..6)].#{reduce_alias}(0) do |acc, elems|
+            elems.each_with_index do |elem, i|
+              next if i == 1
+              acc << elem
+            end
+            acc
+          end
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/lint/rand_one_spec.rb
+++ b/spec/rubocop/cop/lint/rand_one_spec.rb
@@ -6,14 +6,10 @@ RSpec.describe RuboCop::Cop::Lint::RandOne do
   shared_examples 'offenses' do |source|
     describe source do
       it 'registers an offense' do
-        inspect_source(source)
-        expect(cop.messages).to eq(
-          [
-            "`#{source}` always returns `0`. " \
-            'Perhaps you meant `rand(2)` or `rand`?'
-          ]
-        )
-        expect(cop.highlights).to eq([source])
+        expect_offense(<<~RUBY, source: source)
+          %{source}
+          ^{source} `#{source}` always returns `0`. [...]
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/lint/redundant_splat_expansion_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_splat_expansion_spec.rb
@@ -364,16 +364,26 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSplatExpansion do
     end
 
     context 'splat expansion inside of an array' do
-      it 'changes %i to a list of symbols' do
-        new_source = autocorrect_source('[:a, :b, *%i(c d), :e]')
+      it 'registers an offense and corrects %i to a list of symbols' do
+        expect_offense(<<~RUBY)
+          [:a, :b, *%i(c d), :e]
+                   ^^^^^^^^ Pass array contents as separate arguments.
+        RUBY
 
-        expect(new_source).to eq('[:a, :b, :c, :d, :e]')
+        expect_correction(<<~RUBY)
+          [:a, :b, :c, :d, :e]
+        RUBY
       end
 
-      it 'changes %I to a list of symbols' do
-        new_source = autocorrect_source('[:a, :b, *%I(#{one} two), :e]')
+      it 'registers an offense and changes %I to a list of symbols' do
+        expect_offense(<<~'RUBY')
+          [:a, :b, *%I(#{one} two), :e]
+                   ^^^^^^^^^^^^^^^ Pass array contents as separate arguments.
+        RUBY
 
-        expect(new_source).to eq('[:a, :b, :"#{one}", :"two", :e]')
+        expect_correction(<<~'RUBY')
+          [:a, :b, :"#{one}", :"two", :e]
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/lint/script_permission_spec.rb
+++ b/spec/rubocop/cop/lint/script_permission_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe RuboCop::Cop::Lint::ScriptPermission do
           #!/usr/bin/ruby
           ^^^^^^^^^^^^^^^ Script file #{filename} doesn't have execute permission.
         RUBY
+        expect_correction(<<~RUBY)
+          #!/usr/bin/ruby
+        RUBY
+        expect(file.stat.executable?).to be_truthy
       end
     end
   end
@@ -69,18 +73,6 @@ RSpec.describe RuboCop::Cop::Lint::ScriptPermission do
 
     it 'skips investigation' do
       expect_no_offenses(source)
-    end
-  end
-
-  unless RuboCop::Platform.windows?
-    context 'auto-correct' do
-      it 'adds execute permissions to the file' do
-        File.write(file.path, source)
-
-        autocorrect_source(file.read, file)
-
-        expect(file.stat.executable?).to be_truthy
-      end
     end
   end
 end

--- a/spec/rubocop/cop/lint/unused_block_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_block_argument_spec.rb
@@ -3,14 +3,6 @@
 RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
   let(:cop_config) { { 'AllowUnusedKeywordArguments' => false } }
 
-  shared_examples 'auto-correction' do |name, old_source, new_source|
-    it "auto-corrects #{name}" do
-      corrected_source = autocorrect_source(old_source)
-
-      expect(corrected_source).to eq(new_source)
-    end
-  end
-
   context 'inspection' do
     context 'when a block takes multiple arguments' do
       context 'and an argument is unused' do

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -487,19 +487,18 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   shared_examples 'repeated visibility modifiers' do |keyword, modifier|
     it "registers an offense when `#{modifier}` is repeated" do
-      src = <<~RUBY
+      expect_offense(<<~RUBY, modifier: modifier)
         #{keyword} A
           #{modifier == 'private' ? 'protected' : 'private'}
           def method1
           end
-          #{modifier}
-          #{modifier}
+          %{modifier}
+          %{modifier}
+          ^{modifier} Useless `#{modifier}` access modifier.
           def method2
           end
         end
       RUBY
-      inspect_source(src)
-      expect(cop.offenses.size).to eq(1)
     end
   end
 
@@ -553,23 +552,22 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   shared_examples 'at the end of the body' do |keyword, modifier|
     it "registers an offense for trailing `#{modifier}`" do
-      src = <<~RUBY
+      expect_offense(<<~RUBY, modifier: modifier)
         #{keyword} A
           def method1
           end
           def method2
           end
-          #{modifier}
+          %{modifier}
+          ^{modifier} Useless `#{modifier}` access modifier.
         end
       RUBY
-      inspect_source(src)
-      expect(cop.offenses.size).to eq(1)
     end
   end
 
   shared_examples 'nested in a begin..end block' do |keyword, modifier|
     it "still flags repeated `#{modifier}`" do
-      src = <<~RUBY
+      expect_offense(<<~RUBY, modifier: modifier)
         #{keyword} A
           #{modifier == 'private' ? 'protected' : 'private'}
           def blah
@@ -577,15 +575,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier do
           begin
             def method1
             end
-            #{modifier}
-            #{modifier}
+            %{modifier}
+            %{modifier}
+            ^{modifier} Useless `#{modifier}` access modifier.
             def method2
             end
           end
         end
       RUBY
-      inspect_source(src)
-      expect(cop.offenses.size).to eq(1)
     end
 
     unless modifier == 'public'
@@ -734,44 +731,41 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier do
       end
 
       it 'registers an offense if no method is defined' do
-        src = <<~RUBY
+        expect_offense(<<~RUBY, modifier: modifier)
           #{keyword} A
             class << self
-              #{modifier}
+              %{modifier}
+              ^{modifier} Useless `#{modifier}` access modifier.
             end
           end
         RUBY
-        inspect_source(src)
-        expect(cop.offenses.size).to eq(1)
       end
 
       it 'registers an offense if no method is defined after the modifier' do
-        src = <<~RUBY
+        expect_offense(<<~RUBY, modifier: modifier)
           #{keyword} A
             class << self
               def method1
               end
-              #{modifier}
+              %{modifier}
+              ^{modifier} Useless `#{modifier}` access modifier.
             end
           end
         RUBY
-        inspect_source(src)
-        expect(cop.offenses.size).to eq(1)
       end
 
       it 'registers an offense even if a non-singleton-class method is ' \
         'defined' do
-        src = <<~RUBY
+        expect_offense(<<~RUBY, modifier: modifier)
           #{keyword} A
             def method1
             end
             class << self
-              #{modifier}
+              %{modifier}
+              ^{modifier} Useless `#{modifier}` access modifier.
             end
           end
         RUBY
-        inspect_source(src)
-        expect(cop.offenses.size).to eq(1)
       end
     end
 
@@ -787,25 +781,23 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier do
       end
 
       it 'registers an offense if no method is defined' do
-        src = <<~RUBY
+        expect_offense(<<~RUBY, modifier: modifier)
           class << A
-            #{modifier}
+            %{modifier}
+            ^{modifier} Useless `#{modifier}` access modifier.
           end
         RUBY
-        inspect_source(src)
-        expect(cop.offenses.size).to eq(1)
       end
 
       it 'registers an offense if no method is defined after the modifier' do
-        src = <<~RUBY
+        expect_offense(<<~RUBY, modifier: modifier)
           class << A
             def method1
             end
-            #{modifier}
+            %{modifier}
+            ^{modifier} Useless `#{modifier}` access modifier.
           end
         RUBY
-        inspect_source(src)
-        expect(cop.offenses.size).to eq(1)
       end
     end
   end
@@ -822,43 +814,41 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier do
     end
 
     it 'registers an offense if no method is defined' do
-      src = <<~RUBY
+      expect_offense(<<~RUBY, modifier: modifier)
         A.class_eval do
-          #{modifier}
+          %{modifier}
+          ^{modifier} Useless `#{modifier}` access modifier.
         end
       RUBY
-      inspect_source(src)
-      expect(cop.offenses.size).to eq(1)
     end
 
     context 'inside a class' do
       it 'registers an offense when a modifier is ouside the block and a ' \
         'method is defined only inside the block' do
-        src = <<~RUBY
+        expect_offense(<<~RUBY, modifier: modifier)
           class A
-            #{modifier}
+            %{modifier}
+            ^{modifier} Useless `#{modifier}` access modifier.
             A.class_eval do
               def method1
               end
             end
           end
         RUBY
-        inspect_source(src)
-        expect(cop.offenses.size).to eq(1)
       end
 
       it 'registers two offenses when a modifier is inside and outside the ' \
         ' block and no method is defined' do
-        src = <<~RUBY
+        expect_offense(<<~RUBY, modifier: modifier)
           class A
-            #{modifier}
+            %{modifier}
+            ^{modifier} Useless `#{modifier}` access modifier.
             A.class_eval do
-              #{modifier}
+              %{modifier}
+              ^{modifier} Useless `#{modifier}` access modifier.
             end
           end
         RUBY
-        inspect_source(src)
-        expect(cop.offenses.size).to eq(2)
       end
     end
   end
@@ -875,13 +865,12 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier do
     end
 
     it "registers an offense if no method is defined in #{klass}.new" do
-      src = <<~RUBY
+      expect_offense(<<~RUBY, modifier: modifier)
         #{klass}.new do
-          #{modifier}
+          %{modifier}
+          ^{modifier} Useless `#{modifier}` access modifier.
         end
       RUBY
-      inspect_source(src)
-      expect(cop.offenses.size).to eq(1)
     end
   end
 
@@ -897,43 +886,41 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier do
     end
 
     it 'registers an offense if no method is defined' do
-      src = <<~RUBY
+      expect_offense(<<~RUBY, modifier: modifier)
         A.instance_eval do
-          #{modifier}
+          %{modifier}
+          ^{modifier} Useless `#{modifier}` access modifier.
         end
       RUBY
-      inspect_source(src)
-      expect(cop.offenses.size).to eq(1)
     end
 
     context 'inside a class' do
       it 'registers an offense when a modifier is ouside the block and a ' \
         'method is defined only inside the block' do
-        src = <<~RUBY
+        expect_offense(<<~RUBY, modifier: modifier)
           class A
-            #{modifier}
+            %{modifier}
+            ^{modifier} Useless `#{modifier}` access modifier.
             self.instance_eval do
               def method1
               end
             end
           end
         RUBY
-        inspect_source(src)
-        expect(cop.offenses.size).to eq(1)
       end
 
       it 'registers two offenses when a modifier is inside and outside the ' \
         ' and no method is defined' do
-        src = <<~RUBY
+        expect_offense(<<~RUBY, modifier: modifier)
           class A
-            #{modifier}
+            %{modifier}
+            ^{modifier} Useless `#{modifier}` access modifier.
             self.instance_eval do
-              #{modifier}
+              %{modifier}
+              ^{modifier} Useless `#{modifier}` access modifier.
             end
           end
         RUBY
-        inspect_source(src)
-        expect(cop.offenses.size).to eq(2)
       end
     end
   end
@@ -958,42 +945,40 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier do
 
     context 'unused modifiers' do
       it "registers an offense with a nested #{keyword}" do
-        src = <<~RUBY
+        expect_offense(<<~RUBY, modifier: modifier)
           #{keyword} A
-            #{modifier}
+            %{modifier}
+            ^{modifier} Useless `#{modifier}` access modifier.
             #{keyword} B
-              #{modifier}
+              %{modifier}
+              ^{modifier} Useless `#{modifier}` access modifier.
             end
           end
         RUBY
-        inspect_source(src)
-        expect(cop.offenses.size).to eq(2)
       end
 
       it "registers an offense when outside a nested #{keyword}" do
-        src = <<~RUBY
+        expect_offense(<<~RUBY, modifier: modifier)
           #{keyword} A
-            #{modifier}
+            %{modifier}
+            ^{modifier} Useless `#{modifier}` access modifier.
             #{keyword} B
               def method1
               end
             end
           end
         RUBY
-        inspect_source(src)
-        expect(cop.offenses.size).to eq(1)
       end
 
       it "registers an offense when inside a nested #{keyword}" do
-        src = <<~RUBY
+        expect_offense(<<~RUBY, modifier: modifier)
           #{keyword} A
             #{keyword} B
-              #{modifier}
+              %{modifier}
+              ^{modifier} Useless `#{modifier}` access modifier.
             end
           end
         RUBY
-        inspect_source(src)
-        expect(cop.offenses.size).to eq(1)
       end
     end
   end

--- a/spec/rubocop/cop/lint/useless_comparison_spec.rb
+++ b/spec/rubocop/cop/lint/useless_comparison_spec.rb
@@ -5,19 +5,21 @@ RSpec.describe RuboCop::Cop::Lint::UselessComparison do
 
   described_class::OPS.each do |op|
     it "registers an offense for a simple comparison with #{op}" do
-      inspect_source(<<~RUBY)
-        5 #{op} 5
-        a #{op} a
+      expect_offense(<<~RUBY, op: op)
+        5 %{op} 5
+          ^{op} Comparison of something with itself detected.
+        a %{op} a
+          ^{op} Comparison of something with itself detected.
       RUBY
-      expect(cop.offenses.size).to eq(2)
     end
 
     it "registers an offense for a complex comparison with #{op}" do
-      inspect_source(<<~RUBY)
-        5 + 10 * 30 #{op} 5 + 10 * 30
-        a.top(x) #{op} a.top(x)
+      expect_offense(<<~RUBY, op: op)
+        5 + 10 * 30 %{op} 5 + 10 * 30
+                    ^{op} Comparison of something with itself detected.
+        a.top(x) %{op} a.top(x)
+                 ^{op} Comparison of something with itself detected.
       RUBY
-      expect(cop.offenses.size).to eq(2)
     end
   end
 

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -7,12 +7,13 @@ RSpec.describe RuboCop::Cop::Lint::Void do
 
   described_class::BINARY_OPERATORS.each do |op|
     it "registers an offense for void op #{op} if not on last line" do
-      inspect_source(<<~RUBY)
-        a #{op} b
-        a #{op} b
-        a #{op} b
+      expect_offense(<<~RUBY, op: op)
+        a %{op} b
+          ^{op} Operator `#{op}` used in void context.
+        a %{op} b
+          ^{op} Operator `#{op}` used in void context.
+        a %{op} b
       RUBY
-      expect(cop.offenses.size).to eq(2)
     end
   end
 
@@ -31,15 +32,31 @@ RSpec.describe RuboCop::Cop::Lint::Void do
     end
   end
 
-  unary_operators = %i[+ - ~ !]
-  unary_operators.each do |op|
-    it "registers an offense for void unary op #{op} if not on last line" do
-      inspect_source(<<~RUBY)
-        #{op}b
-        #{op}b
-        #{op}b
+  sign_unary_operators = %i[+ -]
+  other_unary_operators = %i[~ !]
+  unary_operators = sign_unary_operators + other_unary_operators
+
+  sign_unary_operators.each do |op|
+    it "registers an offense for void sign op #{op} if not on last line" do
+      expect_offense(<<~RUBY, op: op)
+        %{op}b
+        ^{op} Operator `#{op}@` used in void context.
+        %{op}b
+        ^{op} Operator `#{op}@` used in void context.
+        %{op}b
       RUBY
-      expect(cop.offenses.size).to eq(2)
+    end
+  end
+
+  other_unary_operators.each do |op|
+    it "registers an offense for void unary op #{op} if not on last line" do
+      expect_offense(<<~RUBY, op: op)
+        %{op}b
+        ^{op} Operator `#{op}` used in void context.
+        %{op}b
+        ^{op} Operator `#{op}` used in void context.
+        %{op}b
+      RUBY
     end
   end
 
@@ -60,22 +77,22 @@ RSpec.describe RuboCop::Cop::Lint::Void do
 
   %w[var @var @@var VAR $var].each do |var|
     it "registers an offense for void var #{var} if not on last line" do
-      inspect_source(<<~RUBY)
-        #{var} = 5
-        #{var}
+      expect_offense(<<~RUBY, var: var)
+        %{var} = 5
+        %{var}
+        ^{var} Variable `#{var}` used in void context.
         top
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
   end
 
   %w(1 2.0 :test /test/ [1] {}).each do |lit|
     it "registers an offense for void lit #{lit} if not on last line" do
-      inspect_source(<<~RUBY)
-        #{lit}
+      expect_offense(<<~RUBY, lit: lit)
+        %{lit}
+        ^{lit} Literal `#{lit}` used in void context.
         top
       RUBY
-      expect(cop.offenses.size).to eq(1)
     end
   end
 


### PR DESCRIPTION
Part of #8127

Use the newer `expect_offense` API to specify expected offense locations and messages.

Also fixed the offense location for `Lint/LiteralAsCondition` cop in a `case ... when condition`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/