### PR TITLE
Use `Cop::Base` API for `Style` department [N-P]

### DIFF
--- a/lib/rubocop/cop/correctors/condition_corrector.rb
+++ b/lib/rubocop/cop/correctors/condition_corrector.rb
@@ -5,13 +5,11 @@ module RuboCop
     # This class does condition auto-correction
     class ConditionCorrector
       class << self
-        def correct_negative_condition(node)
+        def correct_negative_condition(corrector, node)
           condition = negated_condition(node)
 
-          lambda do |corrector|
-            corrector.replace(node.loc.keyword, node.inverse_keyword)
-            corrector.replace(condition, condition.children.first.source)
-          end
+          corrector.replace(node.loc.keyword, node.inverse_keyword)
+          corrector.replace(condition, condition.children.first.source)
         end
 
         private

--- a/lib/rubocop/cop/correctors/parentheses_corrector.rb
+++ b/lib/rubocop/cop/correctors/parentheses_corrector.rb
@@ -5,15 +5,12 @@ module RuboCop
     # This auto-corrects parentheses
     class ParenthesesCorrector
       class << self
-        def correct(node)
-          lambda do |corrector|
-            corrector.remove(node.loc.begin)
-            corrector.remove(node.loc.end)
+        def correct(corrector, node)
+          corrector.remove(node.loc.begin)
+          corrector.remove(node.loc.end)
+          return unless ternary_condition?(node) && next_char_is_question_mark?(node)
 
-            if ternary_condition?(node) && next_char_is_question_mark?(node)
-              corrector.insert_after(node.loc.end, ' ')
-            end
-          end
+          corrector.insert_after(node.loc.end, ' ')
         end
 
         private

--- a/lib/rubocop/cop/mixin/negative_conditional.rb
+++ b/lib/rubocop/cop/mixin/negative_conditional.rb
@@ -15,7 +15,7 @@ module RuboCop
       def_node_matcher :single_negative?, '(send !(send _ :!) :!)'
       def_node_matcher :empty_condition?, '(begin)'
 
-      def check_negative_conditional(node)
+      def check_negative_conditional(node, message:, &block)
         condition = node.condition
 
         return if empty_condition?(condition)
@@ -25,7 +25,7 @@ module RuboCop
         return unless single_negative?(condition)
         return if node.if_type? && node.else?
 
-        add_offense(node)
+        add_offense(node, message: message, &block)
       end
     end
   end

--- a/lib/rubocop/cop/mixin/rescue_node.rb
+++ b/lib/rubocop/cop/mixin/rescue_node.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     # Common functionality for checking `rescue` nodes.
     module RescueNode
-      def investigate(processed_source)
+      def on_new_investigation
         @modifier_locations = processed_source
                               .tokens
                               .select(&:rescue_modifier?)

--- a/lib/rubocop/cop/style/negated_if.rb
+++ b/lib/rubocop/cop/style/negated_if.rb
@@ -68,19 +68,19 @@ module RuboCop
       #   if !foo
       #     bar
       #   end
-      class NegatedIf < Cop
+      class NegatedIf < Base
         include ConfigurableEnforcedStyle
         include NegativeConditional
+        extend AutoCorrector
 
         def on_if(node)
           return if node.unless? || node.elsif? || node.ternary?
           return if correct_style?(node)
 
-          check_negative_conditional(node)
-        end
-
-        def autocorrect(node)
-          ConditionCorrector.correct_negative_condition(node)
+          message = message(node)
+          check_negative_conditional(node, message: message) do |corrector|
+            ConditionCorrector.correct_negative_condition(corrector, node)
+          end
         end
 
         private

--- a/lib/rubocop/cop/style/negated_unless.rb
+++ b/lib/rubocop/cop/style/negated_unless.rb
@@ -58,19 +58,19 @@ module RuboCop
       #   unless !foo
       #     bar
       #   end
