### PR TITLE
Handle trailing comma in method call argument list in Style/ExplicitBlockArgument

### DIFF
--- a/lib/rubocop/cop/style/explicit_block_argument.rb
+++ b/lib/rubocop/cop/style/explicit_block_argument.rb
@@ -71,7 +71,10 @@ module RuboCop
         def add_block_argument(node, corrector)
           if node.arguments?
             last_arg = node.arguments.last
-            corrector.insert_after(last_arg, ', &block') unless last_arg.blockarg_type?
+            arg_range = range_with_surrounding_comma(last_arg.source_range, :right)
+            replacement = ' &block'
+            replacement = ",#{replacement}" unless arg_range.source.end_with?(',')
+            corrector.insert_after(arg_range, replacement) unless last_arg.blockarg_type?
           elsif node.send_type?
             corrector.insert_after(node, '(&block)')
           else

--- a/spec/rubocop/cop/style/explicit_block_argument_spec.rb
+++ b/spec/rubocop/cop/style/explicit_block_argument_spec.rb
@@ -48,6 +48,21 @@ RSpec.describe RuboCop::Cop::Style::ExplicitBlockArgument do
     RUBY
   end
 
+  it 'correctly corrects when the method call has a trailing comma in its argument list' do
+    expect_offense(<<~RUBY)
+      def m
+        items.something(a, b,) { |i| yield i }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Consider using explicit block argument in the surrounding method's signature over `yield`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def m(&block)
+        items.something(a, b, &block)
+      end
+    RUBY
+  end
+
   it 'registers an offense and corrects when method contains multiple `yield`s' do
     expect_offense(<<~RUBY)
       def m


### PR DESCRIPTION
A trailing comma is valid syntax after the last positional argument, but not after a block argument.

    $ ruby -ce "foo(a, b,)"
    Syntax OK

    $ ruby -ce "foo(a, &b,)"
    -e:1: syntax error, unexpected ',', expecting ')'
    foo(a, &b,)

I didn't add a changelog entry because this cop hasn't been released yet.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/