### PR TITLE
Add diagnostics to error message in specs code parse

### DIFF
--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -17,7 +17,10 @@ module CopHelper
     RuboCop::Formatter::DisabledConfigFormatter.config_to_allow_offenses = {}
     RuboCop::Formatter::DisabledConfigFormatter.detected_styles = {}
     processed_source = parse_source(source, file)
-    raise 'Error parsing example code' unless processed_source.valid_syntax?
+    unless processed_source.valid_syntax?
+      raise 'Error parsing example code: ' \
+        "#{processed_source.diagnostics.map(&:render).join("\n")}"
+    end
 
     _investigate(cop, processed_source)
   end

--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -128,7 +128,10 @@ module RuboCop
         @processed_source = parse_source(expected_annotations.plain_source,
                                          file)
 
-        raise 'Error parsing example code' unless @processed_source.valid_syntax?
+        unless @processed_source.valid_syntax?
+          raise 'Error parsing example code: ' \
+            "#{@processed_source.diagnostics.map(&:render).join("\n")}"
+        end
 
         offenses = _investigate(cop, @processed_source)
         actual_annotations =


### PR DESCRIPTION
When example code for specs has a syntax error, give further details to help
find it.

For example (from my own mistake that took some spotting of `%{access_modifier)` ending in wrong kind of bracket):

```ruby
expect_offense(<<~RUBY, access_modifier: access_modifier)
  class Test
    %{access_modifier)
    ^{access_modifier} `#{access_modifier}` should be inlined in method definitions.
  end
RUBY
```

```
  1) RuboCop::Cop::Style::AccessModifierDeclarations when `inline` is configured offends when protected is not inlined
     Failure/Error:
       raise 'Error parsing example code: ' \
         "#{@processed_source.diagnostics.map(&:render).join("\n")}"
     
     RuntimeError:
       Error parsing example code: (string):2:3: fatal: unterminated string meets end of file
       (string):2:   %{access_modifier)
       (string):2:   ^                 
     # ./lib/rubocop/rspec/expect_offense.rb:132:in `expect_offense'
     # ./spec/rubocop/cop/style/access_modifier_declarations_spec.rb:89:in `block (4 levels) in <top (required)>'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/