### PR TITLE
Refactor spec/rubocop/cop/layout/ to use expect_offense (A-E). #8127

### DIFF
--- a/spec/rubocop/cop/layout/def_end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/def_end_alignment_spec.rb
@@ -43,17 +43,19 @@ RSpec.describe RuboCop::Cop::Layout::DefEndAlignment, :config do
 
     context 'correct + opposite' do
       it 'registers an offense' do
-        inspect_source(source)
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages.first)
-          .to eq('`end` at 7, 4 is not aligned with `foo def` at 5, 0.')
-        expect(cop.highlights.first).to eq('end')
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-      end
+        expect_offense(<<~RUBY)
+          foo def a
+            a1
+          end
 
-      it 'does auto-correction' do
-        corrected = autocorrect_source(source)
-        expect(corrected).to eq(<<~RUBY)
+          foo def b
+                b1
+              end
+              ^^^ `end` at 7, 4 is not aligned with `foo def` at 5, 0.
+        RUBY
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+
+        expect_correction(<<~RUBY)
           foo def a
             a1
           end
@@ -96,21 +98,22 @@ RSpec.describe RuboCop::Cop::Layout::DefEndAlignment, :config do
 
     context 'correct + opposite' do
       it 'registers an offense' do
-        inspect_source(source)
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages.first)
-          .to eq('`end` at 3, 0 is not aligned with `def` at 1, 4.')
-        expect(cop.highlights.first).to eq('end')
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-      end
+        expect_offense(<<~RUBY)
+          foo def a
+            a1
+          end
+          ^^^ `end` at 3, 0 is not aligned with `def` at 1, 4.
+          foo def b
+                b1
+              end
+        RUBY
 
-      it 'does auto-correction' do
-        corrected = autocorrect_source(source)
-        expect(corrected).to eq(<<~RUBY)
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+
+        expect_correction(<<~RUBY)
           foo def a
             a1
               end
-
           foo def b
                 b1
               end

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -6,31 +6,47 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
 
     %w[private protected public module_function].each do |access_modifier|
       it "requires blank line before #{access_modifier}" do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           class Test
             something
+            #{access_modifier}
+            #{'^' * access_modifier.size} Keep a blank line before and after `#{access_modifier}`.
+
+            def test; end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class Test
+            something
+
             #{access_modifier}
 
             def test; end
           end
         RUBY
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages)
-          .to eq(["Keep a blank line before and after `#{access_modifier}`."])
       end
 
       it "requires blank line after #{access_modifier}" do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           class Test
             something
 
             #{access_modifier}
+            #{'^' * access_modifier.size} Keep a blank line before and after `#{access_modifier}`.
             def test; end
           end
         RUBY
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages)
-          .to eq(["Keep a blank line before and after `#{access_modifier}`."])
+
+        expect_correction(<<~RUBY)
+          class Test
+            something
+
+            #{access_modifier}
+ 
+            def test; end
+          end
+        RUBY
       end
 
       it "ignores comment line before #{access_modifier}" do
@@ -89,56 +105,18 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
         RUBY
       end
 
-      it "autocorrects blank line before #{access_modifier}" do
-        corrected = autocorrect_source(<<~RUBY)
-          class Test
-            something
-            #{access_modifier}
-
-            def test; end
-          end
-        RUBY
-        expect(corrected).to eq(<<~RUBY)
-          class Test
-            something
-
-            #{access_modifier}
-
-            def test; end
-          end
-        RUBY
-      end
-
-      it 'autocorrects blank line after #{access_modifier}' do
-        corrected = autocorrect_source(<<~RUBY)
-          class Test
-            something
-
-            #{access_modifier}
-            def test; end
-          end
-        RUBY
-        expect(corrected).to eq(<<~RUBY)
-          class Test
-            something
-
-            #{access_modifier}
-
-            def test; end
-          end
-        RUBY
-      end
-
       it 'autocorrects blank line after #{access_modifier} with comment' do
-        corrected = autocorrect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           class Test
             something
 
             #{access_modifier} # let's modify the rest
+            #{'^' * access_modifier.size} Keep a blank line before and after `#{access_modifier}`.
             def test; end
           end
         RUBY
-        expect(corrected).to eq(<<~RUBY)
+
+        expect_correction(<<~RUBY)
           class Test
             something
 
@@ -217,16 +195,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
 
       it "requires blank line after, but not before, #{access_modifier} " \
          'when at the beginning of class/module' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           class Test
             #{access_modifier}
+            #{'^' * access_modifier.size} Keep a blank line after `#{access_modifier}`.
             def test
             end
           end
         RUBY
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages)
-          .to eq(["Keep a blank line after `#{access_modifier}`."])
       end
 
       context 'at the beginning of block' do
@@ -252,16 +228,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
           end
 
           it "requires blank line after, but not before, #{access_modifier}" do
-            inspect_source(<<~RUBY)
+            expect_offense(<<~RUBY)
               included do
                 #{access_modifier}
+                #{'^' * access_modifier.size} Keep a blank line after `#{access_modifier}`.
                 def test
                 end
               end
             RUBY
-            expect(cop.offenses.size).to eq(1)
-            expect(cop.messages)
-              .to eq(["Keep a blank line after `#{access_modifier}`."])
           end
         end
 
@@ -321,16 +295,13 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
       end
 
       it 'requires blank line when next line started with end' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           class Test
             #{access_modifier}
+            #{'^' * access_modifier.size} Keep a blank line after `#{access_modifier}`.
             end_this!
           end
         RUBY
-
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages)
-          .to eq(["Keep a blank line after `#{access_modifier}`."])
       end
 
       it 'recognizes blank lines with DOS style line endings' do
@@ -362,33 +333,18 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
       end
 
       it "registers an offense for blank line after #{access_modifier}" do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           class Test
             something
 
             #{access_modifier}
-
+            #{'^' * access_modifier.size} Remove a blank line after `#{access_modifier}`.
+            
             def test; end
           end
         RUBY
 
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages)
-          .to eq(["Remove a blank line after `#{access_modifier}`."])
-      end
-
-      it "autocorrects remove blank line after #{access_modifier}" do
-        corrected = autocorrect_source(<<~RUBY)
-          class Test
-            something
-
-            #{access_modifier}
-
-            def test; end
-          end
-        RUBY
-
-        expect(corrected).to eq(<<~RUBY)
+        expect_correction(<<~RUBY)
           class Test
             something
 
