### PR TITLE
Refactor specs to use expect_offense in Style cops T-Z

### DIFF
--- a/spec/rubocop/cop/style/trailing_body_on_class_spec.rb
+++ b/spec/rubocop/cop/style/trailing_body_on_class_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnClass do
   let(:config) do
     RuboCop::Config.new('Layout/IndentationWidth' => { 'Width' => 2 })
   end
+  let(:trailing_whitespace) { ' ' }
 
   it 'registers an offense when body trails after class definition' do
     expect_offense(<<~RUBY)
@@ -16,12 +17,30 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnClass do
                  ^^^^^^^^^^^^ Place the first line of class body on its own line.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo#{trailing_whitespace}
+        body
+      end
+      class Bar#{trailing_whitespace}
+        def bar; end
+      end
+    RUBY
   end
 
   it 'registers offense with multi-line class' do
     expect_offense(<<~RUBY)
       class Foo; body
                  ^^^^ Place the first line of class body on its own line.
+        def bar
+          qux
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo#{trailing_whitespace}
+        body
         def bar
           qux
         end
@@ -44,52 +63,36 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnClass do
     RUBY
   end
 
-  it 'auto-corrects body after class definition' do
-    corrected = autocorrect_source(<<~RUBY)
-      class Foo; body 
-      end
-    RUBY
-    expect(corrected).to eq(<<~RUBY)
-      class Foo 
-        body 
-      end
-    RUBY
-  end
-
   it 'auto-corrects with comment after body' do
-    corrected = autocorrect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       class BarQux; foo # comment
+                    ^^^ Place the first line of class body on its own line.
       end
     RUBY
-    expect(corrected).to eq(<<~RUBY)
-      # comment
-      class BarQux 
-        foo 
-      end
-    RUBY
-  end
 
-  it 'auto-corrects when there are multiple semicolons' do
-    corrected = autocorrect_source(<<~RUBY)
-      class Bar; def bar; end
-      end
-    RUBY
-    expect(corrected).to eq(<<~RUBY)
-      class Bar 
-        def bar; end
+    expect_correction(<<~RUBY)
+      # comment
+      class BarQux#{trailing_whitespace}
+        foo#{trailing_whitespace}
       end
     RUBY
   end
 
   context 'when class is not on first line of processed_source' do
     it 'auto-correct offense' do
-      corrected = autocorrect_source(['',
-                                      '  class Foo; body ',
-                                      '  end'].join("\n"))
-      expect(corrected).to eq ['',
-                               '  class Foo ',
-                               '    body ',
-                               '  end'].join("\n")
+      expect_offense(<<-RUBY.strip_margin('|'))
+        |
+        |  class Foo; body#{trailing_whitespace}
+        |             ^^^^ Place the first line of class body on its own line.
+        |  end
+      RUBY
+
+      expect_correction(<<-RUBY.strip_margin('|'))
+        |
+        |  class Foo#{trailing_whitespace}
+        |    body#{trailing_whitespace}
+        |  end
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/trailing_body_on_method_definition_spec.rb
+++ b/spec/rubocop/cop/style/trailing_body_on_method_definition_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnMethodDefinition do
   let(:config) do
     RuboCop::Config.new('Layout/IndentationWidth' => { 'Width' => 2 })
   end
+  let(:trailing_whitespace) { ' ' }
 
   it 'registers an offense when body trails after method definition' do
     expect_offense(<<~RUBY)
@@ -19,6 +20,18 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnMethodDefinition do
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ Place the first line of a multi-line method definition's body on its own line.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def some_method#{trailing_whitespace}
+        body
+      end
+      def extra_large#{trailing_whitespace}
+        { size: 15 };
+      end
+      def seven_times(stuff)#{trailing_whitespace}
+        7.times { do_this(stuff) }
+      end
+    RUBY
   end
 
   it 'registers when body starts on def line & continues one more line' do
@@ -28,12 +41,27 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnMethodDefinition do
         more_body(foo)
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def some_method#{trailing_whitespace}
+        foo = {}
+        more_body(foo)
+      end
+    RUBY
   end
 
   it 'registers when body starts on def line & continues many more lines' do
     expect_offense(<<~RUBY)
       def do_stuff(thing) process(thing)
                           ^^^^^^^^^^^^^^ Place the first line of a multi-line method definition's body on its own line.
+        8.times { thing + 9 }
+        even_more(thing)
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def do_stuff(thing)#{trailing_whitespace}
+        process(thing)
         8.times { thing + 9 }
         even_more(thing)
       end
@@ -66,78 +94,64 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnMethodDefinition do
     RUBY
   end
 
-  it 'auto-corrects body after method definition' do
-    corrected = autocorrect_source(['  def some_method; body',
-                                    '  end'].join("\n"))
-    expect(corrected).to eq ['  def some_method ',
-                             '    body',
-                             '  end'].join("\n")
-  end
-
   it 'auto-corrects with comment after body' do
-    corrected = autocorrect_source(['  def some_method; body # stuff',
-                                    '  end'].join("\n"))
-    expect(corrected).to eq ['  # stuff',
-                             '  def some_method ',
-                             '    body ',
-                             '  end'].join("\n")
-  end
+    expect_offense(<<-RUBY.strip_margin('|'))
+      |  def some_method; body # stuff
+      |                   ^^^^ Place the first line of a multi-line method definition's body on its own line.
+      |  end
+    RUBY
 
-  it 'auto-corrects body with method definition with args in parens' do
-    corrected = autocorrect_source(['  def some_method(arg1, arg2) body',
-                                    '  end'].join("\n"))
-    expect(corrected).to eq ['  def some_method(arg1, arg2) ',
-                             '    body',
-                             '  end'].join("\n")
+    expect_correction(<<-RUBY.strip_margin('|'))
+      |  # stuff
+      |  def some_method#{trailing_whitespace}
+      |    body#{trailing_whitespace}
+      |  end
+    RUBY
   end
 
   it 'auto-corrects body with method definition with args not in parens' do
-    corrected = autocorrect_source(['  def some_method arg1, arg2; body',
-                                    '  end'].join("\n"))
-    expect(corrected).to eq ['  def some_method arg1, arg2 ',
-                             '    body',
-                             '  end'].join("\n")
+    expect_offense(<<-RUBY.strip_margin('|'))
+      |  def some_method arg1, arg2; body
+      |                              ^^^^ Place the first line of a multi-line method definition's body on its own line.
+      |  end
+    RUBY
+
+    expect_correction(<<-RUBY.strip_margin('|'))
+      |  def some_method arg1, arg2#{trailing_whitespace}
+      |    body
+      |  end
+    RUBY
   end
 
   it 'auto-correction removes semicolon from method definition but not body' do
-    corrected = autocorrect_source(['  def some_method; body; more_body;',
-                                    '  end'].join("\n"))
-    expect(corrected).to eq ['  def some_method ',
-                             '    body; more_body;',
-                             '  end'].join("\n")
-  end
+    expect_offense(<<-RUBY.strip_margin('|'))
+      |  def some_method; body; more_body;
+      |                   ^^^^ Place the first line of a multi-line method definition's body on its own line.
+      |  end
+    RUBY
 
-  it 'auto-corrects when body continues on one more line' do
-    corrected = autocorrect_source(['  def some_method; body',
-                                    '    more_body',
-                                    '  end'].join("\n"))
-    expect(corrected).to eq ['  def some_method ',
-                             '    body',
-                             '    more_body',
-                             '  end'].join("\n")
-  end
-
-  it 'auto-corrects when body continues on multiple more line' do
-    corrected = autocorrect_source(['  def some_method; []',
-                                    '    more_body',
-                                    '    even_more',
-                                    '  end'].join("\n"))
-    expect(corrected).to eq ['  def some_method ',
-                             '    []',
-                             '    more_body',
-                             '    even_more',
-                             '  end'].join("\n")
+    expect_correction(<<-RUBY.strip_margin('|'))
+      |  def some_method#{trailing_whitespace}
+      |    body; more_body;
+      |  end
+    RUBY
   end
 
   context 'when method is not on first line of processed_source' do
     it 'auto-corrects offense' do
-      corrected = autocorrect_source(['',
-                                      '  def some_method; body',
-                                      '  end'].join("\n"))
-      expect(corrected).to eq ['',
-                               '  def some_method ',
-                               '    body',
-                               '  end'].join("\n")
+      expect_offense(<<-RUBY.strip_margin('|'))
+        |
+        |  def some_method; body
+        |                   ^^^^ Place the first line of a multi-line method definition's body on its own line.
+        |  end
+      RUBY
+
+      expect_correction(<<-RUBY.strip_margin('|'))
+        |
+        |  def some_method#{trailing_whitespace}
+        |    body
+        |  end
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/trailing_body_on_module_spec.rb
+++ b/spec/rubocop/cop/style/trailing_body_on_module_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnModule do
   let(:config) do
     RuboCop::Config.new('Layout/IndentationWidth' => { 'Width' => 2 })
   end
