### PR TITLE
Use `Cop::Base` API for `Style` department [T-Z]

### DIFF
--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -54,10 +54,11 @@ module RuboCop
       #   # bad
       #   foo = (bar = baz) ? a : b
       #
-      class TernaryParentheses < Cop
+      class TernaryParentheses < Base
         include SafeAssignment
         include ConfigurableEnforcedStyle
         include SurroundingSpace
+        extend AutoCorrector
 
         VARIABLE_TYPES = AST::Node::VARIABLES
         NON_COMPLEX_TYPES = [*VARIABLE_TYPES, :const, :defined?, :yield].freeze
@@ -70,14 +71,20 @@ module RuboCop
           return if only_closing_parenthesis_is_last_line?(node.condition)
           return unless node.ternary? && !infinite_loop? && offense?(node)
 
-          add_offense(node, location: node.source_range)
+          message = message(node)
+
+          add_offense(node.source_range, message: message) do |corrector|
+            autocorrect(corrector, node)
+          end
         end
 
         def only_closing_parenthesis_is_last_line?(condition)
           condition.source.split("\n").last == ')'
         end
 
-        def autocorrect(node)
+        private
+
+        def autocorrect(corrector, node)
           condition = node.condition
 
           return nil if parenthesized?(condition) &&
@@ -85,13 +92,11 @@ module RuboCop
                         unsafe_autocorrect?(condition))
 
           if parenthesized?(condition)
-            correct_parenthesized(condition)
+            correct_parenthesized(corrector, condition)
           else
-            correct_unparenthesized(condition)
+            correct_unparenthesized(corrector, condition)
           end
         end
-
-        private
 
         def offense?(node)
           condition = node.condition
@@ -191,22 +196,18 @@ module RuboCop
            (send {_ nil?} $_ _ ...)}
         PATTERN
 
-        def correct_parenthesized(condition)
-          lambda do |corrector|
-            corrector.remove(condition.loc.begin)
-            corrector.remove(condition.loc.end)
+        def correct_parenthesized(corrector, condition)
+          corrector.remove(condition.loc.begin)
+          corrector.remove(condition.loc.end)
 
-            # Ruby allows no space between the question mark and parentheses.
-            # If we remove the parentheses, we need to add a space or we'll
-            # generate invalid code.
-            corrector.insert_after(condition.loc.end, ' ') unless whitespace_after?(condition)
-          end
+          # Ruby allows no space between the question mark and parentheses.
+          # If we remove the parentheses, we need to add a space or we'll
+          # generate invalid code.
+          corrector.insert_after(condition.loc.end, ' ') unless whitespace_after?(condition)
         end
 
-        def correct_unparenthesized(condition)
-          lambda do |corrector|
-            corrector.wrap(condition, '(', ')')
-          end
+        def correct_unparenthesized(corrector, condition)
+          corrector.wrap(condition, '(', ')')
         end
 
         def whitespace_after?(node)

--- a/lib/rubocop/cop/style/trailing_body_on_class.rb
+++ b/lib/rubocop/cop/style/trailing_body_on_class.rb
@@ -15,20 +15,17 @@ module RuboCop
       #     def foo; end
       #   end
       #
-      class TrailingBodyOnClass < Cop
+      class TrailingBodyOnClass < Base
         include Alignment
         include TrailingBody
+        extend AutoCorrector
 
         MSG = 'Place the first line of class body on its own line.'
 
         def on_class(node)
           return unless trailing_body?(node)
 
