### PR TITLE
Prevent missing final zero of version number for docs/antora.yml

### DIFF
--- a/tasks/cut_release.rake
+++ b/tasks/cut_release.rake
@@ -32,7 +32,7 @@ namespace :cut_release do
     File.open('docs/antora.yml', 'w') do |f|
       f << antora_metadata.sub(
         'version: master',
-        "version: #{version_sans_patch(new_version)}"
+        "version: '#{version_sans_patch(new_version)}'"
       )
     end
 


### PR DESCRIPTION
This PR wraps quotes as a string to prevent `1.10` from interpreted as `1.1` for docs/antora.yml.

Without quoting, version `1.10` is interpreted as float `1.1`, so final `0` is missing.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
