### PR TITLE
[Fix #8518] Fix `Lint/ConstantResolution` cop reporting offense for `module` and `class` definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#8507](https://github.com/rubocop-hq/rubocop/issues/8507): Fix `Style/RescueModifier` to handle parentheses around rescue modifiers. ([@dsavochkin][])
 * [#8527](https://github.com/rubocop-hq/rubocop/pull/8527): Prevent an incorrect auto-correction for `Style/CaseEquality` cop when comparing with `===` against a regular expression receiver. ([@koic][])
 * [#8524](https://github.com/rubocop-hq/rubocop/issues/8524): Fix `Layout/EmptyLinesAroundClassBody`  and `Layout/EmptyLinesAroundModuleBody` to correctly handle an access modifier as a first child. ([@dsavochkin][])
+* [#8518](https://github.com/rubocop-hq/rubocop/issues/8518): Fix `Lint/ConstantResolution` cop reporting offense for `module` and `class` definitions. ([@tejasbubane][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/constant_resolution.rb
+++ b/lib/rubocop/cop/lint/constant_resolution.rb
@@ -63,7 +63,7 @@ module RuboCop
         PATTERN
 
         def on_const(node)
-          return unless unqualified_const?(node)
+          return if !unqualified_const?(node) || node.parent&.defined_module
 
           add_offense(node)
         end

--- a/spec/rubocop/cop/lint/constant_resolution_spec.rb
+++ b/spec/rubocop/cop/lint/constant_resolution_spec.rb
@@ -27,6 +27,15 @@ RSpec.describe RuboCop::Cop::Lint::ConstantResolution, :config do
     RUBY
   end
 
+  context 'module & class definitions' do
+    it 'does not register offense' do
+      expect_no_offenses(<<~RUBY)
+        module Foo; end
+        class Bar; end
+      RUBY
+    end
+  end
+
   context 'with Only set' do
     let(:cop_config) { { 'Only' => ['MY_CONST'] } }
 


### PR DESCRIPTION
Closes #8518

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/