### PR TITLE
Don't load configuration files outside of the current project unless there's no project specific configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#8289](https://github.com/rubocop-hq/rubocop/issues/8289): Fix `Style/AccessorGrouping` to not register offense for accessor with comment. ([@tejasbubane][])
 * [#8310](https://github.com/rubocop-hq/rubocop/pull/8310): Handle major version requirements in `Gemspec/RequiredRubyVersion`. ([@eugeneius][])
 * [#8315](https://github.com/rubocop-hq/rubocop/pull/8315): Fix crash for `Style/PercentLiteralDelimiters` when the source contains invalid characters. ([@eugeneius][])
+* [#8239](https://github.com/rubocop-hq/rubocop/pull/8239): Don't load `.rubocop.yml` files at all outside of the current project, unless they are personal configuration files and the project has no configuration. ([@deivid-rodriguez][])
 
 ### Changes
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -24,7 +24,7 @@ module RuboCop
 
       attr_accessor :debug, :ignore_parent_exclusion,
                     :disable_pending_cops, :enable_pending_cops
-      attr_writer :default_configuration
+      attr_writer :default_configuration, :project_root
 
       alias debug? debug
       alias ignore_parent_exclusion? ignore_parent_exclusion
@@ -164,7 +164,7 @@ module RuboCop
       private
 
       def find_project_dotfile(target_dir)
-        find_file_upwards(DOTFILE, target_dir)
+        find_file_upwards(DOTFILE, target_dir, project_root)
       end
 
       def find_project_root

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -118,7 +118,7 @@ module RuboCop
       end
 
       def add_excludes_from_files(config, config_file)
-        exclusion_file = find_last_file_upwards(DOTFILE, config_file)
+        exclusion_file = find_last_file_upwards(DOTFILE, config_file, project_root)
 
         return unless exclusion_file
         return if PathUtil.relative_path(exclusion_file) == PathUtil.relative_path(config_file)
@@ -132,6 +132,12 @@ module RuboCop
                                      print 'Default ' if debug?
                                      load_file(DEFAULT_FILE)
                                    end
+      end
+
+      # Returns the path rubocop inferred as the root of the project. No file
+      # searches will go past this directory.
+      def project_root
+        @project_root ||= find_project_root
       end
 
       def warn_on_pending_cops(pending_cops)
@@ -159,6 +165,14 @@ module RuboCop
 
       def find_project_dotfile(target_dir)
         find_file_upwards(DOTFILE, target_dir)
+      end
+
+      def find_project_root
+        pwd = Dir.pwd
+        gems_file = find_last_file_upwards('Gemfile', pwd) || find_last_file_upwards('gems.rb', pwd)
+        return unless gems_file
+
+        File.dirname(gems_file)
       end
 
       def find_user_dotfile

--- a/lib/rubocop/file_finder.rb
+++ b/lib/rubocop/file_finder.rb
@@ -9,20 +9,20 @@ module RuboCop
       @root_level = level
     end
 
-    def self.root_level?(path)
-      @root_level == path.to_s
+    def self.root_level?(path, stop_dir)
+      (@root_level || stop_dir) == path.to_s
     end
 
-    def find_file_upwards(filename, start_dir)
-      traverse_files_upwards(filename, start_dir) do |file|
+    def find_file_upwards(filename, start_dir, stop_dir = nil)
+      traverse_files_upwards(filename, start_dir, stop_dir) do |file|
         # minimize iteration for performance
         return file if file
       end
     end
 
-    def find_last_file_upwards(filename, start_dir)
+    def find_last_file_upwards(filename, start_dir, stop_dir = nil)
       last_file = nil
-      traverse_files_upwards(filename, start_dir) do |file|
+      traverse_files_upwards(filename, start_dir, stop_dir) do |file|
         last_file = file
       end
       last_file
@@ -30,12 +30,12 @@ module RuboCop
 
     private
 
-    def traverse_files_upwards(filename, start_dir)
+    def traverse_files_upwards(filename, start_dir, stop_dir)
       Pathname.new(start_dir).expand_path.ascend do |dir|
         file = dir + filename
         yield(file.to_s) if file.exist?
 
-        break if FileFinder.root_level?(dir)
+        break if FileFinder.root_level?(dir, stop_dir)
       end
     end
   end

--- a/lib/rubocop/file_finder.rb
+++ b/lib/rubocop/file_finder.rb
@@ -32,10 +32,10 @@ module RuboCop
 
     def traverse_files_upwards(filename, start_dir)
       Pathname.new(start_dir).expand_path.ascend do |dir|
-        break if FileFinder.root_level?(dir)
-
         file = dir + filename
         yield(file.to_s) if file.exist?
+
+        break if FileFinder.root_level?(dir)
       end
     end
   end

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -12,16 +12,17 @@ RSpec.shared_context 'isolated environment', :isolated_environment do
       # get mismatched pathnames when loading config files later on.
       tmpdir = File.realpath(tmpdir)
 
+      virtual_home = File.expand_path(File.join(tmpdir, 'home'))
+      Dir.mkdir(virtual_home)
+      ENV['HOME'] = virtual_home
+      ENV.delete('XDG_CONFIG_HOME')
+
+      working_dir = File.join(tmpdir, 'work')
+
       # Make upwards search for .rubocop.yml files stop at this directory.
-      RuboCop::FileFinder.root_level = tmpdir
+      RuboCop::FileFinder.root_level = working_dir
 
       begin
-        virtual_home = File.expand_path(File.join(tmpdir, 'home'))
-        Dir.mkdir(virtual_home)
-        ENV['HOME'] = virtual_home
-        ENV.delete('XDG_CONFIG_HOME')
-
-        working_dir = File.join(tmpdir, 'work')
         Dir.mkdir(working_dir)
 
         Dir.chdir(working_dir) do

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -17,7 +17,8 @@ RSpec.shared_context 'isolated environment', :isolated_environment do
       ENV['HOME'] = virtual_home
       ENV.delete('XDG_CONFIG_HOME')
 
-      working_dir = File.join(tmpdir, 'work')
+      base_dir = example.metadata[:project_inside_home] ? virtual_home : tmpdir
+      working_dir = File.join(base_dir, 'work')
 
       # Make upwards search for .rubocop.yml files stop at this directory.
       RuboCop::FileFinder.root_level = working_dir

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -18,13 +18,14 @@ RSpec.shared_context 'isolated environment', :isolated_environment do
       ENV.delete('XDG_CONFIG_HOME')
 
       base_dir = example.metadata[:project_inside_home] ? virtual_home : tmpdir
-      working_dir = File.join(base_dir, 'work')
+      root = example.metadata[:root]
+      working_dir = root ? File.join(base_dir, 'work', root) : File.join(base_dir, 'work')
 
       # Make upwards search for .rubocop.yml files stop at this directory.
       RuboCop::FileFinder.root_level = working_dir
 
       begin
-        Dir.mkdir(working_dir)
+        FileUtils.mkdir_p(working_dir)
 
         Dir.chdir(working_dir) do
           example.run

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -82,6 +82,26 @@ RSpec.describe RuboCop::ConfigLoader do
       end
     end
 
+    context 'when there is a spurious rubocop config outside of the project', root: 'dir' do
+      let(:dir_path) { 'dir' }
+
+      before do
+        # Force reload of project root
+        described_class.project_root = nil
+        create_empty_file('Gemfile')
+        create_empty_file('../.rubocop.yml')
+      end
+
+      after do
+        # Don't leak project root change
+        described_class.project_root = nil
+      end
+
+      it 'ignores the spurious config and falls back to the provided default file if run from the project' do
+        expect(configuration_file_for).to end_with('config/default.yml')
+      end
+    end
+
     context 'when a config file exists in the parent directory' do
       let(:dir_path) { 'dir' }
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -197,6 +197,35 @@ RSpec.describe RuboCop::ConfigLoader do
       end
     end
 
+    context 'when project has a Gemfile', :project_inside_home do
+      let(:file_path) { '.rubocop.yml' }
+
+      before do
+        create_empty_file('Gemfile')
+
+        create_file(file_path, <<~YAML)
+          AllCops:
+            Exclude:
+              - vendor/**
+        YAML
+      end
+
+      context 'and there is a personal config file in the home folder' do
+        before do
+          create_file('~/.rubocop.yml', <<~YAML)
+            AllCops:
+              Exclude:
+                - tmp/**
+          YAML
+        end
+
+        it 'ignores personal AllCops/Exclude' do
+          excludes = configuration_from_file['AllCops']['Exclude']
+          expect(excludes).to eq([File.expand_path('vendor/**')])
+        end
+      end
+    end
+
     context 'when a parent file specifies DisabledByDefault: true' do
       let(:file_path) { '.rubocop.yml' }
 


### PR DESCRIPTION
In previous PRs, #8176 and #8239, I fixed particular cases of this problem, but it was still not fixed in general. So, if I have my personal configuration at `~/.config/rubocop/config.yml` and my project is at `~/Code/my_project`, then my personal configuration won't be loaded thanks to those PRs. However, if I have my personal configuration at `~/.rubocop.yml`, then `rubocop` will still load exclusions from there because `$HOME` is an ancestor of the current project folder, and that's how `find_last_file_upwards` currently works.

To fix this problem in general, I made sure `find_last_file_upwards` (and any configuration search in general) doesn't go past the current project's root. To do that, I needed to define what the root of a project is. While there were other options, like presence of a `.git` folder, for example, I decided go with "the highest folder up in the directory hierarchy containing a Gemfile or gems.rb" file.

This is the same definition `bundler` uses and I believe it makes sense, specially because the original problems I want to solve here manifest were personal configuration files try to load rubocop plugins outside of the current bundle, and thus making rubocop crash. See https://github.com/rubocop-hq/rubocop/issues/7433. By using Gemfile presence as a criteria, we prevent exactly this kind of problem.

As a note, the reason the test suite never catched this issue is that it intentionally defines a not very common folder structure where the current project folder _is not_ inside `$HOME`. I think that _maybe_ the structure was defined this way in order to workaround this problem.

Finally, although this should work for most ruby projects out there, projects without a `Gemfile` don't fit into this criteria. I believe we can leave it as it is tough, and wait for issues from such projects before adding more fallbacks to this "root of a project" definition.

I'd be very happy to hear your thoughts, thanks for reading!

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/