### PR TITLE
[Fix #7957] Fix Style/IfUnlessModifier to remain multiline if code after end keyword makes it too long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [#8424](https://github.com/rubocop-hq/rubocop/issues/8424): Fix an error for `Lint/IneffectiveAccessModifier` when there is `begin...end` before a method definition. ([@koic][])
 * [#8006](https://github.com/rubocop-hq/rubocop/issues/8006): Fix line length calculation for `Style/IfUnlessModifier` to correctly take into account code before the if condition when considering conversation to a single-line form. ([@dsavochkin][])
 * [#8283](https://github.com/rubocop-hq/rubocop/issues/8283): Fix line length calculation for `Style/IfUnlessModifier` to correctly take into account a comment on the first line when considering conversation to a single-line form. ([@dsavochkin][])
+* [#7957](https://github.com/rubocop-hq/rubocop/issues/7957): Fix line length calculation for `Style/IfUnlessModifier` to correctly take into account code on the last line after the end keyword when considering conversion to a single-line form. ([@dsavochkin][])
 * [#8226](https://github.com/rubocop-hq/rubocop/issues/8226): Fix `Style/IfUnlessModifier` to add parentheses when converting if-end condition inside an array or a hash to a single-line form. ([@dsavochkin][])
 * [#8443](https://github.com/rubocop-hq/rubocop/pull/8443): Fix an incorrect auto-correct for `Style/StructInheritance` when there is a comment before class declaration. ([@koic][])
 * [#8444](https://github.com/rubocop-hq/rubocop/issues/8444): Fix an error for `Layout/FirstMethodArgumentLineBreak` when using kwargs in `super`. ([@koic][])

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -40,10 +40,12 @@ module RuboCop
       end
 
       def length_in_modifier_form(node)
-        keyword = node.loc.keyword
-        prefix = keyword.source_line[0...keyword.column]
+        keyword_element = node.loc.keyword
+        end_element = node.loc.end
+        code_before = keyword_element.source_line[0...keyword_element.column]
+        code_after = end_element.source_line[end_element.last_column..-1]
         expression = to_modifier_form(node)
-        line_length("#{prefix}#{expression}")
+        line_length("#{code_before}#{expression}#{code_after}")
       end
 
       def to_modifier_form(node)

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -740,4 +740,33 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
       end
     end
   end
+
+  context 'when if-end condition has some code after the end keyword' do
+    let(:source) do
+      <<~RUBY
+        [
+          1, if foo
+               #{'b' * body_length}
+             end, 300_000_000
+        ]
+      RUBY
+    end
+
+    context 'when it is short enough to fit on a single line' do
+      let(:body_length) { 53 }
+
+      it 'corrects it to the single-line form' do
+        corrected = autocorrect_source(source)
+        expect(corrected).to eq "[\n  1, (#{'b' * body_length} if foo), 300_000_000\n]\n"
+      end
+    end
+
+    context 'when it is not short enough to fit on a single line' do
+      let(:body_length) { 54 }
+
+      it 'accepts it in the multiline form' do
+        expect_no_offenses(source)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #7957. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
