### PR TITLE
Handle to_h with block in Style/HashTransformKeys and Style/HashTransformValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#8362](https://github.com/rubocop-hq/rubocop/issues/8362): Add numbers of correctable offenses to summary. ([@nguyenquangminh0711][])
 * [#8513](https://github.com/rubocop-hq/rubocop/pull/8513): Clarify the ruby warning mentioned in the `Lint/ShadowingOuterLocalVariable` documentation. ([@chocolateboy][])
+* [#8517](https://github.com/rubocop-hq/rubocop/pull/8517): Make `Style/HashTransformKeys` and `Style/HashTransformValues` aware of `to_h` with block. ([@eugeneius][])
 
 ## 0.89.1 (2020-08-10)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -3101,15 +3101,17 @@ Style/HashSyntax:
   PreferHashRocketsForNonAlnumEndingSymbols: false
 
 Style/HashTransformKeys:
-  Description: 'Prefer `transform_keys` over `each_with_object` and `map`.'
+  Description: 'Prefer `transform_keys` over `each_with_object`, `map`, or `to_h`.'
   Enabled: 'pending'
   VersionAdded: '0.80'
+  VersionChanged: '0.90'
   Safe: false
 
 Style/HashTransformValues:
-  Description: 'Prefer `transform_values` over `each_with_object` and `map`.'
+  Description: 'Prefer `transform_values` over `each_with_object`, `map`, or `to_h`.'
   Enabled: 'pending'
   VersionAdded: '0.80'
+  VersionChanged: '0.90'
   Safe: false
 
 Style/IdenticalConditionalBranches:

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -3794,7 +3794,7 @@ NOTE: Required Ruby version: 2.5
 | No
 | Yes (Unsafe)
 | 0.80
-| -
+| 0.90
 |===
 
 This cop looks for uses of `_.each_with_object({}) {...}`,
@@ -3815,7 +3815,9 @@ This cop should only be enabled on Ruby version 2.5 or newer
 ----
 # bad
 {a: 1, b: 2}.each_with_object({}) { |(k, v), h| h[foo(k)] = v }
-{a: 1, b: 2}.map { |k, v| [k.to_s, v] }
+Hash[{a: 1, b: 2}.collect { |k, v| [foo(k), v] }]
+{a: 1, b: 2}.map { |k, v| [k.to_s, v] }.to_h
+{a: 1, b: 2}.to_h { |k, v| [k.to_s, v] }
 
 # good
 {a: 1, b: 2}.transform_keys { |k| foo(k) }
@@ -3831,7 +3833,7 @@ This cop should only be enabled on Ruby version 2.5 or newer
 | No
 | Yes (Unsafe)
 | 0.80
-| -
+| 0.90
 |===
 
 This cop looks for uses of `_.each_with_object({}) {...}`,
@@ -3852,7 +3854,9 @@ This cop should only be enabled on Ruby version 2.4 or newer
 ----
 # bad
 {a: 1, b: 2}.each_with_object({}) { |(k, v), h| h[k] = foo(v) }
-{a: 1, b: 2}.map { |k, v| [k, v * v] }
+Hash[{a: 1, b: 2}.collect { |k, v| [k, foo(v)] }]
+{a: 1, b: 2}.map { |k, v| [k, v * v] }.to_h
+{a: 1, b: 2}.to_h { |k, v| [k, v * v] }
 
 # good
 {a: 1, b: 2}.transform_values { |v| foo(v) }

--- a/lib/rubocop/cop/mixin/hash_transform_method.rb
+++ b/lib/rubocop/cop/mixin/hash_transform_method.rb
@@ -9,6 +9,12 @@ module RuboCop
         on_bad_each_with_object(node) do |*match|
           handle_possible_offense(node, match, 'each_with_object')
         end
+
+        return if target_ruby_version < 2.6
+
+        on_bad_to_h(node) do |*match|
+          handle_possible_offense(node, match, 'to_h {...}')
+        end
       end
 
       def on_send(node)
@@ -40,6 +46,11 @@ module RuboCop
 
       # @abstract Implemented with `def_node_matcher`
       def on_bad_map_to_h(_node)
+        raise NotImplementedError
+      end
+
+      # @abstract Implemented with `def_node_matcher`
+      def on_bad_to_h(_node)
         raise NotImplementedError
       end
 
@@ -82,6 +93,8 @@ module RuboCop
           Autocorrection.from_hash_brackets_map(node, match)
         elsif (match = on_bad_map_to_h(node))
           Autocorrection.from_map_to_h(node, match)
+        elsif (match = on_bad_to_h(node))
+          Autocorrection.from_to_h(node, match)
         else
           raise 'unreachable'
         end
@@ -135,6 +148,10 @@ module RuboCop
           end
 
           new(match, node.children.first, 0, strip_trailing_chars)
+        end
+
+        def self.from_to_h(node, match)
+          new(match, node, 0, 0)
         end
 
         def strip_prefix_and_suffix(node, corrector)

--- a/lib/rubocop/cop/style/hash_transform_keys.rb
+++ b/lib/rubocop/cop/style/hash_transform_keys.rb
@@ -18,7 +18,9 @@ module RuboCop
       # @example
       #   # bad
       #   {a: 1, b: 2}.each_with_object({}) { |(k, v), h| h[foo(k)] = v }
-      #   {a: 1, b: 2}.map { |k, v| [k.to_s, v] }
+      #   Hash[{a: 1, b: 2}.collect { |k, v| [foo(k), v] }]
+      #   {a: 1, b: 2}.map { |k, v| [k.to_s, v] }.to_h
+      #   {a: 1, b: 2}.to_h { |k, v| [k.to_s, v] }
       #
       #   # good
       #   {a: 1, b: 2}.transform_keys { |k| foo(k) }
@@ -66,6 +68,17 @@ module RuboCop
                 (arg _val))
               (array $_ $(lvar _val)))
             :to_h)