+  let(:trailing_whitespace) { ' ' }
 
   it 'registers an offense when body trails after module definition' do
     expect_offense(<<~RUBY)
@@ -14,6 +15,15 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnModule do
       end
       module Bar extend self
                  ^^^^^^^^^^^ Place the first line of module body on its own line.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      module Foo#{trailing_whitespace}
+        body
+      end
+      module Bar#{trailing_whitespace}
+        extend self
       end
     RUBY
   end
@@ -27,12 +37,27 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnModule do
         end
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      module Foo#{trailing_whitespace}
+        body
+        def bar
+          qux
+        end
+      end
+    RUBY
   end
 
   it 'registers offense when module definition uses semicolon' do
     expect_offense(<<~RUBY)
       module Foo; do_stuff
                   ^^^^^^^^ Place the first line of module body on its own line.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      module Foo#{trailing_whitespace}
+        do_stuff
       end
     RUBY
   end
@@ -45,54 +70,48 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnModule do
     RUBY
   end
 
-  it 'auto-corrects body after module definition' do
-    corrected = autocorrect_source(<<~RUBY)
-      module Foo extend self 
-      end
-    RUBY
-    expect(corrected).to eq(<<~RUBY)
-      module Foo 
-        extend self 
-      end
-    RUBY
-  end
-
   it 'auto-corrects with comment after body' do
-    corrected = autocorrect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       module BarQux; foo # comment
+                     ^^^ Place the first line of module body on its own line.
       end
     RUBY
-    expect(corrected).to eq(<<~RUBY)
+
+    expect_correction(<<~RUBY)
       # comment
-      module BarQux 
-        foo 
+      module BarQux#{trailing_whitespace}
+        foo#{trailing_whitespace}
       end
     RUBY
   end
 
   it 'auto-corrects when there are multiple semicolons' do
-    corrected = autocorrect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       module Bar; def bar; end
+                  ^^^^^^^^^^^^ Place the first line of module body on its own line.
       end
     RUBY
-    expect(corrected).to eq(<<~RUBY)
-      module Bar 
+
+    expect_correction(<<~RUBY)
+      module Bar#{trailing_whitespace}
         def bar; end
       end
     RUBY
   end
 
   context 'when module is not on first line of processed_source' do
-    it 'auto-correct offense' do
-      corrected = autocorrect_source(<<~RUBY)
+    it 'auto-corrects offense' do
+      expect_offense(<<~RUBY)
 
-        module Foo; body 
+        module Foo; body#{trailing_whitespace}
+                    ^^^^ Place the first line of module body on its own line.
         end
       RUBY
-      expect(corrected).to eq(<<~RUBY)
 
-        module Foo 
-          body 
+      expect_correction(<<~RUBY)
+
+        module Foo#{trailing_whitespace}
+          body#{trailing_whitespace}
         end
       RUBY
     end

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
         some_method(a, b, c, )
                            ^ Avoid comma after the last parameter of a method call#{extra_info}.
       RUBY
+
+      expect_correction(<<~RUBY)
+        some_method(a, b, c )
+      RUBY
     end
 
     it 'registers an offense for trailing comma preceded by whitespace' \
@@ -15,6 +19,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
         some_method(a, b, c , )
                             ^ Avoid comma after the last parameter of a method call#{extra_info}.
       RUBY
+
+      expect_correction(<<~RUBY)
+        some_method(a, b, c  )
+      RUBY
     end
 
     it 'registers an offense for trailing comma in a method call with hash' \
@@ -22,6 +30,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       expect_offense(<<~RUBY)
         some_method(a, b, c: 0, d: 1, )
                                     ^ Avoid comma after the last parameter of a method call#{extra_info}.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        some_method(a, b, c: 0, d: 1 )
       RUBY
     end
 
@@ -53,17 +65,6 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       RUBY
     end
 
-    it 'auto-corrects unwanted comma in a method call' do
-      new_source = autocorrect_source('some_method(a, b, c, )')
-      expect(new_source).to eq('some_method(a, b, c )')
-    end
-
-    it 'auto-corrects unwanted comma in a method call with hash parameters at' \
-       ' the end' do
-      new_source = autocorrect_source('some_method(a, b, c: 0, d: 1, )')
-      expect(new_source).to eq('some_method(a, b, c: 0, d: 1 )')
-    end
-
     it 'accepts heredoc without trailing comma' do
       expect_no_offenses(<<~RUBY)
         route(1, <<-HELP.chomp)
@@ -78,6 +79,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
           receiver&.some_method(a, b, c, )
                                        ^ Avoid comma after the last parameter of a method call#{extra_info}.
         RUBY
+
+        expect_correction(<<~RUBY)
+          receiver&.some_method(a, b, c )
+        RUBY
       end
 
       it 'registers an offense for trailing comma in a method call with hash' \
@@ -86,19 +91,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
           receiver&.some_method(a, b, c: 0, d: 1, )
                                                 ^ Avoid comma after the last parameter of a method call#{extra_info}.
         RUBY
-      end
 
-      it 'auto-corrects unwanted comma in a method call' do
-        new_source = autocorrect_source('receiver&.some_method(a, b, c, )')
-        expect(new_source).to eq('receiver&.some_method(a, b, c )')
-      end
-
-      it 'auto-corrects unwanted comma in a method call with hash parameters' \
-        ' at the end' do
-        new_source = autocorrect_source(
-          'receiver&.some_method(a, b, c: 0, d: 1, )'
-        )
-        expect(new_source).to eq('receiver&.some_method(a, b, c: 0, d: 1 )')
+        expect_correction(<<~RUBY)
+          receiver&.some_method(a, b, c: 0, d: 1 )
+        RUBY
       end
     end
   end
@@ -171,6 +167,14 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
                         d: 1,)
                             ^ Avoid comma after the last parameter of a method call.
         RUBY
+
+        expect_correction(<<~RUBY)
+          some_method(
+                        a,
+                        b,
+                        c: 0,
+                        d: 1)
+        RUBY
       end
 
       it 'accepts a method call with ' \
@@ -239,16 +243,18 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       end
 
       it 'auto-corrects unwanted comma after modified heredoc parameter' do
-        new_source = autocorrect_source(<<~RUBY)
+        expect_offense(<<~'RUBY')
           some_method(
-            <<-LOREM.delete("\\n"),
+            <<-LOREM.delete("\n"),
+                                 ^ Avoid comma after the last parameter of a method call.
               Something with a , in it
             LOREM
           )
         RUBY
-        expect(new_source).to eq(<<~RUBY)
+
+        expect_correction(<<~'RUBY')
           some_method(
-            <<-LOREM.delete("\\n")
+            <<-LOREM.delete("\n")
               Something with a , in it
             LOREM
           )
@@ -278,17 +284,20 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
         end
 
         it 'auto-corrects unwanted comma inside string interpolation' do
-          new_source = autocorrect_source(<<~RUBY)
+          expect_offense(<<~'RUBY')
             some_method(
               bar: <<-BAR,
-                \#{other_method(a, b,)} foo, bar
+                #{other_method(a, b,)} foo, bar
+                                   ^ Avoid comma after the last parameter of a method call.
               BAR
               baz: <<-BAZ
-                \#{third_method(c, d,)} foo, bar
+                #{third_method(c, d,)} foo, bar
+                                   ^ Avoid comma after the last parameter of a method call.
               BAZ
             )
           RUBY
-          expect(new_source).to eq(<<~RUBY)
+
+          expect_correction(<<~RUBY)
             some_method(
               bar: <<-BAR,
                 \#{other_method(a, b)} foo, bar
@@ -299,24 +308,6 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
             )
           RUBY
         end
-      end
-
-      it 'auto-corrects unwanted comma in a method call with hash parameters' \
-         ' at the end' do
-        new_source = autocorrect_source(<<~RUBY)
-          some_method(
-                        a,
-                        b,
-                        c: 0,
-                        d: 1,)
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          some_method(
-                        a,
-                        b,
-                        c: 0,
-                        d: 1)
-        RUBY
       end
     end
 
@@ -342,6 +333,15 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
                         c: 0,
                         d: 1
                         ^^^^ Put a comma after the last parameter of a multiline method call.
+                     )
+        RUBY
+
+        expect_correction(<<~RUBY)
+          some_method(
+                        a,
+                        b,
+                        c: 0,
+                        d: 1,
                      )
         RUBY
       end
@@ -404,26 +404,6 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
         RUBY
       end
 
