### PR TITLE
Put back CodeLength#irrelevant_line.

### DIFF
--- a/lib/rubocop/cop/mixin/code_length.rb
+++ b/lib/rubocop/cop/mixin/code_length.rb
@@ -43,6 +43,11 @@ module RuboCop
           self.max = length
         end
       end
+
+      # Returns true for lines that shall not be included in the count.
+      def irrelevant_line(source_line)
+        source_line.blank? || !count_comments? && comment_line?(source_line)
+      end
     end
   end
 end


### PR DESCRIPTION
Was removed in #8356, but rubocop-rspec uses it.
See https://github.com/rubocop-hq/rubocop-rspec/issues/974
