### PR TITLE
Fix a typo for a deprecated comment API

### DIFF
--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -19,7 +19,7 @@ module RuboCop
         /^\s*#/.match?(line_source)
       end
 
-      # @deprecated Use `ProcessedSource#line_with_comment?`, `contains_comment` or similar
+      # @deprecated Use `ProcessedSource#line_with_comment?`, `contains_comment?` or similar
       def comment_lines?(node)
         processed_source[line_range(node)].any? { |line| comment_line?(line) }
       end


### PR DESCRIPTION
This PR fixes a typo for a deprecated comment API.

The referenced API `ProcessedSource#contains_comment?` is below.
https://github.com/rubocop-hq/rubocop-ast/blob/v0.3.0/lib/rubocop/ast/processed_source.rb#L123-L127

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
