### PR TITLE
Fix an infinite loop error for `Style/EmptyMethod`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#8299](https://github.com/rubocop-hq/rubocop/issues/8299): Fix an incorrect auto-correct for `Style/RedundantCondition` when using `raise`, `rescue`, or `and` without argument parentheses in `else`. ([@koic][])
 * [#8335](https://github.com/rubocop-hq/rubocop/issues/8335): Fix incorrect character class detection for nested or POSIX bracket character classes in `Style/RedundantRegexpEscape`. ([@owst][])
 * [#8347](https://github.com/rubocop-hq/rubocop/issues/8347): Fix an incorrect auto-correct for `EnforcedStyle: hash_rockets` of `Style/HashSyntax` with `Layout/HashAlignment`. ([@koic][])
+* [#8375](https://github.com/rubocop-hq/rubocop/pull/8375): Fix an infinite loop error for `Style/EmptyMethod`. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/empty_method.rb
+++ b/lib/rubocop/cop/style/empty_method.rb
@@ -73,13 +73,13 @@ module RuboCop
         end
 
         def corrected(node)
-          if node.arguments?
-            arguments   = node.arguments.source
-            extra_space = ' ' unless parentheses?(node.arguments)
-          end
           scope = node.receiver ? "#{node.receiver.source}." : ''
+          arguments = if node.arguments?
+                        args = node.arguments.map(&:source).join(', ')
 
-          signature = [scope, node.method_name, extra_space, arguments].join
+                        parentheses?(node.arguments) ? "(#{args})" : " #{args}"
+                      end
+          signature = [scope, node.method_name, arguments].join
 
           ["def #{signature}", 'end'].join(joint(node))
         end

--- a/spec/rubocop/cop/style/empty_method_spec.rb
+++ b/spec/rubocop/cop/style/empty_method_spec.rb
@@ -61,6 +61,11 @@ RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
                        'end'].join("\n"),
                       'def foo; end'
 
+      it_behaves_like 'code with offense',
+                      ['def foo(arg',
+                       '); end'].join("\n"),
+                      'def foo(arg); end'
+
       it_behaves_like 'code without offense',
                       'def foo; end'
     end


### PR DESCRIPTION
This PR fixes the following infinite loop error for `Style/EmptyMethod`.

```ruby
% cat example.rb
def foo(arg
    ); end
```

## Before

The following error occurs without auto-correction.

```console
% bundle exec rubocop --only Style/EmptyMethod -a example.rb
(snip)

Offenses:

example.rb:1:1: C: [Corrected] Style/EmptyMethod: Put empty method
definitions on a single line.
def foo(arg ...
^^^^^^^^^^^^

0 files inspected, 1 offense detected, 1 offense corrected
Infinite loop detected in
/Users/koic/src/github.com/koic/rubocop-issues/empty_method/example.rb.
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:288:in `check_for_infinite_loop'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:271:in `block in iterate_until_no_changes'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:270:in `loop'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:270:in `iterate_until_no_changes'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:241:in `do_inspection_loop'
(snip)

% cat example.rb
def foo(arg
    ); end
```

## After

Auto-corrects without any error.

```console
% bundle exec rubocop --only Style/EmptyMethod -a example.rb
(snip)

Offenses:

example.rb:1:1: C: [Corrected] Style/EmptyMethod: Put empty method
definitions on a single line.
def foo(arg ...
^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected

% cat example.rb
def foo(arg); end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
