### PR TITLE
Use `Cop::Base` API for `Style` department [R-S]

### DIFF
--- a/lib/rubocop/cop/style/random_with_offset.rb
+++ b/lib/rubocop/cop/style/random_with_offset.rb
@@ -23,7 +23,9 @@ module RuboCop
       #   # good
       #   rand(1..6)
       #   rand(1...7)
-      class RandomWithOffset < Cop
+      class RandomWithOffset < Base
+        extend AutoCorrector
+
         MSG = 'Prefer ranges when generating random numbers instead of ' \
           'integers with offsets.'
 
@@ -61,21 +63,8 @@ module RuboCop
                         rand_op_integer?(node) ||
                         rand_modified?(node)
 
-          add_offense(node)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            if integer_op_rand?(node)
-              corrector.replace(node,
-                                corrected_integer_op_rand(node))
-            elsif rand_op_integer?(node)
-              corrector.replace(node,
-                                corrected_rand_op_integer(node))
-            elsif rand_modified?(node)
-              corrector.replace(node,
-                                corrected_rand_modified(node))
-            end
+          add_offense(node) do |corrector|
+            autocorrect(corrector, node)
           end
         end
 
@@ -85,6 +74,16 @@ module RuboCop
           {(send (send $_ _ $_) ...)
            (send _ _ (send $_ _ $_))}
         PATTERN
+
+        def autocorrect(corrector, node)
+          if integer_op_rand?(node)
+            corrector.replace(node, corrected_integer_op_rand(node))
+          elsif rand_op_integer?(node)
+            corrector.replace(node, corrected_rand_op_integer(node))
+          elsif rand_modified?(node)
+            corrector.replace(node, corrected_rand_modified(node))
+          end
+        end
 
         def corrected_integer_op_rand(node)
           random_call(node) do |prefix_node, random_node|

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -54,7 +54,9 @@ module RuboCop
       #       baz
       #     end
       #   end
-      class RedundantBegin < Cop
+      class RedundantBegin < Base
+        extend AutoCorrector
+
         MSG = 'Redundant `begin` block detected.'
 
         def on_def(node)
@@ -71,19 +73,15 @@ module RuboCop
           check(node)
         end
 
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.remove(node.loc.begin)
-            corrector.remove(node.loc.end)
-          end
-        end
-
         private
 
         def check(node)
           return unless node.body&.kwbegin_type?
 
-          add_offense(node.body, location: :begin)
+          add_offense(node.body.loc.begin) do |corrector|
+            corrector.remove(node.body.loc.begin)
+            corrector.remove(node.body.loc.end)
+          end
         end
       end
     end

--- a/lib/rubocop/cop/style/redundant_condition.rb
+++ b/lib/rubocop/cop/style/redundant_condition.rb
@@ -30,8 +30,9 @@ module RuboCop
       #     c
       #   end
       #
-      class RedundantCondition < Cop
+      class RedundantCondition < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Use double pipes `||` instead.'
         REDUNDANT_CONDITION = 'This condition is not needed.'
@@ -40,11 +41,9 @@ module RuboCop
           return if node.elsif_conditional?
           return unless offense?(node)
 
-          add_offense(node, location: range_of_offense(node))
-        end
+          message = message(node)
 
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(range_of_offense(node), message: message) do |corrector|
             if node.ternary?
               correct_ternary(corrector, node)
             elsif node.modifier_form? || !node.else_branch
@@ -68,7 +67,7 @@ module RuboCop
         end
 
         def range_of_offense(node)
-          return :expression unless node.ternary?
+          return node.loc.expression unless node.ternary?
 
           range_between(node.loc.question.begin_pos, node.loc.colon.end_pos)
         end

--- a/lib/rubocop/cop/style/redundant_fetch_block.rb
+++ b/lib/rubocop/cop/style/redundant_fetch_block.rb
@@ -31,9 +31,10 @@ module RuboCop
       #   # good
       #   ENV.fetch(:key, VALUE)
       #