-      class NegatedUnless < Cop
+      class NegatedUnless < Base
         include ConfigurableEnforcedStyle
         include NegativeConditional
+        extend AutoCorrector
 
         def on_if(node)
           return if node.if? || node.elsif? || node.ternary?
           return if correct_style?(node)
 
-          check_negative_conditional(node)
-        end
-
-        def autocorrect(node)
-          ConditionCorrector.correct_negative_condition(node)
+          message = message(node)
+          check_negative_conditional(node, message: message) do |corrector|
+            ConditionCorrector.correct_negative_condition(corrector, node)
+          end
         end
 
         private

--- a/lib/rubocop/cop/style/negated_while.rb
+++ b/lib/rubocop/cop/style/negated_while.rb
@@ -22,26 +22,18 @@ module RuboCop
       #   # good
       #   bar while foo
       #   bar while !foo && baz
-      class NegatedWhile < Cop
+      class NegatedWhile < Base
         include NegativeConditional
+        extend AutoCorrector
 
         def on_while(node)
-          check_negative_conditional(node)
-        end
+          message = format(MSG, inverse: node.inverse_keyword, current: node.keyword)
 
-        def on_until(node)
-          check_negative_conditional(node)
+          check_negative_conditional(node, message: message) do |corrector|
+            ConditionCorrector.correct_negative_condition(corrector, node)
+          end
         end
-
-        def autocorrect(node)
-          ConditionCorrector.correct_negative_condition(node)
-        end
-
-        private
-
-        def message(node)
-          format(MSG, inverse: node.inverse_keyword, current: node.keyword)
-        end
+        alias on_until on_while
       end
     end
   end

--- a/lib/rubocop/cop/style/nested_parenthesized_calls.rb
+++ b/lib/rubocop/cop/style/nested_parenthesized_calls.rb
@@ -12,9 +12,10 @@ module RuboCop
       #
       #   # bad
       #   method1(method2 arg)
-      class NestedParenthesizedCalls < Cop
+      class NestedParenthesizedCalls < Base
         include RangeHelp
         include AllowedMethods
+        extend AutoCorrector
 
         MSG = 'Add parentheses to nested method call `%<source>s`.'
 
@@ -24,14 +25,17 @@ module RuboCop
           node.each_child_node(:send, :csend) do |nested|
             next if allowed_omission?(nested)
 
-            add_offense(nested,
-                        location: nested.source_range,
-                        message: format(MSG, source: nested.source))
+            message = format(MSG, source: nested.source)
+            add_offense(nested.source_range, message: message) do |corrector|
+              autocorrect(corrector, nested)
+            end
           end
         end
         alias on_csend on_send
 
-        def autocorrect(nested)
+        private
+
+        def autocorrect(corrector, nested)
           first_arg = nested.first_argument.source_range
           last_arg = nested.last_argument.source_range
 
@@ -41,13 +45,9 @@ module RuboCop
                                          whitespace: true,
                                          continuations: true)
 
-          lambda do |corrector|
-            corrector.replace(leading_space, '(')
-            corrector.insert_after(last_arg, ')')
-          end
+          corrector.replace(leading_space, '(')
+          corrector.insert_after(last_arg, ')')
         end
-
-        private
 
         def allowed_omission?(send_node)
           !send_node.arguments? || send_node.parenthesized? ||

--- a/lib/rubocop/cop/style/nil_comparison.rb
+++ b/lib/rubocop/cop/style/nil_comparison.rb
@@ -28,8 +28,9 @@ module RuboCop
       #   if x == nil
       #   end
       #
-      class NilComparison < Cop
+      class NilComparison < Base
         include ConfigurableEnforcedStyle
+        extend AutoCorrector
 
         PREDICATE_MSG = 'Prefer the use of the `nil?` predicate.'
         EXPLICIT_MSG = 'Prefer the use of the `==` comparison.'
@@ -39,17 +40,16 @@ module RuboCop
 
         def on_send(node)
           style_check?(node) do
