### PR TITLE
Use new expect_correction in Style F-M

### DIFF
--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -271,7 +271,7 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
         end
       RUBY
 
-      expect { inspect_source(source) }
+      expect { expect_no_offenses(source) }
         .to raise_error('MinBodyLength needs to be a positive integer!')
     end
   end

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -26,8 +26,12 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
 
       it 'registers offense for hash rocket syntax when new is possible' do
         expect_offense(<<~RUBY)
-          x = { :a => 0 }
+          x = { :a => 0, :b   =>  2}
                 ^^^^^ Use the new Ruby 1.9 hash syntax.
+                         ^^^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
+        expect_correction(<<~RUBY)
+          x = { a: 0, b: 2}
         RUBY
       end
 
@@ -36,12 +40,18 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           x = { :a => 0, b: 1 }
                 ^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+        expect_correction(<<~RUBY)
+          x = { a: 0, b: 1 }
+        RUBY
       end
 
       it 'registers an offense for hash rockets in method calls' do
         expect_offense(<<~RUBY)
           func(3, :a => 0)
                   ^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
+        expect_correction(<<~RUBY)
+          func(3, a: 0)
         RUBY
       end
 
@@ -58,11 +68,19 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           x = { :"string" => 0 }
                 ^^^^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+        expect_correction(<<~RUBY)
+          x = { "string": 0 }
+        RUBY
       end
 
       it 'preserves quotes during autocorrection' do
-        new_source = autocorrect_source("{ :'&&' => foo }")
-        expect(new_source).to eq("{ '&&': foo }")
+        expect_offense(<<~RUBY)
+          { :'&&' => foo }
+            ^^^^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
+        expect_correction(<<~RUBY)
+          { '&&': foo }
+        RUBY
       end
 
       context 'if PreferHashRocketsForNonAlnumEndingSymbols is false' do
@@ -71,12 +89,18 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
             x = { :a? => 0 }
                   ^^^^^^ Use the new Ruby 1.9 hash syntax.
           RUBY
+          expect_correction(<<~RUBY)
+            x = { a?: 0 }
+          RUBY
         end
 
         it 'registers an offense for hash rockets when symbols end with !' do
           expect_offense(<<~RUBY)
             x = { :a! => 0 }
                   ^^^^^^ Use the new Ruby 1.9 hash syntax.
+          RUBY
+          expect_correction(<<~RUBY)
+            x = { a!: 0 }
           RUBY
         end
       end
@@ -110,6 +134,9 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           x = { :A => 0 }
                 ^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+        expect_correction(<<~RUBY)
+          x = { A: 0 }
+        RUBY
       end
 
       it 'accepts new syntax in a hash literal' do
@@ -120,22 +147,28 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         expect_no_offenses('func(3, a: 0)')
       end
 
-      it 'auto-corrects old to new style' do
-        new_source = autocorrect_source('{ :a => 1, :b   =>  2}')
-        expect(new_source).to eq('{ a: 1, b: 2}')
-      end
-
       it 'auto-corrects even if it interferes with SpaceAroundOperators' do
         # Clobbering caused by two cops changing in the same range is dealt with
         # by the auto-correct loop, so there's no reason to avoid a change.
-        new_source = autocorrect_source('{ :a=>1, :b=>2 }')
-        expect(new_source).to eq('{ a: 1, b: 2 }')
+        expect_offense(<<~RUBY)
+          { :a=>1, :b=>2 }
+            ^^^^ Use the new Ruby 1.9 hash syntax.
+                   ^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
+        expect_correction(<<~RUBY)
+          { a: 1, b: 2 }
+        RUBY
       end
 
       # Bug: https://github.com/rubocop-hq/rubocop/issues/5019
       it 'auto-corrects a missing space when hash is used as argument' do
-        new_source = autocorrect_source('foo:bar => 1')
-        expect(new_source).to eq('foo bar: 1')
+        expect_offense(<<~RUBY)
+          foo:bar => 1
+             ^^^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
+        expect_correction(<<~RUBY)
+          foo bar: 1
+        RUBY
       end
 
       context 'when using a return value uses `return`' do
@@ -179,8 +212,14 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'auto-corrects even if there is no space around =>' do
-        new_source = autocorrect_source('{ :a=>1, :b=>2 }')
-        expect(new_source).to eq('{ a: 1, b: 2 }')
+        expect_offense(<<~RUBY)
+          { :a=>1, :b=>2 }
+            ^^^^ Use the new Ruby 1.9 hash syntax.
+                   ^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
+        expect_correction(<<~RUBY)
+          { a: 1, b: 2 }
+        RUBY
       end
     end
 
@@ -212,6 +251,9 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                 ^^ Use hash rockets syntax.
                       ^^ Use hash rockets syntax.
         RUBY
+        expect_correction(<<~RUBY)
+          x = { :a => 1, :b => :c }
+        RUBY
       end
 
       it 'registers an offense when any element has a symbol value ' \
@@ -219,6 +261,9 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         expect_offense(<<~RUBY)
           func(3, b: :c)
                   ^^ Use hash rockets syntax.
+        RUBY
+        expect_correction(<<~RUBY)
+          func(3, :b => :c)
         RUBY
       end
 
@@ -229,6 +274,9 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                 ^^^^^ Use the new Ruby 1.9 hash syntax.
                          ^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+        expect_correction(<<~RUBY)
+          x = { a: 1, b: 2 }
+        RUBY
       end
 
       it 'registers an offense for hashes with elements on multiple lines' do
@@ -237,6 +285,10 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                 ^^ Use hash rockets syntax.
            c: :d }
            ^^ Use hash rockets syntax.
+        RUBY
+        expect_correction(<<~RUBY)
+          x = { :a => :b,
+           :c => :d }
         RUBY
       end
 
@@ -247,27 +299,22 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
-      it 'auto-corrects to ruby19 style when there are no symbol values' do
-        new_source = autocorrect_source('{ :a => 1, :b => 2 }')
-        expect(new_source).to eq('{ a: 1, b: 2 }')
-      end
-
-      it 'auto-corrects to hash rockets ' \
-        'when there is an element with a symbol value' do
-        new_source = autocorrect_source('{ a: 1, :b => :c }')
-        expect(new_source).to eq('{ :a => 1, :b => :c }')
-      end
-
       it 'auto-corrects to hash rockets ' \
         'when all elements have symbol value' do
-        new_source = autocorrect_source('{ a: :b, c: :d }')
-        expect(new_source).to eq('{ :a => :b, :c => :d }')
+        expect_offense(<<~RUBY)
+          { a: :b, c: :d }
+            ^^ Use hash rockets syntax.
+                   ^^ Use hash rockets syntax.
+        RUBY
+        expect_correction(<<~RUBY)
+          { :a => :b, :c => :d }
+        RUBY
       end
 
-      it 'auto-correct does not change anything when the hash ' \
-        'is already ruby19 style and there are no symbol values' do
-        new_source = autocorrect_source('{ a: 1, b: 2 }')
-        expect(new_source).to eq('{ a: 1, b: 2 }')
+      it 'accepts hash in ruby19 style with no symbol values' do
+        expect_no_offenses(<<~RUBY)
+          { a: 1, b: 2 }
+        RUBY
       end
     end
   end
@@ -283,8 +330,12 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
 
     it 'registers offense for Ruby 1.9 style' do
       expect_offense(<<~RUBY)
-        x = { a: 0 }
+        x = { a: 0, b: 2}
               ^^ Use hash rockets syntax.
+                    ^^ Use hash rockets syntax.
+      RUBY
+      expect_correction(<<~RUBY)
+        x = { :a => 0, :b => 2}
       RUBY
     end
 
@@ -293,12 +344,18 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         x = { a => 0, b: 1 }
                       ^^ Use hash rockets syntax.
       RUBY
+      expect_correction(<<~RUBY)
+        x = { a => 0, :b => 1 }
+      RUBY
     end
 
     it 'registers an offense for 1.9 style in method calls' do
       expect_offense(<<~RUBY)
         func(3, a: 0)
                 ^^ Use hash rockets syntax.
+      RUBY
+      expect_correction(<<~RUBY)
+        func(3, :a => 0)
       RUBY
     end
 
@@ -312,11 +369,6 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
 
     it 'accepts an empty hash' do
       expect_no_offenses('{}')
-    end
-
-    it 'auto-corrects new style to hash rockets' do
-      new_source = autocorrect_source('{ a: 1, b: 2}')
-      expect(new_source).to eq('{ :a => 1, :b => 2}')
     end
 
     context 'UseHashRocketsWithSymbolValues has no impact' do
@@ -349,8 +401,12 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
 
       it 'registers offense for hash rocket syntax when new is possible' do
         expect_offense(<<~RUBY)
-          x = { :a => 0 }
+          x = { :a => 0, :b => 2 }
                 ^^^^^ Use the new Ruby 1.9 hash syntax.
+                         ^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
+        expect_correction(<<~RUBY)
+          x = { a: 0, b: 2 }
         RUBY
       end
 
@@ -358,6 +414,9 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         expect_offense(<<~RUBY)
           x = { :a => 0, b: 1 }
                 ^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
+        expect_correction(<<~RUBY)
+          x = { a: 0, b: 1 }
         RUBY
       end
 
@@ -369,6 +428,9 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         expect_offense(<<~RUBY)
           func(3, :a => 0)
                   ^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
+        expect_correction(<<~RUBY)
+          func(3, a: 0)
         RUBY
       end
 
@@ -386,12 +448,18 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                 ^^ Don't mix styles in the same hash.
         RUBY
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+        expect_correction(<<~RUBY)
+          x = { :a => 0, "b" => 1 }
+        RUBY
       end
 
       it 'registers an offense when keys have whitespaces in them' do
         expect_offense(<<~RUBY)
           x = { :"t o" => 0 }
                 ^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
+        expect_correction(<<~RUBY)
+          x = { "t o": 0 }
         RUBY
       end
 
@@ -400,6 +468,9 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           x = { :"\tab" => 1 }
                 ^^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+        expect_correction(<<~'RUBY')
+          x = { "\tab": 1 }
+        RUBY
       end
 
       it 'registers an offense when keys start with a digit' do
@@ -407,21 +478,13 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           x = { :"1" => 1 }
                 ^^^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+        expect_correction(<<~RUBY)
+          x = { "1": 1 }
+        RUBY
       end
 
       it 'accepts new syntax when keys are interpolated string' do
         expect_no_offenses('{"#{foo}": 1, "#{@foo}": 2, "#@foo": 3}')