-      class RedundantFetchBlock < Cop
+      class RedundantFetchBlock < Base
         include FrozenStringLiteral
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Use `%<good>s` instead of `%<bad>s`.'
 
@@ -52,17 +53,7 @@ module RuboCop
             good = build_good_method(send, body)
             bad = build_bad_method(send, body)
 
-            add_offense(
-              node,
-              location: range,
-              message: format(MSG, good: good, bad: bad)
-            )
-          end
-        end
-
-        def autocorrect(node)
-          redundant_fetch_block_candidate?(node) do |send, body|
-            lambda do |corrector|
+            add_offense(range, message: format(MSG, good: good, bad: bad)) do |corrector|
               receiver, _, key = send.children
               default_value = body ? body.source : 'nil'
 

--- a/lib/rubocop/cop/style/redundant_file_extension_in_require.rb
+++ b/lib/rubocop/cop/style/redundant_file_extension_in_require.rb
@@ -24,7 +24,9 @@ module RuboCop
       #   require_relative '../foo'
       #   require_relative '../foo.so'
       #
-      class RedundantFileExtensionInRequire < Cop
+      class RedundantFileExtensionInRequire < Base
+        extend AutoCorrector
+
         MSG = 'Redundant `.rb` file extension detected.'
 
         def_node_matcher :require_call?, <<~PATTERN
@@ -33,15 +35,13 @@ module RuboCop
 
         def on_send(node)
           require_call?(node) do |name_node|
-            add_offense(name_node) if name_node.value.end_with?('.rb')
-          end
-        end
+            return unless name_node.value.end_with?('.rb')
 
-        def autocorrect(node)
-          correction = node.value.sub(/\.rb\z/, '')
+            add_offense(name_node) do |corrector|
+              correction = name_node.value.sub(/\.rb\z/, '')
 
-          lambda do |corrector|
-            corrector.replace(node, "'#{correction}'")
+              corrector.replace(name_node, "'#{correction}'")
+            end
           end
         end
       end

--- a/lib/rubocop/cop/style/redundant_freeze.rb
+++ b/lib/rubocop/cop/style/redundant_freeze.rb
@@ -11,7 +11,8 @@ module RuboCop
       #
       #   # good
       #   CONST = 1
-      class RedundantFreeze < Cop
+      class RedundantFreeze < Base
+        extend AutoCorrector
         include FrozenStringLiteral
 
         MSG = 'Do not freeze immutable objects, as freezing them has no ' \
@@ -22,11 +23,7 @@ module RuboCop
                         (immutable_literal?(node.receiver) ||
                          operation_produces_immutable_object?(node.receiver))
 
-          add_offense(node)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(node) do |corrector|
             corrector.remove(node.loc.dot)
             corrector.remove(node.loc.selector)
           end

--- a/lib/rubocop/cop/style/return_nil.rb
+++ b/lib/rubocop/cop/style/return_nil.rb
@@ -28,8 +28,9 @@ module RuboCop
       #   def foo(arg)
       #     return nil if arg
       #   end
-      class ReturnNil < Cop
+      class ReturnNil < Base
         include ConfigurableEnforcedStyle
+        extend AutoCorrector
 
         RETURN_MSG = 'Use `return` instead of `return nil`.'
         RETURN_NIL_MSG = 'Use `return nil` instead of `return`.'
@@ -54,12 +55,11 @@ module RuboCop
             return nil if chained_send?(send_node)
           end
 
-          add_offense(node) unless correct_style?(node)
-        end
+          return if correct_style?(node)
 
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(node) do |corrector|
             corrected = style == :return ? 'return' : 'return nil'
+
             corrector.replace(node, corrected)
           end
         end

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -58,9 +58,10 @@ module RuboCop
       #   foo.baz = bar if foo
       #   foo.baz + bar if foo
       #   foo.bar > 2 if foo
-      class SafeNavigation < Cop
+      class SafeNavigation < Base
         include NilMethods
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Use safe navigation (`&.`) instead of checking if an object ' \
               'exists before calling the method.'