-            add_offense(node, location: :selector)
-          end
-        end
+            add_offense(node.loc.selector) do |corrector|
+              new_code = if prefer_comparison?
+                           node.source.sub('.nil?', ' == nil')
+                         else
+                           node.source.sub(/\s*={2,3}\s*nil/, '.nil?')
+                         end
 
-        def autocorrect(node)
-          new_code = if prefer_comparison?
-                       node.source.sub('.nil?', ' == nil')
-                     else
-                       node.source.sub(/\s*={2,3}\s*nil/, '.nil?')
-                     end
-          ->(corrector) { corrector.replace(node, new_code) }
+              corrector.replace(node, new_code)
+            end
+          end
         end
 
         private

--- a/lib/rubocop/cop/style/non_nil_check.rb
+++ b/lib/rubocop/cop/style/non_nil_check.rb
@@ -38,7 +38,9 @@ module RuboCop
       #   if !x.nil?
       #   end
       #
-      class NonNilCheck < Cop
+      class NonNilCheck < Base
+        extend AutoCorrector
+
         def_node_matcher :not_equal_to_nil?, '(send _ :!= nil)'
         def_node_matcher :unless_check?, '(if (send _ :nil?) ...)'
         def_node_matcher :nil_check?, '(send _ :nil?)'
@@ -46,12 +48,11 @@ module RuboCop
 
         def on_send(node)
           return if ignored_node?(node)
+          return unless (offense_node = find_offense_node(node))
 
-          if not_equal_to_nil?(node)
-            add_offense(node, location: :selector)
-          elsif include_semantic_changes? &&
-                (not_and_nil_check?(node) || unless_and_nil_check?(node))
-            add_offense(node)
+          message = message(node)
+          add_offense(offense_node, message: message) do |corrector|
+            autocorrect(corrector, node)
           end
         end
 
@@ -68,18 +69,27 @@ module RuboCop
         end
         alias on_defs on_def
 
-        def autocorrect(node)
-          case node.method_name
-          when :!=
-            autocorrect_comparison(node)
-          when :!
-            autocorrect_non_nil(node, node.receiver)
-          when :nil?
-            autocorrect_unless_nil(node, node.receiver)
+        private
+
+        def find_offense_node(node)
+          if not_equal_to_nil?(node)
+            node.loc.selector
+          elsif include_semantic_changes? &&
+                (not_and_nil_check?(node) || unless_and_nil_check?(node))
+            node
           end
         end
 
-        private
+        def autocorrect(corrector, node)
+          case node.method_name
+          when :!=
+            autocorrect_comparison(corrector, node)
+          when :!
+            autocorrect_non_nil(corrector, node, node.receiver)
+          when :nil?
+            autocorrect_unless_nil(corrector, node, node.receiver)
+          end
+        end
 
         def unless_and_nil_check?(send_node)
           parent = send_node.parent
@@ -100,7 +110,7 @@ module RuboCop
           cop_config['IncludeSemanticChanges']
         end
 
-        def autocorrect_comparison(node)
+        def autocorrect_comparison(corrector, node)
           expr = node.source
 
           new_code = if include_semantic_changes?
@@ -111,24 +121,20 @@ module RuboCop
 
           return if expr == new_code
 
-          ->(corrector) { corrector.replace(node, new_code) }
+          corrector.replace(node, new_code)
         end
 
-        def autocorrect_non_nil(node, inner_node)
-          lambda do |corrector|
-            if inner_node.receiver
-              corrector.replace(node, inner_node.receiver.source)
-            else
-              corrector.replace(node, 'self')
-            end
+        def autocorrect_non_nil(corrector, node, inner_node)
+          if inner_node.receiver
+            corrector.replace(node, inner_node.receiver.source)
+          else
+            corrector.replace(node, 'self')
           end
         end
 
