### PR TITLE
Config#for_department: be more accurate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 
 * [#8350](https://github.com/rubocop-hq/rubocop/pull/8350): Set default max line length to 120 for `Style/MultilineMethodSignature`. ([@koic][])
 
+### Changes
+
+* [#8338](https://github.com/rubocop-hq/rubocop/pull/8338): **potentially breaking**. Config#for_department now returns only the config specified for that department; the 'Enabled' attribute is no longer calculated. ([@marcandre][])
+
 ## 0.88.0 (2020-07-13)
 
 ### New features

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -112,8 +112,13 @@ module RuboCop
     end
 
     # @return [Config] for the given department name.
+    # Note: the 'Enabled' attribute will be present only if specified
+    # at the department's level
     def for_department(department_name)
-      @for_cop[department_name]
+      @for_department ||= Hash.new do |h, dept|
+        h[dept] = self[dept] || {}
+      end
+      @for_department[department_name.to_s]
     end
 
     def for_all_cops

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -819,4 +819,31 @@ RSpec.describe RuboCop::Config do
       end
     end
   end
+
+  describe '#for_department' do
+    let(:hash) do
+      {
+        'Foo' => { 'Bar' => 42, 'Baz' => true },
+        'Foo/Foo' => { 'Bar' => 42, 'Qux' => true }
+      }
+    end
+
+    around do |test|
+      RuboCop::Cop::Registry.with_temporary_global do
+        test.run
+      end
+    end
+
+    before do
+      stub_const('RuboCop::Foo::Foo', Class.new(RuboCop::Cop::Base))
+    end
+
+    it "always returns the department's config" do
+      expect(configuration.for_department('Foo')).to eq hash['Foo']
+    end
+
+    it 'accepts a Symbol' do
+      expect(configuration.for_department(:Foo)).to eq hash['Foo']
+    end
+  end
 end


### PR DESCRIPTION
I noticed that `for_department` is quite error prone. This fixes it:

* Don't rely on the department name being an unknown cop. E.g. `for_department('Foo')` would return the config for the cop "Foo/Foo" if it exists, instead of the department's.

* Don't provide 'Enabled' at the department level unless it is specified in the config.

* Accept symbols (like that returned by `Badge#department`) too
