### PR TITLE
Set valid ref range when regexp is matched in Lint/OutOfRangeRegexpRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#8463](https://github.com/rubocop-hq/rubocop/pull/8463): Fix false positives for `Lint/OutOfRangeRegexpRef` when a regexp is defined and matched in separate steps. ([@eugeneius][])
+
 ## 0.89.0 (2020-08-05)
 
 ### New features

--- a/spec/rubocop/cop/lint/out_of_range_regexp_ref_spec.rb
+++ b/spec/rubocop/cop/lint/out_of_range_regexp_ref_spec.rb
@@ -78,4 +78,59 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef do
       puts $2
     RUBY
   end
+
+  it 'registers an offense when the regexp comes after `=~`' do
+    expect_offense(<<~RUBY)
+      "foobar" =~ /(foo)(bar)/
+      puts $3
+           ^^ Do not use out of range reference for the Regexp.
+    RUBY
+  end
+
+  it 'registers an offense when the regexp is matched with `===`' do
+    expect_offense(<<~RUBY)
+      /(foo)(bar)/ === "foobar"
+      puts $3
+           ^^ Do not use out of range reference for the Regexp.
+    RUBY
+  end
+
+  it 'registers an offense when the regexp is matched with `match`' do
+    expect_offense(<<~RUBY)
+      /(foo)(bar)/.match("foobar")
+      puts $3
+           ^^ Do not use out of range reference for the Regexp.
+    RUBY
+  end
+
+  it 'ignores calls to `match?`' do
+    expect_offense(<<~RUBY)
+      /(foo)(bar)/.match("foobar")
+      /(foo)(bar)(baz)/.match?("foobarbaz")
+      puts $3
+           ^^ Do not use out of range reference for the Regexp.
+    RUBY
+  end
+
+  it 'handles `match` with no arguments' do
+    expect_no_offenses(<<~RUBY)
+      foo.match
+    RUBY
+  end
+
+  it 'handles `match` with no receiver' do
+    expect_no_offenses(<<~RUBY)
+      match(bar)
+    RUBY
+  end
+
+  it 'only registers an offense when the regexp is matched as a literal' do
+    expect_no_offenses(<<~RUBY)
+      foo_bar_regexp = /(foo)(bar)/
+      foo_regexp = /(foo)/
+
+      foo_bar_regexp =~ 'foobar'
+      puts $2
+    RUBY
+  end
 end


### PR DESCRIPTION
Last match global variables are set when the regexp is matched, not when it's defined. This meant that the previous implementation gave incorrect results when those things happened separately, e.g. when a regexp was assigned to a local variable or a constant and then matched elsewhere.

This change means that the cop only handles matching on regexp literals, but that was the only case where it worked correctly before anyway. It should be possible to improve the cop to handle more complex cases with `VariableForce`, but that can be done as a separate change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/