### PR TITLE
[#8362] Display correctable offenses in summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+### Changes
+* [#8362](https://github.com/rubocop-hq/rubocop/issues/8362): Add numbers of correctable offenses to summary. ([@nguyenquangminh0711][])
+
 ## 0.89.1 (2020-08-10)
 
 ### Bug fixes
@@ -4773,3 +4776,4 @@
 [@dsavochkin]: https://github.com/dmytro-savochkin
 [@sonalinavlakhe]: https://github.com/sonalinavlakhe
 [@wcmonty]: https://github.com/wcmonty
+[@nguyenquangminh0711]: https://github.com/nguyenquangminh0711

--- a/lib/rubocop/formatter/auto_gen_config_formatter.rb
+++ b/lib/rubocop/formatter/auto_gen_config_formatter.rb
@@ -9,7 +9,8 @@ module RuboCop
 
         report_summary(inspected_files.size,
                        @total_offense_count,
-                       @total_correction_count)
+                       @total_correction_count,
+                       @total_correctable_count)
       end
     end
   end

--- a/lib/rubocop/formatter/progress_formatter.rb
+++ b/lib/rubocop/formatter/progress_formatter.rb
@@ -45,7 +45,8 @@ module RuboCop
 
         report_summary(inspected_files.size,
                        @total_offense_count,
-                       @total_correction_count)
+                       @total_correction_count,
+                       @total_correctable_count)
       end
 
       def report_file_as_mark(offenses)

--- a/lib/rubocop/formatter/quiet_formatter.rb
+++ b/lib/rubocop/formatter/quiet_formatter.rb
@@ -5,7 +5,7 @@ module RuboCop
     # If no offenses are found, no output is displayed.
     # Otherwise, SimpleTextFormatter's output is displayed.
     class QuietFormatter < SimpleTextFormatter
-      def report_summary(file_count, offense_count, correction_count)
+      def report_summary(file_count, offense_count, correction_count, correctable_count)
         super unless offense_count.zero?
       end
     end

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             == example.rb ==
             C:  2: 91: Layout/LineLength: Line is too long. [99/90]
 
-            1 file inspected, 1 offense detected
+            1 file inspected, 1 offense detected, 1 offense auto-correctable
           OUTPUT
         end
       end
@@ -1111,7 +1111,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           Inspecting 1 file
           C
 
-          1 file inspected, 1 offense detected
+          1 file inspected, 1 offense detected, 1 offense auto-correctable
           Created .rubocop_todo.yml.
         OUTPUT
       end

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1410,7 +1410,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       C:  2: 34: Style/Semicolon: Do not use semicolons to terminate expressions.
       W:  3: 27: Lint/UnusedMethodArgument: Unused method argument - bar.
 
-      1 file inspected, 3 offenses detected
+      1 file inspected, 3 offenses detected, 3 more offenses can be corrected with `rubocop -A`
     RESULT
   end
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           C:  1:  1: Layout/EndOfLine: Carriage return character detected.
           C:  1:  1: Style/FrozenStringLiteralComment: Missing frozen string literal comment.
 
-          1 file inspected, 2 offenses detected
+          1 file inspected, 2 offenses detected, 1 offense auto-correctable
       RESULT
       expect($stderr.string).to eq(<<~RESULT)
         #{abs('.rubocop.yml')}: Warning: no department given for EndOfLine.
@@ -145,7 +145,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         == example.rb ==
         C:  3:  6: Layout/TrailingWhitespace: Trailing whitespace detected.
 
-        1 file inspected, 1 offense detected
+        1 file inspected, 1 offense detected, 1 offense auto-correctable
     RESULT
   end
 
@@ -486,7 +486,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
               == example.rb ==
               C:  1:  3: Layout/LineLength: Line is too long. [5/2]
 
-              1 file inspected, 1 offense detected
+              1 file inspected, 1 offense detected, 1 offense auto-correctable
             RESULT
         end
 
@@ -729,7 +729,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
               C:  9:  3: Layout/IndentationWidth: Use 2 (not 0) spaces for indented_internal_methods indentation.
               C: 15:  3: Layout/IndentationWidth: Use 2 (not 0) spaces for indented_internal_methods indentation.
 
