### PR TITLE
adds fix for usage docs to point to correct auto-correct docs

### DIFF
--- a/docs/modules/ROOT/pages/usage/basic_usage.adoc
+++ b/docs/modules/ROOT/pages/usage/basic_usage.adoc
@@ -125,7 +125,7 @@ $ rubocop -h
 | Command flag | Description
 
 | `-a/--auto-correct`
-| Auto-correct certain offenses. _Experimental_, use with caution. See xref:auto_correct.adoc[Auto-correct].
+| Auto-correct certain offenses. _Experimental_, use with caution. See xref:usage/auto_correct.adoc[Auto-correct].
 
 | `--auto-gen-config`
 | Generate a configuration file acting as a TODO list.


### PR DESCRIPTION
On the [Command Line flags page](https://docs.rubocop.org/rubocop/usage/basic_usage.html#command-line-flags), the "See Auto-correct" hyperlink is malformed. Currently it points to `xref:auto_correct.adoc` when it should be `xref:usage/auto_correct.adoc`

I wasn't sure if this warranted being included in the changle-log, I couldn't see any examples of others like this in the past so I excluded it and it doesn't look like there's any tests on the docs so these were excluded also.

Edit: These CI Failures seem unrelated to my changes and I took the current master if that helps for my fork

![Basic_Usage____RuboCop_Docs](https://user-images.githubusercontent.com/7063963/89457204-e6f4fe00-d75c-11ea-81ae-2799698a4766.jpg)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
