### PR TITLE
Allow cops to restrict callbacks `on_send` to specific method names only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#8578](https://github.com/rubocop-hq/rubocop/pull/8578): Add `:restore_registry` context and `stub_cop_class` helper class. ([@marcandre][])
 * [#8579](https://github.com/rubocop-hq/rubocop/pull/8579): Add `Cop.documentation_url`.  ([@marcandre][])
 * [#8510](https://github.com/rubocop-hq/rubocop/pull/8510):  Add `RegexpNode#each_capture` and `parsed_tree`. ([@marcandre][])
+* [#8365](https://github.com/rubocop-hq/rubocop/pull/8365): Cops defining `on_send` can be optimized by defining the constant `RESTRICT_ON_SEND` with a list of acceptable method names. ([@marcandre][])
 
 ### Bug fixes
 

--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -210,6 +210,9 @@ def on_send(node)
 end
 ----
 
+The `on_send` callback is the most used and can be optimized by restricting the acceptable
+method names with a constant `RESTRICT_ON_SEND`.
+
 And the final cop code will look like something like this:
 
 [source,ruby]
@@ -232,6 +235,8 @@ module RuboCop
           (send (send $(...) :empty?) :!)
         PATTERN
 
+        RESTRICT_ON_SEND = [:!].freeze # optimization: don't call `on_send` unless
+                                       # the method name is in this list
         def on_send(node)
           return unless not_empty_call?(node)
 

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -46,6 +46,9 @@ module RuboCop
       # Consider creation API private
       InvestigationReport = Struct.new(:cop, :processed_source, :offenses, :corrector)
 
+      # List of methods names to restrict calls for `on_send` / `on_csend`
+      RESTRICT_ON_SEND = Set[].freeze
+
       # List of cops that should not try to autocorrect at the same
       # time as this cop
       #
@@ -285,6 +288,10 @@ module RuboCop
 
       def currently_disabled_lines
         @currently_disabled_lines ||= Set.new
+      end
+
+      private_class_method def self.restrict_on_send
+        @restrict_on_send ||= self::RESTRICT_ON_SEND.to_set.freeze
       end
 
       # Called before any investigation

--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -42,7 +42,7 @@ module RuboCop
         @cops = cops
         @forces = forces
         @options = options
-        @callbacks = {}
+        @callbacks = Hash.new { |h, k| h[k] = cops_callbacks_for(k) }
 
         reset
       end
@@ -83,9 +83,6 @@ module RuboCop
       private
 
       def trigger_responding_cops(callback, node)
-        @callbacks[callback] ||= @cops.select do |cop|
-          cop.respond_to?(callback)
-        end
         @callbacks[callback].each do |cop|
           with_cop_error_handling(cop, node) do
             cop.send(callback, node)
@@ -95,6 +92,12 @@ module RuboCop
 
       def reset
         @errors = []
+      end
+
+      def cops_callbacks_for(callback)
+        @cops.select do |cop|
+          cop.respond_to?(callback)
+        end
       end
 
       def invoke(callback, cops, *args)


### PR DESCRIPTION
Many of the recent optimizations for Cops seem to be to modify `on_send` to check early for the `node.method_name` against a specific list of names.

This PR makes this pattern builtin so it is easy to do (just define `RESTRICT_ON_SEND = %i[foo bar baz]`) *and* makes it even more efficient.

Let's imagine 100 cops defining `on_send` that could have such a restricted method list. On a run over 10k `SendNode`, if these cops are optimized with the first thing in `on_send` being `return if SOME_LIST.include?(node.method_name)`, there would still be 100*10k calls to `on_send`, and 100*10k calls to `Set#include?` (assuming that `SOME_LIST` is a `Set`, as it should). With this PR, if the Cops are optimized with the right constant, then there would be only 10k hash lookups.

cc/ @fatkodima 
