### PR TITLE
Use new expect_correction in Style R-S cops

### DIFF
--- a/spec/rubocop/cop/lint/empty_expression_spec.rb
+++ b/spec/rubocop/cop/lint/empty_expression_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyExpression do
       RUBY
     end
 
-    it 'registers an offense inside `elseif`' do
+    it 'registers an offense inside `elsif`' do
       expect_offense(<<~RUBY)
         if foo
           1

--- a/spec/rubocop/cop/style/random_with_offset_spec.rb
+++ b/spec/rubocop/cop/style/random_with_offset_spec.rb
@@ -10,12 +10,20 @@ RSpec.describe RuboCop::Cop::Style::RandomWithOffset do
       rand(6) + 1
       ^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
     RUBY
+
+    expect_correction(<<~RUBY)
+      rand(1..6)
+    RUBY
   end
 
   it 'registers an offense when using offset + rand(int)' do
     expect_offense(<<~RUBY)
       1 + rand(6)
       ^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      rand(1..6)
     RUBY
   end
 
@@ -24,12 +32,20 @@ RSpec.describe RuboCop::Cop::Style::RandomWithOffset do
       rand(6).succ
       ^^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
     RUBY
+
+    expect_correction(<<~RUBY)
+      rand(1..6)
+    RUBY
   end
 
   it 'registers an offense when using rand(int) - offset' do
     expect_offense(<<~RUBY)
       rand(6) - 1
       ^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      rand(-1..4)
     RUBY
   end
 
@@ -38,12 +54,20 @@ RSpec.describe RuboCop::Cop::Style::RandomWithOffset do
       1 - rand(6)
       ^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
     RUBY
+
+    expect_correction(<<~RUBY)
+      rand(-4..1)
+    RUBY
   end
 
   it 'registers an offense when using rand(int).pred' do
     expect_offense(<<~RUBY)
       rand(6).pred
       ^^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      rand(-1..4)
     RUBY
   end
 
@@ -52,12 +76,20 @@ RSpec.describe RuboCop::Cop::Style::RandomWithOffset do
       rand(6).next
       ^^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
     RUBY
+
+    expect_correction(<<~RUBY)
+      rand(1..6)
+    RUBY
   end
 
   it 'registers an offense when using Kernel.rand' do
     expect_offense(<<~RUBY)
       Kernel.rand(6) + 1
       ^^^^^^^^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Kernel.rand(1..6)
     RUBY
   end
 
@@ -66,12 +98,20 @@ RSpec.describe RuboCop::Cop::Style::RandomWithOffset do
       ::Kernel.rand(6) + 1
       ^^^^^^^^^^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
     RUBY
+
+    expect_correction(<<~RUBY)
+      ::Kernel.rand(1..6)
+    RUBY
   end
 
   it 'registers an offense when using Random.rand' do
     expect_offense(<<~RUBY)
       Random.rand(6) + 1
       ^^^^^^^^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Random.rand(1..6)
     RUBY
   end
 
@@ -80,12 +120,20 @@ RSpec.describe RuboCop::Cop::Style::RandomWithOffset do
       ::Random.rand(6) + 1
       ^^^^^^^^^^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
     RUBY
+
+    expect_correction(<<~RUBY)
+      ::Random.rand(1..6)
+    RUBY
   end
 
   it 'registers an offense when using rand(irange) + offset' do
     expect_offense(<<~RUBY)
       rand(0..6) + 1
       ^^^^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      rand(1..7)
     RUBY
   end
 
@@ -94,121 +142,120 @@ RSpec.describe RuboCop::Cop::Style::RandomWithOffset do
       rand(0...6) + 1
       ^^^^^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
     RUBY
+
+    expect_correction(<<~RUBY)
+      rand(1..6)
+    RUBY
   end
 
-  it 'autocorrects rand(int) + offset' do
-    new_source = autocorrect_source('rand(6) + 1')
-    expect(new_source).to eq 'rand(1..6)'
+  it 'registers an offense when using offset + Random.rand(int)' do
+    expect_offense(<<~RUBY)
+      1 + Random.rand(6)
+      ^^^^^^^^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Random.rand(1..6)
+    RUBY
   end
 
-  it 'autocorrects offset + rand(int)' do
-    new_source = autocorrect_source('1 + rand(6)')
-    expect(new_source).to eq 'rand(1..6)'
+  it 'registers an offense when using offset - ::Random.rand(int)' do
+    expect_offense(<<~RUBY)
+      1 - ::Random.rand(6)
+      ^^^^^^^^^^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ::Random.rand(-4..1)
+    RUBY
   end
 
-  it 'autocorrects rand(int) - offset' do
-    new_source = autocorrect_source('rand(6) - 1')
-    expect(new_source).to eq 'rand(-1..4)'
+  it 'registers an offense when using Random.rand(int).succ' do
+    expect_offense(<<~RUBY)
+      Random.rand(6).succ
+      ^^^^^^^^^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Random.rand(1..6)
+    RUBY
   end
 
-  it 'autocorrects offset - rand(int)' do
-    new_source = autocorrect_source('1 - rand(6)')
-    expect(new_source).to eq 'rand(-4..1)'
+  it 'registers an offense when using ::Random.rand(int).pred' do
+    expect_offense(<<~RUBY)
+      ::Random.rand(6).pred
+      ^^^^^^^^^^^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ::Random.rand(-1..4)
+    RUBY
   end
 
-  it 'autocorrects rand(int).succ' do
-    new_source = autocorrect_source('rand(6).succ')
-    expect(new_source).to eq 'rand(1..6)'
+  it 'registers an offense when using rand(irange) - offset' do
+    expect_offense(<<~RUBY)
+      rand(0..6) - 1
+      ^^^^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      rand(-1..5)
+    RUBY
   end
 
-  it 'autocorrects rand(int).pred' do
-    new_source = autocorrect_source('rand(6).pred')
-    expect(new_source).to eq 'rand(-1..4)'
+  it 'registers an offense when using rand(erange) - offset' do
+    expect_offense(<<~RUBY)
+      rand(0...6) - 1
+      ^^^^^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      rand(-1..4)
+    RUBY
   end
 
-  it 'autocorrects rand(int).next' do
-    new_source = autocorrect_source('rand(6).next')
-    expect(new_source).to eq 'rand(1..6)'
+  it 'registers an offense when using offset - rand(irange)' do
+    expect_offense(<<~RUBY)
+      1 - rand(0..6)
+      ^^^^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      rand(-5..1)
+    RUBY
   end
 
-  it 'autocorrects the use of Random.rand' do
-    new_source = autocorrect_source('Random.rand(6) + 1')
-    expect(new_source).to eq 'Random.rand(1..6)'
+  it 'registers an offense when using offset - rand(erange)' do
+    expect_offense(<<~RUBY)
+      1 - rand(0...6)
+      ^^^^^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      rand(-4..1)
+    RUBY
   end
 
-  it 'autocorrects the use of ::Random.rand' do
-    new_source = autocorrect_source('::Random.rand(6) + 1')
-    expect(new_source).to eq '::Random.rand(1..6)'
+  it 'registers an offense when using rand(irange).succ' do
+    expect_offense(<<~RUBY)
+      rand(0..6).succ
+      ^^^^^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      rand(1..7)
+    RUBY
   end
 
-  it 'autocorrects offset + Random.rand(int)' do
-    new_source = autocorrect_source('1 + Random.rand(6)')
-    expect(new_source).to eq 'Random.rand(1..6)'
-  end
+  it 'registers an offense when using rand(erange).succ' do
+    expect_offense(<<~RUBY)
+      rand(0...6).succ
+      ^^^^^^^^^^^^^^^^ Prefer ranges when generating random numbers instead of integers with offsets.
+    RUBY
 
-  it 'autocorrects offset - ::Random.rand(int)' do
-    new_source = autocorrect_source('1 - ::Random.rand(6)')
-    expect(new_source).to eq '::Random.rand(-4..1)'
-  end
-
-  it 'autocorrects Random.rand(int).succ' do
-    new_source = autocorrect_source('Random.rand(6).succ')
-    expect(new_source).to eq 'Random.rand(1..6)'
-  end
-
-  it 'autocorrects ::Random.rand(int).pred' do
-    new_source = autocorrect_source('::Random.rand(6).pred')
-    expect(new_source).to eq '::Random.rand(-1..4)'
-  end
-
-  it 'autocorrects the use of Kernel.rand' do
-    new_source = autocorrect_source('Kernel.rand(6) + 1')
-    expect(new_source).to eq 'Kernel.rand(1..6)'
-  end
-
-  it 'autocorrects the use of ::Kernel.rand' do
-    new_source = autocorrect_source('::Kernel.rand(6) + 1')
-    expect(new_source).to eq '::Kernel.rand(1..6)'
-  end
-
-  it 'autocorrects rand(irange) + offset' do
-    new_source = autocorrect_source('rand(0..6) + 1')
-    expect(new_source).to eq 'rand(1..7)'
-  end
-
-  it 'autocorrects rand(3range) + offset' do
-    new_source = autocorrect_source('rand(0...6) + 1')
-    expect(new_source).to eq 'rand(1..6)'
-  end
-
-  it 'autocorrects rand(irange) - offset' do
-    new_source = autocorrect_source('rand(0..6) - 1')
-    expect(new_source).to eq 'rand(-1..5)'
-  end
-
-  it 'autocorrects rand(erange) - offset' do
-    new_source = autocorrect_source('rand(0...6) - 1')
-    expect(new_source).to eq 'rand(-1..4)'
-  end
-
-  it 'autocorrects offset - rand(irange)' do
-    new_source = autocorrect_source('1 - rand(0..6)')
-    expect(new_source).to eq 'rand(-5..1)'
-  end
-
-  it 'autocorrects offset - rand(erange)' do
-    new_source = autocorrect_source('1 - rand(0...6)')
-    expect(new_source).to eq 'rand(-4..1)'
-  end
-
-  it 'autocorrects rand(irange).succ' do
-    new_source = autocorrect_source('rand(0..6).succ')
-    expect(new_source).to eq 'rand(1..7)'
-  end
-
-  it 'autocorrects rand(erange).succ' do
-    new_source = autocorrect_source('rand(0...6).succ')
-    expect(new_source).to eq 'rand(1..6)'
+    expect_correction(<<~RUBY)
+      rand(1..6)
+    RUBY
   end
 
   it 'does not register an offense when using range with double dots' do

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
+  let(:trailing_whitespace) { ' ' }
+
   it 'reports an offense for single line def with redundant begin block' do
     expect_offense(<<~RUBY)
       def func; begin; x; y; rescue; z end; end
                 ^^^^^ Redundant `begin` block detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def func; ; x; y; rescue; z ; end
     RUBY
   end
 
@@ -19,6 +25,16 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
         end
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def func
+       #{trailing_whitespace}
+          ala
+        rescue => e
+          bala
+       #{trailing_whitespace}
+      end
+    RUBY
   end
 
   it 'reports an offense for defs with redundant begin block' do
@@ -30,6 +46,16 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
         rescue => e
           bala
         end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def Test.func
+       #{trailing_whitespace}
+          ala
+        rescue => e
+          bala
+       #{trailing_whitespace}
       end
     RUBY
   end
@@ -73,46 +99,11 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
     RUBY
   end
 
-  it 'auto-corrects source separated by newlines ' \
-     'by removing redundant begin blocks' do
-    src = <<~RUBY
-      def func
-        begin
-          foo
-          bar
-        rescue
-          baz
-        end
-      end
-    RUBY
-
-    result_src = <<~RUBY
-      def func
-        
-          foo
-          bar
-        rescue
-          baz
-        
-      end
-    RUBY
-
-    new_source = autocorrect_source(src)
-    expect(new_source).to eq(result_src)
-  end
-
-  it 'auto-corrects source separated by semicolons ' \
-     'by removing redundant begin blocks' do
-    src = '  def func; begin; x; y; rescue; z end end'
-    result_src = '  def func; ; x; y; rescue; z  end'
-    new_source = autocorrect_source(src)
-    expect(new_source).to eq(result_src)
-  end
-
   it "doesn't modify spacing when auto-correcting" do
-    src = <<~RUBY
+    expect_offense(<<~RUBY)
       def method
         begin
+        ^^^^^ Redundant `begin` block detected.
           BlockA do |strategy|
             foo
           end
@@ -127,9 +118,9 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
       end
     RUBY
 
-    result_src = <<~RUBY
+    expect_correction(<<~RUBY)
       def method
-        
+       #{trailing_whitespace}
           BlockA do |strategy|
             foo
           end
@@ -140,24 +131,23 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
 
         rescue => e # some problem
           bar
-        
+       #{trailing_whitespace}
       end
     RUBY
-
-    new_source = autocorrect_source(src)
-    expect(new_source).to eq(result_src)
   end
 
   it 'auto-corrects when there are trailing comments' do
-    src = <<~RUBY
+    expect_offense(<<~RUBY)
       def method
         begin # comment 1
+        ^^^^^ Redundant `begin` block detected.
           do_some_stuff
         rescue # comment 2
         end # comment 3
       end
     RUBY
-    result_src = <<~RUBY
+
+    expect_correction(<<~RUBY)
       def method
          # comment 1
           do_some_stuff
@@ -165,8 +155,6 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
          # comment 3
       end
     RUBY
-    new_source = autocorrect_source(src)
-    expect(new_source).to eq(result_src)
   end
 
   context '< Ruby 2.5', :ruby24 do
@@ -193,6 +181,16 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
           rescue => e
             bar
           end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something do
+         #{trailing_whitespace}
+            foo
+          rescue => e
+            bar
+         #{trailing_whitespace}
         end
       RUBY
     end

--- a/spec/rubocop/cop/style/redundant_conditional_spec.rb
+++ b/spec/rubocop/cop/style/redundant_conditional_spec.rb
@@ -5,129 +5,123 @@ RSpec.describe RuboCop::Cop::Style::RedundantConditional do
 
   let(:config) { RuboCop::Config.new }
 
-  before { inspect_source(source) }
+  it 'registers an offense for ternary with boolean results' do
+    expect_offense(<<~RUBY)
+      x == y ? true : false
+      ^^^^^^^^^^^^^^^^^^^^^ This conditional expression can just be replaced by `x == y`.
+    RUBY
 
-  shared_examples 'code with offense' do |code, expected, message_expression|
-    context "when checking #{code.inspect}" do
-      let(:source) { code }
-
-      it 'registers an offense' do
-        expected_message =
-          'This conditional expression '\
-          "can just be replaced by `#{message_expression || expected}`."
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages).to eq([expected_message])
-      end
-
-      it 'auto-corrects' do
-        expect(autocorrect_source(code)).to eq(expected)
-      end
-
-      it 'claims to auto-correct' do
-        autocorrect_source(code)
-        expect(cop.offenses.last.status).to eq(:corrected)
-      end
-    end
+    expect_correction(<<~RUBY)
+      x == y
+    RUBY
   end
 
-  shared_examples 'code without offense' do |code|
-    let(:source) { code }
+  it 'registers an offense for ternary with negated boolean results' do
+    expect_offense(<<~RUBY)
+      x == y ? false : true
+      ^^^^^^^^^^^^^^^^^^^^^ This conditional expression can just be replaced by `!(x == y)`.
+    RUBY
 
-    context "when checking #{code.inspect}" do
-      it 'does not register an offense' do
-        expect(cop.offenses.empty?).to be(true)
-      end
-    end
+    expect_correction(<<~RUBY)
+      !(x == y)
+    RUBY
   end
 
-  it_behaves_like 'code with offense',
-                  'x == y ? true : false',
-                  'x == y'
+  it 'allows ternary with non-boolean results' do
+    expect_no_offenses('x == y ? 1 : 10')
+  end
 
-  it_behaves_like 'code with offense',
-                  'x == y ? false : true',
-                  '!(x == y)'
+  it 'registers an offense for if/else with boolean results' do
+    expect_offense(<<~RUBY)
+      if x == y
+      ^^^^^^^^^ This conditional expression can just be replaced by `x == y`.
+        true
+      else
+        false
+      end
+    RUBY
 
-  it_behaves_like 'code without offense',
-                  'x == y ? 1 : 10'
+    expect_correction(<<~RUBY)
+      x == y
+    RUBY
+  end
 
-  it_behaves_like 'code with offense',
-                  <<~RUBY,
-                    if x == y
-                      true
-                    else
-                      false
-                    end
-                  RUBY
-                  "x == y\n",
-                  'x == y'
+  it 'registers an offense for if/else with negated boolean results' do
+    expect_offense(<<~RUBY)
+      if x == y
+      ^^^^^^^^^ This conditional expression can just be replaced by `!(x == y)`.
+        false
+      else
+        true
+      end
+    RUBY
 
-  it_behaves_like 'code with offense',
-                  <<~RUBY,
-                    if x == y
-                      false
-                    else
-                      true
-                    end
-                  RUBY
-                  "!(x == y)\n",
-                  '!(x == y)'
+    expect_correction(<<~RUBY)
+      !(x == y)
+    RUBY
+  end
 
-  it_behaves_like 'code with offense',
-                  <<~RUBY,
-                    if cond
-                      false
-                    elsif x == y
-                      true
-                    else
-                      false
-                    end
-                  RUBY
-                  <<~RUBY,
-                    if cond
-                      false
-                    else
-                      x == y
-                    end
-                  RUBY
-                  "\nelse\n  x == y"
+  it 'registers an offense for if/elsif/else with boolean results' do
+    expect_offense(<<~RUBY)
+      if cond
+        false
+      elsif x == y
+      ^^^^^^^^^^^^ This conditional expression can just be replaced by [...]
+        true
+      else
+        false
+      end
+    RUBY
 