-      it 'auto-corrects missing comma in a method call with hash parameters' \
-         ' at the end' do
-        new_source = autocorrect_source(<<~RUBY)
-          some_method(
-                        a,
-                        b,
-                        c: 0,
-                        d: 1
-                     )
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          some_method(
-                        a,
-                        b,
-                        c: 0,
-                        d: 1,
-                     )
-        RUBY
-      end
-
       it 'accepts a multiline call with a single argument and trailing comma' do
         expect_no_offenses(<<~RUBY)
           method(
@@ -469,6 +449,11 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
                         c: "d")
                         ^^^^^^ Put a comma after the last parameter of a multiline method call.
           RUBY
+
+          expect_correction(<<~RUBY)
+            some_method(a: "b",
+                        c: "d",)
+          RUBY
         end
       end
 
@@ -483,6 +468,15 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
                         ^^^^ Put a comma after the last parameter of a multiline method call.
                      )
         RUBY
+
+        expect_correction(<<~RUBY)
+          some_method(
+                        a,
+                        b,
+                        c: 0,
+                        d: 1,
+                     )
+        RUBY
       end
 
       it 'registers an offense for no trailing comma in a method call with' \
@@ -490,6 +484,11 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
         expect_offense(<<~RUBY)
           some_method(a, b
                          ^ Put a comma after the last parameter of a multiline method call.
+                     )
+        RUBY
+
+        expect_correction(<<~RUBY)
+          some_method(a, b,
                      )
         RUBY
       end
@@ -551,37 +550,19 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       end
 
       it 'auto-corrects missing comma after a heredoc' do
-        new_source = autocorrect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           route(1, <<-HELP.chomp
+                   ^^^^^^^^^^^^^ Put a comma after the last parameter of a multiline method call.
           ...
           HELP
           )
         RUBY
-        expect(new_source).to eq(<<~RUBY)
+
+        expect_correction(<<~RUBY)
           route(1, <<-HELP.chomp,
           ...
           HELP
           )
-        RUBY
-      end
-
-      it 'auto-corrects missing comma in a method call with hash parameters' \
-         ' at the end' do
-        new_source = autocorrect_source(<<~RUBY)
-          some_method(
-                        a,
-                        b,
-                        c: 0,
-                        d: 1
-                     )
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          some_method(
-                        a,
-                        b,
-                        c: 0,
-                        d: 1,
-                     )
         RUBY
       end
 

--- a/spec/rubocop/cop/style/trailing_comma_in_array_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_array_literal_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArrayLiteral, :config do
         VALUES = [1001, 2020, 3333, ]
                                   ^ Avoid comma after the last item of an array#{extra_info}.
       RUBY
+
+      expect_correction(<<~RUBY)
+        VALUES = [1001, 2020, 3333 ]
+      RUBY
     end
 
     it 'accepts literal without trailing comma' do
@@ -29,11 +33,6 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArrayLiteral, :config do
         rescue RuntimeError
         end
       RUBY
-    end
-
-    it 'auto-corrects unwanted comma in literal' do
-      new_source = autocorrect_source('VALUES = [1001, 2020, 3333, ]')
-      expect(new_source).to eq('VALUES = [1001, 2020, 3333 ]')
     end
   end
 
@@ -72,6 +71,14 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArrayLiteral, :config do
                          ^ Avoid comma after the last item of an array.
                    ]
         RUBY
+
+        expect_correction(<<~RUBY)
+          VALUES = [
+                     1001,
+                     2020,
+                     3333
+                   ]
+        RUBY
       end
 
       it 'accepts a literal with no trailing comma' do
@@ -79,23 +86,6 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArrayLiteral, :config do
           VALUES = [ 1001,
                      2020,
                      3333 ]
-        RUBY
-      end
-
-      it 'auto-corrects unwanted comma' do
-        new_source = autocorrect_source(<<~RUBY)
-          VALUES = [
-                     1001,
-                     2020,
-                     3333,
-                   ]
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          VALUES = [
-                     1001,
-                     2020,
-                     3333
-                   ]
         RUBY
       end
 
@@ -110,14 +100,16 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArrayLiteral, :config do
       end
 
       it 'auto-corrects unwanted comma where HEREDOC has commas' do
-        new_source = autocorrect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           [
             <<-TEXT, 123,
+                        ^ Avoid comma after the last item of an array.
               Something with a , in it
             TEXT
           ]
         RUBY
-        expect(new_source).to eq(<<~RUBY)
+
+        expect_correction(<<~RUBY)
           [
             <<-TEXT, 123
               Something with a , in it
@@ -159,6 +151,13 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArrayLiteral, :config do
                          ^ Avoid comma after the last item of an array, unless each item is on its own line.
                    ]
         RUBY
+
+        expect_correction(<<~RUBY)
+          VALUES = [
+                     1001, 2020,
+                     3333
+                   ]
+        RUBY
       end
 
       it 'accepts trailing comma' do
@@ -187,22 +186,6 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArrayLiteral, :config do
         RUBY
       end
 
-      it 'auto-corrects literal with two of the values on the same' \
-         ' line and a trailing comma' do
-        new_source = autocorrect_source(<<~RUBY)
-          VALUES = [
-                     1001, 2020,
-                     3333
-                   ]
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          VALUES = [
-                     1001, 2020,
-                     3333
-                   ]
-        RUBY
-      end
-
       it 'accepts a multiline array with a single item and trailing comma' do
         expect_no_offenses(<<~RUBY)
           foo = [
@@ -223,6 +206,13 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArrayLiteral, :config do
                        2020,
                        3333]
                        ^^^^ Put a comma after the last item of a multiline array.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            VALUES = [
+                       1001,
+                       2020,
+                       3333,]
           RUBY
         end
       end
@@ -245,6 +235,13 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArrayLiteral, :config do
                      ^^^^ Put a comma after the last item of a multiline array.
                    ]
         RUBY
+
+        expect_correction(<<~RUBY)
+          VALUES = [
+                     1001, 2020,
+                     3333,
+                   ]
+        RUBY
       end
 
       it 'accepts trailing comma' do
@@ -263,22 +260,6 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArrayLiteral, :config do
             anchovies
             olives
           )
-        RUBY
-      end
-
-      it 'auto-corrects a literal with two of the values on the same' \
-         ' line and a trailing comma' do
-        new_source = autocorrect_source(<<~RUBY)
-          VALUES = [
-                     1001, 2020,
-                     3333
-                   ]
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          VALUES = [
-                     1001, 2020,
-                     3333,
-                   ]
         RUBY
       end
 

--- a/spec/rubocop/cop/style/trailing_comma_in_hash_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_hash_literal_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInHashLiteral, :config do
         MAP = { a: 1001, b: 2020, c: 3333, }
                                          ^ Avoid comma after the last item of a hash#{extra_info}.
       RUBY
+
+      expect_correction(<<~RUBY)
+        MAP = { a: 1001, b: 2020, c: 3333 }
+      RUBY
     end
 
     it 'accepts literal without trailing comma' do
@@ -19,11 +23,6 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInHashLiteral, :config do
 
     it 'accepts empty literal' do
       expect_no_offenses('MAP = {}')
-    end
-
-    it 'auto-corrects unwanted comma in literal' do
-      new_source = autocorrect_source('MAP = { a: 1001, b: 2020, c: 3333, }')
-      expect(new_source).to eq('MAP = { a: 1001, b: 2020, c: 3333 }')
     end
   end
 
@@ -61,6 +60,13 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInHashLiteral, :config do
                          ^ Avoid comma after the last item of a hash.
                 }
         RUBY
+
+        expect_correction(<<~RUBY)
+          MAP = { a: 1001,
+                  b: 2020,
+                  c: 3333
+                }
+        RUBY
       end
 
       it 'accepts literal with no trailing comma' do
@@ -91,21 +97,6 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInHashLiteral, :config do
           }
         RUBY
       end
-
-      it 'auto-corrects unwanted comma in literal' do
-        new_source = autocorrect_source(<<~RUBY)
-          MAP = { a: 1001,
-                  b: 2020,
-                  c: 3333,
-                }
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          MAP = { a: 1001,
-                  b: 2020,
-                  c: 3333
-                }
-        RUBY
-      end
     end
 
     context 'when EnforcedStyleForMultiline is comma' do
@@ -130,6 +121,13 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInHashLiteral, :config do
                   ^^^^^^^ Put a comma after the last item of a multiline hash.
           }
         RUBY
+
+        expect_correction(<<~RUBY)
+          MAP = { a: 1001,
+                  b: 2020,
+                  c: 3333,
+          }
+        RUBY
       end
 
       it 'registers an offense for trailing comma in a comment' do
@@ -138,6 +136,13 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInHashLiteral, :config do
                   b: 2020,
                   c: 3333 # a comment,
                   ^^^^^^^ Put a comma after the last item of a multiline hash.
