### PR TITLE
Fix a false positive for `Style/CaseEquality` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [#8698](https://github.com/rubocop-hq/rubocop/pull/8698): Fix cache to avoid encoding exception. ([@marcandre][])
 * [#8704](https://github.com/rubocop-hq/rubocop/issues/8704): Fix an error for `Lint/AmbiguousOperator` when using safe navigation operator with a unary operator. ([@koic][])
 * [#8661](https://github.com/rubocop-hq/rubocop/pull/8661): Fix an incorrect auto-correct for `Style/MultilineTernaryOperator` when returning a multiline ternary operator expression. ([@koic][])
+* [#8526](https://github.com/rubocop-hq/rubocop/pull/8526): Fix a false positive for `Style/CaseEquality` cop when the receiver is not a camel cased constant. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/case_equality.rb
+++ b/lib/rubocop/cop/style/case_equality.rb
@@ -39,6 +39,8 @@ module RuboCop
 
         def on_send(node)
           case_equality?(node) do |lhs, rhs|
+            return if lhs.const_type? && !lhs.module_name?
+
             add_offense(node.loc.selector) do |corrector|
               replacement = replacement(lhs, rhs)
               corrector.replace(node, replacement) if replacement

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.7')
   s.add_runtime_dependency('rexml')
-  s.add_runtime_dependency('rubocop-ast', '>= 0.3.0', '< 1.0')
+  s.add_runtime_dependency('rubocop-ast', '>= 0.4.0', '< 1.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 2.0')
 

--- a/spec/rubocop/cop/style/case_equality_spec.rb
+++ b/spec/rubocop/cop/style/case_equality_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe RuboCop::Cop::Style::CaseEquality, :config do
       RUBY
     end
 
+    it 'does not register an offense for === when the receiver is not a camel cased constant' do
+      expect_no_offenses(<<~RUBY)
+        REGEXP_CONSTANT === var
+      RUBY
+    end
+
     it 'registers an offense and corrects for === when the receiver is a regexp' do
       expect_offense(<<~RUBY)
         /OMG/ === var


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/8322#discussion_r468443896

Fix a false positive for `Style/CaseEquality` cop when the receiver is not a camel cased constant.

The following constant should not be replaced with `is_a?`.
What kind of object is actually assigned depends on the constant. e.g.:

```ruby
REGEXP_CONSTANT === something #=> does not register an offense.
```

This PR will only consider camel-cased constant as class name. e.g.:

```ruby
Array === something #=> auto-correct to `something.is_a?(Array)`
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