@@ -422,28 +378,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
 
     %w[private protected public module_function].each do |access_modifier|
       it "registers an offense for missing blank line before #{access_modifier}" do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           class Test
             something
             #{access_modifier}
-            def test; end
-          end
-        RUBY
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages)
-          .to eq(["Keep a blank line before `#{access_modifier}`."])
-      end
-
-      it 'autocorrects blank line before #{access_modifier}' do
-        corrected = autocorrect_source(<<~RUBY)
-          class Test
-            something
-            #{access_modifier}
+            #{'^' * access_modifier.size} Keep a blank line before `#{access_modifier}`.
             def test; end
           end
         RUBY
 
-        expect(corrected).to eq(<<~RUBY)
+        expect_correction(<<~RUBY)
           class Test
             something
 

--- a/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
@@ -1,72 +1,103 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
+  let(:empty_line_annotation) { '^{} Empty line detected around arguments.' }
+
   context 'when extra lines' do
-    it 'registers offense for empty line before arg' do
-      inspect_source(<<~RUBY)
+    it 'registers and autocorrects offense for empty line before arg' do
+      expect_offense(<<~RUBY)
         foo(
 
+        #{empty_line_annotation}
           bar
         )
       RUBY
-      expect(cop.messages)
-        .to eq(['Empty line detected around arguments.'])
+
+      expect_correction(<<~RUBY)
+        foo(
+          bar
+        )
+      RUBY
     end
 
-    it 'registers offense for empty line after arg' do
-      inspect_source(<<~RUBY)
+    it 'registers and autocorrects offense for empty line after arg' do
+      expect_offense(<<~RUBY)
         bar(
           [baz, qux]
 
+        #{empty_line_annotation}
         )
       RUBY
-      expect(cop.messages)
-        .to eq(['Empty line detected around arguments.'])
+
+      expect_correction(<<~RUBY)
+        bar(
+          [baz, qux]
+        )
+      RUBY
     end
 
-    it 'registers offense for empty line between args' do
-      inspect_source(<<~RUBY)
+    it 'registers and autocorrects offense for empty line between args' do
+      expect_offense(<<~RUBY)
         foo.do_something(
           baz,
 
+        #{empty_line_annotation}
           qux: 0
         )
       RUBY
-      expect(cop.messages)
-        .to eq(['Empty line detected around arguments.'])
+
+      expect_correction(<<~RUBY)
+        foo.do_something(
+          baz,
+          qux: 0
+        )
+      RUBY
     end
 
-    it 'registers offenses when multiple empty lines are detected' do
-      inspect_source(<<~RUBY)
+    it 'registers and autocorrects offenses when multiple empty lines are detected' do
+      expect_offense(<<~RUBY)
         foo(
           baz,
 
+        #{empty_line_annotation}
           qux,
 
+        #{empty_line_annotation}
           biz,
 
+        #{empty_line_annotation}
         )
       RUBY
-      expect(cop.offenses.size).to eq 3
-      expect(cop.messages.uniq)
-        .to eq(['Empty line detected around arguments.'])
+
+      expect_correction(<<~RUBY)
+        foo(
+          baz,
+          qux,
+          biz,
+        )
+      RUBY
     end
 
-    it 'registers offense when args start on definition line' do
-      inspect_source(<<~RUBY)
+    it 'registers and autocorrects offense when args start on definition line' do
+      expect_offense(<<~RUBY)
         foo(biz,
 
+        #{empty_line_annotation}
             baz: 0)
       RUBY
-      expect(cop.messages)
-        .to eq(['Empty line detected around arguments.'])
+
+      expect_correction(<<~RUBY)
+        foo(biz,
+            baz: 0)
+      RUBY
     end
 
-    it 'registers offense when empty line between normal arg & block arg' do
-      inspect_source(<<~RUBY)
+    it 'registers and autocorrects offense when empty line between normal arg & block arg' do
+      expect_offense(<<~RUBY)
         Foo.prepend(
           a,
 
+        #{empty_line_annotation}
           Module.new do
             def something; end
 
@@ -74,13 +105,21 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
           end
         )
       RUBY
-      expect(cop.offenses.size).to eq 1
-      expect(cop.messages)
-        .to eq(['Empty line detected around arguments.'])
+
+      expect_correction(<<~RUBY)
+        Foo.prepend(
+          a,
+          Module.new do
+            def something; end
+
+            def anything; end
+          end
+        )
+      RUBY
     end
 
-    it 'registers offense on correct line for single offense example' do
-      inspect_source(<<~RUBY)
+    it 'registers and autocorrects offense on correct line for single offense example' do
+      expect_offense(<<~RUBY)
         class Foo
 
           include Bar
@@ -89,128 +128,89 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
             fizz(
               qux,
 
+        #{empty_line_annotation}
               10
             )
           end
         end
       RUBY
-      expect(cop.offenses.size).to eq 1
-      expect(cop.offenses.first.location.line).to eq 8
-      expect(cop.messages.uniq)
-        .to eq(['Empty line detected around arguments.'])
+
+      expect_correction(<<~RUBY)
+        class Foo
+
+          include Bar
+
+          def baz(qux)
+            fizz(
+              qux,
+              10
+            )
+          end
+        end
+      RUBY
     end
 
-    it 'registers offense on correct lines for multi-offense example' do
-      inspect_source(<<~RUBY)
+    it 'registers and autocorrects offense on correct lines for multi-offense example' do
+      expect_offense(<<~RUBY)
         something(1, 5)
         something_else
 
         foo(biz,
 
+        #{empty_line_annotation}
             qux)
 
         quux.map do
 
         end.another.thing(
 
+        #{empty_line_annotation}
           [baz]
         )
       RUBY
-      expect(cop.offenses.size).to eq 2
-      expect(cop.offenses[0].location.line).to eq 5
-      expect(cop.offenses[1].location.line).to eq 11
-      expect(cop.messages.uniq)
-        .to eq(['Empty line detected around arguments.'])
+
+      expect_correction(<<~RUBY)
+        something(1, 5)
+        something_else
+
+        foo(biz,
+            qux)
+
+        quux.map do
+
+        end.another.thing(
+          [baz]
+        )
+      RUBY
     end
 
     context 'when using safe navigation operator' do
-      it 'registers offense for empty line before arg' do
-        inspect_source(<<~RUBY)
+      it 'registers and autocorrects offense for empty line before arg' do
+        expect_offense(<<~RUBY)
           receiver&.foo(
 
+          #{empty_line_annotation}
             bar
           )
         RUBY
