### PR TITLE
Refactor comment access

### DIFF
--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -130,7 +130,7 @@ module RuboCop
     def each_directive
       return if processed_source.comments.nil?
 
-      processed_source.each_comment do |comment|
+      processed_source.comments.each do |comment|
         directive = directive_parts(comment)
         next unless directive
 

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -128,8 +128,6 @@ module RuboCop
     end
 
     def each_directive
-      return if processed_source.comments.nil?
-
       processed_source.comments.each do |comment|
         directive = directive_parts(comment)
         next unless directive

--- a/lib/rubocop/cop/correctors/line_break_corrector.rb
+++ b/lib/rubocop/cop/correctors/line_break_corrector.rb
@@ -16,7 +16,7 @@ module RuboCop
                                   processed_source:)
           @processed_source = processed_source
           range = first_part_of(node.to_a.last)
-          eol_comment = end_of_line_comment(node.source_range.line)
+          eol_comment = processed_source.comment_at_line(node.source_range.line)
 
           break_line_before(range: range, node: node, corrector: corrector,
                             configured_width: configured_width)

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -269,15 +269,11 @@ module RuboCop
         end
 
         def begin_pos_with_comment(node)
-          annotation_line = node.first_line - 1
           first_comment = nil
+          (node.first_line - 1).downto(1) do |annotation_line|
+            break unless (comment = processed_source.comment_at_line(annotation_line))
 
-          processed_source.comments_before_line(annotation_line)
-                          .reverse_each do |comment|
-            if comment.location.line == annotation_line
-              first_comment = comment
-              annotation_line -= 1
-            end
+            first_comment = comment
           end
 
           start_line_position(first_comment || node)

--- a/lib/rubocop/cop/layout/comment_indentation.rb
+++ b/lib/rubocop/cop/layout/comment_indentation.rb
@@ -39,7 +39,7 @@ module RuboCop
           'instead of %<correct_comment_indentation>d).'
 
         def investigate(processed_source)
-          processed_source.each_comment { |comment| check(comment) }
+          processed_source.comments.each { |comment| check(comment) }
         end
 
         def autocorrect(comment)

--- a/lib/rubocop/cop/layout/leading_comment_space.rb
+++ b/lib/rubocop/cop/layout/leading_comment_space.rb
@@ -55,7 +55,7 @@ module RuboCop
         MSG = 'Missing space after `#`.'
 
         def investigate(processed_source)
-          processed_source.each_comment do |comment|
+          processed_source.comments.each do |comment|
             next unless /\A#+[^#\s=:+-]/.match?(comment.text)
             next if comment.loc.line == 1 && allowed_on_first_line?(comment)
             next if doxygen_comment_style?(comment)

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -41,13 +41,12 @@ module RuboCop
         def on_new_investigation
           return unless offenses_to_check
 
-          comments = processed_source.comments
           cop_disabled_line_ranges = processed_source.disabled_line_ranges
 
           redundant_cops = Hash.new { |h, k| h[k] = Set.new }
 
           each_redundant_disable(cop_disabled_line_ranges,
-                                 offenses_to_check, comments) do |comment, redundant_cop|
+                                 offenses_to_check) do |comment, redundant_cop|
             redundant_cops[comment].add(redundant_cop)
           end
 
@@ -88,25 +87,25 @@ module RuboCop
                                        newlines: false)
         end
 
-        def each_redundant_disable(cop_disabled_line_ranges, offenses, comments,
+        def each_redundant_disable(cop_disabled_line_ranges, offenses,
                                    &block)
           disabled_ranges = cop_disabled_line_ranges[COP_NAME] || [0..0]
 
           cop_disabled_line_ranges.each do |cop, line_ranges|
             each_already_disabled(line_ranges,
-                                  disabled_ranges, comments) do |comment|
+                                  disabled_ranges) do |comment|
               yield comment, cop
             end
 