@@ -104,28 +105,28 @@ module RuboCop
           return if chain_size(method_chain, method) > 1
           return if unsafe_method_used?(method_chain, method)
 
-          add_offense(node)
+          add_offense(node) do |corrector|
+            autocorrect(corrector, node)
+          end
         end
 
         def use_var_only_in_unless_modifier?(node, variable)
           node.if_type? && node.unless? && !method_called?(variable)
         end
 
-        def autocorrect(node)
+        private
+
+        def autocorrect(corrector, node)
           body = node.node_parts[1]
           method_call = method_call(node)
 
-          lambda do |corrector|
-            corrector.remove(begin_range(node, body))
-            corrector.remove(end_range(node, body))
-            corrector.insert_before(method_call.loc.dot, '&')
-            handle_comments(corrector, node, method_call)
+          corrector.remove(begin_range(node, body))
+          corrector.remove(end_range(node, body))
+          corrector.insert_before(method_call.loc.dot, '&')
+          handle_comments(corrector, node, method_call)
 
-            add_safe_nav_to_all_methods_in_chain(corrector, method_call, body)
-          end
+          add_safe_nav_to_all_methods_in_chain(corrector, method_call, body)
         end
-
-        private
 
         def handle_comments(corrector, node, method_call)
           comments = comments(node)

--- a/lib/rubocop/cop/style/sample.rb
+++ b/lib/rubocop/cop/style/sample.rb
@@ -27,7 +27,9 @@ module RuboCop
       #   [1, 2, 3].shuffle[1..3]    # sample(3) might return a longer Array
       #   [1, 2, 3].shuffle[foo, bar]
       #   [1, 2, 3].shuffle(random: Random.new)
-      class Sample < Cop
+      class Sample < Base
+        extend AutoCorrector
+
         MSG = 'Use `%<correct>s` instead of `%<incorrect>s`.'
 
         def_node_matcher :sample_candidate?, <<~PATTERN
@@ -35,22 +37,17 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          sample_candidate?(node) do |shuffle, shuffle_arg, method, method_args|
+          sample_candidate?(node) do |shuffle_node, shuffle_arg, method, method_args|
             return unless offensive?(method, method_args)
 
-            range = source_range(shuffle, node)
+            range = source_range(shuffle_node, node)
             message = message(shuffle_arg, method, method_args, range)
-            add_offense(node, location: range, message: message)
-          end
-        end
 
-        def autocorrect(node)
-          shuffle_node, shuffle_arg, method, method_args =
-            sample_candidate?(node)
-
-          lambda do |corrector|
-            corrector.replace(source_range(shuffle_node, node),
-                              correction(shuffle_arg, method, method_args))
+            add_offense(range, message: message) do |corrector|
+              corrector.replace(
+                source_range(shuffle_node, node), correction(shuffle_arg, method, method_args)
+              )
+            end
           end
         end
 

--- a/lib/rubocop/cop/style/semicolon.rb
+++ b/lib/rubocop/cop/style/semicolon.rb
@@ -26,12 +26,13 @@ module RuboCop
       # @example AllowAsExpressionSeparator: true
       #   # good
       #   foo = 1; bar = 2
-      class Semicolon < Cop
+      class Semicolon < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Do not use semicolons to terminate expressions.'
 
-        def investigate(processed_source)
+        def on_new_investigation
           return if processed_source.blank?
 
           @processed_source = processed_source
@@ -66,12 +67,6 @@ module RuboCop
           end
         end
 
-        def autocorrect(range)
-          return unless range
-
-          ->(corrector) { corrector.remove(range) }
-        end
-
         private
 
         def check_for_line_terminator_or_opener
@@ -93,7 +88,9 @@ module RuboCop
           range = source_range(@processed_source.buffer, line, column)
           # Don't attempt to autocorrect if semicolon is separating statements
           # on the same line
-          add_offense(autocorrect ? range : nil, location: range)
+          add_offense(range) do |corrector|
+            corrector.remove(range) if autocorrect
+          end
         end
       end
     end