-        expect(cop.messages)
-          .to eq(['Empty line detected around arguments.'])
+
+        expect_correction(<<~RUBY)
+          receiver&.foo(
+            bar
+          )
+        RUBY
       end
     end
 
-    it 'autocorrects empty line detected at top' do
-      corrected = autocorrect_source(<<~RUBY)
-        foo(
-
-          bar
-        )
-      RUBY
-
-      expect(corrected).to eq(<<~RUBY)
-        foo(
-          bar
-        )
-      RUBY
-    end
-
-    it 'autocorrects empty line detected at bottom' do
-      corrected = autocorrect_source(<<~RUBY)
-        foo(
-          baz: 1
-
-        )
-      RUBY
-
-      expect(corrected).to eq(<<~RUBY)
-        foo(
-          baz: 1
-        )
-      RUBY
-    end
-
-    it 'autocorrects empty line detected in the middle' do
-      corrected = autocorrect_source(<<~RUBY)
-        do_something(
-          [baz],
-
-          qux: 0
-        )
-      RUBY
-
-      expect(corrected).to eq(<<~RUBY)
-        do_something(
-          [baz],
-          qux: 0
-        )
-      RUBY
-    end
-
-    it 'autocorrects multiple empty lines' do
-      corrected = autocorrect_source(<<~RUBY)
-        do_stuff(
-          baz,
-
-          qux,
-
-          bar: 0,
-        )
-      RUBY
-
-      expect(corrected).to eq(<<~RUBY)
-        do_stuff(
-          baz,
-          qux,
-          bar: 0,
-        )
-      RUBY
-    end
-
-    it 'autocorrects args that start on definition line' do
-      corrected = autocorrect_source(<<~RUBY)
+    it 'registers autocorrects empty line whetn args start on definition line' do
+      expect_offense(<<~RUBY)
         bar(qux,
 
+        #{empty_line_annotation}
             78)
       RUBY
 
-      expect(corrected).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         bar(qux,
             78)
       RUBY

--- a/spec/rubocop/cop/layout/empty_lines_around_begin_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_begin_body_spec.rb
@@ -5,156 +5,173 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
 
   let(:config) { RuboCop::Config.new }
 
-  shared_examples 'offense' do |name, message, code, correction|
-    it "registers an offense for #{name} with a blank" do
-      inspect_source(code)
-      expect(cop.messages)
-        .to eq(["Extra empty line detected at `begin` body #{message}."])
-    end
-
-    it "autocorrects for #{name} with a blank" do
-      corrected = autocorrect_source(code)
-
-      expect(corrected).to eq(correction)
-    end
-  end
-
   shared_examples 'accepts' do |name, code|
     it "accepts #{name}" do
       expect_no_offenses(code)
     end
   end
 
-  include_examples 'offense', 'begin body starting', 'beginning',
-                   <<-CODE, <<-CORRECTION
-    begin
-
-      foo
-    end
-  CODE
-    begin
-      foo
-    end
-  CORRECTION
-
-  include_examples 'offense', 'begin body ending', 'end', <<-CODE, <<-CORRECTION
-    begin
-      foo
-
-    end
-  CODE
-    begin
-      foo
-    end
-  CORRECTION
-
-  include_examples 'offense',
-                   'begin body starting in method', 'beginning',
-                   <<-CODE, <<-CORRECTION
-    def bar
+  it 'registers an offense for begin body starting with a blank' do
+    expect_offense(<<~RUBY)
       begin
 
+      ^{} Extra empty line detected at `begin` body beginning.
         foo
       end
-    end
-  CODE
-    def bar
+    RUBY
+
+    expect_correction(<<~RUBY)
       begin
         foo
       end
-    end
-  CORRECTION
+    RUBY
+  end
 
-  include_examples 'offense',
-                   'begin body ending in method', 'end', <<-CODE, <<-CORRECTION
-    def bar
+  it 'registers an offense for ensure body ending' do
+    expect_offense(<<~RUBY)
+      begin
+        foo
+      ensure
+        bar
+
+      ^{} Extra empty line detected at `begin` body end.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      begin
+        foo
+      ensure
+        bar
+      end
+    RUBY
+  end
+
+  it 'registers an offense for begin body ending with a blank' do
+    expect_offense(<<~RUBY)
       begin
         foo
 
+      ^{} Extra empty line detected at `begin` body end.
       end
-    end
-  CODE
-    def bar
+    RUBY
+
+    expect_correction(<<~RUBY)
       begin
         foo
       end
-    end
-  CORRECTION
+    RUBY
+  end
 
-  include_examples 'offense',
-                   'begin body starting with rescue', 'beginning',
-                   <<-CODE, <<-CORRECTION
-    begin
+  it 'registers an offense for begin body starting in method' do
+    expect_offense(<<~RUBY)
+      def bar
+        begin
 
-      foo
-    rescue
-      bar
-    end
-  CODE
-    begin
-      foo
-    rescue
-      bar
-    end
-  CORRECTION
+      ^{} Extra empty line detected at `begin` body beginning.
+          foo
+        end
+      end
+    RUBY
 
-  include_examples 'offense',
-                   'rescue body ending', 'end',
-                   <<-CODE, <<-CORRECTION
-    begin
-      foo
-    rescue
-      bar
+    expect_correction(<<~RUBY)
+      def bar
+        begin
+          foo
+        end
+      end
+    RUBY
+  end
 
-    end
-  CODE
-    begin
-      foo
-    rescue
-      bar
-    end
-  CORRECTION
+  it 'registers an offense for begin body ending in method' do
+    expect_offense(<<~RUBY)
+      def bar
+        begin
+          foo
 
-  include_examples 'offense', 'else body ending', 'end', <<-CODE, <<-CORRECTION
-    begin
-      foo
-    rescue
-      bar
-    else
-      baz
+      ^{} Extra empty line detected at `begin` body end.
+        end
+      end
+    RUBY
 
-    end
-  CODE
-    begin
-      foo
-    rescue
-      bar
-    else
-      baz
-    end
-  CORRECTION
+    expect_correction(<<~RUBY)
+      def bar
+        begin
+          foo
+        end
+      end
+    RUBY
+  end
 
