### PR TITLE
Small `Style` cops perf tweaks

### DIFF
--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -65,6 +65,8 @@ module RuboCop
       class AccessModifierDeclarations < Cop
         include ConfigurableEnforcedStyle
 
+        ACCESS_MODIFIERS = %i[private protected public module_function].to_set.freeze
+
         GROUP_STYLE_MESSAGE = [
           '`%<access_modifier>s` should not be',
           'inlined in method definitions.'
@@ -80,7 +82,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return unless node.access_modifier?
+          return unless access_modifier?(node)
           return if node.parent.pair_type?
           return if cop_config['AllowModifiersOnSymbols'] &&
                     access_modifier_with_symbol?(node)
@@ -95,6 +97,14 @@ module RuboCop
         end
 
         private
+
+        def access_modifier?(node)
+          maybe_access_modifier?(node) && node.access_modifier?
+        end
+
+        def maybe_access_modifier?(node)
+          !node.receiver && ACCESS_MODIFIERS.include?(node.method_name)
+        end
 
         def offense?(node)
           (group_style? && access_modifier_is_inlined?(node)) ||

--- a/lib/rubocop/cop/style/colon_method_call.rb
+++ b/lib/rubocop/cop/style/colon_method_call.rb
@@ -30,11 +30,11 @@ module RuboCop
         end
 
         def on_send(node)
-          # ignore Java interop code like Java::int
-          return if java_type_node?(node)
-
           return unless node.receiver && node.double_colon?
           return if node.camel_case_method?
+
+          # ignore Java interop code like Java::int
+          return if java_type_node?(node)
 
           add_offense(node, location: :dot)
         end

--- a/lib/rubocop/cop/style/eval_with_location.rb
+++ b/lib/rubocop/cop/style/eval_with_location.rb
@@ -37,6 +37,8 @@ module RuboCop
         MSG_INCORRECT_LINE = 'Use `%<expected>s` instead of `%<actual>s`, ' \
                              'as they are used by backtraces.'
 
+        EVAL_METHODS = %i[eval class_eval module_eval instance_eval].to_set.freeze
+
         def_node_matcher :eval_without_location?, <<~PATTERN
           {
             (send nil? :eval ${str dstr})
@@ -61,6 +63,8 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          return unless EVAL_METHODS.include?(node.method_name)
+
           eval_without_location?(node) do |code|
             if with_lineno?(node)
               on_with_lineno(node, code)

--- a/lib/rubocop/cop/style/expand_path_arguments.rb
+++ b/lib/rubocop/cop/style/expand_path_arguments.rb
@@ -73,7 +73,10 @@ module RuboCop
                 $_) :parent) :expand_path)
         PATTERN
 
+        # rubocop:disable Metrics/PerceivedComplexity
         def on_send(node)
+          return unless node.method?(:expand_path)
+
           if (captured_values = file_expand_path(node))
             current_path, default_dir = captured_values
 
@@ -88,6 +91,7 @@ module RuboCop
             add_offense(node, message: PATHNAME_NEW_MSG)
           end
         end
+        # rubocop:enable Metrics/PerceivedComplexity
 
         def autocorrect(node)
           lambda do |corrector|

--- a/lib/rubocop/cop/style/format_string.rb
+++ b/lib/rubocop/cop/style/format_string.rb
@@ -40,6 +40,8 @@ module RuboCop
 
         MSG = 'Favor `%<prefer>s` over `%<current>s`.'
 
