### PR TITLE
Workaround for JRuby 9.2.13.0 regression

### DIFF
--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1563,7 +1563,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                 ''].join("\n"))
     end
 
-    it 'fails when a configuration file has invalid YAML syntax' do
+    # FIXME: Remove `broken_on: jruby`, which works around a JRuby 9.2.13.0 regression:
+    # https://github.com/jruby/jruby/issues/6365
+    it 'fails when a configuration file has invalid YAML syntax', broken_on: :jruby do
       create_file('example/.rubocop.yml', <<~YAML)
         AllCops:
           Exclude:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,4 +51,8 @@ RSpec.configure do |config|
   if %w[ruby-head-ascii_spec ruby-head-spec].include? ENV['CIRCLE_STAGE']
     config.filter_run_excluding broken_on: :ruby_head
   end
+
+  if %w[jruby-9.2-ascii_spec jruby-9.2-spec].include? ENV['CIRCLE_STAGE']
+    config.filter_run_excluding broken_on: :jruby
+  end
 end


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/8588#issuecomment-680679448

This PR skips a test due to the following JRuby 9.2.13.0 regression:
https://github.com/jruby/jruby/issues/6365

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