--- a/lib/rubocop/cop/style/send.rb
+++ b/lib/rubocop/cop/style/send.rb
@@ -13,7 +13,7 @@ module RuboCop
       #   # good
       #   Foo.__send__(:bar)
       #   quuz.public_send(:fred)
-      class Send < Cop
+      class Send < Base
         MSG = 'Prefer `Object#__send__` or `Object#public_send` to ' \
               '`send`.'
 
@@ -22,7 +22,7 @@ module RuboCop
         def on_send(node)
           return unless sending?(node) && node.arguments?
 
-          add_offense(node, location: :selector)
+          add_offense(node.loc.selector)
         end
         alias on_csend on_send
       end

--- a/lib/rubocop/cop/style/signal_exception.rb
+++ b/lib/rubocop/cop/style/signal_exception.rb
@@ -104,8 +104,9 @@ module RuboCop
       #
       #   explicit_receiver.fail
       #   explicit_receiver.raise
-      class SignalException < Cop
+      class SignalException < Base
         include ConfigurableEnforcedStyle
+        extend AutoCorrector
 
         FAIL_MSG = 'Use `fail` instead of `raise` to signal exceptions.'
         RAISE_MSG = 'Use `raise` instead of `fail` to ' \
@@ -115,7 +116,7 @@ module RuboCop
         def_node_search :custom_fail_methods,
                         '{(def :fail ...) (defs _ :fail ...)}'
 
-        def investigate(processed_source)
+        def on_new_investigation
           ast = processed_source.ast
           @custom_fail_defined = ast && custom_fail_methods(ast).any?
         end
@@ -145,20 +146,6 @@ module RuboCop
           end
         end
 
-        def autocorrect(node)
-          lambda do |corrector|
-            name =
-              case style
-              when :semantic
-                command_or_kernel_call?(:raise, node) ? 'fail' : 'raise'
-              when :only_raise then 'raise'
-              when :only_fail then 'fail'
-              end
-
-            corrector.replace(node.loc.selector, name)
-          end
-        end
-
         private
 
         def message(method_name)
@@ -178,8 +165,9 @@ module RuboCop
           each_command_or_kernel_call(method_name, node) do |send_node|
             next if ignored_node?(send_node)
 
-            add_offense(send_node,
-                        location: :selector, message: message(method_name))
+            add_offense(send_node.loc.selector, message: message(method_name)) do |corrector|
+              autocorrect(corrector, send_node)
+            end
             ignore_node(send_node)
           end
         end
@@ -187,7 +175,21 @@ module RuboCop
         def check_send(method_name, node)
           return unless node && command_or_kernel_call?(method_name, node)
 
-          add_offense(node, location: :selector, message: message(method_name))
+          add_offense(node.loc.selector, message: message(method_name)) do |corrector|
+            autocorrect(corrector, node)
+          end
+        end
+
+        def autocorrect(corrector, node)
+          name =
+            case style
+            when :semantic
+              command_or_kernel_call?(:raise, node) ? 'fail' : 'raise'
+            when :only_raise then 'raise'
+            when :only_fail then 'fail'
+            end
+
+          corrector.replace(node.loc.selector, name)
         end
 
         def command_or_kernel_call?(name, node)

--- a/lib/rubocop/cop/style/single_line_block_params.rb
+++ b/lib/rubocop/cop/style/single_line_block_params.rb
@@ -28,7 +28,7 @@ module RuboCop
       #   foo.reduce do |c, d|
       #     c + d
       #   end
-      class SingleLineBlockParams < Cop
+      class SingleLineBlockParams < Base
         MSG = 'Name `%<method>s` block params `|%<params>s|`.'
 
         def on_block(node)
@@ -39,7 +39,9 @@ module RuboCop
 
           return if args_match?(node.send_node.method_name, node.arguments)
 
-          add_offense(node.arguments)
+          message = message(node.arguments)
+
+          add_offense(node.arguments, message: message)
         end
 
         private

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -24,8 +24,9 @@ module RuboCop
       #   # bad
       #   def no_op; end
       #
-      class SingleLineMethods < Cop
+      class SingleLineMethods < Base
         include Alignment
