### PR TITLE
Refactored specs in spec/rubocop/cop/layout to use 'expect_offense'

### DIFF
--- a/spec/rubocop/cop/layout/empty_lines_around_module_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_module_body_spec.rb
@@ -117,9 +117,10 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
       end
 
       it 'registers offense for namespace body starting with a blank' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           module Parent
 
+          ^{} #{extra_begin}
             module Child
 
               do_something
@@ -127,12 +128,10 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
             end
           end
         RUBY
-
-        expect(cop.messages).to eq([extra_begin])
       end
 
       it 'registers offense for namespace body ending with a blank' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           module Parent
             module Child
 
@@ -140,52 +139,53 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
 
             end
 
+          ^{} #{extra_end}
           end
         RUBY
-
-        expect(cop.messages).to eq([extra_end])
       end
 
       it 'registers offenses for namespaced module body not starting '\
           'with a blank' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           module Parent
             module Child
               do_something
+          ^ #{missing_begin}
 
             end
           end
         RUBY
-
-        expect(cop.messages).to eq([missing_begin])
       end
 
       it 'registers offenses for namespaced module body not ending '\
           'with a blank' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           module Parent
             module Child
 
               do_something
             end
+          ^ #{missing_end}
           end
         RUBY
-
-        expect(cop.messages).to eq([missing_end])
       end
 
       it 'autocorrects beginning and end' do
-        new_source = autocorrect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           module Parent
 
+          ^{} #{extra_begin}
             module Child
               do_something
+          ^ #{missing_begin}
             end
+          ^ #{missing_end}
 
+          ^{} #{extra_end}
           end
         RUBY
 
-        expect(new_source).to eq(<<~RUBY)
+        expect_correction(<<~RUBY)
           module Parent
             module Child
 
@@ -209,29 +209,27 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
       end
 
       it 'registers offense for namespace body starting with a blank' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           module Parent
 
+          ^{} #{extra_begin}
             class SomeClass
               do_something
             end
           end
         RUBY
-
-        expect(cop.messages).to eq([extra_begin])
       end
 
       it 'registers offense for namespace body ending with a blank' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           module Parent
             class SomeClass
               do_something
             end
 
+          ^{} #{extra_end}
           end
         RUBY
-
-        expect(cop.messages).to eq([extra_end])
       end
     end
 

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -13,15 +13,20 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
   end
 
   it "registers an offense for a line that's 81 characters wide" do
-    inspect_source('#' * 81)
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.offenses.first.message).to eq('Line is too long. [81/80]')
+    maximum_string = '#' * 80
+    expect_offense(<<~RUBY, maximum_string: maximum_string)
+      #{maximum_string}#
+      _{maximum_string}^ Line is too long. [81/80]
+    RUBY
     expect(cop.config_to_allow_offenses).to eq(exclude_limit: { 'Max' => 81 })
   end
 
   it 'highlights excessive characters' do
-    inspect_source("#{'#' * 80}abc")
-    expect(cop.highlights).to eq(['abc'])
+    maximum_string = '#' * 80
+    expect_offense(<<~RUBY, maximum_string: maximum_string)
+      #{maximum_string}abc
+      _{maximum_string}^^^ Line is too long. [83/80]
+    RUBY
   end
 
   it "accepts a line that's 80 characters wide" do
@@ -37,10 +42,13 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
   end
 
   it 'registers an offense for long line before __END__ but not after' do
-    inspect_source(['#' * 150,
-                    '__END__',
-                    '#' * 200].join("\n"))
-    expect(cop.messages).to eq(['Line is too long. [150/80]'])
+    maximum_string = '#' * 80
+    expect_offense(<<~RUBY, maximum_string: maximum_string)
+      #{maximum_string}#{'#' * 70}
+      _{maximum_string}#{'^' * 70} Line is too long. [150/80]
+      __END__
+      #{'#' * 200}
+    RUBY
   end
 
   context 'when line is indented with tabs' do
@@ -122,23 +130,21 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
         { 'Max' => 80, 'AllowURI' => true, 'URISchemes' => %w[LDAP] }
       end
 
-      let(:source) { <<-RUBY }
-        xxxxxxxxxxxxxxxxxxxxxxxxxxxxzxxxxxxxxxxx = LDAP::DEFAULT_GROUP_UNIQUE_MEMBER_LIST_KEY
-      RUBY
-
       it 'does not crash' do
-        expect { inspect_source(source) }.not_to raise_error
+        expect do
+          inspect_source(<<~RUBY)
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxzxxxxxxxxxxx = LDAP::DEFAULT_GROUP_UNIQUE_MEMBER_LIST_KEY
+          RUBY
+        end.not_to raise_error
       end
     end
 
     context 'and the URL does not have a http(s) scheme' do