-          add_offense(node, location: first_part_of(node.to_a.last))
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(first_part_of(node.to_a.last)) do |corrector|
             LineBreakCorrector.correct_trailing_body(
               configured_width: configured_indentation_width,
               corrector: corrector,

--- a/lib/rubocop/cop/style/trailing_body_on_method_definition.rb
+++ b/lib/rubocop/cop/style/trailing_body_on_method_definition.rb
@@ -24,9 +24,10 @@ module RuboCop
       #     b[c: x]
       #   end
       #
-      class TrailingBodyOnMethodDefinition < Cop
+      class TrailingBodyOnMethodDefinition < Base
         include Alignment
         include TrailingBody
+        extend AutoCorrector
 
         MSG = "Place the first line of a multi-line method definition's " \
               'body on its own line.'
@@ -34,12 +35,7 @@ module RuboCop
         def on_def(node)
           return unless trailing_body?(node)
 
-          add_offense(node, location: first_part_of(node.body))
-        end
-        alias on_defs on_def
-
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(first_part_of(node.body)) do |corrector|
             LineBreakCorrector.correct_trailing_body(
               configured_width: configured_indentation_width,
               corrector: corrector,
@@ -48,6 +44,7 @@ module RuboCop
             )
           end
         end
+        alias on_defs on_def
       end
     end
   end

--- a/lib/rubocop/cop/style/trailing_body_on_module.rb
+++ b/lib/rubocop/cop/style/trailing_body_on_module.rb
@@ -15,20 +15,17 @@ module RuboCop
       #     extend self
       #   end
       #
-      class TrailingBodyOnModule < Cop
+      class TrailingBodyOnModule < Base
         include Alignment
         include TrailingBody
+        extend AutoCorrector
 
         MSG = 'Place the first line of module body on its own line.'
 
         def on_module(node)
           return unless trailing_body?(node)
 
-          add_offense(node, location: first_part_of(node.to_a.last))
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(first_part_of(node.to_a.last)) do |corrector|
             LineBreakCorrector.correct_trailing_body(
               configured_width: configured_indentation_width,
               corrector: corrector,

--- a/lib/rubocop/cop/style/trailing_comma_in_block_args.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_block_args.rb
@@ -40,20 +40,21 @@ module RuboCop
       #   add do
       #     foo + bar
       #   end
-      class TrailingCommaInBlockArgs < Cop
+      class TrailingCommaInBlockArgs < Base
+        extend AutoCorrector
+
         MSG = 'Useless trailing comma present in block arguments.'
 
         def on_block(node)
           # lambda literal (`->`) never has block arguments.
           return if node.send_node.lambda_literal?
-
           return unless useless_trailing_comma?(node)
 
-          add_offense(node, location: last_comma(node).pos)
-        end
+          last_comma_pos = last_comma(node).pos
 
-        def autocorrect(node)
-          ->(corrector) { corrector.replace(last_comma(node).pos, '') }
+          add_offense(last_comma_pos) do |corrector|
+            corrector.replace(last_comma_pos, '')
+          end
         end
 
         private

--- a/lib/rubocop/cop/style/trailing_underscore_variable.rb
+++ b/lib/rubocop/cop/style/trailing_underscore_variable.rb
@@ -28,9 +28,10 @@ module RuboCop
       #   # bad
       #   a, b, _something = foo()
       #
-      class TrailingUnderscoreVariable < Cop
+      class TrailingUnderscoreVariable < Base
         include SurroundingSpace
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Do not use trailing `_`s in parallel assignment. ' \
               'Prefer `%<code>s`.'
@@ -44,17 +45,9 @@ module RuboCop
             offset = range.begin_pos - node.source_range.begin_pos
             good_code[offset, range.size] = ''
 
-            add_offense(node,
-                        location: range,
-                        message: format(MSG, code: good_code))
-          end
-        end
-
-        def autocorrect(node)
-          ranges = unneeded_ranges(node)
-
-          lambda do |corrector|
-            ranges.each { |range| corrector.remove(range) if range }
+            add_offense(range, message: format(MSG, code: good_code)) do |corrector|
+              corrector.remove(range)
+            end
           end
         end
 

--- a/lib/rubocop/cop/style/unless_else.rb
+++ b/lib/rubocop/cop/style/unless_else.rb
@@ -19,8 +19,9 @@ module RuboCop
       #   else
       #     # do a different thing...
       #   end
-      class UnlessElse < Cop
+      class UnlessElse < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Do not use `unless` with `else`. Rewrite these with the ' \
               'positive case first.'
@@ -28,14 +29,10 @@ module RuboCop
         def on_if(node)
           return unless node.unless? && node.else?
 
-          add_offense(node)
-        end
+          add_offense(node) do |corrector|
+            body_range = range_between_condition_and_else(node, node.condition)
+            else_range = range_between_else_and_end(node)
 
-        def autocorrect(node)
-          body_range = range_between_condition_and_else(node, node.condition)
-          else_range = range_between_else_and_end(node)
-
-          lambda do |corrector|
             corrector.replace(node.loc.keyword, 'if')
             corrector.replace(body_range, else_range.source)
             corrector.replace(else_range, body_range.source)

--- a/lib/rubocop/cop/style/unpack_first.rb
+++ b/lib/rubocop/cop/style/unpack_first.rb
@@ -17,7 +17,9 @@ module RuboCop
       #   # good
       #   'foo'.unpack1('h*')
       #
-      class UnpackFirst < Cop
+      class UnpackFirst < Base
+        extend AutoCorrector
+
         MSG = 'Use `%<receiver>s.unpack1(%<format>s)` instead of '\
           '`%<receiver>s.unpack(%<format>s)%<method>s`.'
 
@@ -35,13 +37,7 @@ module RuboCop
                              receiver: unpack_call.receiver.source,
                              format: unpack_arg.source,
                              method: range.source)
-            add_offense(node, message: message)
-          end
-        end
-
-        def autocorrect(node)
-          unpack_and_first_element?(node) do |unpack_call, _unpack_arg|
-            lambda do |corrector|
+            add_offense(node, message: message) do |corrector|
               corrector.remove(first_element_range(node, unpack_call))
               corrector.replace(unpack_call.loc.selector, 'unpack1')
             end

--- a/lib/rubocop/cop/style/variable_interpolation.rb
+++ b/lib/rubocop/cop/style/variable_interpolation.rb
@@ -15,28 +15,25 @@ module RuboCop
       #   "His name is #{$name}"
       #   /check #{$pattern}/
       #   "Let's go to the #{@store}"
-      class VariableInterpolation < Cop
+      class VariableInterpolation < Base
         include Interpolation
+        extend AutoCorrector
 
         MSG = 'Replace interpolated variable `%<variable>s` ' \
               'with expression `#{%<variable>s}`.'
 
         def on_node_with_interpolations(node)
           var_nodes(node.children).each do |var_node|
-            add_offense(var_node)
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node, "{#{node.source}}")
+            add_offense(var_node) do |corrector|
+              corrector.replace(var_node, "{#{var_node.source}}")
+            end
           end
         end
 
         private
 
