### PR TITLE
Mark `Lint/FrozenStringLiteralComment` as `Safe`, but with unsafe auto-correction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#8362](https://github.com/rubocop-hq/rubocop/issues/8362): Add numbers of correctable offenses to summary. ([@nguyenquangminh0711][])
 * [#8513](https://github.com/rubocop-hq/rubocop/pull/8513): Clarify the ruby warning mentioned in the `Lint/ShadowingOuterLocalVariable` documentation. ([@chocolateboy][])
 * [#8517](https://github.com/rubocop-hq/rubocop/pull/8517): Make `Style/HashTransformKeys` and `Style/HashTransformValues` aware of `to_h` with block. ([@eugeneius][])
+* [#8529](https://github.com/rubocop-hq/rubocop/pull/8529): Mark `Lint/FrozenStringLiteralComment` as `Safe`, but with unsafe auto-correction. ([@marcandre][])
 
 ## 0.89.1 (2020-08-10)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -3033,7 +3033,7 @@ Style/FrozenStringLiteralComment:
     # `never` will enforce that the frozen string literal comment does not
     # exist in a file.
     - never
-  Safe: false
+  SafeAutoCorrect: false
 
 Style/GlobalStdStream:
   Description: 'Enforces the use of `$stdout/$stderr/$stdin` instead of `STDOUT/STDERR/STDIN`.'

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -3259,7 +3259,7 @@ format('%s', 'Hello')
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
 | Enabled
-| No
+| Yes
 | Yes (Unsafe)
 | 0.36
 | 0.79


### PR DESCRIPTION
@bbatsov [wrote](https://github.com/rubocop-hq/rubocop/pull/7307#discussion_r463971537):
> I think the cop is actually unsafe (as it doesn't actually check the source to figure out if it's ok to add the magic comment). Unsafe for a cop means that it yields false positives or the suggestions can change the meaning of the code. Unsafe for auto-correct means the cop the cop suggestions are safe, but the auto-correct can't apply those reliably.

I would propose a different definition.  Unsafe for a cop means that it yields false positives *and that's it*. (e.g. "don't use `dig` with single argument" is unsafe, as it could be a custom method in a gem dependency and thus perfectly o.k. and without another alternative). The `Lint/FrozenStringLiteral` cop is a good example where the fact that we can't reliably auto-correct a source doesn't mean it can't or shouldn't be done. Since *any source* can modified to have a frozen string literal comment, that all sources *should* be modified, and that the cop will always correctly detect if there is a frozen string literal comment, I believe this cop is safe, only its auto-correction is potentially unsafe.
