### PR TITLE
Optimize `Layout/SpaceBeforeFirstArg` and `Style/RedundantSelf` cops

### DIFF
--- a/lib/rubocop/cop/layout/space_before_first_arg.rb
+++ b/lib/rubocop/cop/layout/space_before_first_arg.rb
@@ -30,15 +30,16 @@ module RuboCop
 
         def on_send(node)
           return unless regular_method_call_with_arguments?(node)
-          return unless expect_params_after_method_name?(node)
 
           first_arg = node.first_argument.source_range
           first_arg_with_space = range_with_surrounding_space(range: first_arg,
                                                               side: :left)
           space = range_between(first_arg_with_space.begin_pos,
                                 first_arg.begin_pos)
+          return if space.length == 1
+          return unless expect_params_after_method_name?(node)
 
-          add_offense(space, location: space) if space.length != 1
+          add_offense(space, location: space)
         end
         alias on_csend on_send
 

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -57,7 +57,7 @@ module RuboCop
         def initialize(config = nil, options = nil)
           super
           @allowed_send_nodes = []
-          @local_variables_scopes = Hash.new { |hash, key| hash[key] = [] }
+          @local_variables_scopes = Hash.new { |hash, key| hash[key] = [] }.compare_by_identity
         end
 
         # Assignment of self.x
@@ -123,7 +123,7 @@ module RuboCop
         private
 
         def add_scope(node, local_variables = [])
-          node.descendants.each do |child_node|
+          node.each_descendant do |child_node|
             @local_variables_scopes[child_node] = local_variables
           end
         end


### PR DESCRIPTION
Ran on 30k files.

### Before
```
(1) 40325  (    4.2%)  RuboCop::Cop::Style::RedundantSelf#on_block
(2) 36305  (    3.8%)  RuboCop::Cop::Layout::SpaceBeforeFirstArg#on_send
    29707  (    3.1%)  RuboCop::Cop::Layout::FirstArgumentIndentation#on_send
    28531  (    3.0%)  RuboCop::Cop::StringHelp#on_str
    26386  (    2.7%)  RuboCop::Cop::Layout::DefEndAlignment#on_send
    26277  (    2.7%)  RuboCop::Cop::Layout::IndentationConsistency#on_begin
    23386  (    2.4%)  RuboCop::Cop::Layout::SpaceInsideReferenceBrackets#on_send
    18628  (    1.9%)  RuboCop::Cop::MultilineExpressionIndentation#on_send
    15428  (    1.6%)  RuboCop::Cop::Layout::ArgumentAlignment#on_send
    14030  (    1.5%)  RuboCop::Cop::Layout::LineLength#on_potential_breakable_node
    12924  (    1.3%)  RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier#on_send
    12491  (    1.3%)  RuboCop::Cop::Layout::SpaceAroundOperators#on_send
    12326  (    1.3%)  RuboCop::Cop::Style::ConditionalAssignment#on_send
    11553  (    1.2%)  RuboCop::Cop::Layout::DotPosition#on_send
    11551  (    1.2%)  RuboCop::Cop::Metrics::BlockLength#on_block
    11277  (    1.2%)  RuboCop::Cop::Style::TrailingCommaInArguments#on_send
    10286  (    1.1%)  RuboCop::Cop::MethodComplexity#on_def
    9341  (    1.0%)  RuboCop::Cop::MethodComplexity#on_def
    9162  (    1.0%)  RuboCop::Cop::Layout::IndentationWidth#on_send
    9039  (    0.9%)  RuboCop::Cop::CheckAssignment#on_send
    8977  (    0.9%)  RuboCop::Cop::StringHelp#on_str
    8906  (    0.9%)  RuboCop::Cop::Interpolation#on_dstr
    8580  (    0.9%)  RuboCop::Cop::Layout::ClosingParenthesisIndentation#on_send
    8489  (    0.9%)  RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets#on_array
    8262  (    0.9%)  RuboCop::Cop::Layout::BlockAlignment#on_block
    7490  (    0.8%)  RuboCop::Cop::Lint::SafeNavigationChain#on_send
    6625  (    0.7%)  RuboCop::Cop::CheckAssignment#on_send
    6560  (    0.7%)  RuboCop::Cop::Layout::IndentationWidth#on_block
    6437  (    0.7%)  RuboCop::Cop::Layout::FirstArrayElementIndentation#on_send
(3) 6342  (    0.7%)  RuboCop::Cop::Style::RedundantSelf#on_def
    6286  (    0.7%)  RuboCop::Cop::Style::EmptyLiteral#on_send
    6235  (    0.6%)  RuboCop::Cop::Layout::EmptyLinesAroundArguments#on_send
    6202  (    0.6%)  RuboCop::Cop::Lint::ParenthesesAsGroupedExpression#on_send
    6137  (    0.6%)  RuboCop::Cop::Style::NonNilCheck#on_send
    5826  (    0.6%)  RuboCop::Cop::Layout::SpaceInLambdaLiteral#on_send
```

