### PR TITLE
Remove redundant `require 'set'`

### DIFF
--- a/lib/rubocop/cop/layout/empty_lines.rb
+++ b/lib/rubocop/cop/layout/empty_lines.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'set'
-
 module RuboCop
   module Cop
     module Layout

--- a/lib/rubocop/cop/layout/extra_spacing.rb
+++ b/lib/rubocop/cop/layout/extra_spacing.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'set'
-
 module RuboCop
   module Cop
     module Layout

--- a/lib/rubocop/cop/layout/indentation_style.rb
+++ b/lib/rubocop/cop/layout/indentation_style.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'set'
-
 module RuboCop
   module Cop
     module Layout

--- a/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'set'
-
 module RuboCop
   module Cop
     module Metrics

--- a/lib/rubocop/cop/style/bisected_attr_accessor.rb
+++ b/lib/rubocop/cop/style/bisected_attr_accessor.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'set'
-
 module RuboCop
   module Cop
     module Style

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'set'
-
 module RuboCop
   # This class finds target files to inspect by scanning the directory tree
   # and picking ruby files.


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/commit/8798bc8.

~~RuboCop AST 0.1.0 requires `Set`.~~
~~https://github.com/rubocop-hq/rubocop-ast/commit/8e595c3.~~

~~RuboCop requires RuboCop AST 0.1.0 or higher. Therefore this PR removes redundant `require 'set'`.~~

This PR makes RuboCop to explicitly require `set` only once at lib/rubocop.rb
https://github.com/rubocop-hq/rubocop/blob/v0.88.0/lib/rubocop.rb#L6

It focuses on the obviously redundant code in the rubocop repository.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
