### PR TITLE
Recognise < > as comparison operators in cond assign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 * [#8480](https://github.com/rubocop-hq/rubocop/issues/8480): Tweak callback list of `Lint/MissingSuper`. ([@marcandre][])
 * [#8481](https://github.com/rubocop-hq/rubocop/pull/8481): Fix autocorrect for elements with newlines in `Style/SymbolArray` and `Style/WordArray`. ([@biinari][])
 
+### Changes
+
+* [#8487](https://github.com/rubocop-hq/rubocop/pull/8487): Detect `<` and `>` as comparison operators in `Style/ConditionalAssignment` cop. ([@biinari][])
+
 ## 0.89.0 (2020-08-05)
 
 ### New features

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -233,7 +233,7 @@ module RuboCop
         def_node_matcher :assignment_type?, <<~PATTERN
           {
             #{ASSIGNMENT_TYPES.join(' ')}
-            (send _recv {:[]= :<< :=~ :!~ :<=> #end_with_eq?} ...)
+            (send _recv {:[]= :<< :=~ :!~ :<=> #end_with_eq? :< :>} ...)
           }
         PATTERN
 

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -723,8 +723,6 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
   it_behaves_like('all assignment types', '>>=')
   it_behaves_like('all assignment types', '||=')
   it_behaves_like('all assignment types', '&&=')
-  it_behaves_like('all assignment types', '+=')
-  it_behaves_like('all assignment types', '-=')
   it_behaves_like('all assignment types', '<<', add_parens: true)
 
   it 'registers an offense for assignment in if elsif else' do

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -282,6 +282,8 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
   it_behaves_like('comparison methods', '===')
   it_behaves_like('comparison methods', '<=')
   it_behaves_like('comparison methods', '>=')
+  it_behaves_like('comparison methods', '<')
+  it_behaves_like('comparison methods', '>')
 
   context 'empty branch' do
     it 'allows an empty if statement' do


### PR DESCRIPTION
`Style/ConditionalAssignment` cop detects most comparison operators: `<=`, `>=`, `==`, `!=`, `===`, `<=>`, `=~`, `!~`.

Add detection for `<` and `>`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/