-      let(:source) { <<-RUBY }
-        xxxxxxxxxxxxxxxxxxxxxxxxxxxxzxxxxxxxxxxx = 'otherprotocol://a.very.long.line.which.violates.LineLength/sadf'
-      RUBY
-
       it 'rejects the line' do
-        inspect_source(source)
-        expect(cop.offenses.size).to eq(1)
+        expect_offense(<<~RUBY)
+          #{'x' * 40} = 'otherprotocol://a.very.long.line.which.violates.LineLength/sadf'
+          #{' ' * 40}                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [108/80]
+        RUBY
       end
 
       context 'and the scheme has been configured' do
@@ -147,7 +153,9 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
         end
 
         it 'does not register an offense' do
-          expect_no_offenses(source)
+          expect_no_offenses(<<~RUBY)
+            #{'x' * 40} = 'otherprotocol://a.very.long.line.which.violates.LineLength/sadf'
+          RUBY
         end
       end
     end
@@ -161,9 +169,10 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
       }
     end
 
-    let(:source) do
-      <<~RUBY
+    it 'accepts long lines matching a pattern but not other long lines' do
+      expect_offense(<<~RUBY)
         class ExampleTest < TestCase
+                          ^^^^^^^^^^ Line is too long. [28/18]
           test 'some really long test description which exceeds length' do
           end
           def test_some_other_long_test_description_which_exceeds_length
@@ -171,31 +180,24 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
         end
       RUBY
     end
-
-    it 'accepts long lines matching a pattern but not other long lines' do
-      inspect_source(source)
-      expect(cop.highlights).to eq(['< TestCase'])
-    end
   end
 
   context 'when AllowHeredoc option is enabled' do
     let(:cop_config) { { 'Max' => 80, 'AllowHeredoc' => true } }
 
-    let(:source) { <<-RUBY }
-      <<-SQL
-        SELECT posts.id, posts.title, users.name FROM posts LEFT JOIN users ON posts.user_id = users.id;
-      SQL
-    RUBY
-
     it 'accepts long lines in heredocs' do
-      expect_no_offenses(source)
+      expect_no_offenses(<<~RUBY)
+        <<-SQL
+          SELECT posts.id, posts.title, users.name FROM posts LEFT JOIN users ON posts.user_id = users.id;
+        SQL
+      RUBY
     end
 
     context 'when the source has no AST' do
-      let(:source) { '# this results in AST being nil' }
-
       it 'does not crash' do
-        expect { inspect_source(source) }.not_to raise_error
+        expect do
+          inspect_source('# this results in AST being nil')
+        end.not_to raise_error
       end
     end
 
@@ -204,31 +206,32 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
         { 'Max' => 80, 'AllowHeredoc' => %w[SQL OK], 'IgnoredPatterns' => [] }
       end
 
-      let(:source) { <<-RUBY }
-        foo(<<-DOC, <<-SQL, <<-FOO)
-          1st offense: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-          \#{<<-OK}
+      it 'rejects long lines in heredocs with not permitted delimiters' do
+        expect_offense(<<-RUBY)
+          foo(<<-DOC, <<-SQL, <<-FOO)
+            1st offense: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            #{' ' * 68}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [149/80]
+            \#{<<-OK}
+              no offense (permitted): Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            OK
+            2nd offense: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            #{' ' * 68}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [149/80]
+          DOC
             no offense (permitted): Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-          OK
-          2nd offense: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        DOC
-          no offense (permitted): Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-          \#{<<-XXX}
-            no offense (nested inside permitted): Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-          XXX
-          no offense (permitted): Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        SQL
-          3rd offense: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-          \#{<<-SQL}
+            \#{<<-XXX}
+              no offense (nested inside permitted): Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            XXX
             no offense (permitted): Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
           SQL
-          4th offense: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        FOO
-      RUBY
-
-      it 'rejects long lines in heredocs with not permitted delimiters' do
-        inspect_source(source)
-        expect(cop.offenses.size).to eq(4)
+            3rd offense: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            #{' ' * 68}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [149/80]
+            \#{<<-SQL}
+              no offense (permitted): Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            SQL
+            4th offense: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            #{' ' * 68}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [149/80]
+          FOO
+        RUBY
       end
     end
   end
@@ -251,41 +254,31 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
     let(:cop_config) { { 'Max' => 80, 'IgnoreCopDirectives' => false } }
 
     context 'and the source is acceptable length' do
-      let(:acceptable_source) { 'a' * 80 }
-
       context 'with a trailing RuboCop directive' do
-        let(:cop_directive) { ' # rubcop:disable Layout/SomeCop' }
-        let(:source) { acceptable_source + cop_directive }
-
         it 'registers an offense for the line' do