-  it_behaves_like 'code with offense',
-                  <<~RUBY,
-                    if cond
-                      false
-                    elsif x == y
-                      false
-                    else
-                      true
-                    end
-                  RUBY
-                  <<~RUBY,
-                    if cond
-                      false
-                    else
-                      !(x == y)
-                    end
-                  RUBY
-                  "\nelse\n  !(x == y)"
+    expect_correction(<<~RUBY)
+      if cond
+        false
+      else
+        x == y
+      end
+    RUBY
+  end
 
-  it_behaves_like 'code without offense',
-                  <<~RUBY
-                    if x == y
-                      1
-                    else
-                      2
-                    end
-                  RUBY
+  it 'registers an offense for if/elsif/else with negated boolean results' do
+    expect_offense(<<~RUBY)
+      if cond
+        false
+      elsif x == y
+      ^^^^^^^^^^^^ This conditional expression can just be replaced by [...]
+        false
+      else
+        true
+      end
+    RUBY
 
-  it_behaves_like 'code without offense',
-                  <<~RUBY
-                    if cond
-                      1
-                    elseif x == y
-                      2
-                    else
-                      3
-                    end
-                  RUBY
+    expect_correction(<<~RUBY)
+      if cond
+        false
+      else
+        !(x == y)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for if/else with non-boolean results' do
+    expect_no_offenses(<<~RUBY)
+      if x == y
+        1
+      else
+        2
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for if/elsif/else with non-boolean results' do
+    expect_no_offenses(<<~RUBY)
+      if cond
+        1
+      elseif x == y
+        2
+      else
+        3
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/style/redundant_conditional_spec.rb
+++ b/spec/rubocop/cop/style/redundant_conditional_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantConditional do
     expect_no_offenses(<<~RUBY)
       if cond
         1
-      elseif x == y
+      elsif x == y
         2
       else
         3

--- a/spec/rubocop/cop/style/redundant_fetch_block_spec.rb
+++ b/spec/rubocop/cop/style/redundant_fetch_block_spec.rb
@@ -115,13 +115,11 @@ RSpec.describe RuboCop::Cop::Style::RedundantFetchBlock do
     end
 
     it 'does not register an offense when using `#fetch` with interpolated Symbol in the block' do
-      inspect_source('hash.fetch(:key) { :"value_#{value}" }')
-      expect(cop.offenses.size).to eq(0)
+      expect_no_offenses('hash.fetch(:key) { :"value_#{value}" }')
     end
 
     it 'does not register an offense when using `#fetch` with an argument in the block' do
-      inspect_source('hash.fetch(:key) { |k| "missing-#{k}" }')
-      expect(cop.offenses.size).to eq(0)
+      expect_no_offenses('hash.fetch(:key) { |k| "missing-#{k}" }')
     end
 
     it 'does not register an offense when using `#fetch` with `Rails.cache`' do

--- a/spec/rubocop/cop/style/redundant_freeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_freeze_spec.rb
@@ -7,15 +7,14 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze do
 
   shared_examples 'immutable objects' do |o|
     it "registers an offense for frozen #{o}" do
-      source = [prefix, "CONST = #{o}.freeze"].compact.join("\n")
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-    end
+      expect_offense([prefix, <<~RUBY].compact.join("\n"), o: o)
+        CONST = %{o}.freeze
+                ^{o}^^^^^^^ Do not freeze immutable objects, as freezing them has no effect.
+      RUBY
 
-    it 'auto-corrects by removing .freeze' do
-      source = [prefix, "CONST = #{o}.freeze"].compact.join("\n")
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(source.chomp('.freeze'))
+      expect_correction([prefix, <<~RUBY].compact.join("\n"))
+        CONST = #{o}
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -3,16 +3,16 @@
 RSpec.describe RuboCop::Cop::Style::RedundantParentheses do
   subject(:cop) { described_class.new }
 
-  shared_examples 'redundant' do |expr, correct, type, highlight = nil|
+  shared_examples 'redundant' do |expr, correct, type|
     it "registers an offense for parentheses around #{type}" do
-      inspect_source(expr)
-      expect(cop.messages)
-        .to eq(["Don't use parentheses around #{type}."])
-      expect(cop.highlights).to eq([highlight || expr])
-    end
+      expect_offense(<<~RUBY, expr: expr)
+        %{expr}
+        ^{expr} Don't use parentheses around #{type}.
+      RUBY
 
-    it 'auto-corrects' do
-      expect(autocorrect_source(expr)).to eq correct
+      expect_correction(<<~RUBY)
+        #{correct}
+      RUBY
     end
   end
 
@@ -60,8 +60,19 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses do
   it_behaves_like 'redundant', '(retry)', 'retry', 'a keyword'
   it_behaves_like 'redundant', '(self)', 'self', 'a keyword'
 
-  it_behaves_like 'redundant', '(X) ? Y : N', 'X ? Y : N', 'a constant', '(X)'
-  it_behaves_like 'redundant', '(X)? Y : N', 'X ? Y : N', 'a constant', '(X)'
+  it 'registers an offense for parens around constant ternary condition' do
+    expect_offense(<<~RUBY)
+      (X) ? Y : N
+      ^^^ Don't use parentheses around a constant.
+      (X)? Y : N
+      ^^^ Don't use parentheses around a constant.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      X ? Y : N
+      X ? Y : N
+    RUBY
+  end
 
   it_behaves_like 'keyword with return value', 'break'
   it_behaves_like 'keyword with return value', 'next'
@@ -78,7 +89,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses do
   it_behaves_like 'plausible', '(a until b)'
   it_behaves_like 'plausible', '(a while b)'
 
-  it_behaves_like 'redundant', 'x = 1; (x)', 'x = 1; x', 'a variable', '(x)'
+  it 'registers an offense for parens around a variable after semicolon' do
+    expect_offense(<<~RUBY)
+      x = 1; (x)
+             ^^^ Don't use parentheses around a variable.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x = 1; x
+    RUBY
+  end
+
   it_behaves_like 'redundant', '(@x)', '@x', 'a variable'
   it_behaves_like 'redundant', '(@@x)', '@@x', 'a variable'
   it_behaves_like 'redundant', '($x)', '$x', 'a variable'
@@ -107,17 +128,107 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses do
   it_behaves_like 'plausible', '+(1.foo.bar)'
   it_behaves_like 'plausible', '()'
 
-  it_behaves_like 'redundant', '[(1)]', '[1]', 'a literal', '(1)'
-  it_behaves_like 'redundant', "[(1\n)]", "[1\n]", 'a literal', "(1\n)"
+  it 'registers an offense for parens around a literal in array' do
+    expect_offense(<<~RUBY)
+      [(1)]
+       ^^^ Don't use parentheses around a literal.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1]
+    RUBY
+  end
+
+  it 'registers an offense for parens around a literal in array ' \
+     'and following newline' do
+    expect_offense(<<~RUBY)
+      [(1
+       ^^ Don't use parentheses around a literal.
+      )]
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1
+      ]
+    RUBY
+  end
+
   it_behaves_like 'plausible', "[(1\n),]"
-  it_behaves_like 'redundant', '{a: (1)}', '{a: 1}', 'a literal', '(1)'
-  it_behaves_like 'redundant', "{a: (1\n)}", "{a: 1\n}", 'a literal', "(1\n)"
+
+  it 'registers an offense for parens around a literal hash value' do
+    expect_offense(<<~RUBY)
+      {a: (1)}
+          ^^^ Don't use parentheses around a literal.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      {a: 1}
+    RUBY
+  end
+
+  it 'registers an offense for parens around a literal hash value ' \
+     'and following newline' do
+    expect_offense(<<~RUBY)
+      {a: (1
+          ^^ Don't use parentheses around a literal.
+      )}
+    RUBY
+
+    expect_correction(<<~RUBY)
+      {a: 1
+      }
+    RUBY
+  end
+
   it_behaves_like 'plausible', "{a: (1\n),}"
-  it_behaves_like 'redundant', '(0)**2', '0**2', 'a literal', '(0)'
-  it_behaves_like 'redundant', '(2)**2', '2**2', 'a literal', '(2)'
-  it_behaves_like 'redundant', '(2.1)**2', '2.1**2', 'a literal', '(2.1)'
-  it_behaves_like 'redundant', '2**(-2)', '2**-2', 'a literal', '(-2)'
-  it_behaves_like 'redundant', '2**(2)', '2**2', 'a literal', '(2)'
+
+  it 'registers an offense for parens around an integer exponentiation base' do
+    expect_offense(<<~RUBY)
+      (0)**2
+      ^^^ Don't use parentheses around a literal.
+      (2)**2
+      ^^^ Don't use parentheses around a literal.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      0**2
+      2**2
+    RUBY
+  end
+
+  it 'registers an offense for parens around a float exponentiation base' do
+    expect_offense(<<~RUBY)
+      (2.1)**2
+      ^^^^^ Don't use parentheses around a literal.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      2.1**2
+    RUBY
+  end
+
+  it 'registers an offense for parens around a negative exponent' do
+    expect_offense(<<~RUBY)
+      2**(-2)
+         ^^^^ Don't use parentheses around a literal.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      2**-2
+    RUBY
+  end
+
+  it 'registers an offense for parens around a positive exponent' do
+    expect_offense(<<~RUBY)
+      2**(2)
+         ^^^ Don't use parentheses around a literal.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      2**2
+    RUBY
+  end
+
   it_behaves_like 'plausible', '(-2)**2'
   it_behaves_like 'plausible', '(-2.1)**2'
 
@@ -125,46 +236,70 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses do
   it_behaves_like 'plausible', 'x += (foo; bar)'
   it_behaves_like 'plausible', 'x + (foo; bar)'
   it_behaves_like 'plausible', 'x((foo; bar))'
-  it_behaves_like 'redundant', <<-RUBY, <<-RUBY2, 'a method call', '(foo; bar)'
-    def x
-      (foo; bar)
-    end
-  RUBY
-    def x
-      foo; bar
-    end
-  RUBY2
-  it_behaves_like 'redundant', <<-RUBY, <<-RUBY2, 'a method call', '(foo; bar)'
-    def x
-      baz
-      (foo; bar)
-    end
-  RUBY
-    def x
-      baz
-      foo; bar
-    end
-  RUBY2
-  it_behaves_like 'redundant', <<-RUBY, <<-RUBY2, 'a method call', '(foo; bar)'
-    x do
-      (foo; bar)
-    end
-  RUBY
-    x do
-      foo; bar
-    end
-  RUBY2
-  it_behaves_like 'redundant', <<-RUBY, <<-RUBY2, 'a method call', '(foo; bar)'
-    x do
-      baz
-      (foo; bar)
-    end
-  RUBY
-    x do
-      baz
-      foo; bar
-    end
-  RUBY2
+
+  it 'registers an offense for parens around method body' do
+    expect_offense(<<~RUBY)
+      def x
+        (foo; bar)
+        ^^^^^^^^^^ Don't use parentheses around a method call.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def x
+        foo; bar
+      end
+    RUBY
+  end
+
+  it 'registers an offense for parens around last expressions in method body' do
+    expect_offense(<<~RUBY)
+      def x
+        baz
+        (foo; bar)
+        ^^^^^^^^^^ Don't use parentheses around a method call.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def x
+        baz
+        foo; bar
+      end
+    RUBY
+  end
+
+  it 'registers an offense for parens around a block body' do
+    expect_offense(<<~RUBY)
+      x do
+        (foo; bar)
+        ^^^^^^^^^^ Don't use parentheses around a method call.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x do
+        foo; bar
+      end
+    RUBY
+  end
+
+  it 'registers an offense for parens around last expressions in block body' do
+    expect_offense(<<~RUBY)
+      x do
+        baz
+        (foo; bar)
+        ^^^^^^^^^^ Don't use parentheses around a method call.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x do
+        baz
+        foo; bar
+      end
+    RUBY
+  end
 
   it 'accepts parentheses around a method call with unparenthesized ' \
      'arguments' do

--- a/spec/rubocop/cop/style/redundant_percent_q_spec.rb
+++ b/spec/rubocop/cop/style/redundant_percent_q_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe RuboCop::Cop::Style::RedundantPercentQ do
         %q('hi')
         ^^^^^^^^ Use `%q` only for strings that contain both single quotes and double quotes.
       RUBY
+
+      expect_correction(<<~RUBY)
+        "'hi'"
+      RUBY
     end
 
     it 'registers an offense for only double quotes' do
@@ -16,12 +20,20 @@ RSpec.describe RuboCop::Cop::Style::RedundantPercentQ do
         %q("hi")
         ^^^^^^^^ Use `%q` only for strings that contain both single quotes and double quotes.
       RUBY
+
+      expect_correction(<<~RUBY)
+        '"hi"'
+      RUBY
     end
 
     it 'registers an offense for no quotes' do
       expect_offense(<<~RUBY)
         %q(hi)
         ^^^^^^ Use `%q` only for strings that contain both single quotes and double quotes.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        'hi'
       RUBY
     end
 
@@ -33,6 +45,10 @@ RSpec.describe RuboCop::Cop::Style::RedundantPercentQ do
       expect_offense(<<~'RUBY')
         %q(\\\\foo\\\\)
         ^^^^^^^^^^^^^^^ Use `%q` only for strings that contain both single quotes and double quotes.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        '\\\\foo\\\\'
       RUBY
     end
 
@@ -48,35 +64,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantPercentQ do
       expect_no_offenses('/%q?/')
     end
 
-    context 'auto-correct' do
-      it 'registers an offense for only single quotes' do
-        new_source = autocorrect_source("%q('hi')")
+    it 'auto-corrects for strings that are concatenated with backslash' do
+      expect_offense(<<~'RUBY')
+        %q(foo bar baz) \
+        ^^^^^^^^^^^^^^^ Use `%q` only for strings that contain both single quotes and double quotes.
+          'boogers'
+      RUBY
 
-        expect(new_source).to eq(%q("'hi'"))
-      end
-
-      it 'registers an offense for only double quotes' do
-        new_source = autocorrect_source('%q("hi")')
-
-        expect(new_source).to eq(%q('"hi"'))
-      end
-
-      it 'registers an offense for no quotes' do
-        new_source = autocorrect_source('%q(hi)')
-
-        expect(new_source).to eq("'hi'")
-      end
-
-      it 'auto-corrects for strings that is concated with backslash' do
-        new_source = autocorrect_source(<<~'RUBY')
-          %q(foo bar baz) \
-            'boogers'
-        RUBY
-        expect(new_source).to eq(<<~'RUBY')
-          'foo bar baz' \
-            'boogers'
-        RUBY
-      end
+      expect_correction(<<~'RUBY')
+        'foo bar baz' \
+          'boogers'
+      RUBY
     end
   end
 
@@ -86,6 +84,10 @@ RSpec.describe RuboCop::Cop::Style::RedundantPercentQ do
         %Q(hi)
         ^^^^^^ Use `%Q` only for strings that contain both single quotes and double quotes, or for dynamic strings that contain double quotes.
       RUBY
+
+      expect_correction(<<~RUBY)
+        "hi"
+      RUBY
     end
 
     it 'registers an offense for static string with only double quotes' do
@@ -93,12 +95,20 @@ RSpec.describe RuboCop::Cop::Style::RedundantPercentQ do
         %Q("hi")
         ^^^^^^^^ Use `%Q` only for strings that contain both single quotes and double quotes, or for dynamic strings that contain double quotes.
       RUBY
