### PR TITLE
Use `Cop::Base` API for `Style` department [A-E]

### DIFF
--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -62,7 +62,7 @@ module RuboCop
       #     private :bar, :baz
       #
       #   end
-      class AccessModifierDeclarations < Cop
+      class AccessModifierDeclarations < Base
         include ConfigurableEnforcedStyle
 
         ACCESS_MODIFIERS = %i[private protected public module_function].to_set.freeze
@@ -84,13 +84,10 @@ module RuboCop
         def on_send(node)
           return unless access_modifier?(node)
           return if node.parent.pair_type?
-          return if cop_config['AllowModifiersOnSymbols'] &&
-                    access_modifier_with_symbol?(node)
+          return if cop_config['AllowModifiersOnSymbols'] && access_modifier_with_symbol?(node)
 
           if offense?(node)
-            add_offense(node, location: :selector) do
-              opposite_style_detected
-            end
+            add_offense(node.loc.selector) if opposite_style_detected
           else
             correct_style_detected
           end
@@ -127,8 +124,8 @@ module RuboCop
           !access_modifier_is_inlined?(node)
         end
 
-        def message(node)
-          access_modifier = node.loc.selector.source
+        def message(range)
+          access_modifier = range.source
 
           if group_style?
             format(GROUP_STYLE_MESSAGE, access_modifier: access_modifier)

--- a/lib/rubocop/cop/style/alias.rb
+++ b/lib/rubocop/cop/style/alias.rb
@@ -22,8 +22,9 @@ module RuboCop
       #
       #   # good
       #   alias_method :bar, :foo
-      class Alias < Cop
+      class Alias < Base
         include ConfigurableEnforcedStyle
+        extend AutoCorrector
 
         MSG_ALIAS = 'Use `alias_method` instead of `alias`.'
         MSG_ALIAS_METHOD = 'Use `alias` instead of `alias_method` ' \
@@ -36,30 +37,36 @@ module RuboCop
           return unless style == :prefer_alias && alias_keyword_possible?(node)
 
           msg = format(MSG_ALIAS_METHOD, current: lexical_scope_type(node))
-          add_offense(node, location: :selector, message: msg)
+          add_offense(node.loc.selector, message: msg) do |corrector|
+            autocorrect(corrector, node)
+          end
         end
 
         def on_alias(node)
           return unless alias_method_possible?(node)
 
           if scope_type(node) == :dynamic || style == :prefer_alias_method
-            add_offense(node, location: :keyword, message: MSG_ALIAS)
+            add_offense(node.loc.keyword, message: MSG_ALIAS) do |corrector|
+              autocorrect(corrector, node)
+            end
           elsif node.children.none? { |arg| bareword?(arg) }
-            add_offense_for_args(node)
-          end
-        end
-
-        def autocorrect(node)
-          if node.send_type?
-            correct_alias_method_to_alias(node)
-          elsif scope_type(node) == :dynamic || style == :prefer_alias_method
-            correct_alias_to_alias_method(node)
-          else
-            correct_alias_with_symbol_args(node)
+            add_offense_for_args(node) do |corrector|
+              autocorrect(corrector, node)
+            end
           end
         end
 
         private
+
+        def autocorrect(corrector, node)
+          if node.send_type?
+            correct_alias_method_to_alias(corrector, node)
+          elsif scope_type(node) == :dynamic || style == :prefer_alias_method
+            correct_alias_to_alias_method(corrector, node)
+          else
+            correct_alias_with_symbol_args(corrector, node)
+          end
+        end
 
         def alias_keyword_possible?(node)
           scope_type(node) != :dynamic && node.arguments.all?(&:sym_type?)
@@ -70,14 +77,14 @@ module RuboCop
             node.children.none?(&:gvar_type?)
         end
 
-        def add_offense_for_args(node)
+        def add_offense_for_args(node, &block)
           existing_args  = node.children.map(&:source).join(' ')
           preferred_args = node.children.map { |a| a.source[1..-1] }.join(' ')
           arg_ranges     = node.children.map(&:source_range)
           msg            = format(MSG_SYMBOL_ARGS,
                                   prefer: preferred_args,
                                   current: existing_args)
-          add_offense(node, location: arg_ranges.reduce(&:join), message: msg)
+          add_offense(arg_ranges.reduce(&:join), message: msg, &block)
         end
 
         # In this expression, will `self` be the same as the innermost enclosing
@@ -115,31 +122,25 @@ module RuboCop
           !sym_node.source.start_with?(':')
         end
 
-        def correct_alias_method_to_alias(send_node)
-          lambda do |corrector|
-            new, old = *send_node.arguments
-            replacement = "alias #{identifier(new)} #{identifier(old)}"
-            corrector.replace(send_node, replacement)
-          end
+        def correct_alias_method_to_alias(corrector, send_node)
+          new, old = *send_node.arguments
+          replacement = "alias #{identifier(new)} #{identifier(old)}"
+
+          corrector.replace(send_node, replacement)
         end
 
-        def correct_alias_to_alias_method(node)
-          lambda do |corrector|
-            replacement =
-              'alias_method ' \
-              ":#{identifier(node.new_identifier)}, " \
-              ":#{identifier(node.old_identifier)}"
-            corrector.replace(node, replacement)
-          end
+        def correct_alias_to_alias_method(corrector, node)
+          replacement =
+            'alias_method ' \
+            ":#{identifier(node.new_identifier)}, " \
+            ":#{identifier(node.old_identifier)}"
+
+          corrector.replace(node, replacement)
         end
 