-              1 file inspected, 2 offenses detected
+              1 file inspected, 2 offenses detected, 2 offenses auto-correctable
           RESULT
         end
       end
@@ -818,7 +818,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
               == example.rb ==
               C:  3:  6: Layout/TrailingWhitespace: Trailing whitespace detected.
 
-              1 file inspected, 1 offense detected
+              1 file inspected, 1 offense detected, 1 offense auto-correctable
             RESULT
         end
       end
@@ -858,7 +858,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         == example1.rb ==
         C:  3:  6: Layout/TrailingWhitespace: Trailing whitespace detected.
 
-        2 files inspected, 2 offenses detected
+        2 files inspected, 2 offenses detected, 2 offenses auto-correctable
       RESULT
     end
 
@@ -884,7 +884,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         == example1.rb ==
         C:  3:  6: Layout/TrailingWhitespace: Trailing whitespace detected.
 
-        2 files inspected, 2 offenses detected
+        2 files inspected, 2 offenses detected, 2 offenses auto-correctable
       RESULT
     end
 
@@ -1032,7 +1032,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         == special.dsl ==
         C:  3:  9: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
 
-        1 file inspected, 1 offense detected
+        1 file inspected, 1 offense detected, 1 offense auto-correctable
       RESULT
     end
 
@@ -1072,7 +1072,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           == example1.rb ==
           C:  3:  7: Layout/TrailingWhitespace: Trailing whitespace detected.
 
-          1 file inspected, 1 offense detected
+          1 file inspected, 1 offense detected, 1 offense auto-correctable
         RESULT
     end
 
@@ -1095,7 +1095,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             == example1.rb ==
             C:  3:  7: Layout/TrailingWhitespace: Trailing whitespace detected.
 
-            1 file inspected, 1 offense detected
+            1 file inspected, 1 offense detected, 1 offense auto-correctable
           RESULT
       end
     end
@@ -1155,7 +1155,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         C:  4:  6: Style/PercentLiteralDelimiters: %q-literals should be delimited by ( and ).
         C:  4:  6: Style/RedundantPercentQ: Use %q only for strings that contain both single quotes and double quotes.
 
-        1 file inspected, 3 offenses detected
+        1 file inspected, 3 offenses detected, 3 offenses auto-correctable
       RESULT
     end
 
@@ -1186,7 +1186,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           C:  1:  5: Style/CollectionMethods: Prefer find_all over select.
           C:  1: 26: Style/CollectionMethods: Prefer map over collect.
 
-          1 file inspected, 2 offenses detected
+          1 file inspected, 2 offenses detected, 2 offenses auto-correctable
         RESULT
     end
 
@@ -1211,7 +1211,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         == example1.rb ==
         C:  3:  1: Style/IfUnlessModifier: Favor modifier if usage when having a single-line body. Another good alternative is the usage of control flow &&/||.
 
-        1 file inspected, 1 offense detected
+        1 file inspected, 1 offense detected, 1 offense auto-correctable
       RESULT
       expect(result).to eq(1)
     end
@@ -1234,7 +1234,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           == example_src/example1.rb ==
           C:  3:  7: Layout/TrailingWhitespace: Trailing whitespace detected.
 
-          1 file inspected, 1 offense detected
+          1 file inspected, 1 offense detected, 1 offense auto-correctable
         RESULT
     end
 
@@ -1273,7 +1273,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         == example/lib/example1.rb ==
         C:  3:121: Layout/LineLength: Line is too long. [130/120]
 
-        2 files inspected, 1 offense detected
+        2 files inspected, 1 offense detected, 1 offense auto-correctable
       RESULT
     end
 
@@ -1329,7 +1329,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         == example/tmp/test/example1.rb ==
         C:  3:121: Layout/LineLength: Line is too long. [130/120]
 
-        1 file inspected, 1 offense detected
+        1 file inspected, 1 offense detected, 1 offense auto-correctable
       RESULT
     end
 
@@ -1538,7 +1538,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           C:  3: 46: Style/CommentedKeyword: Do not place comments on the same line as the def keyword.
           E:  3:121: Layout/LineLength: Line is too long. [130/120]
 
