### PR TITLE
Use `Cop::Base` API for `Layout` department [A-E]

### DIFF
--- a/lib/rubocop/cop/correctors/alignment_corrector.rb
+++ b/lib/rubocop/cop/correctors/alignment_corrector.rb
@@ -29,13 +29,13 @@ module RuboCop
           end
         end
 
-        def align_end(processed_source, node, align_to)
+        def align_end(corrector, processed_source, node, align_to)
           @processed_source = processed_source
           whitespace = whitespace_range(node)
           return false unless whitespace.source.strip.empty?
 
           column = alignment_column(align_to)
-          ->(corrector) { corrector.replace(whitespace, ' ' * column) }
+          corrector.replace(whitespace, ' ' * column)
         end
 
         private

--- a/lib/rubocop/cop/correctors/empty_line_corrector.rb
+++ b/lib/rubocop/cop/correctors/empty_line_corrector.rb
@@ -5,15 +5,14 @@ module RuboCop
     # This class does empty line auto-correction
     class EmptyLineCorrector
       class << self
-        def correct(node)
+        def correct(corrector, node)
           offense_style, range = node
-          lambda do |corrector|
-            case offense_style
-            when :no_empty_lines
-              corrector.remove(range)
-            when :empty_lines
-              corrector.insert_before(range, "\n")
-            end
+
+          case offense_style
+          when :no_empty_lines
+            corrector.remove(range)
+          when :empty_lines
+            corrector.insert_before(range, "\n")
           end
         end
 

--- a/lib/rubocop/cop/layout/block_alignment.rb
+++ b/lib/rubocop/cop/layout/block_alignment.rb
@@ -61,9 +61,10 @@ module RuboCop
       #     .each do
       #        baz
       #   end
-      class BlockAlignment < Cop
+      class BlockAlignment < Base
         include ConfigurableEnforcedStyle
         include RangeHelp
+        extend AutoCorrector
 
         MSG = '%<current>s is not aligned with %<prefer>s%<alt_prefer>s.'
 
@@ -82,19 +83,6 @@ module RuboCop
 
         def style_parameter_name
           'EnforcedStyleAlignWith'
-        end
-
-        def autocorrect(node)
-          ancestor_node = start_for_block_node(node)
-          start_col = compute_start_col(ancestor_node, node)
-          loc_end = node.loc.end
-          delta = start_col - loc_end.column
-
-          if delta.positive?
-            add_space_before(loc_end, delta)
-          elsif delta.negative?
-            remove_space_before(loc_end.begin_pos, -delta)
-          end
         end
 
         private
@@ -163,7 +151,22 @@ module RuboCop
           message = format_message(start_loc, end_loc, do_source_line_column,
                                    error_source_line_column)
 
