### PR TITLE
Fix build error when using Ruby 2.8.0-dev

### DIFF
--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -107,7 +107,7 @@ module RuboCop
     def cop_line_ranges(analysis)
       return analysis.line_ranges unless analysis.start_line_number
 
-      analysis.line_ranges + [(analysis.start_line_number..Float::INFINITY)]
+      analysis.line_ranges + [(analysis.start_line_number.to_f..Float::INFINITY)]
     end
 
     def each_mentioned_cop


### PR DESCRIPTION
This PR fixes the following build error when using Ruby 2.8.0-dev.

```console
% ruby -v
ruby 2.8.0dev (2020-07-14T04:19:55Z master e60cd14d85) [x86_64-darwin17]

% bundle exec rspec ./spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb:47
Run options: include {:focus=>true,
:locations=>{"./spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb"=>[47]}}

Randomized with seed 2998
F

Failures:

  1) RuboCop::Cop::Lint::RedundantCopDisableDirective.check when there
  are disabled lines and there are no offenses and a comment disables
  itself and another cop disabled on the same range returns no offense
       Failure/Error: range.cover?(line_range.min) && range.cover?(line_range.max)

  FloatDomainError:
    Infinity
  # ./lib/rubocop/cop/lint/redundant_cop_disable_directive.rb:164:in `floor'
  # ./lib/rubocop/cop/lint/redundant_cop_disable_directive.rb:164:in `max'
  # ./lib/rubocop/cop/lint/redundant_cop_disable_directive.rb:164:in `block in ignore_offense?'
  # ./lib/rubocop/cop/lint/redundant_cop_disable_directive.rb:163:in `any?'
  # ./lib/rubocop/cop/lint/redundant_cop_disable_directive.rb:163:in `ignore_offense?'
  # ./lib/rubocop/cop/lint/redundant_cop_disable_directive.rb:110:in `block in each_line_range'
```

The above error is due to the following Ruby 2.8.0-dev's changeset.
https://github.com/ruby/ruby/commit/8900a25

## Ruby 2.7.1

```
% ruby -ve 'p (42..Float::INFINITY).max'
ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-darwin17]
Infinity
```

## Ruby 2.8.0-dev

```console
% ruby -ve '(42..Float::INFINITY).max'
ruby 2.8.0dev (2020-07-14T04:19:55Z master e60cd14d85) [x86_64-darwin17]
-e:1:in `floor': Infinity (FloatDomainError)
        from -e:1:in `max'
        from -e:1:in `<main>'
```

I asked the following address and it's an expected behaviour.
https://bugs.ruby-lang.org/issues/17017

Perhaps there is still a possibility that the behavior will change while Ruby 2.8 (3.0) is being developed.
First of all, this PR is updating according to the current expectation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