+        extend AutoCorrector
 
         MSG = 'Avoid single-line method definitions.'
 
@@ -33,29 +34,29 @@ module RuboCop
           return unless node.single_line?
           return if allow_empty? && !node.body
 
-          add_offense(node)
+          add_offense(node) do |corrector|
+            autocorrect(corrector, node)
+          end
         end
         alias on_defs on_def
 
-        def autocorrect(node)
-          lambda do |corrector|
-            each_part(node.body) do |part|
-              LineBreakCorrector.break_line_before(
-                range: part, node: node, corrector: corrector,
-                configured_width: configured_indentation_width
-              )
-            end
-
-            LineBreakCorrector.break_line_before(
-              range: node.loc.end, node: node, corrector: corrector,
-              indent_steps: 0, configured_width: configured_indentation_width
-            )
-
-            move_comment(node, corrector)
-          end
-        end
-
         private
+
+        def autocorrect(corrector, node)
+          each_part(node.body) do |part|
+            LineBreakCorrector.break_line_before(
+              range: part, node: node, corrector: corrector,
+              configured_width: configured_indentation_width
+            )
+          end
+
+          LineBreakCorrector.break_line_before(
+            range: node.loc.end, node: node, corrector: corrector,
+            indent_steps: 0, configured_width: configured_indentation_width
+          )
+
+          move_comment(node, corrector)
+        end
 
         def allow_empty?
           cop_config['AllowIfMethodIsEmpty']

--- a/lib/rubocop/cop/style/slicing_with_range.rb
+++ b/lib/rubocop/cop/style/slicing_with_range.rb
@@ -12,7 +12,8 @@ module RuboCop
       #
       #   # good
       #   items[1..]
-      class SlicingWithRange < Cop
+      class SlicingWithRange < Base
+        extend AutoCorrector
         extend TargetRubyVersion
 
         minimum_target_ruby_version 2.6
@@ -25,12 +26,8 @@ module RuboCop
           return unless node.method?(:[]) && node.arguments.count == 1
           return unless range_till_minus_one?(node.arguments.first)
 
-          add_offense(node.arguments.first)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.remove(node.end)
+          add_offense(node.first_argument) do |corrector|
+            corrector.remove(node.first_argument.end)
           end
         end
       end

--- a/lib/rubocop/cop/style/stabby_lambda_parentheses.rb
+++ b/lib/rubocop/cop/style/stabby_lambda_parentheses.rb
@@ -19,26 +19,26 @@ module RuboCop
       #
       #   # good
       #   ->a,b,c { a + b + c}
-      class StabbyLambdaParentheses < Cop
+      class StabbyLambdaParentheses < Base
         include ConfigurableEnforcedStyle
+        extend AutoCorrector
 
         MSG_REQUIRE = 'Wrap stabby lambda arguments with parentheses.'
         MSG_NO_REQUIRE = 'Do not wrap stabby lambda arguments ' \
                          'with parentheses.'
         def on_send(node)
           return unless stabby_lambda_with_args?(node)
-          return unless redundant_parentheses?(node) ||
-                        missing_parentheses?(node)
+          return unless redundant_parentheses?(node) || missing_parentheses?(node)
 
-          add_offense(node.block_node.arguments)
-        end
+          arguments = node.block_node.arguments
 
-        def autocorrect(node)
-          case style
-          when :require_parentheses
-            missing_parentheses_corrector(node)
-          when :require_no_parentheses
-            unwanted_parentheses_corrector(node)
+          add_offense(arguments) do |corrector|
+            case style
+            when :require_parentheses
+              missing_parentheses_corrector(corrector, arguments)
+            when :require_no_parentheses
+              unwanted_parentheses_corrector(corrector, arguments)
+            end
           end
         end
 
@@ -56,19 +56,15 @@ module RuboCop
           style == :require_parentheses ? MSG_REQUIRE : MSG_NO_REQUIRE
         end
 
