### PR TITLE
[Fix 8497] Fix Style/IfUnlessModifier to handle if-end condition in method argument list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#8480](https://github.com/rubocop-hq/rubocop/issues/8480): Tweak callback list of `Lint/MissingSuper`. ([@marcandre][])
 * [#8481](https://github.com/rubocop-hq/rubocop/pull/8481): Fix autocorrect for elements with newlines in `Style/SymbolArray` and `Style/WordArray`. ([@biinari][])
 * [#8475](https://github.com/rubocop-hq/rubocop/issues/8475): Fix a false positive for `Style/HashAsLastArrayItem` when there are duplicate hashes in the array. ([@wcmonty][])
+* [#8497](https://github.com/rubocop-hq/rubocop/issues/8497): Fix `Style/IfUnlessModifier` to add parentheses when converting if-end condition inside a parenthesized method argument list. ([@dsavochkin][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -72,7 +72,7 @@ module RuboCop
         return true if parent.assignment? || parent.operator_keyword?
         return true if %i[array pair].include?(parent.type)
 
-        node.parent.send_type? && !node.parent.parenthesized?
+        node.parent.send_type?
       end
 
       def max_line_length

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -457,7 +457,7 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
   end
 
   context 'if-end is argument to a parenthesized method call' do
-    it "doesn't add redundant parentheses" do
+    it 'adds parentheses because otherwise it would cause SyntaxError' do
       expect_offense(<<~RUBY)
         puts("string", if a
                        ^^ Favor modifier `if` usage when having a single-line body. [...]
@@ -466,7 +466,7 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
       RUBY
 
       expect_correction(<<~RUBY)
-        puts("string", 1 if a)
+        puts("string", (1 if a))
       RUBY
     end
   end


### PR DESCRIPTION
Fixes #8497.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
