### PR TITLE
Small `Lint` cops perf tweaks

### DIFF
--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -30,10 +30,11 @@ module RuboCop
               'call.'
 
         def on_send(node)
-          return if !node.arguments? || node.parenthesized? ||
-                    node.last_argument.lambda? || allowed_method?(node)
+          return unless node.arguments?
 
           return unless ambiguous_block_association?(node)
+          return if node.parenthesized? ||
+                    node.last_argument.lambda? || allowed_method?(node)
 
           add_offense(node)
         end

--- a/lib/rubocop/cop/lint/big_decimal_new.rb
+++ b/lib/rubocop/cop/lint/big_decimal_new.rb
@@ -24,7 +24,9 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return unless big_decimal_new(node) do |captured_value|
+          return unless node.method?(:new)
+
+          big_decimal_new(node) do |captured_value|
             double_colon = captured_value ? '::' : ''
             message = format(MSG, double_colon: double_colon)
 

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'set'
+
 module RuboCop
   module Cop
     module Lint
@@ -35,6 +37,11 @@ module RuboCop
       class Debugger < Cop
         MSG = 'Remove debugger entry point `%<source>s`.'
 
+        DEBUGGER_METHODS = %i[
+          debugger byebug remote_byebug pry remote_pry pry_remote console rescue
+          save_and_open_page save_and_open_screenshot save_screenshot irb
+        ].to_set.freeze
+
         def_node_matcher :kernel?, <<~PATTERN
           {
             (const nil? :Kernel)
@@ -57,6 +64,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          return unless DEBUGGER_METHODS.include?(node.method_name)
           return unless debugger_call?(node) || binding_irb?(node)
 
           add_offense(node)

--- a/lib/rubocop/cop/lint/deprecated_class_methods.rb
+++ b/lib/rubocop/cop/lint/deprecated_class_methods.rb
@@ -60,7 +60,11 @@ module RuboCop
                                     replacement: :block_given?)
         ].freeze
 
+        DEPRECATED_METHODS = DEPRECATED_METHODS_OBJECT.map(&:deprecated_method).freeze
+
         def on_send(node)
+          return unless DEPRECATED_METHODS.include?(node.method_name)
+
           check(node) do |data|
             message = format(MSG, current: deprecated_method(data),
                                   prefer: replacement_method(data))

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -44,9 +44,10 @@ module RuboCop
         KERNEL = 'Kernel'
         SHOVEL = '<<'
         STRING_TYPES = %i[str dstr].freeze
+        FORMAT_METHODS = %i[format sprintf %].freeze
 
         def on_send(node)
-          return unless format_string?(node)
+          return unless FORMAT_METHODS.include?(node.method_name) && format_string?(node)
 
           if invalid_format_string?(node)
             add_offense(node, location: :selector, message: MSG_INVALID)

--- a/lib/rubocop/cop/lint/inherit_exception.rb
+++ b/lib/rubocop/cop/lint/inherit_exception.rb
@@ -69,6 +69,8 @@ module RuboCop
         end
 
         def on_send(node)
+          return unless node.method?(:new)
+
           constant = class_new_call?(node)
           return unless constant && illegal_class_name?(constant)
 

--- a/lib/rubocop/cop/lint/interpolation_check.rb
+++ b/lib/rubocop/cop/lint/interpolation_check.rb
@@ -21,11 +21,10 @@ module RuboCop
               'Use double quoted strings if you need interpolation.'
 
         def on_str(node)
-          return if heredoc?(node)
-
           parent = node.parent
           return if parent && (parent.dstr_type? || parent.regexp_type?)
           return unless /(?<!\\)#\{.*\}/.match?(node.source.scrub)
+          return if heredoc?(node)
 
           add_offense(node)
         end

--- a/lib/rubocop/cop/lint/rand_one.rb
+++ b/lib/rubocop/cop/lint/rand_one.rb
@@ -29,7 +29,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return unless rand_one?(node)
+          return unless node.method?(:rand) && rand_one?(node)
 
           add_offense(node)
         end