+        FORMAT_METHODS = %i[format sprintf %].freeze
+
         def_node_matcher :formatter, <<~PATTERN
           {
             (send nil? ${:sprintf :format} _ _ ...)
@@ -53,6 +55,8 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          return unless FORMAT_METHODS.include?(node.method_name)
+
           formatter(node) do |selector|
             detected_style = selector == :% ? :percent : selector
 

--- a/lib/rubocop/cop/style/format_string_token.rb
+++ b/lib/rubocop/cop/style/format_string_token.rb
@@ -41,6 +41,7 @@ module RuboCop
         include ConfigurableEnforcedStyle
 
         def on_str(node)
+          return unless node.value.include?('%')
           return if node.each_ancestor(:xstr, :regexp).any?
 
           tokens(node) do |detected_style, token_range|

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -62,6 +62,7 @@ module RuboCop
         MSG_NO_MIXED_KEYS = "Don't mix styles in the same hash."
         MSG_HASH_ROCKETS = 'Use hash rockets syntax.'
 
+        # rubocop:disable Metrics/PerceivedComplexity, Metrics/AbcSize
         def on_hash(node)
           pairs = node.pairs
 
@@ -73,10 +74,11 @@ module RuboCop
             ruby19_no_mixed_keys_check(pairs)
           elsif style == :no_mixed_keys
             no_mixed_keys_check(pairs)
-          else
+          elsif node.source.include?('=>')
             ruby19_check(pairs)
           end
         end
+        # rubocop:enable Metrics/PerceivedComplexity, Metrics/AbcSize
 
         def ruby19_check(pairs)
           check(pairs, '=>', MSG_19) if sym_indices?(pairs)

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -64,12 +64,11 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return if part_of_ignored_node?(node)
-
           inverse_candidate?(node) do |_method_call, lhs, method, rhs|
             return unless inverse_methods.key?(method)
-            return if possible_class_hierarchy_check?(lhs, rhs, method)
             return if negated?(node)
+            return if part_of_ignored_node?(node)
+            return if possible_class_hierarchy_check?(lhs, rhs, method)
 
             add_offense(node,
                         message: format(MSG, method: method,

--- a/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
@@ -18,8 +18,8 @@ module RuboCop
               'no arguments.'
 
         def on_send(node)
-          return if ineligible_node?(node)
           return unless !node.arguments? && node.parenthesized?
+          return if ineligible_node?(node)
           return if ignored_method?(node.method_name)
           return if same_name_assignment?(node)
 

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -53,7 +53,11 @@ module RuboCop
           'negative?' => '<'
         }.freeze
 
+        COMPARISON_METHODS = %i[== > < positive? negative? zero?].to_set.freeze
+
         def on_send(node)
+          return unless COMPARISON_METHODS.include?(node.method_name)
+
           numeric, replacement = check(node)
           return unless numeric
 

--- a/lib/rubocop/cop/style/random_with_offset.rb
+++ b/lib/rubocop/cop/style/random_with_offset.rb
@@ -56,6 +56,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          return unless node.receiver
           return unless integer_op_rand?(node) ||
                         rand_op_integer?(node) ||
                         rand_modified?(node)

--- a/lib/rubocop/cop/style/redundant_exception.rb
+++ b/lib/rubocop/cop/style/redundant_exception.rb
@@ -23,9 +23,13 @@ module RuboCop
         MSG_2 = 'Redundant `RuntimeError.new` call can be replaced with ' \
                 'just the message.'
 
+        RAISE_METHODS = %i[raise fail].freeze
+
         # Switch `raise RuntimeError, 'message'` to `raise 'message'`, and
         # `raise RuntimeError.new('message')` to `raise 'message'`.
         def on_send(node)
+          return unless RAISE_METHODS.include?(node.method_name)
+
           fix_exploded(node) || fix_compact(node)
         end
 

--- a/lib/rubocop/cop/style/signal_exception.rb
+++ b/lib/rubocop/cop/style/signal_exception.rb
@@ -191,6 +191,8 @@ module RuboCop
         end
 
         def command_or_kernel_call?(name, node)
+          return unless node.method?(name)
+
           node.command?(name) || kernel_call?(node, name)
         end
 

--- a/lib/rubocop/cop/style/zero_length_predicate.rb
+++ b/lib/rubocop/cop/style/zero_length_predicate.rb
@@ -30,6 +30,8 @@ module RuboCop
         NONZERO_MSG = 'Use `!empty?` instead of ' \
                       '`%<lhs>s %<opr>s %<rhs>s`.'
 
+        LENGTH_METHODS = %i[size length].freeze
+
         def on_send(node)
           check_zero_length_predicate(node)
           check_nonzero_length_predicate(node)
@@ -44,31 +46,33 @@ module RuboCop
         private
 
         def check_zero_length_predicate(node)
-          zero_length_predicate = zero_length_predicate(node)
+          return unless LENGTH_METHODS.include?(node.method_name)
 
+          zero_length_predicate = zero_length_predicate(node.parent)
           return unless zero_length_predicate
 
           lhs, opr, rhs = zero_length_predicate
 
-          return if non_polymorphic_collection?(node)
+          return if non_polymorphic_collection?(node.parent)
 
           add_offense(
-            node,
+            node.parent,
             message: format(ZERO_MSG, lhs: lhs, opr: opr, rhs: rhs)
           )
         end
 
         def check_nonzero_length_predicate(node)
-          nonzero_length_predicate = nonzero_length_predicate(node)
+          return unless LENGTH_METHODS.include?(node.method_name)
 
+          nonzero_length_predicate = nonzero_length_predicate(node.parent)
           return unless nonzero_length_predicate
 
           lhs, opr, rhs = nonzero_length_predicate
 
-          return if non_polymorphic_collection?(node)
+          return if non_polymorphic_collection?(node.parent)
 
           add_offense(
-            node,
+            node.parent,
             message: format(NONZERO_MSG, lhs: lhs, opr: opr, rhs: rhs)
           )
         end


### PR DESCRIPTION
Ran on `discourse` codebase:
```
$ bin/rubocop-profile --force-default-config --cache false --only Style ../discourse
```

### Before
```
     5228  (    9.0%)  RuboCop::Cop::Style::RedundantSelf#on_block
     3376  (    5.8%)  RuboCop::Cop::StringHelp#on_str
 1   1975  (    3.4%)  RuboCop::Cop::Style::AccessModifierDeclarations#on_send
 2   1960  (    3.4%)  RuboCop::Cop::Style::FormatStringToken#on_str
     1712  (    2.9%)  RuboCop::Cop::Style::TrailingCommaInArguments#on_send
 3   1560  (    2.7%)  RuboCop::Cop::Style::NumericPredicate#on_send
     1471  (    2.5%)  RuboCop::Cop::Style::ConditionalAssignment#on_send
 4   1453  (    2.5%)  RuboCop::Cop::Style::MethodCallWithoutArgsParentheses#on_send
 5   1278  (    2.2%)  RuboCop::Cop::Style::ZeroLengthPredicate#on_send
 6   1150  (    2.0%)  RuboCop::Cop::Style::RedundantSort#on_send
 7   1041  (    1.8%)  RuboCop::Cop::Style::InverseMethods#on_send
      982  (    1.7%)  RuboCop::Cop::StringHelp#on_str
 8    974  (    1.7%)  RuboCop::Cop::Style::SignalException#on_send
      964  (    1.7%)  RuboCop::Cop::Style::BlockDelimiters#on_send
 9    962  (    1.7%)  RuboCop::Cop::Style::HashSyntax#on_hash
      939  (    1.6%)  RuboCop::Cop::Style::RedundantSelf#on_def
 10   913  (    1.6%)  RuboCop::Cop::Style::ColonMethodCall#on_send
 11   864  (    1.5%)  RuboCop::Cop::Style::EvalWithLocation#on_send
 12   851  (    1.5%)  RuboCop::Cop::Style::ExpandPathArguments#on_send
      829  (    1.4%)  RuboCop::Cop::Style::EmptyLiteral#on_send
 13   791  (    1.4%)  RuboCop::Cop::Style::FormatString#on_send
      784  (    1.3%)  RuboCop::Cop::Style::NonNilCheck#on_send
 14   777  (    1.3%)  RuboCop::Cop::Style::RedundantException#on_send
      777  (    1.3%)  RuboCop::Cop::Style::StabbyLambdaParentheses#on_send
      767  (    1.3%)  RuboCop::Cop::Style::NestedParenthesizedCalls#on_send
 15   749  (    1.3%)  RuboCop::Cop::Style::RandomWithOffset#on_send
      724  (    1.2%)  RuboCop::Cop::Style::NilComparison#on_send
```

### After
```
    4277  (   12.4%)  RuboCop::Cop::Style::RedundantSelf#on_block
    2307  (    6.7%)  RuboCop::Cop::StringHelp#on_str
    1167  (    3.4%)  RuboCop::Cop::Style::TrailingCommaInArguments#on_send
    1159  (    3.4%)  RuboCop::Cop::Style::ConditionalAssignment#on_send
     730  (    2.1%)  RuboCop::Cop::Style::RedundantSelf#on_def
     707  (    2.0%)  RuboCop::Cop::StringHelp#on_str
     688  (    2.0%)  RuboCop::Cop::Style::BlockDelimiters#on_send
     633  (    1.8%)  RuboCop::Cop::Style::EmptyLiteral#on_send
     570  (    1.6%)  RuboCop::Cop::Style::StabbyLambdaParentheses#on_send
 7   556  (    1.6%)  RuboCop::Cop::Style::InverseMethods#on_send
     538  (    1.6%)  RuboCop::Cop::Style::NonNilCheck#on_send
     523  (    1.5%)  RuboCop::Cop::Style::NestedParenthesizedCalls#on_send
     506  (    1.5%)  RuboCop::Cop::Style::Sample#on_send
     477  (    1.4%)  RuboCop::Cop::Style::FloatDivision#on_send
     469  (    1.4%)  RuboCop::Cop::Style::NilComparison#on_send
     460  (    1.3%)  RuboCop::Cop::Style::UnpackFirst#on_send
 1   446  (    1.3%)  RuboCop::Cop::Style::AccessModifierDeclarations#on_send
10   445  (    1.3%)  RuboCop::Cop::Style::ColonMethodCall#on_send
     443  (    1.3%)  RuboCop::Cop::Style::CaseEquality#on_send
 8   418  (    1.2%)  RuboCop::Cop::Style::SignalException#on_send
     400  (    1.2%)  RuboCop::Cop::Style::IfUnlessModifier#on_if
     398  (    1.2%)  RuboCop::Cop::Style::StderrPuts#on_send
     394  (    1.1%)  RuboCop::Cop::Style::ArrayJoin#on_send
     392  (    1.1%)  RuboCop::Cop::Style::Strip#on_send
     382  (    1.1%)  RuboCop::Cop::Style::Dir#on_send
     381  (    1.1%)  RuboCop::Cop::Style::EvenOdd#on_send
     364  (    1.1%)  RuboCop::Cop::Style::PreferredHashMethods#on_send
 3   362  (    1.0%)  RuboCop::Cop::Style::NumericPredicate#on_send
     335  (    1.0%)  RuboCop::Cop::StringHelp#on_str
     333  (    1.0%)  RuboCop::Cop::Style::MixinUsage#on_send
     332  (    1.0%)  RuboCop::Cop::Style::YodaCondition#on_send
     330  (    1.0%)  RuboCop::Cop::Style::Documentation#on_class
 5   328  (    0.9%)  RuboCop::Cop::Style::ZeroLengthPredicate#on_send
     318  (    0.9%)  RuboCop::Cop::Style::RaiseArgs#on_send
     312  (    0.9%)  RuboCop::Cop::Style::BlockDelimiters#on_block
     308  (    0.9%)  RuboCop::Cop::Style::Semicolon#on_begin
     306  (    0.9%)  RuboCop::Cop::Style::ClassCheck#on_send
     305  (    0.9%)  RuboCop::Cop::Style::BarePercentLiterals#on_str
     305  (    0.9%)  RuboCop::Cop::Style::Not#on_send
```