### PR TITLE
Remove unnecessary `extend AutoCorrector` for `Lint/EmptyFile`

### DIFF
--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -1116,7 +1116,7 @@ end
 
 | Pending
 | Yes
-| Yes
+| No
 | 0.90
 | -
 |===

--- a/lib/rubocop/cop/lint/empty_file.rb
+++ b/lib/rubocop/cop/lint/empty_file.rb
@@ -22,7 +22,6 @@ module RuboCop
       #
       class EmptyFile < Base
         include RangeHelp
-        extend AutoCorrector
 
         MSG = 'Empty file detected.'
 


### PR DESCRIPTION
Follow #8532.

`Lint/EmptyFile` cop does not support auto-correction. This PR removes unnecessary `extend AutoCorrector` for `Lint/EmptyFile`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
