### PR TITLE
Use expect_offense in support shared examples

### DIFF
--- a/spec/support/alignment_examples.rb
+++ b/spec/support/alignment_examples.rb
@@ -35,7 +35,6 @@ shared_examples_for 'aligned' do |alignment_base, arg, end_kw, name|
   name ||= alignment_base
   name = name.gsub(/\n/, ' <newline>')
   it "accepts matching #{name} ... end" do
-    inspect_source("#{alignment_base} #{arg}\n#{end_kw}")
-    expect(cop.offenses.empty?).to be(true)
+    expect_no_offenses("#{alignment_base} #{arg}\n#{end_kw}")
   end
 end

--- a/spec/support/multiline_literal_brace_layout_method_argument_examples.rb
+++ b/spec/support/multiline_literal_brace_layout_method_argument_examples.rb
@@ -6,34 +6,38 @@ shared_examples_for 'multiline literal brace layout method argument' do
   context 'when arguments to a method' do
     let(:prefix) { 'bar(' }
     let(:suffix) { ')' }
-    let(:source) { construct(false, true) }
 
     context 'and a comment after the last element' do
       let(:b_comment) { ' # comment b' }
 
       it 'detects closing brace on separate line from last element' do
-        inspect_source(source)
+        expect_offense(<<~RUBY, close: close)
+          #{prefix}#{open}#{a},
+          #{b}#{b_comment}
+          %{close}
+          ^{close} #{described_class::SAME_LINE_MESSAGE}
+          #{suffix}
+        RUBY
 
-        expect(cop.highlights).to eq([close])
-        expect(cop.messages)
-          .to eq([described_class::SAME_LINE_MESSAGE])
-      end
-
-      it 'does not autocorrect the closing brace' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq([source].join($RS))
+        expect_no_corrections
       end
     end
 
     context 'but no comment after the last element' do
-      let(:b_comment) { '' }
-
       it 'autocorrects the closing brace' do
-        new_source = autocorrect_source(source)
+        expect_offense(<<~RUBY, close: close)
+          #{prefix}#{open}#{a},
+          #{b}
+          %{close}
+          ^{close} #{described_class::SAME_LINE_MESSAGE}
+          #{suffix}
+        RUBY
 
-        expect(new_source).to eq(["#{prefix}#{open}#{a},",
-                                  "#{b}#{close}",
-                                  suffix].join($RS))
+        expect_correction(<<~RUBY)
+          #{prefix}#{open}#{a},
+          #{b}#{close}
+          #{suffix}
+        RUBY
       end
     end
   end


### PR DESCRIPTION
Part of #8127

Refactor from `inspect_source` and `autocorrect_source` to `expect_offense` and
`expect_correction` in support shared examples.

Unroll `construct()` in multiline examples to make (most) annotations clearer.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/