### PR TITLE
[fixes #8385] Fix Lint/EnsureReturn autocorrect and false negatives

### DIFF
--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -1035,9 +1035,11 @@ end
 |===
 
 This cop checks for `return` from an `ensure` block.
-Explicit return from an ensure block alters the control flow
-as the return will take precedence over any exception being raised,
+`return` from an ensure block is a dangerous code smell as it
+will take precedence over any exception being raised,
 and the exception will be silently thrown away as if it were rescued.
+
+If you want to rescue some (or all) exceptions, best to do it explicitly
 
 === Examples
 
@@ -1045,11 +1047,11 @@ and the exception will be silently thrown away as if it were rescued.
 ----
 # bad
 
-begin
+def foo
   do_something
 ensure
-  do_something_else
-  return
+  cleanup
+  return self
 end
 ----
 
@@ -1057,10 +1059,24 @@ end
 ----
 # good
 
-begin
+def foo
   do_something
+  self
 ensure
-  do_something_else
+  cleanup
+end
+
+# also good
+
+def foo
+  begin
+    do_something
+  rescue SomeException
+    # Let's ignore this exception
+  end
+  self
+ensure
+  cleanup
 end
 ----
 

--- a/spec/rubocop/cop/lint/ensure_return_spec.rb
+++ b/spec/rubocop/cop/lint/ensure_return_spec.rb
@@ -14,13 +14,7 @@ RSpec.describe RuboCop::Cop::Lint::EnsureReturn do
       end
     RUBY
 
-    expect_correction(<<~RUBY)
-      begin
-        something
-      ensure
-        file.close
-      end
-    RUBY
+    expect_no_corrections
   end
 
   it 'registers an offense and corrects for return with argument in ensure' do
@@ -28,20 +22,26 @@ RSpec.describe RuboCop::Cop::Lint::EnsureReturn do
       begin
         foo
       ensure
-        bar
         return baz
-        ^^^^^^ Do not return from an `ensure` block.
+        ^^^^^^^^^^ Do not return from an `ensure` block.
       end
     RUBY
 
-    expect_correction(<<~RUBY)
+    expect_no_corrections
+  end
+
+  it 'registers an offense when returning multiple values in `ensure`' do
+    expect_offense(<<~RUBY)
       begin
-        foo
+        something
       ensure
-        bar
-        baz
+        do_something
+        return foo, bar
+        ^^^^^^^^^^^^^^^ Do not return from an `ensure` block.
       end
     RUBY
+
+    expect_no_corrections
   end
 
   it 'does not register an offense for return outside ensure' do
@@ -51,16 +51,6 @@ RSpec.describe RuboCop::Cop::Lint::EnsureReturn do
         return
       ensure
         file.close
-      end
-    RUBY
-  end
-
-  it "doesn't register an offense when returning multiple values in `ensure`" do
-    expect_no_offenses(<<~RUBY)
-      begin
-        something
-      ensure
-        return foo, bar
       end
     RUBY
   end


### PR DESCRIPTION
`Lint/EnsureReturn` autocorrection had many issues.

It was attempting to autocorrect `return` statements but was producing completely different expressions, potentiall losing comments too.

There is no way to auto-correct a `return` statement in an ensure because without one, the result of the block is not the last expression of the ensure block:

```
def foo
  bar
ensure
  return 42
end
```
This always return `42` and not the result of `bar`, and there is no other ensure block that can do this.