### PR TITLE
[Fix #8422] Fix an error for `Lint/SelfAssignment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#8391](https://github.com/rubocop-hq/rubocop/issues/8391): Mark `Style/ArrayCoercion` as not safe. ([@marcandre][])
 * [#8406](https://github.com/rubocop-hq/rubocop/issues/8406): Improve `Style/AccessorGrouping`'s auto-correction to remove redundant blank lines. ([@koic][])
 * [#8330](https://github.com/rubocop-hq/rubocop/issues/8330): Fix a false positive for `Style/MissingRespondToMissing` when defined method with inline access modifier. ([@koic][])
+* [#8422](https://github.com/rubocop-hq/rubocop/issues/8422): Fix an error for `Lint/SelfAssignment` when using or-assignment for constant. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/self_assignment.rb
+++ b/lib/rubocop/cop/lint/self_assignment.rb
@@ -40,7 +40,7 @@ module RuboCop
 
         def on_casgn(node)
           lhs_scope, lhs_name, rhs = *node
-          return unless rhs.const_type?
+          return unless rhs&.const_type?
 
           rhs_scope, rhs_name = *rhs
           add_offense(node) if lhs_scope == rhs_scope && lhs_name == rhs_name

--- a/spec/rubocop/cop/lint/self_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/self_assignment_spec.rb
@@ -68,6 +68,12 @@ RSpec.describe RuboCop::Cop::Lint::SelfAssignment do
     RUBY
   end
 
+  it 'does not register an offense when using constant var or-assignment for constant from another scope' do
+    expect_no_offenses(<<~RUBY)
+      Foo ||= ::Foo
+    RUBY
+  end
+
   it 'registers an offense when using multiple var self-assignment' do
     expect_offense(<<~RUBY)
       foo, bar = foo, bar


### PR DESCRIPTION
Fixes #8422.

Fix an error for `Lint/SelfAssignment` when using or-assignment for constant.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