-  include_examples 'offense',
-                   'ensure body ending', 'end',
-                   <<-CODE, <<-CORRECTION
-    begin
-      foo
-    ensure
-      bar
-
-    end
-  CODE
-    begin
-      foo
-    ensure
-      bar
-    end
-  CORRECTION
-
-  context 'with complex begin-end' do
-    let(:source) { <<~RUBY }
+  it 'registers an offense for begin body starting with rescue' do
+    expect_offense(<<~RUBY)
       begin
 
+      ^{} Extra empty line detected at `begin` body beginning.
+        foo
+      rescue
+        bar
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      begin
+        foo
+      rescue
+        bar
+      end
+    RUBY
+  end
+
+  it 'registers an offense for rescue body ending' do
+    expect_offense(<<~RUBY)
+      begin
+        foo
+      rescue
+        bar
+
+      ^{} Extra empty line detected at `begin` body end.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      begin
+        foo
+      rescue
+        bar
+      end
+    RUBY
+  end
+
+  it 'registers an offense for else body ending' do
+    expect_offense(<<~RUBY)
+      begin
+        foo
+      rescue
+        bar
+      else
+        baz
+
+      ^{} Extra empty line detected at `begin` body end.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      begin
+        foo
+      rescue
+        bar
+      else
+        baz
+      end
+    RUBY
+  end
+
+  it 'registers many offenses with complex begin-end' do
+    expect_offense(<<~RUBY)
+      begin
+
+      ^{} Extra empty line detected at `begin` body beginning.
         do_something1
       rescue RuntimeError
         do_something2
@@ -167,10 +184,11 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
       ensure
         do_something4
 
+      ^{} Extra empty line detected at `begin` body end.
       end
     RUBY
 
-    let(:correction) { <<~RUBY }
+    expect_correction(<<~RUBY)
       begin
         do_something1
       rescue RuntimeError
@@ -185,16 +203,6 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
         do_something4
       end
     RUBY
-
-    it 'registers many offenses' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(2)
-    end
-
-    it 'autocorrects' do
-      corrected = autocorrect_source(source)
-      expect(corrected).to eq correction
-    end
   end
 
   include_examples 'accepts', 'begin block without empty line', <<-RUBY

--- a/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
@@ -1,46 +1,43 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBlockBody, :config do
+  let(:beginning_offense_annotation) { '^{} Extra empty line detected at block body beginning.' }
+
   # Test blocks using both {} and do..end
   [%w[{ }], %w[do end]].each do |open, close|
     context "when EnforcedStyle is no_empty_lines for #{open} #{close} block" do
       let(:cop_config) { { 'EnforcedStyle' => 'no_empty_lines' } }
 
       it 'registers an offense for block body starting with a blank' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           some_method #{open}
 
+          #{beginning_offense_annotation}
             do_something
           #{close}
         RUBY
 
-        expect(cop.messages)
-          .to eq(['Extra empty line detected at block body beginning.'])
-      end
-
-      it 'autocorrects block body containing only a blank' do
-        corrected = autocorrect_source(<<~RUBY)
+        expect_correction(<<~RUBY)
           some_method #{open}
-
-          #{close}
-        RUBY
-
-        expect(corrected).to eq(<<~RUBY)
-          some_method #{open}
+            do_something
           #{close}
         RUBY
       end
 
       it 'registers an offense for block body ending with a blank' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           some_method #{open}
             do_something
-
+  
+          ^{} Extra empty line detected at block body end.
             #{close}
         RUBY
 
-        expect(cop.messages)
-          .to eq(['Extra empty line detected at block body end.'])
+        expect_correction(<<~RUBY)
+          some_method #{open}
+            do_something
+            #{close}
+        RUBY
       end
 
       it 'accepts block body starting with a line with spaces' do
@@ -54,16 +51,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBlockBody, :config do
 
       it 'registers an offense for block body starting with a blank passed to '\
          'a multi-line method call' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           some_method arg,
             another_arg #{open}
 
+          #{beginning_offense_annotation}
             do_something
           #{close}
         RUBY
-
-        expect(cop.messages)
-          .to eq(['Extra empty line detected at block body beginning.'])
       end
 
       it 'is not fooled by single line blocks' do
@@ -80,37 +75,25 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBlockBody, :config do
 
       it 'registers an offense for block body not starting or ending with a ' \
          'blank' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           some_method #{open}
             do_something
+          ^ Empty line missing at block body beginning.
           #{close}
+          ^ Empty line missing at block body end.
         RUBY
 
-        expect(cop.messages).to eq(['Empty line missing at block body '\
-                                    'beginning.',
-                                    'Empty line missing at block body end.'])
+        expect_correction(<<~RUBY)
+          some_method #{open}
+
+            do_something
+
+          #{close}
+        RUBY
       end
 
       it 'ignores block with an empty body' do
-        source = "some_method #{open}\n#{close}"
-        corrected = autocorrect_source(source)
-        expect(corrected).to eq(source)
-      end
-
-      it 'autocorrects beginning and end' do
-        new_source = autocorrect_source(<<~RUBY)
-          some_method #{open}
-            do_something
-          #{close}
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          some_method #{open}
-
-            do_something
-
-          #{close}
-        RUBY
+        expect_no_offenses("some_method #{open}\n#{close}")
       end
 
       it 'is not fooled by single line blocks' do

--- a/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
@@ -12,71 +12,65 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'no_empty_lines' } }
 
     it 'registers an offense for class body starting with a blank' do
-      inspect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         class SomeClass
 
+        ^{} #{extra_begin}
           do_something
         end
       RUBY
-      expect(cop.messages)
-        .to eq([extra_begin])
-    end
 
-    it 'autocorrects class body containing only a blank' do
-      corrected = autocorrect_source(<<~RUBY)
+      expect_correction(<<~RUBY)
         class SomeClass
-
-        end
-      RUBY
-      expect(corrected).to eq <<~RUBY
-        class SomeClass
+          do_something
         end
       RUBY
     end
 
     it 'registers an offense for class body ending with a blank' do
-      inspect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         class SomeClass
           do_something
 
+        ^{} #{extra_end}
         end
       RUBY
-      expect(cop.messages)
-        .to eq([extra_end])
-    end
 
-    it 'registers an offense for singleton class body starting with a blank' do
-      inspect_source(<<~RUBY)
-        class << self
-
+      expect_correction(<<~RUBY)
+        class SomeClass
           do_something
         end
       RUBY
-      expect(cop.messages)
-        .to eq([extra_begin])
     end
 
     it 'autocorrects singleton class body containing only a blank' do
