### PR TITLE
[Fix #8330] Fix a false positive for `Style/MissingRespondToMissing`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#8385](https://github.com/rubocop-hq/rubocop/pull/8385): Remove auto-correction for `Lint/EnsureReturn`. ([@marcandre][])
 * [#8391](https://github.com/rubocop-hq/rubocop/issues/8391): Mark `Style/ArrayCoercion` as not safe. ([@marcandre][])
 * [#8406](https://github.com/rubocop-hq/rubocop/issues/8406): Improve `Style/AccessorGrouping`'s auto-correction to remove redundant blank lines. ([@koic][])
+* [#8330](https://github.com/rubocop-hq/rubocop/issues/8330): Fix a false positive for `Style/MissingRespondToMissing` when defined method with inline access modifier. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/missing_respond_to_missing.rb
+++ b/lib/rubocop/cop/style/missing_respond_to_missing.rb
@@ -36,9 +36,16 @@ module RuboCop
         private
 
         def implements_respond_to_missing?(node)
-          node.parent.each_child_node(node.type).any? do |sibling|
-            sibling.method?(:respond_to_missing?)
+          return false unless (grand_parent = node.parent.parent)
+
+          grand_parent.each_descendant(node.type) do |descendant|
+            return true if descendant.method?(:respond_to_missing?)
+
+            child = descendant.children.first
+            return true if child.respond_to?(:method?) && child.method?(:respond_to_missing?)
           end
+
+          false
         end
       end
     end

--- a/spec/rubocop/cop/style/missing_respond_to_missing_spec.rb
+++ b/spec/rubocop/cop/style/missing_respond_to_missing_spec.rb
@@ -52,6 +52,31 @@ RSpec.describe RuboCop::Cop::Style::MissingRespondToMissing do
     RUBY
   end
 
+  it 'allows method_missing and respond_to_missing? when defined with inline access modifier' do
+    expect_no_offenses(<<~RUBY)
+      class Test
+        private def respond_to_missing?
+        end
+
+        private def method_missing
+        end
+      end
+    RUBY
+  end
+
+  it 'allows method_missing and respond_to_missing? when defined with inline access modifier and ' \
+     'method_missing is not qualified by inline access modifier' do
+    expect_no_offenses(<<~RUBY)
+      class Test
+        private def respond_to_missing?
+        end
+
+        def method_missing
+        end
+      end
+    RUBY
+  end
+
   it 'registers an offense respond_to_missing? is implemented as ' \
     'an instance method and method_missing is implemented as a class method' do
     expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #8330.

This PR fixes a false positive for `Style/MissingRespondToMissing` when defined method with inline access modifier.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
