### PR TITLE
Don't mutate `#arguments`.

### DIFF
--- a/lib/rubocop/cop/layout/multiline_method_argument_line_breaks.rb
+++ b/lib/rubocop/cop/layout/multiline_method_argument_line_breaks.rb
@@ -37,7 +37,7 @@ module RuboCop
           # ...then each key/value pair is treated as a method 'argument'
           # when determining where line breaks should appear.
           if (last_arg = args.last)
-            args = args.concat(args.pop.children) if last_arg.hash_type? && !last_arg.braces?
+            args = args[0...-1] + last_arg.children if last_arg.hash_type? && !last_arg.braces?
           end
 
           check_line_breaks(node, args)

--- a/lib/rubocop/cop/mixin/check_line_breakable.rb
+++ b/lib/rubocop/cop/mixin/check_line_breakable.rb
@@ -171,7 +171,7 @@ module RuboCop
         # ...then each key/value pair is treated as a method 'argument'
         # when determining where line breaks should appear.
         if (last_arg = args.last)
-          args = args.concat(args.pop.children) if last_arg.hash_type? && !last_arg.braces?
+          args = args[0...-1] + last_arg.children if last_arg.hash_type? && !last_arg.braces?
         end
         args
       end


### PR DESCRIPTION
Required for rubocop-hq/rubocop-ast#91