-          inspect_source(source)
-          expect(cop.offenses.size).to eq(1)
-        end
-
-        it 'highlights the excess directive' do
-          inspect_source(source)
-          expect(cop.highlights).to eq([cop_directive])
+          expect_offense(<<~RUBY)
+            #{'a' * 80} # rubcop:disable Layout/SomeCop
+            #{' ' * 80}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [112/80]
+          RUBY
         end
       end
 
       context 'with an inline comment' do
-        let(:excess_comment) { ' ###' }
-        let(:source) { acceptable_source + excess_comment }
-
         it 'highlights the excess comment' do
-          inspect_source(source)
-          expect(cop.highlights).to eq([excess_comment])
+          expect_offense(<<~RUBY)
+            #{'a' * 80} ###
+            #{' ' * 80}^^^^ Line is too long. [84/80]
+          RUBY
         end
       end
     end
 
     context 'and the source is too long and has a trailing cop directive' do
-      let(:excess_with_directive) { 'b # rubocop:disable Metrics/AbcSize' }
-      let(:source) { 'a' * 80 + excess_with_directive }
-
       it 'highlights the excess source and cop directive' do
-        inspect_source(source)
-        expect(cop.highlights).to eq([excess_with_directive])
+        expect_offense(<<~RUBY)
+          #{'a' * 80} b # rubocop:disable Metrics/AbcSize
+          #{' ' * 80}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [116/80]
+        RUBY
       end
     end
   end
@@ -294,81 +287,56 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
     let(:cop_config) { { 'Max' => 80, 'IgnoreCopDirectives' => true } }
 
     context 'and the Rubocop directive is excessively long' do
-      let(:source) { <<-RUBY }
-        # rubocop:disable Metrics/SomeReallyLongMetricNameThatShouldBeMuchShorterAndNeedsANameChange
-      RUBY
-
       it 'accepts the line' do
-        expect_no_offenses(source)
+        expect_no_offenses(<<~RUBY)
+          # rubocop:disable Metrics/SomeReallyLongMetricNameThatShouldBeMuchShorterAndNeedsANameChange
+        RUBY
       end
     end
 
     context 'and the Rubocop directive causes an excessive line length' do
-      let(:source) { <<-RUBY }
-        def method_definition_that_is_just_under_the_line_length_limit(foo, bar) # rubocop:disable Metrics/AbcSize
-          # complex method
-        end
-      RUBY
-
       it 'accepts the line' do
-        expect_no_offenses(source)
+        expect_no_offenses(<<~RUBY)
+          def method_definition_that_is_just_under_the_line_length_limit(foo, bar) # rubocop:disable Metrics/AbcSize
+            # complex method
+          end
+        RUBY
       end
 
       context 'and has explanatory text' do
-        let(:source) { <<-RUBY }
-          def method_definition_that_is_just_under_the_line_length_limit(foo) # rubocop:disable Metrics/AbcSize inherently complex!
-            # complex
-          end
-        RUBY
-
         it 'does not register an offense' do
-          expect_no_offenses(source)
+          expect_no_offenses(<<~RUBY)
+            def method_definition_that_is_just_under_the_line_length_limit(foo) # rubocop:disable Metrics/AbcSize inherently complex!
+              # complex
+            end
+          RUBY
         end
       end
     end
 
     context 'and the source is too long' do
-      let(:source) { "#{'a' * 80}bcd # rubocop:enable Style/ClassVars" }
-
-      it 'registers an offense for the line' do
-        inspect_source(source)
-        expect(cop.offenses.size).to eq(1)
-      end
-
       it 'highlights only the non-directive part' do
-        inspect_source(source)
-        expect(cop.highlights).to eq(['bcd'])
+        expect_offense(<<~RUBY)
+          #{'a' * 80}bcd # rubocop:enable Style/ClassVars
+          #{' ' * 80}^^^ Line is too long. [116/80]
+        RUBY
       end
 
       context 'and the source contains non-directive # as comment' do
-        let(:source) { <<-RUBY }
-          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # bbbbbbbbbbbbbb # rubocop:enable Style/ClassVars'
-        RUBY
-
-        it 'registers an offense for the line' do
-          inspect_source(source)
-          expect(cop.offenses.size).to eq(1)
-        end
-
         it 'highlights only the non-directive part' do
-          inspect_source(source)
-          expect(cop.highlights).to eq(['bbbbbbb'])
+          expect_offense(<<~RUBY)
+            #{'a' * 70} # bbbbbbbbbbbbbb # rubocop:enable Style/ClassVars'
+            #{' ' * 70}          ^^^^^^^ Line is too long. [121/80]
+          RUBY
         end
       end
 
       context 'and the source contains non-directive #s as non-comment' do
