### PR TITLE
[Fix #8354] Fix Style/CaseLikeIf to handle regexp named captures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#8801](https://github.com/rubocop-hq/rubocop/issues/8801): Fix `Layout/SpaceAroundEqualsInParameterDefault` only registered once in a line. ([@rdunlop][])
 * [#8514](https://github.com/rubocop-hq/rubocop/issues/8514): Correct multiple `Style/MethodDefParentheses` per file. ([@rdunlop][])
 * [#8825](https://github.com/rubocop-hq/rubocop/issues/8825): Fix crash in `Style/ExplicitBlockArgument` when code is called outside of a method. ([@ghiculescu][])
+* [#8354](https://github.com/rubocop-hq/rubocop/issues/8354): Detect regexp named captures in `Style/CaseLikeIf` cop. ([@dsavochkin][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/case_like_if_spec.rb
+++ b/spec/rubocop/cop/style/case_like_if_spec.rb
@@ -344,4 +344,78 @@ RSpec.describe RuboCop::Cop::Style::CaseLikeIf do
       end
     RUBY
   end
+
+  context 'when using regexp with named captures' do
+    it 'does not register an offense with =~ and regexp on lhs' do
+      expect_no_offenses(<<~RUBY)
+        if /(?<name>.*)/ =~ foo
+        elsif foo == 123
+        end
+      RUBY
+    end
+
+    it 'registers and corrects an offense with =~ and regexp on rhs' do
+      expect_offense(<<~RUBY)
+        if foo =~ /(?<name>.*)/
+        ^^^^^^^^^^^^^^^^^^^^^^^ Convert `if-elsif` to `case-when`.
+        elsif foo == 123
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        case foo
+        when /(?<name>.*)/
+        when 123
+        end
+      RUBY
+    end
+
+    it 'does not register an offense with match and regexp on lhs' do
+      expect_no_offenses(<<~RUBY)
+        if /(?<name>.*)/.match(foo)
+        elsif foo == 123
+        end
+      RUBY
+    end
+
+    it 'does not register an offense with match and regexp on rhs' do
+      expect_no_offenses(<<~RUBY)
+        if foo.match(/(?<name>.*)/)
+        elsif foo == 123
+        end
+      RUBY
+    end
+
+    it 'registers and corrects an offense with match? and regexp on lhs' do
+      expect_offense(<<~RUBY)
+        if /(?<name>.*)/.match?(foo)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert `if-elsif` to `case-when`.
+        elsif foo == 123
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        case foo
+        when /(?<name>.*)/
+        when 123
+        end
+      RUBY
+    end
+
+    it 'registers and corrects an offense with match? and regexp on rhs' do
+      expect_offense(<<~RUBY)
+        if foo.match?(/(?<name>.*)/)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert `if-elsif` to `case-when`.
+        elsif foo == 123
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        case foo
+        when /(?<name>.*)/
+        when 123
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #8354.
Fixes #8541.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