-      corrected = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         class << self
 
+        ^{} #{extra_begin}
         end
       RUBY
-      expect(corrected).to eq <<~RUBY
+
+      expect_correction(<<~RUBY)
         class << self
         end
       RUBY
     end
 
     it 'registers an offense for singleton class body ending with a blank' do
-      inspect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         class << self
           do_something
 
+        ^{} #{extra_end}
         end
       RUBY
-      expect(cop.messages)
-        .to eq([extra_end])
+
+      expect_correction(<<~RUBY)
+        class << self
+          do_something
+        end
+      RUBY
     end
   end
 
@@ -109,64 +103,48 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
 
     it 'registers an offense for class body not starting or ending with a ' \
        'blank' do
-      inspect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         class SomeClass
           do_something
+        ^ #{missing_begin}
+        end
+        ^ #{missing_end}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class SomeClass
+
+          do_something
+
         end
       RUBY
-      expect(cop.messages).to eq([missing_begin, missing_end])
     end
 
-    it 'ignores classes with an empty body' do
-      source = "class SomeClass\nend"
-      corrected = autocorrect_source(source)
-      expect(corrected).to eq(source)
-    end
-
-    it 'autocorrects beginning and end' do
-      new_source = autocorrect_source(<<~RUBY)
-        class SomeClass
-          do_something
-        end
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
-        class SomeClass
-
-          do_something
-
-        end
-      RUBY
+    it 'accepts classes with an empty body' do
+      expect_no_offenses("class SomeClass\nend")
     end
 
     it 'registers an offense for singleton class body not starting or ending ' \
        'with a blank' do
-      inspect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         class << self
           do_something
+        ^ #{missing_begin}
+        end
+        ^ #{missing_end}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class << self
+
+          do_something
+
         end
       RUBY
-      expect(cop.messages).to eq([missing_begin, missing_end])
     end
 
-    it 'ignores singleton classes with an empty body' do
-      source = "class << self\nend"
-      corrected = autocorrect_source(source)
-      expect(corrected).to eq(source)
-    end
-
-    it 'autocorrects beginning and end for `class << self`' do
-      new_source = autocorrect_source(<<~RUBY)
-        class << self
-          do_something
-        end
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
-        class << self
-
-          do_something
-
-        end
-      RUBY
+    it 'accepts singleton classes with an empty body' do
+      expect_no_offenses("class << self\nend")
     end
   end
 
@@ -187,9 +165,10 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
       end
 
       it 'registers offense for namespace body starting with a blank' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           class Parent
 
+          ^{} #{extra_begin}
             class Child
 
               do_something
@@ -197,11 +176,10 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
             end
           end
         RUBY
-        expect(cop.messages).to eq([extra_begin])
       end
 
       it 'registers offense for namespace body ending with a blank' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           class Parent
             class Child
 
@@ -209,17 +187,18 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
 
             end
 
+          ^{} #{extra_end}
           end
         RUBY
-        expect(cop.messages).to eq([extra_end])
       end
 
       it 'registers offenses for namespaced class body not starting '\
           'with a blank' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           class Parent
             class Child
               do_something
+          ^ #{missing_begin}
 
             end
           end
@@ -229,28 +208,33 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
 
       it 'registers offenses for namespaced class body not ending '\
           'with a blank' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           class Parent
             class Child
 
               do_something
             end
+          ^ #{missing_end}
           end
         RUBY
-        expect(cop.messages).to eq([missing_end])
       end
 
       it 'autocorrects beginning and end' do
-        new_source = autocorrect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           class Parent < Base
 
+          ^{} #{extra_begin}
             class Child
               do_something
+          ^ #{missing_begin}
             end
+          ^ #{missing_end}
 
+          ^{} #{extra_end}
           end
         RUBY
-        expect(new_source).to eq(<<~RUBY)
+
+        expect_correction(<<~RUBY)
           class Parent < Base
             class Child
 
@@ -274,27 +258,27 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
       end
 
       it 'registers offense for namespace body starting with a blank' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           class Parent
 
+          ^{} #{extra_begin}
             module Child
               do_something
             end
           end
         RUBY
-        expect(cop.messages).to eq([extra_begin])
       end
 
       it 'registers offense for namespace body ending with a blank' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           class Parent
             module Child
               do_something
             end
 
+          ^{} #{extra_end}
           end
         RUBY
-        expect(cop.messages).to eq([extra_end])
       end
     end
 
@@ -318,19 +302,20 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
 
       it 'registers offenses for namespace body starting '\
         'and ending without a blank' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           class Parent
             class Mom
-
+          ^ #{missing_begin}
               do_something
-
+          ^ #{missing_begin}
             end
+          ^ #{missing_end}
             class Dad
 
             end
           end
+          ^ #{missing_end}
         RUBY
-        expect(cop.messages).to eq([missing_begin, missing_end])
       end
     end
   end
@@ -348,27 +333,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
     end
 
     it 'registers an offense for an empty line at the end of a class' do
-      inspect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         class SomeClass
 
           do_something
 
+        ^{} #{extra_end}
         end
       RUBY
 
-      expect(cop.messages).to eq([extra_end])
-    end
-
-    it 'autocorrects end' do
-      new_source = autocorrect_source(<<~RUBY)
-        class SomeClass
-
-          do_something
-
-        end
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         class SomeClass
 
           do_something
@@ -390,27 +364,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
     end
 
     it 'registers an offense for an empty line at the end of a class' do
-      inspect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         class SomeClass
 
+        ^{} #{extra_begin}
           do_something
 
         end
       RUBY
 
-      expect(cop.messages).to eq([extra_begin])
-    end
-
-    it 'autocorrects end' do
-      new_source = autocorrect_source(<<~RUBY)
-        class SomeClass
-
-          do_something
-
-        end
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         class SomeClass
           do_something
 

--- a/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb
@@ -4,19 +4,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords d
   subject(:cop) { described_class.new(config) }
 
   let(:config) { RuboCop::Config.new }
-
-  shared_examples 'offense' do |name, message, code, correction|
-    it "registers an offense for #{name} with a blank" do
-      inspect_source(code)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(["Extra empty line detected #{message}."])
-    end
-
-    it "autocorrects for #{name} with a blank" do
-      corrected = autocorrect_source(code)
-      expect(corrected).to eq(correction)
-    end
-  end
+  let(:message) { '^{} Extra empty line detected' }
 
   shared_examples 'accepts' do |name, code|
     it "accepts #{name}" do
