### PR TITLE
[Fix #8283] Fix length calculation for `Style/IfUnlessModifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
 * [#8422](https://github.com/rubocop-hq/rubocop/issues/8422): Fix an error for `Lint/SelfAssignment` when using or-assignment for constant. ([@koic][])
 * [#8423](https://github.com/rubocop-hq/rubocop/issues/8423): Fix an error for `Style/SingleArgumentDig` when without a receiver. ([@koic][])
 * [#8424](https://github.com/rubocop-hq/rubocop/issues/8424): Fix an error for `Lint/IneffectiveAccessModifier` when there is `begin...end` before a method definition. ([@koic][])
+* [#8006](https://github.com/rubocop-hq/rubocop/issues/8006): Fix line length calculation for `Style/IfUnlessModifier` to correctly take into account code before the if condition when considering conversation to a single-line form. ([@dsavochkin][])
+* [#8283](https://github.com/rubocop-hq/rubocop/issues/8283): Fix line length calculation for `Style/IfUnlessModifier` to correctly take into account a comment on the first line when considering conversation to a single-line form. ([@dsavochkin][])
+* [#8226](https://github.com/rubocop-hq/rubocop/issues/8226): Fix `Style/IfUnlessModifier` to add parentheses when converting if-end condition inside an array or a hash to a single-line form. ([@dsavochkin][])
 
 ### Changes
 
@@ -4736,3 +4739,4 @@
 [@knejad]: https://github.com/knejad
 [@iamravitejag]: https://github.com/iamravitejag
 [@volfgox]: https://github.com/volfgox
+[@dsavochkin]: https://github.com/dmytro-savochkin

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -36,14 +36,41 @@ module RuboCop
       def modifier_fits_on_single_line?(node)
         return true unless max_line_length
 
-        length_in_modifier_form(node, node.condition) <= max_line_length
+        length_in_modifier_form(node) <= max_line_length
       end
 
-      def length_in_modifier_form(node, cond)
+      def length_in_modifier_form(node)
         keyword = node.loc.keyword
-        indentation = keyword.source_line[/^\s*/]
-        line_length("#{indentation}#{node.body.source} #{keyword.source} " \
-                    "#{cond.source}")
+        prefix = keyword.source_line[0...keyword.column]
+        expression = to_modifier_form(node)
+        line_length("#{prefix}#{expression}")
+      end
+
+      def to_modifier_form(node)
+        expression = [node.body.source,
+                      node.keyword,
+                      node.condition.source].compact.join(' ')
+        parenthesized = parenthesize?(node) ? "(#{expression})" : expression
+        [parenthesized, first_line_comment(node)].compact.join(' ')
+      end
+
+      def first_line_comment(node)
+        comment =
+          processed_source.find_comment { |c| c.loc.line == node.loc.line }
+
+        comment ? comment.loc.expression.source : nil
+      end
+
+      def parenthesize?(node)
+        # Parenthesize corrected expression if changing to modifier-if form
+        # would change the meaning of the parent expression
+        # (due to the low operator precedence of modifier-if)
+        parent = node.parent
+        return false if parent.nil?
+        return true if parent.assignment? || parent.operator_keyword?
+        return true if %i[array pair].include?(parent.type)
+
+        node.parent.send_type? && !node.parent.parenthesized?
       end
 
       def max_line_length

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -148,26 +148,6 @@ module RuboCop
             sibling.source_range.first_line == line_no
         end
 
-        def parenthesize?(node)
-          # Parenthesize corrected expression if changing to modifier-if form
-          # would change the meaning of the parent expression
-          # (due to the low operator precedence of modifier-if)
-          parent = node.parent
-          return false if parent.nil?
-          return true if parent.assignment? || parent.operator_keyword?
-
-          node.parent.send_type? && !node.parent.parenthesized?
-        end
-
-        def to_modifier_form(node)
-          expression = [node.body.source,
-                        node.keyword,
-                        node.condition.source,
-                        first_line_comment(node)].compact.join(' ')
-
-          parenthesize?(node) ? "(#{expression})" : expression
-        end
-
         def to_normal_form(node)
           indentation = ' ' * node.source_range.column
           <<~RUBY.chomp

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -609,4 +609,146 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
       RUBY
     end
   end
+
+  context 'when if-end condition is assigned to a variable' do
+    context 'with variable being on the same line' do
+      let(:source) do
+        <<~RUBY
+          x = if a
+            #{'b' * body_length}
+          end
+        RUBY
+      end
+
+      context 'when it is short enough to fit on a single line' do
+        let(:body_length) { 69 }
+
+        it 'corrects it to the single-line form' do
+          corrected = autocorrect_source(source)
+          expect(corrected).to eq "x = (#{'b' * body_length} if a)\n"
+        end
+      end
+
+      context 'when it is not short enough to fit on a single line' do
+        let(:body_length) { 70 }
+
+        it 'accepts it in the multiline form' do
+          expect_no_offenses(source)
+        end
+      end
+    end
+
+    context 'with variable being on the previous line' do
+      let(:source) do
+        <<~RUBY
+          x =
+            if a
+              #{'b' * body_length}
+            end
+        RUBY
+      end
+
+      context 'when it is short enough to fit on a single line' do
+        let(:body_length) { 71 }
+
+        it 'corrects it to the single-line form' do
+          corrected = autocorrect_source(source)
+          expect(corrected).to eq "x =\n  (#{'b' * body_length} if a)\n"
+        end
+      end
+
+      context 'when it is not short enough to fit on a single line' do
+        let(:body_length) { 72 }
+
+        it 'accepts it in the multiline form' do
+          expect_no_offenses(source)
+        end
+      end
+    end
+  end
+
+  context 'when if-end condition is an element of an array' do
+    let(:source) do
+      <<~RUBY
+        [
+          if a
+            #{'b' * body_length}
+          end
+        ]
+      RUBY
+    end
+
+    context 'when short enough to fit on a single line' do
+      let(:body_length) { 71 }
+
+      it 'corrects it to the single-line form' do
+        corrected = autocorrect_source(source)
+        expect(corrected).to eq "[\n  (#{'b' * body_length} if a)\n]\n"
+      end
+    end
+
+    context 'when not short enough to fit on a single line' do
+      let(:body_length) { 72 }
+
+      it 'accepts it in the multiline form' do
+        expect_no_offenses(source)
+      end
+    end
+  end
+
+  context 'when if-end condition is a value in a hash' do
+    let(:source) do
+      <<~RUBY
+        {
+          x: if a
+               #{'b' * body_length}
+             end
+        }
+      RUBY
+    end
+
+    context 'when it is short enough to fit on a single line' do
+      let(:body_length) { 68 }
+
+      it 'corrects it to the single-line form' do
+        corrected = autocorrect_source(source)
+        expect(corrected).to eq "{\n  x: (#{'b' * body_length} if a)\n}\n"
+      end
+    end
+
+    context 'when it is not short enough to fit on a single line' do
+      let(:body_length) { 69 }
+
+      it 'accepts it in the multiline form' do
+        expect_no_offenses(source)
+      end
+    end
+  end
+
+  context 'when if-end condition has a first line comment' do
+    let(:source) do
+      <<~RUBY
+        if foo # #{'c' * comment_length}
+          bar
+        end
+      RUBY
+    end
+
+    context 'when it is short enough to fit on a single line' do
+      let(:comment_length) { 67 }
+
+      it 'corrects it to the single-line form' do
+        corrected = autocorrect_source(source)
+        expect(corrected).to eq "bar if foo # #{'c' * comment_length}\n"
+      end
+    end
+
+    context 'when it is not short enough to fit on a single line' do
+      let(:comment_length) { 68 }
+
+      it 'accepts it in the multiline form' do
+        expect_no_offenses(source)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #8283.
Fixes #8226.
Fixes #8025, #8006, #7969 (look like duplicates).

1. The code to calculate line length for `Style/IfUnlessModifier` when considering conversion to single-line form now uses the same method that actually computes the replacement. This allows us to take into account a comment on a first line of the if-end condition or some code that is on the same line before the if-condition (which both contribute to the line length).
2. Added code so that if-end condition that is either an element of an array or a value of a hash now correctly converted to a single-line form with parentheses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.