### PR TITLE
[Fix #8499] Fix Style/IfUnlessModifier to prevent offense when first-line comment and code after end block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#8499](https://github.com/rubocop-hq/rubocop/issues/8499): Fix `Style/IfUnlessModifier` and `Style/WhileUntilModifier` to prevent an offense if there are both first-line comment and code after `end` block. ([@dsavochkin][])
+
 ## 1.2.0 (2020-11-05)
 
 ### New features

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -4485,14 +4485,18 @@ unless qux.empty?
   Foo.do_something
 end
 
-do_something_in_a_method_with_a_long_name(arg) if long_condition
+do_something_with_a_long_name(arg) if long_condition_that_prevents_code_fit_on_single_line
 
 # good
 do_stuff(bar) if condition
 Foo.do_something unless qux.empty?
 
-if long_condition
-  do_something_in_a_method_with_a_long_name(arg)
+if long_condition_that_prevents_code_fit_on_single_line
+  do_something_with_a_long_name(arg)
+end
+
+if short_condition # a long comment that makes it too long if it were just a single line
+  do_something
 end
 ----
 
@@ -11239,6 +11243,17 @@ end
 
 # good
 x += 1 until x > 10
+----
+
+[source,ruby]
+----
+# bad
+x += 100 while x < 500 # a long comment that makes code too long if it were a single line
+
+# good
+while x < 500 # a long comment that makes code too long if it were a single line
+  x += 100
+end
 ----
 
 === References

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -19,7 +19,8 @@ module RuboCop
       def non_eligible_node?(node)
         node.modifier_form? ||
           node.nonempty_line_count > 3 ||
-          processed_source.line_with_comment?(node.loc.last_line)
+          processed_source.line_with_comment?(node.loc.last_line) ||
+          (first_line_comment(node) && code_after(node))
       end
 
       def non_eligible_body?(body)
@@ -41,11 +42,9 @@ module RuboCop
 
       def length_in_modifier_form(node)
         keyword_element = node.loc.keyword
-        end_element = node.loc.end
         code_before = keyword_element.source_line[0...keyword_element.column]
-        code_after = end_element.source_line[end_element.last_column..-1]
         expression = to_modifier_form(node)
-        line_length("#{code_before}#{expression}#{code_after}")
+        line_length("#{code_before}#{expression}#{code_after(node)}")
       end
 
       def to_modifier_form(node)
@@ -62,6 +61,12 @@ module RuboCop
 
         comment_source = comment.loc.expression.source
         comment_source unless comment_disables_cop?(comment_source)
+      end
+
+      def code_after(node)
+        end_element = node.loc.end
+        code = end_element.source_line[end_element.last_column..-1]
+        code unless code.empty?
       end
 
       def parenthesize?(node)

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -21,14 +21,18 @@ module RuboCop
       #     Foo.do_something
       #   end
       #
-      #   do_something_in_a_method_with_a_long_name(arg) if long_condition
+      #   do_something_with_a_long_name(arg) if long_condition_that_prevents_code_fit_on_single_line
       #
       #   # good
       #   do_stuff(bar) if condition
       #   Foo.do_something unless qux.empty?
       #
-      #   if long_condition
-      #     do_something_in_a_method_with_a_long_name(arg)
+      #   if long_condition_that_prevents_code_fit_on_single_line
+      #     do_something_with_a_long_name(arg)
+      #   end
+      #
+      #   if short_condition # a long comment that makes it too long if it were just a single line
+      #     do_something
       #   end
       class IfUnlessModifier < Base
         include StatementModifier

--- a/lib/rubocop/cop/style/while_until_modifier.rb
+++ b/lib/rubocop/cop/style/while_until_modifier.rb
@@ -24,6 +24,15 @@ module RuboCop
       #
       #   # good
       #   x += 1 until x > 10
+      #
+      # @example
+      #   # bad
+      #   x += 100 while x < 500 # a long comment that makes code too long if it were a single line
+      #
+      #   # good
+      #   while x < 500 # a long comment that makes code too long if it were a single line
+      #     x += 100
+      #   end
       class WhileUntilModifier < Base
         include StatementModifier
         extend AutoCorrector

--- a/spec/support/condition_modifier_cop.rb
+++ b/spec/support/condition_modifier_cop.rb
@@ -89,5 +89,17 @@ RSpec.shared_examples 'condition modifier cop' do |keyword, extra_message = nil|
         RUBY
       end
     end
+
+    context 'when there is a comment on the first line and some code after the end keyword' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          [
+            1, #{keyword} foo # bar
+                 baz
+               end, 3
+          ]
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #8499.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