@@ -24,85 +12,93 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords d
     end
   end
 
-  include_examples 'offense',
-                   'above rescue keyword',
-                   'before the `rescue`',
-                   <<-CODE, <<-CORRECTION
-    begin
-      f1
+  it 'registers an offense for above rescue keyword with a blank' do
+    expect_offense(<<~RUBY)
+      begin
+        f1
 
-    rescue
-      f2
-    end
-  CODE
-    begin
-      f1
-    rescue
-      f2
-    end
-  CORRECTION
+      #{message} before the `rescue`.
+      rescue
+        f2
+      end
+    RUBY
 
-  include_examples 'offense',
-                   'rescue section starting',
-                   'after the `rescue`',
-                   <<-CODE, <<-CORRECTION
-    begin
-      f1
-    rescue
+    expect_correction(<<~RUBY)
+      begin
+        f1
+      rescue
+        f2
+      end
+    RUBY
+  end
 
-      f2
-    end
-  CODE
-    begin
-      f1
-    rescue
-      f2
-    end
-  CORRECTION
+  it 'registers an offense for rescue section starting with a blank' do
+    expect_offense(<<~RUBY)
+      begin
+        f1
+      rescue
 
-  include_examples 'offense',
-                   'rescue section ending',
-                   'before the `else`',
-                   <<-CODE, <<-CORRECTION
-    begin
-      f1
-    rescue
-      f2
+      #{message} after the `rescue`.
+        f2
+      end
+    RUBY
 
-    else
-      f3
-    end
-  CODE
-    begin
-      f1
-    rescue
-      f2
-    else
-      f3
-    end
-  CORRECTION
+    expect_correction(<<~RUBY)
+      begin
+        f1
+      rescue
+        f2
+      end
+    RUBY
+  end
 
-  include_examples 'offense',
-                   'rescue section ending for method definition',
-                   'before the `else`',
-                   <<-CODE, <<-CORRECTION
-    def foo
-      f1
-    rescue
-      f2
+  it 'registers an offense for rescue section ending with a blank' do
+    expect_offense(<<~RUBY)
+      begin
+        f1
+      rescue
+        f2
 
-    else
-      f3
-    end
-  CODE
-    def foo
-      f1
-    rescue
-      f2
-    else
-      f3
-    end
-  CORRECTION
+      #{message} before the `else`.
+      else
+        f3
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      begin
+        f1
+      rescue
+        f2
+      else
+        f3
+      end
+    RUBY
+  end
+
+  it 'registers an offense for rescue section ending for method definition a blank' do
+    expect_offense(<<~RUBY)
+      def foo
+        f1
+      rescue
+        f2
+
+      #{message} before the `else`.
+      else
+        f3
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        f1
+      rescue
+        f2
+      else
+        f3
+      end
+    RUBY
+  end
 
   include_examples 'accepts', 'no empty line', <<~RUBY
     begin
@@ -134,36 +130,46 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords d
     end
   RUBY
 
-  context 'with complex begin-end' do
-    let(:source) { <<~RUBY }
+  it 'with complex begin-end - registers many offenses' do
+    expect_offense(<<~RUBY)
       begin
 
         do_something1
 
+      #{message} before the `rescue`.
       rescue RuntimeError
 
+      #{message} after the `rescue`.
         do_something2
 
+      #{message} before the `rescue`.
       rescue ArgumentError => ex
 
+      #{message} after the `rescue`.
         do_something3
 
+      #{message} before the `rescue`.
       rescue
 
+      #{message} after the `rescue`.
         do_something3
 
+      #{message} before the `else`.
       else
 
+      #{message} after the `else`.
         do_something4
 
+      #{message} before the `ensure`.
       ensure
 
+      #{message} after the `ensure`.
         do_something4
 
       end
     RUBY
 
-    let(:correction) { <<~RUBY }
+    expect_correction(<<~RUBY)
       begin
 
         do_something1
@@ -180,48 +186,48 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords d
 
       end
     RUBY
-
-    it 'registers many offenses' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(10)
-    end
-
-    it 'autocorrects' do
-      corrected = autocorrect_source(source)
-      expect(corrected).to eq correction
-    end
   end
 
-  context 'with complex method definition' do
-    let(:source) { <<~RUBY }
+  it 'with complex method definition - registers many offenses' do
+    expect_offense(<<~RUBY)
       def foo
 
         do_something1
 
+      #{message} before the `rescue`.
       rescue RuntimeError
 
+      #{message} after the `rescue`.
         do_something2
 
+      #{message} before the `rescue`.
       rescue ArgumentError => ex
 
+      #{message} after the `rescue`.
         do_something3
 
+      #{message} before the `rescue`.
       rescue
 
+      #{message} after the `rescue`.
         do_something3
 
+      #{message} before the `else`.
       else
 
+      #{message} after the `else`.
         do_something4
 
+      #{message} before the `ensure`.
       ensure
 
+      #{message} after the `ensure`.
         do_something4
 
       end
     RUBY
 
-    let(:correction) { <<~RUBY }
+    expect_correction(<<~RUBY)
       def foo
 
         do_something1
@@ -238,15 +244,5 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords d
 
       end
     RUBY
-
-    it 'registers many offenses' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(10)
-    end
-
-    it 'autocorrects' do
-      corrected = autocorrect_source(source)
-      expect(corrected).to eq correction
-    end
   end
 end

--- a/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
@@ -3,15 +3,23 @@
 RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundMethodBody do
   subject(:cop) { described_class.new }
 
+  let(:beginning_offense_annotation) { '^{} Extra empty line detected at method body beginning.' }
+  let(:end_offense_annotation) { '^{} Extra empty line detected at method body end.' }
+
   it 'registers an offense for method body starting with a blank' do
-    inspect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       def some_method
 
+      #{beginning_offense_annotation}
         do_something
       end
     RUBY
-    expect(cop.messages)
-      .to eq(['Extra empty line detected at method body beginning.'])
+
+    expect_correction(<<~RUBY)
+      def some_method
+        do_something
+      end
+    RUBY
   end
 
   # The cop only registers an offense if the extra line is completely empty. If
@@ -25,39 +33,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundMethodBody do
                         'end'].join("\n"))
   end
 
