### PR TITLE
Lint/ShadowingOuterLocalVariable: clarify the ruby warning [doc]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [#8362](https://github.com/rubocop-hq/rubocop/issues/8362): Add numbers of correctable offenses to summary. ([@nguyenquangminh0711][])
+* [#8513](https://github.com/rubocop-hq/rubocop/pull/8513): Clarify the ruby warning mentioned in the `Lint/ShadowingOuterLocalVariable` documentation. ([@chocolateboy][])
 
 ## 0.89.1 (2020-08-10)
 
@@ -4778,3 +4779,4 @@
 [@sonalinavlakhe]: https://github.com/sonalinavlakhe
 [@wcmonty]: https://github.com/wcmonty
 [@nguyenquangminh0711]: https://github.com/nguyenquangminh0711
+[@chocolateboy]: https://github.com/chocolateboy

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -3481,10 +3481,10 @@ end
 | -
 |===
 
-This cop looks for use of the same name as outer local variables
-for block arguments or block local variables.
-This is a mimic of the warning
-"shadowing outer local variable - foo" from `ruby -cw`.
+This cop checks for the use of local variable names from an outer scope
+in block arguments or block-local variables. This mirrors the warning
+given by `ruby -cw` prior to Ruby 2.6:
+"shadowing outer local variable - foo".
 
 === Examples
 

--- a/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
+++ b/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
@@ -3,10 +3,10 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop looks for use of the same name as outer local variables
-      # for block arguments or block local variables.
-      # This is a mimic of the warning
-      # "shadowing outer local variable - foo" from `ruby -cw`.
+      # This cop checks for the use of local variable names from an outer scope
+      # in block arguments or block-local variables. This mirrors the warning
+      # given by `ruby -cw` prior to Ruby 2.6:
+      # "shadowing outer local variable - foo".
       #
       # @example
       #


### PR DESCRIPTION
Make it clear that ruby [no longer warns](https://docs.ruby-lang.org/en/2.6.0/NEWS.html#label-Language+changes) about variable shadowing:

> The “shadowing outer local variable” warning is removed. [Feature [#12490](https://bugs.ruby-lang.org/issues/12490)]