### PR TITLE
Fix a false positive for `Lint/UriRegexp`

### DIFF
--- a/spec/rubocop/cop/lint/uri_regexp_spec.rb
+++ b/spec/rubocop/cop/lint/uri_regexp_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe RuboCop::Cop::Lint::UriRegexp do
     RUBY
   end
 
+  it 'does not register an offense when using `regexp` with variable receiver' do
+    expect_no_offenses(<<~RUBY)
+      m.regexp('http://example.com')
+    RUBY
+  end
+
   it 'registers an offense and corrects using `URI.regexp` with argument' do
     expect_offense(<<~RUBY)
       URI.regexp('http://example.com')


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/8467#issuecomment-669996714.

This PR fixes false positive for `Lint/UriRegexp` when using `regexp` with variable receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