-      end
-
-      it 'auto-corrects old to new style' do
-        new_source = autocorrect_source('{ :a => 1, :b => 2 }')
-        expect(new_source).to eq('{ a: 1, b: 2 }')
-      end
-
-      it 'auto-corrects to hash rockets when new style cannot be used ' \
-        'for all' do
-        new_source = autocorrect_source('{ a: 1, "b" => 2 }')
-        expect(new_source).to eq('{ :a => 1, "b" => 2 }')
       end
     end
 
@@ -439,6 +502,9 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                 ^^ Use hash rockets syntax.
                       ^^ Use hash rockets syntax.
         RUBY
+        expect_correction(<<~RUBY)
+          x = { :a => 1, :b => :c }
+        RUBY
       end
 
       it 'registers an offense when any element has a symbol value ' \
@@ -447,18 +513,21 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           func(3, b: :c)
                   ^^ Use hash rockets syntax.
         RUBY
-      end
-
-      it 'auto-corrects to hash rockets ' \
-        'when there is an element with a symbol value' do
-        new_source = autocorrect_source('{ a: 1, :b => :c }')
-        expect(new_source).to eq('{ :a => 1, :b => :c }')
+        expect_correction(<<~RUBY)
+          func(3, :b => :c)
+        RUBY
       end
 
       it 'auto-corrects to hash rockets ' \
         'when all elements have symbol value' do
-        new_source = autocorrect_source('{ a: :b, c: :d }')
-        expect(new_source).to eq('{ :a => :b, :c => :d }')
+        expect_offense(<<~RUBY)
+          { a: :b, c: :d }
+            ^^ Use hash rockets syntax.
+                   ^^ Use hash rockets syntax.
+        RUBY
+        expect_correction(<<~RUBY)
+          { :a => :b, :c => :d }
+        RUBY
       end
 
       it 'accepts new syntax in a hash literal' do
@@ -467,11 +536,15 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
 
       it 'registers offense for hash rocket syntax when new is possible' do
         expect_offense(<<~RUBY)
-          x = { :a => 0 }
+          x = { :a => 0, :b => 2 }
                 ^^^^^ Use the new Ruby 1.9 hash syntax.
+                         ^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
         expect(cop.config_to_allow_offenses)
           .to eq('EnforcedStyle' => 'hash_rockets')
+        expect_correction(<<~RUBY)
+          x = { a: 0, b: 2 }
+        RUBY
       end
 
       it 'registers an offense for mixed syntax when new is possible' do
@@ -480,6 +553,9 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                 ^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+        expect_correction(<<~RUBY)
+          x = { a: 0, b: 1 }
+        RUBY
       end
 
       it 'accepts new syntax in method calls' do
@@ -490,6 +566,9 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         expect_offense(<<~RUBY)
           func(3, :a => 0)
                   ^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
+        expect_correction(<<~RUBY)
+          func(3, a: 0)
         RUBY
       end
 
@@ -507,12 +586,18 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                 ^^ Don't mix styles in the same hash.
         RUBY
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+        expect_correction(<<~RUBY)
+          x = { :a => 0, "b" => 1 }
+        RUBY
       end
 
       it 'registers an offense when keys have whitespaces in them' do
         expect_offense(<<~RUBY)
           x = { :"t o" => 0 }
                 ^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
+        expect_correction(<<~RUBY)
+          x = { "t o": 0 }
         RUBY
       end
 
@@ -521,6 +606,9 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           x = { :"\tab" => 1 }
                 ^^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+        expect_correction(<<~'RUBY')
+          x = { "\tab": 1 }
+        RUBY
       end
 
       it 'registers an offense when keys start with a digit' do
@@ -528,21 +616,13 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           x = { :"1" => 1 }
                 ^^^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+        expect_correction(<<~RUBY)
+          x = { "1": 1 }
+        RUBY
       end
 
       it 'accepts new syntax when keys are interpolated string' do
         expect_no_offenses('{"#{foo}": 1, "#{@foo}": 2, "#@foo": 3}')
-      end
-
-      it 'auto-corrects old to new style' do
-        new_source = autocorrect_source('{ :a => 1, :b => 2 }')
-        expect(new_source).to eq('{ a: 1, b: 2 }')
-      end
-
-      it 'auto-corrects to hash rockets when new style cannot be used ' \
-        'for all' do
-        new_source = autocorrect_source('{ a: 1, "b" => 2 }')
-        expect(new_source).to eq('{ :a => 1, "b" => 2 }')
       end
     end
   end
@@ -568,6 +648,9 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                        ^^ Don't mix styles in the same hash.
       RUBY
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      expect_correction(<<~RUBY)
+        x = { :a => 0, :b => 1 }
+      RUBY
     end
 
     it 'accepts new syntax in method calls' do
@@ -592,6 +675,9 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
               ^^ Don't mix styles in the same hash.
       RUBY
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      expect_correction(<<~RUBY)
+        x = { :a => 0, "b" => 1 }
+      RUBY
     end
 
     it 'accepts hash rockets when keys have whitespaces in them' do
@@ -604,6 +690,9 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                            ^^ Don't mix styles in the same hash.
       RUBY
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      expect_correction(<<~RUBY)
+        x = { :"t o" => 0, :b => 1 }
+      RUBY
     end
 
     it 'accepts hash rockets when keys have special symbols in them' do
@@ -612,9 +701,14 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
 
     it 'registers an offense when keys have special symbols and '\
       'mix styles' do
-      inspect_source('x = { :"\tab" => 1, b: 1 }')
-      expect(cop.messages).to eq(["Don't mix styles in the same hash."])
+      expect_offense(<<~RUBY, tab: "\t")
+        x = { :"%{tab}ab" => 1, b: 1 }
+                _{tab}          ^^ Don't mix styles in the same hash.
+      RUBY
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      expect_correction(<<~RUBY)
+        x = { :"\tab" => 1, :b => 1 }
+      RUBY
     end
 
     it 'accepts hash rockets when keys start with a digit' do
@@ -627,27 +721,27 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                          ^^ Don't mix styles in the same hash.
       RUBY
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      expect_correction(<<~RUBY)
+        x = { :"1" => 1, :b => 1 }
+      RUBY
     end
 
-    it 'does not auto-correct old to new style' do
-      new_source = autocorrect_source('{ :a => 1, :b => 2 }')
-      expect(new_source).to eq('{ :a => 1, :b => 2 }')
+    it 'accepts old hash rockets style' do
+      expect_no_offenses('{ :a => 1, :b => 2 }')
     end
 
-    it 'does not auto-correct new to hash rockets style' do
-      new_source = autocorrect_source('{ a: 1, b: 2 }')
-      expect(new_source).to eq('{ a: 1, b: 2 }')
+    it 'accepts new hash style' do
+      expect_no_offenses('{ a: 1, b: 2 }')
     end
 
     it 'auto-corrects mixed key hashes' do
-      new_source = autocorrect_source('{ a: 1, :b => 2 }')
-      expect(new_source).to eq('{ a: 1, b: 2 }')
-    end
-
-    it 'auto-corrects to hash rockets when new style cannot be used ' \
-      'for all' do
-      new_source = autocorrect_source('{ a: 1, "b" => 2 }')
-      expect(new_source).to eq('{ :a => 1, "b" => 2 }')
+      expect_offense(<<~RUBY)
+        { a: 1, :b => 2 }
+                ^^^^^ Don't mix styles in the same hash.
+      RUBY
+      expect_correction(<<~RUBY)
+        { a: 1, b: 2 }
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/hash_transform_values_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_values_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
         x.each_with_object({}) {|(k, v), h| h[k] = foo(v)}
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `each_with_object`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        x.transform_values {|v| foo(v)}
+      RUBY
     end
   end
 
@@ -18,6 +22,12 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
           memo[key] = val * val
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        some_hash.transform_values do |val|
+          val * val
+        end
+      RUBY
     end
   end
 
@@ -26,6 +36,10 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
       expect_offense(<<~RUBY)
         x&.each_with_object({}) {|(k, v), h| h[k] = foo(v)}
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `each_with_object`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x&.transform_values {|v| foo(v)}
       RUBY
     end
   end
@@ -61,6 +75,10 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
       x.map {|k, v| [k, foo(v)]}.to_h
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `map {...}.to_h`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      x.transform_values {|v| foo(v)}
+    RUBY
   end
 
   it 'flags _.map {...}.to_h when transform_values could be used ' \
@@ -85,6 +103,10 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
       Hash[x.map {|k, v| [k, foo(v)]}]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `Hash[_.map {...}]`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      x.transform_values {|v| foo(v)}
+    RUBY
   end
 
   it 'does not flag Hash[_.map{...}] when both key & value are transformed' do
@@ -101,43 +123,14 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
     RUBY
   end
 
-  it 'correctly autocorrects each_with_object' do
-    corrected = autocorrect_source(<<~RUBY)
-      {a: 1, b: 2}.each_with_object({}) {|(k, v), h| h[k] = foo(v)}
-    RUBY
-
-    expect(corrected).to eq(<<~RUBY)
-      {a: 1, b: 2}.transform_values {|v| foo(v)}
-    RUBY
-  end
-
-  it 'correctly autocorrects _.map{...}.to_h without block' do
-    corrected = autocorrect_source(<<~RUBY)
-      {a: 1, b: 2}.map {|k, v| [k, foo(v)]}.to_h
-    RUBY
-
-    expect(corrected).to eq(<<~RUBY)
-      {a: 1, b: 2}.transform_values {|v| foo(v)}
-    RUBY
-  end
-
   it 'correctly autocorrects _.map{...}.to_h with block' do
-    corrected = autocorrect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       {a: 1, b: 2}.map {|k, v| [k, foo(v)]}.to_h {|k, v| [v, k]}
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `map {...}.to_h`.
     RUBY
 
-    expect(corrected).to eq(<<~RUBY)
+    expect_correction(<<~RUBY)
       {a: 1, b: 2}.transform_values {|v| foo(v)}.to_h {|k, v| [v, k]}
-    RUBY
-  end
-
-  it 'correctly autocorrects Hash[_.map{...}]' do
-    corrected = autocorrect_source(<<~RUBY)
-      Hash[{a: 1, b: 2}.map {|k, v| [k, foo(v)]}]
-    RUBY
-
-    expect(corrected).to eq(<<~RUBY)
-      {a: 1, b: 2}.transform_values {|v| foo(v)}
     RUBY
   end
 end

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
 
   context 'modifier if that does not fit on one line' do
     let(:spaces) { ' ' * 59 }
