### PR TITLE
Use `Cop::Base` API for `Style` department [F-M]

### DIFF
--- a/lib/rubocop/cop/mixin/hash_transform_method.rb
+++ b/lib/rubocop/cop/mixin/hash_transform_method.rb
@@ -26,13 +26,6 @@ module RuboCop
         end
       end
 
-      def autocorrect(node)
-        lambda do |corrector|
-          correction = prepare_correction(node)
-          execute_correction(corrector, node, correction)
-        end
-      end
-
       private
 
       # @abstract Implemented with `def_node_matcher`
@@ -61,10 +54,11 @@ module RuboCop
         # `transform_values` if value transformation uses key.
         return if captures.transformation_uses_both_args?
 
-        add_offense(
-          node,
-          message: "Prefer `#{new_method_name}` over `#{match_desc}`."
-        )
+        message = "Prefer `#{new_method_name}` over `#{match_desc}`."
+        add_offense(node, message: message) do |corrector|
+          correction = prepare_correction(node)
+          execute_correction(corrector, node, correction)
+        end
       end
 
       # @abstract

--- a/lib/rubocop/cop/style/float_division.rb
+++ b/lib/rubocop/cop/style/float_division.rb
@@ -39,7 +39,7 @@ module RuboCop
       #
       #   # good
       #   a.fdiv(b)
