### PR TITLE
Handle invalid characters in Style/PercentLiteralDelimiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#8282](https://github.com/rubocop-hq/rubocop/issues/8282): Fix `Style/IfUnlessModifier` bad precedence detection. ([@tejasbubane][])
 * [#8289](https://github.com/rubocop-hq/rubocop/issues/8289): Fix `Style/AccessorGrouping` to not register offense for accessor with comment. ([@tejasbubane][])
 * [#8310](https://github.com/rubocop-hq/rubocop/pull/8310): Handle major version requirements in `Gemspec/RequiredRubyVersion`. ([@eugeneius][])
+* [#8315](https://github.com/rubocop-hq/rubocop/pull/8315): Fix crash for `Style/PercentLiteralDelimiters` when the source contains invalid characters. ([@eugeneius][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -102,7 +102,7 @@ module RuboCop
           delimiters_regexp = Regexp.union(delimiters)
           node
             .children.map { |n| string_source(n) }.compact
-            .any? { |s| delimiters_regexp.match?(s) }
+            .any? { |s| delimiters_regexp.match?(s.scrub) }
         end
 
         def string_source(node)

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -58,6 +58,10 @@ RSpec.describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
         ^^^^^^^^^^^^^^^ `%`-literals should be delimited by `[` and `]`.
       RUBY
     end
+
+    it 'does not crash when the source contains invalid characters' do
+      expect { inspect_source('%{\x80}') }.not_to raise_error
+    end
   end
 
   context '`%q` string' do


### PR DESCRIPTION
Previously this would crash with:

    ArgumentError: invalid byte sequence in UTF-8
    lib/rubocop/cop/style/percent_literal_delimiters.rb:105:in `match?'

I discovered this problem by running RuboCop on the [real-world-rails](https://github.com/eliotsykes/real-world-rails) repo, which includes the discourse repo:

https://github.com/discourse/discourse/blob/544a9865c6e5890f37e762292cbe5558db843dcf/spec/helpers/application_helper_spec.rb#L263

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/