-    let(:source) { "puts '#{spaces}' if condition" }
+    let(:body) { "puts '#{spaces}'" }
+    let(:source) { "#{body} if condition" }
     let(:long_url) do
       'https://some.example.com/with/a/rather?long&and=very&complicated=path'
     end
@@ -31,11 +32,11 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
     context 'when Layout/LineLength is enabled' do
       it 'corrects it to normal form' do
         expect(source.length).to be(79) # That's 81 including indentation.
-        expect_offense(<<~RUBY)
+        expect_offense(<<~RUBY, body: body)
           def f
             # Comment 1
-            #{source} # Comment 2
-            #{spaces}        ^^ Modifier form of `if` makes the line too long.
+            %{body} if condition # Comment 2
+            _{body} ^^ Modifier form of `if` makes the line too long.
           end
         RUBY
 
@@ -77,15 +78,15 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
       describe 'IgnoreCopDirectives' do
         let(:spaces) { ' ' * 57 }
         let(:comment) { '# rubocop:disable Style/For' }
-        let(:source) { "puts '#{spaces}' if condition" }
+        let(:body) { "puts '#{spaces}'" }
 
         context 'and the long line is allowed because IgnoreCopDirectives is ' \
                 'true' do
           it 'accepts' do
-            expect(source.length).to eq(77) # That's 79 including indentation.
+            expect("#{body} if condition".length).to eq(77) # That's 79 including indentation.
             expect_no_offenses(<<~RUBY)
               def f
-                #{source} #{comment}
+                #{body} if condition #{comment}
               end
             RUBY
           end
@@ -96,10 +97,18 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
           let(:ignore_cop_directives) { false }
 
           it 'registers an offense' do
-            expect_offense(<<~RUBY)
+            expect_offense(<<~RUBY, body: body)
               def f
-                #{source} #{comment}
-                #{spaces}        ^^ Modifier form of `if` makes the line too long.
+                %{body} if condition #{comment}
+                _{body} ^^ Modifier form of `if` makes the line too long.
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              def f
+                if condition
+                  #{body}
+                end #{comment}
               end
             RUBY
           end
@@ -144,16 +153,6 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
   end
 
   context 'multiline if that fits on one line' do
-    let(:source) do
-      # Empty lines should make no difference.
-      <<~RUBY
-        if #{condition}
-          #{body}
-
-        end
-      RUBY
-    end
-
     let(:condition) { 'a' * 38 }
     let(:body) { 'b' * 38 }
 
@@ -162,17 +161,18 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
       # modifier.
       expect("#{body} if #{condition}".length).to eq(80)
 
-      inspect_source(source)
-      expect(cop.messages).to eq(
-        ['Favor modifier `if` usage when having a single-line' \
-         ' body. Another good alternative is the usage of control flow' \
-         ' `&&`/`||`.']
-      )
-    end
+      # Empty lines should make no difference.
+      expect_offense(<<~RUBY)
+        if #{condition}
+        ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+          #{body}
 
-    it 'does auto-correction' do
-      corrected = autocorrect_source(source)
-      expect(corrected).to eq "#{body} if #{condition}\n"
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        #{body} if #{condition}
+      RUBY
     end
 
     context 'and has two statements separated by semicolon' do
@@ -189,7 +189,6 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
   context 'modifier if that does not fit on one line, but is not the only' \
           ' statement on the line' do
     let(:spaces) { ' ' * 59 }
-    let(:source) { "puts '#{spaces}' if condition; some_method_call" }
 
     # long lines which have multiple statements on the same line can be flagged
     #   by Layout/LineLength, Style/Semicolon, etc.
@@ -198,33 +197,24 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
     it 'accepts' do
       expect_no_offenses(<<~RUBY)
         def f
-          #{source}
+          puts '#{spaces}' if condition; some_method_call
         end
       RUBY
     end
   end
 
   context 'multiline if that fits on one line with comment on first line' do
-    let(:source) do
-      <<~RUBY
-        if a # comment
-          b
-        end
-      RUBY
-    end
-
-    it 'registers an offense' do
+    it 'registers an offense and preserves comment' do
       expect_offense(<<~RUBY)
         if a # comment
         ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
           b
         end
       RUBY
-    end
 
-    it 'does auto-correction and preserves comment' do
-      corrected = autocorrect_source(source)
-      expect(corrected).to eq "b if a # comment\n"
+      expect_correction(<<~RUBY)
+        b if a # comment
+      RUBY
     end
   end
 
@@ -243,24 +233,6 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
   end
 
   context 'short multiline if near an else etc' do
-    let(:source) do
-      <<~RUBY
-        if x
-          y
-        elsif x1
-          y1
-        else
-          z
-        end
-        n = a ? 0 : 1
-        m = 3 if m0
-
-        if a
-          b
-        end
-      RUBY
-    end
-
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         if x
@@ -278,11 +250,8 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
           b
         end
       RUBY
-    end
 
-    it 'does auto-correction' do
-      corrected = autocorrect_source(source)
-      expect(corrected).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         if x
           y
         elsif x1
@@ -299,14 +268,6 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
   end
 
   context 'multiline unless that fits on one line' do
-    let(:source) do
-      <<~RUBY
-        unless a
-          b
-        end
-      RUBY
-    end
-
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         unless a
@@ -314,11 +275,10 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
           b
         end
       RUBY
-    end
 
-    it 'does auto-correction' do
-      corrected = autocorrect_source(source)
-      expect(corrected).to eq "b unless a\n"
+      expect_correction(<<~RUBY)
+        b unless a
+      RUBY
     end
   end
 
@@ -347,14 +307,6 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
   end
 
   context 'with implicit match conditional' do
-    let(:source) do
-      <<-RUBY.strip_margin('|')
-        |  if #{conditional}
-        |    #{body}
-        |  end
-      RUBY
-    end
-
     let(:body) { 'b' * 36 }
 
     context 'when a multiline if fits on one line' do
@@ -363,13 +315,14 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
       it 'registers an offense' do
         expect("  #{body} if #{conditional}".length).to eq(80)
 
-        inspect_source(source)
-        expect(cop.offenses.size).to eq(1)
-      end
+        expect_offense(<<-RUBY.strip_margin('|'))
+          |  if #{conditional}
+          |  ^^ Favor modifier `if` usage when having a single-line body. [...]
+          |    #{body}
+          |  end
+        RUBY
 
-      it 'does auto-correction' do
-        corrected = autocorrect_source(source)
-        expect(corrected).to eq "  #{body} if #{conditional}\n"
+        expect_correction("  #{body} if #{conditional}\n")
       end
     end
 
@@ -379,7 +332,11 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
       it 'accepts' do
         expect("  #{body} if #{conditional}".length).to eq(81)
 
-        expect_no_offenses(source)
+        expect_no_offenses(<<-RUBY.strip_margin('|'))
+          |  if #{conditional}
+          |    #{body}
+          |  end
+        RUBY
       end
     end
   end
@@ -401,48 +358,68 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
   end
 
   it "doesn't break if-end when used as RHS of local var assignment" do
-    corrected = autocorrect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       a = if b
+          ^^ Favor modifier `if` usage when having a single-line body. [...]
         1
       end
     RUBY
-    expect(corrected).to eq "a = (1 if b)\n"
+
+    expect_correction(<<~RUBY)
+      a = (1 if b)
+    RUBY
   end
 
   it "doesn't break if-end when used as RHS of instance var assignment" do
-    corrected = autocorrect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       @a = if b
+           ^^ Favor modifier `if` usage when having a single-line body. [...]
         1
       end
     RUBY
-    expect(corrected).to eq "@a = (1 if b)\n"
+
+    expect_correction(<<~RUBY)
+      @a = (1 if b)
+    RUBY
   end
 
   it "doesn't break if-end when used as RHS of class var assignment" do
-    corrected = autocorrect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       @@a = if b
+            ^^ Favor modifier `if` usage when having a single-line body. [...]
         1
       end
     RUBY
-    expect(corrected).to eq "@@a = (1 if b)\n"
+
+    expect_correction(<<~RUBY)
+      @@a = (1 if b)
+    RUBY
   end
 
   it "doesn't break if-end when used as RHS of constant assignment" do
-    corrected = autocorrect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       A = if b
+          ^^ Favor modifier `if` usage when having a single-line body. [...]
         1
       end
     RUBY
-    expect(corrected).to eq "A = (1 if b)\n"
+
+    expect_correction(<<~RUBY)
+      A = (1 if b)
+    RUBY
   end
 
   it "doesn't break if-end when used as RHS of binary arithmetic" do
-    corrected = autocorrect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       a + if b
+          ^^ Favor modifier `if` usage when having a single-line body. [...]
         1
       end
     RUBY
-    expect(corrected).to eq "a + (1 if b)\n"
+
+    expect_correction(<<~RUBY)
+      a + (1 if b)
+    RUBY
   end
 
   it 'adds parens in autocorrect when if-end used with `||` operator' do
@@ -481,23 +458,31 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
 
   context 'if-end is argument to a parenthesized method call' do
     it "doesn't add redundant parentheses" do
-      corrected = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         puts("string", if a
+                       ^^ Favor modifier `if` usage when having a single-line body. [...]
           1
         end)
       RUBY
-      expect(corrected).to eq "puts(\"string\", 1 if a)\n"
+
+      expect_correction(<<~RUBY)
+        puts("string", 1 if a)
+      RUBY
     end
   end
 
   context 'if-end is argument to a non-parenthesized method call' do
     it 'adds parentheses so as not to change meaning' do
-      corrected = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         puts "string", if a
+                       ^^ Favor modifier `if` usage when having a single-line body. [...]
           1
         end
       RUBY
-      expect(corrected).to eq "puts \"string\", (1 if a)\n"
+
+      expect_correction(<<~RUBY)
+        puts "string", (1 if a)
+      RUBY
     end
   end
 
@@ -533,15 +518,7 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
 
   context 'with tabs used for indentation' do
     shared_examples 'with tabs indentation' do
-      let(:source) do
-        # Empty lines should make no difference.
-        <<-RUBY
-						if #{condition}
-							#{body}
-						end
-        RUBY
-      end
-
+      let(:indent) { "\t" * 6 }
       let(:body) { 'bbb' }
 
       context 'it fits on one line' do
