### PR TITLE
[Fix #8444] Fix an error for `Layout/FirstMethodArgumentLineBreak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [#8283](https://github.com/rubocop-hq/rubocop/issues/8283): Fix line length calculation for `Style/IfUnlessModifier` to correctly take into account a comment on the first line when considering conversation to a single-line form. ([@dsavochkin][])
 * [#8226](https://github.com/rubocop-hq/rubocop/issues/8226): Fix `Style/IfUnlessModifier` to add parentheses when converting if-end condition inside an array or a hash to a single-line form. ([@dsavochkin][])
 * [#8443](https://github.com/rubocop-hq/rubocop/pull/8443): Fix an incorrect auto-correct for `Style/StructInheritance` when there is a comment before class declaration. ([@koic][])
+* [#8444](https://github.com/rubocop-hq/rubocop/issues/8444): Fix an error for `Layout/FirstMethodArgumentLineBreak` when using kwargs in `super`. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/first_method_argument_line_break.rb
+++ b/lib/rubocop/cop/layout/first_method_argument_line_break.rb
@@ -27,7 +27,7 @@ module RuboCop
               'multi-line method argument list.'
 
         def on_send(node)
-          args = node.arguments
+          args = node.arguments.dup
 
           # If there is a trailing hash arg without explicit braces, like this:
           #

--- a/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
@@ -80,6 +80,10 @@ RSpec.describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak do
     expect_no_offenses('foo(bar, baz, bing)')
   end
 
+  it 'ignores kwargs listed on a single line when the arguments are used in `super`' do
+    expect_no_offenses('super(foo: 1, bar: 2)')
+  end
+
   it 'ignores arguments without parens' do
     expect_no_offenses(<<~RUBY)
       foo bar,


### PR DESCRIPTION
Fixes #8444.

This PR fixes an error for `Layout/FirstMethodArgumentLineBreak` when using kwargs in `super`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
