### PR TITLE
[Fix #8475] Fix a false positive for Style/HashAsLastArrayItem when t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#8478](https://github.com/rubocop-hq/rubocop/issues/8478): Relax `Lint/BinaryOperatorWithIdenticalOperands` for mathematical operations. ([@marcandre][])
 * [#8480](https://github.com/rubocop-hq/rubocop/issues/8480): Tweak callback list of `Lint/MissingSuper`. ([@marcandre][])
 * [#8481](https://github.com/rubocop-hq/rubocop/pull/8481): Fix autocorrect for elements with newlines in `Style/SymbolArray` and `Style/WordArray`. ([@biinari][])
+* [#8475](https://github.com/rubocop-hq/rubocop/issues/8475): Fix a false positive for `Style/HashAsLastArrayItem` when there are duplicate hashes in the array. ([@wcmonty][])
 
 ## 0.89.0 (2020-08-05)
 
@@ -4764,3 +4765,4 @@
 [@volfgox]: https://github.com/volfgox
 [@dsavochkin]: https://github.com/dmytro-savochkin
 [@sonalinavlakhe]: https://github.com/sonalinavlakhe
+[@wcmonty]: https://github.com/wcmonty

--- a/lib/rubocop/cop/style/hash_as_last_array_item.rb
+++ b/lib/rubocop/cop/style/hash_as_last_array_item.rb
@@ -40,7 +40,7 @@ module RuboCop
           parent = node.parent
           return false unless parent
 
-          parent.array_type? && parent.values.last == node
+          parent.array_type? && parent.children.last.equal?(node)
         end
 
         def check_braces(node)

--- a/spec/rubocop/cop/style/hash_as_last_array_item_spec.rb
+++ b/spec/rubocop/cop/style/hash_as_last_array_item_spec.rb
@@ -39,12 +39,12 @@ RSpec.describe RuboCop::Cop::Style::HashAsLastArrayItem, :config do
 
     it 'registers an offense and corrects when hash with braces' do
       expect_offense(<<~RUBY)
-        [{ one: 1 }, 2, { three: 3 }]
-                        ^^^^^^^^^^^^ Omit the braces around the hash.
+        [{ one: 1 }, { three: 3 }, 2, { three: 3 }]
+                                      ^^^^^^^^^^^^ Omit the braces around the hash.
       RUBY
 
       expect_correction(<<~RUBY)
-        [{ one: 1 }, 2,  three: 3 ]
+        [{ one: 1 }, { three: 3 }, 2,  three: 3 ]
       RUBY
     end
 


### PR DESCRIPTION
Closes #8475

The issue is that we were previously comparing values to the last node.  If a node equals the last node it will be marked with an offense, when it should not be.