@@ -552,12 +529,16 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
           # modifier.
           expect("#{body} if #{condition}".length).to eq(10)
 
-          inspect_source(source)
-          expect(cop.messages).to eq(
-            ['Favor modifier `if` usage when having a single-line' \
-             ' body. Another good alternative is the usage of control flow' \
-             ' `&&`/`||`.']
-          )
+          expect_offense(<<~RUBY, indent: indent)
+            %{indent}if #{condition}
+            _{indent}^^ Favor modifier `if` usage when having a single-line body. [...]
+            %{indent}\t#{body}
+            %{indent}end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            #{indent}#{body} if #{condition}
+          RUBY
         end
       end
 
@@ -569,7 +550,11 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
           # modifier.
           expect("#{body} if #{condition}".length).to eq(11)
 
-          expect_no_offenses(source)
+          expect_no_offenses(<<~RUBY)
+            #{indent}if #{condition}
+            #{indent}\t#{body}
+            #{indent}end
+          RUBY
         end
       end
     end
@@ -606,6 +591,10 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
         ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
           "This string would make the line longer than eighty characters if combined with the statement."
         end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        "This string would make the line longer than eighty characters if combined with the statement." if foo
       RUBY
     end
   end

--- a/spec/rubocop/cop/style/lambda_call_spec.rb
+++ b/spec/rubocop/cop/style/lambda_call_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
         x.(a, b)
         ^^^^^^^^ Prefer the use of `lambda.call(...)` over `lambda.(...)`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        x.call(a, b)
+      RUBY
     end
 
     it 'registers an offense for correct + opposite' do
@@ -17,15 +21,11 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
         x.(a, b)
         ^^^^^^^^ Prefer the use of `lambda.call(...)` over `lambda.(...)`.
       RUBY
-    end
 
-    it 'accepts x.call()' do
-      expect_no_offenses('x.call(a, b)')
-    end
-
-    it 'auto-corrects x.() to x.call()' do
-      new_source = autocorrect_source('a.(x)')
-      expect(new_source).to eq('a.call(x)')
+      expect_correction(<<~RUBY)
+        x.call(a, b)
+        x.call(a, b)
+      RUBY
     end
   end
 
@@ -37,6 +37,10 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
         x.call(a, b)
         ^^^^^^^^^^^^ Prefer the use of `lambda.(...)` over `lambda.call(...)`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        x.(a, b)
+      RUBY
     end
 
     it 'registers an offense for opposite + correct' do
@@ -45,29 +49,35 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
         ^^^^^^^^^^^^ Prefer the use of `lambda.(...)` over `lambda.call(...)`.
         x.(a, b)
       RUBY
-    end
 
-    it 'accepts x.()' do
-      expect_no_offenses('x.(a, b)')
+      expect_correction(<<~RUBY)
+        x.(a, b)
+        x.(a, b)
+      RUBY
     end
 
     it 'accepts a call without receiver' do
       expect_no_offenses('call(a, b)')
     end
 
-    it 'auto-corrects x.call() to x.()' do
-      new_source = autocorrect_source('a.call(x)')
-      expect(new_source).to eq('a.(x)')
-    end
-
     it 'auto-corrects x.call to x.()' do
-      new_source = autocorrect_source('a.call')
-      expect(new_source).to eq('a.()')
+      expect_offense(<<~RUBY)
+        a.call
+        ^^^^^^ Prefer the use of `lambda.(...)` over `lambda.call(...)`.
+      RUBY
+      expect_correction(<<~RUBY)
+        a.()
+      RUBY
     end
 
     it 'auto-corrects x.call asdf, x123 to x.(asdf, x123)' do
-      new_source = autocorrect_source('a.call asdf, x123')
-      expect(new_source).to eq('a.(asdf, x123)')
+      expect_offense(<<~RUBY)
+        a.call asdf, x123
+        ^^^^^^^^^^^^^^^^^ Prefer the use of `lambda.(...)` over `lambda.call(...)`.
+      RUBY
+      expect_correction(<<~RUBY)
+        a.(asdf, x123)
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -1,87 +1,83 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::Lambda, :config do
-  shared_examples 'registers an offense' do |message|
-    it 'registers an offense' do
-      inspect_source(source)
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq([message])
-    end
-  end
-
-  shared_examples 'auto-correct' do |expected|
-    it 'auto-corrects' do
-      new_source = autocorrect_source(source)
-
-      expect(new_source).to eq(expected)
-    end
-  end
-
   context 'with enforced `lambda` style' do
     let(:cop_config) { { 'EnforcedStyle' => 'lambda' } }
 
     context 'with a single line lambda literal' do
       context 'with arguments' do
-        let(:source) { 'f = ->(x) { x }' }
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            f = ->(x) { x }
+                ^^ Use the `lambda` method for all lambdas.
+          RUBY
 
-        it_behaves_like 'registers an offense',
-                        'Use the `lambda` method for all lambdas.'
-        it_behaves_like 'auto-correct', 'f = lambda { |x| x }'
+          expect_correction(<<~RUBY)
+            f = lambda { |x| x }
+          RUBY
+        end
       end
 
       context 'without arguments' do
-        let(:source) { 'f = -> { x }' }
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            f = -> { x }
+                ^^ Use the `lambda` method for all lambdas.
+          RUBY
 
-        it_behaves_like 'registers an offense',
-                        'Use the `lambda` method for all lambdas.'
-        it_behaves_like 'auto-correct', 'f = lambda { x }'
+          expect_correction(<<~RUBY)
+            f = lambda { x }
+          RUBY
+        end
       end
 
       context 'without argument parens and spaces' do
-        let(:source) { 'f = ->x{ p x }' }
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            f = ->x{ p x }
+                ^^ Use the `lambda` method for all lambdas.
+          RUBY
 
-        it_behaves_like 'registers an offense',
-                        'Use the `lambda` method for all lambdas.'
-        it_behaves_like 'auto-correct', 'f = lambda{ |x| p x }'
+          expect_correction(<<~RUBY)
+            f = lambda{ |x| p x }
+          RUBY
+        end
       end
     end
 
     context 'with a multiline lambda literal' do
       context 'with arguments' do
-        let(:source) do
-          <<~RUBY
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
             f = ->(x) do
+                ^^ Use the `lambda` method for all lambdas.
+              x
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            f = lambda do |x|
               x
             end
           RUBY
         end
-
-        it_behaves_like 'registers an offense',
-                        'Use the `lambda` method for all lambdas.'
-        it_behaves_like 'auto-correct', <<~RUBY
-          f = lambda do |x|
-            x
-          end
-        RUBY
       end
 
       context 'without arguments' do
-        let(:source) do
-          <<~RUBY
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
             f = -> do
+                ^^ Use the `lambda` method for all lambdas.
+              x
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            f = lambda do
               x
             end
           RUBY
         end
-
-        it_behaves_like 'registers an offense',
-                        'Use the `lambda` method for all lambdas.'
-        it_behaves_like 'auto-correct', <<~RUBY
-          f = lambda do
-            x
-          end
-        RUBY
       end
     end
   end
@@ -91,61 +87,65 @@ RSpec.describe RuboCop::Cop::Style::Lambda, :config do
 
     context 'with a single line lambda method call' do
       context 'with arguments' do
-        let(:source) { 'f = lambda { |x| x }' }
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            f = lambda { |x| x }
+                ^^^^^^ Use the `-> { ... }` lambda literal syntax for all lambdas.
+          RUBY
 
-        it_behaves_like 'registers an offense',
-                        'Use the `-> { ... }` lambda literal syntax for ' \
-                        'all lambdas.'
-        it_behaves_like 'auto-correct', 'f = ->(x) { x }'
+          expect_correction(<<~RUBY)
+            f = ->(x) { x }
+          RUBY
+        end
       end
 
       context 'without arguments' do
-        let(:source) { 'f = lambda { x }' }
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            f = lambda { x }
+                ^^^^^^ Use the `-> { ... }` lambda literal syntax for all lambdas.
+          RUBY
 
-        it_behaves_like 'registers an offense',
-                        'Use the `-> { ... }` lambda literal syntax for ' \
-                        'all lambdas.'
-        it_behaves_like 'auto-correct', 'f = -> { x }'
+          expect_correction(<<~RUBY)
+            f = -> { x }
+          RUBY
+        end
       end
     end
 
     context 'with a multiline lambda method call' do
       context 'with arguments' do
-        let(:source) do
-          <<~RUBY
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
             f = lambda do |x|
+                ^^^^^^ Use the `-> { ... }` lambda literal syntax for all lambdas.
+              x
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            f = ->(x) do
               x
             end
           RUBY
         end
-
-        it_behaves_like 'registers an offense',
-                        'Use the `-> { ... }` lambda literal syntax for ' \
-                        'all lambdas.'
-        it_behaves_like 'auto-correct', <<~RUBY
-          f = ->(x) do
-            x
-          end
-        RUBY
       end
 
       context 'without arguments' do
-        let(:source) do
-          <<~RUBY
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
             f = lambda do
+                ^^^^^^ Use the `-> { ... }` lambda literal syntax for all lambdas.
+              x
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            f = -> do
               x
             end
           RUBY
         end
-
-        it_behaves_like 'registers an offense',
-                        'Use the `-> { ... }` lambda literal syntax for ' \
-                        'all lambdas.'
-        it_behaves_like 'auto-correct', <<~RUBY
-          f = -> do
-            x
-          end
-        RUBY
       end
     end
   end
@@ -155,21 +155,29 @@ RSpec.describe RuboCop::Cop::Style::Lambda, :config do
 
     context 'with a single line lambda method call' do
       context 'with arguments' do
-        let(:source) { 'f = lambda { |x| x }' }
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            f = lambda { |x| x }
+                ^^^^^^ Use the `-> { ... }` lambda literal syntax for single line lambdas.
+          RUBY
 
-        it_behaves_like 'registers an offense',
-                        'Use the `-> { ... }` lambda literal syntax for ' \
-                        'single line lambdas.'
-        it_behaves_like 'auto-correct', 'f = ->(x) { x }'
+          expect_correction(<<~RUBY)
+            f = ->(x) { x }
+          RUBY
+        end
       end
 
       context 'without arguments' do
-        let(:source) { 'f = lambda { x }' }
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            f = lambda { x }
+                ^^^^^^ Use the `-> { ... }` lambda literal syntax for single line lambdas.
+          RUBY
 
