### PR TITLE
Fix line continuations in spec examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [#8226](https://github.com/rubocop-hq/rubocop/issues/8226): Fix `Style/IfUnlessModifier` to add parentheses when converting if-end condition inside an array or a hash to a single-line form. ([@dsavochkin][])
 * [#8443](https://github.com/rubocop-hq/rubocop/pull/8443): Fix an incorrect auto-correct for `Style/StructInheritance` when there is a comment before class declaration. ([@koic][])
 * [#8444](https://github.com/rubocop-hq/rubocop/issues/8444): Fix an error for `Layout/FirstMethodArgumentLineBreak` when using kwargs in `super`. ([@koic][])
+* [#8448](https://github.com/rubocop-hq/rubocop/pull/8448): Fix `Style/NestedParenthesizedCalls` to include line continuations in whitespace for auto-correct. ([@biinari][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/nested_parenthesized_calls.rb
+++ b/lib/rubocop/cop/style/nested_parenthesized_calls.rb
@@ -37,7 +37,9 @@ module RuboCop
 
           leading_space =
             range_with_surrounding_space(range: first_arg.begin,
-                                         side: :left)
+                                         side: :left,
+                                         whitespace: true,
+                                         continuations: true)
 
           lambda do |corrector|
             corrector.replace(leading_space, '(')

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -459,7 +459,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'does not check binary operations when string wrapped with backslash' do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~'RUBY')
         flash[:error] = 'Here is a string ' \
                         'That spans' <<
           'multiple lines'

--- a/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
@@ -325,7 +325,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
 
     it 'registers an offense and corrects misaligned string operand ' \
       'when the first operand has backslash continuation' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~'RUBY')
         def f
           flash[:error] = 'Here is a string ' \
                           'That spans' <<
@@ -334,7 +334,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
         end
       RUBY
 
-      expect_correction(<<~RUBY)
+      expect_correction(<<~'RUBY')
         def f
           flash[:error] = 'Here is a string ' \
                           'That spans' <<
@@ -459,7 +459,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'accepts the indentation of a broken string' do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~'RUBY')
         MSG = 'Use 2 (not %d) spaces for indenting a ' \
               'broken line.'
       RUBY

--- a/spec/rubocop/cop/style/nested_parenthesized_calls_spec.rb
+++ b/spec/rubocop/cop/style/nested_parenthesized_calls_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe RuboCop::Cop::Style::NestedParenthesizedCalls do
 
   context 'backslash newline in method call' do
     let(:source) do
-      <<~RUBY
+      <<~'RUBY'
         puts(nex \
                5)
       RUBY

--- a/spec/rubocop/cop/style/redundant_percent_q_spec.rb
+++ b/spec/rubocop/cop/style/redundant_percent_q_spec.rb
@@ -68,11 +68,11 @@ RSpec.describe RuboCop::Cop::Style::RedundantPercentQ do
       end
 
       it 'auto-corrects for strings that is concated with backslash' do
-        new_source = autocorrect_source(<<~RUBY)
+        new_source = autocorrect_source(<<~'RUBY')
           %q(foo bar baz) \
             'boogers'
         RUBY
-        expect(new_source).to eq(<<~RUBY)
+        expect(new_source).to eq(<<~'RUBY')
           'foo bar baz' \
             'boogers'
         RUBY
@@ -142,11 +142,11 @@ RSpec.describe RuboCop::Cop::Style::RedundantPercentQ do
       end
 
       it 'auto-corrects for strings that is concated with backslash' do
-        new_source = autocorrect_source(<<~RUBY)
+        new_source = autocorrect_source(<<~'RUBY')
           %Q(foo bar baz) \
             'boogers'
         RUBY
-        expect(new_source).to eq(<<~RUBY)
+        expect(new_source).to eq(<<~'RUBY')
           "foo bar baz" \
             'boogers'
         RUBY

--- a/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
     end
 
     it 'accepts double quotes on a broken static string' do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~'RUBY')
         "A" \
           "B"
       RUBY

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
       end
 
       it 'accepts continued strings using all single quotes' do
-        expect_no_offenses(<<~RUBY)
+        expect_no_offenses(<<~'RUBY')
           'abc' \
           'def'
         RUBY
@@ -330,7 +330,7 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
       end
 
       it "doesn't register offense for double quotes with embedded single" do
-        expect_no_offenses(<<~RUBY)
+        expect_no_offenses(<<~'RUBY')
           "abc'" \
           "def"
         RUBY
@@ -369,7 +369,7 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
       end
 
       it 'accepts continued strings using all double quotes' do
-        expect_no_offenses(<<~RUBY)
+        expect_no_offenses(<<~'RUBY')
           "abc" \
           "def"
         RUBY
@@ -392,7 +392,7 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
       end
 
       it "doesn't register offense for single quotes with embedded double" do
-        expect_no_offenses(<<~RUBY)
+        expect_no_offenses(<<~'RUBY')
           'abc"' \
           'def'
         RUBY


### PR DESCRIPTION
When describing the code that should be detected / auto-corrected, some specs do not escape line continuations properly.

For example:

```ruby
<<~RUBY
  something \
    continues
RUBY
```

results in the string `"something   continues\n"` instead of the desired `"something \\\n  continues\n"`

Correct specs escape the backslash or use single quoted heredocs to keep the line continuation in the source under test, like:

```ruby
# single quoted heredoc (looks more like the source would)
<<~'RUBY'
  something \
    continues
RUBY

# or escape the backslash (allows interpolation and other escapes where needed)
<<~RUBY
  something \\
    continues
RUBY
```

In correcting the specs, it became apparent that `Style/NestedParenthesizedCalls` cop did not behave as intended. `RangeHelp` mixin has been adapted to optionally include line continuations (backslash newline sequence).

Feedback is welcome on whether this behaviour on replacing whitespace with parentheses matches with your expectations.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/