-        def autocorrect_unless_nil(node, receiver)
-          lambda do |corrector|
-            corrector.replace(node.parent.loc.keyword, 'if')
-            corrector.replace(node, receiver.source)
-          end
+        def autocorrect_unless_nil(corrector, node, receiver)
+          corrector.replace(node.parent.loc.keyword, 'if')
+          corrector.replace(node, receiver.source)
         end
       end
     end

--- a/lib/rubocop/cop/style/not.rb
+++ b/lib/rubocop/cop/style/not.rb
@@ -13,8 +13,9 @@ module RuboCop
       #   # good
       #   x = !something
       #
-      class Not < Cop
+      class Not < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Use `!` instead of `not`.'
 
@@ -30,19 +31,16 @@ module RuboCop
         def on_send(node)
           return unless node.prefix_not?
 
-          add_offense(node, location: :selector)
-        end
+          add_offense(node.loc.selector) do |corrector|
+            range = range_with_surrounding_space(range: node.loc.selector, side: :right)
 
-        def autocorrect(node)
-          range = range_with_surrounding_space(range: node.loc.selector,
-                                               side: :right)
-
-          if opposite_method?(node.receiver)
-            correct_opposite_method(range, node.receiver)
-          elsif requires_parens?(node.receiver)
-            correct_with_parens(range, node)
-          else
-            correct_without_parens(range)
+            if opposite_method?(node.receiver)
+              correct_opposite_method(corrector, range, node.receiver)
+            elsif requires_parens?(node.receiver)
+              correct_with_parens(corrector, range, node)
+            else
+              correct_without_parens(corrector, range)
+            end
           end
         end
 
@@ -58,23 +56,18 @@ module RuboCop
             child.if_type? && child.ternary?
         end
 
-        def correct_opposite_method(range, child)
-          lambda do |corrector|
-            corrector.remove(range)
-            corrector.replace(child.loc.selector,
-                              OPPOSITE_METHODS[child.method_name].to_s)
-          end
+        def correct_opposite_method(corrector, range, child)
+          corrector.remove(range)
+          corrector.replace(child.loc.selector, OPPOSITE_METHODS[child.method_name].to_s)
         end
 
-        def correct_with_parens(range, node)
-          lambda do |corrector|
-            corrector.replace(range, '!(')
-            corrector.insert_after(node, ')')
-          end
+        def correct_with_parens(corrector, range, node)
+          corrector.replace(range, '!(')
+          corrector.insert_after(node, ')')
         end
 
-        def correct_without_parens(range)
-          ->(corrector) { corrector.replace(range, '!') }
+        def correct_without_parens(corrector, range)
+          corrector.replace(range, '!')
         end
       end
     end

--- a/lib/rubocop/cop/style/numeric_literal_prefix.rb
+++ b/lib/rubocop/cop/style/numeric_literal_prefix.rb
@@ -33,8 +33,9 @@ module RuboCop
       #
       #   # good
       #   num = 01234
-      class NumericLiteralPrefix < Cop
+      class NumericLiteralPrefix < Base
         include IntegerNode
+        extend AutoCorrector
 
         OCTAL_ZERO_ONLY_REGEX = /^0[Oo][0-7]+$/.freeze
         OCTAL_REGEX = /^0O?[0-7]+$/.freeze
@@ -53,14 +54,8 @@ module RuboCop
 
           return unless type
 
-          add_offense(node)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            type = literal_type(node)
-            corrector.replace(node,
-                              send(:"format_#{type}", node.source))
+          add_offense(node) do |corrector|
+            corrector.replace(node, send(:"format_#{type}", node.source))
           end
         end
 

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -41,9 +41,10 @@ module RuboCop
       #   foo == 0
       #   0 > foo
       #   bar.baz > 0
-      class NumericPredicate < Cop
+      class NumericPredicate < Base
         include ConfigurableEnforcedStyle
         include IgnoredMethods
+        extend AutoCorrector
 
         MSG = 'Use `%<prefer>s` instead of `%<current>s`.'
 