-            each_line_range(line_ranges, disabled_ranges, offenses, comments,
+            each_line_range(line_ranges, disabled_ranges, offenses,
                             cop, &block)
           end
         end
 
-        def each_line_range(line_ranges, disabled_ranges, offenses, comments,
+        def each_line_range(line_ranges, disabled_ranges, offenses,
                             cop)
           line_ranges.each_with_index do |line_range, ix|
-            comment = comments.find { |c| c.loc.line == line_range.begin }
+            comment = processed_source.comment_at_line(line_range.begin)
             next if ignore_offense?(disabled_ranges, line_range)
 
             redundant_cop = find_redundant(comment, offenses, cop, line_range,
@@ -115,7 +114,7 @@ module RuboCop
           end
         end
 
-        def each_already_disabled(line_ranges, disabled_ranges, comments)
+        def each_already_disabled(line_ranges, disabled_ranges)
           line_ranges.each_cons(2) do |previous_range, range|
             next if ignore_offense?(disabled_ranges, range)
             next if previous_range.end != range.begin
@@ -124,14 +123,12 @@ module RuboCop
             # the end of the previous range, it means that the cop was
             # already disabled by an earlier comment. So it's redundant
             # whether there are offenses or not.
-            redundant_comment = comments.find do |c|
-              c.loc.line == range.begin &&
-                # Comments disabling all cops don't count since it's reasonable
-                # to disable a few select cops first and then all cops further
-                # down in the code.
-                !all_disabled?(c)
-            end
-            yield redundant_comment if redundant_comment
+            comment = processed_source.comment_at_line(range.begin)
+
+            # Comments disabling all cops don't count since it's reasonable
+            # to disable a few select cops first and then all cops further
+            # down in the code.
+            yield comment if comment && !all_disabled?(comment)
           end
         end
 

--- a/lib/rubocop/cop/migration/department_name.rb
+++ b/lib/rubocop/cop/migration/department_name.rb
@@ -20,7 +20,7 @@ module RuboCop
         DISABLING_COPS_CONTENT_TOKEN = %r{[A-z]+/[A-z]+|all}.freeze
 
         def on_new_investigation
-          processed_source.each_comment do |comment|
+          processed_source.comments.each do |comment|
             next if comment.text !~ DISABLE_COMMENT_FORMAT
 
             offset = Regexp.last_match(1).length

--- a/lib/rubocop/cop/mixin/alignment.rb
+++ b/lib/rubocop/cop/mixin/alignment.rb
@@ -64,8 +64,9 @@ module RuboCop
         inner.begin_pos >= outer.begin_pos && inner.end_pos <= outer.end_pos
       end
 
+      # @deprecated Use processed_source.comment_at_line(line)
       def end_of_line_comment(line)
-        processed_source.find_comment { |c| c.loc.line == line }
+        processed_source.line_with_comment?(line)
       end
     end
   end

--- a/lib/rubocop/cop/mixin/check_line_breakable.rb
+++ b/lib/rubocop/cop/mixin/check_line_breakable.rb
@@ -59,7 +59,7 @@ module RuboCop
         return if safe_to_ignore?(node)
 
         line = processed_source.lines[node.first_line - 1]
-        return if processed_source.commented?(node.loc.begin)
+        return if processed_source.line_with_comment?(node.loc.line)
         return if line.length <= max
 
         extract_first_element_over_column_limit(node, elements, max)

--- a/lib/rubocop/cop/mixin/line_length_help.rb
+++ b/lib/rubocop/cop/mixin/line_length_help.rb
@@ -12,9 +12,7 @@ module RuboCop
 
       def directive_on_source_line?(line_index)
         source_line_number = line_index + processed_source.buffer.first_line
-        comment =
-          processed_source.comments
-                          .detect { |e| e.location.line == source_line_number }
+        comment = processed_source.comment_at_line(source_line_number)
 
         return false unless comment
 

--- a/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
+++ b/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
@@ -27,8 +27,7 @@ module RuboCop
         last_element_line =
           last_element_range_with_trailing_comma(node).last_line
 
-        last_element_commented =
-          processed_source.comments.any? { |c| c.loc.line == last_element_line }
+        last_element_commented = processed_source.comment_at_line(last_element_line)
 
         last_element_commented && (node.chained? || node.argument?)
       end

--- a/lib/rubocop/cop/mixin/percent_array.rb
+++ b/lib/rubocop/cop/mixin/percent_array.rb
@@ -28,12 +28,8 @@ module RuboCop
       end
 
       def comments_in_array?(node)
-        comments = processed_source.comments
-        array_range = node.source_range.to_a
-
-        comments.any? do |comment|
-          !(comment.loc.expression.to_a & array_range).empty?
-        end
+        line_span = node.source_range.first_line...node.source_range.last_line
+        processed_source.each_comment_in_lines(line_span).any?
       end
 
       def check_percent_array(node)

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -19,14 +19,14 @@ module RuboCop
       def non_eligible_node?(node)
         node.modifier_form? ||
           node.nonempty_line_count > 3 ||
-          processed_source.commented?(node.loc.end)
+          processed_source.line_with_comment?(node.loc.last_line)
       end
 
       def non_eligible_body?(body)
         body.nil? ||
           body.empty_source? ||
           body.begin_type? ||
-          processed_source.commented?(body.source_range)
+          processed_source.contains_comment?(body.source_range)
       end
 
       def non_eligible_condition?(condition)

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -74,10 +74,8 @@ module RuboCop
       end
 
       def inside_comment?(range, comma_offset)
-        processed_source.comments.any? do |comment|
-          comment_offset = comment.loc.expression.begin_pos - range.begin_pos
-          comment_offset >= 0 && comment_offset < comma_offset
-        end
+        comment = processed_source.comment_at_line(range.line)
+        comment && comment.loc.expression.begin_pos < range.begin_pos + comma_offset
       end
 
       # Returns true if the node has round/square/curly brackets.

--- a/lib/rubocop/cop/style/ascii_comments.rb
+++ b/lib/rubocop/cop/style/ascii_comments.rb
@@ -21,7 +21,7 @@ module RuboCop
         MSG = 'Use only ascii symbols in comments.'
 
         def on_new_investigation
-          processed_source.each_comment do |comment|
+          processed_source.comments.each do |comment|
             next if comment.text.ascii_only?
             next if only_allowed_non_ascii_chars?(comment.text)
 

--- a/lib/rubocop/cop/style/block_comments.rb
+++ b/lib/rubocop/cop/style/block_comments.rb
@@ -25,7 +25,7 @@ module RuboCop
         END_LENGTH = "\n=end".length
 
         def on_new_investigation
-          processed_source.each_comment do |comment|
+          processed_source.comments.each do |comment|
             next unless comment.document?
 
             add_offense(comment) do |corrector|

--- a/lib/rubocop/cop/style/commented_keyword.rb
+++ b/lib/rubocop/cop/style/commented_keyword.rb
@@ -38,7 +38,7 @@ module RuboCop
               '`%<keyword>s` keyword.'
 
         def investigate(processed_source)
-          processed_source.each_comment do |comment|
+          processed_source.comments.each do |comment|
             add_offense(comment) if offensive?(comment)
           end
         end

--- a/lib/rubocop/cop/style/empty_case_condition.rb
+++ b/lib/rubocop/cop/style/empty_case_condition.rb
@@ -73,7 +73,7 @@ module RuboCop
 
           corrector.replace(case_range, 'if')
 
-          keep_first_when_comment(case_node, when_nodes.first, corrector)
+          keep_first_when_comment(case_range, corrector)
 
           when_nodes[1..-1].each do |when_node|
             corrector.replace(when_node.loc.keyword, 'elsif')
@@ -93,15 +93,14 @@ module RuboCop
           end
         end
 
-        def keep_first_when_comment(case_node, first_when_node, corrector)
-          comment = processed_source.comments_before_line(
-            first_when_node.loc.keyword.line
-          ).map(&:text).join("\n")
+        def keep_first_when_comment(case_range, corrector)
+          indent = ' ' * case_range.column
+          comments = processed_source.each_comment_in_lines(
+            case_range.first_line...case_range.last_line
+          ).map { |comment| "#{indent}#{comment.text}\n" }.join
 
-          line = range_by_whole_lines(case_node.source_range)
-
-          corrector.insert_before(line, "#{comment}\n") if !comment.empty? &&
-                                                           !case_node.parent
+          line_beginning = case_range.adjust(begin_pos: -case_range.column)
+          corrector.insert_before(line_beginning, comments)
         end
       end
     end

--- a/lib/rubocop/cop/style/empty_else.rb
+++ b/lib/rubocop/cop/style/empty_else.rb
@@ -138,21 +138,16 @@ module RuboCop
 
         def autocorrect(corrector, node)
           return false if autocorrect_forbidden?(node.type.to_s)
-          return false if comment_in_else?(node)
+          return false if comment_in_else?(node.loc)
 
           end_pos = base_node(node).loc.end.begin_pos
           corrector.remove(range_between(node.loc.else.begin_pos, end_pos))
         end
 
-        def comment_in_else?(node)
-          range = else_line_range(node.loc)
-          processed_source.find_comment { |c| range.include?(c.loc.line) }
-        end
+        def comment_in_else?(loc)
+          return false if loc.else.nil? || loc.end.nil?
 
-        def else_line_range(loc)
-          return 0..0 if loc.else.nil? || loc.end.nil?
-
-          loc.else.first_line..loc.end.first_line
+          processed_source.contains_comment?(loc.else.join(loc.end))
         end
 
         def base_node(node)

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -159,10 +159,7 @@ module RuboCop
         end
 
         def first_line_comment(node)
-          comment =
-            processed_source.find_comment { |c| c.loc.line == node.loc.line }
-
-          comment ? comment.loc.expression.source : nil
+          processed_source.comment_at_line(node.loc.line)&.text
         end
       end
     end

--- a/lib/rubocop/cop/style/inline_comment.rb
+++ b/lib/rubocop/cop/style/inline_comment.rb
@@ -21,7 +21,7 @@ module RuboCop
         MSG = 'Avoid trailing inline comments.'
 
         def on_new_investigation
-          processed_source.each_comment do |comment|
+          processed_source.comments.each do |comment|
             next if comment_line?(processed_source[comment.loc.line - 1]) ||
                     comment.text.match?(/\A# rubocop:(enable|disable)/)
 

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -136,10 +136,10 @@ module RuboCop
         end
 
         def comments(node)
-          processed_source.comments.select do |comment|
-            comment.loc.first_line > node.loc.first_line &&
-              comment.loc.last_line < node.loc.last_line
-          end
+          processed_source.each_comment_in_lines(
+            node.loc.first_line...
+            node.loc.last_line
+          ).to_a
         end
 
         def allowed_if_condition?(node)

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -73,7 +73,7 @@ module RuboCop
 
         def move_comment(node, corrector)
           LineBreakCorrector.move_comment(
-            eol_comment: end_of_line_comment(node.source_range.line),
+            eol_comment: processed_source.comment_at_line(node.source_range.line),
             node: node, corrector: corrector
           )
         end

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -14,10 +14,12 @@ module RuboCop
 
       module_function
 
+      # This is a bad API
       def comment_line?(line_source)
         /^\s*#/.match?(line_source)
       end
 
+      # @deprecated Use `ProcessedSource#line_with_comment?`, `contains_comment` or similar
       def comment_lines?(node)
         processed_source[line_range(node)].any? { |line| comment_line?(line) }
       end

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.7')
   s.add_runtime_dependency('rexml')
-  s.add_runtime_dependency('rubocop-ast', '>= 0.1.0', '< 1.0')
+  s.add_runtime_dependency('rubocop-ast', '>= 0.3.0', '< 1.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 2.0')
 

--- a/spec/rubocop/cop/style/empty_case_condition_spec.rb
+++ b/spec/rubocop/cop/style/empty_case_condition_spec.rb
@@ -49,33 +49,40 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition do
     context 'with multiple when branches and an `else` with code comments' do
       let(:source) do
         <<~RUBY
-          case
-          ^^^^ Do not use empty `case` condition, instead use an `if` expression.
-          # condition a
-          # This is a multi-line comment
-          when 1 == 2
-            foo
-          # condition b
-          when 1 == 1
-            bar
-          # condition c
-          else
-            baz
+          def example
+            # Comment before everything
+            case # first comment
+            ^^^^ Do not use empty `case` condition, instead use an `if` expression.
+            # condition a
+            # This is a multi-line comment
+            when 1 == 2
+              foo
+            # condition b
+            when 1 == 1
+              bar
+            # condition c
+            else
+              baz
+            end
           end
         RUBY
       end
       let(:corrected_source) do
         <<~RUBY
-          # condition a
-          # This is a multi-line comment
-          if 1 == 2
-            foo
-          # condition b
-          elsif 1 == 1
-            bar
-          # condition c
-          else
-            baz
+          def example
+            # Comment before everything
+            # first comment
+            # condition a
+            # This is a multi-line comment
+            if 1 == 2
+              foo
+            # condition b
+            elsif 1 == 1
+              bar
+            # condition c
+            else
+              baz
+            end
           end
         RUBY
       end

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -674,18 +674,19 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
 
       it 'does not lose comments within if expression' do
         expect_offense(<<~RUBY, variable: variable)
-          if %{variable}
-          ^^^^{variable} Use safe navigation (`&.`) instead [...]
+          if %{variable} # hello
+          ^^^^{variable}^^^^^^^^ Use safe navigation (`&.`) instead [...]
             # this is a comment
             # another comment
             %{variable}.bar
-          end
+          end # bye!
         RUBY
 
         expect_correction(<<~RUBY)
+          # hello
           # this is a comment
           # another comment
-          #{variable}&.bar
+          #{variable}&.bar # bye!
         RUBY
       end
 


### PR DESCRIPTION
This PR fixes all occurrences of `ProcessedSource#find_comment`, `each_comment`, `comments_before_line`, `commented?` and improves processing in general.

Fixes two cops with bad comment treatment: `Style/EmptyCaseCondition`, `SaveNavigation`. I didn't check other cops, is just that the processing for these was clearly erroneous.

`util.rb`'s `comment_line?` remains though, even though it is a bad API (it should probably be something like `ProcessedSource#line_is_comment?(line_nb)` instead).

This PR relies on [an unreleased version of `rubocop-ast`](https://github.com/rubocop-hq/rubocop-ast/pull/83)