-        it_behaves_like 'registers an offense',
-                        'Use the `-> { ... }` lambda literal syntax for ' \
-                        'single line lambdas.'
-        it_behaves_like 'auto-correct', 'f = -> { x }'
+          expect_correction(<<~RUBY)
+            f = -> { x }
+          RUBY
+        end
       end
     end
 
@@ -195,12 +203,16 @@ RSpec.describe RuboCop::Cop::Style::Lambda, :config do
     context '>= Ruby 2.7', :ruby27 do
       context 'when using numbered parameter' do
         context 'with a single line lambda method call' do
-          let(:source) { 'f = lambda { _1 }' }
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              f = lambda { _1 }
+                  ^^^^^^ Use the `-> { ... }` lambda literal syntax for single line lambdas.
+            RUBY
 
-          it_behaves_like 'registers an offense',
-                          'Use the `-> { ... }` lambda literal syntax for ' \
-                          'single line lambdas.'
-          it_behaves_like 'auto-correct', 'f = -> { _1 }'
+            expect_correction(<<~RUBY)
+              f = -> { _1 }
+            RUBY
+          end
         end
 
         context 'with a multiline lambda method call' do
@@ -226,39 +238,37 @@ RSpec.describe RuboCop::Cop::Style::Lambda, :config do
 
     context 'with a multiline lambda literal' do
       context 'with arguments' do
-        let(:source) do
-          <<~RUBY
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
             f = ->(x) do
+                ^^ Use the `lambda` method for multiline lambdas.
+              x
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            f = lambda do |x|
               x
             end
           RUBY
         end
-
-        it_behaves_like 'registers an offense',
-                        'Use the `lambda` method for multiline lambdas.'
-        it_behaves_like 'auto-correct', <<~RUBY
-          f = lambda do |x|
-            x
-          end
-        RUBY
       end
 
       context 'without arguments' do
-        let(:source) do
-          <<~RUBY
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
             f = -> do
+                ^^ Use the `lambda` method for multiline lambdas.
+              x
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            f = lambda do
               x
             end
           RUBY
         end
-
-        it_behaves_like 'registers an offense',
-                        'Use the `lambda` method for multiline lambdas.'
-        it_behaves_like 'auto-correct', <<~RUBY
-          f = lambda do
-            x
-          end
-        RUBY
       end
     end
 
@@ -269,154 +279,157 @@ RSpec.describe RuboCop::Cop::Style::Lambda, :config do
       # See rubocop/cop/style/block_delimiters.rb.
       # Tests correction of an issue resulting in `lambdado` syntax errors.
       context 'without any spacing' do
-        let(:source) do
-          <<~RUBY
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
             ->(x)do
+            ^^ Use the `lambda` method for multiline lambdas.
+              x
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            lambda do |x|
               x
             end
           RUBY
         end
-
-        it_behaves_like 'auto-correct', <<~RUBY
-          lambda do |x|
-            x
-          end
-        RUBY
       end
 
       context 'without spacing after arguments' do
-        let(:source) do
-          <<~RUBY
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
             -> (x)do
+            ^^ Use the `lambda` method for multiline lambdas.
+              x
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            lambda do |x|
               x
             end
           RUBY
         end
-
-        it_behaves_like 'auto-correct', <<~RUBY
-          lambda do |x|
-            x
-          end
-        RUBY
       end
 
       context 'without spacing before arguments' do
-        let(:source) do
-          <<~RUBY
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
             ->(x) do
+            ^^ Use the `lambda` method for multiline lambdas.
+              x
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            lambda do |x|
               x
             end
           RUBY
         end
-
-        it_behaves_like 'auto-correct', <<~RUBY
-          lambda do |x|
-            x
-          end
-        RUBY
       end
 
       context 'with a multiline lambda literal' do
         context 'with empty arguments' do
-          let(:source) do
-            <<~RUBY
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
               ->()do
+              ^^ Use the `lambda` method for multiline lambdas.
+                x
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              lambda do
                 x
               end
             RUBY
           end
-
-          it_behaves_like 'auto-correct', <<~RUBY
-            lambda do
-              x
-            end
-          RUBY
         end
 
         context 'with no arguments and bad spacing' do
-          let(:source) do
-            <<~RUBY
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
               -> ()do
+              ^^ Use the `lambda` method for multiline lambdas.
+                x
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              lambda do
                 x
               end
             RUBY
           end
-
-          it_behaves_like 'auto-correct', <<~RUBY
-            lambda do
-              x
-            end
-          RUBY
         end
 
         context 'with no arguments and no spacing' do
-          let(:source) do
-            <<~RUBY
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
               ->do
+              ^^ Use the `lambda` method for multiline lambdas.
+                x
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              lambda do
                 x
               end
             RUBY
           end
-
-          it_behaves_like 'auto-correct', <<~RUBY
-            lambda do
-              x
-            end
-          RUBY
         end
 
         context 'without parentheses' do
-          let(:source) do
-            <<~RUBY
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
               -> hello do
+              ^^ Use the `lambda` method for multiline lambdas.
+                puts hello
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              lambda do |hello|
                 puts hello
               end
             RUBY
           end
-
-          it_behaves_like 'registers an offense',
-                          'Use the `lambda` method for multiline lambdas.'
-          it_behaves_like 'auto-correct', <<~RUBY
-            lambda do |hello|
-              puts hello
-            end
-          RUBY
         end
 
         context 'with no parentheses and bad spacing' do
-          let(:source) do
-            <<~RUBY
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
               ->   hello  do
+              ^^ Use the `lambda` method for multiline lambdas.
+                puts hello
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              lambda do |hello|
                 puts hello
               end
             RUBY
           end
-
-          it_behaves_like 'registers an offense',
-                          'Use the `lambda` method for multiline lambdas.'
-          it_behaves_like 'auto-correct', <<~RUBY
-            lambda do |hello|
-              puts hello
-            end
-          RUBY
         end
 
         context 'with no parentheses and many args' do
-          let(:source) do
-            <<~RUBY
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
               ->   hello, user  do
+              ^^ Use the `lambda` method for multiline lambdas.
+                puts hello
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              lambda do |hello, user|
                 puts hello
               end
             RUBY
           end
-
-          it_behaves_like 'registers an offense',
-                          'Use the `lambda` method for multiline lambdas.'
-          it_behaves_like 'auto-correct', <<~RUBY
-            lambda do |hello, user|
-              puts hello
-            end
-          RUBY
         end
       end
     end
@@ -428,79 +441,75 @@ RSpec.describe RuboCop::Cop::Style::Lambda, :config do
     end
 
     context 'with a multiline lambda literal as an argument' do
-      let(:source) do
-        <<~RUBY
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
           has_many :kittens, -> do
+                             ^^ Use the `lambda` method for multiline lambdas.
             where(cats: Cat.young.where_values_hash)
           end, source: cats
         RUBY
-      end
 
-      it_behaves_like 'registers an offense',
-                      'Use the `lambda` method for multiline lambdas.'
-      it_behaves_like 'auto-correct', <<~RUBY
-        has_many :kittens, lambda {
-          where(cats: Cat.young.where_values_hash)
-        }, source: cats
-      RUBY
+        expect_correction(<<~RUBY)
+          has_many :kittens, lambda {
+            where(cats: Cat.young.where_values_hash)
+          }, source: cats
+        RUBY
+      end
     end
 
     context 'with a multiline braces lambda literal as a keyword argument' do
-      let(:source) do
-        <<~RUBY
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
           has_many opt: -> do
+                        ^^ Use the `lambda` method for multiline lambdas.
             where(cats: Cat.young.where_values_hash)
           end
         RUBY
-      end
 
