### PR TITLE
Fix autocorrect for percent literal array with newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#8466](https://github.com/rubocop-hq/rubocop/issues/8466): Fix a false positive for `Lint/UriRegexp` when using `regexp` method without receiver. ([@koic][])
 * [#8478](https://github.com/rubocop-hq/rubocop/issues/8478): Relax `Lint/BinaryOperatorWithIdenticalOperands` for mathematical operations. ([@marcandre][])
 * [#8480](https://github.com/rubocop-hq/rubocop/issues/8480): Tweak callback list of `Lint/MissingSuper`. ([@marcandre][])
+* [#8481](https://github.com/rubocop-hq/rubocop/pull/8481): Fix autocorrect for elements with newlines in `Style/SymbolArray` and `Style/WordArray`. ([@biinari][])
 
 ## 0.89.0 (2020-08-05)
 

--- a/lib/rubocop/cop/correctors/percent_literal_corrector.rb
+++ b/lib/rubocop/cop/correctors/percent_literal_corrector.rb
@@ -71,7 +71,7 @@ module RuboCop
                                     prev_line_num,
                                     base_line_num,
                                     index)
-          prev_line_num = word_node.first_line
+          prev_line_num = word_node.last_line
           content = fix_escaped_content(word_node, escape, delimiters)
           line_breaks + content
         end

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
       expect(new_source).to eq('%i(one)')
     end
 
+    it 'autocorrects arrays of symbols with embedded newlines and tabs' do
+      expect_offense(<<~RUBY, tab: "\t")
+        [:"%{tab}", :"two
+        ^^^^{tab}^^^^^^^^ Use `%i` or `%I` for an array of symbols.
+        ", :three]
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        %I(\t two\n three)
+      RUBY
+    end
+
     it 'autocorrects arrays of symbols with new line' do
       new_source = autocorrect_source("[:one,\n:two, :three,\n:four]")
       expect(new_source).to eq("%i(one\ntwo three\nfour)")

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -58,9 +58,16 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       RUBY
     end
 
-    it 'registers an offense for strings with embedded newlines and tabs' do
-      inspect_source(%(["one\n", "hi\tthere"]))
-      expect(cop.offenses.size).to eq(1)
+    it 'uses %W when autocorrecting strings with embedded newlines and tabs' do
+      expect_offense(<<~RUBY)
+        ["one
+        ^^^^^ Use `%w` or `%W` for an array of words.
+        ", "hi\tthere"]
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        %W(one\n hi\tthere)
+      RUBY
     end
 
     it 'registers an offense for strings with newline and tab escapes' do


### PR DESCRIPTION
Fix line number when array element contains newline so that extra newlines
are not added to the result

Use `expect_correction` for embedded newline in percent literal array

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/