+          }
+        RUBY
+
+        expect_correction(<<~RUBY)
+          MAP = { a: 1001,
+                  b: 2020,
+                  c: 3333, # a comment,
           }
         RUBY
       end
@@ -159,21 +164,6 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInHashLiteral, :config do
           ...
           HELP
           })
-        RUBY
-      end
-
-      it 'auto-corrects missing comma' do
-        new_source = autocorrect_source(<<~RUBY)
-          MAP = { a: 1001,
-                  b: 2020,
-                  c: 3333
-          }
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          MAP = { a: 1001,
-                  b: 2020,
-                  c: 3333,
-          }
         RUBY
       end
 
@@ -198,18 +188,12 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInHashLiteral, :config do
                        d: "e"}
                        ^^^^^^ Put a comma after the last item of a multiline hash.
           RUBY
-        end
 
-        it 'auto-corrects a missing comma' do
-          new_source = autocorrect_source(<<~RUBY)
-            MAP = { a: 1001,
-                    b: 2020,
-                    c: 3333}
-          RUBY
-          expect(new_source).to eq(<<~RUBY)
-            MAP = { a: 1001,
-                    b: 2020,
-                    c: 3333,}
+          expect_correction(<<~RUBY)
+            VALUES = {
+                       a: "b",
+                       b: "c",
+                       d: "e",}
           RUBY
         end
       end
@@ -220,6 +204,13 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInHashLiteral, :config do
                   b: 2020,
                   c: 3333
                   ^^^^^^^ Put a comma after the last item of a multiline hash.
+          }
+        RUBY
+
+        expect_correction(<<~RUBY)
+          MAP = { a: 1001,
+                  b: 2020,
+                  c: 3333,
           }
         RUBY
       end
@@ -241,21 +232,6 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInHashLiteral, :config do
           ...
           HELP
           })
-        RUBY
-      end
-
-      it 'auto-corrects missing comma' do
-        new_source = autocorrect_source(<<~RUBY)
-          MAP = { a: 1001,
-                  b: 2020,
-                  c: 3333
-          }
-        RUBY
-        expect(new_source).to eq(<<~RUBY)
-          MAP = { a: 1001,
-                  b: 2020,
-                  c: 3333,
-          }
         RUBY
       end
 

--- a/spec/rubocop/cop/style/trailing_method_end_statement_spec.rb
+++ b/spec/rubocop/cop/style/trailing_method_end_statement_spec.rb
@@ -6,12 +6,19 @@ RSpec.describe RuboCop::Cop::Style::TrailingMethodEndStatement do
   let(:config) do
     RuboCop::Config.new('Layout/IndentationWidth' => { 'Width' => 2 })
   end
+  let(:trailing_whitespace) { ' ' }
 
   it 'register offense with trailing end on 2 line method' do
     expect_offense(<<~RUBY)
       def some_method
       foo; end
            ^^^ Place the end statement of a multi-line method on its own line.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def some_method
+      foo;#{trailing_whitespace}
+      end
     RUBY
   end
 
@@ -22,6 +29,13 @@ RSpec.describe RuboCop::Cop::Style::TrailingMethodEndStatement do
       { foo: bar }; end
                     ^^^ Place the end statement of a multi-line method on its own line.
     RUBY
+
+    expect_correction(<<~RUBY)
+      def a
+        b
+      { foo: bar };#{trailing_whitespace}
+      end
+    RUBY
   end
 
   it 'register offense with trailing end on method with comment' do
@@ -30,6 +44,13 @@ RSpec.describe RuboCop::Cop::Style::TrailingMethodEndStatement do
         b = calculation
         [b] end # because b
             ^^^ Place the end statement of a multi-line method on its own line.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def c
+        b = calculation
+        [b]#{trailing_whitespace}
+      end # because b
     RUBY
   end
 
@@ -41,6 +62,14 @@ RSpec.describe RuboCop::Cop::Style::TrailingMethodEndStatement do
         end end
             ^^^ Place the end statement of a multi-line method on its own line.
     RUBY
+
+    expect_correction(<<~RUBY)
+      def d
+        block do
+          foo
+        end#{trailing_whitespace}
+      end
+    RUBY
   end
 
   it 'register offense with trailing end inside class' do
@@ -49,6 +78,14 @@ RSpec.describe RuboCop::Cop::Style::TrailingMethodEndStatement do
         def some_method
         foo; end
              ^^^ Place the end statement of a multi-line method on its own line.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo
+        def some_method
+        foo;#{trailing_whitespace}
+        end
       end
     RUBY
   end
@@ -65,78 +102,25 @@ RSpec.describe RuboCop::Cop::Style::TrailingMethodEndStatement do
     RUBY
   end
 
-  it 'auto-corrects trailing end in 2 line method' do
-    corrected = autocorrect_source(<<~RUBY)
-      def some_method
-        []; end
-    RUBY
-    expect(corrected).to eq(<<~RUBY)
-      def some_method
-        []; 
-      end
-    RUBY
-  end
-
-  it 'auto-corrects trailing end in 3 line method' do
-    corrected = autocorrect_source(<<~RUBY)
-      def do_this(x)
-        y = x + 5
-        y / 2; end
-    RUBY
-    expect(corrected).to eq(<<~RUBY)
-      def do_this(x)
-        y = x + 5
-        y / 2; 
-      end
-    RUBY
-  end
-
-  it 'auto-corrects trailing end with comment' do
-    corrected = autocorrect_source(<<~RUBY)
-      def f(x, y)
-        process(x)
-        process(y) end # comment
-    RUBY
-    expect(corrected).to eq(<<~RUBY)
-      def f(x, y)
-        process(x)
-        process(y) 
-      end # comment
-    RUBY
-  end
-
-  it 'auto-corrects trailing end on method with block' do
-    corrected = autocorrect_source(<<~RUBY)
-      def d
-        block do
-          foo
-        end end
-    RUBY
-    expect(corrected).to eq(<<~RUBY)
-      def d
-        block do
-          foo
-        end 
-      end
-    RUBY
-  end
-
   it 'auto-corrects all trailing ends for larger example' do
-    corrected = autocorrect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       class Foo
         def some_method
           [] end
+             ^^^ Place the end statement of a multi-line method on its own line.
         def another_method
           {} end
+             ^^^ Place the end statement of a multi-line method on its own line.
       end
     RUBY
-    expect(corrected).to eq(<<~RUBY)
+
+    expect_correction(<<~RUBY)
       class Foo
         def some_method
-          [] 
+          []#{trailing_whitespace}
         end
         def another_method
-          {} 
+          {}#{trailing_whitespace}
         end
       end
     RUBY

--- a/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
+++ b/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
@@ -168,27 +168,47 @@ RSpec.describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
     describe 'autocorrect' do
       context 'with parentheses' do
         it 'leaves parentheses but removes trailing underscores' do
-          new_source = autocorrect_source('(a, b, _) = foo()')
+          expect_offense(<<~RUBY)
+            (a, b, _) = foo()
+                  ^^ Do not use trailing `_`s in parallel assignment. [...]
+          RUBY
 
-          expect(new_source).to eq('(a, b,) = foo()')
+          expect_correction(<<~RUBY)
+            (a, b,) = foo()
+          RUBY
         end
 
         it 'removes assignment part when every assignment is to `_`' do
-          new_source = autocorrect_source('(_, _, _,) = foo()')
+          expect_offense(<<~RUBY)
+            (_, _, _,) = foo()
+            ^^^^^^^^^^^^^ Do not use trailing `_`s in parallel assignment. [...]
+          RUBY
 
-          expect(new_source).to eq('foo()')
+          expect_correction(<<~RUBY)
+            foo()
+          RUBY
         end
 
         it 'removes assignment part when it is the only variable' do
-          new_source = autocorrect_source('(_,) = foo()')
+          expect_offense(<<~RUBY)
+            (_,) = foo()
+            ^^^^^^^ Do not use trailing `_`s in parallel assignment. [...]
+          RUBY
 
-          expect(new_source).to eq('foo()')
+          expect_correction(<<~RUBY)
+            foo()
+          RUBY
         end
 
         it 'leaves parentheses but removes trailing underscores and commas' do
-          new_source = autocorrect_source('(a, _, _,) = foo()')
+          expect_offense(<<~RUBY)
+            (a, _, _,) = foo()
+               ^^^^^^ Do not use trailing `_`s in parallel assignment. [...]
+          RUBY
 
-          expect(new_source).to eq('(a,) = foo()')
+          expect_correction(<<~RUBY)
+            (a,) = foo()
+          RUBY
         end
       end
     end

--- a/spec/rubocop/cop/style/unpack_first_spec.rb
+++ b/spec/rubocop/cop/style/unpack_first_spec.rb
@@ -7,12 +7,20 @@ RSpec.describe RuboCop::Cop::Style::UnpackFirst, :config do
         x.unpack('h*').first
         ^^^^^^^^^^^^^^^^^^^^ Use `x.unpack1('h*')` instead of `x.unpack('h*').first`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        x.unpack1('h*')
