### PR TITLE
Revert "Workaround to skip some tests when using JRuby"

### DIFF
--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -87,20 +87,11 @@ RSpec.describe RuboCop::Cop::Style::ParallelAssignment, :config do
   RUBY
   it_behaves_like('allowed', 'a, b = Float::INFINITY')
   it_behaves_like('allowed', 'a[0], a[1] = a[1], a[0]')
+  it_behaves_like('allowed', 'obj.attr1, obj.attr2 = obj.attr2, obj.attr1')
+  it_behaves_like('allowed', 'obj.attr1, ary[0] = ary[0], obj.attr1')
   it_behaves_like('allowed', 'ary[0], ary[1], ary[2] = ary[1], ary[2], ary[0]')
-
-  # FIXME: Remove `RUBY_ENGINE` condition, which works around
-  # a JRuby 9.2.9.0 regression:
-  # https://github.com/jruby/jruby/issues/5968
-  # Originally, both MRI and JRuby are successful tests.
-  # The tests fail as follows:
-  # https://circleci.com/gh/rubocop-hq/rubocop/74069
-  unless RUBY_ENGINE == 'jruby'
-    it_behaves_like('allowed', 'obj.attr1, obj.attr2 = obj.attr2, obj.attr1')
-    it_behaves_like('allowed', 'obj.attr1, ary[0] = ary[0], obj.attr1')
-    it_behaves_like('allowed', 'self.a, self.b = self.b, self.a')
-    it_behaves_like('allowed', 'self.a, self.b = b, a')
-  end
+  it_behaves_like('allowed', 'self.a, self.b = self.b, self.a')
+  it_behaves_like('allowed', 'self.a, self.b = b, a')
 
   it 'highlights the entire expression' do
     expect_offense(<<~RUBY)


### PR DESCRIPTION
This reverts commit 7743366d6ed9203d16cae443b8b8e22a54cc21ba.

https://github.com/jruby/jruby/issues/5968 has been solved by JRuby 9.2.12.0.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