-  it 'autocorrects method body starting with a blank' do
-    corrected = autocorrect_source(<<~RUBY)
-      def some_method
-
-        do_something
-      end
-    RUBY
-    expect(corrected).to eq <<~RUBY
-      def some_method
-        do_something
-      end
-    RUBY
-  end
-
   it 'registers an offense for class method body starting with a blank' do
-    inspect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       def Test.some_method
 
+      #{beginning_offense_annotation}
         do_something
       end
     RUBY
-    expect(cop.messages)
-      .to eq(['Extra empty line detected at method body beginning.'])
-  end
 
-  it 'autocorrects class method body starting with a blank' do
-    corrected = autocorrect_source(<<~RUBY)
-      def Test.some_method
-
-        do_something
-      end
-    RUBY
-    expect(corrected).to eq <<~RUBY
+    expect_correction(<<~RUBY)
       def Test.some_method
         do_something
       end
@@ -65,25 +50,23 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundMethodBody do
   end
 
   it 'registers an offense for method body ending with a blank' do
-    inspect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       def some_method
         do_something
 
+      #{end_offense_annotation}
       end
     RUBY
-    expect(cop.messages)
-      .to eq(['Extra empty line detected at method body end.'])
   end
 
   it 'registers an offense for class method body ending with a blank' do
-    inspect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       def Test.some_method
         do_something
-
+      
+      #{end_offense_annotation}
       end
     RUBY
-    expect(cop.messages)
-      .to eq(['Extra empty line detected at method body end.'])
   end
 
   it 'is not fooled by single line methods' do

--- a/spec/rubocop/cop/layout/empty_lines_around_module_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_module_body_spec.rb
@@ -12,37 +12,37 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'no_empty_lines' } }
 
     it 'registers an offense for module body starting with a blank' do
-      inspect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         module SomeModule
 
+        ^{} #{extra_begin}
           do_something
         end
       RUBY
-
-      expect(cop.messages).to eq([extra_begin])
     end
 
     it 'registers an offense for module body ending with a blank' do
-      inspect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         module SomeModule
           do_something
 
+        ^{} #{extra_end}
         end
       RUBY
-
-      expect(cop.messages).to eq([extra_end])
     end
 
     it 'autocorrects beginning and end' do
-      new_source = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         module SomeModule
 
+        ^{} #{extra_begin}
           do_something
 
+        ^{} #{extra_end}
         end
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         module SomeModule
           do_something
         end
@@ -55,13 +55,13 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
 
     it 'registers an offense for module body not starting or ending with a ' \
        'blank' do
-      inspect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         module SomeModule
           do_something
+        ^ #{missing_begin}
         end
+        ^ #{missing_end}
       RUBY
-
-      expect(cop.messages).to eq([missing_begin, missing_end])
     end
 
     it 'registers an offense for module body not ending with a blank' do
@@ -70,18 +70,20 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
 
           do_something
         end
-        ^ Empty line missing at module body end.
+        ^ #{missing_end}
       RUBY
     end
 
     it 'autocorrects beginning and end' do
-      new_source = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         module SomeModule
           do_something
+        ^ #{missing_begin}
         end
+        ^ #{missing_end}
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         module SomeModule
 
           do_something
@@ -253,9 +255,10 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
 
       it 'registers offenses for namespace body starting '\
         'and ending without a blank' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           module Parent
             module Mom
+          ^ #{missing_begin}
 
               do_something
 
@@ -264,9 +267,8 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
 
             end
           end
+          ^ #{missing_end}
         RUBY
-
-        expect(cop.messages).to eq([missing_begin, missing_end])
       end
     end
   end

--- a/spec/rubocop/cop/layout/empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_spec.rb
@@ -4,26 +4,15 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLines do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for consecutive empty lines' do
-    inspect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       test = 5
 
 
-
-      top
-    RUBY
-    expect(cop.offenses.size).to eq(2)
-  end
-
-  it 'auto-corrects consecutive empty lines' do
-    corrected = autocorrect_source(<<~RUBY)
-      test = 5
-
-
-
+      ^{} Extra blank line detected.
       top
     RUBY
 
-    expect(corrected).to eq(<<~RUBY)
+    expect_correction(<<~RUBY)
       test = 5
 
       top

--- a/spec/support/empty_lines_around_body_shared_examples.rb
+++ b/spec/support/empty_lines_around_body_shared_examples.rb
@@ -16,23 +16,17 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
       end
 
       context 'source without blank lines' do
-        let(:source) do
-          <<~RUBY
+        it "registers an offense for #{type} not beginning "\
+           'and ending with a blank line' do
+          expect_offense(<<~RUBY)
             #{type} SomeObject
               def do_something; end
+            ^ #{missing_begin}
             end
+            ^ #{missing_end}
           RUBY
-        end
 
-        it "registers an offense for #{type} not beginning "\
-          'and ending with a blank line' do
-          inspect_source(source)
-          expect(cop.messages).to eq([missing_begin, missing_end])
-        end
-
-        it 'autocorrects the offenses' do
-          new_source = autocorrect_source(source)
-          expect(new_source).to eq(<<~RUBY)
+          expect_correction(<<~RUBY)
             #{type} SomeObject
 
               def do_something; end
@@ -58,20 +52,19 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
         end
 
         context 'source without blank lines' do
-          let(:source) do
-            <<~RUBY
+          it 'registers and autocorrects the offenses' do
+            expect_offense(<<~RUBY)
               #{type} Parent
                 #{type} SomeObject
                   def do_something
+              ^ #{missing_begin}
                   end
                 end
+              ^ #{missing_end}
               end
             RUBY
-          end
 
-          it 'autocorrects the offenses' do
-            new_source = autocorrect_source(source)
-            expect(new_source).to eq(<<~RUBY)
+            expect_correction(<<~RUBY)
               #{type} Parent
                 #{type} SomeObject
 
@@ -85,10 +78,11 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
         end
 
         context 'source with blank lines' do
-          let(:source) do
-            <<~RUBY
+          it 'autocorrects the offenses' do
+            expect_offense(<<~RUBY)
               #{type} Parent
 
+              ^{} #{extra_begin}
                 #{type} SomeObject
 
                   def do_something
@@ -96,13 +90,11 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
 
                 end
 
+              ^{} #{extra_end}
               end
             RUBY
-          end
 
-          it 'autocorrects the offenses' do
-            new_source = autocorrect_source(source)
-            expect(new_source).to eq(<<~RUBY)
+            expect_correction(<<~RUBY)
               #{type} Parent
                 #{type} SomeObject
 