-          add_offense(block_node, location: end_loc, message: message)
+          add_offense(end_loc, message: message) do |corrector|
+            autocorrect(corrector, block_node)
+          end
+        end
+
+        def autocorrect(corrector, node)
+          ancestor_node = start_for_block_node(node)
+          start_col = compute_start_col(ancestor_node, node)
+          loc_end = node.loc.end
+          delta = start_col - loc_end.column
+
+          if delta.positive?
+            add_space_before(corrector, loc_end, delta)
+          elsif delta.negative?
+            remove_space_before(corrector, loc_end.begin_pos, -delta)
+          end
         end
 
         def format_message(start_loc, end_loc, do_source_line_column,
@@ -230,13 +233,14 @@ module RuboCop
           (ancestor_node || node).source_range.column
         end
 
-        def add_space_before(loc, delta)
-          ->(corrector) { corrector.insert_before(loc, ' ' * delta) }
+        def add_space_before(corrector, loc, delta)
+          corrector.insert_before(loc, ' ' * delta)
         end
 
-        def remove_space_before(end_pos, delta)
+        def remove_space_before(corrector, end_pos, delta)
           range = range_between(end_pos - delta, end_pos)
-          ->(corrector) { corrector.remove(range) }
+
+          corrector.remove(range)
         end
       end
     end

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -133,9 +133,9 @@ module RuboCop
       #   end
       #
       # @see https://rubystyle.guide#consistent-classes
-      class ClassStructure < Cop
-        include CommentsHelp
+      class ClassStructure < Base
         include VisibilityHelp
+        extend AutoCorrector
 
         HUMANIZED_NODE_TYPE = {
           casgn: :constants,
@@ -156,14 +156,18 @@ module RuboCop
             if index < previous
               message = format(MSG, category: category,
                                     previous: expected_order[previous])
-              add_offense(node, message: message)
+              add_offense(node, message: message) do |corrector|
+                autocorrect(corrector, node)
+              end
             end
             previous = index
           end
         end
 
+        private
+
         # Autocorrect by swapping between two nodes autocorrecting them
-        def autocorrect(node)
+        def autocorrect(corrector, node)
           node_classification = classify(node)
           previous = left_siblings_of(node).find do |sibling|
             classification = classify(sibling)
@@ -173,13 +177,9 @@ module RuboCop
           current_range = source_range_with_comment(node)
           previous_range = source_range_with_comment(previous)
 
-          lambda do |corrector|
-            corrector.insert_before(previous_range, current_range.source)
-            corrector.remove(current_range)
-          end
+          corrector.insert_before(previous_range, current_range.source)
+          corrector.remove(current_range)
         end
-
-        private
 
         # Classifies a node to match with something in the {expected_order}
         # @param node to be analysed

--- a/lib/rubocop/cop/layout/closing_heredoc_indentation.rb
+++ b/lib/rubocop/cop/layout/closing_heredoc_indentation.rb
@@ -46,8 +46,9 @@ module RuboCop
       #         Hi
       #       EOS
       #
-      class ClosingHeredocIndentation < Cop
+      class ClosingHeredocIndentation < Base
         include Heredoc
+        extend AutoCorrector
 
         SIMPLE_HEREDOC = '<<'
         MSG = '`%<closing>s` is not aligned with `%<opening>s`.'
@@ -59,11 +60,8 @@ module RuboCop
                     opening_indentation(node) == closing_indentation(node) ||
                     argument_indentation_correct?(node)
 
-          add_offense(node, location: :heredoc_end)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          message = message(node)
+          add_offense(node.loc.heredoc_end, message: message) do |corrector|
             corrector.replace(node.loc.heredoc_end, indented_end(node))
           end
         end

--- a/lib/rubocop/cop/layout/def_end_alignment.rb
+++ b/lib/rubocop/cop/layout/def_end_alignment.rb
@@ -33,9 +33,10 @@ module RuboCop
       #
       #   private def foo
       #           end
-      class DefEndAlignment < Cop
+      class DefEndAlignment < Base
         include EndKeywordAlignment
         include RangeHelp
+        extend AutoCorrector
 
         MSG = '`end` at %d, %d is not aligned with `%s` at %d, %d.'
 
@@ -61,11 +62,13 @@ module RuboCop
           ignore_node(method_def) # Don't check the same `end` again.
         end
 
-        def autocorrect(node)
+        private
+
+        def autocorrect(corrector, node)
           if style == :start_of_line && node.parent && node.parent.send_type?
-            AlignmentCorrector.align_end(processed_source, node, node.parent)
+            AlignmentCorrector.align_end(corrector, processed_source, node, node.parent)
           else
-            AlignmentCorrector.align_end(processed_source, node, node)
+            AlignmentCorrector.align_end(corrector, processed_source, node, node)
           end
         end
       end

--- a/lib/rubocop/cop/layout/empty_line_after_magic_comment.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_magic_comment.rb
@@ -20,29 +20,29 @@ module RuboCop
       #   class Person
       #     # Some code
       #   end
-      class EmptyLineAfterMagicComment < Cop
+      class EmptyLineAfterMagicComment < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Add an empty line after magic comments.'
 
-        def investigate(source)
-          return unless source.ast &&
-                        (last_magic_comment = last_magic_comment(source))
-          return if source[last_magic_comment.loc.line].strip.empty?
+        def on_new_investigation
+          return unless processed_source.ast &&
+                        (last_magic_comment = last_magic_comment(processed_source))
+          return if processed_source[last_magic_comment.loc.line].strip.empty?
 
-          offending_range =
-            source_range(source.buffer, last_magic_comment.loc.line + 1, 0)
+          offending_range = offending_range(last_magic_comment)
 
-          add_offense(offending_range, location: offending_range)
-        end
-
-        def autocorrect(token)
-          lambda do |corrector|
-            corrector.insert_before(token, "\n")
+          add_offense(offending_range) do |corrector|
+            corrector.insert_before(offending_range, "\n")
           end
         end
 
         private
+
+        def offending_range(last_magic_comment)
+          source_range(processed_source.buffer, last_magic_comment.loc.line + 1, 0)
+        end
 
         # Find the last magic comment in the source file.
         #

--- a/lib/rubocop/cop/layout/empty_line_between_defs.rb
+++ b/lib/rubocop/cop/layout/empty_line_between_defs.rb
@@ -29,8 +29,9 @@ module RuboCop
       #
       #   def b
       #   end
-      class EmptyLineBetweenDefs < Cop
+      class EmptyLineBetweenDefs < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Use empty lines between method definitions.'
 
@@ -57,10 +58,12 @@ module RuboCop
                     cop_config['AllowAdjacentOneLineDefs']
 
           location = nodes.last.loc.keyword.join(nodes.last.loc.name)
-          add_offense(nodes.last, location: location)
+          add_offense(location) do |corrector|
+            autocorrect(corrector, nodes.last)
+          end
         end
 
-        def autocorrect(node)
+        def autocorrect(corrector, node)
           prev_def = prev_node(node)
 
           # finds position of first newline
@@ -71,9 +74,9 @@ module RuboCop
           count = blank_lines_count_between(prev_def, node)
 
           if count > maximum_empty_lines
-            autocorrect_remove_lines(newline_pos, count)
+            autocorrect_remove_lines(corrector, newline_pos, count)
           else
-            autocorrect_insert_lines(newline_pos, count)
+            autocorrect_insert_lines(corrector, newline_pos, count)
           end
         end
 
@@ -131,20 +134,18 @@ module RuboCop
           node.loc.end.line
         end
 
-        def autocorrect_remove_lines(newline_pos, count)
+        def autocorrect_remove_lines(corrector, newline_pos, count)
           difference = count - maximum_empty_lines
           range_to_remove = range_between(newline_pos, newline_pos + difference)
-          lambda do |corrector|
-            corrector.remove(range_to_remove)
-          end
+
+          corrector.remove(range_to_remove)
         end
 
-        def autocorrect_insert_lines(newline_pos, count)
+        def autocorrect_insert_lines(corrector, newline_pos, count)
           difference = minimum_empty_lines - count
           where_to_insert = range_between(newline_pos, newline_pos + 1)
-          lambda do |corrector|
-            corrector.insert_after(where_to_insert, "\n" * difference)
-          end
+
+          corrector.insert_after(where_to_insert, "\n" * difference)
         end
       end
     end

--- a/lib/rubocop/cop/layout/empty_lines.rb
+++ b/lib/rubocop/cop/layout/empty_lines.rb
@@ -18,13 +18,14 @@ module RuboCop
       #   # one empty line
       #   some_method
       #
-      class EmptyLines < Cop
+      class EmptyLines < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Extra blank line detected.'
         LINE_OFFSET = 2
 
-        def investigate(processed_source)
+        def on_new_investigation
           return if processed_source.tokens.empty?
 
           lines = Set.new
@@ -33,12 +34,10 @@ module RuboCop
           end
 
           each_extra_empty_line(lines.sort) do |range|
-            add_offense(range, location: range)
+            add_offense(range) do |corrector|
+              corrector.remove(range)
+            end
           end
-        end
-
-        def autocorrect(range)
-          ->(corrector) { corrector.remove(range) }
         end
 
         private

--- a/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
@@ -40,9 +40,10 @@ module RuboCop
       #     def baz; end
       #   end
       #
-      class EmptyLinesAroundAccessModifier < Cop
+      class EmptyLinesAroundAccessModifier < Base
         include ConfigurableEnforcedStyle
         include RangeHelp
+        extend AutoCorrector
 
         MSG_AFTER = 'Keep a blank line after `%<modifier>s`.'
         MSG_BEFORE_AND_AFTER = 'Keep a blank line before and after ' \
@@ -92,11 +93,8 @@ module RuboCop
             return if allowed_only_before_style?(node)
           end
 
-          add_offense(node)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          message = message(node)
+          add_offense(node, message: message) do |corrector|
             line = range_by_whole_lines(node.source_range)
 
             corrector.insert_before(line, "\n") unless previous_line_empty?(node.first_line)

--- a/lib/rubocop/cop/layout/empty_lines_around_arguments.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_arguments.rb
@@ -38,23 +38,22 @@ module RuboCop
       #     x: y
       #   )
       #
-      class EmptyLinesAroundArguments < Cop
+      class EmptyLinesAroundArguments < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Empty line detected around arguments.'
 
         def on_send(node)
           return if node.single_line? || node.arguments.empty?
 
-          extra_lines(node) { |range| add_offense(node, location: range) }
-        end
-        alias on_csend on_send
-
-        def autocorrect(node)
-          lambda do |corrector|
-            extra_lines(node) { |range| corrector.remove(range) }
+          extra_lines(node) do |range|
+            add_offense(range) do |corrector|
+              corrector.remove(range)
+            end
           end
         end
+        alias on_csend on_send
 
         private
 

--- a/lib/rubocop/cop/layout/empty_lines_around_attribute_accessor.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_attribute_accessor.rb
@@ -60,9 +60,10 @@ module RuboCop
       #   def do_something
       #   end
       #
-      class EmptyLinesAroundAttributeAccessor < Cop
+      class EmptyLinesAroundAttributeAccessor < Base
         include RangeHelp
         include AllowedMethods
+        extend AutoCorrector
 
         MSG = 'Add an empty line after attribute accessor.'
 
@@ -73,11 +74,7 @@ module RuboCop
           next_line_node = next_line_node(node)
           return unless require_empty_line?(next_line_node)
 
-          add_offense(node)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(node) do |corrector|
             range = range_by_whole_lines(node.source_range)
 
             corrector.insert_after(range, "\n")

--- a/lib/rubocop/cop/layout/empty_lines_around_begin_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_begin_body.rb
@@ -21,17 +21,14 @@ module RuboCop
       #     # ...
       #
       #   end
-      class EmptyLinesAroundBeginBody < Cop
+      class EmptyLinesAroundBeginBody < Base
         include EmptyLinesAroundBody
+        extend AutoCorrector
 
         KIND = '`begin`'
 
         def on_kwbegin(node)
           check(node, nil)
-        end
-
-        def autocorrect(node)
-          EmptyLineCorrector.correct(node)
         end
 
         private

--- a/lib/rubocop/cop/layout/empty_lines_around_block_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_block_body.rb
@@ -21,8 +21,9 @@ module RuboCop
       #   foo do |bar|
       #     # ...
       #   end
-      class EmptyLinesAroundBlockBody < Cop
+      class EmptyLinesAroundBlockBody < Base
         include EmptyLinesAroundBody
+        extend AutoCorrector
 
         KIND = 'block'
 
@@ -30,10 +31,6 @@ module RuboCop
           first_line = node.send_node.last_line
 
           check(node, node.body, adjusted_first_line: first_line)
-        end
-
-        def autocorrect(node)
-          EmptyLineCorrector.correct(node)
         end
       end
     end

--- a/lib/rubocop/cop/layout/empty_lines_around_class_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_class_body.rb
@@ -64,8 +64,9 @@ module RuboCop
       #       # ...
       #     end
       #   end
-      class EmptyLinesAroundClassBody < Cop
+      class EmptyLinesAroundClassBody < Base
         include EmptyLinesAroundBody
+        extend AutoCorrector
 
         KIND = 'class'
 
@@ -77,10 +78,6 @@ module RuboCop
 
         def on_sclass(node)
           check(node, node.body)
-        end
-
-        def autocorrect(node)
-          EmptyLineCorrector.correct(node)
         end
       end
     end

--- a/lib/rubocop/cop/layout/empty_lines_around_exception_handling_keywords.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_exception_handling_keywords.rb
@@ -58,8 +58,9 @@ module RuboCop
       #
       #     do_something2
       #   end
-      class EmptyLinesAroundExceptionHandlingKeywords < Cop
+      class EmptyLinesAroundExceptionHandlingKeywords < Base
         include EmptyLinesAroundBody
+        extend AutoCorrector
 
         MSG = 'Extra empty line detected %<location>s the `%<keyword>s`.'
 
@@ -71,10 +72,6 @@ module RuboCop
         def on_kwbegin(node)
           body, = *node
           check_body(body)
-        end
-
-        def autocorrect(node)
-          EmptyLineCorrector.correct(node)
         end
 
         private

--- a/lib/rubocop/cop/layout/empty_lines_around_method_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_method_body.rb
@@ -20,8 +20,9 @@ module RuboCop
       #     # ...
       #
       #   end
-      class EmptyLinesAroundMethodBody < Cop
+      class EmptyLinesAroundMethodBody < Base
         include EmptyLinesAroundBody
+        extend AutoCorrector
 
         KIND = 'method'
 
@@ -29,10 +30,6 @@ module RuboCop
           check(node, node.body)
         end
         alias on_defs on_def
-
-        def autocorrect(node)
-          EmptyLineCorrector.correct(node)
-        end
 
         private
 

--- a/lib/rubocop/cop/layout/empty_lines_around_module_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_module_body.rb
@@ -44,17 +44,14 @@ module RuboCop
       #       # ...
       #     end
       #   end
-      class EmptyLinesAroundModuleBody < Cop
+      class EmptyLinesAroundModuleBody < Base
         include EmptyLinesAroundBody
+        extend AutoCorrector
 
         KIND = 'module'
 
         def on_module(node)
           check(node, node.body)
-        end
-
-        def autocorrect(node)
-          EmptyLineCorrector.correct(node)
         end
       end
     end

--- a/lib/rubocop/cop/layout/end_alignment.rb
+++ b/lib/rubocop/cop/layout/end_alignment.rb
@@ -67,10 +67,11 @@ module RuboCop
       #   variable =
       #     if true
       #     end
-      class EndAlignment < Cop
+      class EndAlignment < Base
         include CheckAssignment
         include EndKeywordAlignment
         include RangeHelp
+        extend AutoCorrector
 
         def on_class(node)
           check_other_alignment(node)
@@ -100,13 +101,11 @@ module RuboCop
           end
         end
 
-        def autocorrect(node)
-          AlignmentCorrector.align_end(processed_source,
-                                       node,
-                                       alignment_node(node))
-        end
-
         private
+
+        def autocorrect(corrector, node)
+          AlignmentCorrector.align_end(corrector, processed_source, node, alignment_node(node))
+        end
 
         def check_assignment(node, rhs)
           # If there are method calls chained to the right hand side of the

--- a/lib/rubocop/cop/mixin/empty_lines_around_body.rb
+++ b/lib/rubocop/cop/mixin/empty_lines_around_body.rb
@@ -101,7 +101,9 @@ module RuboCop
 
           offset = style == :empty_lines && msg.include?('end.') ? 2 : 1
           range = source_range(processed_source.buffer, line + offset, 0)
-          add_offense([style, range], location: range, message: msg)
+          add_offense(range, message: msg) do |corrector|
+            EmptyLineCorrector.correct(corrector, [style, range])
+          end
         end
 
         def check_deferred_empty_line(body)
@@ -113,11 +115,9 @@ module RuboCop
 
           range = source_range(processed_source.buffer, line + 2, 0)
 
-          add_offense(
-            [:empty_lines, range],
-            location: range,
-            message: deferred_message(node)
-          )
+          add_offense(range, message: deferred_message(node)) do |corrector|
+            EmptyLineCorrector.correct(corrector, [:empty_lines, range])
+          end
         end
 
         def namespace?(body, with_one_child: false)

--- a/lib/rubocop/cop/mixin/end_keyword_alignment.rb
+++ b/lib/rubocop/cop/mixin/end_keyword_alignment.rb
@@ -46,7 +46,9 @@ module RuboCop
                           source: align_with.source,
                           align_line: align_with.line,
                           align_col: align_with.column)
-        add_offense(node, location: end_loc, message: msg)
+        add_offense(end_loc, message: msg) do |corrector|
+          autocorrect(corrector, node)
+        end
       end
 
       def accept_end_kw_alignment?(end_loc)

--- a/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
@@ -203,7 +203,6 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
             end
           end
         RUBY
-        expect(cop.messages).to eq([missing_begin])
       end
 
       it 'registers offenses for namespaced class body not ending '\


### PR DESCRIPTION
Follow #7868.

This PR uses `Cop::Base` API for almost `Style` department's cops.
It targets cop that names begin between A and E. And some A-E cops will be excluded from this PR target and addressed separately.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