-        def correct_alias_with_symbol_args(node)
-          lambda do |corrector|
-            corrector.replace(node.new_identifier,
-                              node.new_identifier.source[1..-1])
-            corrector.replace(node.old_identifier,
-                              node.old_identifier.source[1..-1])
-          end
+        def correct_alias_with_symbol_args(corrector, node)
+          corrector.replace(node.new_identifier, node.new_identifier.source[1..-1])
+          corrector.replace(node.old_identifier, node.old_identifier.source[1..-1])
         end
 
         def_node_matcher :identifier, <<~PATTERN

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -36,9 +36,10 @@ module RuboCop
       #   # good
       #   if foo && bar
       #   end
-      class AndOr < Cop
+      class AndOr < Base
         include ConfigurableEnforcedStyle
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Use `%<prefer>s` instead of `%<current>s`.'
 
@@ -55,8 +56,13 @@ module RuboCop
         alias on_until      on_if
         alias on_until_post on_if
 
-        def autocorrect(node)
-          lambda do |corrector|
+        private
+
+        def process_logical_operator(node)
+          return if node.logical_operator?
+
+          message = message(node)
+          add_offense(node.loc.operator, message: message) do |corrector|
             node.each_child_node do |expr|
               if expr.send_type?
                 correct_send(expr, corrector)
@@ -71,18 +77,10 @@ module RuboCop
           end
         end
 
-        private
-
         def on_conditionals(node)
           node.condition.each_node(*AST::Node::OPERATOR_KEYWORDS) do |operator|
             process_logical_operator(operator)
           end
-        end
-
-        def process_logical_operator(node)
-          return if node.logical_operator?
-
-          add_offense(node, location: :operator)
         end
 
         def message(node)

--- a/lib/rubocop/cop/style/array_join.rb
+++ b/lib/rubocop/cop/style/array_join.rb
@@ -17,20 +17,18 @@ module RuboCop
       #   # good
       #   %w(foo bar baz).join(",")
       #
-      class ArrayJoin < Cop
+      class ArrayJoin < Base
+        extend AutoCorrector
+
         MSG = 'Favor `Array#join` over `Array#*`.'
 
         def_node_matcher :join_candidate?, '(send $array :* $str)'
 
         def on_send(node)
-          join_candidate?(node) { add_offense(node, location: :selector) }
-        end
+          return unless (array, join_arg = join_candidate?(node))
 
-        def autocorrect(node)
-          array, join_arg = join_candidate?(node).map(&:source)
-
-          lambda do |corrector|
-            corrector.replace(node, "#{array}.join(#{join_arg})")
+          add_offense(node.loc.selector) do |corrector|
+            corrector.replace(node, "#{array.source}.join(#{join_arg.source})")
           end
         end
       end

--- a/lib/rubocop/cop/style/ascii_comments.rb
+++ b/lib/rubocop/cop/style/ascii_comments.rb
@@ -15,17 +15,17 @@ module RuboCop
       #
       #   # good
       #   # Translates from English to Japanese
-      class AsciiComments < Cop
+      class AsciiComments < Base
         include RangeHelp
 
         MSG = 'Use only ascii symbols in comments.'
 
-        def investigate(processed_source)
+        def on_new_investigation
           processed_source.each_comment do |comment|
             next if comment.text.ascii_only?
             next if only_allowed_non_ascii_chars?(comment.text)
 
-            add_offense(comment, location: first_offense_range(comment))
+            add_offense(first_offense_range(comment))
           end
         end
 

--- a/lib/rubocop/cop/style/attr.rb
+++ b/lib/rubocop/cop/style/attr.rb
@@ -14,8 +14,9 @@ module RuboCop
       #   attr_accessor :something
       #   attr_reader :one, :two, :three
       #
-      class Attr < Cop
+      class Attr < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Do not use `attr`. Use `%<replacement>s` instead.'
 
@@ -26,10 +27,15 @@ module RuboCop
                     !node.parent.class_type? &&
                     !class_eval?(node.parent)
 
-          add_offense(node, location: :selector)
+          message = message(node)
+          add_offense(node.loc.selector, message: message) do |corrector|
+            autocorrect(corrector, node)
+          end
         end
 
-        def autocorrect(node)
+        private
+
+        def autocorrect(corrector, node)
           attr_name, setter = *node.arguments
 
           node_expr = node.source_range
@@ -37,13 +43,9 @@ module RuboCop
 
           remove = range_between(attr_expr.end_pos, node_expr.end_pos) if setter&.boolean_type?
 
-          lambda do |corrector|
-            corrector.replace(node.loc.selector, replacement_method(node))
-            corrector.remove(remove) if remove
-          end
+          corrector.replace(node.loc.selector, replacement_method(node))
+          corrector.remove(remove) if remove
         end
-
-        private
 
         def message(node)
           format(MSG, replacement: replacement_method(node))

--- a/lib/rubocop/cop/style/auto_resource_cleanup.rb
+++ b/lib/rubocop/cop/style/auto_resource_cleanup.rb
@@ -16,7 +16,7 @@ module RuboCop
       #   File.open('file') do |f|
       #     # ...
       #   end