@@ -66,16 +67,8 @@ module RuboCop
                       ignored_method?(ancestor.method_name)
                     end
 
-          add_offense(node,
-                      message: format(MSG,
-                                      prefer: replacement,
-                                      current: node.source))
-        end
-
-        def autocorrect(node)
-          _, replacement = check(node)
-
-          lambda do |corrector|
+          message = format(MSG, prefer: replacement, current: node.source)
+          add_offense(node, message: message) do |corrector|
             corrector.replace(node, replacement)
           end
         end

--- a/lib/rubocop/cop/style/one_line_conditional.rb
+++ b/lib/rubocop/cop/style/one_line_conditional.rb
@@ -22,8 +22,9 @@ module RuboCop
       #   else
       #     doo
       #   end
-      class OneLineConditional < Cop
+      class OneLineConditional < Base
         include OnNormalIfUnless
+        extend AutoCorrector
 
         MSG = 'Favor the ternary operator (`?:`) ' \
               'over `%<keyword>s/then/else/end` constructs.'
@@ -31,11 +32,8 @@ module RuboCop
         def on_normal_if_unless(node)
           return unless node.single_line? && node.else_branch
 
-          add_offense(node)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          message = message(node)
+          add_offense(node, message: message) do |corrector|
             corrector.replace(node, replacement(node))
           end
         end

--- a/lib/rubocop/cop/style/option_hash.rb
+++ b/lib/rubocop/cop/style/option_hash.rb
@@ -19,7 +19,7 @@ module RuboCop
       #   def fry(temperature: 300)
       #     # ...
       #   end
-      class OptionHash < Cop
+      class OptionHash < Base
         MSG = 'Prefer keyword arguments to options hashes.'
 
         def_node_matcher :option_hash, <<~PATTERN

--- a/lib/rubocop/cop/style/optional_arguments.rb
+++ b/lib/rubocop/cop/style/optional_arguments.rb
@@ -17,7 +17,7 @@ module RuboCop
       #
       #   def foobar(a = 1, b = 2, c = 3)
       #   end
-      class OptionalArguments < Cop
+      class OptionalArguments < Base
         MSG = 'Optional arguments should appear at the end ' \
               'of the argument list.'
 

--- a/lib/rubocop/cop/style/or_assignment.rb
+++ b/lib/rubocop/cop/style/or_assignment.rb
@@ -26,7 +26,9 @@ module RuboCop
       #
       #   # good - set name to 'Bozhidar', only if it's nil or false
       #   name ||= 'Bozhidar'
-      class OrAssignment < Cop
+      class OrAssignment < Base
+        extend AutoCorrector
+
         MSG = 'Use the double pipe equals operator `||=` instead.'
 
         def_node_matcher :ternary_assignment?, <<~PATTERN
@@ -47,34 +49,35 @@ module RuboCop
         def on_if(node)
           return unless unless_assignment?(node)
 
-          add_offense(node)
+          add_offense(node) do |corrector|
+            autocorrect(corrector, node)
+          end
         end
 
         def on_lvasgn(node)
           return unless (else_branch = ternary_assignment?(node))
           return if else_branch.if_type?
 
-          add_offense(node)
+          add_offense(node) do |corrector|
+            autocorrect(corrector, node)
+          end
         end
 
         alias on_ivasgn on_lvasgn
         alias on_cvasgn on_lvasgn
         alias on_gvasgn on_lvasgn
 
-        def autocorrect(node)
+        private
+
+        def autocorrect(corrector, node)
           if ternary_assignment?(node)
             variable, default = take_variable_and_default_from_ternary(node)
           else
             variable, default = take_variable_and_default_from_unless(node)
           end
 
-          lambda do |corrector|
-            corrector.replace(node,
-                              "#{variable} ||= #{default.source}")
-          end
+          corrector.replace(node, "#{variable} ||= #{default.source}")
         end