-        def message(node)
-          format(MSG, variable: node.source)
+        def message(range)
+          format(MSG, variable: range.source)
         end
 
         def var_nodes(nodes)

--- a/lib/rubocop/cop/style/when_then.rb
+++ b/lib/rubocop/cop/style/when_then.rb
@@ -17,17 +17,15 @@ module RuboCop
       #   when 1 then 'baz'
       #   when 2 then 'bar'
       #   end
-      class WhenThen < Cop
+      class WhenThen < Base
+        extend AutoCorrector
+
         MSG = 'Do not use `when x;`. Use `when x then` instead.'
 
         def on_when(node)
           return if node.multiline? || node.then? || !node.body
 
-          add_offense(node, location: :begin)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(node.loc.begin) do |corrector|
             corrector.replace(node.loc.begin, ' then')
           end
         end

--- a/lib/rubocop/cop/style/while_until_do.rb
+++ b/lib/rubocop/cop/style/while_until_do.rb
@@ -28,31 +28,21 @@ module RuboCop
       #   until x.empty?
       #     do_something(x.pop)
       #   end
-      class WhileUntilDo < Cop
+      class WhileUntilDo < Base
+        extend AutoCorrector
+
         MSG = 'Do not use `do` with multi-line `%<keyword>s`.'
 
         def on_while(node)
-          handle(node)
-        end
-
-        def on_until(node)
-          handle(node)
-        end
-
-        def handle(node)
           return unless node.multiline? && node.do?
 
-          add_offense(node, location: :begin,
-                            message: format(MSG, keyword: node.keyword))
-        end
+          add_offense(node.loc.begin, message: format(MSG, keyword: node.keyword)) do |corrector|
+            do_range = node.condition.source_range.end.join(node.loc.begin)
 
-        def autocorrect(node)
-          do_range = node.condition.source_range.end.join(node.loc.begin)
-
-          lambda do |corrector|
             corrector.remove(do_range)
           end
         end
+        alias on_until on_while
       end
     end
   end

--- a/lib/rubocop/cop/style/while_until_modifier.rb
+++ b/lib/rubocop/cop/style/while_until_modifier.rb
@@ -24,37 +24,23 @@ module RuboCop
       #
       #   # good
       #   x += 1 until x > 10
-      class WhileUntilModifier < Cop
+      class WhileUntilModifier < Base
         include StatementModifier
+        extend AutoCorrector
 
         MSG = 'Favor modifier `%<keyword>s` usage when ' \
               'having a single-line body.'
 
         def on_while(node)
