### PR TITLE
Handle major version requirements in Gemspec/RequiredRubyVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#7776](https://github.com/rubocop-hq/rubocop/issues/7776): Fix crash for `Layout/MultilineMethodCallBraceLayout` when comment is present before closing braces. ([@shekhar-patil][])
 * [#8282](https://github.com/rubocop-hq/rubocop/issues/8282): Fix `Style/IfUnlessModifier` bad precedence detection. ([@tejasbubane][])
 * [#8289](https://github.com/rubocop-hq/rubocop/issues/8289): Fix `Style/AccessorGrouping` to not register offense for accessor with comment. ([@tejasbubane][])
+* [#8310](https://github.com/rubocop-hq/rubocop/pull/8310): Handle major version requirements in `Gemspec/RequiredRubyVersion`. ([@eugeneius][])
 
 ### Changes
 

--- a/docs/modules/ROOT/pages/cops_gemspec.adoc
+++ b/docs/modules/ROOT/pages/cops_gemspec.adoc
@@ -187,6 +187,11 @@ end
 Gem::Specification.new do |spec|
   spec.required_ruby_version = ['>= 2.5.0', '< 2.7.0']
 end
+
+# good
+Gem::Specification.new do |spec|
+  spec.required_ruby_version = '~> 2.5'
+end
 ----
 
 === Configurable attributes

--- a/lib/rubocop/cop/gemspec/required_ruby_version.rb
+++ b/lib/rubocop/cop/gemspec/required_ruby_version.rb
@@ -35,6 +35,11 @@ module RuboCop
       #   Gem::Specification.new do |spec|
       #     spec.required_ruby_version = ['>= 2.5.0', '< 2.7.0']
       #   end
+      #
+      #   # good
+      #   Gem::Specification.new do |spec|
+      #     spec.required_ruby_version = '~> 2.5'
+      #   end
       class RequiredRubyVersion < Cop
         MSG = '`required_ruby_version` (%<required_ruby_version>s, ' \
               'declared in %<gemspec_filename>s) and `TargetRubyVersion` ' \
@@ -68,7 +73,7 @@ module RuboCop
             end
           end
 
-          required_ruby_version.str_content.match(/(\d\.\d)/)[1]
+          required_ruby_version.str_content.scan(/\d/).first(2).join('.')
         end
 
         def message(required_ruby_version, target_ruby_version)

--- a/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
+++ b/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
@@ -2,11 +2,19 @@
 
 RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
   context 'target ruby version > 2.7', :ruby27 do
-    it 'registers an offense when `required_ruby_version` is lower than ' \
-       '`TargetRubyVersion`' do
+    it 'registers an offense when `required_ruby_version` is specified with >= and is lower than `TargetRubyVersion`' do
       expect_offense(<<~RUBY, '/path/to/foo.gemspec')
         Gem::Specification.new do |spec|
           spec.required_ruby_version = '>= 2.6.0'
+                                       ^^^^^^^^^^ `required_ruby_version` (2.6, declared in foo.gemspec) and `TargetRubyVersion` (2.7, which may be specified in .rubocop.yml) should be equal.
+        end
+      RUBY
+    end
+
+    it 'registers an offense when `required_ruby_version` is specified with ~> and is lower than `TargetRubyVersion`' do
+      expect_offense(<<~RUBY, '/path/to/foo.gemspec')
+        Gem::Specification.new do |spec|
+          spec.required_ruby_version = '~> 2.6.0'
                                        ^^^^^^^^^^ `required_ruby_version` (2.6, declared in foo.gemspec) and `TargetRubyVersion` (2.7, which may be specified in .rubocop.yml) should be equal.
         end
       RUBY
@@ -37,8 +45,7 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
   end
 
   context 'target ruby version > 2.5', :ruby25 do
-    it 'registers an offense when `required_ruby_version` is higher than ' \
-       '`TargetRubyVersion`' do
+    it 'registers an offense when `required_ruby_version` is specified with >= and is higher than `TargetRubyVersion`' do
       expect_offense(<<~RUBY, '/path/to/bar.gemspec')
         Gem::Specification.new do |spec|
           spec.required_ruby_version = '>= 2.6.0'
@@ -46,11 +53,19 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
         end
       RUBY
     end
+
+    it 'registers an offense when `required_ruby_version` is specified with ~> and is higher than `TargetRubyVersion`' do
+      expect_offense(<<~RUBY, '/path/to/bar.gemspec')
+        Gem::Specification.new do |spec|
+          spec.required_ruby_version = '~> 2.6.0'
+                                       ^^^^^^^^^^ `required_ruby_version` (2.6, declared in bar.gemspec) and `TargetRubyVersion` (2.5, which may be specified in .rubocop.yml) should be equal.
+        end
+      RUBY
+    end
   end
 
   context 'target ruby version > 2.6', :ruby26 do
-    it 'does not register an offense when `required_ruby_version` equals ' \
-       '`TargetRubyVersion`' do
+    it 'does not register an offense when `required_ruby_version` is specified with >= and equals `TargetRubyVersion`' do
       expect_no_offenses(<<~RUBY)
         Gem::Specification.new do |spec|
           spec.required_ruby_version = '>= 2.6.0'
@@ -58,11 +73,28 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
       RUBY
     end
 
-    it 'does not register an offense when `required_ruby_version` ' \
-       '(omit patch version) equals `TargetRubyVersion`' do
+    it 'does not register an offense when `required_ruby_version` is specified with ~> and equals `TargetRubyVersion`' do
+      expect_no_offenses(<<~RUBY)
+        Gem::Specification.new do |spec|
+          spec.required_ruby_version = '~> 2.6.0'
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when `required_ruby_version` is specified with >= without a patch version and ' \
+       'equals `TargetRubyVersion`' do
       expect_no_offenses(<<~RUBY)
         Gem::Specification.new do |spec|
           spec.required_ruby_version = '>= 2.6'
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when `required_ruby_version` is specified with ~> without a patch version and ' \
+       'equals `TargetRubyVersion`' do
+      expect_no_offenses(<<~RUBY)
+        Gem::Specification.new do |spec|
+          spec.required_ruby_version = '~> 2.6'
         end
       RUBY
     end
@@ -72,6 +104,26 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
       expect_no_offenses(<<~RUBY)
         Gem::Specification.new do |spec|
           spec.required_ruby_version = ['>= 2.6.0', '< 2.8.0']
+        end
+      RUBY
+    end
+
+    it 'registers an offense when `required_ruby_version` is specified with >= without a minor version and is lower ' \
+       'than `TargetRubyVersion`' do
+      expect_offense(<<~RUBY, 'bar.gemspec')
+        Gem::Specification.new do |spec|
+          spec.required_ruby_version = '>= 2'
+                                       ^^^^^^ `required_ruby_version` (2, declared in bar.gemspec) and `TargetRubyVersion` (2.6, which may be specified in .rubocop.yml) should be equal.
+        end
+      RUBY
+    end
+
+    it 'registers an offense when `required_ruby_version` is specified with ~> without a minor version and is lower ' \
+       'than `TargetRubyVersion`' do
+      expect_offense(<<~RUBY, 'bar.gemspec')
+        Gem::Specification.new do |spec|
+          spec.required_ruby_version = '~> 2'
+                                       ^^^^^^ `required_ruby_version` (2, declared in bar.gemspec) and `TargetRubyVersion` (2.6, which may be specified in .rubocop.yml) should be equal.
         end
       RUBY
     end


### PR DESCRIPTION
It's possible to use `required_ruby_version` to allow all minor versions of a particular major version of Ruby:

    spec.required_ruby_version = '~> 2'

Previously this would cause `Gemspec/RequiredRubyVersion` to crash with:

    undefined method `[]' for nil:NilClass
    lib/rubocop/cop/gemspec/required_ruby_version.rb:71:in `extract_ruby_version'

I discovered this problem by running RuboCop on the [real-world-ruby-apps](https://github.com/jeromedalbert/real-world-ruby-apps) repo, which includes the htty gem:

https://github.com/htty/htty/blob/8db7a36d5dffcd6eef66580f052a86bcf1f3636b/htty.gemspec#L21

I've added docs and tests for the pessimistic operator, which otherwise works well.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/