-
-        private
 
         def take_variable_and_default_from_ternary(node)
           variable, if_statement = *node

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -22,8 +22,9 @@ module RuboCop
       #   a = 1
       #   b = 2
       #   c = 3
-      class ParallelAssignment < Cop
+      class ParallelAssignment < Base
         include RescueNode
+        extend AutoCorrector
 
         MSG = 'Do not use parallel assignment.'
 
@@ -35,23 +36,22 @@ module RuboCop
           return if allowed_lhs?(lhs) || allowed_rhs?(rhs) ||
                     allowed_masign?(lhs_elements, rhs_elements)
 
-          add_offense(node)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            left, right = *node
-            left_elements = *left
-            right_elements = Array(right).compact
-            order = find_valid_order(left_elements, right_elements)
-            correction = assignment_corrector(node, order)
-
-            corrector.replace(correction.correction_range,
-                              correction.correction)
+          add_offense(node) do |corrector|
+            autocorrect(corrector, node)
           end
         end
 
         private
+
+        def autocorrect(corrector, node)
+          left, right = *node
+          left_elements = *left
+          right_elements = Array(right).compact
+          order = find_valid_order(left_elements, right_elements)
+          correction = assignment_corrector(node, order)
+
+          corrector.replace(correction.correction_range, correction.correction)
+        end
 
         def allowed_masign?(lhs_elements, rhs_elements)
           lhs_elements.size != rhs_elements.size ||

--- a/lib/rubocop/cop/style/parentheses_around_condition.rb
+++ b/lib/rubocop/cop/style/parentheses_around_condition.rb
@@ -53,9 +53,10 @@ module RuboCop
       #      y > 10)
       #   end
       #
-      class ParenthesesAroundCondition < Cop
+      class ParenthesesAroundCondition < Base
         include SafeAssignment
         include Parentheses
+        extend AutoCorrector
 
         def on_if(node)
           return if node.ternary?
@@ -67,10 +68,6 @@ module RuboCop
           process_control_op(node)
         end
         alias on_until on_while
-
-        def autocorrect(node)
-          ParenthesesCorrector.correct(node)
-        end
 
         private
 
@@ -85,7 +82,10 @@ module RuboCop
             return if modifier_op?(first_child)
             return if parens_allowed?(cond)
 
-            add_offense(cond)
+            message = message(cond)
+            add_offense(cond, message: message) do |corrector|
+              ParenthesesCorrector.correct(corrector, cond)
+            end
           end
         end
 

--- a/lib/rubocop/cop/style/perl_backrefs.rb
+++ b/lib/rubocop/cop/style/perl_backrefs.rb
@@ -12,23 +12,21 @@ module RuboCop
       #
       #   # good
       #   puts Regexp.last_match(1)
-      class PerlBackrefs < Cop
+      class PerlBackrefs < Base
+        extend AutoCorrector
+
         MSG = 'Avoid the use of Perl-style backrefs.'
 
         def on_nth_ref(node)
-          add_offense(node)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(node) do |corrector|
             backref, = *node
             parent_type = node.parent ? node.parent.type : nil
+
             if %i[dstr xstr regexp].include?(parent_type)
-              corrector.replace(node,
-                                "{Regexp.last_match(#{backref})}")
+              corrector.replace(node, "{Regexp.last_match(#{backref})}")
+
             else
-              corrector.replace(node,
-                                "Regexp.last_match(#{backref})")
+              corrector.replace(node, "Regexp.last_match(#{backref})")
             end
           end
         end

--- a/lib/rubocop/cop/style/preferred_hash_methods.rb
+++ b/lib/rubocop/cop/style/preferred_hash_methods.rb
@@ -25,8 +25,9 @@ module RuboCop
       #  # good
       #  Hash#has_key?
       #  Hash#has_value?
-      class PreferredHashMethods < Cop
+      class PreferredHashMethods < Base
         include ConfigurableEnforcedStyle