-          check(node)
-        end
+          return unless node.multiline? && single_line_as_modifier?(node)
 
-        def on_until(node)
-          check(node)
-        end
+          add_offense(node.loc.keyword, message: format(MSG, keyword: node.keyword)) do |corrector|
+            oneline = "#{node.body.source} #{node.keyword} #{node.condition.source}"
 
-        def autocorrect(node)
-          oneline = "#{node.body.source} #{node.keyword} " \
-                    "#{node.condition.source}"
-
-          lambda do |corrector|
             corrector.replace(node, oneline)
           end
         end
-
-        private
-
-        def check(node)
-          return unless node.multiline? && single_line_as_modifier?(node)
-
-          add_offense(node, location: :keyword,
-                            message: format(MSG, keyword: node.keyword))
-        end
+        alias on_until on_while
       end
     end
   end

--- a/lib/rubocop/cop/style/yoda_condition.rb
+++ b/lib/rubocop/cop/style/yoda_condition.rb
@@ -52,9 +52,10 @@ module RuboCop
       #   # good
       #   99 == foo
       #   "bar" != foo
-      class YodaCondition < Cop
+      class YodaCondition < Base
         include ConfigurableEnforcedStyle
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Reverse the order of the operands `%<source>s`.'
 
@@ -80,11 +81,7 @@ module RuboCop
           return if equality_only? && non_equality_operator?(node) ||
                     file_constant_equal_program_name?(node)
 
-          valid_yoda?(node) || add_offense(node)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          valid_yoda?(node) || add_offense(node) do |corrector|
             corrector.replace(actual_code_range(node), corrected_code(node))
           end
         end

--- a/lib/rubocop/cop/style/zero_length_predicate.rb
+++ b/lib/rubocop/cop/style/zero_length_predicate.rb
@@ -25,7 +25,9 @@ module RuboCop
       #   !{a: 1, b: 2}.empty?
       #   !string.empty?
       #   !hash.empty?
-      class ZeroLengthPredicate < Cop
+      class ZeroLengthPredicate < Base
+        extend AutoCorrector
+
         ZERO_MSG = 'Use `empty?` instead of `%<lhs>s %<opr>s %<rhs>s`.'
         NONZERO_MSG = 'Use `!empty?` instead of ' \
                       '`%<lhs>s %<opr>s %<rhs>s`.'
@@ -35,12 +37,6 @@ module RuboCop
         def on_send(node)
           check_zero_length_predicate(node)
           check_nonzero_length_predicate(node)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node, replacement(node))
-          end
         end
 
         private
@@ -56,9 +52,10 @@ module RuboCop
           return if non_polymorphic_collection?(node.parent)
 
           add_offense(
-            node.parent,
-            message: format(ZERO_MSG, lhs: lhs, opr: opr, rhs: rhs)
-          )
+            node.parent, message: format(ZERO_MSG, lhs: lhs, opr: opr, rhs: rhs)
+          ) do |corrector|
+            corrector.replace(node.parent, replacement(node.parent))
+          end
         end
 
         def check_nonzero_length_predicate(node)
@@ -72,9 +69,10 @@ module RuboCop
           return if non_polymorphic_collection?(node.parent)
 
           add_offense(
-            node.parent,
-            message: format(NONZERO_MSG, lhs: lhs, opr: opr, rhs: rhs)
-          )
+            node.parent, message: format(NONZERO_MSG, lhs: lhs, opr: opr, rhs: rhs)
+          ) do |corrector|
+            corrector.replace(node.parent, replacement(node.parent))
+          end
         end
 
         def_node_matcher :zero_length_predicate, <<~PATTERN

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -167,7 +167,12 @@ RSpec.describe RuboCop::Cop::Cop, :config do
     end
 
     context 'when cop supports autocorrection' do
-      let(:cop_class) { RuboCop::Cop::Style::ZeroLengthPredicate }
+      let(:cop_class) do
+        stub_cop = Class.new(RuboCop::Cop::Cop) do
+          def autocorrect(node); end
+        end
+        stub_const('RuboCop::Cop::Test::StubCop', stub_cop)
+      end
 
       context 'when offense was corrected' do
         before do


### PR DESCRIPTION
Follow #7868.

This PR uses `Cop::Base` API for almost `Style` department's T-Z cops.
It targets cop that names begin between T and Z. And several T-Z cops will be excluded from this PR target and addressed separately.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