+        PATTERN
+
+        def_node_matcher :on_bad_to_h, <<~PATTERN
+          (block
+            ({send csend}
+              !{(send _ :each_with_index) (array ...)}
+              :to_h)
+            (args
+              (arg $_)
+              (arg _val))
+            (array $_ $(lvar _val)))
         PATTERN
 
         private

--- a/lib/rubocop/cop/style/hash_transform_values.rb
+++ b/lib/rubocop/cop/style/hash_transform_values.rb
@@ -18,7 +18,9 @@ module RuboCop
       # @example
       #   # bad
       #   {a: 1, b: 2}.each_with_object({}) { |(k, v), h| h[k] = foo(v) }
-      #   {a: 1, b: 2}.map { |k, v| [k, v * v] }
+      #   Hash[{a: 1, b: 2}.collect { |k, v| [k, foo(v)] }]
+      #   {a: 1, b: 2}.map { |k, v| [k, v * v] }.to_h
+      #   {a: 1, b: 2}.to_h { |k, v| [k, v * v] }
       #
       #   # good
       #   {a: 1, b: 2}.transform_values { |v| foo(v) }
@@ -63,6 +65,17 @@ module RuboCop
                 (arg $_))
               (array $(lvar _key) $_))
             :to_h)
+        PATTERN
+
+        def_node_matcher :on_bad_to_h, <<~PATTERN
+          (block
+            ({send csend}
+              !{(send _ :each_with_index) (array ...)}
+              :to_h)
+            (args
+              (arg _key)
+              (arg $_))
+            (array $(lvar _key) $_))
         PATTERN
 
         private

--- a/spec/rubocop/cop/style/hash_transform_keys_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_keys_spec.rb
@@ -171,4 +171,25 @@ RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
       expect_no_offenses('x.each_with_object({}) {|(k, v), h| h[foo(k)] = v}')
     end
   end
+
+  context 'when using Ruby 2.6 or newer', :ruby26 do
+    it 'flags _.to_h{...} when transform_keys could be used' do
+      expect_offense(<<~RUBY)
+        x.to_h {|k, v| [k.to_sym, v]}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `to_h {...}`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.transform_keys {|k| k.to_sym}
+      RUBY
+    end
+  end
+
+  context 'below Ruby 2.6', :ruby25 do
+    it 'does not flag _.to_h{...}' do
+      expect_no_offenses(<<~RUBY)
+        x.to_h {|k, v| [k.to_sym, v]}
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/style/hash_transform_values_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_values_spec.rb
@@ -133,4 +133,25 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
       {a: 1, b: 2}.transform_values {|v| foo(v)}.to_h {|k, v| [v, k]}
     RUBY
   end
+
+  context 'when using Ruby 2.6 or newer', :ruby26 do
+    it 'flags _.to_h{...} when transform_values could be used' do
+      expect_offense(<<~RUBY)
+        x.to_h {|k, v| [k, foo(v)]}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `to_h {...}`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.transform_values {|v| foo(v)}
+      RUBY
+    end
+  end
+
+  context 'below Ruby 2.6', :ruby25 do
+    it 'does not flag _.to_h{...}' do
+      expect_no_offenses(<<~RUBY)
+        x.to_h {|k, v| [k, foo(v)]}
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Followup to https://github.com/rubocop-hq/rubocop/pull/7663.

Since Ruby 2.6, `Hash#to_h` accepts a block which is called with each pair and must return a key and value to include in the new hash: https://rubyreferences.github.io/rubychanges/2.6.html#to_h-with-a-block

If either the key or the value are always returned unchanged, using `Hash#transform_keys` or `Hash#transform_values` is faster and clearer.

This is similar to the existing logic that detects `map { ... }.to_h`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/