### PR TITLE
remove `let(:source)` from `shared_contexts.rb`

### DIFF
--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -44,8 +44,6 @@ end
 RSpec.shared_context 'config', :config do # rubocop:disable Metrics/BlockLength
   ### Meant to be overridden at will
 
-  let(:source) { 'code = {some: :ruby}' }
-
   let(:cop_class) do
     unless described_class.is_a?(Class) && described_class < RuboCop::Cop::Base
       raise 'Specify which cop class to use (e.g `let(:cop_class) { RuboCop::Cop::Base }`, ' \
@@ -97,9 +95,7 @@ RSpec.shared_context 'config', :config do # rubocop:disable Metrics/BlockLength
   end
 
   let(:cop) do
-    cop_class.new(config, cop_options).tap do |cop|
-      cop.send :begin_investigation, processed_source
-    end
+    cop_class.new(config, cop_options)
   end
 end
 

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Cop, :config do
-  let(:location) do
-    source_range(0...1)
-  end
+  let(:source) { 'code = {some: :ruby}' }
+  let(:location) { source_range(0...1) }
+
+  before { cop.send(:begin_investigation, processed_source) }
 
   it 'initially has 0 offenses' do
     expect(cop.offenses.empty?).to be(true)

--- a/spec/rubocop/formatter/clang_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/clang_style_formatter_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe RuboCop::Formatter::ClangStyleFormatter, :config do
   let(:cop_class) { RuboCop::Cop::Cop }
   let(:output) { StringIO.new }
 
+  before { cop.send(:begin_investigation, processed_source) }
+
   describe '#report_file' do
     let(:file) { '/path/to/file' }
 

--- a/spec/rubocop/formatter/emacs_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/emacs_style_formatter_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe RuboCop::Formatter::EmacsStyleFormatter, :config do
   let(:source) { %w[a b cdefghi].join("\n") }
   let(:output) { StringIO.new }
 
+  before { cop.send(:begin_investigation, processed_source) }
+
   describe '#file_finished' do
     it 'displays parsable text' do
       cop.add_offense(

--- a/spec/rubocop/formatter/file_list_formatter_spec.rb
+++ b/spec/rubocop/formatter/file_list_formatter_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe RuboCop::Formatter::FileListFormatter, :config do
   let(:cop_class) { RuboCop::Cop::Cop }
   let(:source) { %w[a b cdefghi].join("\n") }
 
+  before { cop.send(:begin_investigation, processed_source) }
+
   describe '#file_finished' do
     it 'displays parsable text' do
       cop.add_offense(

--- a/spec/rubocop/formatter/junit_formatter_spec.rb
+++ b/spec/rubocop/formatter/junit_formatter_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe RuboCop::Formatter::JUnitFormatter, :config do
   let(:cop_class) { RuboCop::Cop::Layout::SpaceInsideBlockBraces }
   let(:source) { %w[foo bar baz].join("\n") }
 
+  before { cop.send(:begin_investigation, processed_source) }
+
   describe '#file_finished' do
     before do
       cop.add_offense(


### PR DESCRIPTION
Poking around in the tests, I noticed that we were parsing this source
for every test, even in cases where we never use it, which is most of
them. This removes the default `let(:source)` and stops automatically
calling `begin_investigation` on the cop. Instead it calls it in places
where it is necessary.

I benchmarked it locally, and while not a huge win, it consistently cut
about 2-3 seconds off my build times, from ~52 seconds to ~50 seconds.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