-          1 file inspected, 4 offenses detected
+          1 file inspected, 4 offenses detected, 1 offense auto-correctable
         RESULT
         expect($stderr.string).to eq('')
       end

--- a/spec/rubocop/formatter/auto_gen_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/auto_gen_config_formatter_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe RuboCop::Formatter::AutoGenConfigFormatter do
       it 'outputs report summary' do
         formatter.finished(files)
         expect(output.string).to include <<~OUTPUT
-          3 files inspected, 1 offense detected
+          3 files inspected, 1 offense detected, 1 offense auto-correctable
         OUTPUT
       end
     end

--- a/spec/rubocop/formatter/quiet_formatter_spec.rb
+++ b/spec/rubocop/formatter/quiet_formatter_spec.rb
@@ -76,21 +76,21 @@ RSpec.describe RuboCop::Formatter::QuietFormatter do
   describe '#report_summary' do
     context 'when no files inspected' do
       it 'handles pluralization correctly' do
-        formatter.report_summary(0, 0, 0)
+        formatter.report_summary(0, 0, 0, 0)
         expect(output.string.empty?).to eq(true)
       end
     end
 
     context 'when a file inspected and no offenses detected' do
       it 'handles pluralization correctly' do
-        formatter.report_summary(1, 0, 0)
+        formatter.report_summary(1, 0, 0, 0)
         expect(output.string.empty?).to eq(true)
       end
     end
 
     context 'when a offense detected' do
       it 'handles pluralization correctly' do
-        formatter.report_summary(1, 1, 0)
+        formatter.report_summary(1, 1, 0, 0)
         expect(output.string).to eq(<<~OUTPUT)
 
           1 file inspected, 1 offense detected
@@ -98,9 +98,19 @@ RSpec.describe RuboCop::Formatter::QuietFormatter do
       end
     end
 
+    context 'when a offense detected and a offense correctable' do
+      it 'handles pluralization correctly' do
+        formatter.report_summary(1, 1, 0, 1)
+        expect(output.string).to eq(<<~OUTPUT)
+
+          1 file inspected, 1 offense detected, 1 offense auto-correctable
+        OUTPUT
+      end
+    end
+
     context 'when 2 offenses detected' do
       it 'handles pluralization correctly' do
-        formatter.report_summary(2, 2, 0)
+        formatter.report_summary(2, 2, 0, 0)
         expect(output.string).to eq(<<~OUTPUT)
 
           2 files inspected, 2 offenses detected
@@ -108,9 +118,19 @@ RSpec.describe RuboCop::Formatter::QuietFormatter do
       end
     end
 
+    context 'when 2 offenses detected and 2 offenses correctable' do
+      it 'handles pluralization correctly' do
+        formatter.report_summary(2, 2, 0, 2)
+        expect(output.string).to eq(<<~OUTPUT)
+
+          2 files inspected, 2 offenses detected, 2 offenses auto-correctable
+        OUTPUT
+      end
+    end
+
     context 'when an offense is corrected' do
       it 'prints about correction' do
-        formatter.report_summary(1, 1, 1)
+        formatter.report_summary(1, 1, 1, 0)
         expect(output.string).to eq(<<~OUTPUT)
 
           1 file inspected, 1 offense detected, 1 offense corrected
@@ -120,10 +140,20 @@ RSpec.describe RuboCop::Formatter::QuietFormatter do
 
     context 'when 2 offenses are corrected' do
       it 'handles pluralization correctly' do
-        formatter.report_summary(1, 1, 2)
+        formatter.report_summary(1, 1, 2, 0)
         expect(output.string).to eq(<<~OUTPUT)
 
           1 file inspected, 1 offense detected, 2 offenses corrected
+        OUTPUT
+      end
+    end
+
+    context 'when 2 offenses are corrected and 2 offenses correctable' do
+      it 'handles pluralization correctly' do
+        formatter.report_summary(1, 1, 2, 2)
+        expect(output.string).to eq(<<~OUTPUT)
+
+          1 file inspected, 1 offense detected, 2 offenses corrected, 2 offenses auto-correctable
         OUTPUT
       end
     end

