### PR TITLE
Optimize `Lint/DuplicateMethods`, `Lint/NestedMethodDefinition`, `Style/AutoResourceCleanup` and `Style/NumericPredicate` cops a bit

### DIFF
--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -126,7 +126,7 @@ module RuboCop
         end
 
         def message_for_dup(node, method_name)
-          format(MSG, method: method_name, defined: @definitions[method_name],
+          format(MSG, method: method_name, defined: source_location(@definitions[method_name]),
                       current: source_location(node))
         end
 
@@ -152,7 +152,7 @@ module RuboCop
 
             add_offense(node, location: loc, message: message)
           else
-            @definitions[method_name] = source_location(node)
+            @definitions[method_name] = node
           end
         end
 

--- a/lib/rubocop/cop/style/auto_resource_cleanup.rb
+++ b/lib/rubocop/cop/style/auto_resource_cleanup.rb
@@ -25,10 +25,11 @@ module RuboCop
 
         def on_send(node)
           TARGET_METHODS.each do |target_class, target_method|
-            target_receiver = s(:const, nil, target_class)
-
-            next if node.receiver != target_receiver
             next if node.method_name != target_method
+
+            target_receiver = s(:const, nil, target_class)
+            next if node.receiver != target_receiver
+
             next if cleanup?(node)
 
             add_offense(node,

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -54,14 +54,13 @@ module RuboCop
         }.freeze
 
         def on_send(node)
+          numeric, replacement = check(node)
+          return unless numeric
+
           return if ignored_method?(node.method_name) ||
                     node.each_ancestor(:send, :block).any? do |ancestor|
                       ignored_method?(ancestor.method_name)
                     end
-
-          numeric, replacement = check(node)
-
-          return unless numeric
 
           add_offense(node,
                       message: format(MSG,


### PR DESCRIPTION
Tested on `rails` codebase.

### Before
```
stackprof tmp/stackprof.dump --text --method 'RuboCop::Cop::Commissioner#trigger_responding_cops'
    8202  (    3.5%)  RuboCop::Cop::Layout::SpaceInsideReferenceBrackets#on_send
    8089  (    3.4%)  RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets#on_array
    4437  (    1.9%)  RuboCop::Cop::Layout::SpaceBeforeFirstArg#on_send
    4172  (    1.8%)  RuboCop::Cop::Style::DocumentationMethod#on_def
    3988  (    1.7%)  RuboCop::Cop::Style::NumericPredicate#on_send   <============= 1
    3642  (    1.5%)  RuboCop::Cop::Layout::IndentationConsistency#on_begin
    3596  (    1.5%)  RuboCop::Cop::Layout::FirstArgumentIndentation#on_send
    3428  (    1.5%)  RuboCop::Cop::Lint::DuplicateMethods#on_def       <============= 2
    3079  (    1.3%)  RuboCop::Cop::Layout::ArgumentAlignment#on_send
    3008  (    1.3%)  RuboCop::Cop::Rails::FilePath#on_send
    2931  (    1.2%)  RuboCop::Cop::Layout::DefEndAlignment#on_send
    2929  (    1.2%)  RuboCop::Cop::Style::AutoResourceCleanup#on_send    <============= 3
    2653  (    1.1%)  RuboCop::Cop::MultilineExpressionIndentation#on_send
    2516  (    1.1%)  RuboCop::Cop::Lint::ConstantResolution#on_const
    2330  (    1.0%)  RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces#on_hash
    2158  (    0.9%)  RuboCop::Cop::Lint::NestedMethodDefinition#on_def    <============= 4
    2048  (    0.9%)  RuboCop::Cop::Lint::MixedRegexpCaptureTypes#on_regexp
    2038  (    0.9%)  RuboCop::Cop::StringHelp#on_str
```

### After
```
stackprof tmp/stackprof.dump --text --method 'RuboCop::Cop::Commissioner#trigger_responding_cops'
    7970  (    3.9%)  RuboCop::Cop::Layout::SpaceInsideReferenceBrackets#on_send
    7707  (    3.7%)  RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets#on_array
    3978  (    1.9%)  RuboCop::Cop::Layout::SpaceBeforeFirstArg#on_send
    ......
    1407  (    0.7%)  RuboCop::Cop::Layout::LineLength#on_potential_breakable_node
    1400  (    0.7%)  RuboCop::Cop::Style::NumericPredicate#on_send    <============= 1
    1371  (    0.7%)  RuboCop::Cop::Layout::FirstMethodArgumentLineBreak#on_send
    .....
     722  (    0.3%)  RuboCop::Cop::Lint::FormatParameterMismatch#on_send
     720  (    0.3%)  RuboCop::Cop::Lint::DuplicateMethods#on_send    <============= 2
     712  (    0.3%)  RuboCop::Cop::CheckAssignment#on_send
     709  (    0.3%)  RuboCop::Cop::EnforceSuperclass#on_send
     ......
     411  (    0.2%)  RuboCop::Cop::Style::YodaCondition#on_send
     411  (    0.2%)  RuboCop::Cop::Style::AutoResourceCleanup#on_send    <============= 3
     402  (    0.2%)  RuboCop::Cop::Style::MixinUsage#on_send
     ........
     190  (    0.1%)  RuboCop::Cop::Layout::SpaceAroundOperators#on_assignment
     189  (    0.1%)  RuboCop::Cop::Lint::NestedMethodDefinition#on_def     <============= 4
     189  (    0.1%)  RuboCop::Cop::Naming::MemoizedInstanceVariableName#on_def
     .......
```

Improvements: `(1.7 + 1.5 + 1.2 + 0.9) - (0.7 + 0.3 + 0.2 + 0.1)` = `4.0%`