### PR TITLE
[Fix #8524] Fix `Layout/EmptyLinesAroundClassBody` and `Layout/EmptyLinesAroundModuleBody` to handle access modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#8537](https://github.com/rubocop-hq/rubocop/pull/8537): Allow a trailing comment as a description comment for `Bundler/GemComment`. ([@pocke][])
 * [#8507](https://github.com/rubocop-hq/rubocop/issues/8507): Fix `Style/RescueModifier` to handle parentheses around rescue modifiers. ([@dsavochkin][])
 * [#8527](https://github.com/rubocop-hq/rubocop/pull/8527): Prevent an incorrect auto-correction for `Style/CaseEquality` cop when comparing with `===` against a regular expression receiver. ([@koic][])
+* [#8524](https://github.com/rubocop-hq/rubocop/issues/8524): Fix `Layout/EmptyLinesAroundClassBody`  and `Layout/EmptyLinesAroundModuleBody` to correctly handle an access modifier as a first child. ([@dsavochkin][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/empty_lines_around_body.rb
+++ b/lib/rubocop/cop/mixin/empty_lines_around_body.rb
@@ -19,7 +19,8 @@ module RuboCop
         private
 
         def_node_matcher :constant_definition?, '{class module}'
-        def_node_matcher :empty_line_required?, '{def defs class module}'
+        def_node_matcher :empty_line_required?,
+                         '{def defs class module (send nil? {:private :protected :public})}'
 
         def check(node, body, adjusted_first_line: nil)
           return if valid_body_style?(body)

--- a/spec/support/empty_lines_around_body_shared_examples.rb
+++ b/spec/support/empty_lines_around_body_shared_examples.rb
@@ -4,7 +4,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
   context 'when EnforcedStyle is empty_lines_special' do
     let(:cop_config) { { 'EnforcedStyle' => 'empty_lines_special' } }
 
-    context 'when first child is method' do
+    context 'when first child is a method' do
       it "requires blank line at the beginning and ending of #{type} body" do
         expect_no_offenses(<<~RUBY)
           #{type} SomeObject
@@ -105,6 +105,43 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
               end
             RUBY
           end
+        end
+      end
+    end
+
+    context 'when first child is an access modifier' do
+      context "with blank lines at the beginning and ending of #{type} body" do
+        it 'registers no offense' do
+          expect_no_offenses(<<~RUBY)
+            #{type} SomeObject
+
+              private
+              def do_something; end
+
+            end
+          RUBY
+        end
+      end
+
+      context "with no blank lines at the beginning and ending of #{type} body" do
+        it 'registers and corrects an offense' do
+          expect_offense(<<~RUBY)
+            #{type} SomeObject
+              private
+            ^ #{missing_begin}
+              def do_something; end
+            end
+            ^ #{missing_end}
+          RUBY
+
+          expect_correction(<<~RUBY)
+            #{type} SomeObject
+
+              private
+              def do_something; end
+
+            end
+          RUBY
         end
       end
     end


### PR DESCRIPTION
Fixes #8524. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
