### PR TITLE
[Fix #8424] Fix an error for `Lint/IneffectiveAccessModifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [#8330](https://github.com/rubocop-hq/rubocop/issues/8330): Fix a false positive for `Style/MissingRespondToMissing` when defined method with inline access modifier. ([@koic][])
 * [#8422](https://github.com/rubocop-hq/rubocop/issues/8422): Fix an error for `Lint/SelfAssignment` when using or-assignment for constant. ([@koic][])
 * [#8423](https://github.com/rubocop-hq/rubocop/issues/8423): Fix an error for `Style/SingleArgumentDig` when without a receiver. ([@koic][])
+* [#8424](https://github.com/rubocop-hq/rubocop/issues/8424): Fix an error for `Lint/IneffectiveAccessModifier` when there is `begin...end` before a method definition. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/ineffective_access_modifier.rb
+++ b/lib/rubocop/cop/lint/ineffective_access_modifier.rb
@@ -96,9 +96,7 @@ module RuboCop
         end
 
         # rubocop:disable Metrics/CyclomaticComplexity
-        def ineffective_modifier(node, modifier = nil, &block)
-          ignored_methods = nil
-
+        def ineffective_modifier(node, ignored_methods = nil, modifier = nil, &block)
           node.each_child_node do |child|
             case child.type
             when :send

--- a/spec/rubocop/cop/lint/ineffective_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/ineffective_access_modifier_spec.rb
@@ -118,4 +118,18 @@ RSpec.describe RuboCop::Cop::Lint::IneffectiveAccessModifier do
       RUBY
     end
   end
+
+  context 'when there is `begin` before a method definition' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class C
+          begin
+          end
+
+          def do_something
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #8424.

This PR fixes an error for `Lint/IneffectiveAccessModifier` when there is `begin...end` before a method definition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