+
+      expect_correction(<<~RUBY)
+        '"hi"'
+      RUBY
     end
 
     it 'registers an offense for dynamic string without quotes' do
       expect_offense(<<~'RUBY')
         %Q(hi#{4})
         ^^^^^^^^^^ Use `%Q` only for strings that contain both single quotes and double quotes, or for dynamic strings that contain double quotes.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        "hi#{4}"
       RUBY
     end
 
@@ -122,35 +132,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantPercentQ do
       expect_no_offenses('/%Q?/')
     end
 
-    context 'auto-correct' do
-      it 'corrects a static string without quotes' do
-        new_source = autocorrect_source('%Q(hi)')
+    it 'auto-corrects for strings that are concatenated with backslash' do
+      expect_offense(<<~'RUBY')
+        %Q(foo bar baz) \
+        ^^^^^^^^^^^^^^^ Use `%Q` only for strings that contain both single [...]
+          'boogers'
+      RUBY
 
-        expect(new_source).to eq('"hi"')
-      end
-
-      it 'corrects a static string with only double quotes' do
-        new_source = autocorrect_source('%Q("hi")')
-
-        expect(new_source).to eq(%q('"hi"'))
-      end
-
-      it 'corrects a dynamic string without quotes' do
-        new_source = autocorrect_source("%Q(hi\#{4})")
-
-        expect(new_source).to eq(%("hi\#{4}"))
-      end
-
-      it 'auto-corrects for strings that is concated with backslash' do
-        new_source = autocorrect_source(<<~'RUBY')
-          %Q(foo bar baz) \
-            'boogers'
-        RUBY
-        expect(new_source).to eq(<<~'RUBY')
-          "foo bar baz" \
-            'boogers'
-        RUBY
-      end
+      expect_correction(<<~'RUBY')
+        "foo bar baz" \
+          'boogers'
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf do
       a = self.b
           ^^^^^^ Redundant `self` detected.
     RUBY
+
+    expect_correction(<<~RUBY)
+      a = b
+    RUBY
   end
 
   it 'does not report an offense when receiver and lvalue have the same name' do
@@ -219,11 +223,10 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf do
       self.call
       ^^^^^^^^^ Redundant `self` detected.
     RUBY
-  end
 
-  it 'auto-corrects by removing redundant self' do
-    new_source = autocorrect_source('self.x')
-    expect(new_source).to eq('x')
+    expect_correction(<<~RUBY)
+      call
+    RUBY
   end
 
   it 'accepts a self receiver of methods also defined on `Kernel`' do

--- a/spec/rubocop/cop/style/redundant_sort_by_spec.rb
+++ b/spec/rubocop/cop/style/redundant_sort_by_spec.rb
@@ -4,28 +4,37 @@ RSpec.describe RuboCop::Cop::Style::RedundantSortBy do
   subject(:cop) { described_class.new }
 
   it 'autocorrects array.sort_by { |x| x }' do
-    new_source = autocorrect_source('array.sort_by { |x| x }')
-    expect(new_source).to eq 'array.sort'
-  end
-
-  it 'autocorrects array.sort_by { |y| y }' do
-    new_source = autocorrect_source('array.sort_by { |y| y }')
-    expect(new_source).to eq 'array.sort'
-  end
-
-  it 'autocorrects array.sort_by do |x| x end' do
-    new_source = autocorrect_source(<<~RUBY)
-      array.sort_by do |x|
-        x
-      end
-    RUBY
-    expect(new_source).to eq "array.sort\n"
-  end
-
-  it 'formats the error message correctly for array.sort_by { |x| x }' do
     expect_offense(<<~RUBY)
       array.sort_by { |x| x }
             ^^^^^^^^^^^^^^^^^ Use `sort` instead of `sort_by { |x| x }`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array.sort
+    RUBY
+  end
+
+  it 'autocorrects array.sort_by { |y| y }' do
+    expect_offense(<<~RUBY)
+      array.sort_by { |y| y }
+            ^^^^^^^^^^^^^^^^^ Use `sort` instead of `sort_by { |y| y }`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array.sort
+    RUBY
+  end
+
+  it 'autocorrects array.sort_by do |x| x end' do
+    expect_offense(<<~RUBY)
+      array.sort_by do |x|
+            ^^^^^^^^^^^^^^ Use `sort` instead of `sort_by { |x| x }`.
+        x
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array.sort
     RUBY
   end
 end

--- a/spec/rubocop/cop/style/redundant_sort_spec.rb
+++ b/spec/rubocop/cop/style/redundant_sort_spec.rb
@@ -8,12 +8,31 @@ RSpec.describe RuboCop::Cop::Style::RedundantSort do
       [1, 2, 3].sort.first
                 ^^^^^^^^^^ Use `min` instead of `sort...first`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3].min
+    RUBY
+  end
+
+  it 'registers an offense when last is called with sort' do
+    expect_offense(<<~RUBY)
+      [1, 2].sort.last
+             ^^^^^^^^^ Use `max` instead of `sort...last`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2].max
+    RUBY
   end
 
   it 'registers an offense when last is called on sort with comparator' do
     expect_offense(<<~RUBY)
       foo.sort { |a, b| b <=> a }.last
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `max` instead of `sort...last`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo.max { |a, b| b <=> a }
     RUBY
   end
 
@@ -22,12 +41,53 @@ RSpec.describe RuboCop::Cop::Style::RedundantSort do
       [1, 2, 3].sort_by { |x| x.length }.first
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `min_by` instead of `sort_by...first`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3].min_by { |x| x.length }
+    RUBY
+  end
+
+  it 'registers an offense when last is called on sort_by' do
+    expect_offense(<<~RUBY)
+      foo.sort_by { |x| x.something }.last
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `max_by` instead of `sort_by...last`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo.max_by { |x| x.something }
+    RUBY
+  end
+
+  it 'registers an offense when first is called on sort_by no block' do
+    expect_offense(<<~RUBY)
+      [1, 2].sort_by(&:something).first
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `min_by` instead of `sort_by...first`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2].min_by(&:something)
+    RUBY
   end
 
   it 'registers an offense when last is called on sort_by no block' do
     expect_offense(<<~RUBY)
       [1, 2, 3].sort_by(&:length).last
                 ^^^^^^^^^^^^^^^^^^^^^^ Use `max_by` instead of `sort_by...last`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3].max_by(&:length)
+    RUBY
+  end
+
+  it 'registers an offense when at(-1) is called with sort' do
+    expect_offense(<<~RUBY)
+      [1, 2].sort.at(-1)
+             ^^^^^^^^^^^ Use `max` instead of `sort...at(-1)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2].max
     RUBY
   end
 
@@ -36,12 +96,20 @@ RSpec.describe RuboCop::Cop::Style::RedundantSort do
       [1, 2, 3].sort.slice(0)
                 ^^^^^^^^^^^^^ Use `min` instead of `sort...slice(0)`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3].min
+    RUBY
   end
 
   it 'registers an offense when [0] is called on sort' do
     expect_offense(<<~RUBY)
       [1, 2, 3].sort[0]
                 ^^^^^^^ Use `min` instead of `sort...[0]`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3].min
     RUBY
   end
 
@@ -50,12 +118,42 @@ RSpec.describe RuboCop::Cop::Style::RedundantSort do
       [1, 2, 3].sort.[](0)
                 ^^^^^^^^^^ Use `min` instead of `sort...[](0)`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3].min
+    RUBY
+  end
+
+  it 'registers an offense when [](-1) is called on sort_by' do
+    expect_offense(<<~RUBY)
+      foo.sort_by { |x| x.foo }.[](-1)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `max_by` instead of `sort_by...[](-1)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo.max_by { |x| x.foo }
+    RUBY
   end
 
   it 'registers an offense when at(0) is called on sort_by' do
     expect_offense(<<~RUBY)
       [1, 2, 3].sort_by(&:foo).at(0)
                 ^^^^^^^^^^^^^^^^^^^^ Use `min_by` instead of `sort_by...at(0)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3].min_by(&:foo)
+    RUBY
+  end
+
+  it 'registers an offense when slice(0) is called on sort_by' do
+    expect_offense(<<~RUBY)
+      [1, 2].sort_by(&:foo).slice(0)
+             ^^^^^^^^^^^^^^^^^^^^^^^ Use `min_by` instead of `sort_by...slice(0)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2].min_by(&:foo)
     RUBY
   end
 
@@ -64,12 +162,42 @@ RSpec.describe RuboCop::Cop::Style::RedundantSort do
       [1, 2, 3].sort_by(&:foo).slice(-1)
                 ^^^^^^^^^^^^^^^^^^^^^^^^ Use `max_by` instead of `sort_by...slice(-1)`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3].max_by(&:foo)
+    RUBY
   end
 
   it 'registers an offense when [-1] is called on sort' do
     expect_offense(<<~RUBY)
       [1, 2, 3].sort[-1]
                 ^^^^^^^^ Use `max` instead of `sort...[-1]`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3].max
+    RUBY
+  end
+
+  it 'registers an offense when [0] is called on sort_by' do
+    expect_offense(<<~RUBY)
+      [1, 2].sort_by(&:foo)[0]
+             ^^^^^^^^^^^^^^^^^ Use `min_by` instead of `sort_by...[0]`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2].min_by(&:foo)
+    RUBY
+  end
+
+  it 'registers an offense when [-1] is called on sort_by' do
+    expect_offense(<<~RUBY)
+      foo.sort_by { |x| x.foo }[-1]
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `max_by` instead of `sort_by...[-1]`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo.max_by { |x| x.foo }
     RUBY
   end
 
@@ -113,69 +241,6 @@ RSpec.describe RuboCop::Cop::Style::RedundantSort do
 
     it 'does not register an offense when at(-2) is called on sort_by' do
       expect_no_offenses('[1, 2, 3].sort_by(&:foo).at(-2)')
-    end
-  end
-
-  context 'autocorrect' do
-    it 'corrects sort.first to min' do
-      new_source = autocorrect_source('[1, 2].sort.first')
-
-      expect(new_source).to eq('[1, 2].min')
-    end
-
-    it 'corrects sort.last to max' do
-      new_source = autocorrect_source('[1, 2].sort.last')
-
-      expect(new_source).to eq('[1, 2].max')
-    end
-
-    it 'corrects sort.first (with comparator) to min' do
-      new_source = autocorrect_source('[1, 2].sort { |a, b| b <=> a }.first')
-
-      expect(new_source).to eq('[1, 2].min { |a, b| b <=> a }')
-    end
-
-    it 'corrects sort.at(-1) to max' do
-      new_source = autocorrect_source('[1, 2].sort.at(-1)')
-
-      expect(new_source).to eq('[1, 2].max')
-    end
-
-    it 'corrects sort_by(&:foo).slice(0) to min_by(&:foo)' do
-      new_source = autocorrect_source('[1, 2].sort_by(&:foo).slice(0)')
-
-      expect(new_source).to eq('[1, 2].min_by(&:foo)')
-    end
-
-    it 'corrects sort_by(&:foo)[0] to min_by(&:foo)' do
-      new_source = autocorrect_source('[1, 2].sort_by(&:foo)[0]')
-
-      expect(new_source).to eq('[1, 2].min_by(&:foo)')
-    end
-
-    it 'corrects sort_by(&:something).first to min_by(&:something)' do
-      new_source = autocorrect_source('[1, 2].sort_by(&:something).first')
-
-      expect(new_source).to eq('[1, 2].min_by(&:something)')
-    end
-
-    it 'corrects sort_by { |x| x.foo }[-1] to max_by { |x| x.foo }' do
-      new_source = autocorrect_source('foo.sort_by { |x| x.foo }[-1]')
-
-      expect(new_source).to eq('foo.max_by { |x| x.foo }')
-    end
-
-    it 'corrects sort_by { |x| x.foo }.[](-1) to max_by { |x| x.foo }' do
-      new_source = autocorrect_source('foo.sort_by { |x| x.foo }.[](-1)')
-
-      expect(new_source).to eq('foo.max_by { |x| x.foo }')
-    end
-
-    it 'corrects sort_by { |x| x.something }.last ' \
-       'to max_by { |x| x.something }' do
-      new_source = autocorrect_source('foo.sort_by { |x| x.something }.last')
-
-      expect(new_source).to eq('foo.max_by { |x| x.something }')
     end
   end
 

--- a/spec/rubocop/cop/style/rescue_modifier_spec.rb
+++ b/spec/rubocop/cop/style/rescue_modifier_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe RuboCop::Cop::Style::RescueModifier do
       method rescue handle
       ^^^^^^^^^^^^^^^^^^^^ Avoid using `rescue` in its modifier form.
     RUBY
+
+    expect_correction(<<~RUBY)
+      begin
+        method
+      rescue
+        handle
+      end
+    RUBY
   end
 
   it 'registers an offense for modifier rescue around parallel assignment' do
@@ -39,6 +47,18 @@ RSpec.describe RuboCop::Cop::Style::RescueModifier do
         normal_handle
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      begin
+        begin
+          test
+        rescue
+          modifier_handle
+        end
+      rescue
+        normal_handle
+      end
+    RUBY
   end
 
   it 'handles modifier rescue in a method' do
@@ -46,6 +66,16 @@ RSpec.describe RuboCop::Cop::Style::RescueModifier do
       def a_method
         test rescue nil
         ^^^^^^^^^^^^^^^ Avoid using `rescue` in its modifier form.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def a_method
+        begin
+          test
+        rescue
+          nil
+        end
       end
     RUBY
   end
@@ -133,72 +163,17 @@ RSpec.describe RuboCop::Cop::Style::RescueModifier do
   end
 
   context 'autocorrect' do
-    it 'corrects basic rescue modifier' do
-      new_source = autocorrect_source(<<~RUBY)
-        foo rescue bar
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        begin
-          foo
-        rescue
-          bar
-        end
-      RUBY
-    end
-
     it 'corrects complex rescue modifier' do
-      new_source = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         foo || bar rescue bar
+        ^^^^^^^^^^^^^^^^^^^^^ Avoid using `rescue` in its modifier form.
       RUBY
 
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         begin
           foo || bar
         rescue
           bar
-        end
-      RUBY
-    end
-
-    it 'corrects rescue modifier nested inside of def' do
-      source = <<~RUBY
-        def foo
-          test rescue modifier_handle
-        end
-      RUBY
-      new_source = autocorrect_source(source)
-
-      expect(new_source).to eq(<<~RUBY)
-        def foo
-          begin
-            test
-          rescue
-            modifier_handle
-          end
-        end
-      RUBY
-    end
-
-    it 'corrects nested rescue modifier' do
-      source = <<~RUBY
-        begin
-          test rescue modifier_handle
-        rescue
-          normal_handle
-        end
-      RUBY
-      new_source = autocorrect_source(source)
-
-      expect(new_source).to eq(<<~RUBY)
-        begin
-          begin
-            test
-          rescue
-            modifier_handle
-          end
-        rescue
-          normal_handle
         end
       RUBY
     end

--- a/spec/rubocop/cop/style/return_nil_spec.rb
+++ b/spec/rubocop/cop/style/return_nil_spec.rb
@@ -18,14 +18,10 @@ RSpec.describe RuboCop::Cop::Style::ReturnNil do
         return nil
         ^^^^^^^^^^ Use `return` instead of `return nil`.
       RUBY
-    end
 
-    it 'auto-corrects `return nil` into `return`' do
-      expect(autocorrect_source('return nil')).to eq 'return'
-    end
-
-    it 'does not register an offense for return' do
-      expect_no_offenses('return')
+      expect_correction(<<~RUBY)
+        return
+      RUBY
     end
 
     it 'does not register an offense for returning others' do
@@ -56,14 +52,10 @@ RSpec.describe RuboCop::Cop::Style::ReturnNil do
         return
         ^^^^^^ Use `return nil` instead of `return`.
       RUBY
-    end
 
-    it 'auto-corrects `return` into `return nil`' do
-      expect(autocorrect_source('return')).to eq 'return nil'
-    end
-
-    it 'does not register an offense for return nil' do
-      expect_no_offenses('return nil')
+      expect_correction(<<~RUBY)
+        return nil
+      RUBY
     end
 
     it 'does not register an offense for returning others' do

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -184,193 +184,530 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
 
       it 'registers an offense for a method call that nil responds to ' \
          'safe guarded by an object check' do
-        inspect_source("#{variable}.to_i if #{variable}")
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.to_i if %{variable}
+          ^{variable}^^^^^^^^^^{variable} Use safe navigation (`&.`) instead of checking if an object exists before calling the method.
+        RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.to_i
+        RUBY
       end
 
       it 'registers an offense for a method call on an accessor ' \
          'safeguarded by a check for the accessed variable' do
-        inspect_source("#{variable}[1].bar if #{variable}[1]")
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}[1].bar if %{variable}[1]
+          ^{variable}^^^^^^^^^^^^{variable}^^^ Use safe navigation (`&.`) instead [...]
+        RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}[1]&.bar
+        RUBY
       end
 
       it 'registers an offense for a method call safeguarded with a check ' \
          'for the object' do
-        inspect_source("#{variable}.bar if #{variable}")
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.bar if %{variable}
+          ^{variable}^^^^^^^^^{variable} Use safe navigation (`&.`) instead [...]
+        RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.bar
+        RUBY
       end
 
       it 'registers an offense for a method call with params safeguarded ' \
          'with a check for the object' do
-        inspect_source("#{variable}.bar(baz) if #{variable}")
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.bar(baz) if %{variable}
+          ^{variable}^^^^^^^^^^^^^^{variable} Use safe navigation (`&.`) instead [...]
+        RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.bar(baz)
+        RUBY
       end
 
       it 'registers an offense for a method call with a block safeguarded ' \
          'with a check for the object' do
-        inspect_source("#{variable}.bar { |e| e.qux } if #{variable}")
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.bar { |e| e.qux } if %{variable}
+          ^{variable}^^^^^^^^^^^^^^^^^^^^^^^{variable} Use safe navigation (`&.`) instead [...]
+        RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.bar { |e| e.qux }
+        RUBY
       end
 
       it 'registers an offense for a method call with params and a block ' \
          'safeguarded with a check for the object' do
-        inspect_source("#{variable}.bar(baz) { |e| e.qux } if #{variable}")
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.bar(baz) { |e| e.qux } if %{variable}
+          ^{variable}^^^^^^^^^^^^^^^^^^^^^^^^^^^^{variable} Use safe navigation (`&.`) instead [...]
+        RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.bar(baz) { |e| e.qux }
+        RUBY
+      end
+
+      it 'registers an offense for a chained method call safeguarded ' \
+          'with a check for the object' do
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.one.two(baz) { |e| e.qux } if %{variable}
+          ^{variable}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^{variable} Use safe navigation (`&.`) instead [...]
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{variable}&.one&.two(baz) { |e| e.qux }
+        RUBY
       end
 
       it 'registers an offense for a method call safeguarded with a ' \
          'negative check for the object' do
-        inspect_source("#{variable}.bar unless !#{variable}")
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.bar unless !%{variable}
+          ^{variable}^^^^^^^^^^^^^^{variable} Use safe navigation (`&.`) instead [...]
+        RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.bar
+        RUBY
       end
 
       it 'registers an offense for a method call with params safeguarded ' \
          'with a negative check for the object' do
-        inspect_source("#{variable}.bar(baz) unless !#{variable}")
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.bar(baz) unless !%{variable}
+          ^{variable}^^^^^^^^^^^^^^^^^^^{variable} Use safe navigation (`&.`) instead [...]
+        RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.bar(baz)
+        RUBY
       end
 
       it 'registers an offense for a method call with a block safeguarded ' \
          'with a negative check for the object' do
