### PR TITLE
Handle more matching methods in Lint/OutOfRangeRegexpRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#8463](https://github.com/rubocop-hq/rubocop/pull/8463): Fix false positives for `Lint/OutOfRangeRegexpRef` when a regexp is defined and matched in separate steps. ([@eugeneius][])
+* [#8464](https://github.com/rubocop-hq/rubocop/pull/8464): Handle regexps matched with `when`, `grep`, `gsub`, `gsub!`, `sub`, `sub!`, `[]`, `slice`, `slice!`, `scan`, `index`, `rindex`, `partition`, `rpartition`, `start_with?`, and `end_with?` in `Lint/OutOfRangeRegexpRef`. ([@eugeneius][])
 * [#8466](https://github.com/rubocop-hq/rubocop/issues/8466): Fix a false positive for `Lint/UriRegexp` when using `regexp` method without receiver. ([@koic][])
 * [#8478](https://github.com/rubocop-hq/rubocop/issues/8478): Relax `Lint/BinaryOperatorWithIdenticalOperands` for mathematical operations. ([@marcandre][])
 

--- a/spec/rubocop/cop/lint/out_of_range_regexp_ref_spec.rb
+++ b/spec/rubocop/cop/lint/out_of_range_regexp_ref_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef do
     RUBY
   end
 
-  it 'registers an offense when the regexp comes after `=~`' do
+  it 'registers an offense when the regexp appears on the right hand side of `=~`' do
     expect_offense(<<~RUBY)
       "foobar" =~ /(foo)(bar)/
       puts $3
@@ -132,5 +132,154 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef do
       foo_bar_regexp =~ 'foobar'
       puts $2
     RUBY
+  end
+
+  it 'does not register an offense when in range references are used inside a when clause' do
+    expect_no_offenses(<<~RUBY)
+      case "foobar"
+      when /(foo)(bar)/
+        $2
+      end
+    RUBY
+  end
+
+  it 'registers an offense when out of range references are used inside a when clause' do
+    expect_offense(<<~RUBY)
+      case "foobar"
+      when /(foo)(bar)/
+        $3
+        ^^ Do not use out of range reference for the Regexp.
+      end
+    RUBY
+  end
+
+  it 'uses the maximum number of captures for when clauses with multiple conditions' do
+    expect_no_offenses(<<~RUBY)
+      case "foobarbaz"
+      when /(foo)(bar)/, /(bar)baz/
+        $2
+      end
+    RUBY
+
+    expect_offense(<<~RUBY)
+      case "foobarbaz"
+      when /(foo)(bar)/, /(bar)baz/
+        $3
+        ^^ Do not use out of range reference for the Regexp.
+      end
+    RUBY
+  end
+
+  it 'only registers an offense for when clauses when the regexp is matched as a literal' do
+    expect_no_offenses(<<~RUBY)
+      case some_string
+      when some_regexp
+        $2
+      end
+    RUBY
+  end
+
+  it 'ignores regexp when clause conditions that contain interpolations' do
+    expect_offense(<<~'RUBY')
+      case "foobarbaz"
+      when /(foo)(bar)/, /#{var}/
+        $3
+        ^^ Do not use out of range reference for the Regexp.
+      end
+    RUBY
+  end
+
+  context 'matching with `grep`' do
+    it 'does not register an offense when in range references are used' do
+      expect_no_offenses(<<~RUBY)
+        %w[foo foobar].grep(/(foo)/) { $1 }
+      RUBY
+    end
+
+    it 'registers an offense when out of range references are used' do
+      expect_offense(<<~RUBY)
+        %w[foo foobar].grep(/(foo)/) { $2 }
+                                       ^^ Do not use out of range reference for the Regexp.
+      RUBY
+    end
+
+    it 'only registers an offense when the regexp is matched as a literal' do
+      expect_no_offenses(<<~RUBY)
+        %w[foo foobar].grep(some_regexp) { $2 }
+      RUBY
+    end
+  end
+
+  context 'matching with `[]`' do
+    it 'does not register an offense when in range references are used' do
+      expect_no_offenses(<<~RUBY)
+        "foobar"[/(foo)(bar)/]
+        puts $2
+      RUBY
+    end
+
+    it 'registers an offense when out of range references are used' do
+      expect_offense(<<~RUBY)
+        "foobar"[/(foo)(bar)/]
+        puts $3
+             ^^ Do not use out of range reference for the Regexp.
+      RUBY
+    end
+
+    it 'only registers an offense when the regexp is matched as a literal' do
+      expect_no_offenses(<<~RUBY)
+        "foobar"[some_regexp]
+        puts $3
+      RUBY
+    end
+  end
+
+  %i[gsub gsub! sub sub! scan].each do |method|
+    context "matching with #{method}" do
+      it 'does not register an offense when in range references are used' do
+        expect_no_offenses(<<~RUBY)
+          "foobar".#{method}(/(foo)(bar)/) { $2 }
+        RUBY
+      end
+
+      it 'registers an offense when out of range references are used' do
+        expect_offense(<<~RUBY, method: method)
+          "foobar".%{method}(/(foo)(bar)/) { $3 }
+                   _{method}                 ^^ Do not use out of range reference for the Regexp.
+        RUBY
+      end
+
+      it 'only registers an offense when the regexp is matched as a literal' do
+        expect_no_offenses(<<~RUBY)
+          some_string.#{method}(some_regexp) { $3 }
+        RUBY
+      end
+    end
+  end
+
+  %i[match slice slice! index rindex partition rpartition start_with? end_with?].each do |method|
+    context "matching with #{method}" do
+      it 'does not register an offense when in range references are used' do
+        expect_no_offenses(<<~RUBY)
+          "foobar".#{method}(/(foo)(bar)/)
+          puts $2
+        RUBY
+      end
+
+      it 'registers an offense when out of range references are used' do
+        expect_offense(<<~RUBY)
+          "foobar".#{method}(/(foo)(bar)/)
+          puts $3
+               ^^ Do not use out of range reference for the Regexp.
+        RUBY
+      end
+
+      it 'only registers an offense when the regexp is matched as a literal' do
+        expect_no_offenses(<<~RUBY)
+          "foobar".#{method}(some_regexp)
+          puts $3
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Followup to @marcandre's comment here: https://github.com/rubocop-hq/rubocop/pull/8463#issuecomment-669550324

`when`, `grep`, `gsub`, `gsub!` `sub`, `sub!`, `[]`, `slice`, `slice!` `scan`, `index`, `rindex`, `partition`, `rpartition`, `start_with?`, and `end_with?` can all be used to match regexps and set last match global variables, so we should update the range of valid references when we encounter them.

These were all of the relevant methods I could find from a quick grep of [ruby/spec](https://github.com/ruby/spec), although there could well be more.

**Update:** I read through the [String class' docs](https://ruby-doc.org/core-2.7.1/String.html) and added several more methods.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/