### PR TITLE
[Fix #8335] Improve class detection in `Style/RedundantRegexpEscape`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#8324](https://github.com/rubocop-hq/rubocop/issues/8324): Fix crash for `Layout/SpaceAroundMethodCallOperator` when using `Proc#call` shorthand syntax. ([@fatkodima][])
 * [#8323](https://github.com/rubocop-hq/rubocop/issues/8323): Fix a false positive for `Style/HashAsLastArrayItem` when hash is not a last array item. ([@fatkodima][])
 * [#8299](https://github.com/rubocop-hq/rubocop/issues/8299): Fix an incorrect auto-correct for `Style/RedundantCondition` when using `raise`, `rescue`, or `and` without argument parentheses in `else`. ([@koic][])
+* [#8335](https://github.com/rubocop-hq/rubocop/issues/8335): Fix incorrect character class detection for nested or POSIX bracket character classes in `Style/RedundantRegexpEscape`. ([@owst][])
 
 ## 0.88.0 (2020-07-13)
 

--- a/lib/rubocop/cop/style/redundant_regexp_escape.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_escape.rb
@@ -92,18 +92,18 @@ module RuboCop
 
         def each_escape(node)
           pattern_source(node).each_char.with_index.reduce(
-            [nil, false]
-          ) do |(previous, within_character_class), (current, index)|
+            [nil, 0]
+          ) do |(previous, char_class_depth), (current, index)|
             if previous == '\\'
-              yield [current, index - 1, within_character_class]
+              yield [current, index - 1, !char_class_depth.zero?]
 
-              [nil, within_character_class]
-            elsif previous == '[' && current != ':'
-              [current, true]
-            elsif previous != ':' && current == ']'
-              [current, false]
+              [nil, char_class_depth]
+            elsif previous == '['
+              [current, char_class_depth + 1]
+            elsif current == ']'
+              [current, char_class_depth - 1]
             else
-              [current, within_character_class]
+              [current, char_class_depth]
             end
           end
         end

--- a/spec/rubocop/cop/style/redundant_regexp_escape_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_escape_spec.rb
@@ -67,6 +67,19 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpEscape do
       end
     end
 
+    context 'with an escaped . inside a character class beginning with :' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~'RUBY')
+          foo = /[:\.]/
+                   ^^ Redundant escape inside regexp literal
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          foo = /[:.]/
+        RUBY
+      end
+    end
+
     context 'with an escaped character class and following escaped char' do
       it 'does not register an offense' do
         expect_no_offenses('foo = /\[\+/')
@@ -79,9 +92,41 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpEscape do
       end
     end
 
-    context 'with a POSIX character class inside a character class' do
+    context 'with a nested character class then allowed escape' do
+      it 'does not register an offense' do
+        expect_no_offenses('foo = /[a-w&&[^c-g]\-]/')
+      end
+    end
+
+    context 'with a nested character class containing redundant escape' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~'RUBY')
+          foo = /[[:punct:]&&[^\.]]/
+                               ^^ Redundant escape inside regexp literal
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          foo = /[[:punct:]&&[^.]]/
+        RUBY
+      end
+    end
+
+    context 'with a POSIX character class then allowed escape inside a character class' do
       it 'does not register an offense' do
         expect_no_offenses('foo = /[[:alnum:]\-_]+/')
+      end
+    end
+
+    context 'with a POSIX character class then disallowed escape inside a character class' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~'RUBY')
+          foo = /[[:alnum:]\.]/
+                           ^^ Redundant escape inside regexp literal
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          foo = /[[:alnum:].]/
+        RUBY
       end
     end
 


### PR DESCRIPTION
The previous code wouldn't detect character classes that had ":" as
their first element (due to a poor attempt at avoiding issues due to
POSIX bracket expressions). The handling of nested character classes was
also improved to avoid false-negatives.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