-        inspect_source("#{variable}.bar { |e| e.qux } unless !#{variable}")
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.bar { |e| e.qux } unless !%{variable}
+          ^{variable}^^^^^^^^^^^^^^^^^^^^^^^^^^^^{variable} Use safe navigation (`&.`) instead [...]
+        RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.bar { |e| e.qux }
+        RUBY
       end
 
       it 'registers an offense for a method call with params and a block ' \
          'safeguarded with a negative check for the object' do
-        inspect_source(<<~RUBY)
-          #{variable}.bar(baz) { |e| e.qux } unless !#{variable}
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.bar(baz) { |e| e.qux } unless !%{variable}
+          ^{variable}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^{variable} Use safe navigation (`&.`) instead [...]
         RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.bar(baz) { |e| e.qux }
+        RUBY
       end
 
       it 'registers an offense for a method call safeguarded with a nil ' \
          'check for the object' do
-        inspect_source("#{variable}.bar unless #{variable}.nil?")
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.bar unless %{variable}.nil?
+          ^{variable}^^^^^^^^^^^^^{variable}^^^^^ Use safe navigation (`&.`) instead [...]
+        RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.bar
+        RUBY
       end
 
       it 'registers an offense for a method call with params safeguarded ' \
          'with a nil check for the object' do
-        inspect_source("#{variable}.bar(baz) unless #{variable}.nil?")
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.bar(baz) unless %{variable}.nil?
+          ^{variable}^^^^^^^^^^^^^^^^^^{variable}^^^^^ Use safe navigation (`&.`) instead [...]
+        RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.bar(baz)
+        RUBY
       end
 
       it 'registers an offense for a method call with a block safeguarded ' \
          'with a nil check for the object' do
-        inspect_source(<<~RUBY)
-          #{variable}.bar { |e| e.qux } unless #{variable}.nil?
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.bar { |e| e.qux } unless %{variable}.nil?
+          ^{variable}^^^^^^^^^^^^^^^^^^^^^^^^^^^{variable}^^^^^ Use safe navigation (`&.`) instead [...]
         RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.bar { |e| e.qux }
+        RUBY
       end
 
       it 'registers an offense for a method call with params and a block ' \
          'safeguarded with a nil check for the object' do
-        inspect_source(<<~RUBY)
-          #{variable}.bar(baz) { |e| e.qux } unless #{variable}.nil?
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.bar(baz) { |e| e.qux } unless %{variable}.nil?
+          ^{variable}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^{variable}^^^^^ Use safe navigation (`&.`) instead [...]
         RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.bar(baz) { |e| e.qux }
+        RUBY
+      end
+
+      it 'registers an offense for a chained method call safeguarded ' \
+          'with an unless nil check for the object' do
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.one.two(baz) { |e| e.qux } unless %{variable}.nil?
+          ^{variable}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^{variable}^^^^^ Use safe navigation (`&.`) instead [...]
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{variable}&.one&.two(baz) { |e| e.qux }
+        RUBY
       end
 
       it 'registers an offense for a method call safeguarded with a ' \
          'negative nil check for the object' do
-        inspect_source("#{variable}.bar if !#{variable}.nil?")
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.bar if !%{variable}.nil?
+          ^{variable}^^^^^^^^^^{variable}^^^^^ Use safe navigation (`&.`) instead [...]
+        RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.bar
+        RUBY
       end
 
       it 'registers an offense for a method call with params safeguarded ' \
          'with a negative nil check for the object' do
-        inspect_source("#{variable}.bar(baz) if !#{variable}.nil?")
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.bar(baz) if !%{variable}.nil?
+          ^{variable}^^^^^^^^^^^^^^^{variable}^^^^^ Use safe navigation (`&.`) instead [...]
+        RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.bar(baz)
+        RUBY
       end
 
       it 'registers an offense for a method call with a block safeguarded ' \
          'with a negative nil check for the object' do
-        inspect_source(<<~RUBY)
-          #{variable}.bar { |e| e.qux } if !#{variable}.nil?
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.bar { |e| e.qux } if !%{variable}.nil?
+          ^{variable}^^^^^^^^^^^^^^^^^^^^^^^^{variable}^^^^^ Use safe navigation (`&.`) instead [...]
         RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.bar { |e| e.qux }
+        RUBY
       end
 
       it 'registers an offense for a method call with params and a block ' \
          'safeguarded with a negative nil check for the object' do
-        inspect_source(<<~RUBY)
-          #{variable}.bar(baz) { |e| e.qux } if !#{variable}.nil?
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.bar(baz) { |e| e.qux } if !%{variable}.nil?
+          ^{variable}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^{variable}^^^^^ Use safe navigation (`&.`) instead [...]
         RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.bar(baz) { |e| e.qux }
+        RUBY
       end
 
       it 'registers an offense for a chained method call safeguarded ' \
          'with a negative nil check for the object' do
-        inspect_source(<<~RUBY)
-          #{variable}.one.two(baz) { |e| e.qux } if !#{variable}.nil?
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.one.two(baz) { |e| e.qux } if !%{variable}.nil?
+          ^{variable}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^{variable}^^^^^ Use safe navigation (`&.`) instead [...]
         RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.one&.two(baz) { |e| e.qux }
+        RUBY
+      end
+
+      it 'registers an offense for an object check followed by a method call ' \
+         'with a comment at EOL' do
+        expect_offense(<<~RUBY, variable: variable)
+          foo if %{variable} && %{variable}.bar # comment
+                 ^{variable}^^^^^{variable}^^^^ Use safe navigation (`&.`) instead [...]
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo if #{variable}&.bar # comment
+        RUBY
       end
     end
 
     context 'if expression' do
       it 'registers an offense for a single method call inside of a check ' \
          'for the object' do
-        inspect_source(<<~RUBY)
-          if #{variable}
-            #{variable}.bar
+        expect_offense(<<~RUBY, variable: variable)
+          if %{variable}
+          ^^^^{variable} Use safe navigation (`&.`) instead [...]
+            %{variable}.bar
           end
         RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.bar
+        RUBY
+      end
+
+      it 'registers an offense for a single method call with params ' \
+         'inside of a check for the object' do
+        expect_offense(<<~RUBY, variable: variable)
+          if %{variable}
+          ^^^^{variable} Use safe navigation (`&.`) instead [...]
+            %{variable}.bar(baz)
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{variable}&.bar(baz)
+        RUBY
+      end
+
+      it 'registers an offense for a single method call with a block ' \
+         'inside of a check for the object' do
+        expect_offense(<<~RUBY, variable: variable)
+          if %{variable}
+          ^^^^{variable} Use safe navigation (`&.`) instead [...]
+            %{variable}.bar { |e| e.qux }
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{variable}&.bar { |e| e.qux }
+        RUBY
+      end
+
+      it 'registers an offense for a single method call with params ' \
+         'and a block inside of a check for the object' do
+        expect_offense(<<~RUBY, variable: variable)
+          if %{variable}
+          ^^^^{variable} Use safe navigation (`&.`) instead [...]
+            %{variable}.bar(baz) { |e| e.qux }
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{variable}&.bar(baz) { |e| e.qux }
+        RUBY
       end
 
       it 'registers an offense for a single method call inside of a ' \
          'non-nil check for the object' do
-        inspect_source(<<~RUBY)
-          if !#{variable}.nil?
-            #{variable}.bar
+        expect_offense(<<~RUBY, variable: variable)
+          if !%{variable}.nil?
+          ^^^^^{variable}^^^^^ Use safe navigation (`&.`) instead [...]
+            %{variable}.bar
           end
         RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.bar
+        RUBY
+      end
+
+      it 'registers an offense for a single method call with params ' \
+         'inside of a non-nil check for the object' do
+        expect_offense(<<~RUBY, variable: variable)
+          if !%{variable}.nil?
+          ^^^^^{variable}^^^^^ Use safe navigation (`&.`) instead [...]
+            %{variable}.bar(baz)
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{variable}&.bar(baz)
+        RUBY
+      end
+
+      it 'registers an offense for a single method call with a block ' \
+         'inside of a non-nil check for the object' do
+        expect_offense(<<~RUBY, variable: variable)
+          if !%{variable}.nil?
+          ^^^^^{variable}^^^^^ Use safe navigation (`&.`) instead [...]
+            %{variable}.bar { |e| e.qux }
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{variable}&.bar { |e| e.qux }
+        RUBY
+      end
+
+      it 'registers an offense for a single method call with params ' \
+         'and a block inside of a non-nil check for the object' do
+        expect_offense(<<~RUBY, variable: variable)
+          if !%{variable}.nil?
+          ^^^^^{variable}^^^^^ Use safe navigation (`&.`) instead [...]
+            %{variable}.bar(baz) { |e| e.qux }
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{variable}&.bar(baz) { |e| e.qux }
+        RUBY
       end
 
       it 'registers an offense for a single method call inside of an ' \
          'unless nil check for the object' do
-        inspect_source(<<~RUBY)
-          unless #{variable}.nil?
-            #{variable}.bar
+        expect_offense(<<~RUBY, variable: variable)
+          unless %{variable}.nil?
+          ^^^^^^^^{variable}^^^^^ Use safe navigation (`&.`) instead [...]
+            %{variable}.bar
           end
         RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.bar
+        RUBY
+      end
+
+      it 'registers an offense for a single method call with params ' \
+         'inside of an unless nil check for the object' do
+        expect_offense(<<~RUBY, variable: variable)
+          unless %{variable}.nil?
+          ^^^^^^^^{variable}^^^^^ Use safe navigation (`&.`) instead [...]
+            %{variable}.bar(baz)
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{variable}&.bar(baz)
+        RUBY
+      end
+
+      it 'registers an offense for a single method call with a block ' \
+         'inside of an unless nil check for the object' do
+        expect_offense(<<~RUBY, variable: variable)
+          unless %{variable}.nil?
+          ^^^^^^^^{variable}^^^^^ Use safe navigation (`&.`) instead [...]
+            %{variable}.bar { |e| e.qux }
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{variable}&.bar { |e| e.qux }
+        RUBY
+      end
+
+      it 'registers an offense for a single method call with params ' \
+         'and a block inside of an unless nil check for the object' do
+        expect_offense(<<~RUBY, variable: variable)
+          unless %{variable}.nil?
+          ^^^^^^^^{variable}^^^^^ Use safe navigation (`&.`) instead [...]
+            %{variable}.bar(baz) { |e| e.qux }
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{variable}&.bar(baz) { |e| e.qux }
+        RUBY
       end
 
       it 'registers an offense for a single method call inside of an ' \
          'unless negative check for the object' do
-        inspect_source(<<~RUBY)
-          unless !#{variable}
-            #{variable}.bar
+        expect_offense(<<~RUBY, variable: variable)
+          unless !%{variable}
+          ^^^^^^^^^{variable} Use safe navigation (`&.`) instead [...]
+            %{variable}.bar
           end
         RUBY
 
-        expect(cop.messages).to eq([message])
+        expect_correction(<<~RUBY)
+          #{variable}&.bar
+        RUBY
+      end
+
+      it 'registers an offense for a single method call with params ' \
+         'inside of an unless negative check for the object' do
+        expect_offense(<<~RUBY, variable: variable)
+          unless !%{variable}
+          ^^^^^^^^^{variable} Use safe navigation (`&.`) instead [...]
+            %{variable}.bar(baz)
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{variable}&.bar(baz)
+        RUBY
+      end
+
+      it 'registers an offense for a single method call with a block ' \
+         'inside of an unless negative check for the object' do
+        expect_offense(<<~RUBY, variable: variable)
+          unless !%{variable}
+          ^^^^^^^^^{variable} Use safe navigation (`&.`) instead [...]
+            %{variable}.bar { |e| e.qux }
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{variable}&.bar { |e| e.qux }
+        RUBY
+      end
+
+      it 'registers an offense for a single method call with params ' \
+         'and a block inside of an unless negative check for the object' do
+        expect_offense(<<~RUBY, variable: variable)
+          unless !%{variable}
+          ^^^^^^^^^{variable} Use safe navigation (`&.`) instead [...]
+            %{variable}.bar(baz) { |e| e.qux }
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{variable}&.bar(baz) { |e| e.qux }
+        RUBY
+      end
+
+      it 'does not lose comments within if expression' do
+        expect_offense(<<~RUBY, variable: variable)
+          if %{variable}
+          ^^^^{variable} Use safe navigation (`&.`) instead [...]
+            # this is a comment
+            # another comment
+            %{variable}.bar
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # this is a comment
+          # another comment
+          #{variable}&.bar
+        RUBY
+      end
+
+      it 'only moves comments that fall within the expression' do
+        expect_offense(<<~RUBY, variable: variable)
+          # comment one
+          def foobar
+            if %{variable}
+            ^^^^{variable} Use safe navigation (`&.`) instead [...]
+              # comment 2
+              %{variable}.bar
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # comment one
+          def foobar
+            # comment 2
+          #{variable}&.bar
+          end
+        RUBY
       end
 
       it 'allows a single method call inside of a check for the object ' \
@@ -399,85 +736,139 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
 
         it 'registers an offense for a non-nil object check followed by a ' \
            'method call' do
-          inspect_source("!#{variable}.nil? && #{variable}.bar")
+          expect_offense(<<~RUBY, variable: variable)
+            !%{variable}.nil? && %{variable}.bar
+            ^^{variable}^^^^^^^^^^{variable}^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
 
-          expect(cop.messages).to eq([message])
+          expect_correction(<<~RUBY)
+            #{variable}&.bar
+          RUBY
         end
 
         it 'registers an offense for a non-nil object check followed by a ' \
            'method call with params' do
-          inspect_source("!#{variable}.nil? && #{variable}.bar(baz)")
+          expect_offense(<<~RUBY, variable: variable)
+            !%{variable}.nil? && %{variable}.bar(baz)
+            ^^{variable}^^^^^^^^^^{variable}^^^^^^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
 
-          expect(cop.messages).to eq([message])
+          expect_correction(<<~RUBY)
+            #{variable}&.bar(baz)
+          RUBY
         end
 
         it 'registers an offense for a non-nil object check followed by a ' \
            'method call with a block' do
-          inspect_source(<<~RUBY)
-            !#{variable}.nil? && #{variable}.bar { |e| e.qux }
+          expect_offense(<<~RUBY, variable: variable)
+            !%{variable}.nil? && %{variable}.bar { |e| e.qux }
+            ^^{variable}^^^^^^^^^^{variable}^^^^^^^^^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
           RUBY
 
-          expect(cop.messages).to eq([message])
+          expect_correction(<<~RUBY)
+            #{variable}&.bar { |e| e.qux }
+          RUBY
         end
 
         it 'registers an offense for a non-nil object check followed by a ' \
            'method call with params and a block' do
-          inspect_source(<<~RUBY)
-            !#{variable}.nil? && #{variable}.bar(baz) { |e| e.qux }
+          expect_offense(<<~RUBY, variable: variable)
+            !%{variable}.nil? && %{variable}.bar(baz) { |e| e.qux }
+            ^^{variable}^^^^^^^^^^{variable}^^^^^^^^^^^^^^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
           RUBY
 
-          expect(cop.messages).to eq([message])
+          expect_correction(<<~RUBY)
+            #{variable}&.bar(baz) { |e| e.qux }
+          RUBY
         end
 
         it 'registers an offense for an object check followed by a ' \
            'method call' do
-          inspect_source("#{variable} && #{variable}.bar")
+          expect_offense(<<~RUBY, variable: variable)
+            %{variable} && %{variable}.bar
+            ^{variable}^^^^^{variable}^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
 
-          expect(cop.messages).to eq([message])
+          expect_correction(<<~RUBY)
+            #{variable}&.bar
+          RUBY
         end
 
         it 'registers an offense for an object check followed by a ' \
            'method call with params' do
-          inspect_source("#{variable} && #{variable}.bar(baz)")
+          expect_offense(<<~RUBY, variable: variable)
+            %{variable} && %{variable}.bar(baz)
+            ^{variable}^^^^^{variable}^^^^^^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
 
-          expect(cop.messages).to eq([message])
+          expect_correction(<<~RUBY)
+            #{variable}&.bar(baz)
+          RUBY
         end
 
         it 'registers an offense for an object check followed by a ' \
            'method call with a block' do
-          inspect_source("#{variable} && #{variable}.bar { |e| e.qux }")
+          expect_offense(<<~RUBY, variable: variable)
+            %{variable} && %{variable}.bar { |e| e.qux }
+            ^{variable}^^^^^{variable}^^^^^^^^^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
 
-          expect(cop.messages).to eq([message])
+          expect_correction(<<~RUBY)
+            #{variable}&.bar { |e| e.qux }
+          RUBY
         end
 
         it 'registers an offense for an object check followed by a ' \
            'method call with params and a block' do
-          inspect_source(<<~RUBY)
-            #{variable} && #{variable}.bar(baz) { |e| e.qux }
+          expect_offense(<<~RUBY, variable: variable)
+            %{variable} && %{variable}.bar(baz) { |e| e.qux }
+            ^{variable}^^^^^{variable}^^^^^^^^^^^^^^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
           RUBY
 
-          expect(cop.messages).to eq([message])
+          expect_correction(<<~RUBY)
+            #{variable}&.bar(baz) { |e| e.qux }
+          RUBY
         end
 
         it 'registers an offense for a check for the object followed by a ' \
            'method call in the condition for an if expression' do
-          inspect_source(<<~RUBY)
-            if #{variable} && #{variable}.bar
+          expect_offense(<<~RUBY, variable: variable)
+            if %{variable} && %{variable}.bar
+               ^{variable}^^^^^{variable}^^^^ Use safe navigation (`&.`) instead [...]
               something
             end
           RUBY
 