--- a/spec/rubocop/formatter/simple_text_formatter_spec.rb
+++ b/spec/rubocop/formatter/simple_text_formatter_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe RuboCop::Formatter::SimpleTextFormatter do
   describe '#report_summary' do
     context 'when no files inspected' do
       it 'handles pluralization correctly' do
-        formatter.report_summary(0, 0, 0)
+        formatter.report_summary(0, 0, 0, 0)
         expect(output.string).to eq(<<~OUTPUT)
 
           0 files inspected, no offenses detected
@@ -95,7 +95,7 @@ RSpec.describe RuboCop::Formatter::SimpleTextFormatter do
 
     context 'when a file inspected and no offenses detected' do
       it 'handles pluralization correctly' do
-        formatter.report_summary(1, 0, 0)
+        formatter.report_summary(1, 0, 0, 0)
         expect(output.string).to eq(<<~OUTPUT)
 
           1 file inspected, no offenses detected
@@ -105,7 +105,7 @@ RSpec.describe RuboCop::Formatter::SimpleTextFormatter do
 
     context 'when a offense detected' do
       it 'handles pluralization correctly' do
-        formatter.report_summary(1, 1, 0)
+        formatter.report_summary(1, 1, 0, 0)
         expect(output.string).to eq(<<~OUTPUT)
 
           1 file inspected, 1 offense detected
@@ -113,9 +113,19 @@ RSpec.describe RuboCop::Formatter::SimpleTextFormatter do
       end
     end
 
+    context 'when a offense detected and a offense auto-correctable' do
+      it 'handles pluralization correctly' do
+        formatter.report_summary(1, 1, 0, 1)
+        expect(output.string).to eq(<<~OUTPUT)
+
+          1 file inspected, 1 offense detected, 1 offense auto-correctable
+        OUTPUT
+      end
+    end
+
     context 'when 2 offenses detected' do
       it 'handles pluralization correctly' do
-        formatter.report_summary(2, 2, 0)
+        formatter.report_summary(2, 2, 0, 0)
         expect(output.string).to eq(<<~OUTPUT)
 
           2 files inspected, 2 offenses detected
@@ -123,9 +133,19 @@ RSpec.describe RuboCop::Formatter::SimpleTextFormatter do
       end
     end
 
+    context 'when 2 offenses detected and 2 offenses auto-correctable' do
+      it 'handles pluralization correctly' do
+        formatter.report_summary(2, 2, 0, 2)
+        expect(output.string).to eq(<<~OUTPUT)
+
+          2 files inspected, 2 offenses detected, 2 offenses auto-correctable
+        OUTPUT
+      end
+    end
+
     context 'when an offense is corrected' do
       it 'prints about correction' do
-        formatter.report_summary(1, 1, 1)
+        formatter.report_summary(1, 1, 1, 0)
         expect(output.string).to eq(<<~OUTPUT)
 
           1 file inspected, 1 offense detected, 1 offense corrected
@@ -135,10 +155,20 @@ RSpec.describe RuboCop::Formatter::SimpleTextFormatter do
 
     context 'when 2 offenses are corrected' do
       it 'handles pluralization correctly' do
-        formatter.report_summary(1, 1, 2)
+        formatter.report_summary(1, 1, 2, 0)
         expect(output.string).to eq(<<~OUTPUT)
 
           1 file inspected, 1 offense detected, 2 offenses corrected
+        OUTPUT
+      end
+    end
+
+    context 'when 2 offenses are corrected and 2 offenses auto-correctable' do
+      it 'handles pluralization correctly' do
+        formatter.report_summary(1, 1, 2, 2)
+        expect(output.string).to eq(<<~OUTPUT)
+
+          1 file inspected, 1 offense detected, 2 offenses corrected, 2 offenses auto-correctable
         OUTPUT
       end
     end


### PR DESCRIPTION
Solve https://github.com/rubocop-hq/rubocop/issues/8362

- When doing investigation only, without `-a`. It
![Screenshot from 2020-08-10 20-51-16](https://user-images.githubusercontent.com/11613517/89789884-6747a480-db4b-11ea-958f-f394802a6de0.png)

- When running safe corrector:
![Screenshot from 2020-08-10 20-51-27](https://user-images.githubusercontent.com/11613517/89789978-83e3dc80-db4b-11ea-9e30-a08beb7f0f9d.png)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