-      class AutoResourceCleanup < Cop
+      class AutoResourceCleanup < Base
         MSG = 'Use the block version of `%<class>s.%<method>s`.'
 
         TARGET_METHODS = {
@@ -32,10 +32,7 @@ module RuboCop
 
             next if cleanup?(node)
 
-            add_offense(node,
-                        message: format(MSG,
-                                        class: target_class,
-                                        method: target_method))
+            add_offense(node, message: format(MSG, class: target_class, method: target_method))
           end
         end
 

--- a/lib/rubocop/cop/style/bare_percent_literals.rb
+++ b/lib/rubocop/cop/style/bare_percent_literals.rb
@@ -23,8 +23,9 @@ module RuboCop
       #   %Q|He said: "#{greeting}"|
       #   %q/She said: 'Hi'/
       #
-      class BarePercentLiterals < Cop
+      class BarePercentLiterals < Base
         include ConfigurableEnforcedStyle
+        extend AutoCorrector
 
         MSG = 'Use `%%%<good>s` instead of `%%%<bad>s`.'
 
@@ -34,14 +35,6 @@ module RuboCop
 
         def on_str(node)
           check(node)
-        end
-
-        def autocorrect(node)
-          src = node.loc.begin.source
-          replacement = src.start_with?('%Q') ? '%' : '%Q'
-          lambda do |corrector|
-            corrector.replace(node.loc.begin, src.sub(/%Q?/, replacement))
-          end
         end
 
         private
@@ -68,9 +61,14 @@ module RuboCop
         end
 
         def add_offense_for_wrong_style(node, good, bad)
-          add_offense(node, location: :begin, message: format(MSG,
-                                                              good: good,
-                                                              bad: bad))
+          location = node.loc.begin
+
+          add_offense(location, message: format(MSG, good: good, bad: bad)) do |corrector|
+            source = location.source
+            replacement = source.start_with?('%Q') ? '%' : '%Q'
+
+            corrector.replace(location, source.sub(/%Q?/, replacement))
+          end
         end
       end
     end

--- a/lib/rubocop/cop/style/begin_block.rb
+++ b/lib/rubocop/cop/style/begin_block.rb
@@ -10,11 +10,11 @@ module RuboCop
       #   # bad
       #   BEGIN { test }
       #
-      class BeginBlock < Cop
+      class BeginBlock < Base
         MSG = 'Avoid the use of `BEGIN` blocks.'
 
         def on_preexe(node)
-          add_offense(node, location: :keyword)
+          add_offense(node.loc.keyword)
         end
       end
     end

--- a/lib/rubocop/cop/style/block_comments.rb
+++ b/lib/rubocop/cop/style/block_comments.rb
@@ -16,34 +16,30 @@ module RuboCop
       #   # Multiple lines
       #   # of comments...
       #
-      class BlockComments < Cop
+      class BlockComments < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Do not use block comments.'
         BEGIN_LENGTH = "=begin\n".length
         END_LENGTH = "\n=end".length
 
-        def investigate(processed_source)
+        def on_new_investigation
           processed_source.each_comment do |comment|
             next unless comment.document?
 
-            add_offense(comment)
-          end
-        end
+            add_offense(comment) do |corrector|
+              eq_begin, eq_end, contents = parts(comment)
 
-        def autocorrect(comment)
-          eq_begin, eq_end, contents = parts(comment)
-
-          lambda do |corrector|
-            corrector.remove(eq_begin)
-            unless contents.length.zero?
-              corrector.replace(contents,
-                                contents.source
-                                  .gsub(/\A/, '# ')
-                                  .gsub(/\n\n/, "\n#\n")
-                                  .gsub(/\n(?=[^#])/, "\n# "))
+              corrector.remove(eq_begin)
+              unless contents.length.zero?
+                corrector.replace(
+                  contents,
+                  contents.source.gsub(/\A/, '# ').gsub(/\n\n/, "\n#\n").gsub(/\n(?=[^#])/, "\n# ")
+                )
+              end
+              corrector.remove(eq_end)
             end
-            corrector.remove(eq_end)
           end
         end
 

--- a/lib/rubocop/cop/style/class_check.rb
+++ b/lib/rubocop/cop/style/class_check.rb
@@ -23,8 +23,9 @@ module RuboCop
       #   var.kind_of?(Time)
       #   var.kind_of?(String)
       #
-      class ClassCheck < Cop
+      class ClassCheck < Base
         include ConfigurableEnforcedStyle
+        extend AutoCorrector
 
         MSG = 'Prefer `Object#%<prefer>s` over `Object#%<current>s`.'
 
@@ -34,15 +35,12 @@ module RuboCop
           class_check?(node) do |method_name|
             return if style == method_name
 
-            add_offense(node, location: :selector)
-          end
-        end
+            message = message(node)
+            add_offense(node.loc.selector, message: message) do |corrector|
+              replacement = node.method?(:is_a?) ? 'kind_of?' : 'is_a?'
 
-        def autocorrect(node)
-          lambda do |corrector|
-            replacement = node.method?(:is_a?) ? 'kind_of?' : 'is_a?'
-
-            corrector.replace(node.loc.selector, replacement)
+              corrector.replace(node.loc.selector, replacement)
+            end
           end
         end
 

--- a/lib/rubocop/cop/style/class_methods.rb
+++ b/lib/rubocop/cop/style/class_methods.rb
@@ -20,7 +20,9 @@ module RuboCop
       #       # ...
       #     end
       #   end
-      class ClassMethods < Cop
+      class ClassMethods < Base
+        extend AutoCorrector
+
         MSG = 'Use `self.%<method>s` instead of `%<class>s.%<method>s`.'
 
         def on_class(node)
@@ -36,23 +38,17 @@ module RuboCop
         end
         alias on_module on_class
 
-        def autocorrect(node)
-          ->(corrector) { corrector.replace(node.loc.name, 'self') }
-        end
-
         private
 
         def check_defs(name, node)
           # check if the class/module name matches the definee for the defs node
           return unless name == node.receiver
 
-          add_offense(node.receiver, location: :name)
-        end
+          message = format(MSG, method: node.method_name, class: name.source)
 
-        def message(node)
-          _, class_name = *node
-
-          format(MSG, method: node.parent.method_name, class: class_name)
+          add_offense(node.receiver.loc.name, message: message) do |corrector|
+            corrector.replace(node.receiver, 'self')
+          end
         end
       end
     end

--- a/lib/rubocop/cop/style/class_vars.rb
+++ b/lib/rubocop/cop/style/class_vars.rb
@@ -45,23 +45,19 @@ module RuboCop
       #     end
       #   end
       #
-      class ClassVars < Cop
-        MSG = 'Replace class var %<class_var>s with a class ' \
-              'instance var.'
+      class ClassVars < Base
+        MSG = 'Replace class var %<class_var>s with a class instance var.'
 
         def on_cvasgn(node)
-          add_offense(node, location: :name)
+          add_offense(node.loc.name, message: format(MSG, class_var: node.children.first))
         end
 
         def on_send(node)
           return unless node.method?(:class_variable_set)
 
-          add_offense(node.first_argument)
-        end
-
-        def message(node)
-          class_var, = *node
-          format(MSG, class_var: class_var)
+          add_offense(
+            node.first_argument, message: format(MSG, class_var: node.first_argument.source)
+          )
         end
       end
     end

--- a/lib/rubocop/cop/style/colon_method_call.rb
+++ b/lib/rubocop/cop/style/colon_method_call.rb
@@ -17,7 +17,9 @@ module RuboCop
       #   FileUtils.rmdir(dir)
       #   Marshal.dump(obj)
       #
-      class ColonMethodCall < Cop
+      class ColonMethodCall < Base
+        extend AutoCorrector
+
         MSG = 'Do not use `::` for method calls.'
 
         def_node_matcher :java_type_node?, <<~PATTERN
@@ -32,15 +34,12 @@ module RuboCop
         def on_send(node)
           return unless node.receiver && node.double_colon?
           return if node.camel_case_method?
-
           # ignore Java interop code like Java::int
           return if java_type_node?(node)
 
-          add_offense(node, location: :dot)
-        end
-
-        def autocorrect(node)
-          ->(corrector) { corrector.replace(node.loc.dot, '.') }
+          add_offense(node.loc.dot) do |corrector|
+            corrector.replace(node.loc.dot, '.')
+          end
         end
       end
     end

--- a/lib/rubocop/cop/style/colon_method_definition.rb
+++ b/lib/rubocop/cop/style/colon_method_definition.rb
@@ -19,17 +19,17 @@ module RuboCop
       #     end
       #   end
       #
-      class ColonMethodDefinition < Cop
+      class ColonMethodDefinition < Base
+        extend AutoCorrector
+
         MSG = 'Do not use `::` for defining class methods.'
 
         def on_defs(node)
           return unless node.loc.operator.source == '::'
 
-          add_offense(node, location: :operator)
-        end
-
-        def autocorrect(node)
-          ->(corrector) { corrector.replace(node.loc.operator, '.') }
+          add_offense(node.loc.operator) do |corrector|
+            corrector.replace(node.loc.operator, '.')
+          end
         end
       end
     end

--- a/lib/rubocop/cop/style/comment_annotation.rb
+++ b/lib/rubocop/cop/style/comment_annotation.rb
@@ -30,9 +30,10 @@ module RuboCop
       #
       #   # good
       #   # OPTIMIZE: does not work
-      class CommentAnnotation < Cop
+      class CommentAnnotation < Base
         include AnnotationComment
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Annotation keywords like `%<keyword>s` should be all ' \
               'upper case, followed by a colon, and a space, ' \
@@ -40,7 +41,7 @@ module RuboCop
         MISSING_NOTE = 'Annotation comment, with keyword `%<keyword>s`, ' \
                        'is missing a note.'
 
-        def investigate(processed_source)
+        def on_new_investigation
           processed_source.comments.each_with_index do |comment, index|
             next unless first_comment_line?(processed_source.comments, index) ||
                         inline_comment?(comment)
@@ -49,25 +50,24 @@ module RuboCop
             next unless annotation?(comment) &&
                         !correct_annotation?(first_word, colon, space, note)
 
-            add_offense(
-              comment,
-              location: annotation_range(comment, margin,
-                                         first_word, colon, space),
-              message: format(note ? MSG : MISSING_NOTE, keyword: first_word)
-            )
+            range = annotation_range(comment, margin, first_word, colon, space)
+
+            register_offense(range, note, first_word)
           end
         end
 
-        def autocorrect(comment)
-          margin, first_word, colon, space, note = split_comment(comment)
-          return if note.nil?
-
-          range = annotation_range(comment, margin, first_word, colon, space)
-
-          ->(corrector) { corrector.replace(range, "#{first_word.upcase}: ") }
-        end
-
         private
+
+        def register_offense(range, note, first_word)
+          add_offense(
+            range,
+            message: format(note ? MSG : MISSING_NOTE, keyword: first_word)
+          ) do |corrector|
+            next if note.nil?
+
+            corrector.replace(range, "#{first_word.upcase}: ")
+          end
+        end
 
         def first_comment_line?(comments, index)
           index.zero? ||

--- a/lib/rubocop/cop/style/constant_visibility.rb
+++ b/lib/rubocop/cop/style/constant_visibility.rb
@@ -26,7 +26,7 @@ module RuboCop
       #     public_constant :BAZ
       #   end
       #
-      class ConstantVisibility < Cop
+      class ConstantVisibility < Base
         MSG = 'Explicitly make `%<constant_name>s` public or private using ' \
               'either `#public_constant` or `#private_constant`.'
 
@@ -34,7 +34,8 @@ module RuboCop
           return unless class_or_module_scope?(node)
           return if visibility_declaration?(node)
 
-          add_offense(node)
+          message = message(node)
+          add_offense(node, message: message)
         end
 
         private

--- a/lib/rubocop/cop/style/copyright.rb
+++ b/lib/rubocop/cop/style/copyright.rb
@@ -15,28 +15,24 @@ module RuboCop
       # that RuboCop scans, a comment that matches this regex must be found or
       # an offense is reported.
       #
-      class Copyright < Cop
+      class Copyright < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Include a copyright notice matching /%<notice>s/ before ' \
               'any code.'
         AUTOCORRECT_EMPTY_WARNING = 'An AutocorrectNotice must be defined in ' \
                                     'your RuboCop config'
 
-        def investigate(processed_source)
-          return if notice.empty?
-          return if notice_found?(processed_source)
+        def on_new_investigation
+          return if notice.empty? || notice_found?(processed_source)
 
-          range = source_range(processed_source.buffer, 1, 0)
-          add_offense(insert_notice_before(processed_source),
-                      location: range, message: format(MSG, notice: notice))
-        end
+          add_offense(offense_range, message: format(MSG, notice: notice)) do |corrector|
+            verify_autocorrect_notice!
 
-        def autocorrect(token)
-          verify_autocorrect_notice!
-
-          lambda do |corrector|
+            token = insert_notice_before(processed_source)
             range = token.nil? ? range_between(0, 0) : token.pos
+
             corrector.insert_before(range, "#{autocorrect_notice}\n")
           end
         end
@@ -49,6 +45,10 @@ module RuboCop
 
         def autocorrect_notice
           cop_config['AutocorrectNotice']
+        end
+
+        def offense_range
+          source_range(processed_source.buffer, 1, 0)
         end
 
         def verify_autocorrect_notice!

--- a/lib/rubocop/cop/style/date_time.rb
+++ b/lib/rubocop/cop/style/date_time.rb
@@ -41,7 +41,7 @@ module RuboCop
       #
       #   # good
       #   something.to_time
-      class DateTime < Cop
+      class DateTime < Base
         CLASS_MSG = 'Prefer Time over DateTime.'
         COERCION_MSG = 'Do not use #to_datetime.'
 

--- a/lib/rubocop/cop/style/def_with_parentheses.rb
+++ b/lib/rubocop/cop/style/def_with_parentheses.rb
@@ -33,24 +33,22 @@ module RuboCop
       #   def Baz.foo
       #     # does a thing
       #   end
-      class DefWithParentheses < Cop
+      class DefWithParentheses < Base
+        extend AutoCorrector
+
         MSG = "Omit the parentheses in defs when the method doesn't accept " \
               'any arguments.'
 
         def on_def(node)
           return if node.single_line?
-          return unless !node.arguments? && node.arguments.loc.begin
+          return unless !node.arguments? && (node_arguments_loc_begin = node.arguments.loc.begin)
 
-          add_offense(node.arguments, location: :begin)
-        end
-        alias on_defs on_def
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.remove(node.loc.begin)
-            corrector.remove(node.loc.end)
+          add_offense(node_arguments_loc_begin) do |corrector|
+            corrector.remove(node_arguments_loc_begin)
+            corrector.remove(node.arguments.loc.end)
           end
         end
+        alias on_defs on_def
       end
     end
   end

--- a/lib/rubocop/cop/style/dir.rb
+++ b/lib/rubocop/cop/style/dir.rb
@@ -16,9 +16,10 @@ module RuboCop
       #
       #   # good
       #   path = __dir__
-      class Dir < Cop
-        MSG = 'Use `__dir__` to get an absolute path to the current ' \
-              "file's directory."
+      class Dir < Base
+        extend AutoCorrector
+
+        MSG = "Use `__dir__` to get an absolute path to the current file's directory."
 
         def_node_matcher :dir_replacement?, <<~PATTERN
           {(send (const {nil? cbase} :File) :expand_path (send (const {nil? cbase} :File) :dirname  #file_keyword?))
@@ -27,13 +28,9 @@ module RuboCop
 
         def on_send(node)
           dir_replacement?(node) do
-            add_offense(node)
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node, '__dir__')
+            add_offense(node) do |corrector|
+              corrector.replace(node, '__dir__')
+            end
           end
         end
 

--- a/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
+++ b/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
@@ -20,21 +20,19 @@ module RuboCop
       #   def fixed_method_name_and_no_rubocop_comments
       #   end
       #
-      class DisableCopsWithinSourceCodeDirective < Cop
+      class DisableCopsWithinSourceCodeDirective < Base
+        extend AutoCorrector
+
         # rubocop:enable Lint/RedundantCopDisableDirective
         MSG = 'Comment to disable/enable RuboCop.'
 
-        def investigate(processed_source)
+        def on_new_investigation
           processed_source.comments.each do |comment|
             next unless rubocop_directive_comment?(comment)
 
-            add_offense(comment)
-          end
-        end
-
-        def autocorrect(comment)
-          lambda do |corrector|
-            corrector.replace(comment, '')
+            add_offense(comment) do |corrector|
+              corrector.replace(comment, '')
+            end
           end
         end
 

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -55,7 +55,7 @@ module RuboCop
       #       Public = Class.new
       #     end
       #
-      class Documentation < Cop
+      class Documentation < Base
         include DocumentationComment
 
         MSG = 'Missing top-level %<type>s documentation comment.'
@@ -84,9 +84,7 @@ module RuboCop
           return if compact_namespace?(node) &&
                     nodoc_comment?(outer_module(node).first)
 
-          add_offense(node,
-                      location: :keyword,
-                      message: format(MSG, type: type))
+          add_offense(node.loc.keyword, message: format(MSG, type: type))
         end
 
         def namespace?(node)

--- a/lib/rubocop/cop/style/documentation_method.rb
+++ b/lib/rubocop/cop/style/documentation_method.rb
@@ -91,7 +91,7 @@ module RuboCop
       #     end
       #   end
       #
-      class DocumentationMethod < Cop
+      class DocumentationMethod < Base
         include DocumentationComment
         include DefNode
 

--- a/lib/rubocop/cop/style/double_cop_disable_directive.rb
+++ b/lib/rubocop/cop/style/double_cop_disable_directive.rb
@@ -24,29 +24,26 @@ module RuboCop
       #   def f # rubocop:disable Style/For, Metrics/AbcSize
       #   end
       #
-      class DoubleCopDisableDirective < Cop
+      class DoubleCopDisableDirective < Base
+        extend AutoCorrector
+
         # rubocop:enable Style/For, Style/DoubleCopDisableDirective
         # rubocop:enable Lint/RedundantCopDisableDirective, Metrics/AbcSize
         MSG = 'More than one disable comment on one line.'
 
-        def investigate(processed_source)
+        def on_new_investigation
           processed_source.comments.each do |comment|
             next unless comment.text.scan(/# rubocop:(?:disable|todo)/).size > 1
 
-            add_offense(comment)
-          end
-        end
+            add_offense(comment) do |corrector|
+              prefix = if comment.text.start_with?('# rubocop:disable')
+                         '# rubocop:disable'
+                       else
+                         '# rubocop:todo'
+                       end
 
-        def autocorrect(comment)
-          prefix = if comment.text.start_with?('# rubocop:disable')
-                     '# rubocop:disable'
-                   else
-                     '# rubocop:todo'
-                   end
-
-          lambda do |corrector|
-            corrector.replace(comment,
-                              comment.text[/#{prefix} \S+/])
+              corrector.replace(comment, comment.text[/#{prefix} \S+/])
+            end
           end
         end
       end

--- a/lib/rubocop/cop/style/double_negation.rb
+++ b/lib/rubocop/cop/style/double_negation.rb
@@ -32,7 +32,7 @@ module RuboCop
       # !!something and !something.nil? are not the same thing.
       # As you're unlikely to write code that can accept values of any type
       # this is rarely a problem in practice.
-      class DoubleNegation < Cop
+      class DoubleNegation < Base
         include ConfigurableEnforcedStyle
 
         MSG = 'Avoid the use of double negation (`!!`).'
@@ -43,7 +43,7 @@ module RuboCop
           return unless double_negative?(node) && node.prefix_bang?
           return if style == :allowed_in_returns && allowed_in_returns?(node)
 
-          add_offense(node, location: :selector)
+          add_offense(node.loc.selector)
         end
 
         private

--- a/lib/rubocop/cop/style/each_for_simple_loop.rb
+++ b/lib/rubocop/cop/style/each_for_simple_loop.rb
@@ -22,7 +22,9 @@ module RuboCop
       #
       #   # good
       #   10.times {}
-      class EachForSimpleLoop < Cop
+      class EachForSimpleLoop < Base
+        extend AutoCorrector
+
         MSG = 'Use `Integer#times` for a simple loop which iterates a fixed ' \
               'number of times.'
 
@@ -33,17 +35,12 @@ module RuboCop
 
           range = send_node.receiver.source_range.join(send_node.loc.selector)
 
-          add_offense(node, location: range)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(range) do |corrector|
             range_type, min, max = offending_each_range(node)
 
             max += 1 if range_type == :irange
 
-            corrector.replace(node.send_node,
-                              "#{max - min}.times")
+            corrector.replace(node.send_node, "#{max - min}.times")
           end
         end
 

--- a/lib/rubocop/cop/style/each_with_object.rb
+++ b/lib/rubocop/cop/style/each_with_object.rb
@@ -16,7 +16,8 @@ module RuboCop
       #
       #   # good
       #   [1, 2].each_with_object({}) { |e, a| a[e] = e }
-      class EachWithObject < Cop
+      class EachWithObject < Base
+        extend AutoCorrector
         include RangeHelp
 
         MSG = 'Use `each_with_object` instead of `%<method>s`.'
@@ -36,31 +37,29 @@ module RuboCop
             return unless first_argument_returned?(args, return_value)
             return if accumulator_param_assigned_to?(body, args)
 
-            add_offense(node, location: method.loc.selector,
-                              message: format(MSG, method: method_name))
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.send_node.loc.selector, 'each_with_object')
-
-            first_arg, second_arg = *node.arguments
-
-            corrector.replace(first_arg, second_arg.source)
-            corrector.replace(second_arg, first_arg.source)
-
-            return_value = return_value(node.body)
-
-            if return_value_occupies_whole_line?(return_value)
-              corrector.remove(whole_line_expression(return_value))
-            else
-              corrector.remove(return_value)
+            message = format(MSG, method: method_name)
+            add_offense(method.loc.selector, message: message) do |corrector|
+              autocorrect(corrector, node, return_value)
             end
           end
         end
 
         private
+
+        def autocorrect(corrector, node, return_value)
+          corrector.replace(node.send_node.loc.selector, 'each_with_object')
+
+          first_arg, second_arg = *node.arguments
+
+          corrector.replace(first_arg, second_arg.source)
+          corrector.replace(second_arg, first_arg.source)
+
+          if return_value_occupies_whole_line?(return_value)
+            corrector.remove(whole_line_expression(return_value))
+          else
+            corrector.remove(return_value)
+          end
+        end
 
         def simple_method_arg?(method_arg)
           method_arg&.basic_literal?

--- a/lib/rubocop/cop/style/empty_case_condition.rb
+++ b/lib/rubocop/cop/style/empty_case_condition.rb
@@ -35,11 +35,11 @@ module RuboCop
       #   else
       #     puts 'more'
       #   end
-      class EmptyCaseCondition < Cop
+      class EmptyCaseCondition < Base
         include RangeHelp
+        extend AutoCorrector
 
-        MSG = 'Do not use empty `case` condition, instead use an `if` '\
-              'expression.'
+        MSG = 'Do not use empty `case` condition, instead use an `if` expression.'
 
         def on_case(case_node)
           return if case_node.condition
@@ -54,19 +54,19 @@ module RuboCop
             body.each_descendant.any?(&:return_type?)
           end
 
-          add_offense(case_node, location: :keyword)
-        end
-
-        def autocorrect(case_node)
-          when_branches = case_node.when_branches
-
-          lambda do |corrector|
-            correct_case_when(corrector, case_node, when_branches)
-            correct_when_conditions(corrector, when_branches)
+          add_offense(case_node.loc.keyword) do |corrector|
+            autocorrect(corrector, case_node)
           end
         end
 
         private
+
+        def autocorrect(corrector, case_node)
+          when_branches = case_node.when_branches
+
+          correct_case_when(corrector, case_node, when_branches)
+          correct_when_conditions(corrector, when_branches)
+        end
 
         def correct_case_when(corrector, case_node, when_nodes)
           case_range = case_node.loc.keyword.join(when_nodes.first.loc.keyword)

--- a/lib/rubocop/cop/style/empty_else.rb
+++ b/lib/rubocop/cop/style/empty_else.rb
@@ -89,10 +89,11 @@ module RuboCop
       #   if condition
       #     statement
       #   end
-      class EmptyElse < Cop
+      class EmptyElse < Base
         include OnNormalIfUnless
         include ConfigurableEnforcedStyle
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Redundant `else`-clause.'
 
@@ -102,16 +103,6 @@ module RuboCop
 
         def on_case(node)
           check(node)
-        end
-
-        def autocorrect(node)
-          return false if autocorrect_forbidden?(node.type.to_s)
-          return false if comment_in_else?(node)
-
-          lambda do |corrector|
-            end_pos = base_node(node).loc.end.begin_pos
-            corrector.remove(range_between(node.loc.else.begin_pos, end_pos))
-          end
         end
 
         private
@@ -132,13 +123,25 @@ module RuboCop
         def empty_check(node)
           return unless node.else? && !node.else_branch
 
-          add_offense(node, location: :else)
+          add_offense(node.loc.else) do |corrector|
+            autocorrect(corrector, node)
+          end
         end
 
         def nil_check(node)
           return unless node.else_branch&.nil_type?
 
-          add_offense(node, location: :else)
+          add_offense(node.loc.else) do |corrector|
+            autocorrect(corrector, node)
+          end
+        end
+
+        def autocorrect(corrector, node)
+          return false if autocorrect_forbidden?(node.type.to_s)
+          return false if comment_in_else?(node)
+
+          end_pos = base_node(node).loc.end.begin_pos
+          corrector.remove(range_between(node.loc.else.begin_pos, end_pos))
         end
 
         def comment_in_else?(node)

--- a/lib/rubocop/cop/style/empty_method.rb
+++ b/lib/rubocop/cop/style/empty_method.rb
@@ -40,8 +40,9 @@ module RuboCop
       #
       #   def self.foo(bar)
       #   end
-      class EmptyMethod < Cop
+      class EmptyMethod < Base
         include ConfigurableEnforcedStyle
+        extend AutoCorrector
 
         MSG_COMPACT = 'Put empty method definitions on a single line.'
         MSG_EXPANDED = 'Put the `end` of empty method definitions on the ' \
@@ -51,19 +52,15 @@ module RuboCop
           return if node.body || comment_lines?(node)
           return if correct_style?(node)
 
-          add_offense(node)
-        end
-        alias on_defs on_def
-
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(node) do |corrector|
             corrector.replace(node, corrected(node))
           end
         end
+        alias on_defs on_def
 
         private
 
-        def message(_node)
+        def message(_range)
           compact_style? ? MSG_COMPACT : MSG_EXPANDED
         end
 

--- a/lib/rubocop/cop/style/encoding.rb
+++ b/lib/rubocop/cop/style/encoding.rb
@@ -9,27 +9,23 @@ module RuboCop
       #   # encoding: UTF-8
       #   # coding: UTF-8
       #   # -*- coding: UTF-8 -*-
-      class Encoding < Cop
+      class Encoding < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG_UNNECESSARY = 'Unnecessary utf-8 encoding comment.'
         ENCODING_PATTERN = /#.*coding\s?[:=]\s?(?:UTF|utf)-8/.freeze
         SHEBANG = '#!'
 
-        def investigate(processed_source)
+        def on_new_investigation
           return if processed_source.buffer.source.empty?
 
           line_number = encoding_line_number(processed_source)
           return unless (@message = offense(processed_source, line_number))
 
           range = processed_source.buffer.line_range(line_number + 1)
-          add_offense(range, location: range, message: @message)
-        end
-
-        def autocorrect(range)
-          lambda do |corrector|
-            corrector.remove(range_with_surrounding_space(range: range,
-                                                          side: :right))
+          add_offense(range, message: @message) do |corrector|
+            corrector.remove(range_with_surrounding_space(range: range, side: :right))
           end
         end
 

--- a/lib/rubocop/cop/style/end_block.rb
+++ b/lib/rubocop/cop/style/end_block.rb
@@ -12,16 +12,14 @@ module RuboCop
       #   # good
       #   at_exit { puts 'Goodbye!' }
       #
-      class EndBlock < Cop
+      class EndBlock < Base
+        extend AutoCorrector
+
         MSG = 'Avoid the use of `END` blocks. ' \
               'Use `Kernel#at_exit` instead.'
 
         def on_postexe(node)
-          add_offense(node, location: :keyword)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(node.loc.keyword) do |corrector|
             corrector.replace(node.loc.keyword, 'at_exit')
           end
         end

--- a/lib/rubocop/cop/style/eval_with_location.rb
+++ b/lib/rubocop/cop/style/eval_with_location.rb
@@ -31,7 +31,7 @@ module RuboCop
       #     def do_something
       #     end
       #   RUBY
-      class EvalWithLocation < Cop
+      class EvalWithLocation < Base
         MSG = 'Pass `__FILE__` and `__LINE__` to `eval` method, ' \
               'as they are used by backtraces.'
         MSG_INCORRECT_LINE = 'Use `%<expected>s` instead of `%<actual>s`, ' \
@@ -126,23 +126,21 @@ module RuboCop
           end
         end
 
-        def add_offense_for_same_line(node, line_node)
+        def add_offense_for_same_line(_node, line_node)
           return if special_line_keyword?(line_node)
 
           add_offense(
-            node,
-            location: line_node.loc.expression,
+            line_node.loc.expression,
             message: message_incorrect_line(line_node, nil, 0)
           )
         end
 
-        def add_offense_for_different_line(node, line_node, line_diff)
+        def add_offense_for_different_line(_node, line_node, line_diff)
           sign = line_diff.positive? ? :+ : :-
           return if line_with_offset?(line_node, sign, line_diff.abs)
 
           add_offense(
-            node,
-            location: line_node.loc.expression,
+            line_node.loc.expression,
             message: message_incorrect_line(line_node, sign, line_diff.abs)
           )
         end

--- a/lib/rubocop/cop/style/even_odd.rb
+++ b/lib/rubocop/cop/style/even_odd.rb
@@ -15,7 +15,9 @@ module RuboCop
       #   # good
       #   if x.even?
       #   end
-      class EvenOdd < Cop
+      class EvenOdd < Base
+        extend AutoCorrector
+
         MSG = 'Replace with `Integer#%<method>s?`.'
 
         def_node_matcher :even_odd_candidate?, <<~PATTERN
@@ -27,18 +29,12 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          even_odd_candidate?(node) do |_base_number, method, arg|
-            replacement_method = replacement_method(arg, method)
-            add_offense(node, message: format(MSG, method: replacement_method))
-          end
-        end
-
-        def autocorrect(node)
           even_odd_candidate?(node) do |base_number, method, arg|
             replacement_method = replacement_method(arg, method)
-
-            correction = "#{base_number.source}.#{replacement_method}?"
-            ->(corrector) { corrector.replace(node, correction) }
+            add_offense(node, message: format(MSG, method: replacement_method)) do |corrector|
+              correction = "#{base_number.source}.#{replacement_method}?"
+              corrector.replace(node, correction)
+            end
           end
         end
 

--- a/lib/rubocop/cop/style/exponential_notation.rb
+++ b/lib/rubocop/cop/style/exponential_notation.rb
@@ -58,7 +58,7 @@ module RuboCop
       #   1e4
       #   12e5
       #
-      class ExponentialNotation < Cop
+      class ExponentialNotation < Base
         include ConfigurableEnforcedStyle
         MESSAGES = {
           scientific: 'Use a mantissa in [1, 10[.',

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe RuboCop::Cop::Cop, :config do
     end
 
     context 'when cop supports autocorrection' do
-      let(:cop_class) { RuboCop::Cop::Style::Alias }
+      let(:cop_class) { RuboCop::Cop::Style::ZeroLengthPredicate }
 
       context 'when offense was corrected' do
         before do

--- a/spec/rubocop/cop/style/class_vars_spec.rb
+++ b/spec/rubocop/cop/style/class_vars_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::Style::ClassVars do
     expect_offense(<<~RUBY)
       class TestClass
         class_variable_set(:@@test, 2)
-                           ^^^^^^^ Replace class var @@test with a class instance var.
+                           ^^^^^^^ Replace class var :@@test with a class instance var.
       end
     RUBY
   end
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::Style::ClassVars do
     expect_offense(<<~RUBY)
       class TestClass; end
       TestClass.class_variable_set(:@@test, 42)
-                                   ^^^^^^^ Replace class var @@test with a class instance var.
+                                   ^^^^^^^ Replace class var :@@test with a class instance var.
     RUBY
   end
 


### PR DESCRIPTION
Follow #7868.

This PR uses `Cop::Base` API for almost `Style` department's cops.
It targets cop that names begin between A and E. And several A-E cops will be excluded from this PR target and addressed separately.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
