### PR TITLE
Allow parentheses in single-line inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* [#8346](https://github.com/rubocop-hq/rubocop/pull/8346): Allow parentheses in single-line inheritance with `Style/MethodCallWithArgsParentheses` `EnforcedStyle: omit_parentheses` to fix invalid Ruby auto-correction. ([@gsamokovarov][])
 * [#8324](https://github.com/rubocop-hq/rubocop/issues/8324): Fix crash for `Layout/SpaceAroundMethodCallOperator` when using `Proc#call` shorthand syntax. ([@fatkodima][])
 * [#8344](https://github.com/rubocop-hq/rubocop/issues/8344): Fix crash for `Style/CaseLikeIf` when checking against `equal?` and `match?` without a receiver. ([@fatkodima][])
 * [#8323](https://github.com/rubocop-hq/rubocop/issues/8323): Fix a false positive for `Style/HashAsLastArrayItem` when hash is not a last array item. ([@fatkodima][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -60,6 +60,7 @@ module RuboCop
               call_with_ambiguous_arguments?(node) ||
               call_in_logical_operators?(node) ||
               call_in_optional_arguments?(node) ||
+              call_in_single_line_inheritance?(node) ||
               allowed_multiline_call_with_parentheses?(node) ||
               allowed_chained_call_with_parentheses?(node)
           end
@@ -84,6 +85,10 @@ module RuboCop
           def call_in_optional_arguments?(node)
             node.parent &&
               (node.parent.optarg_type? || node.parent.kwoptarg_type?)
+          end
+
+          def call_in_single_line_inheritance?(node)
+            node.parent&.class_type? && node.parent&.single_line?
           end
 
           def call_with_ambiguous_arguments?(node)

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -404,6 +404,20 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
+    it 'register an offense in multi-line inheritance' do
+      expect_offense(<<~RUBY)
+        class Point < Struct.new(:x, :y)
+                                ^^^^^^^^ Omit parentheses for method calls with arguments.
+        end
+      RUBY
+    end
+
+    it 'accepts parens in single-line inheritance' do
+      expect_no_offenses(<<-RUBY)
+        class Point < Struct.new(:x, :y); end
+      RUBY
+    end
+
     it 'accepts no parens in method call without args' do
       expect_no_offenses('top.test')
     end
@@ -578,6 +592,18 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
         foo \\
           bar: 3
 
+      RUBY
+    end
+
+    it 'auto-corrects multi-line class definitions with inheritance' do
+      original = <<~RUBY
+        class Point < Struct.new(:x, :y)
+        end
+      RUBY
+
+      expect(autocorrect_source(original)).to eq(<<~RUBY)
+        class Point < Struct.new :x, :y
+        end
       RUBY
     end
 


### PR DESCRIPTION
`class Point < Struct.new(:x, :y); end` was getting auto-corrected to
`class Point < Struct.new :x, :y; end` which is invalid Ruby code. Allow
the parentheses in this case for the following configurations:

```ruby
Style/MethodCallWithArgsParentheses:
  EnforcedStyle: omit_parentheses
```