### PR TITLE
[Fixes #8352] Allow multiple cops in shared_context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#8352](https://github.com/rubocop-hq/rubocop/issues/8352): Allow multiple cops in shared_context. ([@dorner][])
+
 ### Bug fixes
 
 * [#8324](https://github.com/rubocop-hq/rubocop/issues/8324): Fix crash for `Layout/SpaceAroundMethodCallOperator` when using `Proc#call` shorthand syntax. ([@fatkodima][])
@@ -4698,3 +4700,4 @@
 [@CamilleDrapier]: https://github.com/CamilleDrapier
 [@shekhar-patil]: https://github.com/shekhar-patil
 [@knejad]: https://github.com/knejad
+[@dorner]: https://github.com/dorner

--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -25,6 +25,11 @@ module RuboCop
           @correctors ||= cop_reports.map(&:corrector)
         end
 
+        # @return [Corrector]
+        def merged_correctors
+          correctors.compact.inject(:merge!)
+        end
+
         def offenses
           @offenses ||= offenses_per_cop.flatten(1)
         end

--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -27,7 +27,7 @@ module RuboCop
 
         # @return [Corrector]
         def merged_correctors
-          correctors.inject(Corrector.new(processed_source), :merge!)
+          correctors.compact.inject(Corrector.new(processed_source), :merge!)
         end
 
         def offenses

--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -27,7 +27,7 @@ module RuboCop
 
         # @return [Corrector]
         def merged_correctors
-          correctors.compact.inject(:merge!)
+          correctors.inject(Corrector.new(processed_source), :merge!)
         end
 
         def offenses

--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -50,7 +50,7 @@ module CopHelper
     cop_array = Array(cops)
     team = RuboCop::Cop::Team.new(cop_array, nil, raise_error: true)
     report = team.investigate(processed_source)
-    @last_corrector = report.merged_correctors || RuboCop::Cop::Corrector.new(processed_source)
+    @last_corrector = report.merged_correctors
     report.offenses
   end
 end

--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -46,11 +46,20 @@ module CopHelper
     @last_corrector.rewrite
   end
 
-  def _investigate(cop, processed_source)
-    team = RuboCop::Cop::Team.new([cop], nil, raise_error: true)
+  def _investigate(cops, processed_source)
+    cop_array = Array(cops)
+    team = RuboCop::Cop::Team.new(cop_array, nil, raise_error: true)
     report = team.investigate(processed_source)
-    @last_corrector = report.correctors.first || RuboCop::Cop::Corrector.new(processed_source)
+    @last_corrector = _corrector(report, processed_source)
     report.offenses
+  end
+
+  def _corrector(report, processed_source)
+    corrector = report.correctors.first || RuboCop::Cop::Corrector.new(processed_source)
+    if report.correctors&.compact&.any?
+      report.correctors.compact[1..-1].each { |corr| corrector.merge!(corr) }
+    end
+    corrector
   end
 end
 

--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -50,16 +50,8 @@ module CopHelper
     cop_array = Array(cops)
     team = RuboCop::Cop::Team.new(cop_array, nil, raise_error: true)
     report = team.investigate(processed_source)
-    @last_corrector = _corrector(report, processed_source)
+    @last_corrector = report.merged_correctors || RuboCop::Cop::Corrector.new(processed_source)
     report.offenses
-  end
-
-  def _corrector(report, processed_source)
-    corrector = report.correctors.first || RuboCop::Cop::Corrector.new(processed_source)
-    if report.correctors&.compact&.any?
-      report.correctors.compact[1..-1].each { |corr| corrector.merge!(corr) }
-    end
-    corrector
   end
 end
 

--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -130,7 +130,8 @@ module RuboCop
 
         raise 'Error parsing example code' unless @processed_source.valid_syntax?
 
-        offenses = _investigate(cop, @processed_source)
+        first_cops = respond_to?(:run_first_cops) ? run_first_cops : []
+        offenses = _investigate(first_cops + [cop], @processed_source)
         actual_annotations =
           expected_annotations.with_offense_annotations(offenses)
 
@@ -158,7 +159,8 @@ module RuboCop
           # Prepare for next loop
           @processed_source = parse_source(corrected_source,
                                            @processed_source.path)
-          _investigate(cop, @processed_source)
+          first_cops = respond_to?(:run_first_cops) ? run_first_cops : []
+          _investigate(first_cops + [cop], @processed_source)
         end
 
         expect(new_source).to eq(correction)


### PR DESCRIPTION
Fixes #8352.

This allows additional cops to be run before the current one, allowing us to test interactions between cops more effectively.

cc: @marcandre 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
