### PR TITLE
Use new expect_offense in remaining Style cops

### DIFF
--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -601,20 +601,22 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
 
   context 'when if-end condition is assigned to a variable' do
     context 'with variable being on the same line' do
-      let(:source) do
-        <<~RUBY
-          x = if a
-            #{'b' * body_length}
-          end
-        RUBY
-      end
+      let(:body) { 'b' * body_length }
 
       context 'when it is short enough to fit on a single line' do
         let(:body_length) { 69 }
 
         it 'corrects it to the single-line form' do
-          corrected = autocorrect_source(source)
-          expect(corrected).to eq "x = (#{'b' * body_length} if a)\n"
+          expect_offense(<<~RUBY, body: body)
+            x = if a
+                ^^ Favor modifier `if` usage [...]
+              %{body}
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            x = (#{body} if a)
+          RUBY
         end
       end
 
@@ -622,27 +624,34 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
         let(:body_length) { 70 }
 
         it 'accepts it in the multiline form' do
-          expect_no_offenses(source)
+          expect_no_offenses(<<~RUBY)
+            x = if a
+              #{body}
+            end
+          RUBY
         end
       end
     end
 
     context 'with variable being on the previous line' do
-      let(:source) do
-        <<~RUBY
-          x =
-            if a
-              #{'b' * body_length}
-            end
-        RUBY
-      end
+      let(:body) { 'b' * body_length }
 
       context 'when it is short enough to fit on a single line' do
         let(:body_length) { 71 }
 
         it 'corrects it to the single-line form' do
-          corrected = autocorrect_source(source)
-          expect(corrected).to eq "x =\n  (#{'b' * body_length} if a)\n"
+          expect_offense(<<~RUBY, body: body)
+            x =
+              if a
+              ^^ Favor modifier `if` usage [...]
+                %{body}
+              end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            x =
+              (#{body} if a)
+          RUBY
         end
       end
 
@@ -650,29 +659,38 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
         let(:body_length) { 72 }
 
         it 'accepts it in the multiline form' do
-          expect_no_offenses(source)
+          expect_no_offenses(<<~RUBY)
+            x =
+              if a
+                #{body}
+              end
+          RUBY
         end
       end
     end
   end
 
   context 'when if-end condition is an element of an array' do
-    let(:source) do
-      <<~RUBY
-        [
-          if a
-            #{'b' * body_length}
-          end
-        ]
-      RUBY
-    end
+    let(:body) { 'b' * body_length }
 
     context 'when short enough to fit on a single line' do
       let(:body_length) { 71 }
 
       it 'corrects it to the single-line form' do
-        corrected = autocorrect_source(source)
-        expect(corrected).to eq "[\n  (#{'b' * body_length} if a)\n]\n"
+        expect_offense(<<~RUBY, body: body)
+          [
+            if a
+            ^^ Favor modifier `if` usage [...]
+              %{body}
+            end
+          ]
+        RUBY
+
+        expect_correction(<<~RUBY)
+          [
+            (#{body} if a)
+          ]
+        RUBY
       end
     end
 
@@ -680,28 +698,38 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
       let(:body_length) { 72 }
 
       it 'accepts it in the multiline form' do
-        expect_no_offenses(source)
+        expect_no_offenses(<<~RUBY)
+          [
+            if a
+              #{body}
+            end
+          ]
+        RUBY
       end
     end
   end
 
   context 'when if-end condition is a value in a hash' do
-    let(:source) do
-      <<~RUBY
-        {
-          x: if a
-               #{'b' * body_length}
-             end
-        }
-      RUBY
-    end
+    let(:body) { 'b' * body_length }
 
     context 'when it is short enough to fit on a single line' do
       let(:body_length) { 68 }
 
       it 'corrects it to the single-line form' do
-        corrected = autocorrect_source(source)
-        expect(corrected).to eq "{\n  x: (#{'b' * body_length} if a)\n}\n"
+        expect_offense(<<~RUBY, body: body)
+          {
+            x: if a
+               ^^ Favor modifier `if` usage [...]
+                 %{body}
+               end
+          }
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {
+            x: (#{body} if a)
+          }
+        RUBY
       end
     end
 
@@ -709,26 +737,34 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
       let(:body_length) { 69 }
 
       it 'accepts it in the multiline form' do
-        expect_no_offenses(source)
+        expect_no_offenses(<<~RUBY)
+          {
+            x: if a
+                 #{body}
+               end
+          }
+        RUBY
       end
     end
   end
 
   context 'when if-end condition has a first line comment' do
-    let(:source) do
-      <<~RUBY
-        if foo # #{'c' * comment_length}
-          bar
-        end
-      RUBY
-    end
+    let(:comment) { 'c' * comment_length }
 
     context 'when it is short enough to fit on a single line' do
       let(:comment_length) { 67 }
 
       it 'corrects it to the single-line form' do
-        corrected = autocorrect_source(source)
-        expect(corrected).to eq "bar if foo # #{'c' * comment_length}\n"
+        expect_offense(<<~RUBY, comment: comment)
+          if foo # %{comment}
+          ^^ Favor modifier `if` usage [...]
+            bar
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          bar if foo # #{comment}
+        RUBY
       end
     end
 
@@ -736,28 +772,36 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
       let(:comment_length) { 68 }
 
       it 'accepts it in the multiline form' do
-        expect_no_offenses(source)
+        expect_no_offenses(<<~RUBY)
+          if foo # #{comment}
+            bar
+          end
+        RUBY
       end
     end
   end
 
   context 'when if-end condition has some code after the end keyword' do
-    let(:source) do
-      <<~RUBY
-        [
-          1, if foo
-               #{'b' * body_length}
-             end, 300_000_000
-        ]
-      RUBY
-    end
+    let(:body) { 'b' * body_length }
 
     context 'when it is short enough to fit on a single line' do
       let(:body_length) { 53 }
 
       it 'corrects it to the single-line form' do
-        corrected = autocorrect_source(source)
-        expect(corrected).to eq "[\n  1, (#{'b' * body_length} if foo), 300_000_000\n]\n"
+        expect_offense(<<~RUBY, body: body)
+          [
+            1, if foo
+               ^^ Favor modifier `if` usage [...]
+                 %{body}
+               end, 300_000_000
+          ]
+        RUBY
+
+        expect_correction(<<~RUBY)
+          [
+            1, (#{body} if foo), 300_000_000
+          ]
+        RUBY
       end
     end
 
@@ -765,7 +809,13 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
       let(:body_length) { 54 }
 
       it 'accepts it in the multiline form' do
-        expect_no_offenses(source)
+        expect_no_offenses(<<~RUBY)
+          [
+            1, if foo
+                 #{body}
+               end, 300_000_000
+          ]
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/style/non_nil_check_spec.rb
+++ b/spec/rubocop/cop/style/non_nil_check_spec.rb
@@ -65,9 +65,8 @@ RSpec.describe RuboCop::Cop::Style::NonNilCheck, :config do
       RUBY
     end
 
-    it 'does not blow up when autocorrecting implicit receiver' do
-      corrected = autocorrect_source('!nil?')
-      expect(corrected).to eq '!nil?'
+    it 'does not register an offense with implicit receiver' do
+      expect_no_offenses('!nil?')
     end
 
     it 'does not report corrected when the code was not modified' do

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -222,8 +222,8 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'accepts comma inside a heredoc in brackets' do
         expect_no_offenses(<<~RUBY)
-          new_source = autocorrect_source(
-            autocorrect_source(<<~SOURCE)
+          expect_no_offenses(
+            expect_no_offenses(<<~SOURCE)
               run(
                     :foo, defaults.merge(
                                           bar: 3))

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -317,7 +317,7 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       cop2 = described_class.new(config)
       RuboCop::Formatter::DisabledConfigFormatter.config_to_allow_offenses = {}
       RuboCop::Formatter::DisabledConfigFormatter.detected_styles = {}
-      # Don't use `inspect_source`; it resets `config_to_allow_offenses` each
+      # Don't use `expect_offense`; it resets `config_to_allow_offenses` each
       #   time, which suppresses the bug we are checking for
       _investigate(cop1, parse_source("['g', 'h']"))
       _investigate(cop2, parse_source('%w(a b c)'))


### PR DESCRIPTION
Part of #8127

Use newer `expect_offense` and `expect_correction` in remaining specs for Style cops.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/