### PR TITLE
Use new expect_correction in Style A-E

### DIFF
--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -28,11 +28,11 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
       let(:cop_config) { { 'AllowModifiersOnSymbols' => false } }
 
       it 'accepts when argument to #{access_modifier} is a symbol' do
-        expect_offense(<<~RUBY)
+        expect_offense(<<~RUBY, access_modifier: access_modifier)
           class Foo
             foo
-            #{access_modifier} :bar
-            #{'^' * access_modifier.length} `#{access_modifier}` should not be inlined in method definitions.
+            %{access_modifier} :bar
+            ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
           end
         RUBY
       end
@@ -48,10 +48,10 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
 
     %w[private protected public].each do |access_modifier|
       it "offends when #{access_modifier} is inlined with a method" do
-        expect_offense(<<~RUBY)
+        expect_offense(<<~RUBY, access_modifier: access_modifier)
           class Test
-            #{access_modifier} def foo; end
-            #{'^' * access_modifier.length} `#{access_modifier}` should not be inlined in method definitions.
+            %{access_modifier} def foo; end
+            ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
           end
         RUBY
       end
@@ -86,19 +86,19 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
 
     %w[private protected public].each do |access_modifier|
       it "offends when #{access_modifier} is not inlined" do
-        expect_offense(<<~RUBY)
+        expect_offense(<<~RUBY, access_modifier: access_modifier)
           class Test
-            #{access_modifier}
-            #{'^' * access_modifier.length} `#{access_modifier}` should be inlined in method definitions.
+            %{access_modifier}
+            ^{access_modifier} `#{access_modifier}` should be inlined in method definitions.
           end
         RUBY
       end
 
       it "offends when #{access_modifier} is not inlined and has a comment" do
-        expect_offense(<<~RUBY)
+        expect_offense(<<~RUBY, access_modifier: access_modifier)
           class Test
-            #{access_modifier} # hey
-            #{'^' * access_modifier.length} `#{access_modifier}` should be inlined in method definitions.
+            %{access_modifier} # hey
+            ^{access_modifier} `#{access_modifier}` should be inlined in method definitions.
           end
         RUBY
       end

--- a/spec/rubocop/cop/style/alias_spec.rb
+++ b/spec/rubocop/cop/style/alias_spec.rb
@@ -9,11 +9,10 @@ RSpec.describe RuboCop::Cop::Style::Alias, :config do
         alias :ala :bala
         ^^^^^ Use `alias_method` instead of `alias`.
       RUBY
-    end
 
-    it 'autocorrects alias with symbol args' do
-      corrected = autocorrect_source('alias :ala :bala')
-      expect(corrected).to eq 'alias_method :ala, :bala'
+      expect_correction(<<~RUBY)
+        alias_method :ala, :bala
+      RUBY
     end
 
     it 'registers an offense for alias with bareword args' do
@@ -21,11 +20,10 @@ RSpec.describe RuboCop::Cop::Style::Alias, :config do
         alias ala bala
         ^^^^^ Use `alias_method` instead of `alias`.
       RUBY
-    end
 
-    it 'autocorrects alias with bareword args' do
-      corrected = autocorrect_source('alias ala bala')
-      expect(corrected).to eq 'alias_method :ala, :bala'
+      expect_correction(<<~RUBY)
+        alias_method :ala, :bala
+      RUBY
     end
 
     it 'does not register an offense for alias_method' do
@@ -57,11 +55,10 @@ RSpec.describe RuboCop::Cop::Style::Alias, :config do
         alias :ala :bala
               ^^^^^^^^^^ Use `alias ala bala` instead of `alias :ala :bala`.
       RUBY
-    end
 
-    it 'autocorrects alias with symbol args' do
-      corrected = autocorrect_source('alias :ala :bala')
-      expect(corrected).to eq 'alias ala bala'
+      expect_correction(<<~RUBY)
+        alias ala bala
+      RUBY
     end
 
     it 'does not register an offense for alias with bareword args' do
@@ -73,11 +70,10 @@ RSpec.describe RuboCop::Cop::Style::Alias, :config do
         alias_method :ala, :bala
         ^^^^^^^^^^^^ Use `alias` instead of `alias_method` at the top level.
       RUBY
-    end
 
-    it 'autocorrects alias_method at the top level' do
-      corrected = autocorrect_source('alias_method :ala, :bala')
-      expect(corrected).to eq 'alias ala bala'
+      expect_correction(<<~RUBY)
+        alias ala bala
+      RUBY
     end
 
     it 'registers an offense for alias_method in a class block' do
@@ -87,15 +83,8 @@ RSpec.describe RuboCop::Cop::Style::Alias, :config do
           ^^^^^^^^^^^^ Use `alias` instead of `alias_method` in a class body.
         end
       RUBY
-    end
 
-    it 'autocorrects alias_method in a class block' do
-      corrected = autocorrect_source(<<~RUBY)
-        class C
-          alias_method :ala, :bala
-        end
-      RUBY
-      expect(corrected).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         class C
           alias ala bala
         end
@@ -109,15 +98,8 @@ RSpec.describe RuboCop::Cop::Style::Alias, :config do
           ^^^^^^^^^^^^ Use `alias` instead of `alias_method` in a module body.
         end
       RUBY
-    end
 
-    it 'autocorrects alias_method in a module block' do
-      corrected = autocorrect_source(<<~RUBY)
-        module M
-          alias_method :ala, :bala
-        end
-      RUBY
-      expect(corrected).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         module M
           alias ala bala
         end

--- a/spec/rubocop/cop/style/array_join_spec.rb
+++ b/spec/rubocop/cop/style/array_join_spec.rb
@@ -8,24 +8,30 @@ RSpec.describe RuboCop::Cop::Style::ArrayJoin do
       %w(one two three) * ", "
                         ^ Favor `Array#join` over `Array#*`.
     RUBY
-  end
 
-  it "autocorrects '*' to 'join' when there are spaces" do
-    corrected =
-      autocorrect_source('%w(one two three) * ", "')
-    expect(corrected).to eq '%w(one two three).join(", ")'
+    expect_correction(<<~RUBY)
+      %w(one two three).join(", ")
+    RUBY
   end
 
   it "autocorrects '*' to 'join' when there are no spaces" do
-    corrected =
-      autocorrect_source('%w(one two three)*", "')
-    expect(corrected).to eq '%w(one two three).join(", ")'
+    expect_offense(<<~RUBY)
+      %w(one two three)*", "
+                       ^ Favor `Array#join` over `Array#*`.
+    RUBY
+    expect_correction(<<~RUBY)
+      %w(one two three).join(", ")
+    RUBY
   end
 
   it "autocorrects '*' to 'join' when setting to a variable" do
-    corrected =
-      autocorrect_source('foo = %w(one two three)*", "')
-    expect(corrected).to eq 'foo = %w(one two three).join(", ")'
+    expect_offense(<<~RUBY)
+      foo = %w(one two three)*", "
+                             ^ Favor `Array#join` over `Array#*`.
+    RUBY
+    expect_correction(<<~RUBY)
+      foo = %w(one two three).join(", ")
+    RUBY
   end
 
   it 'does not register an offense for numbers' do

--- a/spec/rubocop/cop/style/attr_spec.rb
+++ b/spec/rubocop/cop/style/attr_spec.rb
@@ -54,52 +54,42 @@ RSpec.describe RuboCop::Cop::Style::Attr do
 
   context 'auto-corrects' do
     it 'attr to attr_reader' do
-      new_source = autocorrect_source('attr :name')
-      expect(new_source).to eq('attr_reader :name')
+      expect_offense(<<~RUBY)
+        attr :name
+        ^^^^ Do not use `attr`. Use `attr_reader` instead.
+      RUBY
+      expect_correction(<<~RUBY)
+        attr_reader :name
+      RUBY
     end
 
     it 'attr, false to attr_reader' do
-      new_source = autocorrect_source('attr :name, false')
-      expect(new_source).to eq('attr_reader :name')
+      expect_offense(<<~RUBY)
+        attr :name, false
+        ^^^^ Do not use `attr`. Use `attr_reader` instead.
+      RUBY
+      expect_correction(<<~RUBY)
+        attr_reader :name
+      RUBY
     end
 
     it 'attr :name, true to attr_accessor :name' do
-      new_source = autocorrect_source('attr :name, true')
-      expect(new_source).to eq('attr_accessor :name')
+      expect_offense(<<~RUBY)
+        attr :name, true
+        ^^^^ Do not use `attr`. Use `attr_accessor` instead.
+      RUBY
+      expect_correction(<<~RUBY)
+        attr_accessor :name
+      RUBY
     end
 
     it 'attr with multiple names to attr_reader' do
-      new_source = autocorrect_source('attr :foo, :bar')
-      expect(new_source).to eq('attr_reader :foo, :bar')
-    end
-  end
-
-  context 'offense message' do
-    it 'for attr :name suggests to use attr_reader' do
-      expect_offense(<<~RUBY)
-        attr :foo
-        ^^^^ Do not use `attr`. Use `attr_reader` instead.
-      RUBY
-    end
-
-    it 'for attr :name, false suggests to use attr_reader' do
-      expect_offense(<<~RUBY)
-        attr :foo, false
-        ^^^^ Do not use `attr`. Use `attr_reader` instead.
-      RUBY
-    end
-
-    it 'for attr :name, true suggests to use attr_accessor' do
-      expect_offense(<<~RUBY)
-        attr :foo, true
-        ^^^^ Do not use `attr`. Use `attr_accessor` instead.
-      RUBY
-    end
-
-    it 'for attr with multiple names suggests to use attr_reader' do
       expect_offense(<<~RUBY)
         attr :foo, :bar
         ^^^^ Do not use `attr`. Use `attr_reader` instead.
+      RUBY
+      expect_correction(<<~RUBY)
+        attr_reader :foo, :bar
       RUBY
     end
   end

--- a/spec/rubocop/cop/style/bare_percent_literals_spec.rb
+++ b/spec/rubocop/cop/style/bare_percent_literals_spec.rb
@@ -44,11 +44,9 @@ RSpec.describe RuboCop::Cop::Style::BarePercentLiterals, :config do
           %(hi)
           ^^ Use `%Q` instead of `%`.
         RUBY
-      end
-
-      it 'auto-corrects' do
-        new_source = autocorrect_source('%(hi)')
-        expect(new_source).to eq('%Q(hi)')
+        expect_correction(<<~RUBY)
+          %Q(hi)
+        RUBY
       end
 
       it 'accepts %Q()' do
