### PR TITLE
[Fix #8406] Improve `Style/AccessorGrouping`'s auto-correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#8375](https://github.com/rubocop-hq/rubocop/pull/8375): Fix an infinite loop error for `Style/EmptyMethod`. ([@koic][])
 * [#8385](https://github.com/rubocop-hq/rubocop/pull/8385): Remove auto-correction for `Lint/EnsureReturn`. ([@marcandre][])
 * [#8391](https://github.com/rubocop-hq/rubocop/issues/8391): Mark `Style/ArrayCoercion` as not safe. ([@marcandre][])
+* [#8406](https://github.com/rubocop-hq/rubocop/issues/8406): Improve `Style/AccessorGrouping`'s auto-correction to remove redundant blank lines. ([@koic][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/accessor_grouping_spec.rb
+++ b/spec/rubocop/cop/style/accessor_grouping_spec.rb
@@ -25,9 +25,7 @@ RSpec.describe RuboCop::Cop::Style::AccessorGrouping, :config do
       expect_correction(<<~RUBY)
         class Foo
           attr_reader :bar1, :bar2, :bar3, :bar4
-          
           attr_accessor :quux
-          
           other_macro :zoo
         end
       RUBY
@@ -61,7 +59,6 @@ RSpec.describe RuboCop::Cop::Style::AccessorGrouping, :config do
       expect_correction(<<~RUBY)
         class Foo
           attr_reader :bar1, :bar2, :bar3
-          
 
           protected
           attr_accessor :quux
@@ -69,10 +66,8 @@ RSpec.describe RuboCop::Cop::Style::AccessorGrouping, :config do
           private
           attr_reader :baz1, :baz2, :baz4
           attr_writer :baz3
-          
 
           public
-          
           other_macro :zoo
         end
       RUBY
@@ -105,12 +100,10 @@ RSpec.describe RuboCop::Cop::Style::AccessorGrouping, :config do
 
           class << self
             attr_reader :baz1, :baz2, :baz3
-            
 
             private
 
             attr_reader :quux1, :quux2
-            
           end
         end
       RUBY
@@ -160,7 +153,6 @@ RSpec.describe RuboCop::Cop::Style::AccessorGrouping, :config do
           attr_reader :three
 
           attr_reader :four, :five
-          
         end
       RUBY
     end


### PR DESCRIPTION
## Summary

Fixes #8406.

This PR improves `Style/AccessorGrouping`'s auto-correction to remove redundant blank lines.

## Other Information

This PR doesn't update to `Cop::Base` to make it clear the difference between the changes. Will be updated with other `Style` cops in different PR.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
