### PR TITLE
Use newer expect_offense in Metric cops

### DIFF
--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -136,6 +136,8 @@ module RuboCop
 
         expect(actual_annotations).to eq(expected_annotations), ''
         expect(offenses.map(&:severity).uniq).to eq([severity]) if severity
+
+        offenses
       end
 
       def expect_correction(correction, loop: true)

--- a/spec/rubocop/cop/metrics/abc_size_spec.rb
+++ b/spec/rubocop/cop/metrics/abc_size_spec.rb
@@ -145,11 +145,14 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
         # Build an amount of code large enough to register an offense.
         code = ['  x = Hash.new if 1 == 1 || 2 == 2'] * max
 
-        offenses = inspect_source(['def method_name', *code, 'end'].join("\n"))
+        expect_offense(<<~RUBY)
+          def method_name
+          ^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [#{presentation}]
+            #{code.join("\n  ")}
+          end
+        RUBY
 
-        expect(offenses.sort.map(&:message))
-          .to eq(['Assignment Branch Condition size for method_name is too ' \
-                  "high. [#{presentation}]"])
+        expect_no_corrections
       end
     end
   end

--- a/spec/rubocop/cop/metrics/block_length_spec.rb
+++ b/spec/rubocop/cop/metrics/block_length_spec.rb
@@ -40,15 +40,15 @@ RSpec.describe RuboCop::Cop::Metrics::BlockLength, :config do
   end
 
   it 'reports the correct beginning and end lines' do
-    offenses = inspect_source(<<~RUBY)
+    offenses = expect_offense(<<~RUBY)
       something do
+      ^^^^^^^^^^^^ Block has too many lines. [3/2]
         a = 1
         a = 2
         a = 3
       end
     RUBY
     offense = offenses.first
-    expect(offense.location.first_line).to eq(1)
     expect(offense.location.last_line).to eq(5)
   end
 

--- a/spec/rubocop/cop/metrics/block_nesting_spec.rb
+++ b/spec/rubocop/cop/metrics/block_nesting_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe RuboCop::Cop::Metrics::BlockNesting, :config do
       expect_offense(<<~RUBY)
         if a
           if b
-            if cinspect_source
-            ^^^^^^^^^^^^^^^^^^ Avoid more than 2 levels of block nesting.
+            if c
+            ^^^^ Avoid more than 2 levels of block nesting.
               puts c
             end
           end

--- a/spec/rubocop/cop/metrics/class_length_spec.rb
+++ b/spec/rubocop/cop/metrics/class_length_spec.rb
@@ -18,8 +18,9 @@ RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
   end
 
   it 'reports the correct beginning and end lines' do
-    offenses = inspect_source(<<~RUBY)
+    offenses = expect_offense(<<~RUBY)
       class Test
+      ^^^^^^^^^^ Class has too many lines. [6/5]
         a = 1
         a = 2
         a = 3
@@ -30,7 +31,6 @@ RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
     RUBY
 
     offense = offenses.first
-    expect(offense.location.first_line).to eq(1)
     expect(offense.location.last_line).to eq(8)
   end
 

--- a/spec/rubocop/cop/metrics/module_length_spec.rb
+++ b/spec/rubocop/cop/metrics/module_length_spec.rb
@@ -18,8 +18,9 @@ RSpec.describe RuboCop::Cop::Metrics::ModuleLength, :config do
   end
 
   it 'reports the correct beginning and end lines' do
-    offenses = inspect_source(<<~RUBY)
+    offenses = expect_offense(<<~RUBY)
       module Test
+      ^^^^^^^^^^^ Module has too many lines. [6/5]
         a = 1
         a = 2
         a = 3
@@ -29,7 +30,6 @@ RSpec.describe RuboCop::Cop::Metrics::ModuleLength, :config do
       end
     RUBY
     offense = offenses.first
-    expect(offense.location.first_line).to eq(1)
     expect(offense.location.last_line).to eq(8)
   end
 


### PR DESCRIPTION
Replace `inspect_source` with `expect_offense` in Metric cop specs.

Return offenses from `expect_offense` to allow specifying offense end line.

Part of #8127

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/