### PR TITLE
[Fix #8466] Fix a false positive for `Lint/UriRegexp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#8463](https://github.com/rubocop-hq/rubocop/pull/8463): Fix false positives for `Lint/OutOfRangeRegexpRef` when a regexp is defined and matched in separate steps. ([@eugeneius][])
+* [#8466](https://github.com/rubocop-hq/rubocop/issues/8466): Fix a false positive for `Lint/UriRegexp` when using `regexp` method without receiver. ([@koic][])
 
 ## 0.89.0 (2020-08-05)
 

--- a/lib/rubocop/cop/lint/uri_regexp.rb
+++ b/lib/rubocop/cop/lint/uri_regexp.rb
@@ -32,7 +32,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return unless node.method?(:regexp)
+          return unless node.method?(:regexp) && node.receiver
 
           captured_values = uri_regexp_with_argument?(node) || uri_regexp_without_argument?(node)
 

--- a/spec/rubocop/cop/lint/uri_regexp_spec.rb
+++ b/spec/rubocop/cop/lint/uri_regexp_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe RuboCop::Cop::Lint::UriRegexp do
 
   let(:config) { RuboCop::Config.new }
 
+  it 'does not register an offense when using `regexp` without receiver' do
+    expect_no_offenses(<<~RUBY)
+      regexp('http://example.com')
+    RUBY
+  end
+
   it 'registers an offense and corrects using `URI.regexp` with argument' do
     expect_offense(<<~RUBY)
       URI.regexp('http://example.com')


### PR DESCRIPTION
Fixes #8466.

This PR fixes a false positive for `Lint/UriRegexp` when using `regexp` method without receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