--- a/lib/rubocop/cop/lint/uri_regexp.rb
+++ b/lib/rubocop/cop/lint/uri_regexp.rb
@@ -30,6 +30,8 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          return unless node.method?(:regexp)
+
           uri_regexp_with_argument?(node) do |double_colon, arg|
             register_offense(
               node, top_level: double_colon ? '::' : '', arg: "(#{arg.source})"


### PR DESCRIPTION
Ran on larger `discourse` codebase (3.5k files).
```
$ bin/rubocop-profile --force-default-config --cache false --only Lint ../discourse
```

### Before
```
 1   965  (    7.3%)  RuboCop::Cop::Lint::DeprecatedClassMethods#on_send
 2   952  (    7.2%)  RuboCop::Cop::Lint::Debugger#on_send
 3   806  (    6.1%)  RuboCop::Cop::Lint::AmbiguousBlockAssociation#on_send
     642  (    4.8%)  RuboCop::Cop::Lint::ParenthesesAsGroupedExpression#on_send
     623  (    4.7%)  RuboCop::Cop::Lint::SafeNavigationChain#on_send
 4   605  (    4.6%)  RuboCop::Cop::Lint::FormatParameterMismatch#on_send
 5   533  (    4.4%)  RuboCop::Cop::Lint::DuplicateMethods#on_send
 6   500  (    3.8%)  RuboCop::Cop::Lint::InterpolationCheck#on_str
 7   493  (    3.7%)  RuboCop::Cop::Lint::IneffectiveAccessModifier#on_class
 8   473  (    3.6%)  RuboCop::Cop::Lint::BigDecimalNew#on_send
     467  (    3.5%)  RuboCop::Cop::Lint::RequireParentheses#on_send
 9   464  (    3.5%)  RuboCop::Cop::Lint::UriRegexp#on_send
     403  (    3.0%)  RuboCop::Cop::Lint::MultipleComparison#on_send
     376  (    2.8%)  RuboCop::Cop::Lint::Void#on_begin
     332  (    2.5%)  RuboCop::Cop::Lint::UriEscapeUnescape#on_send
     313  (    2.4%)  RuboCop::Cop::Lint::UnreachableCode#on_begin
     312  (    2.4%)  RuboCop::Cop::Lint::DuplicateMethods#on_def
10   312  (    2.4%)  RuboCop::Cop::Lint::InheritException#on_send
     299  (    2.3%)  RuboCop::Cop::Lint::UselessComparison#on_send
     296  (    2.2%)  RuboCop::Cop::Lint::DuplicateHashKey#on_hash
     259  (    2.0%)  RuboCop::Cop::Lint::EachWithObjectArgument#on_send
11   252  (    1.9%)  RuboCop::Cop::Lint::RandOne#on_send
     228  (    1.7%)  RuboCop::Cop::Lint::LiteralAsCondition#on_send
```

### After
```
     635  (    7.3%)  RuboCop::Cop::Lint::SafeNavigationChain#on_send
     597  (    6.9%)  RuboCop::Cop::Lint::ParenthesesAsGroupedExpression#on_send
     451  (    5.2%)  RuboCop::Cop::Lint::RequireParentheses#on_send
3    404  (    4.7%)  RuboCop::Cop::Lint::AmbiguousBlockAssociation#on_send
     346  (    4.0%)  RuboCop::Cop::Lint::Void#on_begin
5    320  (    3.7%)  RuboCop::Cop::Lint::DuplicateMethods#on_def
     312  (    3.6%)  RuboCop::Cop::Lint::UriEscapeUnescape#on_send
     303  (    3.5%)  RuboCop::Cop::Lint::UselessComparison#on_send
     291  (    3.4%)  RuboCop::Cop::Lint::UnreachableCode#on_begin
     280  (    3.2%)  RuboCop::Cop::Lint::MultipleComparison#on_send
     275  (    3.2%)  RuboCop::Cop::Lint::EachWithObjectArgument#on_send
     263  (    3.0%)  RuboCop::Cop::Lint::DuplicateHashKey#on_hash
     250  (    2.9%)  RuboCop::Cop::Lint::SendWithMixinArgument#on_send
7    240  (    2.8%)  RuboCop::Cop::Lint::IneffectiveAccessModifier#on_class
6    239  (    2.5%)  RuboCop::Cop::Lint::InterpolationCheck#on_str
     188  (    2.2%)  RuboCop::Cop::Lint::ImplicitStringConcatenation#on_dstr
     187  (    2.2%)  RuboCop::Cop::Lint::RedundantRequireStatement#on_send
8    184  (    2.1%)  RuboCop::Cop::Lint::BigDecimalNew#on_send
2    182  (    2.1%)  RuboCop::Cop::Lint::Debugger#on_send
     176  (    2.0%)  RuboCop::Cop::Lint::DuplicateMethods#on_send
     168  (    1.9%)  RuboCop::Cop::Lint::UselessAccessModifier#on_class
     166  (    1.9%)  RuboCop::Cop::Lint::LiteralAsCondition#on_send
 9   159  (    1.8%)  RuboCop::Cop::Lint::UriRegexp#on_send
 1   143  (    1.7%)  RuboCop::Cop::Lint::DeprecatedClassMethods#on_send
 4   140  (    1.6%)  RuboCop::Cop::Lint::FormatParameterMismatch#on_send
     113  (    1.3%)  RuboCop::Cop::Lint::AssignmentInCondition#on_if
      91  (    1.1%)  RuboCop::Cop::Lint::UselessAccessModifier#on_block