### PR TITLE
Optimize getting node tokens

### DIFF
--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -23,6 +23,7 @@ require_relative 'rubocop/string_interpreter'
 require_relative 'rubocop/error'
 require_relative 'rubocop/warning'
 
+require_relative 'rubocop/cop/tokens_util'
 require_relative 'rubocop/cop/util'
 require_relative 'rubocop/cop/offense'
 require_relative 'rubocop/cop/message_annotator'

--- a/lib/rubocop/cop/mixin/surrounding_space.rb
+++ b/lib/rubocop/cop/mixin/surrounding_space.rb
@@ -30,31 +30,6 @@ module RuboCop
         Parser::Source::Range.new(buffer, begin_pos, end_pos)
       end
 
-      def index_of_first_token(node)
-        range = node.source_range
-        token_table[range.line][range.column]
-      end
-
-      def index_of_last_token(node)
-        range = node.source_range
-        table_row = token_table[range.last_line]
-        (0...range.last_column).reverse_each do |c|
-          ix = table_row[c]
-          return ix if ix
-        end
-      end
-
-      def token_table
-        @token_table ||= begin
-          table = {}
-          processed_source.tokens.each_with_index do |t, ix|
-            table[t.line] ||= {}
-            table[t.line][t.column] = ix
-          end
-          table
-        end
-      end
-
       def on_new_investigation
         @token_table = nil
         super

--- a/lib/rubocop/cop/tokens_util.rb
+++ b/lib/rubocop/cop/tokens_util.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module RuboCop
+  # Common methods and behaviors for dealing with tokens.
+  module TokensUtil
+    module_function
+
+    # rubocop:disable Metrics/AbcSize
+    def tokens(node)
+      @tokens ||= {}
+      return @tokens[node.object_id] if @tokens[node.object_id]
+
+      @tokens[node.object_id] =
+        # The tokens list is always sorted by token position,
+        # except for cases when heredoc is passed as a method argument.
+        # In this case tokens are interleaved by heredoc contents' tokens.
+        # We can try a fast (binary) search, assuming the mentioned cases are rare,
+        # and fallback to linear search if failed.
+        if (tokens = fast_tokens(node))
+          tokens
+        else
+          begin_pos = node.source_range.begin_pos
+          end_pos   = node.source_range.end_pos
+
+          processed_source.tokens.select do |token|
+            token.end_pos <= end_pos && token.begin_pos >= begin_pos
+          end
+        end
+    end
+    # rubocop:enable Metrics/AbcSize
+
+    def index_of_first_token(node)
+      index = fast_index_of_first_token(node)
+      return index if index
+
+      begin_pos = node.source_range.begin_pos
+      processed_source.tokens.index { |token| token.begin_pos == begin_pos }
+    end
+
+    def index_of_last_token(node)
+      index = fast_index_of_last_token(node)
+      return index if index
+
+      end_pos = node.source_range.end_pos
+      processed_source.tokens.index { |token| token.end_pos == end_pos }
+    end
+
+    private
+
+    def fast_index_of_first_token(node)
+      begin_pos = node.source_range.begin_pos
+      tokens = processed_source.tokens
+
+      index = tokens.bsearch_index { |token| token.begin_pos >= begin_pos }
+      index if index && tokens[index].begin_pos == begin_pos
+    end
+
+    def fast_index_of_last_token(node)
+      end_pos = node.source_range.end_pos
+      tokens = processed_source.tokens
+
+      index = tokens.bsearch_index { |token| token.end_pos >= end_pos }
+      index if index && tokens[index].end_pos == end_pos
+    end
+
+    def fast_tokens(node)
+      begin_index = index_of_first_token(node)
+      end_index   = index_of_last_token(node)
+
+      tokens = processed_source.tokens[begin_index..end_index]
+      tokens if sorted_tokens?(tokens)
+    end
+
+    def sorted_tokens?(tokens)
+      prev_begin_pos = -1
+      tokens.each do |token|
+        return false if token.begin_pos < prev_begin_pos
+
+        prev_begin_pos = token.begin_pos
+      end
+      true
+    end
+  end
+end

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -5,6 +5,7 @@ module RuboCop
     # This module contains a collection of useful utility methods.
     module Util
       include PathUtil
+      include TokensUtil
 
       # Match literal regex characters, not including anchors, character
       # classes, alternatives, groups, repetitions, references, etc
@@ -125,19 +126,6 @@ module RuboCop
         enforced_style
           .sub(/^Enforced/, 'Supported')
           .sub('Style', 'Styles')
-      end
-
-      def tokens(node)
-        @tokens ||= {}
-        return @tokens[node.object_id] if @tokens[node.object_id]
-
-        source_range = node.source_range
-        begin_pos = source_range.begin_pos
-        end_pos = source_range.end_pos
-
-        @tokens[node.object_id] = processed_source.tokens.select do |token|
-          token.end_pos <= end_pos && token.begin_pos >= begin_pos
-        end
       end
 
       private