+        extend AutoCorrector
 
         MSG = 'Use `Hash#%<prefer>s` instead of `Hash#%<current>s`.'
 
@@ -36,26 +37,20 @@ module RuboCop
         }.freeze
 
         def on_send(node)
-          return unless node.arguments.one? &&
-                        offending_selector?(node.method_name)
+          return unless node.arguments.one? && offending_selector?(node.method_name)
 
-          add_offense(node, location: :selector)
+          message = message(node.method_name)
+
+          add_offense(node.loc.selector, message: message) do |corrector|
+            corrector.replace(node.loc.selector, proper_method_name(node.loc.selector.source))
+          end
         end
         alias on_csend on_send
 
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.loc.selector,
-                              proper_method_name(node.loc.selector.source))
-          end
-        end
-
         private
 
-        def message(node)
-          format(MSG,
-                 prefer: proper_method_name(node.method_name),
-                 current: node.method_name)
+        def message(method_name)
+          format(MSG, prefer: proper_method_name(method_name), current: method_name)
         end
 
         def proper_method_name(method_name)

--- a/lib/rubocop/cop/style/proc.rb
+++ b/lib/rubocop/cop/style/proc.rb
@@ -13,7 +13,9 @@ module RuboCop
       #   # good
       #   p = proc { |n| puts n }
       #
-      class Proc < Cop
+      class Proc < Base
+        extend AutoCorrector
+
         MSG = 'Use `proc` instead of `Proc.new`.'
 
         def_node_matcher :proc_new?,
@@ -21,12 +23,10 @@ module RuboCop
 
         def on_block(node)
           proc_new?(node) do |block_method|
-            add_offense(block_method)
+            add_offense(block_method) do |corrector|
+              corrector.replace(block_method, 'proc')
+            end
           end
-        end
-
-        def autocorrect(node)
-          ->(corrector) { corrector.replace(node, 'proc') }
         end
       end
     end

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -13,8 +13,9 @@ module RuboCop
       #   # good
       #   x if y.z.nil?
       #
-      class RedundantParentheses < Cop
+      class RedundantParentheses < Base
         include Parentheses
+        extend AutoCorrector
 
         def_node_matcher :square_brackets?,
                          '(send {(send _recv _msg) str array hash} :[] ...)'
@@ -30,10 +31,6 @@ module RuboCop
                                     node.parent.until_post_type?)
 
           check(node)
-        end
-
-        def autocorrect(node)
-          ParenthesesCorrector.correct(node)
         end
 
         private
@@ -123,7 +120,9 @@ module RuboCop
         end
 
         def offense(node, msg)
-          add_offense(node, message: "Don't use parentheses around #{msg}.")
+          add_offense(node, message: "Don't use parentheses around #{msg}.") do |corrector|
+            ParenthesesCorrector.correct(corrector, node)
+          end
         end
 
         def suspect_unary?(node)

--- a/spec/rubocop/cop/style/non_nil_check_spec.rb
+++ b/spec/rubocop/cop/style/non_nil_check_spec.rb
@@ -71,11 +71,12 @@ RSpec.describe RuboCop::Cop::Style::NonNilCheck, :config do
     end
 
     it 'does not report corrected when the code was not modified' do
-      source = 'return nil unless (line =~ //) != nil'
-      corrected = autocorrect_source(source)
+      expect_offense(<<~RUBY)
+        return nil unless (line =~ //) != nil
+                                       ^^ Prefer `!expression.nil?` over `expression != nil`.
+      RUBY
 
-      expect(corrected).to eq(source)
-      expect(cop.corrections.empty?).to be(true)
+      expect_no_corrections
     end
   end
 


### PR DESCRIPTION
Follow #7868.

This PR uses `Cop::Base` API for almost `Style` department's N-P cops.
It targets cop that names begin between N and P. And several N-P cops will be excluded from this PR target and addressed separately.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