-        let(:source) { <<-RUBY }
-          LARGE_DATA_STRING_PATTERN = %r{\A([A-Za-z0-9\+\/#]*\={0,2})#([A-Za-z0-9\+\/#]*\={0,2})#([A-Za-z0-9\+\/#]*\={0,2})\z} # rubocop:disable Layout/LineLength
-        RUBY
-
         it 'registers an offense for the line' do
-          inspect_source(source)
-          expect(cop.offenses.size).to eq(1)
-        end
-
-        it 'highlights only the non-directive part' do
-          inspect_source(source)
-          expect(cop.highlights).to eq([']*={0,2})#([A-Za-z0-9+/#]*={0,2})z}'])
+          expect_offense(<<-RUBY)
+            LARGE_DATA_STRING_PATTERN = %r{\A([A-Za-z0-9\+\/#]*\={0,2})#([A-Za-z0-9\+\/#]*\={0,2})#([A-Za-z0-9\+\/#]*\={0,2})\z} # rubocop:disable Layout/LineLength
+            #{' ' * 68}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [153/80]
+          RUBY
         end
       end
     end
@@ -378,16 +346,11 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
     shared_examples 'with tabs indentation' do
       it "registers an offense for a line that's including 2 tab with size 2" \
          ' and 28 other characters' do
-        inspect_source("\t\t#{'#' * 28}")
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.offenses.first.message).to eq('Line is too long. [32/30]')
-        expect(cop.config_to_allow_offenses)
-          .to eq(exclude_limit: { 'Max' => 32 })
-      end
-
-      it 'highlights excessive characters' do
-        inspect_source("\t#{'#' * 28}a")
-        expect(cop.highlights).to eq(['a'])
+        expect_offense(<<~RUBY)
+          \t\t#{'#' * 28}a
+              #{' ' * 24}^^^ Line is too long. [33/30]
+        RUBY
+        expect(cop.config_to_allow_offenses).to eq(exclude_limit: { 'Max' => 33 })
       end
 
       it "accepts a line that's including 1 tab with size 2" \

--- a/spec/rubocop/cop/layout/space_after_comma_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_comma_spec.rb
@@ -8,17 +8,16 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAfterComma do
   end
   let(:brace_config) { {} }
 
-  shared_examples 'ends with an item' do |items, correct_items|
-    it 'registers an offense' do
-      inspect_source(source.call(items))
-      expect(cop.messages).to eq(
-        ['Space missing after comma.']
-      )
-    end
+  shared_examples 'ends with an item' do |items, annotation_start, correct_items|
+    it 'registers an offense and does autocorrection' do
+      expect_offense(<<~RUBY)
+        #{source.call(items)}
+        #{' ' * annotation_start}^ Space missing after comma.
+      RUBY
 
-    it 'does auto-correction' do
-      new_source = autocorrect_source(source.call(items))
-      expect(new_source).to eq source.call(correct_items)
+      expect_correction(<<~RUBY)
+        #{source.call(correct_items)}
+      RUBY
     end
   end
 
@@ -29,23 +28,23 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAfterComma do
   end
 
   context 'block argument commas without space' do
-    let(:source) { ->(args) { "each { |#{args}| }" } }
+    let(:source) { ->(items) { "each { |#{items}| }" } }
 
-    it_behaves_like 'ends with an item', 's,t', 's, t'
+    it_behaves_like 'ends with an item', 's,t', 9, 's, t'
     it_behaves_like 'trailing comma', 's, t,'
   end
 
   context 'array index commas without space' do
     let(:source) { ->(items) { "formats[#{items}]" } }
 
-    it_behaves_like 'ends with an item', '0,1', '0, 1'
+    it_behaves_like 'ends with an item', '0,1', 9, '0, 1'
     it_behaves_like 'trailing comma', '0,'
   end
 
   context 'method call arg commas without space' do
     let(:source) { ->(args) { "a(#{args})" } }
 
-    it_behaves_like 'ends with an item', '1,2', '1, 2'
+    it_behaves_like 'ends with an item', '1,2', 3, '1, 2'
   end
 
   context 'inside hash braces' do

--- a/spec/rubocop/cop/layout/space_around_keyword_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_keyword_spec.rb
@@ -6,28 +6,26 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword do
   shared_examples 'missing before' do |highlight, expr, correct|
     it 'registers an offense for missing space before keyword in ' \
        "`#{expr}`" do
-      inspect_source(expr)
-      expect(cop.messages)
-        .to eq(["Space before keyword `#{highlight}` is missing."])
-      expect(cop.highlights).to eq([highlight])
-    end
+      h_index = expr.index(highlight)
+      expect_offense(<<~RUBY)
+        #{expr}
+        #{' ' * h_index}#{'^' * highlight.size} Space before keyword `#{highlight}` is missing.
+      RUBY
 
-    it 'auto-corrects' do
-      expect(autocorrect_source(expr)).to eq correct
+      expect_correction("#{correct}\n")
     end
   end
 
   shared_examples 'missing after' do |highlight, expr, correct|
     it 'registers an offense for missing space after keyword in ' \
-       "`#{expr}`" do
-      inspect_source(expr)
-      expect(cop.messages)
-        .to eq(["Space after keyword `#{highlight}` is missing."])
-      expect(cop.highlights).to eq([highlight])
-    end
+       "`#{expr}` and autocorrects" do
+      h_index = expr.index(highlight)
+      expect_offense(<<~RUBY)
+        #{expr}
+        #{' ' * h_index}#{'^' * highlight.size} Space after keyword `#{highlight}` is missing.
+      RUBY
 
-    it 'auto-corrects' do
-      expect(autocorrect_source(expr)).to eq correct
+      expect_correction("#{correct}\n")
     end
   end
 

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -245,18 +245,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
   describe 'missing space around operators' do
     shared_examples 'modifier with missing space' do |keyword|
       it "registers an offense in presence of modifier #{keyword} statement" do
-        src = <<~RUBY
+        expect_offense(<<~RUBY)
           a=1 #{keyword} condition
+           ^ Surrounding space missing for operator `=`.
           c=2
+           ^ Surrounding space missing for operator `=`.
         RUBY
-        inspect_source(src)
-        expect(cop.offenses.map(&:line)).to eq([1, 2])
-        expect(cop.messages).to eq(
-          ['Surrounding space missing for operator `=`.'] * 2
-        )
 
-        new_source = autocorrect_source(src)
-        expect(new_source).to eq(<<~RUBY)
+        expect_correction(<<~RUBY)
           a = 1 #{keyword} condition
           c = 2
         RUBY
@@ -595,18 +591,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
   describe 'extra space around operators' do
     shared_examples 'modifier with extra space' do |keyword|
       it "registers an offense in presence of modifier #{keyword} statement" do
-        src = <<~RUBY
+        expect_offense(<<~RUBY)
           a =  1 #{keyword} condition
+            ^ Operator `=` should be surrounded by a single space.
           c =   2
+            ^ Operator `=` should be surrounded by a single space.
         RUBY
-        inspect_source(src)
-        expect(cop.offenses.map(&:line)).to eq([1, 2])
-        expect(cop.messages).to eq(
-          ['Operator `=` should be surrounded by a single space.'] * 2
-        )
 
-        new_source = autocorrect_source(src)
-        expect(new_source).to eq(<<~RUBY)
+        expect_correction(<<~RUBY)
           a = 1 #{keyword} condition
           c = 2
         RUBY

--- a/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
@@ -2,15 +2,16 @@
 
 RSpec.describe RuboCop::Cop::Layout::SpaceBeforeFirstArg, :config do
   let(:cop_config) { { 'AllowForAlignment' => true } }
+  let(:message) { 'Put one space between the method name and the first argument.' }
 
   context 'for method calls without parentheses' do
     it 'registers an offense and corrects method call with two spaces ' \
       'before the first arg' do
       expect_offense(<<~RUBY)
         something  x
-                 ^^ Put one space between the method name and the first argument.
+                 ^^ #{message}
         a.something  y, z
-                   ^^ Put one space between the method name and the first argument.
+                   ^^ #{message}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -24,7 +25,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeFirstArg, :config do
         'before the first arg' do
         expect_offense(<<~RUBY)
           a&.something  y, z
-                      ^^ Put one space between the method name and the first argument.
+                      ^^ #{message}
         RUBY
 
         expect_correction(<<~RUBY)
@@ -35,23 +36,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeFirstArg, :config do
 
     it 'registers an offense for method call with no spaces before the '\
        'first arg' do
-      inspect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         something'hello'
+                 ^{} #{message}
         a.something'hello world'
+                   ^{} #{message}
       RUBY
 
-      expect(cop.messages)
-        .to eq(['Put one space between the method name and the first ' \
-                'argument.'] * 2)
-    end
-
-    it 'auto-corrects missing space' do
-      new_source = autocorrect_source(<<~RUBY)
-        something'hello'
-        a.something'hello world'
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         something 'hello'
         a.something 'hello world'
       RUBY
@@ -59,23 +51,13 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeFirstArg, :config do
 
     context 'when a vertical argument positions are aligned' do
       it 'registers an offense' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           obj = a_method(arg, arg2)
           obj.no_parenthesized'asdf'
+                              ^{} #{message}
         RUBY
 
-        expect(cop.messages).to eq(
-          ['Put one space between the method name and the first argument.']
-        )
-      end
-
-      it 'auto-corrects missing space' do
-        new_source = autocorrect_source(<<~RUBY)
-          obj = a_method(arg, arg2)
-          obj.no_parenthesized'asdf'
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
+        expect_correction(<<~RUBY)
           obj = a_method(arg, arg2)
           obj.no_parenthesized 'asdf'
         RUBY

--- a/spec/rubocop/cop/layout/space_inside_array_literal_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_array_literal_brackets_spec.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
+  let(:no_space_in_empty_message) { 'Do not use space inside empty array brackets.' }
+  let(:no_space_message) { 'Do not use space inside array brackets.' }
+  let(:one_space_message) { 'Use one space inside empty array brackets.' }
+  let(:use_space_message) { 'Use space inside array brackets.' }
+
   it 'does not register offense for any kind of reference brackets' do
     expect_no_offenses(<<~RUBY)
       a[1]
@@ -20,7 +25,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
     it 'registers an offense and corrects empty brackets with 1 space inside' do
       expect_offense(<<~RUBY)
         a = [ ]
-            ^^^ Do not use space inside empty array brackets.
+            ^^^ #{no_space_in_empty_message}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -32,7 +37,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       'with multiple spaces inside' do
       expect_offense(<<~RUBY)
         a = [     ]
-            ^^^^^^^ Do not use space inside empty array brackets.
+            ^^^^^^^ #{no_space_in_empty_message}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -43,7 +48,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
     it 'registers an offense and corrects multiline spaces' do
       expect_offense(<<~RUBY)
         a = [
-            ^ Do not use space inside empty array brackets.
+            ^ #{no_space_in_empty_message}
         ]
       RUBY
 
@@ -64,7 +69,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       'with no space inside' do
       expect_offense(<<~RUBY)
         a = []
-            ^^ Use one space inside empty array brackets.
+            ^^ #{one_space_message}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -76,7 +81,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       'with more than one space inside' do
       expect_offense(<<~RUBY)
         a = [      ]
-            ^^^^^^^^ Use one space inside empty array brackets.
+            ^^^^^^^^ #{one_space_message}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -199,7 +204,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       'with leading whitespace' do
       expect_offense(<<~RUBY)
         [ 2, 3, 4]
-         ^ Do not use space inside array brackets.
+         ^ #{no_space_message}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -211,7 +216,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       'with trailing whitespace' do
       expect_offense(<<~RUBY)
         [b, c, d   ]
-                ^^^ Do not use space inside array brackets.
+                ^^^ #{no_space_message}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -222,7 +227,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
     it 'registers an offense and corrects an array when two on one line' do
       expect_offense(<<~RUBY)
         ['qux', 'baz'  ] - ['baz']
-                     ^^ Do not use space inside array brackets.
+                     ^^ #{no_space_message}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -235,7 +240,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
         ['ok',
          'still good',
          'not good' ]
-                   ^ Do not use space inside array brackets.
+                   ^ #{no_space_message}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -250,7 +255,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       expect_offense(<<~RUBY)
         [:good,
          :bad  ].compact
-             ^^ Do not use space inside array brackets.
+             ^^ #{no_space_message}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -262,7 +267,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
     it 'registers an offense and corrects 2 arrays on one line' do
       expect_offense(<<~RUBY)
         [2,3,4] - [ 3,4]
-                   ^ Do not use space inside array brackets.
+                   ^ #{no_space_message}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -274,7 +279,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
        'an argument with trailing whitespace after a heredoc is started' do
       expect_offense(<<~RUBY)
         ActiveRecord::Base.connection.execute(<<-SQL, [self.class.to_s ]).first["count"]
-                                                                      ^ Do not use space inside array brackets.
+                                                                      ^ #{no_space_message}
           SELECT COUNT(widgets.id) FROM widgets
           WHERE widget_type = $1
         SQL
@@ -382,7 +387,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       'with no leading whitespace' do
       expect_offense(<<~RUBY)
         [2, 3, 4 ]
-        ^ Use space inside array brackets.
+        ^ #{use_space_message}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -394,7 +399,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       'with no trailing whitespace' do
       expect_offense(<<~RUBY)
         [ b, c, d]
-                 ^ Use space inside array brackets.
+                 ^ #{use_space_message}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -406,7 +411,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       'when there is more than one array on a line' do
       expect_offense(<<~RUBY)
         [ 'qux', 'baz'] - [ 'baz' ]
-                      ^ Use space inside array brackets.
+                      ^ #{use_space_message}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -419,7 +424,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
         [ 'ok',
           'still good',
           'not good']
-                    ^ Use space inside array brackets.
+                    ^ #{use_space_message}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -434,7 +439,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       expect_offense(<<~RUBY)
         [ :good,
           :bad].compact
-              ^ Use space inside array brackets.
+              ^ #{use_space_message}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -446,7 +451,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
     it 'register an offense and corrects when 2 arrays are on one line' do
       expect_offense(<<~RUBY)
         [ 2, 3, 4 ] - [3, 4 ]
-                      ^ Use space inside array brackets.
+                      ^ #{use_space_message}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -493,7 +498,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
     it 'registers an offense and corrects space between 2 closing brackets' do
       expect_offense(<<~RUBY)
         [ 1, [ 2,3,4 ], [ 5,6,7 ] ]
-                                 ^ Do not use space inside array brackets.
+                                 ^ #{no_space_message}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -504,7 +509,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
     it 'registers an offense and corrects space between 2 opening brackets' do
       expect_offense(<<~RUBY)
         [ [ 2,3,4 ], [ 5,6,7 ], 8 ]
-         ^ Do not use space inside array brackets.
+         ^ #{no_space_message}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -524,7 +529,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
         expect_offense(<<~RUBY)
           multiline = [[ 1, 2, 3, 4 ],
             [ 3, 4, 5, 6 ] ]
-                          ^ Do not use space inside array brackets.
+                          ^ #{no_space_message}
         RUBY
 
         expect_correction(<<~RUBY, loop: false)
@@ -538,8 +543,8 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       'with extra spaces' do
       expect_offense(<<~RUBY)
         [ [ a, b ], [ 1, 7 ] ]
-                            ^ Do not use space inside array brackets.
-         ^ Do not use space inside array brackets.
+                            ^ #{no_space_message}
+         ^ #{no_space_message}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -551,13 +556,13 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       'with extra spaces' do
       expect_offense(<<~RUBY)
         [ [a, b ], [foo, [bar, baz] ] ]
-                                     ^ Do not use space inside array brackets.
-                                   ^ Do not use space inside array brackets.
-                                  ^ Use space inside array brackets.
-                         ^ Use space inside array brackets.
-                   ^ Use space inside array brackets.
-          ^ Use space inside array brackets.
-         ^ Do not use space inside array brackets.
+                                     ^ #{no_space_message}
+                                   ^ #{no_space_message}
+                                  ^ #{use_space_message}
+                         ^ #{use_space_message}
+                   ^ #{use_space_message}
+          ^ #{use_space_message}
+         ^ #{no_space_message}
       RUBY
 
       expect_correction(<<~RUBY)
@@ -566,31 +571,15 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
     end
 
     context 'multiline array does not collapse successive left-brackets' do
-      it 'registers an offense' do
-        # In this example, we cannot use `expect_offense` because the offense
-        # has no highlight (actually, a zero-width `column_range`) so our caret
-        # would not match.
-        inspect_source(<<~RUBY)
+      it 'registers an offense, and auto-corrects' do
+        expect_offense(<<~RUBY)
           multiline = [
+                       ^{} #{no_space_message}
             [ 1, 2, 3, 4 ],
             [ 3, 4, 5, 6 ]]
         RUBY
 
-        expect(cop.offenses.size).to eq(1)
-        offense = cop.offenses.first
-        expect(offense.line).to eq(1)
-        expect(offense.column_range).to eq(13...13) # thus, can't expect_offense
-        expect(offense.message).to eq('Do not use space inside array brackets.')
-      end
-
-      it 'auto-corrects' do
-        new_source = autocorrect_source(<<~RUBY)
-          multiline = [
-            [ 1, 2, 3, 4 ],
-            [ 3, 4, 5, 6 ]]
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
+        expect_correction(<<~RUBY, loop: false)
           multiline = [
             [ 1, 2, 3, 4 ],
             [ 3, 4, 5, 6 ] ]
@@ -599,35 +588,16 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
     end
 
     context 'multiline array does not collapse any successive brackets' do
-      it 'registers an offense' do
-        # In this example, we cannot use `expect_offense` because the offense
-        # has no highlight (actually, a zero-width `column_range`) so our caret
-        # would not match.
-        inspect_source(<<~RUBY)
+      it 'registers an offense, but does not autocorrect' do
+        expect_offense(<<~RUBY)
           array = [
+                   ^{} #{no_space_message}
             [ a ],
             [ b, c ]
           ]
         RUBY
 
-        expect(cop.offenses.size).to eq(1)
-        offense = cop.offenses.first
-        expect(offense.line).to eq(1)
-        expect(offense.column_range).to eq(9...9) # thus, can't expect_offense
-        expect(offense.message).to eq('Do not use space inside array brackets.')
-      end
-
-      it 'does not auto-corrects' do
-        source = <<~RUBY
-          array = [
-            [ a ],
-            [ b, c ]
-          ]
-        RUBY
-
-        new_source = autocorrect_source(source)
-
-        expect(new_source).to eq(source)
+        expect_no_corrections
       end
     end
   end

--- a/spec/rubocop/cop/layout/space_inside_array_percent_literal_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_array_percent_literal_spec.rb
@@ -14,31 +14,31 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayPercentLiteral do
           ['%', type, ldelim, content, rdelim].join
         end
 
-        def expect_corrected(source, expected)
-          expect(autocorrect_source(source)).to eq expected
-        end
-
         it 'registers an offense for unnecessary spaces' do
-          source = code_example('1   2')
-          inspect_source(source)
-          expect(cop.offenses.size).to eq(1)
-          expect(cop.highlights).to eq(['   '])
-          expect(cop.messages).to eq([message])
-          expect_corrected(source, code_example('1 2'))
+          expect_offense(<<~RUBY)
+            #{code_example('1   2')}
+                ^^^ Use only a single space inside array percent literal.
+          RUBY
+
+          expect_correction("#{code_example('1 2')}\n")
         end
 
         it 'registers an offense for multiple spaces between items' do
-          source = code_example('1   2   3')
-          inspect_source(source)
-          expect(cop.offenses.size).to eq(2)
-          expect_corrected(source, code_example('1 2 3'))
+          expect_offense(<<~RUBY)
+            #{code_example('1   2   3')}
+                    ^^^ Use only a single space inside array percent literal.
+                ^^^ Use only a single space inside array percent literal.
+          RUBY
+
+          expect_correction("#{code_example('1 2 3')}\n")
         end
 
         it 'accepts literals with escaped and additional spaces' do
-          source = code_example('a\   b \ c')
-          inspect_source(source)
-          expect(cop.offenses.size).to eq(1)
-          expect_corrected(source, code_example('a\  b \ c'))
+          expect_offense(<<~RUBY)
+            #{code_example('a\   b \ c')}
+                  ^^ Use only a single space inside array percent literal.
+          RUBY
+          expect_correction("#{code_example('a\  b \ c')}\n")
         end
 
         it 'accepts literals without additional spaces' do

--- a/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
@@ -345,14 +345,12 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
 
         it 'registers an offense when braces are not aligned in ' \
            'multiline block' do
-          inspect_source(<<~RUBY)
+          expect_offense(<<~RUBY)
             items.map {|item|
               item.do_something
+                               ^{} Space inside } detected.
               }
           RUBY
-
-          expect(cop.offenses.size).to eq(1)
-          expect(cop.messages).to eq(['Space inside } detected.'])
         end
       end
     end

--- a/spec/rubocop/cop/layout/space_inside_percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_percent_literal_delimiters_spec.rb
@@ -14,38 +14,41 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsidePercentLiteralDelimiters do
           ['%', type, ldelim, content, rdelim].join
         end
 
-        def expect_corrected(source, expected)
-          expect(autocorrect_source(source)).to eq expected
-        end
-
         it 'registers an offense for unnecessary spaces' do
-          source = code_example(' 1 2  ')
-          inspect_source(source)
-          expect(cop.offenses.size).to eq(2)
-          expect(cop.messages.uniq).to eq([message])
-          expect(cop.highlights).to eq([' ', '  '])
-          expect_corrected(source, code_example('1 2'))
+          expect_offense(<<~RUBY)
+            #{code_example(' 1 2  ')}
+                   ^^ #{message}
+               ^ #{message}
+          RUBY
+
+          expect_correction("#{code_example('1 2')}\n")
         end
 
         it 'registers an offense for spaces after first delimiter' do
-          source = code_example(' 1 2')
-          inspect_source(source)
-          expect(cop.offenses.size).to eq(1)
-          expect_corrected(source, code_example('1 2'))
+          expect_offense(<<~RUBY)
+            #{code_example(' 1 2')}
+               ^ #{message}
+          RUBY
+
+          expect_correction("#{code_example('1 2')}\n")
         end
 
         it 'registers an offense for spaces before final delimiter' do
-          source = code_example('1 2 ')
-          inspect_source(source)
-          expect(cop.offenses.size).to eq(1)
-          expect_corrected(source, code_example('1 2'))
+          expect_offense(<<~RUBY)
+            #{code_example('1 2 ')}
+                  ^ #{message}
+          RUBY
+
+          expect_correction("#{code_example('1 2')}\n")
         end
 
         it 'registers an offense for literals with escaped and other spaces' do
-          source = code_example(' \ a b c\  ')
-          inspect_source(source)
-          expect(cop.offenses.size).to eq(2)
-          expect_corrected(source, code_example('\ a b c\ '))
+          expect_offense(<<~RUBY)
+            #{code_example(' \ a b c\  ')}
+                         ^ #{message}
+               ^ #{message}
+          RUBY
+          expect_correction("#{code_example('\ a b c\ ')}\n")
         end
 
         it 'accepts literals without additional spaces' do


### PR DESCRIPTION
Part of #8127
Refactored specs in spec/rubocop/cop/layout/ starting with letters (E-S) to use newer helpers expect_offense / expect_correction instead of old inspect_source / autocorrect_source

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