-        def missing_parentheses_corrector(node)
-          lambda do |corrector|
-            corrector.wrap(node, '(', ')')
-          end
+        def missing_parentheses_corrector(corrector, node)
+          corrector.wrap(node, '(', ')')
         end
 
-        def unwanted_parentheses_corrector(node)
-          lambda do |corrector|
-            args_loc = node.loc
+        def unwanted_parentheses_corrector(corrector, node)
+          args_loc = node.loc
 
-            corrector.replace(args_loc.begin, '')
-            corrector.remove(args_loc.end)
-          end
+          corrector.replace(args_loc.begin, '')
+          corrector.remove(args_loc.end)
         end
 
         def stabby_lambda_with_args?(node)

--- a/lib/rubocop/cop/style/stderr_puts.rb
+++ b/lib/rubocop/cop/style/stderr_puts.rb
@@ -14,8 +14,9 @@ module RuboCop
       #   # good
       #   warn('hello')
       #
-      class StderrPuts < Cop
+      class StderrPuts < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG =
           'Use `warn` instead of `%<bad>s` to allow such output to be disabled.'
@@ -30,11 +31,8 @@ module RuboCop
         def on_send(node)
           return unless stderr_puts?(node)
 
-          add_offense(node, location: stderr_puts_range(node))
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          message = message(node)
+          add_offense(stderr_puts_range(node), message: message) do |corrector|
             corrector.replace(stderr_puts_range(node), 'warn')
           end
         end

--- a/lib/rubocop/cop/style/string_hash_keys.rb
+++ b/lib/rubocop/cop/style/string_hash_keys.rb
@@ -12,7 +12,9 @@ module RuboCop
       #
       #   # good
       #   { one: 1, two: 2, three: 3 }
-      class StringHashKeys < Cop
+      class StringHashKeys < Base
+        extend AutoCorrector
+
         MSG = 'Prefer symbols instead of strings as hash keys.'
 
         def_node_matcher :string_hash_key?, <<~PATTERN
@@ -35,13 +37,10 @@ module RuboCop
           return unless string_hash_key?(node)
           return if receive_environments_method?(node)
 
-          add_offense(node.key)
-        end
+          add_offense(node.key) do |corrector|
+            symbol_content = node.key.str_content.to_sym.inspect
 
-        def autocorrect(node)
-          lambda do |corrector|
-            symbol_content = node.str_content.to_sym.inspect
-            corrector.replace(node, symbol_content)
+            corrector.replace(node.key, symbol_content)
           end
         end
       end

--- a/lib/rubocop/cop/style/string_methods.rb
+++ b/lib/rubocop/cop/style/string_methods.rb
@@ -14,32 +14,22 @@ module RuboCop
       #   # good
       #   'name'.to_sym
       #   'var'.preferred_method
-      class StringMethods < Cop
+      class StringMethods < Base
         include MethodPreference
+        extend AutoCorrector
 
         MSG = 'Prefer `%<prefer>s` over `%<current>s`.'
 
         def on_send(node)
-          return unless preferred_method(node.method_name)
+          return unless (preferred_method = preferred_method(node.method_name))
 
-          add_offense(node, location: :selector)
-        end
-        alias on_csend on_send
+          message = format(MSG, prefer: preferred_method, current: node.method_name)
 
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.loc.selector,
-                              preferred_method(node.method_name))
+          add_offense(node.loc.selector, message: message) do |corrector|
+            corrector.replace(node.loc.selector, preferred_method(node.method_name))
           end
         end
-
-        private
-
-        def message(node)
-          format(MSG,
-                 prefer: preferred_method(node.method_name),
-                 current: node.method_name)
-        end
+        alias on_csend on_send
       end
     end
   end

--- a/lib/rubocop/cop/style/strip.rb
+++ b/lib/rubocop/cop/style/strip.rb
@@ -13,8 +13,9 @@ module RuboCop
       #
       #   # good
       #   'abc'.strip
-      class Strip < Cop
+      class Strip < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Use `strip` instead of `%<methods>s`.'
 
