### PR TITLE
No need to clear this cache.

### DIFF
--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -95,7 +95,6 @@ module RuboCop
 
       def reset
         @errors = []
-        @callbacks = {}
       end
 
       def invoke(callback, cops, *args)


### PR DESCRIPTION
`@cops` does not change, so `@callbacks` need not be invalidated. Not particularly relevant as `Commissionner` are currently recreated, but that could change