-          expect(cop.messages).to eq([message])
+          expect_correction(<<~RUBY)
+            if #{variable}&.bar
+              something
+            end
+          RUBY
+        end
+
+        it 'corrects an object check followed by a method call and ' \
+            'another check' do
+          expect_offense(<<~RUBY, variable: variable)
+            %{variable} && %{variable}.bar && something
+            ^{variable}^^^^^{variable}^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            #{variable}&.bar && something
+          RUBY
         end
 
         context 'method chaining' do
           it 'registers an offense for an object check followed by ' \
              'chained method calls with blocks' do
-            inspect_source(<<~RUBY)
-              #{variable} && #{variable}.one { |a| b}.two(baz) { |e| e.qux }
+            expect_offense(<<~RUBY, variable: variable)
+              %{variable} && %{variable}.one { |a| b}.two(baz) { |e| e.qux }
+              ^{variable}^^^^^{variable}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
             RUBY
 
-            expect(cop.messages).to eq([message])
+            expect_correction(<<~RUBY)
+              #{variable}&.one { |a| b}&.two(baz) { |e| e.qux }
+            RUBY
           end
 
           context 'with Lint/SafeNavigationChain disabled' do
@@ -532,50 +923,128 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
 
         it 'registers an offense for an object check followed by ' \
            'a method calls that nil responds to ' do
-          inspect_source("#{variable} && #{variable}.to_i")
+          expect_offense(<<~RUBY, variable: variable)
+            %{variable} && %{variable}.to_i
+            ^{variable}^^^^^{variable}^^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
 
-          expect(cop.messages).to eq([message])
+          expect_correction(<<~RUBY)
+            #{variable}&.to_i
+          RUBY
         end
 
         it 'registers an offense for an object check followed by ' \
            'a method call' do
-          inspect_source("#{variable} && #{variable}.bar")
+          expect_offense(<<~RUBY, variable: variable)
+            %{variable} && %{variable}.bar
+            ^{variable}^^^^^{variable}^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
 
-          expect(cop.messages).to eq([message])
+          expect_correction(<<~RUBY)
+            #{variable}&.bar
+          RUBY
         end
 
         it 'registers an offense for an object check followed by ' \
            'a method call with params' do
-          inspect_source("#{variable} && #{variable}.bar(baz)")
+          expect_offense(<<~RUBY, variable: variable)
+            %{variable} && %{variable}.bar(baz)
+            ^{variable}^^^^^{variable}^^^^^^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
 
-          expect(cop.messages).to eq([message])
+          expect_correction(<<~RUBY)
+            #{variable}&.bar(baz)
+          RUBY
         end
 
         it 'registers an offense for an object check followed by ' \
            'a method call with a block' do
-          inspect_source("#{variable} && #{variable}.bar { |e| e.qux }")
+          expect_offense(<<~RUBY, variable: variable)
+            %{variable} && %{variable}.bar { |e| e.qux }
+            ^{variable}^^^^^{variable}^^^^^^^^^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
 
-          expect(cop.messages).to eq([message])
+          expect_correction(<<~RUBY)
+            #{variable}&.bar { |e| e.qux }
+          RUBY
         end
 
         it 'registers an offense for an object check followed by ' \
            'a method call with params and a block' do
-          inspect_source(<<~RUBY)
-            #{variable} && #{variable}.bar(baz) { |e| e.qux }
+          expect_offense(<<~RUBY, variable: variable)
+            %{variable} && %{variable}.bar(baz) { |e| e.qux }
+            ^{variable}^^^^^{variable}^^^^^^^^^^^^^^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
           RUBY
 
-          expect(cop.messages).to eq([message])
+          expect_correction(<<~RUBY)
+            #{variable}&.bar(baz) { |e| e.qux }
+          RUBY
         end
 
         it 'registers an offense for a check for the object followed by ' \
            'a method call in the condition for an if expression' do
-          inspect_source(<<~RUBY)
-            if #{variable} && #{variable}.bar
+          expect_offense(<<~RUBY, variable: variable)
+            if %{variable} && %{variable}.bar
+               ^{variable}^^^^^{variable}^^^^ Use safe navigation (`&.`) instead [...]
               something
             end
           RUBY
 
-          expect(cop.messages).to eq([message])
+          expect_correction(<<~RUBY)
+            if #{variable}&.bar
+              something
+            end
+          RUBY
+        end
+
+        context 'method chaining' do
+          it 'corrects an object check followed by ' \
+             'a chained method call' do
+            expect_offense(<<~RUBY, variable: variable)
+              %{variable} && %{variable}.one.two
+              ^{variable}^^^^^{variable}^^^^^^^^ Use safe navigation (`&.`) instead [...]
+            RUBY
+
+            expect_correction(<<~RUBY)
+              #{variable}&.one&.two
+            RUBY
+          end
+
+          it 'corrects an object check followed by ' \
+             'a chained method call with params' do
+            expect_offense(<<~RUBY, variable: variable)
+              %{variable} && %{variable}.one.two(baz)
+              ^{variable}^^^^^{variable}^^^^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
+            RUBY
+
+            expect_correction(<<~RUBY)
+              #{variable}&.one&.two(baz)
+            RUBY
+          end
+
+          it 'corrects an object check followed by ' \
+             'a chained method call with a symbol proc' do
+            expect_offense(<<~RUBY, variable: variable)
+              %{variable} && %{variable}.one.two(&:baz)
+              ^{variable}^^^^^{variable}^^^^^^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
+            RUBY
+
+            expect_correction(<<~RUBY)
+              #{variable}&.one&.two(&:baz)
+            RUBY
+          end
+
+          it 'corrects an object check followed by ' \
+             'a chained method call with a block' do
+            expect_offense(<<~RUBY, variable: variable)
+              %{variable} && %{variable}.one.two(baz) { |e| e.qux }
+              ^{variable}^^^^^{variable}^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
+            RUBY
+
+            expect_correction(<<~RUBY)
+              #{variable}&.one&.two(baz) { |e| e.qux }
+            RUBY
+          end
         end
       end
 
@@ -652,570 +1121,5 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
        'a respond_to check' do
       expect_no_offenses('foo[0] if foo.respond_to?(:[])')
     end
-  end
-
-  context 'auto-correct' do
-    shared_examples 'all variable types' do |variable|
-      context 'modifier if' do
-        it 'corrects a method call safeguarded with a check for the object' do
-          new_source = autocorrect_source("#{variable}.bar if #{variable}")
-
-          expect(new_source).to eq("#{variable}&.bar")
-        end
-
-        it 'corrects a method call with params safeguarded with a check ' \
-           'for the object' do
-          source = "#{variable}.bar(baz) if #{variable}"
-
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq("#{variable}&.bar(baz)")
-        end
-
-        it 'corrects an object check followed by a method call ' \
-           'with a comment at EOL' do
-          source = "foo if #{variable} && #{variable}.bar # comment"
-
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq("foo if #{variable}&.bar # comment")
-        end
-
-        it 'corrects a method call with a block safeguarded with a check ' \
-           'for the object' do
-          source = "#{variable}.bar { |e| e.qux } if #{variable}"
-
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq("#{variable}&.bar { |e| e.qux }")
-        end
-
-        it 'corrects a method call with params and a block safeguarded ' \
-           'with a check for the object' do
-          source = "#{variable}.bar(baz) { |e| e.qux } if #{variable}"
-
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }")
-        end
-
-        it 'corrects a method call safeguarded with a negative check for ' \
-           'the object' do
-          source = "#{variable}.bar unless !#{variable}"
-
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq("#{variable}&.bar")
-        end
-
-        it 'corrects a method call with params safeguarded with a ' \
-           'negative check for the object' do
-          source = "#{variable}.bar(baz) unless !#{variable}"
-
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq("#{variable}&.bar(baz)")
-        end
-
-        it 'corrects a method call with a block safeguarded with a ' \
-           'negative check for the object' do
-          source = "#{variable}.bar { |e| e.qux } unless !#{variable}"
-
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq("#{variable}&.bar { |e| e.qux }")
-        end
-
-        it 'corrects a method call with params and a block safeguarded ' \
-           'with a negative check for the object' do
-          source = "#{variable}.bar(baz) { |e| e.qux } unless !#{variable}"
-
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }")
-        end
-
-        it 'corrects a method call safeguarded with a nil check for the ' \
-           'object' do
-          source = "#{variable}.bar unless #{variable}.nil?"
-
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq("#{variable}&.bar")
-        end
-
-        it 'corrects a method call with params safeguarded with a nil ' \
-           'check for the object' do
-          source = "#{variable}.bar(baz) unless #{variable}.nil?"
-
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq("#{variable}&.bar(baz)")
-        end
-
-        it 'corrects a method call with a block safeguarded with a nil ' \
-           'check for the object' do
-          source = "#{variable}.bar { |e| e.qux } unless #{variable}.nil?"
-
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq("#{variable}&.bar { |e| e.qux }")
-        end
-
-        it 'corrects a method call with params and a block safeguarded ' \
-           'with a nil check for the object' do
-          new_source = autocorrect_source(<<~RUBY)
-            #{variable}.bar(baz) { |e| e.qux } unless #{variable}.nil?
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
-            #{variable}&.bar(baz) { |e| e.qux }
-          RUBY
-        end
-
-        it 'corrects a method call safeguarded with a negative nil check ' \
-           'for the object' do
-          source = "#{variable}.bar if !#{variable}.nil?"
-
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq("#{variable}&.bar")
-        end
-
-        it 'corrects a method call with params safeguarded with a ' \
-           'negative nil check for the object' do
-          source = "#{variable}.bar(baz) if !#{variable}.nil?"
-
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq("#{variable}&.bar(baz)")
-        end
-
-        it 'corrects a method call with a block safeguarded with a ' \
-           'negative nil check for the object' do
-          source = "#{variable}.bar { |e| e.qux } if !#{variable}.nil?"
-
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq("#{variable}&.bar { |e| e.qux }")
-        end
-
-        it 'corrects a method call with params and a block safeguarded ' \
-           'with a negative nil check for the object' do
-          source = "#{variable}.bar(baz) { |e| e.qux } if !#{variable}.nil?"
-
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }")
-        end
-
-        it 'corrects a method call on an accessor safeguarded by a check ' \
-           'for the accessed variable' do
-          source = "#{variable}[1].bar if #{variable}[1]"
-
-          new_source = autocorrect_source(source)
-
-          expect(new_source).to eq("#{variable}[1]&.bar")
-        end
-
-        it 'corrects a chained method call safeguarded ' \
-           'with a negative nil check for the object' do
-          new_source = autocorrect_source(<<~RUBY)
-            #{variable}.one.two(baz) { |e| e.qux } if !#{variable}.nil?
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
-            #{variable}&.one&.two(baz) { |e| e.qux }
-          RUBY
-        end
-
-        it 'corrects a chained method call safeguarded ' \
-           'with a check for the object' do
-          new_source = autocorrect_source(<<~RUBY)
-            #{variable}.one.two(baz) { |e| e.qux } if #{variable}
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
-            #{variable}&.one&.two(baz) { |e| e.qux }
-          RUBY
-        end
-
-        it 'corrects a chained method call safeguarded ' \
-           'with an unless nil check for the object' do
-          new_source = autocorrect_source(<<~RUBY)
-            #{variable}.one.two(baz) { |e| e.qux } unless #{variable}.nil?
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
-            #{variable}&.one&.two(baz) { |e| e.qux }
-          RUBY
-        end
-      end
-
-      context 'if expression' do
-        it 'corrects a single method call inside of a check for the object' do
-          new_source = autocorrect_source(<<~RUBY)
-            if #{variable}
-              #{variable}.bar
-            end
-          RUBY
-
-          expect(new_source).to eq("#{variable}&.bar\n")
-        end
-
-        it 'corrects a single method call with params inside of a check ' \
-           'for the object' do
-          new_source = autocorrect_source(<<~RUBY)
-            if #{variable}
-              #{variable}.bar(baz)
-            end
-          RUBY
-
-          expect(new_source).to eq("#{variable}&.bar(baz)\n")
-        end
-
-        it 'corrects a single method call with a block inside of a check ' \
-           'for the object' do
-          new_source = autocorrect_source(<<~RUBY)
-            if #{variable}
-              #{variable}.bar { |e| e.qux }
-            end
-          RUBY
-
-          expect(new_source).to eq("#{variable}&.bar { |e| e.qux }\n")
-        end
-
-        it 'corrects a single method call with params and a block inside ' \
-           'of a check for the object' do
-          new_source = autocorrect_source(<<~RUBY)
-            if #{variable}
-              #{variable}.bar(baz) { |e| e.qux }
-            end
-          RUBY
-
-          expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }\n")
-        end
-
-        it 'corrects a single method call inside of a non-nil check for ' \
-           'the object' do
-          new_source = autocorrect_source(<<~RUBY)
-            if !#{variable}.nil?
-              #{variable}.bar
-            end
-          RUBY
-
-          expect(new_source).to eq("#{variable}&.bar\n")
-        end
-
-        it 'corrects a single method call with params inside of a non-nil ' \
-           'check for the object' do
-          new_source = autocorrect_source(<<~RUBY)
-            if !#{variable}.nil?
-              #{variable}.bar(baz)
-            end
-          RUBY
-
-          expect(new_source).to eq("#{variable}&.bar(baz)\n")
-        end
-
-        it 'corrects a single method call with a block inside of a non-nil ' \
-           'check for the object' do
-          new_source = autocorrect_source(<<~RUBY)
-            if !#{variable}.nil?
-              #{variable}.bar { |e| e.qux }
-            end
-          RUBY
-
-          expect(new_source).to eq("#{variable}&.bar { |e| e.qux }\n")
-        end
-
-        it 'corrects a single method call with params and a block inside ' \
-           'of a non-nil check for the object' do
-          new_source = autocorrect_source(<<~RUBY)
-            if !#{variable}.nil?
-              #{variable}.bar(baz) { |e| e.qux }
-            end
-          RUBY
-
-          expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }\n")
-        end
-
-        it 'does not lose comments within if expression' do
-          new_source = autocorrect_source(<<~RUBY)
-            if #{variable}
-              # this is a comment
-              # another comment
-              #{variable}.bar
-            end
-          RUBY
-
-          expected_source = <<~RUBY
-            # this is a comment
-            # another comment
-            #{variable}&.bar
-          RUBY
-          expect(new_source).to eq(expected_source)
-        end
-
-        it 'only moves comments that fall within the expression' do
-          new_source = autocorrect_source(<<~RUBY)
-            # comment one
-            def foobar
-              if #{variable}
-                # comment 2
-                #{variable}.bar
-              end
-            end
-          RUBY
-
-          expect(new_source).to eq(<<~RUBY)
-            # comment one
-            def foobar
-              # comment 2
-            #{variable}&.bar
-            end
-          RUBY
-        end
-
-        it 'corrects a single method call inside of an unless nil check ' \
-           'for the object' do
-          new_source = autocorrect_source(<<~RUBY)
-            unless #{variable}.nil?
-              #{variable}.bar
-            end
-          RUBY
-
-          expect(new_source).to eq("#{variable}&.bar\n")
-        end
-
-        it 'corrects a single method call with params inside of an unless ' \
-           'nil check for the object' do
-          new_source = autocorrect_source(<<~RUBY)
-            unless #{variable}.nil?
-              #{variable}.bar(baz)
-            end
-          RUBY
-
-          expect(new_source).to eq("#{variable}&.bar(baz)\n")
-        end
-
-        it 'corrects a single method call with a block inside of an unless ' \
-           'nil check for the object' do
-          new_source = autocorrect_source(<<~RUBY)
-            unless #{variable}.nil?
-              #{variable}.bar { |e| e.qux }
-            end
-          RUBY
-
-          expect(new_source).to eq("#{variable}&.bar { |e| e.qux }\n")
-        end
-
-        it 'corrects a single method call with params and a block inside ' \
-           'of an unless nil check for the object' do
-          new_source = autocorrect_source(<<~RUBY)
-            unless #{variable}.nil?
-              #{variable}.bar(baz) { |e| e.qux }
-            end
-          RUBY
-
-          expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }\n")
-        end
-
-        it 'corrects a single method call inside of an unless negative ' \
-           'check for the object' do
-          new_source = autocorrect_source(<<~RUBY)
-            unless !#{variable}
-              #{variable}.bar
-            end
-          RUBY
-
-          expect(new_source).to eq("#{variable}&.bar\n")
-        end
-
-        it 'corrects a single method call with params inside of an unless ' \
-           'negative check for the object' do
-          new_source = autocorrect_source(<<~RUBY)
-            unless !#{variable}
-              #{variable}.bar(baz)
-            end
-          RUBY
-
-          expect(new_source).to eq("#{variable}&.bar(baz)\n")
-        end
-
-        it 'corrects a single method call with a block inside of an unless ' \
-           'negative check for the object' do
-          new_source = autocorrect_source(<<~RUBY)
-            unless !#{variable}
-              #{variable}.bar { |e| e.qux }
-            end
-          RUBY
-
-          expect(new_source).to eq("#{variable}&.bar { |e| e.qux }\n")
-        end
-
-        it 'corrects a single method call with params and a block inside ' \
-           'of an unless negative check for the object' do
-          new_source = autocorrect_source(<<~RUBY)
-            unless !#{variable}
-              #{variable}.bar(baz) { |e| e.qux }
-            end
-          RUBY
-
-          expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }\n")
-        end
-      end
-
-      context 'object check before method call' do
-        context 'ConvertCodeThatCanStartToReturnNil true' do
-          let(:cop_config) do
-            { 'ConvertCodeThatCanStartToReturnNil' => true }
-          end
-
-          it 'corrects an object check followed by a method call' do
-            source = "#{variable} && #{variable}.bar"
-
-            new_source = autocorrect_source(source)
-
-            expect(new_source).to eq("#{variable}&.bar")
-          end
-
-          it 'corrects an object check followed by a method call ' \
-             'with params' do
-            source = "#{variable} && #{variable}.bar(baz)"
-
-            new_source = autocorrect_source(source)
-
-            expect(new_source).to eq("#{variable}&.bar(baz)")
-          end
-
-          it 'corrects an object check followed by a method call with ' \
-             'a block' do
-            source = "#{variable} && #{variable}.bar { |e| e.qux }"
-
-            new_source = autocorrect_source(source)
-
-            expect(new_source).to eq("#{variable}&.bar { |e| e.qux }")
-          end
-
-          it 'corrects an object check followed by a method call with ' \
-             'params and a block' do
-            source = "#{variable} && #{variable}.bar(baz) { |e| e.qux }"
-
-            new_source = autocorrect_source(source)
-
-            expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }")
-          end
-
-          it 'corrects a non-nil object check followed by a method call' do
-            source = "!#{variable}.nil? && #{variable}.bar"
-
-            new_source = autocorrect_source(source)
-
-            expect(new_source).to eq("#{variable}&.bar")
-          end
-
-          it 'corrects a non-nil object check followed by a method call ' \
-             'with params' do
-            source = "!#{variable}.nil? && #{variable}.bar(baz)"
-
-            new_source = autocorrect_source(source)
-
-            expect(new_source).to eq("#{variable}&.bar(baz)")
-          end
-
-          it 'corrects a non-nil object check followed by a method call ' \
-             'with a block' do
-            source = "!#{variable}.nil? && #{variable}.bar { |e| e.qux }"
-
-            new_source = autocorrect_source(source)
-
-            expect(new_source).to eq("#{variable}&.bar { |e| e.qux }")
-          end
-
-          it 'corrects a non-nil object check followed by a method call ' \
-             'with params and a block' do
-            source = "!#{variable}.nil? && #{variable}.bar(baz) { |e| e.qux }"
-
-            new_source = autocorrect_source(source)
-
-            expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }")
-          end
-
-          it 'corrects an object check followed by a method call and ' \
-             'another check' do
-            source = "#{variable} && #{variable}.bar && something"
-
-            new_source = autocorrect_source(source)
-
-            expect(new_source).to eq("#{variable}&.bar && something")
-          end
-        end
-
-        context 'method chaining' do
-          it 'corrects an object check followed by ' \
-             'a chained method call' do
-            new_source = autocorrect_source(<<~RUBY)
-              #{variable} && #{variable}.one.two
-            RUBY
-
-            expect(new_source).to eq(<<~RUBY)
-              #{variable}&.one&.two
-            RUBY
-          end
-
-          it 'corrects an object check followed by ' \
-             'a chained method call with params' do
-            new_source = autocorrect_source(<<~RUBY)
-              #{variable} && #{variable}.one.two(baz)
-            RUBY
-
-            expect(new_source).to eq(<<~RUBY)
-              #{variable}&.one&.two(baz)
-            RUBY
-          end
-
-          it 'corrects an object check followed by ' \
-             'a chained method call with a symbol proc' do
-            new_source = autocorrect_source(<<~RUBY)
-              #{variable} && #{variable}.one.two(&:baz)
-            RUBY
-
-            expect(new_source).to eq(<<~RUBY)
-              #{variable}&.one&.two(&:baz)
-            RUBY
-          end
-
-          it 'corrects an object check followed by ' \
-             'a chained method call with a block' do
-            new_source = autocorrect_source(<<~RUBY)
-              #{variable} && #{variable}.one.two(baz) { |e| e.qux }
-            RUBY
-
-            expect(new_source).to eq(<<~RUBY)
-              #{variable}&.one&.two(baz) { |e| e.qux }
-            RUBY
-          end
-
-          it 'corrects an object check followed by ' \
-             'multiple chained method calls with blocks' do
-            new_source = autocorrect_source(<<~RUBY)
-              #{variable} && #{variable}.one { |a| b}.two(baz) { |e| e.qux }
-            RUBY
-
-            expect(new_source).to eq(<<~RUBY)
-              #{variable}&.one { |a| b}&.two(baz) { |e| e.qux }
-            RUBY
-          end
-        end
-      end
-    end
-
-    it_behaves_like('all variable types', 'foo')
-    it_behaves_like('all variable types', 'FOO')
-    it_behaves_like('all variable types', 'FOO::BAR')
-    it_behaves_like('all variable types', '@foo')
-    it_behaves_like('all variable types', '@@foo')
-    it_behaves_like('all variable types', '$FOO')
   end
 end

