### PR TITLE
Revert "Fix build error when using Ruby 2.8.0-dev"

### DIFF
--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -107,7 +107,7 @@ module RuboCop
     def cop_line_ranges(analysis)
       return analysis.line_ranges unless analysis.start_line_number
 
-      analysis.line_ranges + [(analysis.start_line_number.to_f..Float::INFINITY)]
+      analysis.line_ranges + [(analysis.start_line_number..Float::INFINITY)]
     end
 
     def each_mentioned_cop


### PR DESCRIPTION
This reverts commit ee123f42b505f2ae91cd53db0af247bcc3e6cade.

See #8343 