### PR TITLE
Rewrite `Style/TrailingMethodEndStatement` to make it faster

### DIFF
--- a/spec/rubocop/cop/style/trailing_method_end_statement_spec.rb
+++ b/spec/rubocop/cop/style/trailing_method_end_statement_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe RuboCop::Cop::Style::TrailingMethodEndStatement do
     RUBY
     expect(corrected).to eq(<<~RUBY)
       def some_method
-        [] 
-        end
+        []; 
+      end
     RUBY
   end
 
@@ -86,8 +86,8 @@ RSpec.describe RuboCop::Cop::Style::TrailingMethodEndStatement do
     expect(corrected).to eq(<<~RUBY)
       def do_this(x)
         y = x + 5
-        y / 2 
-        end
+        y / 2; 
+      end
     RUBY
   end
 
@@ -101,7 +101,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingMethodEndStatement do
       def f(x, y)
         process(x)
         process(y) 
-        end # comment
+      end # comment
     RUBY
   end
 
@@ -117,7 +117,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingMethodEndStatement do
         block do
           foo
         end 
-        end
+      end
     RUBY
   end
 
@@ -125,9 +125,9 @@ RSpec.describe RuboCop::Cop::Style::TrailingMethodEndStatement do
     corrected = autocorrect_source(<<~RUBY)
       class Foo
         def some_method
-          []; end
+          [] end
         def another_method
-          {}; end
+          {} end
       end
     RUBY
     expect(corrected).to eq(<<~RUBY)


### PR DESCRIPTION
I ran `bin/rubocop-profile` on the `rails/rails` source code with all cops enabled.

```
$ rake prof:slow_cops
```

### Before
```
stackprof tmp/stackprof.dump --text --method 'RuboCop::Cop::Commissioner#trigger_responding_cops'
    17864  (    7.3%)  RuboCop::Cop::Style::TrailingMethodEndStatement#on_def     <=========
    7838  (    3.2%)  RuboCop::Cop::Layout::SpaceInsideReferenceBrackets#on_send
    7395  (    3.0%)  RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets#on_array
    4130  (    1.7%)  RuboCop::Cop::Layout::SpaceBeforeFirstArg#on_send
    3993  (    1.6%)  RuboCop::Cop::Style::DocumentationMethod#on_def
    3705  (    1.5%)  RuboCop::Cop::Style::NumericPredicate#on_send
......
```

### After
```
stackprof tmp/stackprof.dump --text --method 'RuboCop::Cop::Commissioner#trigger_responding_cops'
    7882  (    3.7%)  RuboCop::Cop::Layout::SpaceInsideReferenceBrackets#on_send
    7471  (    3.5%)  RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets#on_array
    4060  (    1.9%)  RuboCop::Cop::Layout::SpaceBeforeFirstArg#on_send
    3914  (    1.8%)  RuboCop::Cop::Style::DocumentationMethod#on_def
    3608  (    1.7%)  RuboCop::Cop::Style::NumericPredicate#on_send
......
```

That line disappeared 🎉 