-      it_behaves_like 'registers an offense',
-                      'Use the `lambda` method for multiline lambdas.'
-      it_behaves_like 'auto-correct', <<~RUBY
-        has_many opt: lambda {
-          where(cats: Cat.young.where_values_hash)
-        }
-      RUBY
-    end
-
-    context 'with a multiline do-end lambda literal as a keyword argument' do
-      let(:source) do
-        <<~RUBY
-          has_many opt: -> {
+        expect_correction(<<~RUBY)
+          has_many opt: lambda {
             where(cats: Cat.young.where_values_hash)
           }
         RUBY
       end
+    end
 
-      it_behaves_like 'registers an offense',
-                      'Use the `lambda` method for multiline lambdas.'
-      it_behaves_like 'auto-correct', <<~RUBY
-        has_many opt: lambda {
-          where(cats: Cat.young.where_values_hash)
-        }
-      RUBY
+    context 'with a multiline do-end lambda literal as a keyword argument' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          has_many opt: -> {
+                        ^^ Use the `lambda` method for multiline lambdas.
+            where(cats: Cat.young.where_values_hash)
+          }
+        RUBY
+
+        expect_correction(<<~RUBY)
+          has_many opt: lambda {
+            where(cats: Cat.young.where_values_hash)
+          }
+        RUBY
+      end
     end
 
     context 'with a multiline do-end lambda as a parenthesized kwarg' do
-      let(:source) do
-        <<~RUBY
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
           has_many(
             opt: -> do
+                 ^^ Use the `lambda` method for multiline lambdas.
+              where(cats: Cat.young.where_values_hash)
+            end
+          )
+        RUBY
+
+        expect_correction(<<~RUBY)
+          has_many(
+            opt: lambda do
               where(cats: Cat.young.where_values_hash)
             end
           )
         RUBY
       end
-
-      it_behaves_like 'registers an offense',
-                      'Use the `lambda` method for multiline lambdas.'
-      it_behaves_like 'auto-correct', <<~RUBY
-        has_many(
-          opt: lambda do
-            where(cats: Cat.young.where_values_hash)
-          end
-        )
-      RUBY
     end
   end
 

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -583,13 +583,13 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
 
     it 'auto-corrects multi-line calls with trailing whitespace' do
       original = <<~RUBY
-        foo(
+        foo( 
           bar: 3
         )
       RUBY
 
       expect(autocorrect_source(original)).to eq(<<~RUBY)
-        foo \\
+        foo \\ 
           bar: 3
 
       RUBY

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
         top.test a, b
         ^^^^^^^^^^^^^ Use parentheses for method calls with arguments.
       RUBY
+
+      expect_correction(<<~RUBY)
+        top.test(a, b)
+      RUBY
     end
 
     context 'when using safe navigation operator' do
@@ -34,6 +38,10 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
         expect_offense(<<~RUBY)
           top&.test a, b
           ^^^^^^^^^^^^^^ Use parentheses for method calls with arguments.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          top&.test(a, b)
         RUBY
       end
     end
@@ -45,6 +53,12 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
           ^^^^^^^^^ Use parentheses for method calls with arguments.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          test(a, b)
+        end
+      RUBY
     end
 
     it 'register an offense for methods starting with capital without parens' do
@@ -54,6 +68,12 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
           ^^^^^^^^^ Use parentheses for method calls with arguments.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          Test(a, b)
+        end
+      RUBY
     end
 
     it 'register an offense for superclass call without parens' do
@@ -61,6 +81,12 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
         def foo
           super a
           ^^^^^^^ Use parentheses for method calls with arguments.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          super(a)
         end
       RUBY
     end
@@ -84,6 +110,12 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
           ^^^^^^^ Use parentheses for method calls with arguments.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          yield(a)
+        end
+      RUBY
     end
 
     it 'accepts no parens for operators' do
@@ -98,57 +130,26 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       expect_no_offenses('!test')
     end
 
-    it 'auto-corrects call by adding needed braces' do
-      new_source = autocorrect_source('top.test a')
-      expect(new_source).to eq('top.test(a)')
-    end
-
-    it 'auto-corrects superclass call by adding needed braces' do
-      new_source = autocorrect_source(<<~RUBY)
-        def foo
-          super a
-        end
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        def foo
-          super(a)
-        end
-      RUBY
-    end
-
-    it 'auto-corrects yield by adding needed braces' do
-      new_source = autocorrect_source(<<~RUBY)
-        def foo
-          yield a
-        end
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        def foo
-          yield(a)
-        end
-      RUBY
-    end
-
     it 'auto-corrects fully parenthesized args by removing space' do
-      new_source = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         top.eq (1 + 2)
+        ^^^^^^^^^^^^^^ Use parentheses for method calls with arguments.
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         top.eq(1 + 2)
       RUBY
     end
 
     it 'auto-corrects parenthesized args for local methods by removing space' do
-      new_source = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         def foo
           eq (1 + 2)
+          ^^^^^^^^^^ Use parentheses for method calls with arguments.
         end
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         def foo
           eq(1 + 2)
         end
@@ -156,14 +157,16 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
     end
 
     it 'auto-corrects call with multiple args by adding braces' do
-      new_source = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         def foo
           eq 1, (2 + 3)
+          ^^^^^^^^^^^^^ Use parentheses for method calls with arguments.
           eq 1, 2, 3
+          ^^^^^^^^^^ Use parentheses for method calls with arguments.
         end
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         def foo
           eq(1, (2 + 3))
           eq(1, 2, 3)
@@ -172,33 +175,36 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
     end
 
     it 'auto-corrects partially parenthesized args by adding needed braces' do
-      new_source = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         top.eq (1 + 2) + 3
+        ^^^^^^^^^^^^^^^^^^ Use parentheses for method calls with arguments.
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         top.eq((1 + 2) + 3)
       RUBY
     end
 
     it 'auto-corrects calls with multiple args by adding needed braces' do
-      new_source = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         top.eq (1 + 2), 3
+        ^^^^^^^^^^^^^^^^^ Use parentheses for method calls with arguments.
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         top.eq((1 + 2), 3)
       RUBY
     end
 
     it 'auto-corrects calls where arg is method call' do
-      new_source = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         def my_method
           foo bar.baz(abc, xyz)
+          ^^^^^^^^^^^^^^^^^^^^^ Use parentheses for method calls with arguments.
         end
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         def my_method
           foo(bar.baz(abc, xyz))
         end
@@ -206,13 +212,14 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
     end
 
     it 'auto-corrects calls where multiple args are method calls' do
-      new_source = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         def my_method
           foo bar.baz(abc, xyz), foo(baz)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use parentheses for method calls with arguments.
         end
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         def my_method
           foo(bar.baz(abc, xyz), foo(baz))
         end
@@ -220,13 +227,14 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
     end
 
     it 'auto-corrects calls where the argument node is a constant' do
-      new_source = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         def my_method
           raise NotImplementedError
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ Use parentheses for method calls with arguments.
         end
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         def my_method
           raise(NotImplementedError)
         end
@@ -234,13 +242,14 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
     end
 
     it 'auto-corrects calls where the argument node is a number' do
-      new_source = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         def my_method
           sleep 1
+          ^^^^^^^ Use parentheses for method calls with arguments.
         end
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         def my_method
           sleep(1)
         end
@@ -304,6 +313,10 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
         top.test()
                 ^^ Omit parentheses for method calls with arguments.
       RUBY
+
+      expect_correction(<<~RUBY)
+        top.test 
+      RUBY
     end
 
     it 'register an offense for multi-line method calls' do
@@ -313,6 +326,12 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
           foo: bar
         )
       RUBY
+
+      expect_correction(<<~RUBY)
+        test \\
+          foo: bar
+
+      RUBY
     end
 
     it 'register an offense for superclass call with parens' do
@@ -320,6 +339,12 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
         def foo
           super(a)
                ^^^ Omit parentheses for method calls with arguments.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          super a
         end
       RUBY
     end
@@ -331,12 +356,22 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
                ^^^ Omit parentheses for method calls with arguments.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          yield a
+        end
+      RUBY
     end
 
     it 'register an offense for parens in the last chain' do
       expect_offense(<<~RUBY)
         foo().bar(3).wait(4)
                          ^^^ Omit parentheses for method calls with arguments.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo().bar(3).wait 4
       RUBY
     end
 
@@ -347,6 +382,12 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
           bar
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        foo :arg do
+          bar
+        end
+      RUBY
     end
 
     it 'register an offense for hashes in keyword values' do
@@ -354,12 +395,20 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
         method_call(hash: {foo: :bar})
                    ^^^^^^^^^^^^^^^^^^^ Omit parentheses for method calls with arguments.
       RUBY
+
+      expect_correction(<<~RUBY)
+        method_call hash: {foo: :bar}
+      RUBY
     end
 
     it 'register an offense for %r regex literal as arguments' do
       expect_offense(<<~RUBY)
         method_call(%r{foo})
                    ^^^^^^^^^ Omit parentheses for method calls with arguments.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        method_call %r{foo}
       RUBY
     end
 
@@ -375,6 +424,18 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
           elsif whatevs?
             h.do_with(kw: value)
                      ^^^^^^^^^^^ Omit parentheses for method calls with arguments.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          if cond.present? && verify?(:something)
+            h.do_with kw: value
+          elsif cond.present? || verify?(:something_else)
+            h.do_with kw: value
+          elsif whatevs?
+            h.do_with kw: value
           end
         end
       RUBY
@@ -395,6 +456,16 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
         bar.foo(42).quux += A::B.new(c)
                                     ^^^ Omit parentheses for method calls with arguments.
       RUBY
+
+      expect_correction(<<~RUBY)
+        foo = A::B.new c
+        bar.foo = A::B.new c
+        bar.foo(42).quux = A::B.new c
+
+        bar.foo(42).quux &&= A::B.new c
+
+        bar.foo(42).quux += A::B.new c
+      RUBY
     end
 
     it 'register an offense for camel-case methods with arguments' do
@@ -402,12 +473,21 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
         Array(:arg)
              ^^^^^^ Omit parentheses for method calls with arguments.
       RUBY
+
+      expect_correction(<<~RUBY)
+        Array :arg
+      RUBY
     end
 
     it 'register an offense in multi-line inheritance' do
       expect_offense(<<~RUBY)
         class Point < Struct.new(:x, :y)
                                 ^^^^^^^^ Omit parentheses for method calls with arguments.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Point < Struct.new :x, :y
         end
       RUBY
     end
@@ -572,72 +652,43 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
     end
 
     it 'auto-corrects single-line calls' do
-      original = <<~RUBY
+      expect_offense(<<~RUBY)
         top.test(1, 2, foo: bar(3))
+                ^^^^^^^^^^^^^^^^^^^ Omit parentheses for method calls with arguments.
       RUBY
 
-      expect(autocorrect_source(original)).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         top.test 1, 2, foo: bar(3)
       RUBY
     end
 
     it 'auto-corrects multi-line calls with trailing whitespace' do
-      original = <<~RUBY
+      expect_offense(<<~RUBY)
         foo( 
+           ^^ Omit parentheses for method calls with arguments.
           bar: 3
         )
       RUBY
 
-      expect(autocorrect_source(original)).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         foo \\ 
           bar: 3
 
       RUBY
     end
 
-    it 'auto-corrects multi-line class definitions with inheritance' do
-      original = <<~RUBY
-        class Point < Struct.new(:x, :y)
-        end
-      RUBY
-
-      expect(autocorrect_source(original)).to eq(<<~RUBY)
-        class Point < Struct.new :x, :y
-        end
-      RUBY
-    end
-
     it 'auto-corrects complex multi-line calls' do
-      original = <<~RUBY
+      expect_offense(<<~RUBY)
         foo(arg,
+           ^^^^^ Omit parentheses for method calls with arguments.
           option: true
         )
       RUBY
 
-      expect(autocorrect_source(original)).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         foo arg,
           option: true
 
-      RUBY
-    end
-
-    it 'auto-corrects chained calls' do
-      original = <<~RUBY
-        foo().bar(3).wait(4)
-      RUBY
-
-      expect(autocorrect_source(original)).to eq(<<~RUBY)
-        foo().bar(3).wait 4
-      RUBY
-    end
-
-    it 'auto-corrects camel-case methods with arguments' do
-      original = <<~RUBY
-        Array(:arg)
-      RUBY
-
-      expect(autocorrect_source(original)).to eq(<<~RUBY)
-        Array :arg
       RUBY
     end
 
@@ -658,6 +709,10 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
           Rails.convoluted.example.logger.error("something")
                                                ^^^^^^^^^^^^^ Omit parentheses for method calls with arguments.
         RUBY
+
+        expect_correction(<<~RUBY)
+          Rails.convoluted.example.logger.error "something"
+        RUBY
       end
 
       it 'register offense for multi-line chaining without previous parens' do
@@ -669,28 +724,22 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
             .error("something")
                   ^^^^^^^^^^^^^ Omit parentheses for method calls with arguments.
         RUBY
+
+        expect_correction(<<~RUBY)
+          Rails
+            .convoluted
+            .example
+            .logger
+            .error "something"
+        RUBY
       end
 
-      it 'accepts parens in the last call if previous calls with parens' do
+      it 'accepts no parens in the last call if previous calls with parens' do
         expect_no_offenses('foo().bar(3).wait 4')
       end
 
-      it 'does not auto-correct if any previous call have parentheses' do
-        original = <<~RUBY
-          foo().bar(3).quux.wait(4)
-        RUBY
-
-        expect(autocorrect_source(original)).to eq(original)
-      end
-
-      it 'auto-correct if previous does calls have parentheses' do
-        original = <<~RUBY
-          foo.bar.wait(4)
-        RUBY
-
-        expect(autocorrect_source(original)).to eq(<<~RUBY)
-          foo.bar.wait 4
-        RUBY
+      it 'accepts parens in the last call if any previous calls with parentheses' do
+        expect_no_offenses('foo().bar(3).quux.wait(4)')
       end
     end
 
@@ -702,22 +751,12 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
         }
       end
 
