### PR TITLE
Use `Cop::Base` API for `PercentLiteral`

### DIFF
--- a/lib/rubocop/cop/layout/space_inside_array_percent_literal.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_percent_literal.rb
@@ -12,9 +12,10 @@ module RuboCop
       #   %w(foo  bar  baz)
       #   # good
       #   %i(foo bar baz)
-      class SpaceInsideArrayPercentLiteral < Cop
+      class SpaceInsideArrayPercentLiteral < Base
         include MatchRange
         include PercentLiteral
+        extend AutoCorrector
 
         MSG = 'Use only a single space inside array percent literal.'
         MULTIPLE_SPACES_BETWEEN_ITEMS_REGEX =
@@ -26,13 +27,7 @@ module RuboCop
 
         def on_percent_literal(node)
           each_unnecessary_space_match(node) do |range|
-            add_offense(node, location: range)
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            each_unnecessary_space_match(node) do |range|
+            add_offense(range) do |corrector|
               corrector.replace(range, ' ')
             end
           end

--- a/lib/rubocop/cop/layout/space_inside_percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/layout/space_inside_percent_literal_delimiters.rb
@@ -16,9 +16,10 @@ module RuboCop
       #
       #   # bad
       #   %x(  ls -l )
-      class SpaceInsidePercentLiteralDelimiters < Cop
+      class SpaceInsidePercentLiteralDelimiters < Base
         include MatchRange
         include PercentLiteral
+        extend AutoCorrector
 
         MSG = 'Do not use spaces inside percent literal delimiters.'
         BEGIN_REGEX = /\A( +)/.freeze
@@ -36,21 +37,15 @@ module RuboCop
           add_offenses_for_unnecessary_spaces(node)
         end
 
-        def autocorrect(node)
-          lambda do |corrector|
-            regex_matches(node) do |match_range|
-              corrector.remove(match_range)
-            end
-          end
-        end
-
         private
 
         def add_offenses_for_unnecessary_spaces(node)
           return unless node.single_line?
 
           regex_matches(node) do |match_range|
-            add_offense(node, location: match_range)
+            add_offense(match_range) do |corrector|
+              corrector.remove(match_range)
+            end
           end
         end
 

--- a/lib/rubocop/cop/lint/percent_string_array.rb
+++ b/lib/rubocop/cop/lint/percent_string_array.rb
@@ -39,22 +39,18 @@ module RuboCop
           return unless contains_quotes_or_commas?(node)
 
           add_offense(node) do |corrector|
-            autocorrect(corrector, node)
+            node.each_value do |value|
+              range = value.loc.expression
+
+              match = range.source.match(TRAILING_QUOTE)
+              corrector.remove_trailing(range, match[0].length) if match
+
+              corrector.remove_leading(range, 1) if LEADING_QUOTE.match?(range.source)
+            end
           end
         end
 
         private
-
-        def autocorrect(corrector, node)
-          node.each_value do |value|
-            range = value.loc.expression
-
-            match = range.source.match(TRAILING_QUOTE)
-            corrector.remove_trailing(range, match[0].length) if match
-
-            corrector.remove_leading(range, 1) if LEADING_QUOTE.match?(range.source)
-          end
-        end
 
         def contains_quotes_or_commas?(node)
           node.values.any? do |value|

--- a/lib/rubocop/cop/style/redundant_capital_w.rb
+++ b/lib/rubocop/cop/style/redundant_capital_w.rb
@@ -14,8 +14,9 @@ module RuboCop
       #   %w/swim run bike/
       #   %w[shirt pants shoes]
       #   %W(apple #{fruit} grape)
-      class RedundantCapitalW < Cop
+      class RedundantCapitalW < Base
         include PercentLiteral
+        extend AutoCorrector
 
         MSG = 'Do not use `%W` unless interpolation is needed. ' \
               'If not, use `%w`.'
@@ -24,19 +25,15 @@ module RuboCop
           process(node, '%W')
         end
 
-        def autocorrect(node)
-          lambda do |corrector|
-            src = node.loc.begin.source
-            corrector.replace(node.loc.begin, src.tr('W', 'w'))
-          end
-        end
-
         private
 
         def on_percent_literal(node)
           return if requires_interpolation?(node)
 
-          add_offense(node)
+          add_offense(node) do |corrector|
+            src = node.loc.begin.source
+            corrector.replace(node.loc.begin, src.tr('W', 'w'))
+          end
         end
 
         def requires_interpolation?(node)


### PR DESCRIPTION
Follow #7868.

This PR uses `Cop::Base` API for cops mixing `PercentLiteral` module.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