@@ -25,20 +26,13 @@ module RuboCop
 
         def on_send(node)
           lstrip_rstrip(node) do |first_send, method_one, method_two|
-            range = range_between(first_send.loc.selector.begin_pos,
-                                  node.source_range.end_pos)
-            add_offense(node,
-                        location: range,
-                        message: format(MSG,
-                                        methods: "#{method_one}.#{method_two}"))
+            range = range_between(first_send.loc.selector.begin_pos, node.source_range.end_pos)
+            message = format(MSG, methods: "#{method_one}.#{method_two}")
+
+            add_offense(range, message: message) do |corrector|
+              corrector.replace(range, 'strip')
+            end
           end
-        end
-
-        def autocorrect(node)
-          range = range_between(node.receiver.loc.selector.begin_pos,
-                                node.source_range.end_pos)
-
-          ->(corrector) { corrector.replace(range, 'strip') }
         end
       end
     end

--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -19,8 +19,9 @@ module RuboCop
       #       42
       #     end
       #   end
-      class StructInheritance < Cop
+      class StructInheritance < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG = "Don't extend an instance initialized by `Struct.new`. " \
               'Use a block to customize the struct.'
@@ -28,11 +29,7 @@ module RuboCop
         def on_class(node)
           return unless struct_constructor?(node.parent_class)
 
-          add_offense(node, location: node.parent_class.source_range)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(node.parent_class.source_range) do |corrector|
             corrector.remove(range_with_surrounding_space(range: node.loc.keyword, newlines: false))
             corrector.replace(node.loc.operator, '=')
 

--- a/lib/rubocop/cop/style/symbol_literal.rb
+++ b/lib/rubocop/cop/style/symbol_literal.rb
@@ -12,17 +12,15 @@ module RuboCop
       #
       #   # good
       #   :symbol
-      class SymbolLiteral < Cop
+      class SymbolLiteral < Base
+        extend AutoCorrector
+
         MSG = 'Do not use strings for word-like symbol literals.'
 
         def on_sym(node)
           return unless /\A:["'][A-Za-z_]\w*["']\z/.match?(node.source)
 
-          add_offense(node)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(node) do |corrector|
             corrector.replace(node, node.source.delete(%q('")))
           end
         end

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -11,9 +11,10 @@ module RuboCop
       #
       #   # good
       #   something.map(&:upcase)
-      class SymbolProc < Cop
+      class SymbolProc < Base
         include RangeHelp
         include IgnoredMethods
+        extend AutoCorrector
 
         MSG = 'Pass `&:%<method>s` as an argument to `%<block_method>s` ' \
               'instead of a block.'
@@ -49,30 +50,25 @@ module RuboCop
           argument_node.one? && argument_node.source.include?(',')
         end
 
-        def autocorrect(node)
-          lambda do |corrector|
-            if node.send_node.arguments?
-              autocorrect_with_args(corrector, node,
-                                    node.send_node.arguments,
-                                    node.body.method_name)
-            else
-              autocorrect_without_args(corrector, node)
-            end
-          end
-        end
-
         private
 
         def register_offense(node, method_name, block_method_name)
           block_start = node.loc.begin.begin_pos
           block_end = node.loc.end.end_pos
           range = range_between(block_start, block_end)
+          message = format(MSG, method: method_name, block_method: block_method_name)
 
-          add_offense(node,
-                      location: range,
-                      message: format(MSG,
-                                      method: method_name,
-                                      block_method: block_method_name))
+          add_offense(range, message: message) do |corrector|
+            autocorrect(corrector, node)
+          end
+        end
+
+        def autocorrect(corrector, node)
+          if node.send_node.arguments?
+            autocorrect_with_args(corrector, node, node.send_node.arguments, node.body.method_name)
+          else
+            autocorrect_without_args(corrector, node)
+          end
         end
 
         def autocorrect_without_args(corrector, node)


### PR DESCRIPTION
Follow #7868.

This PR uses `Cop::Base` API for almost `Style` department's R-S cops.
It targets cop that names begin between R and S. And some R-S cops will be excluded from this PR target and addressed separately.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