-      it 'accepts parens for multi-line calls ' do
+      it 'accepts parens for multi-line calls' do
         expect_no_offenses(<<~RUBY)
           test(
             foo: bar
           )
         RUBY
-      end
-
-      it 'does not auto-correct' do
-        original = <<~RUBY
-          foo(
-            bar: 3
-          )
-        RUBY
-
-        expect(autocorrect_source(original)).to eq(original)
       end
     end
 
@@ -751,16 +790,8 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
             ^^^^^^^^ Use parentheses for method calls with arguments.
           end
         RUBY
-      end
 
-      it 'does autocorrect' do
-        new_source = autocorrect_source(<<~RUBY)
-          class Foo
-            bar :abc
-          end
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
+        expect_correction(<<~RUBY)
           class Foo
             bar(:abc)
           end
@@ -776,16 +807,8 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
             ^^^^^^^^ Use parentheses for method calls with arguments.
           end
         RUBY
-      end
 
-      it 'does autocorrect' do
-        new_source = autocorrect_source(<<~RUBY)
-          module Foo
-            bar :abc
-          end
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
+        expect_correction(<<~RUBY)
           module Foo
             bar(:abc)
           end
@@ -794,7 +817,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
     end
 
     context 'for a macro not on the included list' do
-      it 'finds offense' do
+      it 'allows' do
         expect_no_offenses(<<~RUBY)
           module Foo
             baz :abc
@@ -812,7 +835,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
         }
       end
 
-      it 'finds offense' do
+      it 'allows' do
         expect_no_offenses(<<~RUBY)
           module Foo
             bar :abc

--- a/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses, :config do
       top.test()
               ^^ Do not use parentheses for method calls with no arguments.
     RUBY
+
+    expect_correction(<<~RUBY)
+      top.test
+    RUBY
   end
 
   it 'accepts parentheses for methods starting with an upcase letter' do
     expect_no_offenses('Test()')
-  end
-
-  it 'accepts no parens in method call without args' do
-    expect_no_offenses('top.test')
   end
 
   it 'accepts parens in method call with args' do
@@ -67,12 +67,20 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses, :config do
       obj.method ||= func()
                          ^^ Do not use parentheses for method calls with no arguments.
     RUBY
+
+    expect_correction(<<~RUBY)
+      obj.method ||= func
+    RUBY
   end
 
   it 'registers an offense for `obj.method &&= func()`' do
     expect_offense(<<~RUBY)
       obj.method &&= func()
                          ^^ Do not use parentheses for method calls with no arguments.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      obj.method &&= func
     RUBY
   end
 
@@ -81,23 +89,25 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses, :config do
       obj.method += func()
                         ^^ Do not use parentheses for method calls with no arguments.
     RUBY
-  end
 
-  it 'auto-corrects by removing unneeded braces' do
-    new_source = autocorrect_source('test()')
-    expect(new_source).to eq('test')
+    expect_correction(<<~RUBY)
+      obj.method += func
+    RUBY
   end
 
   # These will be offenses for the EmptyLiteral cop. The autocorrect loop will
   # handle that.
   it 'auto-corrects calls that could be empty literals' do
-    original = <<~RUBY
+    expect_offense(<<~RUBY)
       Hash.new()
+              ^^ Do not use parentheses for method calls with no arguments.
       Array.new()
+               ^^ Do not use parentheses for method calls with no arguments.
       String.new()
+                ^^ Do not use parentheses for method calls with no arguments.
     RUBY
-    new_source = autocorrect_source(original)
-    expect(new_source).to eq(<<~RUBY)
+
+    expect_correction(<<~RUBY)
       Hash.new
       Array.new
       String.new
@@ -114,12 +124,20 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses, :config do
         _a = c(d())
                 ^^ Do not use parentheses for method calls with no arguments.
       RUBY
+
+      expect_correction(<<~RUBY)
+        _a = c(d)
+      RUBY
     end
 
     it 'registers an empty parens offense for multiple assignment' do
       expect_offense(<<~RUBY)
         _a, _b, _c = d(e())
                         ^^ Do not use parentheses for method calls with no arguments.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        _a, _b, _c = d(e)
       RUBY
     end
   end

--- a/spec/rubocop/cop/style/method_def_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_def_parentheses_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
                  ^^^^ Use def with parentheses when there are parameters.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def func(a, b)
+        end
+      RUBY
     end
 
     it 'reports an offense for correct + opposite' do
@@ -20,12 +25,24 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
                  ^^^^ Use def with parentheses when there are parameters.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def func(a, b)
+        end
+        def func(a, b)
+        end
+      RUBY
     end
 
     it 'reports an offense for class def with parameters but no parens' do
       expect_offense(<<~RUBY)
         def Test.func a, b
                       ^^^^ Use def with parentheses when there are parameters.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def Test.func(a, b)
         end
       RUBY
     end
@@ -37,24 +54,26 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
       RUBY
     end
 
-    it 'auto-adds required parens for a def' do
-      new_source = autocorrect_source('def test param; end')
-      expect(new_source).to eq('def test(param); end')
-    end
-
     it 'auto-adds required parens for a defs' do
-      new_source = autocorrect_source('def self.test param; end')
-      expect(new_source).to eq('def self.test(param); end')
+      expect_offense(<<~RUBY)
+        def self.test param; end
+                      ^^^^^ Use def with parentheses when there are parameters.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def self.test(param); end
+      RUBY
     end
 
     it 'auto-adds required parens to argument lists on multiple lines' do
-      new_source = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         def test one,
+                 ^^^^ Use def with parentheses when there are parameters.
         two
         end
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         def test(one,
         two)
         end
@@ -69,6 +88,11 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
       expect_offense(<<~RUBY)
         def func(a, b)
                 ^^^^^^ Use def without parentheses.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def func a, b
         end
       RUBY
     end
@@ -88,12 +112,24 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
         def func a, b
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def func a, b
+        end
+        def func a, b
+        end
+      RUBY
     end
 
     it 'reports an offense for class def with parameters with parens' do
       expect_offense(<<~RUBY)
         def Test.func(a, b)
                      ^^^^^^ Use def without parentheses.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def Test.func a, b
         end
       RUBY
     end
@@ -111,6 +147,11 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
                 ^^ Use def without parentheses.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def func 
+        end
+      RUBY
     end
 
     it 'accepts def with no args and no parens' do
@@ -120,14 +161,14 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
       RUBY
     end
 
-    it 'auto-removes the parens' do
-      new_source = autocorrect_source('def test(param); end')
-      expect(new_source).to eq('def test param; end')
-    end
-
     it 'auto-removes the parens for defs' do
-      new_source = autocorrect_source('def self.test(param); end')
-      expect(new_source).to eq('def self.test param; end')
+      expect_offense(<<~RUBY)
+        def self.test(param); end
+                     ^^^^^^^ Use def without parentheses.
+      RUBY
+      expect_correction(<<~RUBY)
+        def self.test param; end
+      RUBY
     end
   end
 
@@ -147,6 +188,21 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
     end
 
     context 'when args span multiple lines' do
