### PR TITLE
Remove a useless section from spec output

### DIFF
--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -134,7 +134,7 @@ module RuboCop
         actual_annotations =
           expected_annotations.with_offense_annotations(offenses)
 
-        expect(actual_annotations).to eq(expected_annotations)
+        expect(actual_annotations).to eq(expected_annotations), ''
         expect(offenses.map(&:severity).uniq).to eq([severity]) if severity
       end
 


### PR DESCRIPTION
Before
```
  1) RuboCop::Cop::Style::RedundantPercentQ with %q strings registers an offense for only single quotes
     Failure/Error: expect(actual_annotations).to eq(expected_annotations)#, ''

       expected: %q('hi')
       ^^^^^^^^ Use `%q` only for strings that contain oth single quotes and double quotes.

            got: %q('hi')
       ^^^^^^^^ Use `%q` only for strings that contain both single quotes and double quotes.

       (compared using ==)

       Diff:
       @@ -1,3 +1,3 @@
        %q('hi')
       -^^^^^^^^ Use `%q` only for strings that contain oth single quotes and double quotes.
       +^^^^^^^^ Use `%q` only for strings that contain both single quotes and double quotes.

     # ./lib/rubocop/rspec/expect_offense.rb:137:in `expect_offense'
     # ./spec/rubocop/cop/style/redundant_percent_q_spec.rb:8:in `block (3 levels) in <top (required)>'
```
After
```
  1) RuboCop::Cop::Style::RedundantPercentQ with %q strings registers an offense for only single quotes
     Failure/Error: expect(actual_annotations).to eq(expected_annotations), ''

       Diff:
       @@ -1,3 +1,3 @@
        %q('hi')
       -^^^^^^^^ Use `%q` only for strings that contain oth single quotes and double quotes.
       +^^^^^^^^ Use `%q` only for strings that contain both single quotes and double quotes.

     # ./lib/rubocop/rspec/expect_offense.rb:137:in `expect_offense'
     # ./spec/rubocop/cop/style/redundant_percent_q_spec.rb:8:in `block (3 levels) in <top (required)>'
```

![image](https://user-images.githubusercontent.com/6916/88430627-6e5b7c80-ce01-11ea-8f81-8558240d7cb4.png)


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/