@@ -132,23 +124,17 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
       end
 
       context 'source without blank lines' do
-        let(:source) do
-          <<~RUBY
+        it "registers an offense for #{type} not ending with a blank line" do
+          expect_offense(<<~RUBY)
             #{type} SomeObject
               include Something
               def do_something; end
+            ^ #{missing_def}
             end
+            ^ #{missing_end}
           RUBY
-        end
 
-        it "registers an offense for #{type} not ending with a blank line" do
-          inspect_source(source)
-          expect(cop.messages).to eq([missing_def, missing_end])
-        end
-
-        it 'autocorrects the offenses' do
-          new_source = autocorrect_source(source)
-          expect(new_source).to eq(<<~RUBY)
+          expect_correction(<<~RUBY)
             #{type} SomeObject
               include Something
 
@@ -160,25 +146,19 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
       end
 
       context 'source with blank lines' do
-        let(:source) do
-          <<~RUBY
+        it "registers an offense for #{type} beginning with a blank line" do
+          expect_offense(<<~RUBY)
             #{type} SomeObject
 
+            ^{} #{extra_begin}
               include Something
               def do_something; end
+            ^ #{missing_def}
 
             end
           RUBY
-        end
 
-        it "registers an offense for #{type} beginning with a blank line" do
-          inspect_source(source)
-          expect(cop.messages).to eq([extra_begin, missing_def])
-        end
-
-        it 'autocorrects the offenses' do
-          new_source = autocorrect_source(source)
-          expect(new_source).to eq(<<~RUBY)
+          expect_correction(<<~RUBY)
             #{type} SomeObject
               include Something
 
@@ -190,26 +170,20 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
       end
 
       context 'source with comment before method definition' do
-        let(:source) do
-          <<~RUBY
+        it "registers an offense for #{type} beginning with a blank line" do
+          expect_offense(<<~RUBY)
             #{type} SomeObject
 
+            ^{} #{extra_begin}
               include Something
               # Comment
+            ^ #{missing_def}
               def do_something; end
 
             end
           RUBY
-        end
 
-        it "registers an offense for #{type} beginning with a blank line" do
-          inspect_source(source)
-          expect(cop.messages).to eq([extra_begin, missing_def])
-        end
-
-        it 'autocorrects the offenses' do
-          new_source = autocorrect_source(source)
-          expect(new_source).to eq(<<~RUBY)
+          expect_correction(<<~RUBY)
             #{type} SomeObject
               include Something
 
@@ -239,21 +213,20 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
         end
 
         context 'source without blank lines' do
-          let(:source) do
-            <<~RUBY
+          it 'registers and autocorrects the offenses' do
+            expect_offense(<<~RUBY)
               #{type} Parent
                 #{type} SomeObject
                   include Something
                   def do_something
+              ^ #{missing_def}
                   end
                 end
+              ^ #{missing_end}
               end
             RUBY
-          end
 
-          it 'autocorrects the offenses' do
-            new_source = autocorrect_source(source)
-            expect(new_source).to eq(<<~RUBY)
+            expect_correction(<<~RUBY)
               #{type} Parent
                 #{type} SomeObject
                   include Something
@@ -268,12 +241,14 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
         end
 
         context 'source with blank lines' do
-          let(:source) do
-            <<~RUBY
+          it 'registers and autocorrects the offenses' do
+            expect_offense(<<~RUBY)
               #{type} Parent
 
+              ^{} #{extra_begin}
                 #{type} SomeObject
 
+              ^{} #{extra_begin}
                   include Something
 
                   def do_something
@@ -281,13 +256,11 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
 
                 end
 
+              ^{} #{extra_end}
               end
             RUBY
-          end
 
-          it 'autocorrects the offenses' do
-            new_source = autocorrect_source(source)
-            expect(new_source).to eq(<<~RUBY)
+            expect_correction(<<~RUBY)
               #{type} Parent
                 #{type} SomeObject
                   include Something
@@ -302,21 +275,20 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
         end
 
         context 'source with constants' do
-          let(:source) do
-            <<~RUBY
+          it 'registers and autocorrects the offenses' do
+            expect_offense(<<~RUBY)
               #{type} Parent
                 #{type} SomeObject
                   URL = %q(http://example.com)
                   def do_something
+              ^ #{missing_def}
                   end
                 end
+              ^ #{missing_end}
               end
             RUBY
-          end
 
-          it 'autocorrects the offenses' do
-            new_source = autocorrect_source(source)
-            expect(new_source).to eq(<<~RUBY)
+            expect_correction(<<~RUBY)
               #{type} Parent
                 #{type} SomeObject
                   URL = %q(http://example.com)
@@ -353,20 +325,18 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
     end
 
     context "#{type} with only constants" do
-      let(:source) do
-        <<~RUBY
+      it 'registers and autocorrects the offenses' do
+        expect_offense(<<~RUBY)
           #{type} Parent
             #{type} SomeObject
               URL = %q(http://example.com)
               WSDL = %q(http://example.com/wsdl)
             end
+          ^ #{missing_end}
           end
         RUBY
-      end
 
-      it 'autocorrects the offenses' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(<<~RUBY)
+        expect_correction(<<~RUBY)
           #{type} Parent
             #{type} SomeObject
               URL = %q(http://example.com)
@@ -379,28 +349,21 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
     end
 
     context "#{type} with constant and child #{type}" do
-      let(:source) do
-        <<~RUBY
+      it 'registers and autocorrects the offenses' do
+        expect_offense(<<~RUBY)
           #{type} Parent
             URL = %q(http://example.com)
             #{type} SomeObject
+          ^ #{missing_type}
               def do_something; end
+          ^ #{missing_begin}
             end
+          ^ #{missing_end}
           end
+          ^ #{missing_end}
         RUBY
-      end
 
-      it 'registers offenses' do
-        inspect_source(source)
-        expect(cop.messages).to eq([missing_type,
-                                    missing_begin,
-                                    missing_end,
-                                    missing_end])
-      end
-
-      it 'autocorrects the offenses' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(<<~RUBY)
+        expect_correction(<<~RUBY)
           #{type} Parent
             URL = %q(http://example.com)
 


### PR DESCRIPTION
Part of #8127
Refactor specs in spec/rubocop/cop/layout/ starting with letters (A-E) to use newer helpers `expect_offense` / `expect_correction` instead of old `inspect_source` / `autocorrect_source`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