### After
```
    32023  (    3.3%)  RuboCop::Cop::Layout::FirstArgumentIndentation#on_send
    30966  (    3.1%)  RuboCop::Cop::StringHelp#on_str
    28338  (    2.9%)  RuboCop::Cop::Layout::IndentationConsistency#on_begin
    28008  (    2.8%)  RuboCop::Cop::Layout::DefEndAlignment#on_send
    24810  (    2.5%)  RuboCop::Cop::Layout::SpaceInsideReferenceBrackets#on_send
    20067  (    2.0%)  RuboCop::Cop::MultilineExpressionIndentation#on_send
(1) 19676  (    2.0%)  RuboCop::Cop::Style::RedundantSelf#on_block
(2) 18174  (    1.8%)  RuboCop::Cop::Layout::SpaceBeforeFirstArg#on_send
    16676  (    1.7%)  RuboCop::Cop::Layout::ArgumentAlignment#on_send
    14120  (    1.4%)  RuboCop::Cop::Layout::LineLength#on_potential_breakable_node
    14080  (    1.4%)  RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier#on_send
    12506  (    1.3%)  RuboCop::Cop::Style::ConditionalAssignment#on_send
    12433  (    1.3%)  RuboCop::Cop::Layout::DotPosition#on_send
    12082  (    1.2%)  RuboCop::Cop::Metrics::BlockLength#on_block
    12049  (    1.2%)  RuboCop::Cop::Layout::SpaceAroundOperators#on_send
    11414  (    1.2%)  RuboCop::Cop::Style::TrailingCommaInArguments#on_send
    10566  (    1.1%)  RuboCop::Cop::MethodComplexity#on_def
    10038  (    1.0%)  RuboCop::Cop::Layout::IndentationWidth#on_send
    9987  (    1.0%)  RuboCop::Cop::MethodComplexity#on_def
    9509  (    1.0%)  RuboCop::Cop::CheckAssignment#on_send
    9383  (    1.0%)  RuboCop::Cop::Interpolation#on_dstr
    9351  (    0.9%)  RuboCop::Cop::StringHelp#on_str
    9182  (    0.9%)  RuboCop::Cop::Layout::ClosingParenthesisIndentation#on_send
    8988  (    0.9%)  RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets#on_array
    8800  (    0.9%)  RuboCop::Cop::Layout::BlockAlignment#on_block
    7450  (    0.8%)  RuboCop::Cop::Lint::SafeNavigationChain#on_send
    7152  (    0.7%)  RuboCop::Cop::Layout::FirstArrayElementIndentation#on_send
    7136  (    0.7%)  RuboCop::Cop::CheckAssignment#on_send
    7094  (    0.7%)  RuboCop::Cop::Style::EmptyLiteral#on_send
    6820  (    0.7%)  RuboCop::Cop::Layout::IndentationWidth#on_block
    6646  (    0.7%)  RuboCop::Cop::Layout::EmptyLinesAroundArguments#on_send
    6567  (    0.7%)  RuboCop::Cop::Layout::EmptyLinesAroundBlockBody#on_block
    6526  (    0.7%)  RuboCop::Cop::Style::NonNilCheck#on_send
    6503  (    0.7%)  RuboCop::Cop::Lint::ParenthesesAsGroupedExpression#on_send
    6364  (    0.6%)  RuboCop::Cop::MultilineExpressionIndentation#on_send
    5948  (    0.6%)  RuboCop::Cop::CheckAssignment#on_send
    5865  (    0.6%)  RuboCop::Cop::Style::InverseMethods#on_send
    5861  (    0.6%)  RuboCop::Cop::Layout::SpaceAroundKeyword#on_block
    5733  (    0.6%)  RuboCop::Cop::Lint::DuplicateMethods#on_def
    5610  (    0.6%)  RuboCop::Cop::Layout::MultilineMethodCallBraceLayout#on_send
```

So, another `5%` speedup.