### PR TITLE
Alter multiline memoization message for braces enforced style

### DIFF
--- a/lib/rubocop/cop/style/multiline_memoization.rb
+++ b/lib/rubocop/cop/style/multiline_memoization.rb
@@ -34,7 +34,8 @@ module RuboCop
         include ConfigurableEnforcedStyle
         extend AutoCorrector
 
-        MSG = 'Wrap multiline memoization blocks in `begin` and `end`.'
+        KEYWORD_MSG = 'Wrap multiline memoization blocks in `begin` and `end`.'
+        BRACES_MSG = 'Wrap multiline memoization blocks in `(` and `)`.'
 
         def on_or_asgn(node)
           _lhs, rhs = *node
@@ -49,6 +50,10 @@ module RuboCop
               corrector.replace(rhs.loc.end, ')')
             end
           end
+        end
+
+        def message(_node)
+          style == :braces ? BRACES_MSG : KEYWORD_MSG
         end
 
         private

--- a/spec/rubocop/cop/style/multiline_memoization_spec.rb
+++ b/spec/rubocop/cop/style/multiline_memoization_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe RuboCop::Cop::Style::MultilineMemoization, :config do
           it 'registers an offense for begin...end block on first line' do
             expect_offense(<<~RUBY)
               foo ||= begin
-              ^^^^^^^^^^^^^ Wrap multiline memoization blocks in `begin` and `end`.
+              ^^^^^^^^^^^^^ Wrap multiline memoization blocks in `(` and `)`.
                 bar
                 baz
               end
@@ -150,7 +150,7 @@ RSpec.describe RuboCop::Cop::Style::MultilineMemoization, :config do
           it 'registers an offense for begin...end block on following line' do
             expect_offense(<<~RUBY)
               foo ||=
-              ^^^^^^^ Wrap multiline memoization blocks in `begin` and `end`.
+              ^^^^^^^ Wrap multiline memoization blocks in `(` and `)`.
                 begin
                   bar
                   baz


### PR DESCRIPTION
For `Style/MultilineMemoization` cop, when `EnforcedStyle` is `braces`, ensure the offense message reflects that.

With `EnforcedStyle: braces`, multiline memoization should look like:

```ruby
foo ||= (
  bar
  baz
)
```

so an offense for:

```ruby
foo ||= begin
  bar
  baz
end
```

should say:

```
Wrap multiline memoization blocks in `(` and `)`.
```

Found when updating specs in #8438

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/