+      RUBY
     end
 
     it 'when using `#unpack` with square brackets' do
       expect_offense(<<~RUBY)
         ''.unpack(y)[0]
         ^^^^^^^^^^^^^^^ Use `''.unpack1(y)` instead of `''.unpack(y)[0]`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ''.unpack1(y)
       RUBY
     end
 
@@ -21,6 +29,10 @@ RSpec.describe RuboCop::Cop::Style::UnpackFirst, :config do
         ''.unpack(y).[](0)
         ^^^^^^^^^^^^^^^^^^ Use `''.unpack1(y)` instead of `''.unpack(y).[](0)`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        ''.unpack1(y)
+      RUBY
     end
 
     it 'when using `#unpack` with `#slice`' do
@@ -28,12 +40,20 @@ RSpec.describe RuboCop::Cop::Style::UnpackFirst, :config do
         ''.unpack(y).slice(0)
         ^^^^^^^^^^^^^^^^^^^^^ Use `''.unpack1(y)` instead of `''.unpack(y).slice(0)`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        ''.unpack1(y)
+      RUBY
     end
 
     it 'when using `#unpack` with `#at`' do
       expect_offense(<<~RUBY)
         ''.unpack(y).at(0)
         ^^^^^^^^^^^^^^^^^^ Use `''.unpack1(y)` instead of `''.unpack(y).at(0)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ''.unpack1(y)
       RUBY
     end
   end
@@ -49,33 +69,6 @@ RSpec.describe RuboCop::Cop::Style::UnpackFirst, :config do
       expect_no_offenses(<<~RUBY)
         ''.unpack('h*')[1]
       RUBY
-    end
-  end
-
-  context 'autocorrects' do
-    it '`#unpack` with `#first to `#unpack1`' do
-      expect(autocorrect_source("x.unpack('h*').first"))
-        .to eq("x.unpack1('h*')")
-    end
-
-    it 'autocorrects `#unpack` with square brackets' do
-      expect(autocorrect_source("x.unpack('h*')[0]"))
-        .to eq("x.unpack1('h*')")
-    end
-
-    it 'autocorrects `#unpack` with dot and square brackets' do
-      expect(autocorrect_source("x.unpack('h*').[](0)"))
-        .to eq("x.unpack1('h*')")
-    end
-
-    it 'autocorrects `#unpack` with `#slice`' do
-      expect(autocorrect_source("x.unpack('h*').slice(0)"))
-        .to eq("x.unpack1('h*')")
-    end
-
-    it 'autocorrects `#unpack` with `#at`' do
-      expect(autocorrect_source("x.unpack('h*').at(0)"))
-        .to eq("x.unpack1('h*')")
     end
   end
 end

--- a/spec/rubocop/cop/style/variable_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/variable_interpolation_spec.rb
@@ -8,12 +8,20 @@ RSpec.describe RuboCop::Cop::Style::VariableInterpolation do
       puts "this is a #$test"
                        ^^^^^ Replace interpolated variable `$test` with expression `#{$test}`.
     RUBY
+
+    expect_correction(<<~'RUBY')
+      puts "this is a #{$test}"
+    RUBY
   end
 
   it 'registers an offense for interpolated global variables in regexp' do
     expect_offense(<<~'RUBY')
       puts /this is a #$test/
                        ^^^^^ Replace interpolated variable `$test` with expression `#{$test}`.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      puts /this is a #{$test}/
     RUBY
   end
 
@@ -22,12 +30,20 @@ RSpec.describe RuboCop::Cop::Style::VariableInterpolation do
       puts `this is a #$test`
                        ^^^^^ Replace interpolated variable `$test` with expression `#{$test}`.
     RUBY
+
+    expect_correction(<<~'RUBY')
+      puts `this is a #{$test}`
+    RUBY
   end
 
   it 'registers an offense for interpolated global variables in symbol' do
     expect_offense(<<~'RUBY')
       puts :"this is a #$test"
                         ^^^^^ Replace interpolated variable `$test` with expression `#{$test}`.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      puts :"this is a #{$test}"
     RUBY
   end
 
@@ -36,12 +52,20 @@ RSpec.describe RuboCop::Cop::Style::VariableInterpolation do
       puts "this is a #$1"
                        ^^ Replace interpolated variable `$1` with expression `#{$1}`.
     RUBY
+
+    expect_correction(<<~'RUBY')
+      puts "this is a #{$1}"
+    RUBY
   end
 
   it 'registers an offense for interpolated regexp back references' do
     expect_offense(<<~'RUBY')
       puts "this is a #$+"
                        ^^ Replace interpolated variable `$+` with expression `#{$+}`.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      puts "this is a #{$+}"
     RUBY
   end
 
@@ -50,6 +74,10 @@ RSpec.describe RuboCop::Cop::Style::VariableInterpolation do
       puts "this is a #@test"
                        ^^^^^ Replace interpolated variable `@test` with expression `#{@test}`.
     RUBY
+
+    expect_correction(<<~'RUBY')
+      puts "this is a #{@test}"
+    RUBY
   end
 
   it 'registers an offense for interpolated class variables' do
@@ -57,14 +85,13 @@ RSpec.describe RuboCop::Cop::Style::VariableInterpolation do
       puts "this is a #@@t"
                        ^^^ Replace interpolated variable `@@t` with expression `#{@@t}`.
     RUBY
+
+    expect_correction(<<~'RUBY')
+      puts "this is a #{@@t}"
+    RUBY
   end
 
   it 'does not register an offense for variables in expressions' do
     expect_no_offenses('puts "this is a #{@test} #{@@t} #{$t} #{$1} #{$+}"')
-  end
-
-  it 'autocorrects by adding the missing {}' do
-    corrected = autocorrect_source('"some #@var"')
-    expect(corrected).to eq '"some #{@var}"'
   end
 end

--- a/spec/rubocop/cop/style/when_then_spec.rb
+++ b/spec/rubocop/cop/style/when_then_spec.rb
@@ -10,10 +10,8 @@ RSpec.describe RuboCop::Cop::Style::WhenThen do
             ^ Do not use `when x;`. Use `when x then` instead.
       end
     RUBY
-  end
 
-  it 'accepts when x then' do
-    expect_no_offenses(<<~RUBY)
+    expect_correction(<<~RUBY)
       case a
       when b then c
       end
@@ -29,19 +27,6 @@ RSpec.describe RuboCop::Cop::Style::WhenThen do
       case e
       when f
         g; h
-      end
-    RUBY
-  end
-
-  it 'auto-corrects "when x;" with "when x then"' do
-    new_source = autocorrect_source(<<~RUBY)
-      case a
-      when b; c
-      end
-    RUBY
-    expect(new_source).to eq(<<~RUBY)
-      case a
-      when b then c
       end
     RUBY
   end

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -28,12 +28,20 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
         ['one', 'two', 'three']
         ^^^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
       RUBY
+
+      expect_correction(<<~RUBY)
+        %w(one two three)
+      RUBY
     end
 
     it 'registers an offense for arrays of double quoted strings' do
       expect_offense(<<~RUBY)
         ["one", "two", "three"]
         ^^^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        %w(one two three)
       RUBY
     end
 
@@ -42,19 +50,60 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
         ['foo', 'bar', 'foo-bar']
         ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
       RUBY
+
+      expect_correction(<<~RUBY)
+        %w(foo bar foo-bar)
+      RUBY
     end
 
-    it 'registers an offense for arrays of unicode word characters' do
-      expect_offense(<<~RUBY)
-        ["ВУЗ", "вуз", "中文网"]
-        ^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
-      RUBY
+    context 'when the default external encoding is UTF-8' do
+      around do |example|
+        orig_encoding = Encoding.default_external
+        Encoding.default_external = Encoding::UTF_8
+        example.run
+        Encoding.default_external = orig_encoding
+      end
+
+      it 'registers an offense for arrays of unicode word characters' do
+        expect_offense(<<~RUBY, wide: '中文网')
+          ["ВУЗ", "вуз", "%{wide}"]
+          ^^^^^^^^^^^^^^^^^{wide}^^ Use `%w` or `%W` for an array of words.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          %w(ВУЗ вуз 中文网)
+        RUBY
+      end
+    end
+
+    context 'when the default external encoding is US-ASCII' do
+      around do |example|
+        orig_encoding = Encoding.default_external
+        Encoding.default_external = Encoding::US_ASCII
+        example.run
+        Encoding.default_external = orig_encoding
+      end
+
+      it 'registers an offense for arrays of unicode word characters' do
+        expect_offense(<<~RUBY, wide: '中文网')
+          ["ВУЗ", "вуз", "%{wide}"]
+          ^^^^^^^^^^^^^^^^^{wide}^^ Use `%w` or `%W` for an array of words.
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          %W(\u0412\u0423\u0417 \u0432\u0443\u0437 \u4E2D\u6587\u7F51)
+        RUBY
+      end
     end
 
     it 'registers an offense for arrays with character constants' do
       expect_offense(<<~'RUBY')
         ["one", ?\n]
         ^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        %W(one \n)
       RUBY
     end
 
