### PR TITLE
Fix crash for `Style/CaseLikeIf` when checking against `equal?` and `match?` without a receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#8324](https://github.com/rubocop-hq/rubocop/issues/8324): Fix crash for `Layout/SpaceAroundMethodCallOperator` when using `Proc#call` shorthand syntax. ([@fatkodima][])
+* [#8344](https://github.com/rubocop-hq/rubocop/issues/8344): Fix crash for `Style/CaseLikeIf` when checking against `equal?` and `match?` without a receiver. ([@fatkodima][])
 * [#8323](https://github.com/rubocop-hq/rubocop/issues/8323): Fix a false positive for `Style/HashAsLastArrayItem` when hash is not a last array item. ([@fatkodima][])
 * [#8299](https://github.com/rubocop-hq/rubocop/issues/8299): Fix an incorrect auto-correct for `Style/RedundantCondition` when using `raise`, `rescue`, or `and` without argument parentheses in `else`. ([@koic][])
 * [#8335](https://github.com/rubocop-hq/rubocop/issues/8335): Fix incorrect character class detection for nested or POSIX bracket character classes in `Style/RedundantRegexpEscape`. ([@owst][])

--- a/lib/rubocop/cop/style/case_like_if.rb
+++ b/lib/rubocop/cop/style/case_like_if.rb
@@ -112,6 +112,7 @@ module RuboCop
         def find_target_in_equality_node(node)
           argument = node.arguments.first
           receiver = node.receiver
+          return unless receiver
 
           if argument.literal? || const_reference?(argument)
             receiver
@@ -123,6 +124,7 @@ module RuboCop
         def find_target_in_match_node(node)
           argument = node.arguments.first
           receiver = node.receiver
+          return unless receiver
 
           if receiver.regexp_type?
             argument

--- a/spec/rubocop/cop/style/case_like_if_spec.rb
+++ b/spec/rubocop/cop/style/case_like_if_spec.rb
@@ -86,6 +86,15 @@ RSpec.describe RuboCop::Cop::Style::CaseLikeIf do
     RUBY
   end
 
+  it 'does not register an offense when using `equal?` without a receiver' do
+    expect_no_offenses(<<~RUBY)
+      if equal?(Foo)
+      elsif Bar == x
+      else
+      end
+    RUBY
+  end
+
   it 'registers an offense and corrects when using `is_a?`' do
     expect_offense(<<~RUBY)
       if x.is_a?(Foo)
@@ -126,6 +135,15 @@ RSpec.describe RuboCop::Cop::Style::CaseLikeIf do
     expect_no_offenses(<<~RUBY)
       if y.match?(x)
       elsif x.match?('str')
+      else
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `match?` without a receiver' do
+    expect_no_offenses(<<~RUBY)
+      if match?(/foo/)
+      elsif x.match?(/bar/)
       else
       end
     RUBY


### PR DESCRIPTION
Closes #8344 