--- a/spec/rubocop/cop/style/sample_spec.rb
+++ b/spec/rubocop/cop/style/sample_spec.rb
@@ -4,21 +4,20 @@ RSpec.describe RuboCop::Cop::Style::Sample do
   subject(:cop) { described_class.new }
 
   shared_examples 'offense' do |wrong, right|
-    it "when using #{wrong}" do
-      inspect_source("[1, 2, 3].#{wrong}")
-      expect(cop.messages).to eq(["Use `#{right}` instead of `#{wrong}`."])
-    end
+    it "registers an offense for #{wrong}" do
+      expect_offense(<<~RUBY, wrong: wrong)
+        [1, 2, 3].%{wrong}
+                  ^{wrong} Use `#{right}` instead of `#{wrong}`.
+      RUBY
 
-    context 'corrects' do
-      it "#{wrong} to #{right}" do
-        new_source = autocorrect_source("[1, 2, 3].#{wrong}")
-        expect(new_source).to eq("[1, 2, 3].#{right}")
-      end
+      expect_correction(<<~RUBY)
+        [1, 2, 3].#{right}
+      RUBY
     end
   end
 
   shared_examples 'accepts' do |acceptable|
-    it acceptable do
+    it "accepts #{acceptable}" do
       expect_no_offenses("[1, 2, 3].#{acceptable}")
     end
   end

--- a/spec/rubocop/cop/style/self_assignment_spec.rb
+++ b/spec/rubocop/cop/style/self_assignment_spec.rb
@@ -5,19 +5,14 @@ RSpec.describe RuboCop::Cop::Style::SelfAssignment do
 
   %i[+ - * ** / | & || &&].product(['x', '@x', '@@x']).each do |op, var|
     it "registers an offense for non-shorthand assignment #{op} and #{var}" do
-      inspect_source("#{var} = #{var} #{op} y")
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(["Use self-assignment shorthand `#{op}=`."])
-    end
+      expect_offense(<<~RUBY, op: op, var: var)
+        %{var} = %{var} %{op} y
+        ^{var}^^^^{var}^^{op}^^ Use self-assignment shorthand `#{op}=`.
+      RUBY
 
-    it "accepts shorthand assignment for #{op} and #{var}" do
-      expect_no_offenses("#{var} #{op}= y")
-    end
-
-    it "auto-corrects a non-shorthand assignment #{op} and #{var}" do
-      new_source = autocorrect_source("#{var} = #{var} #{op} y")
-      expect(new_source).to eq("#{var} #{op}= y")
+      expect_correction(<<~RUBY)
+        #{var} #{op}= y
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe RuboCop::Cop::Style::Semicolon, :config do
       puts "this is a test";
                            ^ Do not use semicolons to terminate expressions.
     RUBY
+
+    expect_correction(<<~RUBY)
+      puts "this is a test"
+    RUBY
   end
 
   it 'registers an offense for several expressions' do
@@ -15,6 +19,8 @@ RSpec.describe RuboCop::Cop::Style::Semicolon, :config do
       puts "this is a test"; puts "So is this"
                            ^ Do not use semicolons to terminate expressions.
     RUBY
+
+    expect_no_corrections
   end
 
   it 'registers an offense for one line method with two statements' do
@@ -22,6 +28,8 @@ RSpec.describe RuboCop::Cop::Style::Semicolon, :config do
       def foo(a) x(1); y(2); z(3); end
                      ^ Do not use semicolons to terminate expressions.
     RUBY
+
+    expect_no_corrections
   end
 
   it 'accepts semicolon before end if so configured' do
@@ -68,6 +76,10 @@ RSpec.describe RuboCop::Cop::Style::Semicolon, :config do
       module Foo; end;
                      ^ Do not use semicolons to terminate expressions.
     RUBY
+
+    expect_correction(<<~RUBY)
+      module Foo; end
+    RUBY
   end
 
   it 'accept semicolons inside strings' do
@@ -82,25 +94,8 @@ RSpec.describe RuboCop::Cop::Style::Semicolon, :config do
       ; puts 1
       ^ Do not use semicolons to terminate expressions.
     RUBY
-  end
 
-  it 'auto-corrects semicolons when syntactically possible' do
-    corrected =
-      autocorrect_source(<<~RUBY)
-        module Foo; end;
-        puts "this is a test";
-        puts "this is a test"; puts "So is this"
-        def foo(a) x(1); y(2); z(3); end
-        ;puts 1
-      RUBY
-    expect(corrected)
-      .to eq(<<~RUBY)
-        module Foo; end
-        puts "this is a test"
-        puts "this is a test"; puts "So is this"
-        def foo(a) x(1); y(2); z(3); end
-        puts 1
-      RUBY
+    expect_correction(" puts 1\n")
   end
 
   context 'with a multi-expression line without a semicolon' do

--- a/spec/rubocop/cop/style/signal_exception_spec.rb
+++ b/spec/rubocop/cop/style/signal_exception_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe RuboCop::Cop::Style::SignalException, :config do
           #do nothing
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+          fail
+        rescue Exception
+          #do nothing
+        end
+      RUBY
     end
 
     it 'registers an offense for raise in def body' do
@@ -20,6 +28,14 @@ RSpec.describe RuboCop::Cop::Style::SignalException, :config do
         def test
           raise
           ^^^^^ Use `fail` instead of `raise` to signal exceptions.
+        rescue Exception
+          #do nothing
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def test
+          fail
         rescue Exception
           #do nothing
         end
@@ -33,6 +49,14 @@ RSpec.describe RuboCop::Cop::Style::SignalException, :config do
         rescue Exception
           fail
           ^^^^ Use `raise` instead of `fail` to rethrow exceptions.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+          fail
+        rescue Exception
+          raise
         end
       RUBY
     end
@@ -68,6 +92,14 @@ RSpec.describe RuboCop::Cop::Style::SignalException, :config do
           ^^^^ Use `raise` instead of `fail` to rethrow exceptions.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def test
+          fail
+        rescue Exception
+          raise
+        end
+      RUBY
     end
 
     it 'registers an offense for fail in second rescue' do
@@ -81,6 +113,16 @@ RSpec.describe RuboCop::Cop::Style::SignalException, :config do
           ^^^^ Use `raise` instead of `fail` to rethrow exceptions.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def test
+          fail
+        rescue StandardError
+          # handle error
+        rescue Exception
+          raise
+        end
+      RUBY
     end
 
     it 'registers only offense for one raise that should be fail' do
@@ -89,6 +131,12 @@ RSpec.describe RuboCop::Cop::Style::SignalException, :config do
         map do
           raise 'I'
           ^^^^^ Use `fail` instead of `raise` to signal exceptions.
+        end.flatten.compact
+      RUBY
+
+      expect_correction(<<~RUBY)
+        map do
+          fail 'I'
         end.flatten.compact
       RUBY
     end
@@ -124,6 +172,14 @@ RSpec.describe RuboCop::Cop::Style::SignalException, :config do
                  ^^^^ Use `raise` instead of `fail` to rethrow exceptions.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def test
+          Kernel.fail
+        rescue Exception
+          Kernel.raise
+        end
+      RUBY
     end
 
     it 'registers an offense for `raise` and `fail` with `::Kernel` as ' \
@@ -137,6 +193,14 @@ RSpec.describe RuboCop::Cop::Style::SignalException, :config do
                    ^^^^ Use `raise` instead of `fail` to rethrow exceptions.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def test
+          ::Kernel.fail
+        rescue Exception
+          ::Kernel.raise
+        end
+      RUBY
     end
 
     it 'registers an offense for raise not in a begin/rescue/end' do
@@ -148,6 +212,14 @@ RSpec.describe RuboCop::Cop::Style::SignalException, :config do
              ^^^^^ Use `fail` instead of `raise` to signal exceptions.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        case cop_config['EnforcedStyle']
+        when 'single_quotes' then true
+        when 'double_quotes' then false
+        else fail 'Unknown StringLiterals style'
+        end
+      RUBY
     end
 
     it 'registers one offense for each raise' do
@@ -156,6 +228,11 @@ RSpec.describe RuboCop::Cop::Style::SignalException, :config do
                             ^^^^^ Use `fail` instead of `raise` to signal exceptions.
         cop.stub(:on_def) { raise RuntimeError }
                             ^^^^^ Use `fail` instead of `raise` to signal exceptions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        cop.stub(:on_def) { fail RuntimeError }
+        cop.stub(:on_def) { fail RuntimeError }
       RUBY
     end
 
@@ -175,38 +252,17 @@ RSpec.describe RuboCop::Cop::Style::SignalException, :config do
           #do nothing
         end
       RUBY
-    end
 
-    it 'auto-corrects raise to fail when appropriate' do
-      new_source = autocorrect_source(<<~RUBY)
-        begin
-          raise
-        rescue Exception
-          raise
-        end
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         begin
           fail
+          begin
+            fail
+          rescue
+            raise
+          end
         rescue Exception
-          raise
-        end
-      RUBY
-    end
-
-    it 'auto-corrects fail to raise when appropriate' do
-      new_source = autocorrect_source(<<~RUBY)
-        begin
-          fail
-        rescue Exception
-          fail
-        end
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
-        begin
-          fail
-        rescue Exception
-          raise
+          #do nothing
         end
       RUBY
     end
@@ -224,6 +280,14 @@ RSpec.describe RuboCop::Cop::Style::SignalException, :config do
           #do nothing
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+          raise
+        rescue Exception
+          #do nothing
+        end
+      RUBY
     end
 
     it 'registers an offense for fail in def body' do
@@ -231,6 +295,14 @@ RSpec.describe RuboCop::Cop::Style::SignalException, :config do
         def test
           fail
           ^^^^ Always use `raise` to signal exceptions.
+        rescue Exception
+          #do nothing
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def test
+          raise
         rescue Exception
           #do nothing
         end
@@ -244,6 +316,14 @@ RSpec.describe RuboCop::Cop::Style::SignalException, :config do
         rescue Exception
           fail
           ^^^^ Always use `raise` to signal exceptions.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+          raise
+        rescue Exception
+          raise
         end
       RUBY
     end
@@ -281,22 +361,9 @@ RSpec.describe RuboCop::Cop::Style::SignalException, :config do
         Kernel.fail
                ^^^^ Always use `raise` to signal exceptions.
       RUBY
-    end
 
-    it 'auto-corrects fail to raise always' do
-      new_source = autocorrect_source(<<~RUBY)
-        begin
-          fail
-        rescue Exception
-          fail
-        end
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
-        begin
-          raise
-        rescue Exception
-          raise
-        end
+      expect_correction(<<~RUBY)
+        Kernel.raise
       RUBY
     end
   end
@@ -313,6 +380,14 @@ RSpec.describe RuboCop::Cop::Style::SignalException, :config do
           #do nothing
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+          fail
+        rescue Exception
+          #do nothing
+        end
+      RUBY
     end
 
     it 'registers an offense for raise in def body' do
@@ -320,6 +395,14 @@ RSpec.describe RuboCop::Cop::Style::SignalException, :config do
         def test
           raise
           ^^^^^ Always use `fail` to signal exceptions.
+        rescue Exception
+          #do nothing
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def test
+          fail
         rescue Exception
           #do nothing
         end
@@ -335,6 +418,14 @@ RSpec.describe RuboCop::Cop::Style::SignalException, :config do
           ^^^^^ Always use `fail` to signal exceptions.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+          fail
+        rescue Exception
+          fail
+        end
+      RUBY
     end
 
     it 'accepts `raise` with explicit receiver' do
@@ -346,22 +437,9 @@ RSpec.describe RuboCop::Cop::Style::SignalException, :config do
         Kernel.raise
                ^^^^^ Always use `fail` to signal exceptions.
       RUBY
-    end
 
-    it 'auto-corrects raise to fail always' do
-      new_source = autocorrect_source(<<~RUBY)
-        begin
-          raise
-        rescue Exception
-          raise
-        end
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
-        begin
-          fail
-        rescue Exception
-          fail
-        end
+      expect_correction(<<~RUBY)
+        Kernel.fail
       RUBY
     end
   end

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods do
                         'Layout/IndentationWidth' => { 'Width' => 2 })
   end
   let(:cop_config) { { 'AllowIfMethodIsEmpty' => true } }
+  let(:trailing_whitespace) { ' ' }
 
   it 'registers an offense for a single-line method' do
     expect_offense(<<~RUBY)
@@ -17,6 +18,18 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid single-line method definitions.
       def @table.columns; super; end
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid single-line method definitions.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def some_method;#{trailing_whitespace}
+        body#{trailing_whitespace}
+      end
+      def link_to(name, url);#{trailing_whitespace}
+        {:name => name};#{trailing_whitespace}
+      end
+      def @table.columns;#{trailing_whitespace}
+        super;#{trailing_whitespace}
+      end
     RUBY
   end
 
@@ -32,14 +45,13 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods do
         def @table.columns; end
         ^^^^^^^^^^^^^^^^^^^^^^^ Avoid single-line method definitions.
       RUBY
-    end
 
