### PR TITLE
Allow a trailing comment as a description comment for `Bundler/GemComment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#8508](https://github.com/rubocop-hq/rubocop/pull/8508): Fix a false positive for `Style/CaseLikeIf` when conditional contains comparison with a class. Mark `Style/CaseLikeIf` as not safe. ([@fatkodima][])
 * [#8534](https://github.com/rubocop-hq/rubocop/issues/8534): Fix `Lint/BinaryOperatorWithIdenticalOperands` for binary operators used as unary operators. ([@marcandre][])
+* [#8537](https://github.com/rubocop-hq/rubocop/pull/8537): Allow a trailing comment as a description comment for `Bundler/GemComment`. ([@pocke][])
 
 ### Changes
 

--- a/spec/rubocop/cop/bundler/gem_comment_spec.rb
+++ b/spec/rubocop/cop/bundler/gem_comment_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe RuboCop::Cop::Bundler::GemComment, :config do
       end
     end
 
+    context 'and the gem is commented on the same line' do
+      it 'does not register any offenses' do
+        expect_no_offenses(<<~RUBY, 'Gemfile')
+          gem 'rubocop' # Style-guide enforcer.
+        RUBY
+      end
+    end
+
     context 'and the gem is permitted' do
       it 'does not register any offenses' do
         expect_no_offenses(<<~RUBY, 'Gemfile')


### PR DESCRIPTION
`Bundler/GemComment` cop isn't aware of trailing comments.

```ruby
# Gemfile


# It is allowed

# It's a cool gem
gem 'rubocop'


# But it is not allowed

gem 'rubocop' # It's a cool gem
```


This pull request fixes this problem.

The cop will allow both of the `gem 'rubocop'` with this patch.

# Cause


In `gem 'rubocop' # It's a cool gem`, the comment isn't associated with the `send` node. Actually it is associated with the `str` node, which is `'rubocop'`.
So we need to check comments for descendants. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
