### PR TITLE
Register an offense for yield without arguments in Style/ExplicitBlockArgument

### DIFF
--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -2839,6 +2839,11 @@ def with_tmp_dir
   end
 end
 
+# bad
+def nine_times
+  9.times { yield }
+end
+
 # good
 def with_tmp_dir(&block)
   Dir.mktmpdir do |tmp_dir|
@@ -2848,6 +2853,11 @@ end
 
 with_tmp_dir do |dir|
   puts "dir is accessible as a parameter and pwd is set: #{dir}"
+end
+
+# good
+def nine_times(&block)
+  9.times(&block)
 end
 ----
 

--- a/lib/rubocop/cop/style/explicit_block_argument.rb
+++ b/lib/rubocop/cop/style/explicit_block_argument.rb
@@ -14,6 +14,11 @@ module RuboCop
       #     end
       #   end
       #
+      #   # bad
+      #   def nine_times
+      #     9.times { yield }
+      #   end
+      #
       #   # good
       #   def with_tmp_dir(&block)
       #     Dir.mktmpdir do |tmp_dir|
@@ -23,6 +28,11 @@ module RuboCop
       #
       #   with_tmp_dir do |dir|
       #     puts "dir is accessible as a parameter and pwd is set: #{dir}"
+      #   end
+      #
+      #   # good
+      #   def nine_times(&block)
+      #     9.times(&block)
       #   end
       #
       class ExplicitBlockArgument < Base
@@ -61,8 +71,6 @@ module RuboCop
         private
 
         def yielding_arguments?(block_args, yield_args)
-          return false if yield_args.empty?
-
           yield_args.zip(block_args).all? do |yield_arg, block_arg|
             block_arg && yield_arg.children.first == block_arg.children.first
           end

--- a/spec/rubocop/cop/style/explicit_block_argument_spec.rb
+++ b/spec/rubocop/cop/style/explicit_block_argument_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe RuboCop::Cop::Style::ExplicitBlockArgument do
           yield 2
         elsif other_condition
           3.times { yield }
+          ^^^^^^^^^^^^^^^^^ Consider using explicit block argument in the surrounding method's signature over `yield`.
         else
           other_items.something { |i, j| yield i }
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Consider using explicit block argument in the surrounding method's signature over `yield`.
@@ -87,7 +88,7 @@ RSpec.describe RuboCop::Cop::Style::ExplicitBlockArgument do
         if condition
           yield 2
         elsif other_condition
-          3.times { yield }
+          3.times(&block)
         else
           other_items.something(&block)
         end
@@ -103,10 +104,17 @@ RSpec.describe RuboCop::Cop::Style::ExplicitBlockArgument do
     RUBY
   end
 
-  it 'does not register an offense when `yield` inside block has no arguments' do
-    expect_no_offenses(<<~RUBY)
+  it 'registers an offense and corrects when `yield` inside block has no arguments' do
+    expect_offense(<<~RUBY)
       def m
         3.times { yield }
+        ^^^^^^^^^^^^^^^^^ Consider using explicit block argument in the surrounding method's signature over `yield`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def m(&block)
+        3.times(&block)
       end
     RUBY
   end


### PR DESCRIPTION
I don't see a reason not to handle this case, and it's far more common in our codebase than the case where yield is called with arguments.

As with https://github.com/rubocop-hq/rubocop/pull/8453, I didn't add a changelog entry because this cop hasn't been released yet.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/