-      class FloatDivision < Cop
+      class FloatDivision < Base
         include ConfigurableEnforcedStyle
         MESSAGES = {
           left_coerce: 'Prefer using `.to_f` on the left side.',

--- a/lib/rubocop/cop/style/format_string.rb
+++ b/lib/rubocop/cop/style/format_string.rb
@@ -35,8 +35,9 @@ module RuboCop
       #   # good
       #   puts '%10s' % 'hoge'
       #
-      class FormatString < Cop
+      class FormatString < Base
         include ConfigurableEnforcedStyle
+        extend AutoCorrector
 
         MSG = 'Favor `%<prefer>s` over `%<current>s`.'
 
@@ -62,40 +63,37 @@ module RuboCop
 
             return if detected_style == style
 
-            add_offense(node, location: :selector,
-                              message: message(detected_style))
+            add_offense(node.loc.selector, message: message(detected_style)) do |corrector|
+              autocorrect(corrector, node)
+            end
           end
         end
 
+        private
+
         def message(detected_style)
-          format(MSG,
-                 prefer: method_name(style),
-                 current: method_name(detected_style))
+          format(MSG, prefer: method_name(style), current: method_name(detected_style))
         end
 
         def method_name(style_name)
           style_name == :percent ? 'String#%' : style_name
         end
 
-        def autocorrect(node)
+        def autocorrect(corrector, node)
           return if variable_argument?(node)
 
-          lambda do |corrector|
-            case node.method_name
-            when :%
-              autocorrect_from_percent(corrector, node)
+          case node.method_name
+          when :%
+            autocorrect_from_percent(corrector, node)
+          when :format, :sprintf
+            case style
+            when :percent
+              autocorrect_to_percent(corrector, node)
             when :format, :sprintf
-              case style
-              when :percent
-                autocorrect_to_percent(corrector, node)
-              when :format, :sprintf
-                corrector.replace(node.loc.selector, style.to_s)
-              end
+              corrector.replace(node.loc.selector, style.to_s)
             end
           end
         end
-
-        private
 
         def autocorrect_from_percent(corrector, node)
           percent_rhs = node.first_argument

--- a/lib/rubocop/cop/style/format_string_token.rb
+++ b/lib/rubocop/cop/style/format_string_token.rb
@@ -37,7 +37,7 @@ module RuboCop
       #
       #   # good
       #   format('%s', 'Hello')
-      class FormatStringToken < Cop
+      class FormatStringToken < Base
         include ConfigurableEnforcedStyle
 
         def on_str(node)
@@ -45,13 +45,11 @@ module RuboCop
           return if node.each_ancestor(:xstr, :regexp).any?
 
           tokens(node) do |detected_style, token_range|
-            if detected_style == style ||
-               unannotated_format?(node, detected_style)
+            if detected_style == style || unannotated_format?(node, detected_style)
               correct_style_detected
             else
               style_detected(detected_style)
-              add_offense(node, location: token_range,
-                                message: message(detected_style))
+              add_offense(token_range, message: message(detected_style))
             end
           end
         end
@@ -66,8 +64,7 @@ module RuboCop
         PATTERN
 
         def unannotated_format?(node, detected_style)
-          detected_style == :unannotated &&
-            !format_string_in_typical_context?(node)
+          detected_style == :unannotated && !format_string_in_typical_context?(node)
         end
 
         def message(detected_style)

--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -73,10 +73,11 @@ module RuboCop
       #   module Bar
       #     # ...
       #   end
-      class FrozenStringLiteralComment < Cop
+      class FrozenStringLiteralComment < Base
         include ConfigurableEnforcedStyle
         include FrozenStringLiteral
         include RangeHelp
+        extend AutoCorrector
 
         MSG_MISSING_TRUE = 'Missing magic comment `# frozen_string_literal: '\
                            'true`.'
@@ -85,7 +86,7 @@ module RuboCop
         MSG_DISABLED = 'Frozen string literal comment must be set to `true`.'
         SHEBANG = '#!'
 
-        def investigate(processed_source)
+        def on_new_investigation
           return if processed_source.tokens.empty?
 
           case style
@@ -95,23 +96,6 @@ module RuboCop
             ensure_enabled_comment(processed_source)
           else
             ensure_comment(processed_source)
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            case style
-            when :never
-              remove_comment(corrector, node)
-            when :always_true
-              if frozen_string_literal_specified?
-                enable_comment(corrector)
-              else
-                insert_comment(corrector)
-              end
-            else
-              insert_comment(corrector)
-            end
           end
         end
 
@@ -160,51 +144,45 @@ module RuboCop
         end
 
         def missing_offense(processed_source)
-          last_special_comment = last_special_comment(processed_source)
           range = source_range(processed_source.buffer, 0, 0)
 
-          add_offense(last_special_comment,
-                      location: range,
-                      message: MSG_MISSING)
+          add_offense(range, message: MSG_MISSING) do |corrector|
+            insert_comment(corrector)
+          end
         end
 
         def missing_true_offense(processed_source)
-          last_special_comment = last_special_comment(processed_source)
           range = source_range(processed_source.buffer, 0, 0)
 
-          add_offense(last_special_comment,
-                      location: range,
-                      message: MSG_MISSING_TRUE)
+          add_offense(range, message: MSG_MISSING_TRUE) do |corrector|
+            insert_comment(corrector)
+          end
         end
 
         def unnecessary_comment_offense(processed_source)
-          frozen_string_literal_comment =
-            frozen_string_literal_comment(processed_source)
+          frozen_string_literal_comment = frozen_string_literal_comment(processed_source)
 
-          add_offense(frozen_string_literal_comment,
-                      location: frozen_string_literal_comment.pos,
-                      message: MSG_UNNECESSARY)
+          add_offense(frozen_string_literal_comment.pos, message: MSG_UNNECESSARY) do |corrector|
+            remove_comment(corrector, frozen_string_literal_comment)
+          end
         end
 
         def disabled_offense(processed_source)
-          frozen_string_literal_comment =
-            frozen_string_literal_comment(processed_source)
+          frozen_string_literal_comment = frozen_string_literal_comment(processed_source)
 
-          add_offense(frozen_string_literal_comment,
-                      location: frozen_string_literal_comment.pos,
-                      message: MSG_DISABLED)
+          add_offense(frozen_string_literal_comment.pos, message: MSG_DISABLED) do |corrector|
+            enable_comment(corrector)
+          end
         end
 
         def remove_comment(corrector, node)
-          corrector.remove(range_with_surrounding_space(range: node.pos,
-                                                        side: :right))
+          corrector.remove(range_with_surrounding_space(range: node.pos, side: :right))
         end
 
         def enable_comment(corrector)
           comment = frozen_string_literal_comment(processed_source)
 
-          corrector.replace(line_range(comment.line),
-                            FROZEN_STRING_LITERAL_ENABLED)
+          corrector.replace(line_range(comment.line), FROZEN_STRING_LITERAL_ENABLED)
         end
 
         def insert_comment(corrector)

--- a/lib/rubocop/cop/style/global_vars.rb
+++ b/lib/rubocop/cop/style/global_vars.rb
@@ -19,7 +19,7 @@ module RuboCop
       #   FOO = 2
       #   foo = 2
       #   $stdin.read
-      class GlobalVars < Cop
+      class GlobalVars < Base
         MSG = 'Do not introduce global variables.'
 
         # built-in global variables and their English aliases
@@ -72,7 +72,7 @@ module RuboCop
         def check(node)
           global_var, = *node
 
-          add_offense(node, location: :name) unless allowed_var?(global_var)
+          add_offense(node.loc.name) unless allowed_var?(global_var)
         end
       end
     end

--- a/lib/rubocop/cop/style/guard_clause.rb
+++ b/lib/rubocop/cop/style/guard_clause.rb
@@ -46,7 +46,7 @@ module RuboCop
       #   # good
       #   foo || raise('exception') if something
       #   ok
-      class GuardClause < Cop
+      class GuardClause < Base
         include MinBodyLength
         include StatementModifier
 
@@ -105,9 +105,8 @@ module RuboCop
             example = "#{conditional_keyword} #{condition.source}; " \
                       "#{scope_exiting_keyword}; end"
           end
-          add_offense(node,
-                      location: :keyword,
-                      message: format(MSG, example: example))
+
+          add_offense(node.loc.keyword, message: format(MSG, example: example))
         end
 
         def guard_clause_source(guard_clause)

--- a/lib/rubocop/cop/style/hash_each_methods.rb
+++ b/lib/rubocop/cop/style/hash_each_methods.rb
@@ -17,8 +17,9 @@ module RuboCop
       #   # good
       #   hash.each_key { |k| p k }
       #   hash.each_value { |v| p v }
-      class HashEachMethods < Cop
+      class HashEachMethods < Base
         include Lint::UnusedArgument
+        extend AutoCorrector
 
         MSG = 'Use `%<prefer>s` instead of `%<current>s`.'
 
@@ -30,12 +31,6 @@ module RuboCop
           register_kv_offense(node)
         end
 
-        def autocorrect(node)
-          lambda do |corrector|
-            correct_key_value_each(node, corrector)
-          end
-        end
-
         private
 
         def register_kv_offense(node)
@@ -45,7 +40,9 @@ module RuboCop
             msg = format(message, prefer: "each_#{method[0..-2]}",
                                   current: "#{method}.each")
 
-            add_offense(target, location: kv_range(target), message: msg)
+            add_offense(kv_range(target), message: msg) do |corrector|
+              correct_key_value_each(target, corrector)
+            end
           end
         end
 

--- a/lib/rubocop/cop/style/hash_transform_keys.rb
+++ b/lib/rubocop/cop/style/hash_transform_keys.rb
@@ -23,9 +23,10 @@ module RuboCop
       #   # good
       #   {a: 1, b: 2}.transform_keys { |k| foo(k) }
       #   {a: 1, b: 2}.transform_keys { |k| k.to_s }
-      class HashTransformKeys < Cop
-        extend TargetRubyVersion
+      class HashTransformKeys < Base
         include HashTransformMethod
+        extend TargetRubyVersion
+        extend AutoCorrector
 
         minimum_target_ruby_version 2.5
 

--- a/lib/rubocop/cop/style/hash_transform_values.rb
+++ b/lib/rubocop/cop/style/hash_transform_values.rb
@@ -23,8 +23,9 @@ module RuboCop
       #   # good
       #   {a: 1, b: 2}.transform_values { |v| foo(v) }
       #   {a: 1, b: 2}.transform_values { |v| v * v }
-      class HashTransformValues < Cop
+      class HashTransformValues < Base
         include HashTransformMethod
+        extend AutoCorrector
 
         def_node_matcher :on_bad_each_with_object, <<~PATTERN
           (block

--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -62,7 +62,7 @@ module RuboCop
       #     do_x
       #     do_z
       #   end
-      class IdenticalConditionalBranches < Cop
+      class IdenticalConditionalBranches < Base
         MSG = 'Move `%<source>s` out of the conditional.'
 
         def on_if(node)

--- a/lib/rubocop/cop/style/if_inside_else.rb
+++ b/lib/rubocop/cop/style/if_inside_else.rb
@@ -58,7 +58,7 @@ module RuboCop
       #     action_b
       #   end
       #
-      class IfInsideElse < Cop
+      class IfInsideElse < Base
         MSG = 'Convert `if` nested inside `else` to `elsif`.'
 
         def on_if(node)
@@ -69,7 +69,7 @@ module RuboCop
           return unless else_branch&.if_type? && else_branch&.if?
           return if allow_if_modifier_in_else_branch?(else_branch)
 
-          add_offense(else_branch, location: :keyword)
+          add_offense(else_branch.loc.keyword)
         end
 
         private

--- a/lib/rubocop/cop/style/if_unless_modifier_of_if_unless.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier_of_if_unless.rb
@@ -22,20 +22,16 @@ module RuboCop
       #  if running?
       #    tired? ? 'stop' : 'go faster'
       #  end
-      class IfUnlessModifierOfIfUnless < Cop
+      class IfUnlessModifierOfIfUnless < Base
         include StatementModifier
+        extend AutoCorrector
 
         MSG = 'Avoid modifier `%<keyword>s` after another conditional.'
 
         def on_if(node)
           return unless node.modifier_form? && node.body.if_type?
 
-          add_offense(node, location: :keyword,
-                            message: format(MSG, keyword: node.keyword))
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(node.loc.keyword, message: format(MSG, keyword: node.keyword)) do |corrector|
             keyword = node.if? ? 'if' : 'unless'
 
             corrector.replace(node, <<~RUBY.chop)

--- a/lib/rubocop/cop/style/if_with_semicolon.rb
+++ b/lib/rubocop/cop/style/if_with_semicolon.rb
@@ -13,8 +13,9 @@ module RuboCop
       #   # good
       #   result = some_condition ? something : another_thing
       #
-      class IfWithSemicolon < Cop
+      class IfWithSemicolon < Base
         include OnNormalIfUnless
+        extend AutoCorrector
 
         MSG = 'Do not use if x; Use the ternary operator instead.'
 
@@ -24,11 +25,7 @@ module RuboCop
           beginning = node.loc.begin
           return unless beginning&.is?(';')
 
-          add_offense(node)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(node) do |corrector|
             corrector.replace(node, correct_to_ternary(node))
           end
         end

--- a/lib/rubocop/cop/style/implicit_runtime_error.rb
+++ b/lib/rubocop/cop/style/implicit_runtime_error.rb
@@ -14,7 +14,7 @@ module RuboCop
       #
       #   # good
       #   raise ArgumentError, 'Error message here'
-      class ImplicitRuntimeError < Cop
+      class ImplicitRuntimeError < Base
         MSG = 'Use `%<method>s` with an explicit exception class and message,' \
               ' rather than just a message.'
 

--- a/lib/rubocop/cop/style/infinite_loop.rb
+++ b/lib/rubocop/cop/style/infinite_loop.rb
@@ -15,13 +15,15 @@ module RuboCop
       #   loop do
       #     work
       #   end
-      class InfiniteLoop < Cop
+      class InfiniteLoop < Base
+        extend AutoCorrector
+
         LEADING_SPACE = /\A(\s*)/.freeze
 
         MSG = 'Use `Kernel#loop` for infinite loops.'
 
-        def join_force?(force_class)
-          force_class == VariableForce
+        def self.joining_forces
+          VariableForce
         end
 
         def after_leaving_scope(scope, _variable_table)
@@ -40,16 +42,6 @@ module RuboCop
         alias on_while_post on_while
         alias on_until_post on_until
 
-        def autocorrect(node)
-          if node.while_post_type? || node.until_post_type?
-            replace_begin_end_with_modifier(node)
-          elsif node.modifier_form?
-            replace_source(node.source_range, modifier_replacement(node))
-          else
-            replace_source(non_modifier_range(node), 'loop do')
-          end
-        end
-
         private
 
         def while_or_until(node)
@@ -66,7 +58,19 @@ module RuboCop
             referenced_after_loop?(var, range)
           end
 
-          add_offense(node, location: :keyword)
+          add_offense(node.loc.keyword) do |corrector|
+            autocorrect(corrector, node)
+          end
+        end
+
+        def autocorrect(corrector, node)
+          if node.while_post_type? || node.until_post_type?
+            replace_begin_end_with_modifier(corrector, node)
+          elsif node.modifier_form?
+            replace_source(corrector, node.source_range, modifier_replacement(node))
+          else
+            replace_source(corrector, non_modifier_range(node), 'loop do')
+          end
         end
 
         def assigned_inside_loop?(var, range)
@@ -83,17 +87,13 @@ module RuboCop
           var.references.any? { |r| r.node.source_range.begin_pos > e }
         end
 
-        def replace_begin_end_with_modifier(node)
-          lambda do |corrector|
-            corrector.replace(node.body.loc.begin, 'loop do')
-            corrector.remove(node.body.loc.end.end.join(node.source_range.end))
-          end
+        def replace_begin_end_with_modifier(corrector, node)
+          corrector.replace(node.body.loc.begin, 'loop do')
+          corrector.remove(node.body.loc.end.end.join(node.source_range.end))
         end
 
-        def replace_source(range, replacement)
-          lambda do |corrector|
-            corrector.replace(range, replacement)
-          end
+        def replace_source(corrector, range, replacement)
+          corrector.replace(range, replacement)
         end
 
         def modifier_replacement(node)

--- a/lib/rubocop/cop/style/inline_comment.rb
+++ b/lib/rubocop/cop/style/inline_comment.rb
@@ -17,10 +17,10 @@ module RuboCop
       #   foo.each do |f|
       #     f.bar # Trailing inline comment
       #   end
-      class InlineComment < Cop
+      class InlineComment < Base
         MSG = 'Avoid trailing inline comments.'
 
-        def investigate(processed_source)
+        def on_new_investigation
           processed_source.each_comment do |comment|
             next if comment_line?(processed_source[comment.loc.line - 1]) ||
                     comment.text.match?(/\A# rubocop:(enable|disable)/)

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -33,9 +33,10 @@ module RuboCop
       #     next if f.zero?
       #     f != 1
       #   end
-      class InverseMethods < Cop
+      class InverseMethods < Base
         include IgnoredNode
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Use `%<inverse>s` instead of inverting `%<method>s`.'
         CLASS_COMPARISON_METHODS = %i[<= >= < >].freeze
@@ -70,9 +71,9 @@ module RuboCop
             return if part_of_ignored_node?(node)
             return if possible_class_hierarchy_check?(lhs, rhs, method)
 
-            add_offense(node,
-                        message: format(MSG, method: method,
-                                             inverse: inverse_methods[method]))
+            add_offense(node, message: message(method, inverse_methods[method])) do |corrector|
+              correct_inverse_method(corrector, node)
+            end
           end
         end
 
@@ -86,40 +87,28 @@ module RuboCop
             # offense, such as `y.reject { |key, _value| !(key =~ /c\d/) }`,
             # can cause auto-correction to apply improper corrections.
             ignore_node(block)
-            add_offense(node,
-                        message: format(MSG, method: method,
-                                             inverse: inverse_blocks[method]))
+            add_offense(node, message: message(method, inverse_blocks[method])) do |corrector|
+              correct_inverse_block(corrector, node)
+            end
           end
         end
 
-        def autocorrect(node)
-          if node.block_type?
-            correct_inverse_block(node)
-          elsif node.send_type?
-            correct_inverse_method(node)
-          end
-        end
+        private
 
-        def correct_inverse_method(node)
+        def correct_inverse_method(corrector, node)
           method_call, _lhs, method, _rhs = inverse_candidate?(node)
           return unless method_call && method
 
-          lambda do |corrector|
-            corrector.remove(not_to_receiver(node, method_call))
-            corrector.replace(method_call.loc.selector,
-                              inverse_methods[method].to_s)
-            remove_end_parenthesis(corrector, node, method, method_call)
-          end
+          corrector.remove(not_to_receiver(node, method_call))
+          corrector.replace(method_call.loc.selector, inverse_methods[method].to_s)
+          remove_end_parenthesis(corrector, node, method, method_call)
         end
 
-        def correct_inverse_block(node)
+        def correct_inverse_block(corrector, node)
           method_call, method, block = inverse_block?(node)
 
-          lambda do |corrector|
-            corrector.replace(method_call.loc.selector,
-                              inverse_blocks[method].to_s)
-            correct_inverse_selector(block, corrector)
-          end
+          corrector.replace(method_call.loc.selector, inverse_blocks[method].to_s)
+          correct_inverse_selector(block, corrector)
         end
 
         def correct_inverse_selector(block, corrector)
@@ -138,8 +127,6 @@ module RuboCop
             corrector.remove(selector_loc)
           end
         end
-
-        private
 
         def inverse_methods
           @inverse_methods ||= cop_config['InverseMethods']
@@ -189,6 +176,10 @@ module RuboCop
                         method_call.parent.begin_type?
 
           corrector.remove(end_parentheses(node, method_call))
+        end
+
+        def message(method, inverse)
+          format(MSG, method: method, inverse: inverse)
         end
       end
     end

--- a/lib/rubocop/cop/style/lambda_call.rb
+++ b/lib/rubocop/cop/style/lambda_call.rb
@@ -18,30 +18,31 @@ module RuboCop
       #
       #  # good
       #  lambda.(x, y)
-      class LambdaCall < Cop
+      class LambdaCall < Base
         include ConfigurableEnforcedStyle
+        extend AutoCorrector
 
         def on_send(node)
           return unless node.receiver && node.method?(:call)
 
-          if offense?(node)
-            add_offense(node) { opposite_style_detected }
+          if offense?(node) && opposite_style_detected
+            add_offense(node) do |corrector|
+              autocorrect(corrector, node)
+            end
           else
             correct_style_detected
           end
         end
 
-        def autocorrect(node)
-          lambda do |corrector|
-            if explicit_style?
-              receiver = node.receiver.source
-              replacement = node.source.sub("#{receiver}.", "#{receiver}.call")
+        def autocorrect(corrector, node)
+          if explicit_style?
+            receiver = node.receiver.source
+            replacement = node.source.sub("#{receiver}.", "#{receiver}.call")
 
-              corrector.replace(node, replacement)
-            else
-              add_parentheses(node, corrector) unless node.parenthesized?
-              corrector.remove(node.loc.selector)
-            end
+            corrector.replace(node, replacement)
+          else
+            add_parentheses(node, corrector) unless node.parenthesized?
+            corrector.remove(node.loc.selector)
           end
         end
 

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -143,10 +143,11 @@ module RuboCop
       #
       #   # good
       #   Array 1
-      class MethodCallWithArgsParentheses < Cop
+      class MethodCallWithArgsParentheses < Base
         include ConfigurableEnforcedStyle
         include IgnoredMethods
         include IgnoredPattern
+        extend AutoCorrector
 
         def initialize(*)
           super

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -15,14 +15,7 @@ module RuboCop
             return if allowed_camel_case_method_call?(node)
             return if legitimate_call_with_parentheses?(node)
 
-            add_offense(node, location: node.loc.begin.join(node.loc.end))
-          end
-          alias on_csend on_send
-          alias on_super on_send
-          alias on_yield on_send
-
-          def autocorrect(node)
-            lambda do |corrector|
+            add_offense(offense_range(node)) do |corrector|
               if parentheses_at_the_end_of_multiline_call?(node)
                 corrector.replace(args_begin(node), ' \\')
               else
@@ -31,12 +24,19 @@ module RuboCop
               corrector.remove(node.loc.end)
             end
           end
-
-          def message(_node = nil)
-            'Omit parentheses for method calls with arguments.'
-          end
+          alias on_csend on_send
+          alias on_super on_send
+          alias on_yield on_send
 
           private
+
+          def offense_range(node)
+            node.loc.begin.join(node.loc.end)
+          end
+
+          def message(_range = nil)
+            'Omit parentheses for method calls with arguments.'
+          end
 
           def super_call_without_arguments?(node)
             node.super_type? && node.arguments.none?

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/require_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/require_parentheses.rb
@@ -12,19 +12,15 @@ module RuboCop
             return if eligible_for_parentheses_omission?(node)
             return unless node.arguments? && !node.parenthesized?
 
-            add_offense(node)
-          end
-          alias on_csend on_send
-          alias on_super on_send
-          alias on_yield on_send
-
-          def autocorrect(node)
-            lambda do |corrector|
+            add_offense(node) do |corrector|
               corrector.replace(args_begin(node), '(')
 
               corrector.insert_after(args_end(node), ')') unless args_parenthesized?(node)
             end
           end
+          alias on_csend on_send
+          alias on_super on_send
+          alias on_yield on_send
 
           def message(_node = nil)
             'Use parentheses for method calls with arguments.'

--- a/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
@@ -11,8 +11,9 @@ module RuboCop
       #
       #   # good
       #   object.some_method
-      class MethodCallWithoutArgsParentheses < Cop
+      class MethodCallWithoutArgsParentheses < Base
         include IgnoredMethods
+        extend AutoCorrector
 
         MSG = 'Do not use parentheses for method calls with ' \
               'no arguments.'
@@ -23,11 +24,7 @@ module RuboCop
           return if ignored_method?(node.method_name)
           return if same_name_assignment?(node)
 
-          add_offense(node, location: node.loc.begin.join(node.loc.end))
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(offense_range(node)) do |corrector|
             corrector.remove(node.loc.begin)
             corrector.remove(node.loc.end)
           end
@@ -68,6 +65,10 @@ module RuboCop
           var_nodes = *mlhs_node
 
           var_nodes.any? { |n| n.to_a.first == variable_name }
+        end
+
+        def offense_range(node)
+          node.loc.begin.join(node.loc.end)
         end
       end
     end

--- a/lib/rubocop/cop/style/method_called_on_do_end_block.rb
+++ b/lib/rubocop/cop/style/method_called_on_do_end_block.rb
@@ -12,7 +12,7 @@ module RuboCop
       #   a do
       #     b
       #   end.c
-      class MethodCalledOnDoEndBlock < Cop
+      class MethodCalledOnDoEndBlock < Base
         include RangeHelp
 
         MSG = 'Avoid chaining a method call on a do...end block.'
@@ -37,7 +37,7 @@ module RuboCop
           range = range_between(receiver.loc.end.begin_pos,
                                 node.source_range.end_pos)
 
-          add_offense(nil, location: range)
+          add_offense(range)
         end
         alias on_csend on_send
       end

--- a/lib/rubocop/cop/style/min_max.rb
+++ b/lib/rubocop/cop/style/min_max.rb
@@ -14,27 +14,23 @@ module RuboCop
       #   # good
       #   bar = foo.minmax
       #   return foo.minmax
-      class MinMax < Cop
+      class MinMax < Base
+        extend AutoCorrector
+
         MSG = 'Use `%<receiver>s.minmax` instead of `%<offender>s`.'
 
         def on_array(node)
           min_max_candidate(node) do |receiver|
             offender = offending_range(node)
 
-            add_offense(node, location: offender,
-                              message: message(offender, receiver))
+            add_offense(offender, message: message(offender, receiver)) do |corrector|
+              receiver = node.children.first.receiver
+
+              corrector.replace(offending_range(node), "#{receiver.source}.minmax")
+            end
           end
         end
         alias on_return on_array
-
-        def autocorrect(node)
-          receiver = node.children.first.receiver
-
-          lambda do |corrector|
-            corrector.replace(offending_range(node),
-                              "#{receiver.source}.minmax")
-          end
-        end
 
         private
 

--- a/lib/rubocop/cop/style/missing_else.rb
+++ b/lib/rubocop/cop/style/missing_else.rb
@@ -93,7 +93,7 @@ module RuboCop
       #   else
       #     # the content of `else` branch will be determined by Style/EmptyElse
       #   end
-      class MissingElse < Cop
+      class MissingElse < Base
         include OnNormalIfUnless
         include ConfigurableEnforcedStyle
 
@@ -119,20 +119,20 @@ module RuboCop
         private
 
         def check(node)
-          add_offense(node) unless node.else?
+          return if node.else?
+
+          add_offense(node, message: format(message_template, type: node.type))
         end
 
-        def message(node)
-          template = case empty_else_style
-                     when :empty
-                       MSG_NIL
-                     when :nil
-                       MSG_EMPTY
-                     else
-                       MSG
-                     end
-
-          format(template, type: node.type)
+        def message_template
+          case empty_else_style
+          when :empty
+            MSG_NIL
+          when :nil
+            MSG_EMPTY
+          else
+            MSG
+          end
         end
 
         def if_style?

--- a/lib/rubocop/cop/style/missing_respond_to_missing.rb
+++ b/lib/rubocop/cop/style/missing_respond_to_missing.rb
@@ -21,7 +21,7 @@ module RuboCop
       #     # ...
       #   end
       #
-      class MissingRespondToMissing < Cop
+      class MissingRespondToMissing < Base
         MSG =
           'When using `method_missing`, define `respond_to_missing?`.'
 

--- a/lib/rubocop/cop/style/mixin_usage.rb
+++ b/lib/rubocop/cop/style/mixin_usage.rb
@@ -40,7 +40,7 @@ module RuboCop
       #   class C
       #     prepend M
       #   end
-      class MixinUsage < Cop
+      class MixinUsage < Base
         MSG = '`%<statement>s` is used at the top level. Use inside `class` ' \
               'or `module`.'
 

--- a/lib/rubocop/cop/style/multiline_if_modifier.rb
+++ b/lib/rubocop/cop/style/multiline_if_modifier.rb
@@ -14,9 +14,10 @@ module RuboCop
       #
       #   # good
       #   { result: 'ok' } if cond
-      class MultilineIfModifier < Cop
+      class MultilineIfModifier < Base
         include StatementModifier
         include Alignment
+        extend AutoCorrector
 
         MSG = 'Favor a normal %<keyword>s-statement over a modifier' \
               ' clause in a multiline statement.'
@@ -24,20 +25,12 @@ module RuboCop
         def on_if(node)
           return unless node.modifier_form? && node.body.multiline?
 
-          add_offense(node)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(node, message: format(MSG, keyword: node.keyword)) do |corrector|
             corrector.replace(node, to_normal_if(node))
           end
         end
 
         private
-
-        def message(node)
-          format(MSG, keyword: node.keyword)
-        end
 
         def to_normal_if(node)
           indented_body = indented_body(node.body, node)

--- a/lib/rubocop/cop/style/multiline_if_then.rb
+++ b/lib/rubocop/cop/style/multiline_if_then.rb
@@ -16,9 +16,10 @@ module RuboCop
       #   if cond then a
       #   elsif cond then b
       #   end
-      class MultilineIfThen < Cop
+      class MultilineIfThen < Base
         include OnNormalIfUnless
         include RangeHelp
+        extend AutoCorrector
 
         NON_MODIFIER_THEN = /then\s*(#.*)?$/.freeze
 
@@ -27,15 +28,8 @@ module RuboCop
         def on_normal_if_unless(node)
           return unless non_modifier_then?(node)
 
-          add_offense(node, location: :begin,
-                            message: format(MSG, keyword: node.keyword))
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.remove(
-              range_with_surrounding_space(range: node.loc.begin, side: :left)
-            )
+          add_offense(node.loc.begin, message: format(MSG, keyword: node.keyword)) do |corrector|
+            corrector.remove(range_with_surrounding_space(range: node.loc.begin, side: :left))
           end
         end
 

--- a/lib/rubocop/cop/style/multiline_memoization.rb
+++ b/lib/rubocop/cop/style/multiline_memoization.rb
@@ -30,8 +30,9 @@ module RuboCop
       #     bar
       #     baz
       #   )
-      class MultilineMemoization < Cop
+      class MultilineMemoization < Base
         include ConfigurableEnforcedStyle
+        extend AutoCorrector
 
         MSG = 'Wrap multiline memoization blocks in `begin` and `end`.'
 
@@ -40,16 +41,12 @@ module RuboCop
 
           return unless bad_rhs?(rhs)
 
-          add_offense(rhs, location: node.source_range)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(node.source_range) do |corrector|
             if style == :keyword
-              keyword_autocorrect(node, corrector)
+              keyword_autocorrect(rhs, corrector)
             else
-              corrector.replace(node.loc.begin, '(')
-              corrector.replace(node.loc.end, ')')
+              corrector.replace(rhs.loc.begin, '(')
+              corrector.replace(rhs.loc.end, ')')
             end
           end
         end

--- a/lib/rubocop/cop/style/multiline_method_signature.rb
+++ b/lib/rubocop/cop/style/multiline_method_signature.rb
@@ -18,7 +18,7 @@ module RuboCop
       #           baz)
       #   end
       #
-      class MultilineMethodSignature < Cop
+      class MultilineMethodSignature < Base
         MSG = 'Avoid multi-line method signatures.'
 
         def on_def(node)

--- a/lib/rubocop/cop/style/multiline_ternary_operator.rb
+++ b/lib/rubocop/cop/style/multiline_ternary_operator.rb
@@ -22,18 +22,16 @@ module RuboCop
       #   else
       #     c
       #   end
-      class MultilineTernaryOperator < Cop
+      class MultilineTernaryOperator < Base
+        extend AutoCorrector
+
         MSG = 'Avoid multi-line ternary operators, ' \
               'use `if` or `unless` instead.'
 
         def on_if(node)
           return unless node.ternary? && node.multiline?
 
-          add_offense(node)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(node) do |corrector|
             corrector.replace(node, <<~RUBY.chop)
               if #{node.condition.source}
                 #{node.if_branch.source}

--- a/lib/rubocop/cop/style/multiline_when_then.rb
+++ b/lib/rubocop/cop/style/multiline_when_then.rb
@@ -28,8 +28,9 @@ module RuboCop
       #                              arg2)
       #   end
       #
-      class MultilineWhenThen < Cop
+      class MultilineWhenThen < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Do not use `then` for multiline `when` statement.'
 
@@ -46,18 +47,15 @@ module RuboCop
           # With more than one statements after then, there's not offense
           return if accept_node_type?(node.body)
 
-          add_offense(node, location: :begin)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          range = node.loc.begin
+          add_offense(range) do |corrector|
             corrector.remove(
-              range_with_surrounding_space(
-                range: node.loc.begin, side: :left, newlines: false
-              )
+              range_with_surrounding_space(range: range, side: :left, newlines: false)
             )
           end
         end
+
+        private
 
         def require_then?(when_node)
           return false unless when_node.body

--- a/lib/rubocop/cop/style/multiple_comparison.rb
+++ b/lib/rubocop/cop/style/multiple_comparison.rb
@@ -14,7 +14,7 @@ module RuboCop
       #   # good
       #   a = 'a'
       #   foo if ['a', 'b', 'c'].include?(a)
-      class MultipleComparison < Cop
+      class MultipleComparison < Base
         MSG = 'Avoid comparing a variable with multiple items ' \
           'in a conditional, use `Array#include?` instead.'
 

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -118,8 +118,8 @@ RSpec.describe RuboCop::Cop::Cop, :config do
     let(:cop_class) { RuboCop::Cop::Style::For }
 
     it 'registers offense with its name' do
-      cop.add_offense(nil, location: location, message: 'message')
-      expect(cop.offenses.first.cop_name).to eq('Style/For')
+      offenses = cop.add_offense(location, message: 'message')
+      expect(offenses.first.cop_name).to eq('Style/For')
     end
   end
 


### PR DESCRIPTION
Follow #7868.

This PR uses `Cop::Base` API for almost `Style` department's F-M cops.
It targets cop that names begin between F and M. And several F-M cops will be excluded from this PR target and addressed separately.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
