### PR TITLE
Parsed Regexp utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * Add new `Lint/TrailingCommaInAttributeDeclaration` cop. ([@drenmi][])
 * [#8578](https://github.com/rubocop-hq/rubocop/pull/8578): Add `:restore_registry` context and `stub_cop_class` helper class. ([@marcandre][])
 * [#8579](https://github.com/rubocop-hq/rubocop/pull/8579): Add `Cop.documentation_url`.  ([@marcandre][])
-
+* [#8510](https://github.com/rubocop-hq/rubocop/pull/8510):  Add `RegexpNode#each_capture` and `parsed_tree`. ([@marcandre][])
 
 ### Bug fixes
 

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -9,6 +9,7 @@ require 'regexp_parser'
 require 'unicode/display_width/no_string_ext'
 require 'rubocop-ast'
 require_relative 'rubocop/ast_aliases'
+require_relative 'rubocop/ext/regexp_node'
 
 require_relative 'rubocop/version'
 

--- a/lib/rubocop/cop/lint/mixed_regexp_capture_types.rb
+++ b/lib/rubocop/cop/lint/mixed_regexp_capture_types.rb
@@ -25,43 +25,10 @@ module RuboCop
               'in a Regexp literal.'
 
         def on_regexp(node)
-          return if contain_non_literal?(node)
-
-          begin
-            tree = Regexp::Parser.parse(node.content)
-          # Returns if a regular expression that cannot be processed by regexp_parser gem.
-          # https://github.com/rubocop-hq/rubocop/issues/8083
-          rescue Regexp::Scanner::ScannerError
-            return
-          end
-
-          return unless named_capture?(tree)
-          return unless numbered_capture?(tree)
+          return if node.each_capture(named: false).none?
+          return if node.each_capture(named: true).none?
 
           add_offense(node)
-        end
-
-        private
-
-        def contain_non_literal?(node)
-          if node.respond_to?(:type) && (node.variable? || node.send_type? || node.const_type?)
-            return true
-          end
-          return false unless node.respond_to?(:children)
-
-          node.children.any? { |child| contain_non_literal?(child) }
-        end
-
-        def named_capture?(tree)
-          tree.each_expression.any? do |e|
-            e.instance_of?(Regexp::Expression::Group::Capture)
-          end
-        end
-
-        def numbered_capture?(tree)
-          tree.each_expression.any? do |e|
-            e.instance_of?(Regexp::Expression::Group::Named)
-          end
         end
       end
     end

--- a/lib/rubocop/cop/lint/out_of_range_regexp_ref.rb
+++ b/lib/rubocop/cop/lint/out_of_range_regexp_ref.rb
@@ -64,25 +64,15 @@ module RuboCop
 
         private
 
-        def check_regexp(regexp)
-          return if contain_non_literal?(regexp)
+        def check_regexp(node)
+          return if node.interpolation?
 
-          tree = Regexp::Parser.parse(regexp.content)
-          @valid_ref = regexp_captures(tree)
-        end
-
-        def contain_non_literal?(node)
-          node.children.size != 2 || !node.children.first.str_type?
-        end
-
-        def regexp_captures(tree)
-          named_capture = numbered_capture = 0
-          tree.each_expression do |e|
-            if e.type?(:group)
-              e.respond_to?(:name) ? named_capture += 1 : numbered_capture += 1
-            end
-          end
-          named_capture.positive? ? named_capture : numbered_capture
+          named_capture = node.each_capture(named: true).count
+          @valid_ref = if named_capture.positive?
+                         named_capture
+                       else
+                         node.each_capture(named: false).count
+                       end
         end
       end
     end

--- a/lib/rubocop/ext/regexp_node.rb
+++ b/lib/rubocop/ext/regexp_node.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Ext
+    # Extensions to AST::RegexpNode for our cached parsed regexp info
+    module RegexpNode
+      ANY = Object.new
+      def ANY.==(_)
+        true
+      end
+      private_constant :ANY
+
+      class << self
+        attr_reader :parsed_cache
+      end
+      @parsed_cache = {}
+
+      # @return [Regexp::Expression::Root, nil]
+      def parsed_tree
+        return if interpolation?
+
+        str = content
+        Ext::RegexpNode.parsed_cache[str] ||= begin
+                                                Regexp::Parser.parse(str)
+                                              rescue StandardError
+                                                nil
+                                              end
+      end
+
+      def each_capture(named: ANY)
+        return enum_for(__method__, named: named) unless block_given?
+
+        parsed_tree&.traverse do |event, exp, _index|
+          yield(exp) if event == :enter &&
+                        named == exp.respond_to?(:name) &&
+                        exp.respond_to?(:capturing?) &&
+                        exp.capturing?
+        end
+
+        self
+      end
+
+      AST::RegexpNode.include self
+    end
+  end
+end

--- a/spec/rubocop/ext/regexp_node_spec.rb
+++ b/spec/rubocop/ext/regexp_node_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'timeout'
+
+RSpec.describe RuboCop::Ext::RegexpNode do
+  let(:source) { '/(hello)(?<foo>world)(?:not captured)/' }
+  let(:processed_source) { parse_source(source) }
+  let(:ast) { processed_source.ast }
+  let(:node) { ast }
+
+  describe '#each_capture' do
+    subject(:captures) { node.each_capture(**arg).to_a }
+
+    let(:named) { be_instance_of(Regexp::Expression::Group::Named) }
+    let(:positional) { be_instance_of(Regexp::Expression::Group::Capture) }
+
+    context 'when called without argument' do
+      let(:arg) { {} }
+
+      it { is_expected.to match [positional, named] }
+    end
+
+    context 'when called with a `named: false`' do
+      let(:arg) { { named: false } }
+
+      it { is_expected.to match [positional] }
+    end
+
+    context 'when called with a `named: true`' do
+      let(:arg) { { named: true } }
+
+      it { is_expected.to match [named] }
+    end
+  end
+end


### PR DESCRIPTION
We are starting to have more Cops handling `Regexp`. This PR
* simplifies the access to the regexp parsed tree with `RegexpNode#parsed_tree`
* caches to avoid reparsing the same node multiple times
* adds `RegexpNode#each_capture` which simplifies processing.

This could be helpful for #8504 too.

I'm hesitating between adding it to `rubocop-ast` or extending it as in this PR.