### PR TITLE
Use new `RuboCop::Cop::Registry` APIs instead of deprecated APIs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -47,9 +47,9 @@ task :bench_cop, %i[cop srcpath times] do |_task, args|
   iterations = args[:times] ? Integer(args[:times]) : 1
 
   cop_class = if cop_name.include?('/')
-                Cop::Cop.all.find { |klass| klass.cop_name == cop_name }
+                Cop::Registry.all.find { |klass| klass.cop_name == cop_name }
               else
-                Cop::Cop.all.find do |klass|
+                Cop::Registry.all.find do |klass|
                   klass.cop_name[/[a-zA-Z]+$/] == cop_name
                 end
               end
@@ -89,7 +89,7 @@ task documentation_syntax_check: :yard_for_generate_documentation do
 
   ok = true
   YARD::Registry.load!
-  cops = RuboCop::Cop::Cop.registry
+  cops = RuboCop::Cop::Registry.global
   cops.each do |cop|
     next if %i[RSpec Capybara FactoryBot].include?(cop.department)
 

--- a/lib/rubocop/cli/command/show_cops.rb
+++ b/lib/rubocop/cli/command/show_cops.rb
@@ -22,7 +22,7 @@ module RuboCop
         private
 
         def print_available_cops
-          registry = Cop::Cop.registry
+          registry = Cop::Registry.global
           show_all = @options[:show_cops].empty?
 
           if show_all

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -153,11 +153,11 @@ module RuboCop
     end
 
     def qualified_cop_name(cop_name)
-      Cop::Cop.qualified_cop_name(cop_name.strip, processed_source.file_path)
+      Cop::Registry.qualified_cop_name(cop_name.strip, processed_source.file_path)
     end
 
     def all_cop_names
-      @all_cop_names ||= Cop::Cop.registry.names - [REDUNDANT_DISABLE]
+      @all_cop_names ||= Cop::Registry.global.names - [REDUNDANT_DISABLE]
     end
 
     def comment_only_line?(line_number)

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -24,7 +24,7 @@ module RuboCop
     def initialize(hash = {}, loaded_path = nil)
       @loaded_path = loaded_path
       @for_cop = Hash.new do |h, cop|
-        qualified_cop_name = Cop::Cop.qualified_cop_name(cop, loaded_path)
+        qualified_cop_name = Cop::Registry.qualified_cop_name(cop, loaded_path)
         cop_options = self[qualified_cop_name] || {}
         cop_options['Enabled'] = enable_cop?(qualified_cop_name, cop_options)
         h[cop] = cop_options

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -73,7 +73,7 @@ module RuboCop
         # `can't add a new key into hash during iteration` error
         hash_keys = hash.keys
         hash_keys.each do |key|
-          q = Cop::Cop.qualified_cop_name(key, path)
+          q = Cop::Registry.qualified_cop_name(key, path)
           next if q == key
 
           hash[q] = hash.delete(key)

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -84,7 +84,7 @@ module RuboCop
       unknown_cops = []
       invalid_cop_names.each do |name|
         # There could be a custom cop with this name. If so, don't warn
-        next if Cop::Cop.registry.contains_cop_matching?([name])
+        next if Cop::Registry.global.contains_cop_matching?([name])
 
         # Special case for inherit_mode, which is a directive that we keep in
         # the configuration (even though it's not a cop), because it's easier

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -250,7 +250,7 @@ module RuboCop
         end
 
         def all_cop_names
-          @all_cop_names ||= Cop.registry.names
+          @all_cop_names ||= Registry.global.names
         end
 
         def ends_its_line?(range)

--- a/lib/rubocop/cop/migration/department_name.rb
+++ b/lib/rubocop/cop/migration/department_name.rb
@@ -51,7 +51,7 @@ module RuboCop
 
           add_offense(range) do |corrector|
             cop_name = range.source
-            qualified_cop_name = Cop.registry.qualified_cop_name(cop_name, nil, warn: false)
+            qualified_cop_name = Registry.global.qualified_cop_name(cop_name, nil, warn: false)
 
             unless qualified_cop_name.include?('/')
               qualified_cop_name = qualified_legacy_cop_name(cop_name)

--- a/lib/rubocop/cops_documentation_generator.rb
+++ b/lib/rubocop/cops_documentation_generator.rb
@@ -10,7 +10,7 @@ class CopsDocumentationGenerator # rubocop:disable Metrics/ClassLength
   #
   def initialize(departments: [])
     @departments = departments.map(&:to_sym).sort!
-    @cops = RuboCop::Cop::Cop.registry
+    @cops = RuboCop::Cop::Registry.global
     @config = RuboCop::ConfigLoader.default_configuration
   end
 

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -114,7 +114,7 @@ module RuboCop
       def output_cop_comments(output_buffer, cfg, cop_name, offense_count)
         output_buffer.puts "# Offense count: #{offense_count}" if @show_offense_counts
 