### PR DESCRIPTION
Ran on 30k files.

### Before
```
(1) 74659  (    6.8%)  RuboCop::Cop::Layout::SpaceInsideReferenceBrackets#on_send
(2) 39346  (    3.6%)  RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets#on_array
    38575  (    3.5%)  RuboCop::Cop::Style::RedundantSelf#on_block
    33935  (    3.1%)  RuboCop::Cop::Layout::SpaceBeforeFirstArg#on_send
    26757  (    2.4%)  RuboCop::Cop::Layout::FirstArgumentIndentation#on_send
    26271  (    2.4%)  RuboCop::Cop::StringHelp#on_str
    24590  (    2.2%)  RuboCop::Cop::Layout::DefEndAlignment#on_send
    23826  (    2.2%)  RuboCop::Cop::Layout::IndentationConsistency#on_begin
(3) 17870  (    1.6%)  RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces#on_hash
    16582  (    1.5%)  RuboCop::Cop::MultilineExpressionIndentation#on_send
    15623  (    1.4%)  RuboCop::Cop::Interpolation#on_dstr
......
```

### After
```
    45373  (    3.7%)  RuboCop::Cop::Style::RedundantSelf#on_block
    40617  (    3.3%)  RuboCop::Cop::Layout::SpaceBeforeFirstArg#on_send
    36688  (    3.0%)  RuboCop::Cop::Layout::FirstArgumentIndentation#on_send
    31966  (    2.6%)  RuboCop::Cop::StringHelp#on_str
    31289  (    2.5%)  RuboCop::Cop::Layout::DefEndAlignment#on_send
    29682  (    2.4%)  RuboCop::Cop::Layout::IndentationConsistency#on_begin
(1) 25490  (    2.1%)  RuboCop::Cop::Layout::SpaceInsideReferenceBrackets#on_send
    23245  (    1.9%)  RuboCop::Cop::MultilineExpressionIndentation#on_send
    18734  (    1.5%)  RuboCop::Cop::Style::AccessModifierDeclarations#on_send
    17297  (    1.4%)  RuboCop::Cop::Layout::ArgumentAlignment#on_send
    16772  (    1.4%)  RuboCop::Cop::Style::FormatStringToken#on_str
    15592  (    1.3%)  RuboCop::Cop::Style::NumericPredicate#on_send
    14655  (    1.2%)  RuboCop::Cop::Layout::LineLength#on_potential_breakable_node
    14547  (    1.2%)  RuboCop::Cop::Layout::DotPosition#on_send
    13943  (    1.1%)  RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier#on_send
    13836  (    1.1%)  RuboCop::Cop::Layout::SpaceAroundOperators#on_send
    13180  (    1.1%)  RuboCop::Cop::Style::TrailingCommaInArguments#on_send
    12772  (    1.0%)  RuboCop::Cop::Style::ConditionalAssignment#on_send
    12746  (    1.0%)  RuboCop::Cop::Metrics::BlockLength#on_block
    11655  (    0.9%)  RuboCop::Cop::Style::ZeroLengthPredicate#on_send
    11447  (    0.9%)  RuboCop::Cop::Style::MethodCallWithoutArgsParentheses#on_send
    11365  (    0.9%)  RuboCop::Cop::CheckAssignment#on_send
    11055  (    0.9%)  RuboCop::Cop::Layout::IndentationWidth#on_send
    10931  (    0.9%)  RuboCop::Cop::MethodComplexity#on_def
    10492  (    0.9%)  RuboCop::Cop::MethodComplexity#on_def
    10311  (    0.8%)  RuboCop::Cop::Style::InverseMethods#on_send
    10222  (    0.8%)  RuboCop::Cop::StringHelp#on_str
    10211  (    0.8%)  RuboCop::Cop::Layout::ClosingParenthesisIndentation#on_send
    10131  (    0.8%)  RuboCop::Cop::Interpolation#on_dstr
    9837  (    0.8%)  RuboCop::Cop::Style::SignalException#on_send
    9732  (    0.8%)  RuboCop::Cop::Layout::BlockAlignment#on_block
    9620  (    0.8%)  RuboCop::Cop::Style::RedundantSort#on_send
(2) 9319  (    0.8%)  RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets#on_array
    8877  (    0.7%)  RuboCop::Cop::Style::EmptyLiteral#on_send
    8427  (    0.7%)  RuboCop::Cop::Style::RedundantException#on_send
    8300  (    0.7%)  RuboCop::Cop::Style::ExpandPathArguments#on_send
    8288  (    0.7%)  RuboCop::Cop::Lint::SafeNavigationChain#on_send
    7771  (    0.6%)  RuboCop::Cop::CheckAssignment#on_send
    7580  (    0.6%)  RuboCop::Cop::Style::EvalWithLocation#on_send
    7485  (    0.6%)  RuboCop::Cop::Style::NonNilCheck#on_send
```

Improvement: `9-10%`