### PR TITLE
Fix spelling mistake

### DIFF
--- a/lib/rubocop/cop/style/string_concatenation.rb
+++ b/lib/rubocop/cop/style/string_concatenation.rb
@@ -18,7 +18,7 @@ module RuboCop
         include Util
         extend AutoCorrector
 
-        MSG = 'Prefer string interpolation instead of string concatenation.'
+        MSG = 'Prefer string interpolation to string concatenation.'
 
         def_node_matcher :string_concatenation?, <<~PATTERN
           {

--- a/spec/rubocop/cop/style/string_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/string_concatenation_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::Style::StringConcatenation do
   it 'registers an offense and corrects for string concatenation' do
     expect_offense(<<~RUBY)
       email_with_name = user.name + ' <' + user.email + '>'
-                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation instead of string concatenation.
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -17,7 +17,7 @@ RSpec.describe RuboCop::Cop::Style::StringConcatenation do
   it 'registers an offense and corrects for string concatenation as part of other expression' do
     expect_offense(<<~RUBY)
       users = (user.name + ' ' + user.email) * 5
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation instead of string concatenation.
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::Style::StringConcatenation do
   it 'correctly handles strings with special characters' do
     expect_offense(<<-RUBY)
       email_with_name = "\\n" + user.name + ' ' + user.email + '\\n'
-                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation instead of string concatenation.
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
     RUBY
 
     expect_correction(<<-RUBY)


### PR DESCRIPTION
Not a native speaker, but from my point of view it should either be:
 - "Prefer string interpolation to string concatenation", or
 - "Prefer using string interpolation instead of string concatenation"

Rationale:
concatenation is a noun
example from dictionary.com: "those who prefer the bittersweet **to** the saccharine"

* [ ] Update the style guide accordingly

```diff
- Prefer string interpolation and string formatting instead of string concatenation:
+ Prefer using string interpolation and string formatting instead of string concatenation:
+ Prefer string interpolation and string formatting to string concatenation:
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/