### PR TITLE
Fix line number for empty file offense

### DIFF
--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -209,6 +209,7 @@ module RuboCop
               source << source_line
             end
           end
+          annotations.each { |a| a[0] = 1 } if source.empty?
 
           new(source, annotations)
         end


### PR DESCRIPTION
An offense added by a cop to an empty file with have line number = 1.
For example:

```ruby
RSpec.describe RuboCop::Cop::Style::Copyright, :config do
  context 'when the source code file is empty' do
    it 'registers an offense' do
      expect_offense('^ Include a copyright notice matching [...]')
    end
  end
end
```

Ensure the line number matches for `expect_offense` on an empty file.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/