-    it 'auto-corrects an empty method' do
-      corrected = autocorrect_source(<<~RUBY)
-        def x; end
-      RUBY
-      expect(corrected).to eq(<<~RUBY)
-        def x; 
+      expect_correction(<<~RUBY)
+        def no_op;#{trailing_whitespace}
+        end
+        def self.resource_class=(klass);#{trailing_whitespace}
+        end
+        def @table.columns;#{trailing_whitespace}
         end
       RUBY
     end
@@ -73,39 +85,69 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods do
   end
 
   it 'auto-corrects def with semicolon after method name' do
-    corrected = autocorrect_source('  def some_method; body end # Cmnt')
-    expect(corrected).to eq ['  # Cmnt',
-                             '  def some_method; ',
-                             '    body ',
-                             '  end '].join("\n")
+    expect_offense(<<-RUBY.strip_margin('|'))
+      |  def some_method; body end # Cmnt
+      |  ^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid single-line method definitions.
+    RUBY
+
+    expect_correction(<<-RUBY.strip_margin('|'))
+      |  # Cmnt
+      |  def some_method;#{trailing_whitespace}
+      |    body#{trailing_whitespace}
+      |  end#{trailing_whitespace}
+    RUBY
   end
 
   it 'auto-corrects defs with parentheses after method name' do
-    corrected = autocorrect_source('  def self.some_method() body end')
-    expect(corrected).to eq ['  def self.some_method() ',
-                             '    body ',
-                             '  end'].join("\n")
+    expect_offense(<<-RUBY.strip_margin('|'))
+      |  def self.some_method() body end
+      |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid single-line method definitions.
+    RUBY
+
+    expect_correction(<<-RUBY.strip_margin('|'))
+      |  def self.some_method()#{trailing_whitespace}
+      |    body#{trailing_whitespace}
+      |  end
+    RUBY
   end
 
   it 'auto-corrects def with argument in parentheses' do
-    corrected = autocorrect_source('  def some_method(arg) body end')
-    expect(corrected).to eq ['  def some_method(arg) ',
-                             '    body ',
-                             '  end'].join("\n")
+    expect_offense(<<-RUBY.strip_margin('|'))
+      |  def some_method(arg) body end
+      |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid single-line method definitions.
+    RUBY
+
+    expect_correction(<<-RUBY.strip_margin('|'))
+      |  def some_method(arg)#{trailing_whitespace}
+      |    body#{trailing_whitespace}
+      |  end
+    RUBY
   end
 
   it 'auto-corrects def with argument and no parentheses' do
-    corrected = autocorrect_source('  def some_method arg; body end')
-    expect(corrected).to eq ['  def some_method arg; ',
-                             '    body ',
-                             '  end'].join("\n")
+    expect_offense(<<-RUBY.strip_margin('|'))
+      |  def some_method arg; body end
+      |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid single-line method definitions.
+    RUBY
+
+    expect_correction(<<-RUBY.strip_margin('|'))
+      |  def some_method arg;#{trailing_whitespace}
+      |    body#{trailing_whitespace}
+      |  end
+    RUBY
   end
 
   it 'auto-corrects def with semicolon before end' do
-    corrected = autocorrect_source('  def some_method; b1; b2; end')
-    expect(corrected).to eq ['  def some_method; ',
-                             '    b1; ',
-                             '    b2; ',
-                             '  end'].join("\n")
+    expect_offense(<<-RUBY.strip_margin('|'))
+      |  def some_method; b1; b2; end
+      |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid single-line method definitions.
+    RUBY
+
+    expect_correction(<<-RUBY.strip_margin('|'))
+      |  def some_method;#{trailing_whitespace}
+      |    b1;#{trailing_whitespace}
+      |    b2;#{trailing_whitespace}
+      |  end
+    RUBY
   end
 end

--- a/spec/rubocop/cop/style/special_global_vars_spec.rb
+++ b/spec/rubocop/cop/style/special_global_vars_spec.rb
@@ -9,12 +9,20 @@ RSpec.describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
         puts $:
              ^^ Prefer `$LOAD_PATH` over `$:`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        puts $LOAD_PATH
+      RUBY
     end
 
     it 'registers an offense for $"' do
       expect_offense(<<~RUBY)
         puts $"
              ^^ Prefer `$LOADED_FEATURES` over `$"`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        puts $LOADED_FEATURES
       RUBY
     end
 
@@ -23,12 +31,20 @@ RSpec.describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
         puts $0
              ^^ Prefer `$PROGRAM_NAME` over `$0`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        puts $PROGRAM_NAME
