### PR TITLE
Fix crash for `Layout/SpaceAroundMethodCallOperator` when using `Proc#call` shorthand syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#8324](https://github.com/rubocop-hq/rubocop/issues/8324): Fix crash for `Layout/SpaceAroundMethodCallOperator` when using `Proc#call` shorthand syntax. ([@fatkodima][])
+
 ## 0.88.0 (2020-07-13)
 
 ### New features

--- a/lib/rubocop/cop/layout/space_around_method_call_operator.rb
+++ b/lib/rubocop/cop/layout/space_around_method_call_operator.rb
@@ -66,7 +66,15 @@ module RuboCop
 
         def check_space_after_dot(node)
           dot_pos = node.loc.dot.end_pos
-          selector_pos = node.loc.selector.begin_pos
+
+          selector_pos =
+            # `Proc#call` shorthand syntax
+            if node.method?(:call) && !node.loc.selector
+              node.loc.begin.begin_pos
+            else
+              node.loc.selector.begin_pos
+            end
+
           check_space(dot_pos, selector_pos)
         end
 

--- a/spec/rubocop/cop/layout/space_around_method_call_operator_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_method_call_operator_spec.rb
@@ -69,6 +69,16 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundMethodCallOperator do
       foo.bar
     CORRECTION
 
+    include_examples 'offense', 'spaces after `Proc#call` shorthand call',
+                     <<-CODE, <<-OFFENSE, <<-CORRECTION
+      foo. ()
+    CODE
+      foo. ()
+          ^ Avoid using spaces around a method call operator.
+    OFFENSE
+      foo.()
+    CORRECTION
+
     context 'when multi line method call' do
       include_examples 'offense', 'space before method call',
                        <<-CODE, <<-OFFENSE, <<-CORRECTION


### PR DESCRIPTION
Closes #8324
