### PR TITLE
Add rubocop-minitest to the extension list

### DIFF
--- a/docs/modules/ROOT/pages/extensions.adoc
+++ b/docs/modules/ROOT/pages/extensions.adoc
@@ -39,6 +39,8 @@ Performance optimization analysis
 Rails-specific analysis
 * https://github.com/rubocop-hq/rubocop-rspec[rubocop-rspec] -
 RSpec-specific analysis
+* https://github.com/rubocop-hq/rubocop-minitest[rubocop-minitest] -
+Minitest-specific analysis
 * https://github.com/covermymeds/rubocop-thread_safety[rubocop-thread_safety] -
 Thread-safety analysis
 * https://github.com/milch/rubocop-require_tools[rubocop-require_tools] -


### PR DESCRIPTION
This PR adds rubocop-minitest to the extension list.
https://github.com/rubocop-hq/rubocop-minitest

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
