### PR TITLE
Add `:restore_registry` context and `stub_cop_class` helper class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#8472](https://github.com/rubocop-hq/rubocop/issues/8472): Add new `Lint/UselessMethodDefinition` cop. ([@fatkodima][])
 * [#8531](https://github.com/rubocop-hq/rubocop/issues/8531): Add new `Lint/EmptyFile` cop. ([@fatkodima][])
 * Add new `Lint/TrailingCommaInAttributeDeclaration` cop. ([@drenmi][])
+* [#8578](https://github.com/rubocop-hq/rubocop/pull/8578): Add `:restore_registry` context and `stub_cop_class` helper class. ([@marcandre][])
 
 ### Bug fixes
 

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -40,6 +40,18 @@ RSpec.shared_context 'isolated environment', :isolated_environment do
   end
 end
 
+RSpec.shared_context 'maintain registry', :restore_registry do
+  around(:each) do |example|
+    RuboCop::Cop::Registry.with_temporary_global { example.run }
+  end
+
+  def stub_cop_class(name, inherit: RuboCop::Cop::Base, &block)
+    klass = Class.new(inherit, &block)
+    stub_const(name, klass)
+    klass
+  end
+end
+
 # This context assumes nothing and defines `cop`, among others.
 RSpec.shared_context 'config', :config do # rubocop:disable Metrics/BlockLength
   ### Meant to be overridden at will

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -621,11 +621,7 @@ RSpec.describe RuboCop::ConfigLoader do
       include_examples 'resolves enabled/disabled for all cops', true, false
     end
 
-    context 'when a third party require defines a new gem' do
-      around do |example|
-        RuboCop::Cop::Registry.with_temporary_global { example.run }
-      end
-
+    context 'when a third party require defines a new gem', :restore_registry do
       context 'when the gem is not loaded' do
         before do
           create_file('.rubocop.yml', <<~YAML)

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -845,7 +845,7 @@ RSpec.describe RuboCop::Config do
     end
   end
 
-  describe '#for_department' do
+  describe '#for_department', :restore_registry do
     let(:hash) do
       {
         'Foo' => { 'Bar' => 42, 'Baz' => true },
@@ -853,14 +853,8 @@ RSpec.describe RuboCop::Config do
       }
     end
 
-    around do |test|
-      RuboCop::Cop::Registry.with_temporary_global do
-        test.run
-      end
-    end
-
     before do
-      stub_const('RuboCop::Foo::Foo', Class.new(RuboCop::Cop::Base))
+      stub_cop_class('RuboCop::Foo::Foo')
     end
 
     it "always returns the department's config" do

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -166,12 +166,11 @@ RSpec.describe RuboCop::Cop::Cop, :config do
       end
     end
 
-    context 'when cop supports autocorrection' do
+    context 'when cop supports autocorrection', :restore_registry do
       let(:cop_class) do
-        stub_cop = Class.new(RuboCop::Cop::Cop) do
+        stub_cop_class('RuboCop::Cop::Test::StubCop', inherit: described_class) do
           def autocorrect(node); end
         end
-        stub_const('RuboCop::Cop::Test::StubCop', stub_cop)
       end
 
       context 'when offense was corrected' do

--- a/spec/rubocop/cop/mixin/enforce_superclass_spec.rb
+++ b/spec/rubocop/cop/mixin/enforce_superclass_spec.rb
@@ -1,30 +1,20 @@
 # frozen_string_literal: true
 
 # rubocop:disable RSpec/FilePath
-RSpec.describe RuboCop::Cop::EnforceSuperclass do
+RSpec.describe RuboCop::Cop::EnforceSuperclass, :restore_registry do
   subject(:cop) { cop_class.new }
 
   let(:cop_class) { RuboCop::Cop::RSpec::ApplicationRecord }
   let(:msg) { 'Models should subclass `ApplicationRecord`' }
 
   before do
-    stub_const('RuboCop::Cop::RSpec::ApplicationRecord',
-               Class.new(RuboCop::Cop::Cop))
+    stub_cop_class('RuboCop::Cop::RSpec::ApplicationRecord')
     stub_const("#{cop_class}::MSG",
                'Models should subclass `ApplicationRecord`')
     stub_const("#{cop_class}::SUPERCLASS", 'ApplicationRecord')
     stub_const("#{cop_class}::BASE_PATTERN",
                '(const (const {nil? cbase} :ActiveRecord) :Base)')
     RuboCop::Cop::RSpec::ApplicationRecord.include(described_class)
-  end
-
-  # `RuboCop::Cop::Cop` mutates its `registry` when inherited from.
-  # This can introduce nondeterministic failures in other parts of the
-  # specs if this mutation occurs before code that depends on this global cop
-  # store. The workaround is to replace the global cop store with a temporary
-  # store during these tests
-  around do |test|
-    RuboCop::Cop::Registry.with_temporary_global { test.run }
   end
 
   shared_examples 'no offense' do |code|

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -211,13 +211,13 @@ RSpec.describe RuboCop::Cop::Team do
       end
     end
 
-    context 'when done twice' do
+    context 'when done twice', :restore_registry do
       let(:persisting_cop_class) do
-        klass = Class.new(RuboCop::Cop::Base)
-        klass.exclude_from_registry
-        klass.define_singleton_method(:support_multiple_source?) { true }
-        stub_const('Test::Persisting', klass)
-        klass
+        stub_cop_class('Test::Persisting') do
+          def self.support_multiple_source?
+            true
+          end
+        end
       end
       let(:cop_classes) { [persisting_cop_class, RuboCop::Cop::Base] }
 
@@ -358,14 +358,13 @@ RSpec.describe RuboCop::Cop::Team do
       end
     end
 
-    context 'when cop with different checksum joins' do
+    context 'when cop with different checksum joins', :restore_registry do
       before do
-        stub_const('Test::CopWithExternalDeps',
-                   Class.new(::RuboCop::Cop::Cop) do
-                     def external_dependency_checksum
-                       'something other than nil'
-                     end
-                   end)
+        stub_cop_class('Test::CopWithExternalDeps') do
+          def external_dependency_checksum
+            'something other than nil'
+          end
+        end
       end
 
       let(:new_cop_classes) do

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -249,14 +249,11 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
     end
   end
 
-  context 'with auto-correct supported cop' do
+  context 'with auto-correct supported cop', :restore_registry do
     before do
-      stub_const('Test::Cop3',
-                 Class.new(::RuboCop::Cop::Cop) do
-                   def autocorrect
-                     # Dummy method to respond to #support_autocorrect?
-                   end
-                 end)
+      stub_cop_class('Test::Cop3') do
+        extend RuboCop::Cop::AutoCorrector
+      end
 
       formatter.started(['test_auto_correct.rb'])
       formatter.file_started('test_auto_correct.rb', {})


### PR DESCRIPTION
Makes it trivial define a new cop and/or insure that the global cop registry doesn't get polluted.