+      it 'auto-adds required parens to argument lists on multiple lines' do
+        expect_offense(<<~RUBY)
+          def test one,
+                   ^^^^ Use def with parentheses when there are parameters.
+          two
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def test(one,
+          two)
+          end
+        RUBY
+      end
+
       it 'reports an offense for correct + opposite' do
         expect_offense(<<~RUBY)
           def func(a,
@@ -157,18 +213,13 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
                    b
           end
         RUBY
-      end
 
-      it 'auto-adds required parens to argument lists on multiple lines' do
-        new_source = autocorrect_source(<<~RUBY)
-          def test one,
-          two
+        expect_correction(<<~RUBY)
+          def func(a,
+                   b)
           end
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          def test(one,
-          two)
+          def func(a,
+                   b)
           end
         RUBY
       end

--- a/spec/rubocop/cop/style/min_max_spec.rb
+++ b/spec/rubocop/cop/style/min_max_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe RuboCop::Cop::Style::MinMax, :config do
           [foo.min, foo.max]
           ^^^^^^^^^^^^^^^^^^ Use `foo.minmax` instead of `[foo.min, foo.max]`.
         RUBY
+
+        expect_correction(<<~RUBY)
+          foo.minmax
+        RUBY
       end
 
       it 'does not register an offense if the receivers do not match' do
@@ -27,16 +31,6 @@ RSpec.describe RuboCop::Cop::Style::MinMax, :config do
           [min, max]
         RUBY
       end
-
-      it 'auto-corrects an offense to use `#minmax`' do
-        corrected = autocorrect_source(<<~RUBY)
-          [foo.bar.min, foo.bar.max]
-        RUBY
-
-        expect(corrected).to eq(<<~RUBY)
-          foo.bar.minmax
-        RUBY
-      end
     end
 
     context 'when the expression is used in a parallel assignment' do
@@ -44,6 +38,10 @@ RSpec.describe RuboCop::Cop::Style::MinMax, :config do
         expect_offense(<<~RUBY)
           bar = foo.min, foo.max
                 ^^^^^^^^^^^^^^^^ Use `foo.minmax` instead of `foo.min, foo.max`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          bar = foo.minmax
         RUBY
       end
 
@@ -64,16 +62,6 @@ RSpec.describe RuboCop::Cop::Style::MinMax, :config do
           bar = min, max
         RUBY
       end
-
-      it 'auto-corrects an offense to use `#minmax`' do
-        corrected = autocorrect_source(<<~RUBY)
-          baz = foo.bar.min, foo.bar.max
-        RUBY
-
-        expect(corrected).to eq(<<~RUBY)
-          baz = foo.bar.minmax
-        RUBY
-      end
     end
 
     context 'when the expression is used as a return value' do
@@ -81,6 +69,10 @@ RSpec.describe RuboCop::Cop::Style::MinMax, :config do
         expect_offense(<<~RUBY)
           return foo.min, foo.max
                  ^^^^^^^^^^^^^^^^ Use `foo.minmax` instead of `foo.min, foo.max`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          return foo.minmax
         RUBY
       end
 
@@ -99,16 +91,6 @@ RSpec.describe RuboCop::Cop::Style::MinMax, :config do
       it 'does not register an offense if the receiver is implicit' do
         expect_no_offenses(<<~RUBY)
           return min, max
-        RUBY
-      end
-
-      it 'auto-corrects an offense to use `#minmax`' do
-        corrected = autocorrect_source(<<~RUBY)
-          return foo.bar.min, foo.bar.max
-        RUBY
-
-        expect(corrected).to eq(<<~RUBY)
-          return foo.bar.minmax
         RUBY
       end
     end

--- a/spec/rubocop/cop/style/multiline_if_modifier_spec.rb
+++ b/spec/rubocop/cop/style/multiline_if_modifier_spec.rb
@@ -3,111 +3,101 @@
 RSpec.describe RuboCop::Cop::Style::MultilineIfModifier do
   subject(:cop) { described_class.new }
 
-  shared_examples 'offense' do |modifier|
-    it 'registers an offense' do
-      inspect_source(source)
-      expect(cop.messages)
-        .to eq(["Favor a normal #{modifier}-statement over a modifier" \
-                ' clause in a multiline statement.'])
-    end
-  end
-
-  shared_examples 'no offense' do
-    it 'does not register an offense' do
-      expect_no_offenses(source)
-    end
-  end
-
-  shared_examples 'autocorrect' do |correct_code|
-    it 'auto-corrects' do
-      corrected = autocorrect_source(source)
-      expect(corrected).to eq(correct_code)
-    end
-  end
-
   context 'if guard clause' do
-    let(:source) do
-      [
-        '{',
-        '  result: run',
-        '} if cond'
-      ].join("\n")
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        {
+        ^ Favor a normal if-statement over a modifier clause in a multiline statement.
+          result: run
+        } if cond
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if cond
+          {
+            result: run
+          }
+        end
+      RUBY
     end
 
-    include_examples 'offense', 'if'
-    include_examples 'autocorrect', "if cond\n  {\n    result: run\n  }\nend"
-
-    context 'one liner' do
-      let(:source) { 'run if cond' }
-
-      include_examples 'no offense'
+    it 'allows a one liner' do
+      expect_no_offenses(<<~RUBY)
+        run if cond
+      RUBY
     end
 
-    context 'multiline condition' do
-      let(:source) { "run if cond &&\n       cond2" }
-
-      include_examples 'no offense'
+    it 'allows a multiline condition' do
+      expect_no_offenses(<<~RUBY)
+        run if cond &&
+               cond2
+      RUBY
     end
 
-    context 'indented offense' do
-      let(:source) do
-        [
-          '  {',
-          '    result: run',
-          '  } if cond'
-        ].join("\n")
-      end
+    it 'registers an offense when indented' do
+      expect_offense(<<-RUBY.strip_margin('|'))
+        |  {
+        |  ^ Favor a normal if-statement over a modifier clause in a multiline statement.
+        |    result: run
+        |  } if cond
+      RUBY
 
-      include_examples 'autocorrect', "  if cond\n" \
-                                      "    {\n" \
-                                      "      result: run\n" \
-                                      "    }\n" \
-                                      '  end'
+      expect_correction(<<-RUBY.strip_margin('|'))
+        |  if cond
+        |    {
+        |      result: run
+        |    }
+        |  end
+      RUBY
     end
   end
 
   context 'unless guard clause' do
-    let(:source) do
-      [
-        '{',
-        '  result: run',
-        '} unless cond'
-      ].join("\n")
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        {
+        ^ Favor a normal unless-statement over a modifier clause in a multiline statement.
+          result: run
+        } unless cond
+      RUBY
+
+      expect_correction(<<~RUBY)
+        unless cond
+          {
+            result: run
+          }
+        end
+      RUBY
     end
 
-    include_examples 'offense', 'unless'
-    include_examples 'autocorrect', "unless cond\n" \
-                                    "  {\n" \
-                                    "    result: run\n" \
-                                    "  }\n" \
-                                    'end'
-
-    context 'one liner' do
-      let(:source) { 'run unless cond' }
-
-      include_examples 'no offense'
+    it 'allows a one liner' do
+      expect_no_offenses(<<~RUBY)
+        run unless cond
+      RUBY
     end
 
-    context 'multiline condition' do
-      let(:source) { "run unless cond &&\n           cond2" }
-
-      include_examples 'no offense'
+    it 'allows a multiline condition' do
+      expect_no_offenses(<<~RUBY)
+        run unless cond &&
+                   cond2
+      RUBY
     end
 
-    context 'indented offense' do
-      let(:source) do
-        [
-          '  {',
-          '    result: run',
-          '  } unless cond'
-        ].join("\n")
-      end
+    it 'registers an offense when indented' do
+      expect_offense(<<-RUBY.strip_margin('|'))
+        |  {
+        |  ^ Favor a normal unless-statement over a modifier clause in a multiline statement.
+        |    result: run
+        |  } unless cond
+      RUBY
 
-      include_examples 'autocorrect', "  unless cond\n" \
-                                      "    {\n" \
-                                      "      result: run\n" \
-                                      "    }\n" \
-                                      '  end'
+      expect_correction(<<-RUBY.strip_margin('|'))
+        |  unless cond
+        |    {
+        |      result: run
+        |    }
+        |  end
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/multiline_if_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_if_then_spec.rb
@@ -32,6 +32,19 @@ RSpec.describe RuboCop::Cop::Style::MultilineIfThen do
               ^^^^ Do not use `then` for multi-line `if`.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      if cond
+      end
+      if cond\t
+      end
+      if cond
+      end
+      if cond
+      end
+      if cond # bad
+      end
+    RUBY
   end
 
   it 'registers an offense for then in multiline elsif' do
@@ -43,11 +56,12 @@ RSpec.describe RuboCop::Cop::Style::MultilineIfThen do
         b
       end
     RUBY
-  end
 
-  it 'accepts multiline if without then' do
-    expect_no_offenses(<<~RUBY)
-      if cond
+    expect_correction(<<~RUBY)
+      if cond1
+        a
+      elsif cond2
+        b
       end
     RUBY
   end
@@ -84,7 +98,7 @@ RSpec.describe RuboCop::Cop::Style::MultilineIfThen do
 
   it 'does not raise an error for an implicit match if' do
     expect do
-      inspect_source(<<~RUBY)
+      expect_no_offenses(<<~RUBY)
         if //
         end
       RUBY
@@ -99,10 +113,8 @@ RSpec.describe RuboCop::Cop::Style::MultilineIfThen do
                   ^^^^ Do not use `then` for multi-line `unless`.
       end
     RUBY
-  end
 
-  it 'accepts multiline unless without then' do
-    expect_no_offenses(<<~RUBY)
+    expect_correction(<<~RUBY)
       unless cond
       end
     RUBY
@@ -122,23 +134,10 @@ RSpec.describe RuboCop::Cop::Style::MultilineIfThen do
 
   it 'does not raise an error for an implicit match unless' do
     expect do
-      inspect_source(<<~RUBY)
+      expect_no_offenses(<<~RUBY)
         unless //
         end
       RUBY
     end.not_to raise_error
-  end
-
-  it 'auto-corrects the usage of "then" in multiline if' do
-    new_source = autocorrect_source(<<~RUBY)
-      if cond then
-        something
-      end
-    RUBY
-    expect(new_source).to eq(<<~RUBY)
-      if cond
-        something
-      end
-    RUBY
   end
 end

--- a/spec/rubocop/cop/style/multiline_when_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_when_then_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe RuboCop::Cop::Style::MultilineWhenThen do
                ^^^^ Do not use `then` for multiline `when` statement.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      case foo
+      when bar
+      end
+    RUBY
   end
 
   it 'registers an offense for multiline when statement with then' do
@@ -17,6 +23,13 @@ RSpec.describe RuboCop::Cop::Style::MultilineWhenThen do
       case foo
       when bar then
                ^^^^ Do not use `then` for multiline `when` statement.
+      do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      case foo
+      when bar
       do_something
       end
     RUBY
@@ -40,8 +53,8 @@ RSpec.describe RuboCop::Cop::Style::MultilineWhenThen do
     RUBY
   end
 
-  it "doesn't register an offense for multiline when statement
-  with then followed by other lines" do
+  it "doesn't register an offense for multiline when statement" \
+     'with then followed by other lines' do
     expect_no_offenses(<<~RUBY)
       case foo
       when bar then do_something
@@ -87,44 +100,17 @@ RSpec.describe RuboCop::Cop::Style::MultilineWhenThen do
     RUBY
   end
 
-  it 'autocorrects then in empty when' do
-    new_source = autocorrect_source(<<~RUBY)
-      case foo
-      when bar then
-      end
-    RUBY
-    expect(new_source).to eq(<<~RUBY)
-      case foo
-      when bar
-      end
-    RUBY
-  end
-
-  it 'autocorrects then in multiline when' do
-    new_source = autocorrect_source(<<~RUBY)
-      case foo
-      when bar then
-      do_something
-      end
-    RUBY
-    expect(new_source).to eq(<<~RUBY)
-      case foo
-      when bar
-      do_something
-      end
-    RUBY
-  end
-
   it 'autocorrects when the body of `when` branch starts ' \
      'with `then`' do
-    new_source = autocorrect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       case foo
       when bar
         then do_something
+        ^^^^ Do not use `then` for multiline `when` statement.
       end
     RUBY
 
-    expect(new_source).to eq(<<~RUBY)
+    expect_correction(<<~RUBY)
       case foo
       when bar
        do_something


### PR DESCRIPTION
Part of #8127

Use newer `expect_offense` and `expect_correction` in specs for Style cops F-M.

Merge `'register offense'` and `'auto-correct'` spec examples where possible.

Restores trailing whitespace to `method_call_with_args_paretheses_spec.rb` that was accidentally removed by merging examples in #7026

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/