@@ -64,11 +62,9 @@ RSpec.describe RuboCop::Cop::Style::BarePercentLiterals, :config do
           %(#{x})
           ^^ Use `%Q` instead of `%`.
         RUBY
-      end
-
-      it 'auto-corrects' do
-        new_source = autocorrect_source('%(#{x})')
-        expect(new_source).to eq('%Q(#{x})')
+        expect_correction(<<~'RUBY')
+          %Q(#{x})
+        RUBY
       end
 
       it 'accepts %Q()' do
@@ -88,11 +84,9 @@ RSpec.describe RuboCop::Cop::Style::BarePercentLiterals, :config do
           %Q(hi)
           ^^^ Use `%` instead of `%Q`.
         RUBY
-      end
-
-      it 'auto-corrects' do
-        new_source = autocorrect_source('%Q(hi)')
-        expect(new_source).to eq('%(hi)')
+        expect_correction(<<~RUBY)
+          %(hi)
+        RUBY
       end
 
       it 'accepts %()' do
@@ -108,11 +102,9 @@ RSpec.describe RuboCop::Cop::Style::BarePercentLiterals, :config do
           %Q(#{x})
           ^^^ Use `%` instead of `%Q`.
         RUBY
-      end
-
-      it 'auto-corrects' do
-        new_source = autocorrect_source('%Q(#{x})')
-        expect(new_source).to eq('%(#{x})')
+        expect_correction(<<~'RUBY')
+          %(#{x})
+        RUBY
       end
 
       it 'accepts %()' do

--- a/spec/rubocop/cop/style/block_comments_spec.rb
+++ b/spec/rubocop/cop/style/block_comments_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe RuboCop::Cop::Style::BlockComments do
       comment
       =end
     RUBY
+    expect_correction(<<~RUBY)
+      # comment
+    RUBY
   end
 
   it 'accepts regular comments' do
@@ -17,8 +20,9 @@ RSpec.describe RuboCop::Cop::Style::BlockComments do
   end
 
   it 'auto-corrects a block comment into a regular comment' do
-    new_source = autocorrect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       =begin
+      ^^^^^^ Do not use block comments.
       comment line 1
 
       comment line 2
@@ -26,7 +30,7 @@ RSpec.describe RuboCop::Cop::Style::BlockComments do
       def foo
       end
     RUBY
-    expect(new_source).to eq(<<~RUBY)
+    expect_correction(<<~RUBY)
       # comment line 1
       #
       # comment line 2
@@ -36,13 +40,14 @@ RSpec.describe RuboCop::Cop::Style::BlockComments do
   end
 
   it 'auto-corrects an empty block comment by removing it' do
-    new_source = autocorrect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       =begin
+      ^^^^^^ Do not use block comments.
       =end
       def foo
       end
     RUBY
-    expect(new_source).to eq(<<~RUBY)
+    expect_correction(<<~RUBY)
       def foo
       end
     RUBY
@@ -50,22 +55,18 @@ RSpec.describe RuboCop::Cop::Style::BlockComments do
 
   it 'auto-corrects a block comment into a regular comment (without trailing' \
     'newline)' do
-    source = <<~RUBY
+    expect_offense(<<~RUBY)
       =begin
+      ^^^^^^ Do not use block comments.
       comment line 1
 
       comment line 2
       =end
     RUBY
-
-    new_source = autocorrect_source(source.chomp)
-
-    expected_source = <<~RUBY
+    expect_correction(<<~RUBY)
       # comment line 1
       #
       # comment line 2
     RUBY
-
-    expect(new_source).to eq(expected_source)
   end
 end

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -211,111 +211,92 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
     end
 
     context 'with a procedural multi-line block' do
-      let(:corrected_source) do
-        <<~RUBY
+      it 'auto-corrects { and } to do and end' do
+        expect_offense(<<~RUBY)
+          each { |x|
+               ^ Prefer `do...end` over `{...}` for procedural blocks.
+            x
+          }
+        RUBY
+        expect_correction(<<~RUBY)
           each do |x|
             x
           end
         RUBY
       end
 
-      it 'auto-corrects { and } to do and end' do
-        source = <<~RUBY
-          each { |x|
-            x
-          }
-        RUBY
-
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(corrected_source)
-      end
-
       it 'auto-corrects { and } to do and end with appropriate spacing' do
-        source = <<~RUBY
+        expect_offense(<<~RUBY)
           each {|x|
+               ^ Prefer `do...end` over `{...}` for procedural blocks.
             x
           }
         RUBY
-
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(corrected_source)
+        expect_correction(<<~RUBY)
+          each do |x|
+            x
+          end
+        RUBY
       end
     end
 
-    it 'does not auto-correct {} to do-end if it is a known functional ' \
-       'method' do
-      source = <<~RUBY
+    it 'allows {} if it is a known functional method' do
+      expect_no_offenses(<<~RUBY)
         let(:foo) { |x|
           x
         }
       RUBY
-
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(source)
     end
 
-    it 'does not autocorrect do-end to {} if it is a known procedural ' \
-       'method' do
-      source = <<~RUBY
+    it 'allows {} if it is a known procedural method' do
+      expect_no_offenses(<<~RUBY)
         foo = bar.tap do |x|
           x.age = 1
         end
       RUBY
-
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(source)
     end
 
     it 'auto-corrects do-end to {} if it is a functional block' do
-      source = <<~RUBY
+      expect_offense(<<~RUBY)
         foo = map do |x|
+                  ^^ Prefer `{...}` over `do...end` for functional blocks.
           x
         end
       RUBY
-
-      expected_source = <<~RUBY
+      expect_correction(<<~RUBY)
         foo = map { |x|
           x
         }
       RUBY
-
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(expected_source)
     end
 
     it 'auto-corrects do-end to {} with appropriate spacing' do
-      source = <<~RUBY
+      expect_offense(<<~RUBY)
         foo = map do|x|
+                  ^^ Prefer `{...}` over `do...end` for functional blocks.
           x
         end
       RUBY
-
-      expected_source = <<~RUBY
+      expect_correction(<<~RUBY)
         foo = map { |x|
           x
         }
       RUBY
-
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(expected_source)
     end
 
     it 'auto-corrects do-end to {} if it is a functional block and does ' \
        'not change the meaning' do
-      source = <<~RUBY
+      expect_offense(<<~RUBY)
         puts (map do |x|
+                  ^^ Prefer `{...}` over `do...end` for functional blocks.
           x
         end)
       RUBY
-
-      expected_source = <<~RUBY
+      expect_correction(<<~RUBY)
         puts (map { |x|
           x
         })
       RUBY
-
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(expected_source)
     end
   end
 
@@ -330,24 +311,29 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
     include_examples 'syntactic styles'
 
     it 'auto-corrects do and end for single line blocks to { and }' do
-      new_source = autocorrect_source('block do |x| end')
-      expect(new_source).to eq('block { |x| }')
+      expect_offense(<<~RUBY)
+        block do |x| end
+              ^^ Prefer `{...}` over `do...end` for single-line blocks.
+      RUBY
+      expect_correction(<<~RUBY)
+        block { |x| }
+      RUBY
     end
 
     it 'does not auto-correct do-end if {} would change the meaning' do
-      src = "s.subspec 'Subspec' do |sp| end"
-      new_source = autocorrect_source(src)
-      expect(new_source).to eq(src)
+      expect_offense(<<~RUBY)
+        s.subspec 'Subspec' do |sp| end
+                            ^^ Prefer `{...}` over `do...end` for single-line blocks.
+      RUBY
+      expect_no_corrections
     end
 
     it 'does not auto-correct {} if do-end would change the meaning' do
-      src = <<~RUBY
+      expect_no_offenses(<<~RUBY)
         foo :bar, :baz, qux: lambda { |a|
           bar a
         }
       RUBY
-      new_source = autocorrect_source(src)
-      expect(new_source).to eq(src)
     end
 
     context 'when there are braces around a multi-line block' do
@@ -426,33 +412,30 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       end
 
       it 'auto-corrects { and } to do and end' do
-        source = <<~RUBY
+        expect_offense(<<~RUBY)
           each{ |x|
+              ^ Avoid using `{...}` for multi-line blocks.
             some_method
             other_method
           }
         RUBY
-
-        expected_source = <<~RUBY
+        expect_correction(<<~RUBY)
           each do |x|
             some_method
             other_method
           end
         RUBY
-
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(expected_source)
       end
 
       it 'auto-corrects adjacent curly braces correctly' do
-        source = <<~RUBY
+        expect_offense(<<~RUBY)
           (0..3).each { |a| a.times {
+                                    ^ Avoid using `{...}` for multi-line blocks.
+                      ^ Avoid using `{...}` for multi-line blocks.
             puts a
           }}
         RUBY
-
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(<<~RUBY)
+        expect_correction(<<~RUBY)
           (0..3).each do |a| a.times do
             puts a
           end end
@@ -460,13 +443,11 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       end
 
       it 'does not auto-correct {} if do-end would introduce a syntax error' do
-        src = <<~RUBY
+        expect_no_offenses(<<~RUBY)
           my_method :arg1, arg2: proc {
             something
           }, arg3: :another_value
         RUBY
-        new_source = autocorrect_source(src)
-        expect(new_source).to eq(src)
       end
     end
   end
@@ -622,9 +603,11 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
     end
 
     it 'does not auto-correct do-end if {} would change the meaning' do
-      src = "s.subspec 'Subspec' do |sp| end"
-      new_source = autocorrect_source(src)
-      expect(new_source).to eq(src)
+      expect_offense(<<~RUBY)
+        s.subspec 'Subspec' do |sp| end
+                            ^^ Prefer `{...}` over `do...end` for blocks.
+      RUBY
+      expect_no_corrections
     end
 
     it 'accepts a multi-line block that needs braces to be valid ruby' do
@@ -753,22 +736,20 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       end
 
       it 'auto-corrects { and } to do and end' do
-        source = <<~RUBY
+        expect_offense(<<~RUBY)
           each{ |x|
+              ^ Avoid using `{...}` for multi-line blocks.
             some_method
             other_method
           }
         RUBY
 
-        expected_source = <<~RUBY
+        expect_correction(<<~RUBY)
           each do |x|
             some_method
             other_method
           end
         RUBY
-
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(expected_source)
       end
     end
   end

--- a/spec/rubocop/cop/style/character_literal_spec.rb
+++ b/spec/rubocop/cop/style/character_literal_spec.rb
@@ -8,12 +8,18 @@ RSpec.describe RuboCop::Cop::Style::CharacterLiteral do
       x = ?x
           ^^ Do not use the character literal - use string literal instead.
     RUBY
+    expect_correction(<<~RUBY)
+      x = 'x'
+    RUBY
   end
 
   it 'registers an offense for literals like \n' do
     expect_offense(<<~'RUBY')
       x = ?\n
           ^^^ Do not use the character literal - use string literal instead.
+    RUBY
+    expect_correction(<<~'RUBY')
+      x = "\n"
     RUBY
   end
 
@@ -25,18 +31,13 @@ RSpec.describe RuboCop::Cop::Style::CharacterLiteral do
     expect_no_offenses('%w{? A}')
   end
 
-  it "auto-corrects ?x to 'x'" do
-    new_source = autocorrect_source('x = ?x')
-    expect(new_source).to eq("x = 'x'")
-  end
-
-  it 'auto-corrects ?\n to "\\n"' do
-    new_source = autocorrect_source('x = ?\n')
-    expect(new_source).to eq('x = "\\n"')
-  end
-
   it 'auto-corrects ?\' to "\'"' do
-    new_source = autocorrect_source('x = ?\'')
-    expect(new_source).to eq('x = "\'"')
+    expect_offense(<<~RUBY)
+      x = ?'
+          ^^ Do not use the character literal - use string literal instead.
+    RUBY
+    expect_correction(<<~RUBY)
+      x = "'"
+    RUBY
   end
 end

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
               ^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
         end
       RUBY
+      expect_correction(<<~RUBY)
+        module FooClass
+          class BarClass
+          end
+        end
+      RUBY
     end
 
     it 'registers an offense for not nested classes with explicit superclass' do
@@ -18,12 +24,24 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
               ^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
         end
       RUBY
+      expect_correction(<<~RUBY)
+        module FooClass
+          class BarClass < Super
+          end
+        end
+      RUBY
     end
 
     it 'registers an offense for not nested modules' do
       expect_offense(<<~RUBY)
         module FooModule::BarModule
                ^^^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
+        end
+      RUBY
+      expect_correction(<<~RUBY)
+        module FooModule
+          module BarModule
+          end
         end
       RUBY
     end
@@ -66,6 +84,10 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
           end
         end
       RUBY
+      expect_correction(<<~RUBY)
+        class FooClass::BarClass
+        end
+      RUBY
     end
 
     it 'registers a offense for modules with nested children' do
@@ -74,6 +96,10 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
                ^^^^^^^^^ Use compact module/class definition instead of nested style.
           module BarModule
           end
+        end
+      RUBY
+      expect_correction(<<~RUBY)
+        module FooModule::BarModule
         end
       RUBY
     end
@@ -122,174 +148,6 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
           end
         end
       RUBY
-    end
-  end
-
-  context 'autocorrect' do
-    let(:cop_config) do
-      { 'AutoCorrect' => 'true', 'EnforcedStyle' => enforced_style }
-    end
-
-    context 'nested style' do
-      let(:enforced_style) { 'nested' }
-
-      it 'corrects a not nested class' do
-        source = <<~RUBY
-          class FooClass::BarClass
-          end
-        RUBY
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(<<~RUBY)
-          module FooClass
-            class BarClass
-            end
-          end
-        RUBY
-      end
-
-      it 'corrects a not nested class with explicit superclass' do
-        source = <<~RUBY
-          class FooClass::BarClass < Super
-          end
-        RUBY
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(<<~RUBY)
-          module FooClass
-            class BarClass < Super
-            end
-          end
-        RUBY
-      end
-
-      it 'corrects a not nested module' do
-        source = <<~RUBY
-          module FooClass::BarClass
-          end
-        RUBY
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(<<~RUBY)
-          module FooClass
-            module BarClass
-            end
-          end
-        RUBY
-      end
-
-      it 'does not correct nested children' do
-        source = <<~RUBY
-          class FooClass
-            class BarClass
-            end
-          end
-
-          module FooModule
-            module BarModule
-            end
-          end
-        RUBY
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(source)
-      end
-
-      it 'does not correct :: in parent class on inheritance' do
-        source = <<~RUBY
-          class FooClass
-            class BarClass
-            end
-          end
-
-          class BazClass < FooClass::BarClass
-          end
-        RUBY
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(source)
-      end
-    end
-
-    context 'compact style' do
-      let(:enforced_style) { 'compact' }
-
-      it 'corrects nested children' do
-        source = <<~RUBY
-          class FooClass
-            class BarClass
-            end
-          end
-        RUBY
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(<<~RUBY)
-          class FooClass::BarClass
-          end
-        RUBY
-      end
-
-      it 'corrects modules with nested children' do
-        source = <<~RUBY
-          module FooModule
-            module BarModule
-            end
-          end
-        RUBY
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(<<~RUBY)
-          module FooModule::BarModule
-          end
-        RUBY
-      end
-
-      it 'does not correct compact style for classes/modules' do
-        source = <<~RUBY
-          class FooClass::BarClass
-          end
-
-          module FooClass::BarModule
-          end
-        RUBY
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(source)
-      end
-
-      it 'does not correct nested classes/modules with more than one child' do
-        source = <<~RUBY
-          class FooClass
-            class BarClass
-            end
-            class BazClass
-            end
-          end
-
-          module FooModule
-            module BarModule
-            end
-            class BazModule
-            end
-          end
-        RUBY
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(source)
-      end
-
-      it 'does not correct class/module with single method' do
-        source = <<~RUBY
-          class FooClass
-            def bar_method
-            end
-          end
-        RUBY
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(source)
-      end
-
-      it 'does not correct nesting for classes with an explicit superclass' do
-        source = <<~RUBY
-          class FooClass < Super
-            class BarClass
-            end
-          end
-        RUBY
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(source)
-      end
     end
   end
 end

--- a/spec/rubocop/cop/style/class_check_spec.rb
+++ b/spec/rubocop/cop/style/class_check_spec.rb
@@ -4,32 +4,30 @@ RSpec.describe RuboCop::Cop::Style::ClassCheck, :config do
   context 'when enforced style is is_a?' do
     let(:cop_config) { { 'EnforcedStyle' => 'is_a?' } }
 
-    it 'registers an offense for kind_of?' do
+    it 'registers an offense for kind_of? and corrects to is_a?' do
       expect_offense(<<~RUBY)
         x.kind_of? y
           ^^^^^^^^ Prefer `Object#is_a?` over `Object#kind_of?`.
       RUBY
-    end
 
-    it 'auto-corrects kind_of? to is_a?' do
-      corrected = autocorrect_source('x.kind_of? y')
-      expect(corrected).to eq 'x.is_a? y'
+      expect_correction(<<~RUBY)
+        x.is_a? y
+      RUBY
     end
   end
 
   context 'when enforced style is kind_of?' do
     let(:cop_config) { { 'EnforcedStyle' => 'kind_of?' } }
 
-    it 'registers an offense for is_a?' do
+    it 'registers an offense for is_a? and corrects to kind_of?' do
       expect_offense(<<~RUBY)
         x.is_a? y
           ^^^^^ Prefer `Object#kind_of?` over `Object#is_a?`.
       RUBY
-    end
 
-    it 'auto-corrects is_a? to kind_of?' do
-      corrected = autocorrect_source('x.is_a? y')
-      expect(corrected).to eq 'x.kind_of? y'
+      expect_correction(<<~RUBY)
+        x.kind_of? y
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/class_methods_spec.rb
+++ b/spec/rubocop/cop/style/class_methods_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe RuboCop::Cop::Style::ClassMethods do
         end
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      class Test
+        def self.some_method
+          do_something
+        end
+      end
+    RUBY
   end
 
   it 'registers an offense for methods using a module name' do
@@ -19,6 +27,14 @@ RSpec.describe RuboCop::Cop::Style::ClassMethods do
       module Test
         def Test.some_method
             ^^^^ Use `self.some_method` instead of `Test.some_method`.
+          do_something
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      module Test
+        def self.some_method
           do_something
         end
       end
@@ -53,26 +69,5 @@ RSpec.describe RuboCop::Cop::Style::ClassMethods do
         do_something
       end
     RUBY
-  end
-
-  it 'autocorrects class name to self' do
-    src = <<~RUBY
-      class Test
-        def Test.some_method
-          do_something
-        end
-      end
-    RUBY
-
-    correct_source = <<~RUBY
-      class Test
-        def self.some_method
-          do_something
-        end
-      end
-    RUBY
-
-    new_source = autocorrect_source(src)
-    expect(new_source).to eq(correct_source)
   end
 end

--- a/spec/rubocop/cop/style/collection_methods_spec.rb
+++ b/spec/rubocop/cop/style/collection_methods_spec.rb
@@ -17,17 +17,23 @@ RSpec.describe RuboCop::Cop::Style::CollectionMethods, :config do
 
   cop_config['PreferredMethods'].each do |method, preferred_method|
     it "registers an offense for #{method} with block" do
-      inspect_source("[1, 2, 3].#{method} { |e| e + 1 }")
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(["Prefer `#{preferred_method}` over `#{method}`."])
+      expect_offense(<<~RUBY, method: method)
+        [1, 2, 3].%{method} { |e| e + 1 }
+                  ^{method} Prefer `#{preferred_method}` over `#{method}`.
+      RUBY
+      expect_correction(<<~RUBY)
+        [1, 2, 3].#{preferred_method} { |e| e + 1 }
+      RUBY
     end
 
     it "registers an offense for #{method} with proc param" do
-      inspect_source("[1, 2, 3].#{method}(&:test)")
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(["Prefer `#{preferred_method}` over `#{method}`."])
+      expect_offense(<<~RUBY, method: method)
+        [1, 2, 3].%{method}(&:test)
+                  ^{method} Prefer `#{preferred_method}` over `#{method}`.
+      RUBY
+      expect_correction(<<~RUBY)
+        [1, 2, 3].#{preferred_method}(&:test)
+      RUBY
     end
 
     it "accepts #{method} with more than 1 param" do
@@ -40,11 +46,6 @@ RSpec.describe RuboCop::Cop::Style::CollectionMethods, :config do
       expect_no_offenses(<<~RUBY)
         [1, 2, 3].#{method}
       RUBY
-    end
-
-    it 'auto-corrects to preferred method' do
-      new_source = autocorrect_source('some.collect(&:test)')
-      expect(new_source).to eq('some.map(&:test)')
     end
   end
 end

--- a/spec/rubocop/cop/style/colon_method_call_spec.rb
+++ b/spec/rubocop/cop/style/colon_method_call_spec.rb
@@ -8,12 +8,18 @@ RSpec.describe RuboCop::Cop::Style::ColonMethodCall do
       test::method_name
           ^^ Do not use `::` for method calls.
     RUBY
+    expect_correction(<<~RUBY)
+      test.method_name
+    RUBY
   end
 
   it 'registers an offense for instance method call with arg' do
     expect_offense(<<~RUBY)
       test::method_name(arg)
           ^^ Do not use `::` for method calls.
+    RUBY
+    expect_correction(<<~RUBY)
+      test.method_name(arg)
     RUBY
   end
 
@@ -22,12 +28,18 @@ RSpec.describe RuboCop::Cop::Style::ColonMethodCall do
       Class::method_name
            ^^ Do not use `::` for method calls.
     RUBY
+    expect_correction(<<~RUBY)
+      Class.method_name
+    RUBY
   end
 
   it 'registers an offense for class method call with arg' do
     expect_offense(<<~RUBY)
       Class::method_name(arg, arg2)
            ^^ Do not use `::` for method calls.
+    RUBY
+    expect_correction(<<~RUBY)
+      Class.method_name(arg, arg2)
     RUBY
   end
 
@@ -53,10 +65,5 @@ RSpec.describe RuboCop::Cop::Style::ColonMethodCall do
 
   it 'does not register an offense for Java package namespaces' do
     expect_no_offenses('Java::com')
-  end
-
-  it 'auto-corrects "::" with "."' do
-    new_source = autocorrect_source('test::method')
-    expect(new_source).to eq('test.method')
   end
 end

--- a/spec/rubocop/cop/style/command_literal_spec.rb
+++ b/spec/rubocop/cop/style/command_literal_spec.rb
@@ -32,8 +32,13 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
     end
 
     it 'respects the configuration when auto-correcting' do
-      new_source = autocorrect_source('`ls`')
-      expect(new_source).to eq('%x[ls]')
+      expect_offense(<<~RUBY)
+        `ls`
+        ^^^^ Use `%x` around command string.
+      RUBY
+      expect_correction(<<~RUBY)
+        %x[ls]
+      RUBY
     end
   end
 
@@ -44,8 +49,13 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
     end
 
     it 'respects the configuration when auto-correcting' do
-      new_source = autocorrect_source('`ls`')
-      expect(new_source).to eq('%x(ls)')
+      expect_offense(<<~'RUBY')
+        `ls`
+        ^^^^ Use `%x` around command string.
+      RUBY
+      expect_correction(<<~'RUBY')
+        %x(ls)
+      RUBY
     end
   end
 
@@ -55,9 +65,14 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
       { 'PreferredDelimiters' => { '%x' => '[]', 'default' => '()' } }
     end
 
-    it 'ignores the default when auto-correcting and' do
-      new_source = autocorrect_source('`ls`')
-      expect(new_source).to eq('%x[ls]')
+    it 'ignores the default when auto-correcting' do
+      expect_offense(<<~'RUBY')
+        `ls`
+        ^^^^ Use `%x` around command string.
+      RUBY
+      expect_correction(<<~'RUBY')
+        %x[ls]
+      RUBY
     end
   end
 
@@ -83,18 +98,12 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
     end
 
     describe 'a single-line ` string with backticks' do
-      let(:source) { 'foo = `echo \`ls\``' }
-
-      it 'registers an offense' do
+      it 'registers an offense without auto-correction' do
         expect_offense(<<~'RUBY')
           foo = `echo \`ls\``
                 ^^^^^^^^^^^^^ Use `%x` around command string.
         RUBY
-      end
-
-      it 'cannot auto-correct' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(source)
+        expect_no_corrections
       end
 
       describe 'when configured to allow inner backticks' do
@@ -118,16 +127,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
     end
 
     describe 'a multi-line ` string with backticks' do
-      let(:source) do
-        <<~RUBY
-          foo = `
-            echo \`ls\`
-            echo \`ls -l\`
-          `
-        RUBY
-      end
-
-      it 'registers an offense' do
+      it 'registers an offense without auto-correction' do
         expect_offense(<<~'RUBY')
           foo = `
                 ^ Use `%x` around command string.
@@ -135,11 +135,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
             echo \`ls -l\`
           `
         RUBY
-      end
-
-      it 'cannot auto-correct' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(source)
+        expect_no_corrections
       end
 
       describe 'when configured to allow inner backticks' do
@@ -157,24 +153,18 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
     end
 
     describe 'a single-line %x string without backticks' do
-      let(:source) { 'foo = %x(ls)' }
-
-      it 'registers an offense' do
+      it 'registers an offense and corrects to backticks' do
         expect_offense(<<~RUBY)
           foo = %x(ls)
                 ^^^^^^ Use backticks around command string.
         RUBY
-      end
-
-      it 'auto-corrects' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq('foo = `ls`')
+        expect_correction(<<~RUBY)
+          foo = `ls`
+        RUBY
       end
     end
 
     describe 'a single-line %x string with backticks' do
-      let(:source) { 'foo = %x(echo `ls`)' }
-
       it 'is accepted' do
         expect_no_offenses('foo = %x(echo `ls`)')
       end
@@ -182,31 +172,18 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
       describe 'when configured to allow inner backticks' do
         before { cop_config['AllowInnerBackticks'] = true }
 
-        it 'registers an offense' do
+        it 'registers an offense without auto-correction' do
           expect_offense(<<~RUBY)
             foo = %x(echo `ls`)
                   ^^^^^^^^^^^^^ Use backticks around command string.
           RUBY
-        end
-
-        it 'cannot auto-correct' do
-          new_source = autocorrect_source(source)
-          expect(new_source).to eq(source)
+          expect_no_corrections
         end
       end
     end
 
     describe 'a multi-line %x string without backticks' do
-      let(:source) do
-        <<~RUBY
-          foo = %x(
-            ls
-            ls -l
-          )
-        RUBY
-      end
-
-      it 'registers an offense' do
+      it 'registers an offense and corrects to backticks' do
         expect_offense(<<~RUBY)
           foo = %x(
                 ^^^ Use backticks around command string.
@@ -214,11 +191,8 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
             ls -l
           )
         RUBY
-      end
 
-      it 'auto-corrects' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(<<~RUBY)
+        expect_correction(<<~RUBY)
           foo = `
             ls
             ls -l
@@ -228,15 +202,6 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
     end
 
     describe 'a multi-line %x string with backticks' do
-      let(:source) do
-        <<~RUBY
-          foo = %x(
-            echo `ls`
-            echo `ls -l`
-          )
-        RUBY
-      end
-
       it 'is accepted' do
         expect_no_offenses(<<~RUBY)
           foo = %x(
@@ -249,7 +214,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
       describe 'when configured to allow inner backticks' do
         before { cop_config['AllowInnerBackticks'] = true }
 
-        it 'registers an offense' do
+        it 'registers an offense without auto-correction' do
           expect_offense(<<~RUBY)
             foo = %x(
                   ^^^ Use backticks around command string.
@@ -257,11 +222,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
               echo `ls -l`
             )
           RUBY
-        end
-
-        it 'cannot auto-correct' do
-          new_source = autocorrect_source(source)
-          expect(new_source).to eq(source)
+          expect_no_corrections
         end
       end
     end
@@ -271,48 +232,30 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'percent_x' } }
 
     describe 'a single-line ` string without backticks' do
-      let(:source) { 'foo = `ls`' }
-
-      it 'registers an offense' do
+      it 'registers an offense and corrects to %x' do
         expect_offense(<<~RUBY)
           foo = `ls`
                 ^^^^ Use `%x` around command string.
         RUBY
-      end
 
-      it 'auto-corrects' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq('foo = %x(ls)')
+        expect_correction(<<~RUBY)
+          foo = %x(ls)
+        RUBY
       end
     end
 
     describe 'a single-line ` string with backticks' do
-      let(:source) { 'foo = `echo \`ls\``' }
-
-      it 'registers an offense' do
+      it 'registers an offense without auto-correction' do
         expect_offense(<<~'RUBY')
           foo = `echo \`ls\``
                 ^^^^^^^^^^^^^ Use `%x` around command string.
         RUBY
-      end
-
-      it 'cannot auto-correct' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(source)
+        expect_no_corrections
       end
     end
 
     describe 'a multi-line ` string without backticks' do
-      let(:source) do
-        <<~RUBY
-          foo = `
-            ls
-            ls -l
-          `
-        RUBY
-      end
-
-      it 'registers an offense' do
+      it 'registers an offense and corrects to %x' do
         expect_offense(<<~'RUBY')
           foo = `
                 ^ Use `%x` around command string.
@@ -320,11 +263,8 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
             ls -l
           `
         RUBY
-      end
 
-      it 'auto-corrects' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(<<~RUBY)
+        expect_correction(<<~RUBY)
           foo = %x(
             ls
             ls -l
@@ -334,16 +274,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
     end
 
     describe 'a multi-line ` string with backticks' do
-      let(:source) do
-        <<~'RUBY'
-          foo = `
-            echo \`ls\`
-            echo \`ls -l\`
-          `
-        RUBY
-      end
-
-      it 'registers an offense' do
+      it 'registers an offense without auto-correction' do
         expect_offense(<<~'RUBY')
           foo = `
                 ^ Use `%x` around command string.
@@ -351,11 +282,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
             echo \`ls -l\`
           `
         RUBY
-      end
-
-      it 'cannot auto-correct' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(source)
+        expect_no_corrections
       end
     end
 
@@ -404,18 +331,12 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
     end
 
     describe 'a single-line ` string with backticks' do
-      let(:source) { 'foo = `echo \`ls\``' }
-
-      it 'registers an offense' do
+      it 'registers an offense without auto-correction' do
         expect_offense(<<~'RUBY')
           foo = `echo \`ls\``
                 ^^^^^^^^^^^^^ Use `%x` around command string.
         RUBY
-      end
-
-      it 'cannot auto-correct' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(source)
+        expect_no_corrections
       end
 
       describe 'when configured to allow inner backticks' do
@@ -428,16 +349,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
     end
 
     describe 'a multi-line ` string without backticks' do
-      let(:source) do
-        <<~'RUBY'
-          foo = `
-            ls
-            ls -l
-          `
-        RUBY
-      end
-
-      it 'registers an offense' do
+      it 'registers an offense and corrects to %x' do
         expect_offense(<<~RUBY)
           foo = `
                 ^ Use `%x` around command string.
@@ -445,11 +357,8 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
             ls -l
           `
         RUBY
-      end
 
-      it 'auto-corrects' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(<<~RUBY)
+        expect_correction(<<~RUBY)
           foo = %x(
             ls
             ls -l
@@ -459,16 +368,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
     end
 
     describe 'a multi-line ` string with backticks' do
-      let(:source) do
-        <<~'RUBY'
-          foo = `
-            echo \`ls\`
-            echo \`ls -l\`
-          `
-        RUBY
-      end
-
-      it 'registers an offense' do
+      it 'registers an offense without auto-correction' do
         expect_offense(<<~'RUBY')
           foo = `
                 ^ Use `%x` around command string.
@@ -476,33 +376,24 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
             echo \`ls -l\`
           `
         RUBY
-      end
-
-      it 'cannot auto-correct' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(source)
+        expect_no_corrections
       end
     end
 
     describe 'a single-line %x string without backticks' do
-      let(:source) { 'foo = %x(ls)' }
-
-      it 'registers an offense' do
+      it 'registers an offense and corrects to backticks' do
         expect_offense(<<~RUBY)
           foo = %x(ls)
                 ^^^^^^ Use backticks around command string.
         RUBY
-      end
 
-      it 'auto-corrects' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq('foo = `ls`')
+        expect_correction(<<~RUBY)
+          foo = `ls`
+        RUBY
       end
     end
 
     describe 'a single-line %x string with backticks' do
-      let(:source) { 'foo = %x(echo `ls`)' }
-
       it 'is accepted' do
         expect_no_offenses('foo = %x(echo `ls`)')
       end
@@ -510,16 +401,12 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
       describe 'when configured to allow inner backticks' do
         before { cop_config['AllowInnerBackticks'] = true }
 
-        it 'registers an offense' do
+        it 'registers an offense without auto-correction' do
           expect_offense(<<~RUBY)
             foo = %x(echo `ls`)
                   ^^^^^^^^^^^^^ Use backticks around command string.
           RUBY
-        end
-
-        it 'cannot auto-correct' do
-          new_source = autocorrect_source(source)
-          expect(new_source).to eq(source)
+          expect_no_corrections
         end
       end
     end

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -6,16 +6,15 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
   end
 
   context 'missing colon' do
-    it 'registers an offense' do
+    it 'registers an offense and adds colon' do
       expect_offense(<<~RUBY)
         # TODO make better
           ^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a colon, and a space, then a note describing the problem.
       RUBY
-    end
 
-    it 'autocorrects' do
-      corrected = autocorrect_source('# TODO make better')
-      expect(corrected).to eq('# TODO: make better')
+      expect_correction(<<~RUBY)
+        # TODO: make better
+      RUBY
     end
   end
 
@@ -27,68 +26,59 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
         # ISSUE wrong order
           ^^^^^^ Annotation keywords like `ISSUE` should be all upper case, followed by a colon, and a space, then a note describing the problem.
       RUBY
-    end
 
-    it 'autocorrects a missing colon after keyword' do
-      corrected = autocorrect_source('# ISSUE wrong order')
-      expect(corrected).to eq('# ISSUE: wrong order')
+      expect_correction(<<~RUBY)
+        # ISSUE: wrong order
+      RUBY
     end
   end
 
   context 'missing space after colon' do
-    it 'registers an offense' do
+    it 'registers an offense and adds space' do
       expect_offense(<<~RUBY)
         # TODO:make better
           ^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a colon, and a space, then a note describing the problem.
       RUBY
-    end
 
-    it 'autocorrects' do
-      corrected = autocorrect_source('# TODO:make better')
-      expect(corrected).to eq('# TODO: make better')
+      expect_correction(<<~RUBY)
+        # TODO: make better
+      RUBY
     end
   end
 
   context 'lower case keyword' do
-    it 'registers an offense' do
+    it 'registers an offense and upcases' do
       expect_offense(<<~RUBY)
         # fixme: does not work
           ^^^^^^^ Annotation keywords like `fixme` should be all upper case, followed by a colon, and a space, then a note describing the problem.
       RUBY
-    end
 
-    it 'autocorrects' do
-      corrected = autocorrect_source('# fixme: does not work')
-      expect(corrected).to eq('# FIXME: does not work')
+      expect_correction(<<~RUBY)
+        # FIXME: does not work
+      RUBY
     end
   end
 
   context 'capitalized keyword' do
-    it 'registers an offense' do
+    it 'registers an offense and upcases' do
       expect_offense(<<~RUBY)
         # Optimize: does not work
           ^^^^^^^^^^ Annotation keywords like `Optimize` should be all upper case, followed by a colon, and a space, then a note describing the problem.
       RUBY
-    end
 
-    it 'autocorrects' do
-      corrected = autocorrect_source('# Optimize: does not work')
-      expect(corrected).to eq('# OPTIMIZE: does not work')
+      expect_correction(<<~RUBY)
+        # OPTIMIZE: does not work
+      RUBY
     end
   end
 
   context 'upper case keyword with colon by no note' do
-    it 'registers an offense' do
+    it 'registers an offense without auto-correction' do
       expect_offense(<<~RUBY)
         # HACK:
           ^^^^^ Annotation comment, with keyword `HACK`, is missing a note.
       RUBY
-    end
-
-    it 'does not autocorrects' do
-      source = '# HACK:'
-      corrected = autocorrect_source(source)
-      expect(corrected).to eq(source)
+      expect_no_corrections
     end
   end
 

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -134,10 +134,13 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
     expect_no_offenses('bar = foo? ? "a" : "b"')
   end
 
-  it 'registers an offense for assignment in ternary operation' do
+  it 'registers an offense for assignment in ternary operation using strings' do
     expect_offense(<<~RUBY)
       foo? ? bar = "a" : bar = "b"
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
+    RUBY
+    expect_correction(<<~RUBY)
+      bar = foo? ? "a" : "b"
     RUBY
   end
 
@@ -166,6 +169,13 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
         default['key-with-dash'] << b
       end
     RUBY
+    expect_correction(<<~RUBY)
+      default['key-with-dash'] << if condition
+        a
+      else
+        b
+      end
+    RUBY
   end
 
   it "doesn't crash with empty braces" do
@@ -179,38 +189,88 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
   end
 
   shared_examples 'comparison methods' do |method|
-    it 'registers an offense for comparison methods in if else' do
-      expect_offense(<<~RUBY)
-        if foo
-        ^^^^^^ Use the return of the conditional for variable assignment and comparison.
-          a #{method} b
-        else
-          a #{method} d
-        end
+    it 'registers an offense for comparison methods in ternary operations' do
+      source = "foo? ? bar #{method} 1 : bar #{method} 2"
+      expect_offense(<<~RUBY, source: source)
+        %{source}
+        ^{source} Use the return of the conditional for variable assignment and comparison.
+      RUBY
+      expect_correction(<<~RUBY)
+        bar #{method} (foo? ? 1 : 2)
       RUBY
     end
 
-    it 'registers an offense for comparison methods in unless else' do
-      expect_offense(<<~RUBY)
-        unless foo
-        ^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
-          a #{method} b
-        else
-          a #{method} d
-        end
-      RUBY
-    end
+    %w[start_of_line keyword].each do |align_with|
+      context "with end alignment to #{align_with}" do
+        let(:end_alignment_align_with) { align_with }
+        let(:indent_end) { align_with == 'keyword' }
 
-    it 'registers an offense for comparison methods in case when' do
-      expect_offense(<<~RUBY)
-        case foo
-        ^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
-        when bar
-          a #{method} b
-        else
-          a #{method} d
+        it 'corrects comparison methods in if elsif else' do
+          expect_offense(<<~RUBY)
+            if foo
+            ^^^^^^ Use the return of the conditional for variable assignment and comparison.
+              a #{method} b
+            elsif bar
+              a #{method} c
+            else
+              a #{method} d
+            end
+          RUBY
+
+          indent = ' ' * "a #{method} ".length if indent_end
+          expect_correction(<<~RUBY)
+            a #{method} if foo
+              b
+            elsif bar
+              c
+            else
+              d
+            #{indent}end
+          RUBY
         end
-      RUBY
+
+        it 'corrects comparison methods in unless else' do
+          expect_offense(<<~RUBY)
+            unless foo
+            ^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
+              a #{method} b
+            else
+              a #{method} d
+            end
+          RUBY
+
+          indent = ' ' * "a #{method} ".length if indent_end
+          expect_correction(<<~RUBY)
+            a #{method} unless foo
+              b
+            else
+              d
+            #{indent}end
+          RUBY
+        end
+
+        it 'corrects comparison methods in case when' do
+          expect_offense(<<~RUBY)
+            case foo
+            ^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
+            when bar
+              a #{method} b
+            else
+              a #{method} d
+            end
+          RUBY
+
+          indent = ' ' * "a #{method} ".length if indent_end
+          expect_correction(<<~RUBY)
+            a #{method} case foo
+            when bar
+              b
+            else
+              d
+            #{indent}end
+          RUBY
+        end
+      end
     end
   end
 
@@ -219,6 +279,9 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
   it_behaves_like('comparison methods', '=~')
   it_behaves_like('comparison methods', '!~')
   it_behaves_like('comparison methods', '<=>')
+  it_behaves_like('comparison methods', '===')
+  it_behaves_like('comparison methods', '<=')
+  it_behaves_like('comparison methods', '>=')
 
   context 'empty branch' do
     it 'allows an empty if statement' do
@@ -424,6 +487,13 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
         bar = #{'b' * 72}
       end
     RUBY
+    expect_correction(<<~RUBY)
+      bar = if foo
+        #{'a' * 72}
+      else
+        #{'b' * 72}
+      end
+    RUBY
   end
 
   context 'correction would exceed max line length' do
@@ -464,13 +534,18 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
     end
   end
 
-  shared_examples 'all variable types' do |variable|
+  shared_examples 'all variable types' do |variable, add_parens: false|
     it 'registers an offense assigning any variable type in ternary' do
       source = "foo? ? #{variable} = 1 : #{variable} = 2"
-      highlight = '^' * source.length
-      expect_offense(<<~RUBY)
-        #{source}
-        #{highlight} Use the return of the conditional for variable assignment and comparison.
+      expect_offense(<<~RUBY, source: source)
+        %{source}
+        ^{source} Use the return of the conditional for variable assignment and comparison.
+      RUBY
+
+      rhs = 'foo? ? 1 : 2'
+      rhs = "(#{rhs})" if add_parens
+      expect_correction(<<~RUBY)
+        #{variable} = #{rhs}
       RUBY
     end
 
@@ -483,6 +558,14 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
           #{variable} = 2
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        #{variable} = if foo
+          1
+        else
+          2
+        end
+      RUBY
     end
 
     it 'registers an offense assigning any variable type in case when' do
@@ -493,6 +576,15 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
           #{variable} = 1
         else
           #{variable} = 2
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        #{variable} = case foo
+        when "a"
+          1
+        else
+          2
         end
       RUBY
     end
@@ -527,87 +619,95 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
 
   it_behaves_like('all variable types', 'bar')
   it_behaves_like('all variable types', 'BAR')
-  it_behaves_like('all variable types', 'FOO::BAR')
   it_behaves_like('all variable types', '@bar')
   it_behaves_like('all variable types', '@@bar')
   it_behaves_like('all variable types', '$BAR')
-  it_behaves_like('all variable types', 'foo.bar')
+  it_behaves_like('all variable types', 'foo.bar', add_parens: true)
+  it_behaves_like('all variable types', 'foo[1]')
 
-  shared_examples 'all assignment types' do |assignment|
-    let(:end_alignment_align_with) { 'keyword' }
+  shared_examples 'all assignment types' do |assignment, add_parens: false|
+    variable_types = { 'local variable' => 'bar',
+                       'constant' => 'CONST',
+                       'class variable' => '@@cvar',
+                       'instance variable' => '@ivar',
+                       'global variable' => '$gvar' }
 
-    { 'local variable' => 'bar',
-      'constant' => 'CONST',
-      'class variable' => '@@cvar',
-      'instance variable' => '@ivar',
-      'global variable' => '$gvar' }.each do |type, name|
+    variable_types.each do |type, name|
       context "for a #{type} lval" do
         it "registers an offense for assignment using #{assignment} " \
-           'in ternary' do
+          'in ternary' do
           source = "foo? ? #{name} #{assignment} 1 : #{name} #{assignment} 2"
-          highlight = '^' * source.length
-          expect_offense(<<~RUBY)
-            #{source}
-            #{highlight} Use the return of the conditional for variable assignment and comparison.
+          expect_offense(<<~RUBY, source: source)
+            %{source}
+            ^{source} Use the return of the conditional for variable assignment and comparison.
           RUBY
-        end
 
-        it "allows assignment using #{assignment} to ternary" do
-          expect_no_offenses(<<~RUBY)
-            #{name} #{assignment} foo? ? 1 : 2
-          RUBY
-        end
-
-        it "registers an offense for assignment using #{assignment} in " \
-           'if else' do
-          expect_offense(<<~RUBY)
-            if foo
-            ^^^^^^ Use the return of the conditional for variable assignment and comparison.
-              #{name} #{assignment} 1
-            else
-              #{name} #{assignment} 2
-            end
-          RUBY
-        end
-
-        it "registers an offense for assignment using #{assignment} in "\
-        ' case when' do
-          expect_offense(<<~RUBY)
-            case foo
-            ^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
-            when "a"
-              #{name} #{assignment} 1
-            else
-              #{name} #{assignment} 2
-            end
-          RUBY
-        end
-
-        it "autocorrects for assignment using #{assignment} in if else" do
-          expect_offense(<<~RUBY)
-            if foo
-            ^^^^^^ Use the return of the conditional for variable assignment and comparison.
-              #{name} #{assignment} 1
-            else
-              #{name} #{assignment} 2
-            end
-          RUBY
-          indent = ' ' * "#{name} #{assignment} ".length
+          rhs = 'foo? ? 1 : 2'
+          rhs = "(#{rhs})" if add_parens
           expect_correction(<<~RUBY)
-            #{name} #{assignment} if foo
-              1
-            else
-              2
-            #{indent}end
+            #{name} #{assignment} #{rhs}
           RUBY
+        end
+      end
+    end
+
+    %w[start_of_line keyword].each do |align_with|
+      context "with end alignment to #{align_with}" do
+        let(:end_alignment_align_with) { align_with }
+        let(:indent_end) { align_with == 'keyword' }
+
+        variable_types.each do |type, name|
+          context "for a #{type} lval" do
+            it "registers an offense for assignment using #{assignment} in " \
+              'if else' do
+              expect_offense(<<~RUBY)
+                if foo
+                ^^^^^^ Use the return of the conditional for variable assignment and comparison.
+                  #{name} #{assignment} 1
+                else
+                  #{name} #{assignment} 2
+                end
+              RUBY
+
+              indent = ' ' * "#{name} #{assignment} ".length if indent_end
+              expect_correction(<<~RUBY)
+                #{name} #{assignment} if foo
+                  1
+                else
+                  2
+                #{indent}end
+              RUBY
+            end
+
+            it "registers an offense for assignment using #{assignment} in "\
+            ' case when' do
+              expect_offense(<<~RUBY)
+                case foo
+                ^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
+                when "a"
+                  #{name} #{assignment} 1
+                else
+                  #{name} #{assignment} 2
+                end
+              RUBY
+
+              indent = ' ' * "#{name} #{assignment} ".length if indent_end
+              expect_correction(<<~RUBY)
+                #{name} #{assignment} case foo
+                when "a"
+                  1
+                else
+                  2
+                #{indent}end
+              RUBY
+            end
+          end
         end
       end
     end
   end
 
   it_behaves_like('all assignment types', '=')
-  it_behaves_like('all assignment types', '==')
-  it_behaves_like('all assignment types', '===')
   it_behaves_like('all assignment types', '+=')
   it_behaves_like('all assignment types', '-=')
   it_behaves_like('all assignment types', '*=')
@@ -617,15 +717,13 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
   it_behaves_like('all assignment types', '^=')
   it_behaves_like('all assignment types', '&=')
   it_behaves_like('all assignment types', '|=')
-  it_behaves_like('all assignment types', '<=')
-  it_behaves_like('all assignment types', '>=')
   it_behaves_like('all assignment types', '<<=')
   it_behaves_like('all assignment types', '>>=')
   it_behaves_like('all assignment types', '||=')
   it_behaves_like('all assignment types', '&&=')
   it_behaves_like('all assignment types', '+=')
-  it_behaves_like('all assignment types', '<<')
   it_behaves_like('all assignment types', '-=')
+  it_behaves_like('all assignment types', '<<', add_parens: true)
 
   it 'registers an offense for assignment in if elsif else' do
     expect_offense(<<~RUBY)
@@ -636,6 +734,15 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
         bar = 2
       else
         bar = 3
+      end
+    RUBY
+    expect_correction(<<~RUBY)
+      bar = if foo
+        1
+      elsif baz
+        2
+      else
+        3
       end
     RUBY
   end
@@ -651,6 +758,17 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
         bar = 3
       else
         bar = 4
+      end
+    RUBY
+    expect_correction(<<~RUBY)
+      bar = if foo
+        1
+      elsif baz
+        2
+      elsif foobar
+        3
+      else
+        4
       end
     RUBY
   end
@@ -991,11 +1109,18 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
     end
   end
 
-  it 'registers an offense for assignment in if then else' do
+  it 'registers an offense for assignment in if then elsif then else' do
     expect_offense(<<~RUBY)
       if foo then bar = 1
       ^^^^^^^^^^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
+      elsif cond then bar = 2
       else bar = 2
+      end
+    RUBY
+    expect_correction(<<~RUBY)
+      bar = if foo then 1
+      elsif cond then 2
+      else 2
       end
     RUBY
   end
@@ -1009,6 +1134,13 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
         bar = 2
       end
     RUBY
+    expect_correction(<<~RUBY)
+      bar = unless foo
+        1
+      else
+        2
+      end
+    RUBY
   end
 
   it 'registers an offense for assignment in case when then else' do
@@ -1017,6 +1149,12 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
       ^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
       when bar then baz = 1
       else baz = 2
+      end
+    RUBY
+    expect_correction(<<~RUBY)
+      baz = case foo
+      when bar then 1
+      else 2
       end
     RUBY
   end
@@ -1031,6 +1169,16 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
         bar = 2
       else
         bar = 3
+      end
+    RUBY
+    expect_correction(<<~RUBY)
+      bar = case foo
+      when foobar
+        1
+      when baz
+        2
+      else
+        3
       end
     RUBY
   end
@@ -1057,126 +1205,14 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
     RUBY
   end
 
-  context 'auto-correct' do
-    shared_examples 'comparison correction' do |method|
-      let(:end_alignment_align_with) { 'keyword' }
-
-      it 'corrects comparison methods in if elsif else' do
-        expect_offense(<<~RUBY)
-          if foo
-          ^^^^^^ Use the return of the conditional for variable assignment and comparison.
-            a #{method} b
-          elsif bar
-            a #{method} c
-          else
-            a #{method} d
-          end
-        RUBY
-
-        indent = ' ' * "a #{method} ".length
-        expect_correction(<<~RUBY)
-          a #{method} if foo
-            b
-          elsif bar
-            c
-          else
-            d
-          #{indent}end
-        RUBY
-      end
-
-      it 'corrects comparison methods in unless else' do
-        expect_offense(<<~RUBY)
-          unless foo
-          ^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
-            a #{method} b
-          else
-            a #{method} d
-          end
-        RUBY
-
-        indent = ' ' * "a #{method} ".length
-        expect_correction(<<~RUBY)
-          a #{method} unless foo
-            b
-          else
-            d
-          #{indent}end
-        RUBY
-      end
-
-      it 'corrects comparison methods in case when' do
-        expect_offense(<<~RUBY)
-          case foo
-          ^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
-          when bar
-            a #{method} b
-          else
-            a #{method} d
-          end
-        RUBY
-
-        indent = ' ' * "a #{method} ".length
-        expect_correction(<<~RUBY)
-          a #{method} case foo
-          when bar
-            b
-          else
-            d
-          #{indent}end
-        RUBY
-      end
-    end
-
-    it_behaves_like('comparison correction', '==')
-    it_behaves_like('comparison correction', '!=')
-    it_behaves_like('comparison correction', '=~')
-    it_behaves_like('comparison correction', '!~')
-    it_behaves_like('comparison correction', '<=>')
-
-    it 'corrects assignment in ternary operations' do
-      new_source = autocorrect_source('foo? ? bar = 1 : bar = 2')
-
-      expect(new_source).to eq('bar = foo? ? 1 : 2')
-    end
-
-    it 'corrects assignment in ternary operations using strings' do
-      new_source = autocorrect_source('foo? ? bar = "1" : bar = "2"')
-
-      expect(new_source).to eq('bar = foo? ? "1" : "2"')
-    end
-
+  describe 'auto-correct' do
     it 'corrects =~ in ternary operations' do
-      new_source = autocorrect_source('foo? ? bar =~ /a/ : bar =~ /b/')
-      expect(new_source).to eq('bar =~ (foo? ? /a/ : /b/)')
-    end
-
-    it 'corrects aref assignment in ternary operations' do
-      new_source = autocorrect_source('foo? ? bar[1] = 1 : bar[1] = 2')
-      expect(new_source).to eq('bar[1] = foo? ? 1 : 2')
-    end
-
-    it 'corrects << in ternary operations' do
-      new_source = autocorrect_source('foo? ? bar << 1 : bar << 2')
-      expect(new_source).to eq('bar << (foo? ? 1 : 2)')
-    end
-
-    it 'corrects assignment in if else' do
-      expect_offense(<<~RUBY)
-        if foo
-        ^^^^^^ Use the return of the conditional for variable assignment and comparison.
-          bar = 1
-        else
-          bar = 2
-        end
+      expect_offense(<<~'RUBY')
+        foo? ? bar =~ /a/ : bar =~ /b/
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
       RUBY
-
-      expect_correction(<<~RUBY)
-        bar = if foo
-          1
-        else
-          2
-        end
+      expect_correction(<<~'RUBY')
+        bar =~ (foo? ? /a/ : /b/)
       RUBY
     end
 
@@ -1195,193 +1231,6 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
           1
         else
           [2, 5, 6]
-        end
-      RUBY
-    end
-
-    it 'corrects assignment in if elsif else' do
-      expect_offense(<<~RUBY)
-        if foo
-        ^^^^^^ Use the return of the conditional for variable assignment and comparison.
-          bar = 1
-        elsif baz
-          bar = 2
-        else
-          bar = 3
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        bar = if foo
-          1
-        elsif baz
-          2
-        else
-          3
-        end
-      RUBY
-    end
-
-    shared_examples '2 or 3 character assignment types' do |asgn|
-      it "corrects assignment using #{asgn} in if elsif else" do
-        expect_offense(<<~RUBY)
-          if foo
-          ^^^^^^ Use the return of the conditional for variable assignment and comparison.
-            bar #{asgn} 1
-          elsif baz
-            bar #{asgn} 2
-          else
-            bar #{asgn} 3
-          end
-        RUBY
-
-        expect_correction(<<~RUBY)
-          bar #{asgn} if foo
-            1
-          elsif baz
-            2
-          else
-            3
-          end
-        RUBY
-      end
-
-      it "corrects assignment using #{asgn} in case when else" do
-        expect_offense(<<~RUBY)
-          case foo
-          ^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
-          when bar
-            baz #{asgn} 1
-          else
-            baz #{asgn} 2
-          end
-        RUBY
-
-        expect_correction(<<~RUBY)
-          baz #{asgn} case foo
-          when bar
-            1
-          else
-            2
-          end
-        RUBY
-      end
-
-      it "corrects assignment using #{asgn} in unless else" do
-        expect_offense(<<~RUBY)
-          unless foo
-          ^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
-            bar #{asgn} 1
-          else
-            bar #{asgn} 2
-          end
-        RUBY
-
-        expect_correction(<<~RUBY)
-          bar #{asgn} unless foo
-            1
-          else
-            2
-          end
-        RUBY
-      end
-    end
-
-    it_behaves_like('2 or 3 character assignment types', '+=')
-    it_behaves_like('2 or 3 character assignment types', '-=')
-    it_behaves_like('2 or 3 character assignment types', '<<')
-
-    it_behaves_like('2 or 3 character assignment types', '&&=')
-    it_behaves_like('2 or 3 character assignment types', '||=')
-
-    it 'corrects assignment in if elsif else with multiple elsifs' do
-      expect_offense(<<~RUBY)
-        if foo
-        ^^^^^^ Use the return of the conditional for variable assignment and comparison.
-          bar = 1
-        elsif baz
-          bar = 2
-        elsif foobar
-          bar = 3
-        else
-          bar = 4
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        bar = if foo
-          1
-        elsif baz
-          2
-        elsif foobar
-          3
-        else
-          4
-        end
-      RUBY
-    end
-
-    it 'corrects assignment in unless else' do
-      expect_offense(<<~RUBY)
-        unless foo
-        ^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
-          bar = 1
-        else
-          bar = 2
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        bar = unless foo
-          1
-        else
-          2
-        end
-      RUBY
-    end
-
-    it 'corrects assignment in case when else' do
-      expect_offense(<<~RUBY)
-        case foo
-        ^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
-        when bar
-          baz = 1
-        else
-          baz = 2
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        baz = case foo
-        when bar
-          1
-        else
-          2
-        end
-      RUBY
-    end
-
-    it 'corrects assignment in case when else with multiple whens' do
-      expect_offense(<<~RUBY)
-        case foo
-        ^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
-        when bar
-          baz = 1
-        when foobar
-          baz = 2
-        else
-          baz = 3
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        baz = case foo
-        when bar
-          1
-        when foobar
-          2
-        else
-          3
         end
       RUBY
     end
@@ -1442,42 +1291,6 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             foobar(var, all)
           else
             baz(var, all)
-          end
-        RUBY
-      end
-    end
-
-    context 'then' do
-      it 'corrects if then elsif then else' do
-        expect_offense(<<~RUBY)
-          if cond then bar = 1
-          ^^^^^^^^^^^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
-          elsif cond then bar = 2
-          else bar = 3
-          end
-        RUBY
-
-        expect_correction(<<~RUBY)
-          bar = if cond then 1
-          elsif cond then 2
-          else 3
-          end
-        RUBY
-      end
-
-      it 'corrects case when then else' do
-        expect_offense(<<~RUBY)
-          case foo
-          ^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
-          when baz then bar = 1
-          else bar = 2
-          end
-        RUBY
-
-        expect_correction(<<~RUBY)
-          bar = case foo
-          when baz then 1
-          else 2
           end
         RUBY
       end
@@ -1654,6 +1467,16 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 2
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          bar = if foo
+            method_call
+            1
+          else
+            method_call
+            2
+                end
+        RUBY
       end
 
       it 'registers an offense in if elsif else with more than ' \
@@ -1671,6 +1494,19 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 3
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          bar = if foo
+            method_call
+            1
+          elsif foobar
+            method_call
+            2
+          else
+            method_call
+            3
+                end
+        RUBY
       end
 
       it 'register an offense for multiple assignment in if else' do
@@ -1683,6 +1519,16 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             foo = 2
             bar = 2
           end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          bar = if baz
+            foo = 1
+            1
+          else
+            foo = 2
+            2
+                end
         RUBY
       end
 
@@ -1699,6 +1545,19 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             foo = 3
             bar = 3
           end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          bar = if baz
+            foo = 1
+            1
+          elsif foobar
+            foo = 2
+            2
+          else
+            foo = 3
+            3
+                end
         RUBY
       end
 
@@ -1719,6 +1578,22 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 4
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          bar = if baz
+            foo = 1
+            1
+          elsif foobar
+            foo = 2
+            2
+          elsif barfoo
+            foo = 3
+            3
+          else
+            foo = 4
+            4
+                end
+        RUBY
       end
 
       it_behaves_like 'allows out of order multiple assignment in if elsif else'
@@ -1734,6 +1609,16 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 2
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          bar = unless baz
+            foo = 1
+            1
+          else
+            foo = 2
+            2
+                end
+        RUBY
       end
 
       it 'registers offense for multiple assignments in case when with only ' \
@@ -1748,6 +1633,17 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             foo = 3
             bar = 3
           end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          bar = case foo
+          when foobar
+            foo = 1
+            1
+          else
+            foo = 3
+            3
+                end
         RUBY
       end
 
@@ -1766,6 +1662,20 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             foo = 3
             bar = 3
           end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          bar = case foo
+          when foobar
+            foo = 1
+            1
+          when foobaz
+            foo = 2
+            2
+          else
+            foo = 3
+            3
+                end
         RUBY
       end
 
@@ -1786,6 +1696,20 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 4
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          bar = if foo
+            1
+          elsif foobar
+            method_call
+            2
+          elsif baz
+            3
+          else
+            method_call
+            4
+                end
+        RUBY
       end
 
       it 'registers an offense in unless else with more than ' \
@@ -1799,6 +1723,16 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             method_call
             bar = 2
           end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          bar = unless foo
+            method_call
+            1
+          else
+            method_call
+            2
+                end
         RUBY
       end
 
@@ -1814,6 +1748,17 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             method_call
             bar = 2
           end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          bar = case foo
+          when foobar
+            method_call
+            1
+          else
+            method_call
+            2
+                end
         RUBY
       end
 
@@ -1832,6 +1777,19 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
               bar = 3
             end
           RUBY
+
+          expect_correction(<<~RUBY)
+            bar = if foo
+              baz = 1
+              1
+            elsif foobar
+              method_call
+              2
+            else
+              other_method
+              3
+                  end
+          RUBY
         end
 
         it 'registers an offense when multiple assignment is in elsif' do
@@ -1848,6 +1806,19 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
               bar = 3
             end
           RUBY
+
+          expect_correction(<<~RUBY)
+            bar = if foo
+              method_call
+              1
+            elsif foobar
+              baz = 2
+              2
+            else
+              other_method
+              3
+                  end
+          RUBY
         end
 
         it 'registers an offense when multiple assignment is in else' do
@@ -1863,6 +1834,19 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
               baz = 3
               bar = 3
             end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            bar = if foo
+              method_call
+              1
+            elsif foobar
+              other_method
+              2
+            else
+              baz = 3
+              3
+                  end
           RUBY
         end
       end
@@ -1892,6 +1876,16 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
           bar << 3 if foobar
           bar << 4
         end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        bar << if foo
+          bar << 1
+          2
+        else
+          bar << 3 if foobar
+          4
+               end
       RUBY
     end
 

--- a/spec/rubocop/cop/style/copyright_spec.rb
+++ b/spec/rubocop/cop/style/copyright_spec.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-def expect_copyright_offense(cop, source)
-  inspect_source(source)
-  expect(cop.offenses.size).to eq(1)
-end
-
 RSpec.describe RuboCop::Cop::Style::Copyright, :config do
   let(:cop_config) { { 'Notice' => 'Copyright (\(c\) )?2015 Acme Inc' } }
 
@@ -40,19 +35,17 @@ RSpec.describe RuboCop::Cop::Style::Copyright, :config do
   context 'when the copyright notice is missing' do
     let(:source) { <<~RUBY }
       # test
+      ^ Include a copyright notice matching [...]
       # test2
       names = Array.new
       names << 'James'
     RUBY
 
     it 'adds an offense' do
-      expect_copyright_offense(cop, source)
-    end
-
-    it 'correctly autocorrects the source code' do
       cop_config['AutocorrectNotice'] = '# Copyright (c) 2015 Acme Inc.'
 
-      expect(autocorrect_source(source)).to eq(<<~RUBY)
+      expect_offense(source)
+      expect_correction(<<~RUBY)
         # Copyright (c) 2015 Acme Inc.
         # test
         # test2
@@ -65,34 +58,30 @@ RSpec.describe RuboCop::Cop::Style::Copyright, :config do
        'not match the Notice pattern' do
       cop_config['AutocorrectNotice'] = '# Copyleft (c) 2015 Acme Inc.'
       expect do
-        autocorrect_source(source)
+        expect_offense(source)
       end.to raise_error(RuboCop::Warning)
     end
 
     it 'fails to autocorrect if no AutocorrectNotice is given' do
       # cop_config['AutocorrectNotice'] = '# Copyleft (c) 2015 Acme Inc.'
       expect do
-        autocorrect_source(source)
+        expect_offense(source)
       end.to raise_error(RuboCop::Warning)
     end
   end
 
   context 'when the copyright notice comes after any code' do
-    let(:source) { <<~RUBY }
-      # test2
-      names = Array.new
-      # Copyright (c) 2015 Acme Inc.
-      names << 'James'
-    RUBY
-
     it 'adds an offense' do
-      expect_copyright_offense(cop, source)
-    end
-
-    it 'correctly autocorrects the source code' do
       cop_config['AutocorrectNotice'] = '# Copyright (c) 2015 Acme Inc.'
 
-      expect(autocorrect_source(source)).to eq(<<~RUBY)
+      expect_offense(<<~RUBY)
+        # test2
+        ^ Include a copyright notice matching [...]
+        names = Array.new
+        # Copyright (c) 2015 Acme Inc.
+        names << 'James'
+      RUBY
+      expect_correction(<<~RUBY)
         # Copyright (c) 2015 Acme Inc.
         # test2
         names = Array.new
@@ -103,36 +92,30 @@ RSpec.describe RuboCop::Cop::Style::Copyright, :config do
   end
 
   context 'when the source code file is empty' do
-    let(:source) { '' }
-
     it 'adds an offense' do
-      expect_copyright_offense(cop, source)
-    end
-
-    it 'correctly autocorrects the source code' do
       cop_config['AutocorrectNotice'] = '# Copyright (c) 2015 Acme Inc.'
 
-      expect(autocorrect_source(source))
-        .to eq("# Copyright (c) 2015 Acme Inc.\n")
+      expect_offense(<<~'RUBY')
+        ^ Include a copyright notice matching [...]
+      RUBY
+      expect_correction(<<~RUBY)
+        # Copyright (c) 2015 Acme Inc.
+      RUBY
     end
   end
 
   context 'when the copyright notice is missing and ' \
           'the source code file starts with a shebang' do
-    let(:source) { <<~RUBY }
-      #!/usr/bin/env ruby
-      names = Array.new
-      names << 'James'
-    RUBY
-
     it 'adds an offense' do
-      expect_copyright_offense(cop, source)
-    end
-
-    it 'correctly autocorrects the source code' do
       cop_config['AutocorrectNotice'] = '# Copyright (c) 2015 Acme Inc.'
 
-      expect(autocorrect_source(source)).to eq(<<~RUBY)
+      expect_offense(<<~RUBY)
+        #!/usr/bin/env ruby
+        ^ Include a copyright notice matching [...]
+        names = Array.new
+        names << 'James'
+      RUBY
+      expect_correction(<<~RUBY)
         #!/usr/bin/env ruby
         # Copyright (c) 2015 Acme Inc.
         names = Array.new
@@ -143,20 +126,16 @@ RSpec.describe RuboCop::Cop::Style::Copyright, :config do
 
   context 'when the copyright notice is missing and ' \
           'the source code file starts with an encoding comment' do
-    let(:source) { <<~RUBY }
-      # encoding: utf-8
-      names = Array.new
-      names << 'James'
-    RUBY
-
     it 'adds an offense' do
-      expect_copyright_offense(cop, source)
-    end
-
-    it 'correctly autocorrects the source code' do
       cop_config['AutocorrectNotice'] = '# Copyright (c) 2015 Acme Inc.'
 
-      expect(autocorrect_source(source)).to eq(<<~RUBY)
+      expect_offense(<<~RUBY)
+        # encoding: utf-8
+        ^ Include a copyright notice matching [...]
+        names = Array.new
+        names << 'James'
+      RUBY
+      expect_correction(<<~RUBY)
         # encoding: utf-8
         # Copyright (c) 2015 Acme Inc.
         names = Array.new
@@ -168,21 +147,17 @@ RSpec.describe RuboCop::Cop::Style::Copyright, :config do
   context 'when the copyright notice is missing and ' \
           'the source code file starts with shebang and ' \
           'an encoding comment' do
-    let(:source) { <<~RUBY }
-      #!/usr/bin/env ruby
-      # encoding: utf-8
-      names = Array.new
-      names << 'James'
-    RUBY
-
     it 'adds an offense' do
-      expect_copyright_offense(cop, source)
-    end
-
-    it 'correctly autocorrects the source code' do
       cop_config['AutocorrectNotice'] = '# Copyright (c) 2015 Acme Inc.'
 
-      expect(autocorrect_source(source)).to eq(<<~RUBY)
+      expect_offense(<<~RUBY)
+        #!/usr/bin/env ruby
+        ^ Include a copyright notice matching [...]
+        # encoding: utf-8
+        names = Array.new
+        names << 'James'
+      RUBY
+      expect_correction(<<~RUBY)
         #!/usr/bin/env ruby
         # encoding: utf-8
         # Copyright (c) 2015 Acme Inc.

--- a/spec/rubocop/cop/style/def_with_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/def_with_parentheses_spec.rb
@@ -9,12 +9,22 @@ RSpec.describe RuboCop::Cop::Style::DefWithParentheses do
               ^ Omit the parentheses in defs when the method doesn't accept any arguments.
       end
     RUBY
+    expect_correction(<<~RUBY)
+      def func
+      end
+    RUBY
   end
 
   it 'reports an offense for class def with empty parens' do
     expect_offense(<<~RUBY)
       def Test.func()
                    ^ Omit the parentheses in defs when the method doesn't accept any arguments.
+        something
+      end
+    RUBY
+    expect_correction(<<~RUBY)
+      def Test.func
+        something
       end
     RUBY
   end
@@ -28,18 +38,5 @@ RSpec.describe RuboCop::Cop::Style::DefWithParentheses do
 
   it 'accepts empty parentheses in one liners' do
     expect_no_offenses("def to_s() join '/' end")
-  end
-
-  it 'auto-removes unneeded parens' do
-    new_source = autocorrect_source(<<~RUBY)
-      def test();
-      something
-      end
-    RUBY
-    expect(new_source).to eq(<<~RUBY)
-      def test;
-      something
-      end
-    RUBY
   end
 end

--- a/spec/rubocop/cop/style/dir_spec.rb
+++ b/spec/rubocop/cop/style/dir_spec.rb
@@ -1,19 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::Dir, :config do
-  shared_examples 'auto-correct' do |original, expected|
-    it 'auto-corrects' do
-      new_source = autocorrect_source(original)
-
-      expect(new_source).to eq(expected)
-    end
-  end
-
   context 'when using `#expand_path` and `#dirname`' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         File.expand_path(File.dirname(__FILE__))
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `__dir__` to get an absolute path to the current file's directory.
+      RUBY
+      expect_correction(<<~RUBY)
+        __dir__
       RUBY
     end
 
@@ -22,15 +17,10 @@ RSpec.describe RuboCop::Cop::Style::Dir, :config do
         ::File.expand_path(::File.dirname(__FILE__))
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `__dir__` to get an absolute path to the current file's directory.
       RUBY
+      expect_correction(<<~RUBY)
+        __dir__
+      RUBY
     end
-
-    it_behaves_like 'auto-correct',
-                    'File.expand_path(File.dirname(__FILE__))',
-                    '__dir__'
-
-    it_behaves_like 'auto-correct',
-                    '::File.expand_path(::File.dirname(__FILE__))',
-                    '__dir__'
   end
 
   context 'when using `#dirname` and `#realpath`' do
@@ -39,6 +29,9 @@ RSpec.describe RuboCop::Cop::Style::Dir, :config do
         File.dirname(File.realpath(__FILE__))
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `__dir__` to get an absolute path to the current file's directory.
       RUBY
+      expect_correction(<<~RUBY)
+        __dir__
+      RUBY
     end
 
     it 'registers an offense with ::File' do
@@ -46,14 +39,9 @@ RSpec.describe RuboCop::Cop::Style::Dir, :config do
         ::File.dirname(::File.realpath(__FILE__))
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `__dir__` to get an absolute path to the current file's directory.
       RUBY
+      expect_correction(<<~RUBY)
+        __dir__
+      RUBY
     end
-
-    it_behaves_like 'auto-correct',
-                    'File.dirname(File.realpath(__FILE__))',
-                    '__dir__'
-
-    it_behaves_like 'auto-correct',
-                    '::File.dirname(::File.realpath(__FILE__))',
-                    '__dir__'
   end
 end

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -221,8 +221,9 @@ RSpec.describe RuboCop::Cop::Style::Documentation do
 
   it 'does not raise an error for an implicit match conditional' do
     expect do
-      inspect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         class Test
+        ^^^^^ Missing top-level class documentation comment.
           if //
           end
         end
@@ -280,16 +281,16 @@ RSpec.describe RuboCop::Cop::Style::Documentation do
       end
 
       it "ignores sparse comments inside #{keyword} node" do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY, keyword: keyword)
           module TestModule
-            #{keyword} Test
+            %{keyword} Test
+            ^{keyword} Missing top-level #{keyword} documentation comment.
               def method
               end
               # sparse comment
             end
           end
         RUBY
-        expect(cop.offenses.size).to eq(1)
       end
     end
   end
@@ -315,16 +316,16 @@ RSpec.describe RuboCop::Cop::Style::Documentation do
       end
 
       it "registers an offense for nested #{keyword} without documentation" do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY, keyword: keyword)
           module TestModule #:nodoc:
             TEST = 20
-            #{keyword} Test
+            %{keyword} Test
+            ^{keyword} Missing top-level #{keyword} documentation comment.
               def method
               end
             end
           end
         RUBY
-        expect(cop.offenses.size).to eq(1)
       end
 
       context 'with `all` modifier' do

--- a/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
+++ b/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
@@ -3,36 +3,6 @@
 RSpec.describe RuboCop::Cop::Style::EachForSimpleLoop do
   subject(:cop) { described_class.new }
 
-  it 'registers offense for inclusive end range' do
-    expect_offense(<<~RUBY)
-      (0..10).each {}
-      ^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
-    RUBY
-  end
-
-  it 'registers offense for exclusive end range' do
-    expect_offense(<<~RUBY)
-      (0...10).each {}
-      ^^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
-    RUBY
-  end
-
-  it 'registers offense for exclusive end range with do ... end syntax' do
-    expect_offense(<<~RUBY)
-      (0...10).each do
-      ^^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
-      end
-    RUBY
-  end
-
-  it 'registers an offense for range not starting with zero' do
-    expect_offense(<<~RUBY)
-      (3..7).each do
-      ^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
-      end
-    RUBY
-  end
-
   it 'does not register offense if range startpoint is not constant' do
     expect_no_offenses('(a..10).each {}')
   end
@@ -56,83 +26,95 @@ RSpec.describe RuboCop::Cop::Style::EachForSimpleLoop do
     expect_no_offenses("('a'..'b').each {}")
   end
 
-  context 'when using an inclusive range' do
+  context 'when using an inclusive end range' do
     it 'autocorrects the source with inline block' do
-      corrected = autocorrect_source('(0..10).each {}')
-      expect(corrected).to eq '11.times {}'
+      expect_offense(<<~RUBY)
+        (0..10).each {}
+        ^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
+      RUBY
+      expect_correction(<<~RUBY)
+        11.times {}
+      RUBY
     end
 
     it 'autocorrects the source with multiline block' do
-      corrected = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         (0..10).each do
+        ^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
         end
       RUBY
 
-      expect(corrected).to eq <<~RUBY
+      expect_correction(<<~RUBY)
         11.times do
         end
       RUBY
     end
 
     it 'autocorrects the range not starting with zero' do
-      corrected = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         (3..7).each do
+        ^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
         end
       RUBY
 
-      expect(corrected).to eq <<~RUBY
+      expect_correction(<<~RUBY)
         5.times do
         end
       RUBY
     end
 
-    it 'does not autocorrect range not starting with zero and using param' do
-      source = <<~RUBY
+    it 'does not register offense for range not starting with zero and ' \
+       'using param' do
+      expect_no_offenses(<<~RUBY)
         (3..7).each do |n|
         end
       RUBY
-      corrected = autocorrect_source(source)
-      expect(corrected).to eq(source)
     end
   end
 
-  context 'when using an exclusive range' do
+  context 'when using an exclusive end range' do
     it 'autocorrects the source with inline block' do
-      corrected = autocorrect_source('(0...10).each {}')
-      expect(corrected).to eq '10.times {}'
+      expect_offense(<<~RUBY)
+        (0...10).each {}
+        ^^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
+      RUBY
+      expect_correction(<<~RUBY)
+        10.times {}
+      RUBY
     end
 
     it 'autocorrects the source with multiline block' do
-      corrected = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         (0...10).each do
+        ^^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
         end
       RUBY
 
-      expect(corrected).to eq <<~RUBY
+      expect_correction(<<~RUBY)
         10.times do
         end
       RUBY
     end
 
     it 'autocorrects the range not starting with zero' do
-      corrected = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         (3...7).each do
+        ^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
         end
       RUBY
 
-      expect(corrected).to eq <<~RUBY
+      expect_correction(<<~RUBY)
         4.times do
         end
       RUBY
     end
 
-    it 'does not autocorrect range not starting with zero and using param' do
-      source = <<~RUBY
+    it 'does not register offense for range not starting with zero and ' \
+       'using param' do
+      expect_no_offenses(<<~RUBY)
         (3...7).each do |n|
         end
       RUBY
-      corrected = autocorrect_source(source)
-      expect(corrected).to eq(source)
     end
   end
 end

--- a/spec/rubocop/cop/style/each_with_object_spec.rb
+++ b/spec/rubocop/cop/style/each_with_object_spec.rb
@@ -15,17 +15,25 @@ RSpec.describe RuboCop::Cop::Style::EachWithObject do
         a
       end
     RUBY
+    expect_correction(<<~RUBY)
+      [].each_with_object({}) { |e, a|  }
+
+      [].each_with_object({}) do |e, a|
+        a[e] = 1
+        a[e] = 1
+      end
+    RUBY
   end
 
   it 'correctly autocorrects' do
-    corrected = autocorrect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       [1, 2, 3].inject({}) do |h, i|
+                ^^^^^^ Use `each_with_object` instead of `inject`.
         h[i] = i
         h
       end
     RUBY
-
-    expect(corrected).to eq(<<~RUBY)
+    expect_correction(<<~RUBY)
       [1, 2, 3].each_with_object({}) do |i, h|
         h[i] = i
       end
@@ -33,13 +41,13 @@ RSpec.describe RuboCop::Cop::Style::EachWithObject do
   end
 
   it 'correctly autocorrects with return value only' do
-    corrected = autocorrect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       [1, 2, 3].inject({}) do |h, i|
+                ^^^^^^ Use `each_with_object` instead of `inject`.
         h
       end
     RUBY
-
-    expect(corrected).to eq(<<~RUBY)
+    expect_correction(<<~RUBY)
       [1, 2, 3].each_with_object({}) do |i, h|
       end
     RUBY

--- a/spec/rubocop/cop/style/empty_case_condition_spec.rb
+++ b/spec/rubocop/cop/style/empty_case_condition_spec.rb
@@ -3,21 +3,13 @@
 RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition do
   subject(:cop) { described_class.new }
 
-  let(:message) do
-    'Do not use empty `case` condition, instead use an `if` expression.'
-  end
-
   shared_examples 'detect/correct empty case, accept non-empty case' do
-    it 'registers an offense' do
-      inspect_source(source)
-      expect(cop.messages).to eq [message]
+    it 'registers an offense and autocorrects' do
+      expect_offense(source)
+      expect_correction(corrected_source)
     end
 
-    it 'correctly autocorrects' do
-      expect(autocorrect_source(source)).to eq corrected_source
-    end
-
-    let(:source_with_case) { source.sub(/case/, 'case :a') }
+    let(:source_with_case) { source.sub(/case/, 'case :a').sub(/^\s*\^.*\n/, '') }
 
     it 'accepts the source with case' do
       expect_no_offenses(source_with_case)
@@ -29,6 +21,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition do
       let(:source) do
         <<~RUBY
           case
+          ^^^^ Do not use empty `case` condition, instead use an `if` expression.
           when 1 == 2
             foo
           when 1 == 1
@@ -57,6 +50,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition do
       let(:source) do
         <<~RUBY
           case
+          ^^^^ Do not use empty `case` condition, instead use an `if` expression.
           # condition a
           # This is a multi-line comment
           when 1 == 2
@@ -70,7 +64,6 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition do
           end
         RUBY
       end
-
       let(:corrected_source) do
         <<~RUBY
           # condition a
@@ -94,6 +87,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition do
       let(:source) do
         <<~RUBY
           case
+          ^^^^ Do not use empty `case` condition, instead use an `if` expression.
           when 1 == 2
             foo
           when 1 == 1
@@ -118,6 +112,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition do
       let(:source) do
         <<~RUBY
           case
+          ^^^^ Do not use empty `case` condition, instead use an `if` expression.
           when 1 == 2
             foo
           else
@@ -142,6 +137,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition do
       let(:source) do
         <<~RUBY
           case
+          ^^^^ Do not use empty `case` condition, instead use an `if` expression.
           when 1 == 2
             foo
           end
@@ -162,6 +158,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition do
       let(:source) do
         <<~RUBY
           case
+          ^^^^ Do not use empty `case` condition, instead use an `if` expression.
           when false
             foo
           when nil, false, 1
@@ -190,6 +187,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition do
       let(:source) do
         <<~RUBY
           case
+          ^^^^ Do not use empty `case` condition, instead use an `if` expression.
           when false then foo
           when nil, false, 1 then bar
           when false, 1 then baz
@@ -212,6 +210,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition do
       let(:source) do
         <<~RUBY
           case
+          ^^^^ Do not use empty `case` condition, instead use an `if` expression.
           when my.foo?, my.bar?
             something
           when my.baz?
@@ -236,6 +235,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition do
       let(:source) do
         <<~RUBY
           do_some_work case
+                       ^^^^ Do not use empty `case` condition, instead use an `if` expression.
                        when object.nil?
                          Object.new
                        else
@@ -261,6 +261,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition do
         <<~RUBY
           # example.rb
           do_some_work case
+                       ^^^^ Do not use empty `case` condition, instead use an `if` expression.
                        when object.nil?
                          Object.new
                        else

--- a/spec/rubocop/cop/style/empty_method_spec.rb
+++ b/spec/rubocop/cop/style/empty_method_spec.rb
@@ -1,221 +1,274 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
-  before do
-    inspect_source(source)
-  end
-
-  shared_examples 'code with offense' do |code, expected|
-    context "when checking #{code}" do
-      let(:source) { code }
-
-      it 'registers an offense' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages).to eq([message])
-      end
-
-      if expected
-        it 'auto-corrects' do
-          expect(autocorrect_source(code)).to eq(expected)
-        end
-      else
-        it 'does not auto-correct' do
-          expect(autocorrect_source(code)).to eq(code)
-        end
-      end
-    end
-  end
-
-  shared_examples 'code without offense' do |code|
-    let(:source) { code }
-
-    it 'does not register an offense' do
-      expect(cop.offenses.empty?).to be(true)
-    end
-  end
-
   context 'when configured with compact style' do
     let(:cop_config) { { 'EnforcedStyle' => 'compact' } }
 
-    let(:message) { 'Put empty method definitions on a single line.' }
-
     context 'with an empty instance method definition' do
-      it_behaves_like 'code with offense',
-                      ['def foo',
-                       'end'].join("\n"),
-                      'def foo; end'
+      it 'registers an offense for empty method' do
+        expect_offense(<<~'RUBY')
+          def foo
+          ^^^^^^^ Put empty method definitions on a single line.
+          end
+        RUBY
+        expect_correction(<<~'RUBY')
+          def foo; end
+        RUBY
+      end
 
-      it_behaves_like 'code with offense',
-                      ['def foo(bar, baz)',
-                       'end'].join("\n"),
-                      'def foo(bar, baz); end'
+      it 'registers an offense for method with arguments' do
+        expect_offense(<<~'RUBY')
+          def foo(bar, baz)
+          ^^^^^^^^^^^^^^^^^ Put empty method definitions on a single line.
+          end
+        RUBY
+        expect_correction(<<~'RUBY')
+          def foo(bar, baz); end
+        RUBY
+      end
 
-      it_behaves_like 'code with offense',
-                      ['def foo bar, baz',
-                       'end'].join("\n"),
-                      'def foo bar, baz; end'
+      it 'registers an offense for method with arguments without parens' do
+        expect_offense(<<~'RUBY')
+          def foo bar, baz
+          ^^^^^^^^^^^^^^^^ Put empty method definitions on a single line.
+          end
+        RUBY
+        expect_correction(<<~'RUBY')
+          def foo bar, baz; end
+        RUBY
+      end
 
-      it_behaves_like 'code with offense',
-                      ['def foo',
-                       '',
-                       'end'].join("\n"),
-                      'def foo; end'
+      it 'registers an offense for method with blank line' do
+        expect_offense(<<~'RUBY')
+          def foo
+          ^^^^^^^ Put empty method definitions on a single line.
 
-      it_behaves_like 'code with offense',
-                      ['def foo(arg',
-                       '); end'].join("\n"),
-                      'def foo(arg); end'
+          end
+        RUBY
+        expect_correction(<<~'RUBY')
+          def foo; end
+        RUBY
+      end
 
-      it_behaves_like 'code without offense',
-                      'def foo; end'
+      it 'registers an offense for method with closing paren on following line' do
+        expect_offense(<<~RUBY)
+          def foo(arg
+          ^^^^^^^^^^^ Put empty method definitions on a single line.
+          ); end
+        RUBY
+        expect_correction(<<~RUBY)
+          def foo(arg); end
+        RUBY
+      end
+
+      it 'allows single line method' do
+        expect_no_offenses('def foo; end')
+      end
     end
 
     context 'with a non-empty instance method definition' do
-      it_behaves_like 'code without offense',
-                      <<~RUBY
-                        def foo
-                          bar
-                        end
-                      RUBY
+      it 'allows multi line method' do
+        expect_no_offenses(<<~RUBY)
+          def foo
+            bar
+          end
+        RUBY
+      end
 
-      it_behaves_like 'code without offense',
-                      'def foo; bar; end'
+      it 'allows single line method' do
+        expect_no_offenses('def foo; bar; end')
+      end
 
-      it_behaves_like 'code without offense',
-                      <<~RUBY
-                        def foo
-                          # bar
-                        end
-                      RUBY
+      it 'allows multi line method with comment' do
+        expect_no_offenses(<<~RUBY)
+          def foo
+            # bar
+          end
+        RUBY
+      end
     end
 
     context 'with an empty class method definition' do
-      it_behaves_like 'code with offense',
-                      ['def self.foo',
-                       'end'].join("\n"),
-                      'def self.foo; end'
+      it 'registers an offense for empty method' do
+        expect_offense(<<~'RUBY')
+          def self.foo
+          ^^^^^^^^^^^^ Put empty method definitions on a single line.
+          end
+        RUBY
+        expect_correction(<<~'RUBY')
+          def self.foo; end
+        RUBY
+      end
 
-      it_behaves_like 'code with offense',
-                      ['def self.foo(bar, baz)',
-                       'end'].join("\n"),
-                      'def self.foo(bar, baz); end'
+      it 'registers an offense for empty method with arguments' do
+        expect_offense(<<~'RUBY')
+          def self.foo(bar, baz)
+          ^^^^^^^^^^^^^^^^^^^^^^ Put empty method definitions on a single line.
+          end
+        RUBY
+        expect_correction(<<~'RUBY')
+          def self.foo(bar, baz); end
+        RUBY
+      end
 
-      it_behaves_like 'code with offense',
-                      ['def self.foo',
-                       '',
-                       'end'].join("\n"),
-                      'def self.foo; end'
+      it 'registers an offense for method with blank line' do
+        expect_offense(<<~'RUBY')
+          def self.foo
+          ^^^^^^^^^^^^ Put empty method definitions on a single line.
 
-      it_behaves_like 'code without offense',
-                      'def self.foo; end'
+          end
+        RUBY
+        expect_correction(<<~'RUBY')
+          def self.foo; end
+        RUBY
+      end
+
+      it 'allows single line method' do
+        expect_no_offenses('def self.foo; end')
+      end
     end
 
     context 'with a non-empty class method definition' do
-      it_behaves_like 'code without offense',
-                      <<~RUBY
-                        def self.foo
-                          bar
-                        end
-                      RUBY
+      it 'allows multi line method' do
+        expect_no_offenses(<<~RUBY)
+          def self.foo
+            bar
+          end
+        RUBY
+      end
 
-      it_behaves_like 'code without offense',
-                      'def self.foo; bar; end'
+      it 'allows single line method' do
+        expect_no_offenses('def self.foo; bar; end')
+      end
 
-      it_behaves_like 'code without offense',
-                      <<~RUBY
-                        def self.foo
-                          # bar
-                        end
-                      RUBY
+      it 'allows multi line method with comment' do
+        expect_no_offenses(<<~RUBY)
+          def self.foo
+            # bar
+          end
+        RUBY
+      end
     end
   end
 
   context 'when configured with expanded style' do
     let(:cop_config) { { 'EnforcedStyle' => 'expanded' } }
 
-    let(:message) do
-      'Put the `end` of empty method definitions on the next line.'
-    end
-
     context 'with an empty instance method definition' do
-      it_behaves_like 'code without offense',
-                      ['def foo',
-                       'end'].join("\n")
+      it 'allows multi line method' do
+        expect_no_offenses(<<~RUBY)
+          def foo
+          end
+        RUBY
+      end
 
-      it_behaves_like 'code without offense',
-                      ['def foo',
-                       '',
-                       'end'].join("\n")
+      it 'allows multi line method with blank line' do
+        expect_no_offenses(<<~RUBY)
+          def foo
 
-      it_behaves_like 'code with offense',
-                      'def foo; end',
-                      ['def foo',
-                       'end'].join("\n")
+          end
+        RUBY
+      end
+
+      it 'registers an offense for single line method' do
+        expect_offense(<<~'RUBY')
+          def foo; end
+          ^^^^^^^^^^^^ Put the `end` of empty method definitions on the next line.
+        RUBY
+        expect_correction(<<~'RUBY')
+          def foo
+          end
+        RUBY
+      end
     end
 
     context 'with a non-empty instance method definition' do
-      it_behaves_like 'code without offense',
-                      <<~RUBY
-                        def foo
-                          bar
-                        end
-                      RUBY
+      it 'allows multi line method' do
+        expect_no_offenses(<<~RUBY)
+          def foo
+            bar
+          end
+        RUBY
+      end
 
-      it_behaves_like 'code without offense',
-                      'def foo; bar; end'
+      it 'allows single line method' do
+        expect_no_offenses('def foo; bar; end')
+      end
 
-      it_behaves_like 'code without offense',
-                      <<~RUBY
-                        def foo
-                          # bar
-                        end
-                      RUBY
+      it 'allows multi line method with a comment' do
+        expect_no_offenses(<<~RUBY)
+          def foo
+            # bar
+          end
+        RUBY
+      end
     end
 
     context 'with an empty class method definition' do
-      it_behaves_like 'code without offense',
-                      ['def self.foo',
-                       'end'].join("\n")
+      it 'allows empty multi line method' do
+        expect_no_offenses(<<~RUBY)
+          def self.foo
+          end
+        RUBY
+      end
 
-      it_behaves_like 'code without offense',
-                      ['def self.foo',
-                       '',
-                       'end'].join("\n")
+      it 'allows multi line method with a blank line' do
+        expect_no_offenses(<<~RUBY)
+          def self.foo
 
-      it_behaves_like 'code with offense',
-                      'def self.foo; end',
-                      ['def self.foo',
-                       'end'].join("\n")
+          end
+        RUBY
+      end
+
+      it 'registers an offense for single line method' do
+        expect_offense(<<~'RUBY')
+          def self.foo; end
+          ^^^^^^^^^^^^^^^^^ Put the `end` of empty method definitions on the next line.
+        RUBY
+        expect_correction(<<~'RUBY')
+          def self.foo
+          end
+        RUBY
+      end
     end
 
     context 'with a non-empty class method definition' do
-      it_behaves_like 'code without offense',
-                      <<~RUBY
-                        def self.foo
-                          bar
-                        end
-                      RUBY
+      it 'allows multi line method' do
+        expect_no_offenses(<<~RUBY)
+          def self.foo
+            bar
+          end
+        RUBY
+      end
 
-      it_behaves_like 'code without offense',
-                      'def self.foo; bar; end'
+      it 'allows single line method' do
+        expect_no_offenses('def self.foo; bar; end')
+      end
 
-      it_behaves_like 'code without offense',
-                      <<~RUBY
-                        def self.foo
-                          # bar
-                        end
-                      RUBY
+      it 'allows multi line method with comment' do
+        expect_no_offenses(<<~RUBY)
+          def self.foo
+            # bar
+          end
+        RUBY
+      end
     end
 
     context 'when method is nested in class scope' do
-      it_behaves_like 'code with offense',
-                      ['class Foo',
-                       '  def bar; end',
-                       'end'].join("\n"),
-                      ['class Foo',
-                       '  def bar',
-                       '  end',
-                       'end'].join("\n")
+      it 'registers an offense for single line method' do
+        expect_offense(<<~RUBY)
+          class Foo
+            def bar; end
+            ^^^^^^^^^^^^ Put the `end` of empty method definitions on the next line.
+          end
+        RUBY
+        expect_correction(<<~RUBY)
+          class Foo
+            def bar
+            end
+          end
+        RUBY
+      end
     end
   end
 end

--- a/spec/rubocop/cop/style/encoding_spec.rb
+++ b/spec/rubocop/cop/style/encoding_spec.rb
@@ -20,6 +20,9 @@ RSpec.describe RuboCop::Cop::Style::Encoding, :config do
       ^^^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
       def foo() end
     RUBY
+    expect_correction(<<~RUBY)
+      def foo() end
+    RUBY
   end
 
   it 'registers an offense when encoding present on 2nd line after shebang' do
@@ -29,12 +32,19 @@ RSpec.describe RuboCop::Cop::Style::Encoding, :config do
       ^^^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
       def foo() end
     RUBY
+    expect_correction(<<~RUBY)
+      #!/usr/bin/env ruby
+      def foo() end
+    RUBY
   end
 
   it 'registers an offense for vim-style encoding comments' do
     expect_offense(<<~RUBY)
       # vim:filetype=ruby, fileencoding=utf-8
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
+      def foo() end
+    RUBY
+    expect_correction(<<~RUBY)
       def foo() end
     RUBY
   end
@@ -52,13 +62,8 @@ RSpec.describe RuboCop::Cop::Style::Encoding, :config do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
       def foo() 'ä' end
     RUBY
-  end
-
-  context 'auto-correct' do
-    it 'removes encoding comment on first line' do
-      new_source = autocorrect_source("# encoding: utf-8\nblah")
-
-      expect(new_source).to eq('blah')
-    end
+    expect_correction(<<~RUBY)
+      def foo() 'ä' end
+    RUBY
   end
 end

--- a/spec/rubocop/cop/style/even_odd_spec.rb
+++ b/spec/rubocop/cop/style/even_odd_spec.rb
@@ -3,73 +3,103 @@
 RSpec.describe RuboCop::Cop::Style::EvenOdd do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for x % 2 == 0' do
+  it 'converts x % 2 == 0 to #even?' do
     expect_offense(<<~RUBY)
       x % 2 == 0
       ^^^^^^^^^^ Replace with `Integer#even?`.
     RUBY
+    expect_correction(<<~RUBY)
+      x.even?
+    RUBY
   end
 
-  it 'registers an offense for x % 2 != 0' do
+  it 'converts x % 2 != 0 to #odd?' do
     expect_offense(<<~RUBY)
       x % 2 != 0
       ^^^^^^^^^^ Replace with `Integer#odd?`.
     RUBY
+    expect_correction(<<~RUBY)
+      x.odd?
+    RUBY
   end
 
-  it 'registers an offense for (x % 2) == 0' do
+  it 'converts (x % 2) == 0 to #even?' do
     expect_offense(<<~RUBY)
       (x % 2) == 0
       ^^^^^^^^^^^^ Replace with `Integer#even?`.
     RUBY
+    expect_correction(<<~RUBY)
+      x.even?
+    RUBY
   end
 
-  it 'registers an offense for (x % 2) != 0' do
+  it 'converts (x % 2) != 0 to #odd?' do
     expect_offense(<<~RUBY)
       (x % 2) != 0
       ^^^^^^^^^^^^ Replace with `Integer#odd?`.
     RUBY
+    expect_correction(<<~RUBY)
+      x.odd?
+    RUBY
   end
 
-  it 'registers an offense for x % 2 == 1' do
+  it 'converts x % 2 == 1 to #odd?' do
     expect_offense(<<~RUBY)
       x % 2 == 1
       ^^^^^^^^^^ Replace with `Integer#odd?`.
     RUBY
+    expect_correction(<<~RUBY)
+      x.odd?
+    RUBY
   end
 
-  it 'registers an offense for x % 2 != 1' do
+  it 'converts x % 2 != 1 to #even?' do
     expect_offense(<<~RUBY)
       x % 2 != 1
       ^^^^^^^^^^ Replace with `Integer#even?`.
     RUBY
+    expect_correction(<<~RUBY)
+      x.even?
+    RUBY
   end
 
-  it 'registers an offense for (x % 2) == 1' do
+  it 'converts (x % 2) == 1 to #odd?' do
     expect_offense(<<~RUBY)
       (x % 2) == 1
       ^^^^^^^^^^^^ Replace with `Integer#odd?`.
     RUBY
-  end
-
-  it 'registers an offense for (x % 2) != 1' do
-    expect_offense(<<~RUBY)
-      (x % 2) != 1
-      ^^^^^^^^^^^^ Replace with `Integer#even?`.
+    expect_correction(<<~RUBY)
+      x.odd?
     RUBY
   end
 
-  it 'registers an offense for (x.y % 2) != 1' do
+  it 'converts (y % 2) != 1 to #even?' do
+    expect_offense(<<~RUBY)
+      (y % 2) != 1
+      ^^^^^^^^^^^^ Replace with `Integer#even?`.
+    RUBY
+    expect_correction(<<~RUBY)
+      y.even?
+    RUBY
+  end
+
+  it 'converts (x.y % 2) != 1 to #even?' do
     expect_offense(<<~RUBY)
       (x.y % 2) != 1
       ^^^^^^^^^^^^^^ Replace with `Integer#even?`.
     RUBY
+    expect_correction(<<~RUBY)
+      x.y.even?
+    RUBY
   end
 
-  it 'registers an offense for (x(y) % 2) != 1' do
+  it 'converts (x(y) % 2) != 1 to #even?' do
     expect_offense(<<~RUBY)
       (x(y) % 2) != 1
       ^^^^^^^^^^^^^^^ Replace with `Integer#even?`.
+    RUBY
+    expect_correction(<<~RUBY)
+      x(y).even?
     RUBY
   end
 
@@ -85,85 +115,57 @@ RSpec.describe RuboCop::Cop::Style::EvenOdd do
     expect_no_offenses('x % 3 != 0')
   end
 
-  it 'converts x % 2 == 0 to #even?' do
-    corrected = autocorrect_source('x % 2 == 0')
-    expect(corrected).to eq('x.even?')
-  end
-
-  it 'converts x % 2 != 0 to #odd?' do
-    corrected = autocorrect_source('x % 2 != 0')
-    expect(corrected).to eq('x.odd?')
-  end
-
-  it 'converts (x % 2) == 0 to #even?' do
-    corrected = autocorrect_source('(x % 2) == 0')
-    expect(corrected).to eq('x.even?')
-  end
-
-  it 'converts (x % 2) != 0 to #odd?' do
-    corrected = autocorrect_source('(x % 2) != 0')
-    expect(corrected).to eq('x.odd?')
-  end
-
-  it 'converts x % 2 == 1 to odd?' do
-    corrected = autocorrect_source('x % 2 == 1')
-    expect(corrected).to eq('x.odd?')
-  end
-
-  it 'converts x % 2 != 1 to even?' do
-    corrected = autocorrect_source('x % 2 != 1')
-    expect(corrected).to eq('x.even?')
-  end
-
-  it 'converts (x % 2) == 1 to odd?' do
-    corrected = autocorrect_source('(x % 2) == 1')
-    expect(corrected).to eq('x.odd?')
-  end
-
-  it 'converts (y % 2) != 1 to even?' do
-    corrected = autocorrect_source('(y % 2) != 1')
-    expect(corrected).to eq('y.even?')
-  end
-
-  it 'converts (x.y % 2) != 1 to even?' do
-    corrected = autocorrect_source('(x.y % 2) != 1')
-    expect(corrected).to eq('x.y.even?')
-  end
-
-  it 'converts (x(y) % 2) != 1 to even?' do
-    corrected = autocorrect_source('(x(y) % 2) != 1')
-    expect(corrected).to eq('x(y).even?')
-  end
-
   it 'converts (x._(y) % 2) != 1 to even?' do
-    corrected = autocorrect_source('(x._(y) % 2) != 1')
-    expect(corrected).to eq('x._(y).even?')
+    expect_offense(<<~RUBY)
+      (x._(y) % 2) != 1
+      ^^^^^^^^^^^^^^^^^ Replace with `Integer#even?`.
+    RUBY
+    expect_correction(<<~RUBY)
+      x._(y).even?
+    RUBY
   end
 
   it 'converts (x._(y)) % 2 != 1 to even?' do
-    corrected = autocorrect_source('(x._(y)) % 2 != 1')
-    expect(corrected).to eq('(x._(y)).even?')
+    expect_offense(<<~RUBY)
+      (x._(y)) % 2 != 1
+      ^^^^^^^^^^^^^^^^^ Replace with `Integer#even?`.
+    RUBY
+    expect_correction(<<~RUBY)
+      (x._(y)).even?
+    RUBY
   end
 
   it 'converts x._(y) % 2 != 1 to even?' do
-    corrected = autocorrect_source('x._(y) % 2 != 1')
-    expect(corrected).to eq('x._(y).even?')
+    expect_offense(<<~RUBY)
+      x._(y) % 2 != 1
+      ^^^^^^^^^^^^^^^ Replace with `Integer#even?`.
+    RUBY
+    expect_correction(<<~RUBY)
+      x._(y).even?
+    RUBY
   end
 
   it 'converts 1 % 2 != 1 to even?' do
-    corrected = autocorrect_source('1 % 2 != 1')
-    expect(corrected).to eq('1.even?')
+    expect_offense(<<~RUBY)
+      1 % 2 != 1
+      ^^^^^^^^^^ Replace with `Integer#even?`.
+    RUBY
+    expect_correction(<<~RUBY)
+      1.even?
+    RUBY
   end
 
   it 'converts complex examples' do
-    corrected = autocorrect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       if (y % 2) != 1
+         ^^^^^^^^^^^^ Replace with `Integer#even?`.
         method == :== ? :even : :odd
       elsif x % 2 == 1
+            ^^^^^^^^^^ Replace with `Integer#odd?`.
         method == :== ? :odd : :even
       end
     RUBY
-    expect(corrected).to eq(<<~RUBY)
+    expect_correction(<<~RUBY)
       if y.even?
         method == :== ? :even : :odd
       elsif x.odd?


### PR DESCRIPTION
Part of #8127

Use newer `expect_offense` and `expect_correction` in specs for Style cops A-E.

Merge `'register offense'` and `'auto-correct'` spec examples where possible.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/