### PR TITLE
Add internal spec case for expect_offense with MSG

### DIFF
--- a/spec/rubocop/cop/internal_affairs/useless_message_assertion_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/useless_message_assertion_spec.rb
@@ -13,6 +13,18 @@ RSpec.describe RuboCop::Cop::InternalAffairs::UselessMessageAssertion do
     RUBY
   end
 
+  it 'registers an offense for specs that expect offense using the MSG' do
+    expect_offense(<<~'RUBY', 'example_spec.rb')
+      it 'uses described_class::MSG to expect offense' do
+        expect_offense(<<-SOURCE.strip_indent('|'))
+          |  foo
+          |  ^^^ #{described_class::MSG}
+                   ^^^^^^^^^^^^^^^^^^^^ Do not specify cop behavior using `described_class::MSG`.
+        SOURCE
+      end
+    RUBY
+  end
+
   it 'registers an offense for described_class::MSG in let' do
     expect_offense(<<~RUBY, 'example_spec.rb')
       let(:msg) { described_class::MSG }


### PR DESCRIPTION
Related to #8127

Spec case to ensure detection of specs using the new `expect_offense` syntax with `described_class::MSG`.

NOTE: Using `strip_indent` for the inner heredoc to prevent its annotation
being recognised at the outer level.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/