### PR TITLE
[Fix #8576] Fix `Style/IfUnlessModifier` to ignore cop disable comment directives when considering conversion to modifier form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [#8481](https://github.com/rubocop-hq/rubocop/pull/8481): Fix autocorrect for elements with newlines in `Style/SymbolArray` and `Style/WordArray`. ([@biinari][])
 * [#8475](https://github.com/rubocop-hq/rubocop/issues/8475): Fix a false positive for `Style/HashAsLastArrayItem` when there are duplicate hashes in the array. ([@wcmonty][])
 * [#8497](https://github.com/rubocop-hq/rubocop/issues/8497): Fix `Style/IfUnlessModifier` to add parentheses when converting if-end condition inside a parenthesized method argument list. ([@dsavochkin][])
+* [#8576](https://github.com/rubocop-hq/rubocop/issues/8576): Fix `Style/IfUnlessModifier` to ignore cop disable comment directives when considering conversion to the modifier form. ([@dsavochkin][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -57,10 +57,11 @@ module RuboCop
       end
 
       def first_line_comment(node)
-        comment =
-          processed_source.find_comment { |c| c.loc.line == node.loc.line }
+        comment = processed_source.find_comment { |c| c.loc.line == node.loc.line }
+        return unless comment
 
-        comment ? comment.loc.expression.source : nil
+        comment_source = comment.loc.expression.source
+        comment_source unless comment_disables_cop?(comment_source)
       end
 
       def parenthesize?(node)
@@ -79,6 +80,11 @@ module RuboCop
         return unless config.for_cop('Layout/LineLength')['Enabled']
 
         config.for_cop('Layout/LineLength')['Max']
+      end
+
+      def comment_disables_cop?(comment)
+        regexp_pattern = "# rubocop : (disable|todo) ([^,],)* (all|#{cop_name})"
+        Regexp.new(regexp_pattern.gsub(' ', '\s*')).match?(comment)
       end
     end
   end

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -157,10 +157,6 @@ module RuboCop
             #{indentation}end
           RUBY
         end
-
-        def first_line_comment(node)
-          processed_source.comment_at_line(node.loc.line)&.text
-        end
       end
     end
   end

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1607,4 +1607,25 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     RUBY
     expect(source_file.read).to eq(corrected)
   end
+
+  it 'does not correct Style/IfUnlessModifier offense disabled by a comment directive and ' \
+     'does not fire Lint/RedundantCopDisableDirective offense even though that directive ' \
+     'would make the modifier form too long' do
+    create_file('.rubocop.yml', <<~YAML)
+      Style/FrozenStringLiteralComment:
+        Enabled: false
+    YAML
+
+    source_file = Pathname('example.rb')
+    source = <<~RUBY
+      if i > 1 # rubocop:disable Style/IfUnlessModifier
+        raise '_______________________________________________________________________'
+      end
+    RUBY
+    create_file(source_file, source)
+
+    status = cli.run(['--auto-correct-all'])
+    expect(status).to eq(0)
+    expect(source_file.read).to eq(source)
+  end
 end


### PR DESCRIPTION
Fixes #8576.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