@@ -75,11 +124,10 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
         ["one\n", "hi\tthere"]
         ^^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
       RUBY
-    end
 
-    it 'uses %W when autocorrecting strings with newlines and tabs' do
-      new_source = autocorrect_source(%(["one\\n", "hi\\tthere"]))
-      expect(new_source).to eq('%W(one\\n hi\\tthere)')
+      expect_correction(<<~'RUBY')
+        %W(one\n hi\tthere)
+      RUBY
     end
 
     it 'does not register an offense for array of non-words' do
@@ -111,6 +159,10 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       expect_offense(<<~RUBY)
         foo(['bar', 'baz']) { qux }
             ^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo(%w(bar baz)) { qux }
       RUBY
     end
 
@@ -149,40 +201,62 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'auto-corrects an array of words' do
-      new_source = autocorrect_source("['one', %q(two), 'three']")
-      expect(new_source).to eq('%w(one two three)')
+      expect_offense(<<~RUBY)
+        ['one', %q(two), 'three']
+        ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        %w(one two three)
+      RUBY
     end
 
     it 'auto-corrects an array with one element' do
-      new_source = autocorrect_source("['one']")
-      expect(new_source).to eq('%w(one)')
+      expect_offense(<<~RUBY)
+        ['one']
+        ^^^^^^^ Use `%w` or `%W` for an array of words.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        %w(one)
+      RUBY
     end
 
     it 'auto-corrects an array of words and character constants' do
-      new_source = autocorrect_source('[%|one|, %Q(two), ?\n, ?\t]')
-      expect(new_source).to eq('%W(one two \n \t)')
+      expect_offense(<<~'RUBY')
+        [%|one|, %Q(two), ?\n, ?\t]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        %W(one two \n \t)
+      RUBY
     end
 
     it 'keeps the line breaks in place after auto-correct' do
-      new_source = autocorrect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         ['one',
+        ^^^^^^^ Use `%w` or `%W` for an array of words.
         'two', 'three']
       RUBY
-      expect(new_source).to eq(<<~RUBY)
+
+      expect_correction(<<~RUBY)
         %w(one
         two three)
       RUBY
     end
 
     it 'auto-corrects an array of words in multiple lines' do
-      new_source = autocorrect_source(<<-RUBY)
+      expect_offense(<<-RUBY)
         [
+        ^ Use `%w` or `%W` for an array of words.
         "foo",
         "bar",
         "baz"
         ]
       RUBY
