### PR TITLE
Fix an incorrect auto-correct for `Style/StructInheritance`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * [#8006](https://github.com/rubocop-hq/rubocop/issues/8006): Fix line length calculation for `Style/IfUnlessModifier` to correctly take into account code before the if condition when considering conversation to a single-line form. ([@dsavochkin][])
 * [#8283](https://github.com/rubocop-hq/rubocop/issues/8283): Fix line length calculation for `Style/IfUnlessModifier` to correctly take into account a comment on the first line when considering conversation to a single-line form. ([@dsavochkin][])
 * [#8226](https://github.com/rubocop-hq/rubocop/issues/8226): Fix `Style/IfUnlessModifier` to add parentheses when converting if-end condition inside an array or a hash to a single-line form. ([@dsavochkin][])
+* [#8443](https://github.com/rubocop-hq/rubocop/pull/8443): Fix an incorrect auto-correct for `Style/StructInheritance` when there is a comment before class declaration. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -33,7 +33,7 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            corrector.remove(range_with_surrounding_space(range: node.loc.keyword))
+            corrector.remove(range_with_surrounding_space(range: node.loc.keyword, newlines: false))
             corrector.replace(node.loc.operator, '=')
 
             correct_parent(node.parent_class, corrector)

--- a/spec/rubocop/cop/style/struct_inheritance_spec.rb
+++ b/spec/rubocop/cop/style/struct_inheritance_spec.rb
@@ -60,6 +60,22 @@ RSpec.describe RuboCop::Cop::Style::StructInheritance do
     RUBY
   end
 
+  it 'registers an offense when extending instance of `Struct` when there is a comment ' \
+     'before class declaration' do
+    expect_offense(<<~RUBY)
+      # comment
+      class Person < Struct.new(:first_name, :last_name) do end
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't extend an instance initialized by `Struct.new`. Use a block to customize the struct.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # comment
+      Person = Struct.new(:first_name, :last_name) do
+      end
+    RUBY
+  end
+
   it 'accepts plain class' do
     expect_no_offenses(<<~RUBY)
       class Person


### PR DESCRIPTION
This PR fixes the following incorrect auto-correct for `Style/StructInheritance` incorrect auto-correct for `Style/StructInheritance` when there is a comment before class declaration.

```console
% cat example.rb
# comment
class Foo < Struct.new(:foo)
end

% bundle exec rubocop --only Style/StructInheritance -a
(snip)

Offenses:

example.rb:2:13: C: [Corrected] Style/StructInheritance: Don't extend an
instance initialized by Struct.new. Use a block to customize the struct.
class Foo < Struct.new(:foo)
            ^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected

% cat example.rb
# commentFoo = Struct.new(:foo) do
end
```

This issue has been reported on rubocop-jp. (Japanese)
https://github.com/rubocop-hq/rubocop-jp/issues/61

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
