### PR TITLE
Reduce allocated Sets

### DIFF
--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -105,7 +105,7 @@ module RuboCop
       # If message is not specified, the method `message` will be called.
       def add_offense(node_or_range, message: nil, severity: nil, &block)
         range = range_from_node_or_range(node_or_range)
-        return unless @current_offense_locations.add?(range)
+        return unless current_offense_locations.add?(range)
 
         range_to_pass = callback_argument(range)
 
@@ -271,11 +271,19 @@ module RuboCop
 
       ### Reserved for Commissioner:
 
+      def current_offense_locations
+        @current_offense_locations ||= Set.new
+      end
+
+      def currently_disabled_lines
+        @currently_disabled_lines ||= Set.new
+      end
+
       # Called before any investigation
       def begin_investigation(processed_source)
         @current_offenses = []
-        @current_offense_locations = Set[]
-        @currently_disabled_lines = Set[]
+        @current_offense_locations = nil
+        @currently_disabled_lines = nil
         @processed_source = processed_source
         @current_corrector = Corrector.new(@processed_source) if @processed_source.valid_syntax?
       end
@@ -327,7 +335,7 @@ module RuboCop
 
       def disable_uncorrectable(range)
         line = range.line
-        return unless @currently_disabled_lines.add?(line)
+        return unless currently_disabled_lines.add?(line)
 
         disable_offense(range)
       end

--- a/lib/rubocop/cop/style/bisected_attr_accessor.rb
+++ b/lib/rubocop/cop/style/bisected_attr_accessor.rb
@@ -28,6 +28,7 @@ module RuboCop
         def on_class(class_node)
           VISIBILITY_SCOPES.each do |visibility|
             reader_names, writer_names = accessor_names(class_node, visibility)
+            next unless reader_names && writer_names
 
             accessor_macroses(class_node, visibility).each do |macro|
               check(macro, reader_names, writer_names)
@@ -48,17 +49,17 @@ module RuboCop
         private
 
         def accessor_names(class_node, visibility)
-          reader_names = Set.new
-          writer_names = Set.new
+          reader_names = nil
+          writer_names = nil
 
           accessor_macroses(class_node, visibility).each do |macro|
             names = macro.arguments.map(&:source)
 
             names.each do |name|
               if attr_reader?(macro)
-                reader_names.add(name)
+                (reader_names ||= Set.new).add(name)
               else
-                writer_names.add(name)
+                (writer_names ||= Set.new).add(name)
               end
             end
           end

--- a/lib/rubocop/cop/variable_force/variable.rb
+++ b/lib/rubocop/cop/variable_force/variable.rb
@@ -42,10 +42,10 @@ module RuboCop
         def reference!(node)
           reference = Reference.new(node, @scope)
           @references << reference
-          consumed_branches = Set.new
+          consumed_branches = nil
 
           @assignments.reverse_each do |assignment|
-            next if consumed_branches.include?(assignment.branch)
+            next if consumed_branches&.include?(assignment.branch)
 
             assignment.reference!(node) unless assignment.run_exclusively_with?(reference)
 
@@ -58,7 +58,9 @@ module RuboCop
 
             break if !assignment.branch || assignment.branch == reference.branch
 
-            consumed_branches << assignment.branch unless assignment.branch.may_run_incompletely?
+            unless assignment.branch.may_run_incompletely?
+              (consumed_branches ||= Set.new) << assignment.branch
+            end
           end
         end
         # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity


### PR DESCRIPTION
Tested with `memory_profiler`.

```
bin/rubocop-profile lib/rubocop/cop/style
```

### Before
```
Total allocated: 607510304 bytes (7590379 objects)
Total retained:  6108170 bytes (39014 objects)

allocated memory by file
-----------------------------------
  62891167  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/2.6.0/set.rb   <=========
  43983225  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/parser-2.7.1.4/lib/parser/source/tree_rewriter.rb
  43851880  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/base.rb
  43484285  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rubocop-ast-0.1.0/lib/rubocop/ast/node.rb
  28841125  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rubocop-ast-0.1.0/lib/rubocop/ast/node_pattern.rb
.....
```

### After
```
Total allocated: 522243875 bytes (6721583 objects)
Total retained:  6111812 bytes (39039 objects)

allocated memory by file
-----------------------------------
  43983817  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/parser-2.7.1.4/lib/parser/source/tree_rewriter.rb
  43113261  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rubocop-ast-0.1.0/lib/rubocop/ast/node.rb
  37910040  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/base.rb
.......
   8954408  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rubocop-ast-0.1.0/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
   8288295  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/2.6.0/set.rb   <=========
   8150920  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/mixin/surrounding_space.rb
   6802919  /Users/fatkodima/.rbenv/versions/2.6.5/lib/ruby/2.6.0/find.rb
........
```

Memory savings: `(607510304.0 - 522243875) / 607510304.0 * 100 = 14%` ⚡ 