-      expect(new_source).to eq(<<-RUBY)
+
+      expect_correction(<<-RUBY)
         %w(
         foo
         bar
@@ -192,12 +266,14 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'auto-corrects an array of words using partial newlines' do
-      new_source = autocorrect_source(<<-RUBY)
+      expect_offense(<<-RUBY)
         ["foo", "bar", "baz",
+        ^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
         "boz", "buz",
         "biz"]
       RUBY
-      expect(new_source).to eq(<<-RUBY)
+
+      expect_correction(<<-RUBY)
         %w(foo bar baz
         boz buz
         biz)
@@ -205,8 +281,14 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'detects right value of MinSize to use for --auto-gen-config' do
-      inspect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         ['one', 'two', 'three']
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+        %w(a b c d)
+      RUBY
+
+      expect_correction(<<~RUBY)
+        %w(one two three)
         %w(a b c d)
       RUBY
 
@@ -215,8 +297,14 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'detects when the cop must be disabled to avoid offenses' do
-      inspect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         ['one', 'two', 'three']
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+        %w(a b)
+      RUBY
+
+      expect_correction(<<~RUBY)
+        %w(one two three)
         %w(a b)
       RUBY
 
@@ -262,37 +350,65 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
         %w(one two three)
         ^^^^^^^^^^^^^^^^^ Use `[]` for an array of words.
       RUBY
-    end
 
-    it 'auto-corrects a %w() array' do
-      new_source = autocorrect_source('%w(one two three)')
-      expect(new_source).to eq("['one', 'two', 'three']")
+      expect_correction(<<~RUBY)
+        ['one', 'two', 'three']
+      RUBY
     end
 
     it 'autocorrects a %w() array which uses single quotes' do
-      new_source = autocorrect_source("%w(one's two's three's)")
-      expect(new_source).to eq('["one\'s", "two\'s", "three\'s"]')
+      expect_offense(<<~RUBY)
+        %w(one's two's three's)
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use `[]` for an array of words.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ["one's", "two's", "three's"]
+      RUBY
     end
 
     it 'autocorrects a %W() array which uses escapes' do
-      new_source = autocorrect_source('%W(\\n \\t \\b \\v \\f)')
-      expect(new_source).to eq('["\n", "\t", "\b", "\v", "\f"]')
+      expect_offense(<<~'RUBY')
+        %W(\n \t \b \v \f)
+        ^^^^^^^^^^^^^^^^^^ Use `[]` for an array of words.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        ["\n", "\t", "\b", "\v", "\f"]
+      RUBY
     end
 
     it 'autocorrects a %w() array which uses string with hyphen' do
-      new_source = autocorrect_source('%w(foo bar foo-bar)')
-      expect(new_source).to eq("['foo', 'bar', 'foo-bar']")
+      expect_offense(<<~RUBY)
+        %w(foo bar foo-bar)
+        ^^^^^^^^^^^^^^^^^^^ Use `[]` for an array of words.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ['foo', 'bar', 'foo-bar']
+      RUBY
     end
 
     it 'autocorrects a %W() array which uses string with hyphen' do
-      new_source = autocorrect_source('%W(foo bar #{foo}-bar)')
-      expect(new_source).to eq("['foo', 'bar', \"#\{foo}-bar\"]")
+      expect_offense(<<~'RUBY')
+        %W(foo bar #{foo}-bar)
+        ^^^^^^^^^^^^^^^^^^^^^^ Use `[]` for an array of words.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        ['foo', 'bar', "#{foo}-bar"]
+      RUBY
     end
 
     it 'autocorrects a %W() array which uses string interpolation' do
-      new_source = autocorrect_source('%W(#{foo}bar baz)')
+      expect_offense(<<~'RUBY')
+        %W(#{foo}bar baz)
+        ^^^^^^^^^^^^^^^^^ Use `[]` for an array of words.
+      RUBY
 
-      expect(new_source).to eq('["#{foo}bar", \'baz\']')
+      expect_correction(<<~'RUBY')
+        ["#{foo}bar", 'baz']
+      RUBY
     end
 
     it "doesn't fail on strings which are not valid UTF-8" do
@@ -326,11 +442,10 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
         ['a@example.com', 'b@example.com']
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
       RUBY
-    end
 
-    it 'auto-corrects an array of email addresses' do
-      new_source = autocorrect_source("['a@example.com', 'b@example.com']")
-      expect(new_source).to eq('%w(a@example.com b@example.com)')
+      expect_correction(<<~RUBY)
+        %w(a@example.com b@example.com)
+      RUBY
     end
   end
 
@@ -338,7 +453,7 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
     let(:cop_config) { { 'WordRegex' => 'just_a_string' } }
 
     it 'still parses the code without raising an error' do
-      expect { inspect_source('') }.not_to raise_error
+      expect { expect_no_offenses('') }.not_to raise_error
     end
   end
 
@@ -346,13 +461,25 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
     let(:cop_config) { { 'MinSize' => 0, 'WordRegex' => /\S+/ } }
 
     it 'uses %W when autocorrecting strings with non-printable chars' do
-      new_source = autocorrect_source('["\x1f\x1e", "hello"]')
-      expect(new_source).to eq('%W(\u001F\u001E hello)')
+      expect_offense(<<~'RUBY')
+        ["\x1f\x1e", "hello"]
+        ^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        %W(\u001F\u001E hello)
+      RUBY
     end
 
     it 'uses %w for strings which only appear to have an escape' do
-      new_source = autocorrect_source("['hi\\tthere', 'again\\n']")
-      expect(new_source).to eq('%w(hi\\tthere again\\n)')
+      expect_offense(<<~'RUBY')
+        ['hi\tthere', 'again\n']
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        %w(hi\tthere again\n)
+      RUBY
     end
   end
 
@@ -360,13 +487,20 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
     let(:cop_config) { { 'MinSize' => 0, 'WordRegex' => /[\w \[\]()]/ } }
 
     it "doesn't break when words contain whitespace" do
-      new_source = autocorrect_source("['hi there', 'something\telse']")
-      expect(new_source).to eq("['hi there', 'something\telse']")
+      expect_no_offenses(<<~RUBY)
+        ['hi there', 'something\telse']
+      RUBY
     end
 
     it "doesn't break when words contain delimiters" do
-      new_source = autocorrect_source("[')', ']', '(']")
-      expect(new_source).to eq('%w(\\) ] \\()')
+      expect_offense(<<~RUBY)
+        [')', ']', '(']
+        ^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        %w(\) ] \()
+      RUBY
     end
 
     context 'when PreferredDelimiters is specified' do
@@ -381,8 +515,14 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       end
 
       it 'autocorrects an array with delimiters' do
-        new_source = autocorrect_source("[')', ']', '(', '[']")
-        expect(new_source).to eq('%w[) \\] ( \\[]')
+        expect_offense(<<~RUBY)
+          [')', ']', '(', '[']
+          ^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          %w[) \] ( \[]
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/style/zero_length_predicate_spec.rb
+++ b/spec/rubocop/cop/style/zero_length_predicate_spec.rb
@@ -3,156 +3,346 @@
 RSpec.describe RuboCop::Cop::Style::ZeroLengthPredicate do
   subject(:cop) { described_class.new }
 
-  let(:source) { '' }
-
-  before do
-    inspect_source(source)
-  end
-
-  shared_examples 'code with offense' do |code, message, expected|
-    context "when checking #{code}" do
-      let(:source) { code }
-
-      it 'registers an offense' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.offenses.first.message).to eq(message)
-        expect(cop.highlights).to eq([code])
-      end
-
-      it 'auto-corrects' do
-        expect(autocorrect_source(code)).to eq expected
-      end
-    end
-  end
-
-  shared_examples 'code without offense' do |code|
-    let(:source) { code }
-
-    it 'does not register any offense' do
-      expect(cop.offenses.empty?).to be(true)
-    end
-  end
-
   context 'with arrays' do
-    it_behaves_like 'code with offense', '[1, 2, 3].length == 0',
-                    'Use `empty?` instead of `length == 0`.',
-                    '[1, 2, 3].empty?'
-    it_behaves_like 'code with offense', '[1, 2, 3].size == 0',
-                    'Use `empty?` instead of `size == 0`.',
-                    '[1, 2, 3].empty?'
-    it_behaves_like 'code with offense', '0 == [1, 2, 3].length',
-                    'Use `empty?` instead of `0 == length`.',
-                    '[1, 2, 3].empty?'
-    it_behaves_like 'code with offense', '0 == [1, 2, 3].size',
-                    'Use `empty?` instead of `0 == size`.',
-                    '[1, 2, 3].empty?'
+    it 'registers an offense for `array.length == 0`' do
+      expect_offense(<<~RUBY)
+        [1, 2, 3].length == 0
+        ^^^^^^^^^^^^^^^^^^^^^ Use `empty?` instead of `length == 0`.
+      RUBY
 
-    it_behaves_like 'code with offense', '[1, 2, 3].length < 1',
-                    'Use `empty?` instead of `length < 1`.',
-                    '[1, 2, 3].empty?'
-    it_behaves_like 'code with offense', '[1, 2, 3].size < 1',
-                    'Use `empty?` instead of `size < 1`.',
-                    '[1, 2, 3].empty?'
-    it_behaves_like 'code with offense', '1 > [1, 2, 3].length',
-                    'Use `empty?` instead of `1 > length`.',
-                    '[1, 2, 3].empty?'
-    it_behaves_like 'code with offense', '1 > [1, 2, 3].size',
-                    'Use `empty?` instead of `1 > size`.',
-                    '[1, 2, 3].empty?'
+      expect_correction(<<~RUBY)
+        [1, 2, 3].empty?
+      RUBY
+    end
 
-    it_behaves_like 'code with offense', '[1, 2, 3].length > 0',
-                    'Use `!empty?` instead of `length > 0`.',
-                    '![1, 2, 3].empty?'
-    it_behaves_like 'code with offense', '[1, 2, 3].size > 0',
-                    'Use `!empty?` instead of `size > 0`.',
-                    '![1, 2, 3].empty?'
-    it_behaves_like 'code with offense', '[1, 2, 3].length != 0',
-                    'Use `!empty?` instead of `length != 0`.',
-                    '![1, 2, 3].empty?'
-    it_behaves_like 'code with offense', '[1, 2, 3].size != 0',
-                    'Use `!empty?` instead of `size != 0`.',
-                    '![1, 2, 3].empty?'
+    it 'registers an offense for `array.size == 0`' do
+      expect_offense(<<~'RUBY')
+        [1, 2, 3].size == 0
+        ^^^^^^^^^^^^^^^^^^^ Use `empty?` instead of `size == 0`.
+      RUBY
 
-    it_behaves_like 'code with offense', '0 < [1, 2, 3].length',
-                    'Use `!empty?` instead of `0 < length`.',
-                    '![1, 2, 3].empty?'
-    it_behaves_like 'code with offense', '0 < [1, 2, 3].size',
-                    'Use `!empty?` instead of `0 < size`.',
-                    '![1, 2, 3].empty?'
-    it_behaves_like 'code with offense', '0 != [1, 2, 3].length',
-                    'Use `!empty?` instead of `0 != length`.',
-                    '![1, 2, 3].empty?'
-    it_behaves_like 'code with offense', '0 != [1, 2, 3].size',
-                    'Use `!empty?` instead of `0 != size`.',
-                    '![1, 2, 3].empty?'
+      expect_correction(<<~'RUBY')
+        [1, 2, 3].empty?
+      RUBY
+    end
+
+    it 'registers an offense for `0 == array.length`' do
+      expect_offense(<<~'RUBY')
+        0 == [1, 2, 3].length
+        ^^^^^^^^^^^^^^^^^^^^^ Use `empty?` instead of `0 == length`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        [1, 2, 3].empty?
+      RUBY
+    end
+
+    it 'registers an offense for `0 == array.size`' do
+      expect_offense(<<~'RUBY')
+        0 == [1, 2, 3].size
+        ^^^^^^^^^^^^^^^^^^^ Use `empty?` instead of `0 == size`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        [1, 2, 3].empty?
+      RUBY
+    end
+
+    it 'registers an offense for `array.length < 1`' do
+      expect_offense(<<~'RUBY')
+        [1, 2, 3].length < 1
+        ^^^^^^^^^^^^^^^^^^^^ Use `empty?` instead of `length < 1`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        [1, 2, 3].empty?
+      RUBY
+    end
+
+    it 'registers an offense for `array.size < 1`' do
+      expect_offense(<<~'RUBY')
+        [1, 2, 3].size < 1
+        ^^^^^^^^^^^^^^^^^^ Use `empty?` instead of `size < 1`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        [1, 2, 3].empty?
+      RUBY
+    end
+
+    it 'registers an offense for `1 > array.length`' do
+      expect_offense(<<~'RUBY')
+        1 > [1, 2, 3].length
+        ^^^^^^^^^^^^^^^^^^^^ Use `empty?` instead of `1 > length`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        [1, 2, 3].empty?
+      RUBY
+    end
+
+    it 'registers an offense for `1 > array.size`' do
+      expect_offense(<<~'RUBY')
+        1 > [1, 2, 3].size
+        ^^^^^^^^^^^^^^^^^^ Use `empty?` instead of `1 > size`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        [1, 2, 3].empty?
+      RUBY
+    end
+
+    it 'registers an offense for `array.length > 0`' do
+      expect_offense(<<~'RUBY')
+        [1, 2, 3].length > 0
+        ^^^^^^^^^^^^^^^^^^^^ Use `!empty?` instead of `length > 0`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        ![1, 2, 3].empty?
+      RUBY
+    end
+
+    it 'registers an offense for `array.size > 0`' do
+      expect_offense(<<~'RUBY')
+        [1, 2, 3].size > 0
+        ^^^^^^^^^^^^^^^^^^ Use `!empty?` instead of `size > 0`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        ![1, 2, 3].empty?
+      RUBY
+    end
+
+    it 'registers an offense for `array.length != 0`' do
+      expect_offense(<<~'RUBY')
+        [1, 2, 3].length != 0
+        ^^^^^^^^^^^^^^^^^^^^^ Use `!empty?` instead of `length != 0`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        ![1, 2, 3].empty?
+      RUBY
+    end
+
+    it 'registers an offense for `array.size != 0`' do
+      expect_offense(<<~'RUBY')
+        [1, 2, 3].size != 0
+        ^^^^^^^^^^^^^^^^^^^ Use `!empty?` instead of `size != 0`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        ![1, 2, 3].empty?
+      RUBY
+    end
+
+    it 'registers an offense for `0 < array.length' do
+      expect_offense(<<~'RUBY')
+        0 < [1, 2, 3].length
+        ^^^^^^^^^^^^^^^^^^^^ Use `!empty?` instead of `0 < length`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        ![1, 2, 3].empty?
+      RUBY
+    end
+
+    it 'registers an offense for `0 < array.size`' do
+      expect_offense(<<~'RUBY')
+        0 < [1, 2, 3].size
+        ^^^^^^^^^^^^^^^^^^ Use `!empty?` instead of `0 < size`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        ![1, 2, 3].empty?
+      RUBY
+    end
+
+    it 'registers an offense for `0 != array.length`' do
+      expect_offense(<<~'RUBY')
+        0 != [1, 2, 3].length
+        ^^^^^^^^^^^^^^^^^^^^^ Use `!empty?` instead of `0 != length`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        ![1, 2, 3].empty?
+      RUBY
+    end
+
+    it 'registers an offense for `0 != array.size`' do
+      expect_offense(<<~'RUBY')
+        0 != [1, 2, 3].size
+        ^^^^^^^^^^^^^^^^^^^ Use `!empty?` instead of `0 != size`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        ![1, 2, 3].empty?
+      RUBY
+    end
   end
 
   context 'with hashes' do
-    it_behaves_like 'code with offense', '{ a: 1, b: 2 }.size == 0',
-                    'Use `empty?` instead of `size == 0`.',
-                    '{ a: 1, b: 2 }.empty?'
-    it_behaves_like 'code with offense', '0 == { a: 1, b: 2 }.size',
-                    'Use `empty?` instead of `0 == size`.',
-                    '{ a: 1, b: 2 }.empty?'
+    it 'registers an offense for `hash.size == 0`' do
+      expect_offense(<<~'RUBY')
+        { a: 1, b: 2 }.size == 0
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Use `empty?` instead of `size == 0`.
+      RUBY
 
-    it_behaves_like 'code with offense', '{ a: 1, b: 2 }.size != 0',
-                    'Use `!empty?` instead of `size != 0`.',
-                    '!{ a: 1, b: 2 }.empty?'
-    it_behaves_like 'code with offense', '0 != { a: 1, b: 2 }.size',
-                    'Use `!empty?` instead of `0 != size`.',
-                    '!{ a: 1, b: 2 }.empty?'
+      expect_correction(<<~'RUBY')
+        { a: 1, b: 2 }.empty?
+      RUBY
+    end
+
+    it 'registers an offense for `0 == hash.size' do
+      expect_offense(<<~'RUBY')
+        0 == { a: 1, b: 2 }.size
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Use `empty?` instead of `0 == size`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        { a: 1, b: 2 }.empty?
+      RUBY
+    end
+
+    it 'registers an offense for `hash.size != 0`' do
+      expect_offense(<<~'RUBY')
+        { a: 1, b: 2 }.size != 0
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Use `!empty?` instead of `size != 0`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        !{ a: 1, b: 2 }.empty?
+      RUBY
+    end
+
+    it 'registers an offense for `0 != hash.size`' do
+      expect_offense(<<~'RUBY')
+        0 != { a: 1, b: 2 }.size
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Use `!empty?` instead of `0 != size`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        !{ a: 1, b: 2 }.empty?
+      RUBY
+    end
   end
 
   context 'with strings' do
-    it_behaves_like 'code with offense', '"string".size == 0',
-                    'Use `empty?` instead of `size == 0`.',
-                    '"string".empty?'
-    it_behaves_like 'code with offense', '0 == "string".size',
-                    'Use `empty?` instead of `0 == size`.',
-                    '"string".empty?'
+    it 'registers an offense for `string.size == 0`' do
+      expect_offense(<<~'RUBY')
+        "string".size == 0
+        ^^^^^^^^^^^^^^^^^^ Use `empty?` instead of `size == 0`.
+      RUBY
 
-    it_behaves_like 'code with offense', '"string".size != 0',
-                    'Use `!empty?` instead of `size != 0`.',
-                    '!"string".empty?'
-    it_behaves_like 'code with offense', '0 != "string".size',
-                    'Use `!empty?` instead of `0 != size`.',
-                    '!"string".empty?'
+      expect_correction(<<~'RUBY')
+        "string".empty?
+      RUBY
+    end
+
+    it 'registers an offense for `0 == string.size`' do
+      expect_offense(<<~'RUBY')
+        0 == "string".size
+        ^^^^^^^^^^^^^^^^^^ Use `empty?` instead of `0 == size`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        "string".empty?
+      RUBY
+    end
+
+    it 'registers an offense for `string.size != 0`' do
+      expect_offense(<<~'RUBY')
+        "string".size != 0
+        ^^^^^^^^^^^^^^^^^^ Use `!empty?` instead of `size != 0`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        !"string".empty?
+      RUBY
+    end
+
+    it 'registers an offense for `0 != string.size`' do
+      expect_offense(<<~'RUBY')
+        0 != "string".size
+        ^^^^^^^^^^^^^^^^^^ Use `!empty?` instead of `0 != size`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        !"string".empty?
+      RUBY
+    end
   end
 
   context 'with collection variables' do
-    it_behaves_like 'code with offense', 'collection.size == 0',
-                    'Use `empty?` instead of `size == 0`.',
-                    'collection.empty?'
-    it_behaves_like 'code with offense', '0 == collection.size',
-                    'Use `empty?` instead of `0 == size`.',
-                    'collection.empty?'
+    it 'registers an offense for `collection.size == 0`' do
+      expect_offense(<<~'RUBY')
+        collection.size == 0
+        ^^^^^^^^^^^^^^^^^^^^ Use `empty?` instead of `size == 0`.
+      RUBY
 
-    it_behaves_like 'code with offense', 'collection.size != 0',
-                    'Use `!empty?` instead of `size != 0`.',
-                    '!collection.empty?'
-    it_behaves_like 'code with offense', '0 != collection.size',
-                    'Use `!empty?` instead of `0 != size`.',
-                    '!collection.empty?'
+      expect_correction(<<~'RUBY')
+        collection.empty?
+      RUBY
+    end
+
+    it 'registers an offense for `0 == collection.size`' do
+      expect_offense(<<~'RUBY')
+        0 == collection.size
+        ^^^^^^^^^^^^^^^^^^^^ Use `empty?` instead of `0 == size`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        collection.empty?
+      RUBY
+    end
+
+    it 'registers an offense for `collection.size != 0`' do
+      expect_offense(<<~'RUBY')
+        collection.size != 0
+        ^^^^^^^^^^^^^^^^^^^^ Use `!empty?` instead of `size != 0`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        !collection.empty?
+      RUBY
+    end
+
+    it 'registers an offense for `0 != collection.size`' do
+      expect_offense(<<~'RUBY')
+        0 != collection.size
+        ^^^^^^^^^^^^^^^^^^^^ Use `!empty?` instead of `0 != size`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        !collection.empty?
+      RUBY
+    end
   end
 
   context 'when name of the variable is `size` or `length`' do
-    it_behaves_like 'code without offense', 'size == 0'
-    it_behaves_like 'code without offense', 'length == 0'
+    it 'accepts equality check' do
+      expect_no_offenses('size == 0')
+      expect_no_offenses('length == 0')
 
-    it_behaves_like 'code without offense', '0 == size'
-    it_behaves_like 'code without offense', '0 == length'
+      expect_no_offenses('0 == size')
+      expect_no_offenses('0 == length')
+    end
 
-    it_behaves_like 'code without offense', 'size <= 0'
-    it_behaves_like 'code without offense', 'length > 0'
+    it 'accepts comparison' do
+      expect_no_offenses('size <= 0')
+      expect_no_offenses('length > 0')
 
-    it_behaves_like 'code without offense', '0 <= size'
-    it_behaves_like 'code without offense', '0 > length'
+      expect_no_offenses('0 <= size')
+      expect_no_offenses('0 > length')
+    end
 
-    it_behaves_like 'code without offense', 'size != 0'
-    it_behaves_like 'code without offense', 'length != 0'
+    it 'accepts inequality check' do
+      expect_no_offenses('size != 0')
+      expect_no_offenses('length != 0')
 
-    it_behaves_like 'code without offense', '0 != size'
-    it_behaves_like 'code without offense', '0 != length'
+      expect_no_offenses('0 != size')
+      expect_no_offenses('0 != length')
+    end
   end
 
   context 'when inspecting a File::Stat object' do


### PR DESCRIPTION
Part of #8127

Use newer `expect_offense` and `expect_correction` in specs for Style cops T-Z.

Merge `'register offense'` and `'auto-correct'` spec examples where posible.

Fix autocorrect spec for non-ascii word array in `Style/WordArray`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/