### PR TITLE
Prevent an incorrect auto-correction for `Style/CaseEquality` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#8534](https://github.com/rubocop-hq/rubocop/issues/8534): Fix `Lint/BinaryOperatorWithIdenticalOperands` for binary operators used as unary operators. ([@marcandre][])
 * [#8537](https://github.com/rubocop-hq/rubocop/pull/8537): Allow a trailing comment as a description comment for `Bundler/GemComment`. ([@pocke][])
 * [#8507](https://github.com/rubocop-hq/rubocop/issues/8507): Fix `Style/RescueModifier` to handle parentheses around rescue modifiers. ([@dsavochkin][])
+* [#8527](https://github.com/rubocop-hq/rubocop/pull/8527): Prevent an incorrect auto-correction for `Style/CaseEquality` cop when comparing with `===` against a regular expression receiver. ([@koic][])
 
 ### Changes
 

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -825,7 +825,7 @@ Array === something
 # good
 something.is_a?(Array)
 (1..100).include?(7)
-some_string =~ /something/
+/something/.match?(some_string)
 ----
 
 ==== AllowOnConstant
@@ -842,7 +842,7 @@ some_string =~ /something/
 # good
 Array === something
 (1..100).include?(7)
-some_string =~ /something/
+/something/.match?(some_string)
 ----
 
 === Configurable attributes

--- a/lib/rubocop/cop/style/case_equality.rb
+++ b/lib/rubocop/cop/style/case_equality.rb
@@ -14,7 +14,7 @@ module RuboCop
       #   # good
       #   something.is_a?(Array)
       #   (1..100).include?(7)
-      #   some_string =~ /something/
+      #   /something/.match?(some_string)
       #
       # @example AllowOnConstant
       #   # Style/CaseEquality:
@@ -27,7 +27,7 @@ module RuboCop
       #   # good
       #   Array === something
       #   (1..100).include?(7)
-      #   some_string =~ /something/
+      #   /something/.match?(some_string)
       #
       class CaseEquality < Base
         extend AutoCorrector
@@ -58,7 +58,12 @@ module RuboCop
         def replacement(lhs, rhs)
           case lhs.type
           when :regexp
-            "#{rhs.source} =~ #{lhs.source}"
+            # The automatic correction from `a === b` to `a.match?(b)` needs to
+            # consider `Regexp.last_match?`, `$~`, `$1`, and etc.
+            # This correction is expected to be supported by `Performance/Regexp` cop.
+            # See: https://github.com/rubocop-hq/rubocop-performance/issues/152
+            #
+            # So here is noop.
           when :begin
             child = lhs.children.first
             "#{lhs.source}.include?(#{rhs.source})" if child&.range_type?

--- a/spec/rubocop/cop/style/case_equality_spec.rb
+++ b/spec/rubocop/cop/style/case_equality_spec.rb
@@ -14,9 +14,8 @@ RSpec.describe RuboCop::Cop::Style::CaseEquality, :config do
               ^^^ Avoid the use of the case equality operator `===`.
       RUBY
 
-      expect_correction(<<~RUBY)
-        var =~ /OMG/
-      RUBY
+      # This correction is expected to be supported by `Performance/Regexp`.
+      expect_no_corrections
     end
 
     it 'registers an offense and corrects for === when the receiver is a range' do


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/8322#discussion_r468672970

This PR fixes an incorrect auto-correction for `Style/CaseEquality` cop when comparing with `===` against a regular expression receiver.

This PR auto-correct `===` with `match?` to keep compatibility of returning a boolean value.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
