### PR TITLE
Use new expect_correction in remaining Lint cops

### DIFF
--- a/spec/rubocop/cop/lint/binary_operator_with_identical_operands_spec.rb
+++ b/spec/rubocop/cop/lint/binary_operator_with_identical_operands_spec.rb
@@ -4,15 +4,18 @@ RSpec.describe RuboCop::Cop::Lint::BinaryOperatorWithIdenticalOperands do
   subject(:cop) { described_class.new }
 
   it 'registers an offense when binary operator has identical nodes' do
-    offenses = inspect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       x == x
+      ^^^^^^ Binary operator `==` has identical operands.
       y = x && x
+          ^^^^^^ Binary operator `&&` has identical operands.
       y = a.x + a.x
+          ^^^^^^^^^ Binary operator `+` has identical operands.
       a.x(arg) > a.x(arg)
+      ^^^^^^^^^^^^^^^^^^^ Binary operator `>` has identical operands.
       a.(x) > a.(x)
+      ^^^^^^^^^^^^^ Binary operator `>` has identical operands.
     RUBY
-
-    expect(offenses.size).to eq(5)
   end
 
   it 'does not register an offense when using binary operator with different operands' do

--- a/spec/rubocop/cop/lint/float_comparison_spec.rb
+++ b/spec/rubocop/cop/lint/float_comparison_spec.rb
@@ -4,36 +4,42 @@ RSpec.describe RuboCop::Cop::Lint::FloatComparison do
   subject(:cop) { described_class.new }
 
   it 'registers an offense when comparing with float' do
-    offenses = inspect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       x == 0.1
+      ^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
       0.1 == x
+      ^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
       x != 0.1
+      ^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
       0.1 != x
+      ^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
       x.eql?(0.1)
+      ^^^^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
       0.1.eql?(x)
+      ^^^^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
     RUBY
-
-    expect(offenses.size).to eq(6)
   end
 
   it 'registers an offense when comparing with float returning method' do
-    offenses = inspect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       x == Float(1)
+      ^^^^^^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
       x == '0.1'.to_f
+      ^^^^^^^^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
       x == 1.fdiv(2)
+      ^^^^^^^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
     RUBY
-
-    expect(offenses.size).to eq(3)
   end
 
   it 'registers an offense when comparing with arightmetic operator on floats' do
-    offenses = inspect_source(<<~RUBY)
+    expect_offense(<<~RUBY)
       x == 0.1 + y
+      ^^^^^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
       x == y + Float('0.1')
+      ^^^^^^^^^^^^^^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
       x == y + z * (foo(arg) + '0.1'.to_f)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
     RUBY
-
-    expect(offenses.size).to eq(3)
   end
 
   it 'registers an offense when comparing with method on float receiver' do

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedException do
 
     it 'rescue a exception without causing constant name deprecation warning' do
       expect do
-        inspect_source(<<~RUBY)
+        expect_no_offenses(<<~RUBY)
           def foo
             something
           rescue TimeoutError


### PR DESCRIPTION
Part of #8127

Use newer `expect_offense` in remaining Lint cops.

Some new cops have been added following the older `inspect_source` convention. Also spotted one used in checking stderr output that was missed in my earlier PRs.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/