### PR TITLE
Fix expect_offense when annotations missing

### DIFF
--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -235,7 +235,7 @@ module RuboCop
         def match_annotations?(other)
           annotations.zip(other.annotations) do |(_actual_line, actual_annotation),
                                                  (_expected_line, expected_annotation)|
-            if expected_annotation.end_with?(ABBREV)
+            if expected_annotation&.end_with?(ABBREV)
               if actual_annotation.start_with?(expected_annotation[0...-ABBREV.length])
                 expected_annotation.replace(actual_annotation)
               end


### PR DESCRIPTION
Fixes `[...]` abbreviation introduced in #8297

Fix crash in `expect_offense` where multiple offenses are detected by the
cop by some were not included in the annotated source. For example:

```ruby
expect_offense(<<~RUBY)
  x % 2 == 0
  ^^^^^^^^^^ Replace with `Integer#even?`
  x % 2 != 0
  # second offense missing
RUBY
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/