### PR TITLE
Optimize String#blank.

### DIFF
--- a/lib/rubocop/core_ext/string.rb
+++ b/lib/rubocop/core_ext/string.rb
@@ -17,7 +17,7 @@ class String
     # @example
     #   '  test'.blank? #=> false
     def blank?
-      empty? || strip.empty?
+      empty? || lstrip.empty?
     end
   end
 end


### PR DESCRIPTION
I thought that `/\A\s*\z/.match?` would be better, but it is actually much slower (up to 50x).