-        cop_class = Cop::Cop.registry.find_by_cop_name(cop_name)
+        cop_class = Cop::Registry.global.find_by_cop_name(cop_name)
         output_buffer.puts '# Cop supports --auto-correct.' if cop_class&.support_autocorrect?
 
         default_cfg = default_config(cop_name)

--- a/lib/rubocop/formatter/junit_formatter.rb
+++ b/lib/rubocop/formatter/junit_formatter.rb
@@ -34,7 +34,7 @@ module RuboCop
         # https://github.com/mikian/rubocop-junit-formatter/blob/v0.1.4/lib/rubocop/formatter/junit_formatter.rb#L9
         #
         # In the future, it would be preferable to return only enabled cops.
-        Cop::Cop.all.each do |cop|
+        Cop::Registry.all.each do |cop|
           target_offenses = offenses_for_cop(offenses, cop)
 
           next unless relevant_for_output?(options, target_offenses)

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -94,7 +94,7 @@ module RuboCop
             ['']
           else
             list.split(',').map do |c|
-              Cop::Cop.qualified_cop_name(c, "--#{option} option")
+              Cop::Registry.qualified_cop_name(c, "--#{option} option")
             end
           end
       end
@@ -239,8 +239,8 @@ module RuboCop
       def validate_cop_list(names)
         return unless names
 
-        cop_names = Cop::Cop.registry.names
-        departments = Cop::Cop.registry.departments.map(&:to_s)
+        cop_names = Cop::Registry.global.names
+        departments = Cop::Registry.global.departments.map(&:to_s)
 
         names.each do |name|
           next if cop_names.include?(name)

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -306,7 +306,7 @@ module RuboCop
     def mobilized_cop_classes(config)
       @mobilized_cop_classes ||= {}
       @mobilized_cop_classes[config.object_id] ||= begin
-        cop_classes = Cop::Cop.all
+        cop_classes = Cop::Registry.all
 
         OptionsValidator.new(@options).validate_cop_options
 

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'RuboCop Project', type: :feature do
   end
 
   describe 'cop message' do
-    let(:cops) { RuboCop::Cop::Cop.all }
+    let(:cops) { RuboCop::Cop::Registry.all }
 
     it 'end with a period or a question mark' do
       cops.each do |cop|

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -922,8 +922,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
     end
 
-    let(:cops) { RuboCop::Cop::Cop.all }
-    let(:registry) { RuboCop::Cop::Cop.registry }
+    let(:cops) { RuboCop::Cop::Registry.all }
+    let(:registry) { RuboCop::Cop::Registry.global }
 
     let(:global_conf) do
       config_path =

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe RuboCop::CommentConfig do
        'with keyword all' do
       expected_part = (7..8).to_a
 
-      cops = RuboCop::Cop::Cop.all.reject do |klass|
+      cops = RuboCop::Cop::Registry.all.reject do |klass|
         klass == RuboCop::Cop::Lint::RedundantCopDisableDirective
       end
 

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::Team do
   subject(:team) { described_class.mobilize(cop_classes, config, options) }
 
-  let(:cop_classes) { RuboCop::Cop::Cop.registry }
+  let(:cop_classes) { RuboCop::Cop::Registry.global }
   let(:config) { RuboCop::ConfigLoader.default_configuration }
   let(:options) { {} }
   let(:ruby_version) { RuboCop::TargetRuby.supported_versions.last }
@@ -279,7 +279,7 @@ RSpec.describe RuboCop::Cop::Team do
   describe '#forces' do
     subject(:forces) { team.forces }
 
-    let(:cop_classes) { RuboCop::Cop::Cop.registry }
+    let(:cop_classes) { RuboCop::Cop::Registry.global }
 
     it 'returns force instances' do
       expect(forces.empty?).to be(false)

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
       formatter.file_finished('test_b.rb', [offenses.first])
 
       # Cop1 and Cop2 are unknown cops and would raise an validation error
-      allow(RuboCop::Cop::Cop.registry).to receive(:contains_cop_matching?)
+      allow(RuboCop::Cop::Registry.global).to receive(:contains_cop_matching?)
         .and_return(true)
       formatter.finished(['test_a.rb', 'test_b.rb'])
     end

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
     described_class.new(file, team, options, config_store, cache_root)
   end
 
-  let(:cops) { RuboCop::Cop::Cop.all }
-  let(:registry) { RuboCop::Cop::Cop.registry }
+  let(:cops) { RuboCop::Cop::Registry.all }
+  let(:registry) { RuboCop::Cop::Registry.global }
   let(:team) do
     RuboCop::Cop::Team.mobilize(
       registry,


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/8095

This PR uses new `RuboCop::Cop::Registry` APIs instead of deprecated APIs.

- `Cop.registry` -> `Registry.global`
- `Cop.all` -> `Registry.all`
- `Cop.qualified_cop_name` -> `Registry.qualified_cop_name`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
