### PR TITLE
Optimize cli startup time and memory

### DIFF
--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -55,10 +55,25 @@ module RuboCop
     end
 
     def hidden_file_in_not_hidden_dir?(pattern, path)
-      File.fnmatch?(
-        pattern, path,
-        File::FNM_PATHNAME | File::FNM_EXTGLOB | File::FNM_DOTMATCH
-      ) && File.basename(path).start_with?('.') && !hidden_dir?(path)
+      hidden_file?(path) &&
+        File.fnmatch?(
+          pattern, path,
+          File::FNM_PATHNAME | File::FNM_EXTGLOB | File::FNM_DOTMATCH
+        ) &&
+        !hidden_dir?(path)
+    end
+
+    def hidden_file?(path)
+      maybe_hidden_file?(path) && File.basename(path).start_with?('.')
+    end
+
+    # Loose check to reduce memory allocations
+    def maybe_hidden_file?(path)
+      separator_index = path.rindex(File::SEPARATOR)
+      return false unless separator_index
+
+      dot_index = path.index('.', separator_index + 1)
+      dot_index == separator_index + 1
     end
 
     def hidden_dir?(path)

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -114,10 +114,12 @@ module RuboCop
     end
 
     def ruby_extensions
-      ext_patterns = all_cops_include.select do |pattern|
-        pattern.start_with?('**/*.')
+      @ruby_extensions ||= begin
+        ext_patterns = all_cops_include.select do |pattern|
+          pattern.start_with?('**/*.')
+        end
+        ext_patterns.map { |pattern| pattern.sub('**/*', '') }
       end
-      ext_patterns.map { |pattern| pattern.sub('**/*', '') }
     end
 
     def ruby_filename?(file)
@@ -125,14 +127,17 @@ module RuboCop
     end
 
     def ruby_filenames
-      file_patterns = all_cops_include.reject do |pattern|
-        pattern.start_with?('**/*.')
+      @ruby_filenames ||= begin
+        file_patterns = all_cops_include.reject do |pattern|
+          pattern.start_with?('**/*.')
+        end
+        file_patterns.map { |pattern| pattern.sub('**/', '') }
       end
-      file_patterns.map { |pattern| pattern.sub('**/', '') }
     end
 
     def all_cops_include
-      @config_store.for_pwd.for_all_cops['Include'].map(&:to_s)
+      @all_cops_include ||=
+        @config_store.for_pwd.for_all_cops['Include'].map(&:to_s)
     end
 
     def ruby_executable?(file)


### PR DESCRIPTION
I tested only startup time (before any cop starts running):
```
$ exe/rubocop --force-default-config --cache false ../discourse
```

### Before
```
Finished in 16.0 seconds
```

```
Total allocated: 625.52 MB (11372432 objects)
Total retained:  5.48 MB (46807 objects)

allocated memory by location
-----------------------------------
 120.67 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/path_util.rb:58
  89.80 MB  /Users/fatkodima/.rbenv/versions/2.7.0/lib/ruby/2.7.0/pathname.rb:42
  68.33 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/target_finder.rb:120
  67.99 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/target_finder.rb:131
  64.09 MB  /Users/fatkodima/.rbenv/versions/2.7.0/lib/ruby/2.7.0/pathname.rb:46
  24.98 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/target_finder.rb:135
  20.99 MB  /Users/fatkodima/.rbenv/versions/2.7.0/lib/ruby/2.7.0/pathname.rb:119
  13.19 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/target_finder.rb:117
  10.25 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/target_finder.rb:95
  10.12 MB  /Users/fatkodima/.rbenv/versions/2.7.0/lib/ruby/2.7.0/pathname.rb:99
```

### After
```
Finished in 8.7 seconds
```

```
Total allocated: 317.34 MB (5454647 objects)
Total retained:  5.48 MB (46812 objects)

allocated memory by location
-----------------------------------
  89.80 MB  /Users/fatkodima/.rbenv/versions/2.7.0/lib/ruby/2.7.0/pathname.rb:42
  64.09 MB  /Users/fatkodima/.rbenv/versions/2.7.0/lib/ruby/2.7.0/pathname.rb:46
  20.99 MB  /Users/fatkodima/.rbenv/versions/2.7.0/lib/ruby/2.7.0/pathname.rb:119
  10.25 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/target_finder.rb:95
  10.12 MB  /Users/fatkodima/.rbenv/versions/2.7.0/lib/ruby/2.7.0/pathname.rb:99
   9.83 MB  /Users/fatkodima/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rubocop-ast-0.1.0/lib/rubocop/ast/node_pattern.rb:796
```

So, simple changes halved both startup time and memory ⚡ ⚡ ⚡ 