+      RUBY
     end
 
     it 'registers an offense for $$' do
       expect_offense(<<~RUBY)
         puts $$
              ^^ Prefer `$PROCESS_ID` or `$PID` from the stdlib 'English' module (don't forget to require it) over `$$`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        puts $PROCESS_ID
       RUBY
     end
 
@@ -37,42 +53,73 @@ RSpec.describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
         puts $*
              ^^ Prefer `$ARGV` from the stdlib 'English' module (don't forget to require it) or `ARGV` over `$*`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        puts $ARGV
+      RUBY
     end
 
     it 'does not register an offense for backrefs like $1' do
       expect_no_offenses('puts $1')
     end
 
-    it 'auto-corrects $: to $LOAD_PATH' do
-      new_source = autocorrect_source('$:')
-      expect(new_source).to eq('$LOAD_PATH')
-    end
-
     it 'auto-corrects $/ to $INPUT_RECORD_SEPARATOR' do
-      new_source = autocorrect_source('$/')
-      expect(new_source).to eq('$INPUT_RECORD_SEPARATOR')
+      expect_offense(<<~RUBY)
+        $/
+        ^^ Prefer `$INPUT_RECORD_SEPARATOR` or `$RS` from the stdlib 'English' module (don't forget to require it) over `$/`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        $INPUT_RECORD_SEPARATOR
+      RUBY
     end
 
     it 'auto-corrects #$: to #{$LOAD_PATH}' do
-      new_source = autocorrect_source('"#$:"')
-      expect(new_source).to eq('"#{$LOAD_PATH}"')
+      expect_offense(<<~'RUBY')
+        "#$:"
+          ^^ Prefer `$LOAD_PATH` over `$:`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        "#{$LOAD_PATH}"
+      RUBY
     end
 
     it 'auto-corrects #{$!} to #{$ERROR_INFO}' do
-      new_source = autocorrect_source('"#{$!}"')
-      expect(new_source).to eq('"#{$ERROR_INFO}"')
+      expect_offense(<<~'RUBY')
+        "#{$!}"
+           ^^ Prefer `$ERROR_INFO` from the stdlib 'English' module (don't forget to require it) over `$!`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        "#{$ERROR_INFO}"
+      RUBY
     end
 
     it 'generates correct auto-config when Perl variable names are used' do
-      inspect_source('$0')
+      expect_offense(<<~RUBY)
+        $0
+        ^^ Prefer `$PROGRAM_NAME` over `$0`.
+      RUBY
       expect(cop.config_to_allow_offenses).to eq(
         'EnforcedStyle' => 'use_perl_names'
       )
+
+      expect_correction(<<~RUBY)
+        $PROGRAM_NAME
+      RUBY
     end
 
     it 'generates correct auto-config when mixed styles are used' do
-      inspect_source('$!; $ERROR_INFO')
+      expect_offense(<<~RUBY)
+        $!; $ERROR_INFO
+        ^^ Prefer `$ERROR_INFO` from the stdlib 'English' module (don't forget to require it) over `$!`.
+      RUBY
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+
+      expect_correction(<<~RUBY)
+        $ERROR_INFO; $ERROR_INFO
+      RUBY
     end
   end
 
@@ -84,12 +131,20 @@ RSpec.describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
         puts $LOAD_PATH
              ^^^^^^^^^^ Prefer `$:` over `$LOAD_PATH`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        puts $:
+      RUBY
     end
 
     it 'registers an offense for $LOADED_FEATURES' do
       expect_offense(<<~RUBY)
         puts $LOADED_FEATURES
              ^^^^^^^^^^^^^^^^ Prefer `$"` over `$LOADED_FEATURES`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        puts $"
       RUBY
     end
 
@@ -98,12 +153,20 @@ RSpec.describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
         puts $PROGRAM_NAME
              ^^^^^^^^^^^^^ Prefer `$0` over `$PROGRAM_NAME`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        puts $0
+      RUBY
     end
 
     it 'registers an offense for $PID' do
       expect_offense(<<~RUBY)
         puts $PID
              ^^^^ Prefer `$$` over `$PID`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        puts $$
       RUBY
     end
 
@@ -112,25 +175,36 @@ RSpec.describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
         puts $PROCESS_ID
              ^^^^^^^^^^^ Prefer `$$` over `$PROCESS_ID`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        puts $$
+      RUBY
     end
 
     it 'does not register an offense for backrefs like $1' do
       expect_no_offenses('puts $1')
     end
 
-    it 'auto-corrects $LOAD_PATH to $:' do
-      new_source = autocorrect_source('$LOAD_PATH')
-      expect(new_source).to eq('$:')
-    end
-
     it 'auto-corrects $INPUT_RECORD_SEPARATOR to $/' do
-      new_source = autocorrect_source('$INPUT_RECORD_SEPARATOR')
-      expect(new_source).to eq('$/')
+      expect_offense(<<~RUBY)
+        $INPUT_RECORD_SEPARATOR
+        ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `$/` over `$INPUT_RECORD_SEPARATOR`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        $/
+      RUBY
     end
 
     it 'auto-corrects #{$LOAD_PATH} to #$:' do
-      new_source = autocorrect_source('"#{$LOAD_PATH}"')
-      expect(new_source).to eq('"#$:"')
+      expect_offense(<<~'RUBY')
+        "#{$LOAD_PATH}"
+           ^^^^^^^^^^ Prefer `$:` over `$LOAD_PATH`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        "#$:"
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/stabby_lambda_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/stabby_lambda_parentheses_spec.rb
@@ -25,15 +25,14 @@ RSpec.describe RuboCop::Cop::Style::StabbyLambdaParentheses, :config do
         ->a,b,c { a + b + c }
           ^^^^^ Wrap stabby lambda arguments with parentheses.
       RUBY
+
+      expect_correction(<<~RUBY)
+        ->(a,b,c) { a + b + c }
+      RUBY
     end
 
     it 'does not register an offense for a stabby lambda with parentheses' do
       expect_no_offenses('->(a,b,c) { a + b + c }')
-    end
-
-    it 'autocorrects when a stabby lambda has no parentheses' do
-      corrected = autocorrect_source('->a,b,c { a + b + c }')
-      expect(corrected).to eq '->(a,b,c) { a + b + c }'
     end
   end
 
@@ -47,11 +46,10 @@ RSpec.describe RuboCop::Cop::Style::StabbyLambdaParentheses, :config do
         ->(a,b,c) { a + b + c }
           ^^^^^^^ Do not wrap stabby lambda arguments with parentheses.
       RUBY
-    end
 
-    it 'autocorrects when a stabby lambda does not parentheses' do
-      corrected = autocorrect_source('->(a,b,c) { a + b + c }')
-      expect(corrected).to eq '->a,b,c { a + b + c }'
+      expect_correction(<<~RUBY)
+        ->a,b,c { a + b + c }
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/stderr_puts_spec.rb
+++ b/spec/rubocop/cop/style/stderr_puts_spec.rb
@@ -10,12 +10,10 @@ RSpec.describe RuboCop::Cop::Style::StderrPuts do
       $stderr.puts('hello')
       ^^^^^^^^^^^^ Use `warn` instead of `$stderr.puts` to allow such output to be disabled.
     RUBY
-  end
 
-  it 'autocorrects `$stderr.puts` to `warn`' do
-    new_source = autocorrect_source("$stderr.puts('hello')")
-
-    expect(new_source).to eq "warn('hello')"
+    expect_correction(<<~RUBY)
+      warn('hello')
+    RUBY
   end
 
   it 'registers no offense when using `$stderr.puts` with no arguments' do
@@ -29,12 +27,10 @@ RSpec.describe RuboCop::Cop::Style::StderrPuts do
       STDERR.puts('hello')
       ^^^^^^^^^^^ Use `warn` instead of `STDERR.puts` to allow such output to be disabled.
     RUBY
-  end
 
-  it 'autocorrects `STDERR.puts` to `warn`' do
-    new_source = autocorrect_source("STDERR.puts('hello')")
-
-    expect(new_source).to eq "warn('hello')"
+    expect_correction(<<~RUBY)
+      warn('hello')
+    RUBY
   end
 
   it "registers an offense when using `::STDERR.puts('hello')`" do
@@ -42,12 +38,10 @@ RSpec.describe RuboCop::Cop::Style::StderrPuts do
       ::STDERR.puts('hello')
       ^^^^^^^^^^^^^ Use `warn` instead of `::STDERR.puts` to allow such output to be disabled.
     RUBY
-  end
 
-  it 'autocorrects `::STDERR.puts` to `warn`' do
-    new_source = autocorrect_source("::STDERR.puts('hello')")
-
-    expect(new_source).to eq "warn('hello')"
+    expect_correction(<<~RUBY)
+      warn('hello')
+    RUBY
   end
 
   it 'registers no offense when using `STDERR.puts` with no arguments' do

--- a/spec/rubocop/cop/style/string_hash_keys_spec.rb
+++ b/spec/rubocop/cop/style/string_hash_keys_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe RuboCop::Cop::Style::StringHashKeys do
       { 'one' => 1 }
         ^^^^^ Prefer symbols instead of strings as hash keys.
     RUBY
+
+    expect_correction(<<~RUBY)
+      { :one => 1 }
+    RUBY
   end
 
   it 'registers an offense when using strings as keys mixed with other keys' do
@@ -17,21 +21,21 @@ RSpec.describe RuboCop::Cop::Style::StringHashKeys do
       { 'one' => 1, two: 2, 3 => 3 }
         ^^^^^ Prefer symbols instead of strings as hash keys.
     RUBY
-  end
 
-  it 'autocorrects strings as keys into symbols' do
-    new_source = autocorrect_source("{ 'one' => 1 }")
-    expect(new_source).to eq '{ :one => 1 }'
-  end
-
-  it 'autocorrects strings as keys mixed with other keys into symbols' do
-    new_source = autocorrect_source("{ 'one' => 1, two: 2, 3 => 3 }")
-    expect(new_source).to eq '{ :one => 1, two: 2, 3 => 3 }'
+    expect_correction(<<~RUBY)
+      { :one => 1, two: 2, 3 => 3 }
+    RUBY
   end
 
   it 'autocorrects strings as keys into symbols with the correct syntax' do
-    new_source = autocorrect_source("{ 'one two :' => 1 }")
-    expect(new_source).to eq '{ :"one two :" => 1 }'
+    expect_offense(<<~RUBY)
+      { 'one two :' => 1 }
+        ^^^^^^^^^^^ Prefer symbols instead of strings as hash keys.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      { :"one two :" => 1 }
+    RUBY
   end
 
   it 'does not register an offense when not using strings as keys' do

--- a/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
         "#{"A"}"
            ^^^ Prefer single-quoted strings inside interpolations.
       RUBY
+
+      expect_correction(<<~'RUBY')
+        "#{'A'}"
+      RUBY
     end
 
     it 'registers an offense for double quotes within embedded expression in ' \
@@ -17,6 +21,12 @@ RSpec.describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
         <<RUBY
         #{"A"}
           ^^^ Prefer single-quoted strings inside interpolations.
+        RUBY
+      SOURCE
+
+      expect_correction(<<~'SOURCE')
+        <<RUBY
+        #{'A'}
         RUBY
       SOURCE
     end
@@ -52,11 +62,6 @@ RSpec.describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
     it 'can handle character literals' do
       expect_no_offenses('a = ?/')
     end
-
-    it 'auto-corrects " with \'' do
-      new_source = autocorrect_source('s = "#{"abc"}"')
-      expect(new_source).to eq(%q(s = "#{'abc'}"))
-    end
   end
 
   context 'configured with double quotes preferred' do
@@ -66,6 +71,10 @@ RSpec.describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
       expect_offense(<<~'RUBY')
         "#{'A'}"
            ^^^ Prefer double-quoted strings inside interpolations.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        "#{"A"}"
       RUBY
     end
 
@@ -77,6 +86,12 @@ RSpec.describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
           ^^^ Prefer double-quoted strings inside interpolations.
         RUBY
       SOURCE
+
+      expect_correction(<<~'SOURCE')
+        <<RUBY
+        #{"A"}
+        RUBY
+      SOURCE
     end
   end
 
@@ -84,7 +99,7 @@ RSpec.describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'other' } }
 
     it 'fails' do
-      expect { inspect_source('a = "#{"b"}"') }
+      expect { expect_no_offenses('a = "#{"b"}"') }
         .to raise_error(RuntimeError)
     end
   end

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -17,12 +17,24 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
       RUBY
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
                                                  'double_quotes')
+
+      expect_correction(<<~'RUBY')
+        s = 'abc'
+        x = 'a\\b'
+        y ='\\b'
+        z = 'a\\'
+      RUBY
     end
 
     it 'registers offense for correct + opposite' do
       expect_offense(<<~RUBY)
         s = "abc"
             ^^^^^ Prefer single-quoted strings when you don't need string interpolation or special symbols.
+        x = 'abc'
+      RUBY
+
+      expect_correction(<<~RUBY)
+        s = 'abc'
         x = 'abc'
       RUBY
     end
@@ -116,6 +128,11 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
         "y"
         ^^^ Prefer single-quoted strings when you don't need string interpolation or special symbols.
       RUBY
+
+      expect_correction(<<~'RUBY')
+        "#{x}" \
+        'y'
+      RUBY
     end
 
     it 'can handle a built-in constant parsed as string' do
@@ -130,15 +147,14 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
       expect_no_offenses('a = ?/')
     end
 
-    it 'auto-corrects " with \'' do
-      new_source = autocorrect_source('s = "abc"')
-      expect(new_source).to eq("s = 'abc'")
-    end
-
     it 'registers an offense for "\""' do
       expect_offense(<<~'RUBY')
         "\""
         ^^^^ Prefer single-quoted strings when you don't need string interpolation or special symbols.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        '"'
       RUBY
     end
 
@@ -147,22 +163,15 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
         "España"
         ^^^^^^^^ Prefer single-quoted strings when you don't need string interpolation or special symbols.
       RUBY
-    end
 
-    it 'autocorrects words with non-ascii chars' do
-      new_source = autocorrect_source('"España"')
-      expect(new_source).to eq("'España'")
+      expect_correction(<<~RUBY)
+        'España'
+      RUBY
     end
 
     it 'does not register an offense for words with non-ascii chars and ' \
        'other control sequences' do
       expect_no_offenses('"España\n"')
-    end
-
-    it 'does not autocorrect words with non-ascii chars and other control ' \
-       'sequences' do
-      new_source = autocorrect_source('"España\n"')
-      expect(new_source).to eq('"España\n"')
     end
   end
 
@@ -177,6 +186,10 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
       RUBY
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
                                                  'single_quotes')
+
+      expect_correction(<<~RUBY)
+        s = "abc"
+      RUBY
     end
 
     it 'registers offense for opposite + correct' do
@@ -186,6 +199,11 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
             ^^^^^ Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
       RUBY
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+
+      expect_correction(<<~'RUBY')
+        s = "abc"
+        x = "abc"
+      RUBY
     end
 
     it 'registers offense for escaped single quote in single quotes' do
@@ -193,12 +211,20 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
         '\''
         ^^^^ Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
       RUBY
+
+      expect_correction(<<~'RUBY')
+        "'"
+      RUBY
     end
 
     it 'does not accept multiple escaped single quotes in single quotes' do
       expect_offense(<<~'RUBY')
         'This \'string\' has \'multiple\' escaped quotes'
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        "This 'string' has 'multiple' escaped quotes"
       RUBY
     end
 
@@ -247,6 +273,10 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
         a = 'blah #'
             ^^^^^^^^ Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a = "blah #"
+      RUBY
     end
 
     it 'accepts single quotes at the start of regexp literals' do
@@ -264,18 +294,13 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
         end
       RUBY
     end
-
-    it "auto-corrects ' with \"" do
-      new_source = autocorrect_source("s = 'abc'")
-      expect(new_source).to eq('s = "abc"')
-    end
   end
 
   context 'when configured with a bad value' do
     let(:cop_config) { { 'EnforcedStyle' => 'other' } }
 
     it 'fails' do
-      expect { inspect_source('a = "b"') }
+      expect { expect_no_offenses('a = "b"') }
         .to raise_error(RuntimeError)
     end
   end
@@ -297,6 +322,8 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
             LEFT JOIN X on Y
             FROM Models"
         RUBY
+
+        expect_no_corrections
       end
 
       it 'accepts continued strings using all single quotes' do
@@ -312,6 +339,8 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
           ^^^^^^^ Inconsistent quote style.
           "def"
         RUBY
+
+        expect_no_corrections
       end
 
       it 'registers an offense for unneeded double quotes in continuation' do
@@ -320,6 +349,8 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
           ^^^^^^^ Prefer single-quoted strings when you don't need string interpolation or special symbols.
           "def"
         RUBY
+
+        expect_no_corrections
       end
 
       it "doesn't register offense for double quotes with interpolation" do
@@ -381,6 +412,8 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
           ^^^^^^^ Inconsistent quote style.
           "def"
         RUBY
+
+        expect_no_corrections
       end
 
       it 'registers an offense for unneeded single quotes in continuation' do
@@ -389,6 +422,8 @@ RSpec.describe RuboCop::Cop::Style::StringLiterals, :config do
           ^^^^^^^ Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
           'def'
         RUBY
+
+        expect_no_corrections
       end
 
       it "doesn't register offense for single quotes with embedded double" do

--- a/spec/rubocop/cop/style/string_methods_spec.rb
+++ b/spec/rubocop/cop/style/string_methods_spec.rb
@@ -8,12 +8,10 @@ RSpec.describe RuboCop::Cop::Style::StringMethods, :config do
       'something'.intern
                   ^^^^^^ Prefer `to_sym` over `intern`.
     RUBY
-  end
 
-  it 'auto-corrects' do
-    corrected = autocorrect_source("'something'.intern")
-
-    expect(corrected).to eq("'something'.to_sym")
+    expect_correction(<<~RUBY)
+      'something'.to_sym
+    RUBY
   end
 
   context 'when using safe navigation operator' do
@@ -22,12 +20,10 @@ RSpec.describe RuboCop::Cop::Style::StringMethods, :config do
         something&.intern
                    ^^^^^^ Prefer `to_sym` over `intern`.
       RUBY
-    end
 
-    it 'auto-corrects' do
-      corrected = autocorrect_source('something&.intern')
-
-      expect(corrected).to eq('something&.to_sym')
+      expect_correction(<<~RUBY)
+        something&.to_sym
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/strip_spec.rb
+++ b/spec/rubocop/cop/style/strip_spec.rb
@@ -3,20 +3,25 @@
 RSpec.describe RuboCop::Cop::Style::Strip do
   subject(:cop) { described_class.new }
 
-  it 'autocorrects str.lstrip.rstrip' do
-    new_source = autocorrect_source('str.lstrip.rstrip')
-    expect(new_source).to eq 'str.strip'
-  end
-
-  it 'autocorrects str.rstrip.lstrip' do
-    new_source = autocorrect_source('str.rstrip.lstrip')
-    expect(new_source).to eq 'str.strip'
-  end
-
-  it 'formats the error message correctly for str.lstrip.rstrip' do
+  it 'registers an offense for str.lstrip.rstrip' do
     expect_offense(<<~RUBY)
       str.lstrip.rstrip
           ^^^^^^^^^^^^^ Use `strip` instead of `lstrip.rstrip`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      str.strip
+    RUBY
+  end
+
+  it 'registers an offense for str.rstrip.lstrip' do
+    expect_offense(<<~RUBY)
+      str.rstrip.lstrip
+          ^^^^^^^^^^^^^ Use `strip` instead of `rstrip.lstrip`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      str.strip
     RUBY
   end
 end

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -27,16 +27,21 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
         [:one, :two, :three]
         ^^^^^^^^^^^^^^^^^^^^ Use `%i` or `%I` for an array of symbols.
       RUBY
-    end
 
-    it 'autocorrects arrays of symbols' do
-      new_source = autocorrect_source('[:one, :two, :three]')
-      expect(new_source).to eq('%i(one two three)')
+      expect_correction(<<~RUBY)
+        %i(one two three)
+      RUBY
     end
 
     it 'autocorrects arrays of one symbol' do
-      new_source = autocorrect_source('[:one]')
-      expect(new_source).to eq('%i(one)')
+      expect_offense(<<~RUBY)
+        [:one]
+        ^^^^^^ Use `%i` or `%I` for an array of symbols.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        %i(one)
+      RUBY
     end
 
     it 'autocorrects arrays of symbols with embedded newlines and tabs' do
@@ -52,19 +57,40 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
     end
 
     it 'autocorrects arrays of symbols with new line' do
-      new_source = autocorrect_source("[:one,\n:two, :three,\n:four]")
-      expect(new_source).to eq("%i(one\ntwo three\nfour)")
+      expect_offense(<<~RUBY)
+        [:one,
+        ^^^^^^ Use `%i` or `%I` for an array of symbols.
+        :two, :three,
+        :four]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        %i(one
+        two three
+        four)
+      RUBY
     end
 
     it 'uses %I when appropriate' do
-      new_source = autocorrect_source('[:"\\t", :"\\n", :three]')
-      expect(new_source).to eq('%I(\\t \\n three)')
+      expect_offense(<<~'RUBY')
+        [:"\t", :"\n", :three]
+        ^^^^^^^^^^^^^^^^^^^^^^ Use `%i` or `%I` for an array of symbols.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        %I(\t \n three)
+      RUBY
     end
 
     it "doesn't break when a symbol contains )" do
-      source = '[:one, :")", :three, :"(", :"]", :"["]'
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq('%i(one \\) three \\( ] [)')
+      expect_offense(<<~RUBY)
+        [:one, :")", :three, :"(", :"]", :"["]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `%i` or `%I` for an array of symbols.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        %i(one \) three \( ] [)
+      RUBY
     end
 
     it 'does not register an offense for array with non-syms' do
@@ -89,11 +115,16 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
         foo([:bar, :baz]) { qux }
             ^^^^^^^^^^^^ Use `%i` or `%I` for an array of symbols.
       RUBY
+
+      expect_correction(<<~RUBY)
+        foo(%i(bar baz)) { qux }
+      RUBY
     end
 
     it 'detects right value for MinSize to use for --auto-gen-config' do
-      inspect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         [:one, :two, :three]
+        ^^^^^^^^^^^^^^^^^^^^ Use `%i` or `%I` for an array of symbols.
         %i(a b c d)
       RUBY
 
@@ -102,8 +133,9 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
     end
 
     it 'detects when the cop must be disabled to avoid offenses' do
-      inspect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         [:one, :two, :three]
+        ^^^^^^^^^^^^^^^^^^^^ Use `%i` or `%I` for an array of symbols.
         %i(a b)
       RUBY
 
@@ -122,20 +154,27 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
       end
 
       it 'autocorrects an array with delimiters' do
-        source = '[:one, :")", :three, :"(", :"]", :"["]'
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq('%i[one ) three ( \\] \\[]')
+        expect_offense(<<~RUBY)
+          [:one, :")", :three, :"(", :"]", :"["]
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `%i` or `%I` for an array of symbols.
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          %i[one ) three ( \] \[]
+        RUBY
       end
 
       it 'autocorrects an array in multiple lines' do
-        new_source = autocorrect_source(<<-RUBY)
+        expect_offense(<<-RUBY)
           [
+          ^ Use `%i` or `%I` for an array of symbols.
           :foo,
           :bar,
           :baz
           ]
         RUBY
-        expect(new_source).to eq(<<-RUBY)
+
+        expect_correction(<<-RUBY)
           %i[
           foo
           bar
@@ -145,12 +184,14 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
       end
 
       it 'autocorrects an array using partial newlines' do
-        new_source = autocorrect_source(<<-RUBY)
+        expect_offense(<<-RUBY)
           [:foo, :bar, :baz,
+          ^^^^^^^^^^^^^^^^^^ Use `%i` or `%I` for an array of symbols.
           :boz, :buz,
           :biz]
         RUBY
-        expect(new_source).to eq(<<-RUBY)
+
+        expect_correction(<<-RUBY)
           %i[foo bar baz
           boz buz
           biz]
@@ -171,16 +212,32 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
         %i(one two three)
         ^^^^^^^^^^^^^^^^^ Use `[]` for an array of symbols.
       RUBY
+
+      expect_correction(<<~RUBY)
+        [:one, :two, :three]
+      RUBY
     end
 
     it 'autocorrects an array starting with %i' do
-      new_source = autocorrect_source('%i(one @two $three four-five)')
-      expect(new_source).to eq("[:one, :@two, :$three, :'four-five']")
+      expect_offense(<<~RUBY)
+        %i(one @two $three four-five)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `[]` for an array of symbols.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [:one, :@two, :$three, :'four-five']
+      RUBY
     end
 
     it 'autocorrects an array has interpolations' do
-      new_source = autocorrect_source('%I(#{foo} #{foo}bar foo#{bar} foo)')
-      expect(new_source).to eq('[:"#{foo}", :"#{foo}bar", :"foo#{bar}", :foo]')
+      expect_offense(<<~'RUBY')
+        %I(#{foo} #{foo}bar foo#{bar} foo)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `[]` for an array of symbols.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        [:"#{foo}", :"#{foo}bar", :"foo#{bar}", :foo]
+      RUBY
     end
   end
 
@@ -190,7 +247,7 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
         'EnforcedStyle' => 'percent' }
     end
 
-    it 'does not autocorrects array of one symbol if MinSize > 1' do
+    it 'does not autocorrect array of one symbol if MinSize > 1' do
       expect_no_offenses('[:one]')
     end
   end

--- a/spec/rubocop/cop/style/symbol_literal_spec.rb
+++ b/spec/rubocop/cop/style/symbol_literal_spec.rb
@@ -5,8 +5,13 @@ RSpec.describe RuboCop::Cop::Style::SymbolLiteral do
 
   it 'registers an offense for word-line symbols using string syntax' do
     expect_offense(<<~RUBY)
-      x = { :"test" => 0 }
+      x = { :"test" => 0, :"other" => 1 }
+                          ^^^^^^^^ Do not use strings for word-like symbol literals.
             ^^^^^^^ Do not use strings for word-like symbol literals.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x = { :test => 0, :other => 1 }
     RUBY
   end
 
@@ -20,10 +25,5 @@ RSpec.describe RuboCop::Cop::Style::SymbolLiteral do
 
   it 'accepts string syntax when symbol start with a digit' do
     expect_no_offenses('x = { :"1" => 1 }')
-  end
-
-  it 'auto-corrects by removing quotes' do
-    new_source = autocorrect_source('{ :"ala" => 1, :"bala" => 2 }')
-    expect(new_source).to eq('{ :ala => 1, :bala => 2 }')
   end
 end

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -9,12 +9,20 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
       coll.map { |e| e.upcase }
                ^^^^^^^^^^^^^^^^ Pass `&:upcase` as an argument to `map` instead of a block.
     RUBY
+
+    expect_correction(<<~RUBY)
+      coll.map(&:upcase)
+    RUBY
   end
 
-  it 'registers an offense for a block when method in body is unary -/=' do
+  it 'registers an offense for a block when method in body is unary -/+' do
     expect_offense(<<~RUBY)
       something.map { |x| -x }
                     ^^^^^^^^^^ Pass `&:-@` as an argument to `map` instead of a block.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      something.map(&:-@)
     RUBY
   end
 
@@ -78,32 +86,38 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
         method(one, 2) { |x| x.test }
                        ^^^^^^^^^^^^^^ Pass `&:test` as an argument to `method` instead of a block.
       RUBY
-    end
 
-    it 'auto-corrects' do
-      corrected = autocorrect_source(source)
-      expect(corrected).to eq 'method(one, 2, &:test)'
+      expect_correction(<<~RUBY)
+        method(one, 2, &:test)
+      RUBY
     end
-  end
-
-  it 'autocorrects alias with symbols as proc' do
-    corrected = autocorrect_source('coll.map { |s| s.upcase }')
-    expect(corrected).to eq 'coll.map(&:upcase)'
   end
 
   it 'autocorrects multiple aliases with symbols as proc' do
-    corrected = autocorrect_source('coll.map { |s| s.upcase }' \
-                                   '.map { |s| s.downcase }')
-    expect(corrected).to eq 'coll.map(&:upcase).map(&:downcase)'
+    expect_offense(<<~RUBY)
+      coll.map { |s| s.upcase }.map { |s| s.downcase }
+                                    ^^^^^^^^^^^^^^^^^^ Pass `&:downcase` as an argument to `map` instead of a block.
+               ^^^^^^^^^^^^^^^^ Pass `&:upcase` as an argument to `map` instead of a block.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      coll.map(&:upcase).map(&:downcase)
+    RUBY
   end
 
   it 'auto-corrects correctly when there are no arguments in parentheses' do
-    corrected = autocorrect_source('coll.map(   ) { |s| s.upcase }')
-    expect(corrected).to eq 'coll.map(&:upcase)'
+    expect_offense(<<~RUBY)
+      coll.map(   ) { |s| s.upcase }
+                    ^^^^^^^^^^^^^^^^ Pass `&:upcase` as an argument to `map` instead of a block.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      coll.map(&:upcase)
+    RUBY
   end
 
   it 'does not crash with a bare method call' do
-    run = -> { inspect_source('coll.map { |s| bare_method }') }
+    run = -> { expect_no_offenses('coll.map { |s| bare_method }') }
     expect(&run).not_to raise_error
   end
 
@@ -115,11 +129,10 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
         super(one, two) { |x| x.test }
                         ^^^^^^^^^^^^^^ Pass `&:test` as an argument to `super` instead of a block.
       RUBY
-    end
 
-    it 'auto-corrects' do
-      corrected = autocorrect_source(source)
-      expect(corrected).to eq 'super(one, two, &:test)'
+      expect_correction(<<~RUBY)
+        super(one, two, &:test)
+      RUBY
     end
   end
 
@@ -131,22 +144,23 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
         super { |x| x.test }
               ^^^^^^^^^^^^^^ Pass `&:test` as an argument to `super` instead of a block.
       RUBY
-    end
 
-    it 'auto-corrects' do
-      corrected = autocorrect_source(source)
-      expect(corrected).to eq 'super(&:test)'
+      expect_correction(<<~RUBY)
+        super(&:test)
+      RUBY
     end
   end
 
   it 'auto-corrects correctly when args have a trailing comma' do
-    corrected = autocorrect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       mail(
         to: 'foo',
         subject: 'bar',
       ) { |format| format.text }
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Pass `&:text` as an argument to `mail` instead of a block.
     RUBY
-    expect(corrected).to eq(<<~RUBY)
+
+    expect_correction(<<~RUBY)
       mail(
         to: 'foo',
         subject: 'bar', &:text


### PR DESCRIPTION
Part of #8127

Use newer `expect_offense` and `expect_correction` in specs for Style cops R-S.

Merge `'register offense'` and `'auto-correct'` spec examples where possible.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/