### PR TITLE
[Fix #8590] Fix an error when auto-correcting encoding mismatch file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [#8518](https://github.com/rubocop-hq/rubocop/issues/8518): Fix `Lint/ConstantResolution` cop reporting offense for `module` and `class` definitions. ([@tejasbubane][])
 * [#8158](https://github.com/rubocop-hq/rubocop/issues/8158): Fix `Style/MultilineWhenThen` cop to correctly handle cases with multiline body. ([@dsavochkin][])
 * [#7705](https://github.com/rubocop-hq/rubocop/issues/7705): Fix `Style/OneLineConditional` cop to handle if/then/elsif/then/else/end cases. Add `AlwaysCorrectToMultiline` config option to this cop to always convert offenses to the multi-line form (false by default). ([@Lykos][], [@dsavochkin][])
+* [#8590](https://github.com/rubocop-hq/rubocop/issues/8590): Fix an error when auto-correcting encoding mismatch file. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -117,6 +117,7 @@ module RuboCop
       def autocorrect(processed_source, report)
         @updated_source_file = false
         return unless autocorrect?
+        return if report.processed_source.parser_error
 
         new_source = autocorrect_report(report)
 

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -156,6 +156,24 @@ RSpec.describe RuboCop::Cop::Team do
       end
     end
 
+    context 'when autocorrection is enabled and file encoding is mismatch' do
+      let(:options) { { auto_correct: true } }
+
+      before do
+        create_file(file_path, <<~RUBY)
+          # encoding: Shift_JIS
+          puts 'Ｔｈｉｓ ｆｉｌｅ ｅｎｃｏｄｉｎｇ ｉｓ ＵＴＦ－８．'
+        RUBY
+      end
+
+      it 'no error occurs' do
+        source = RuboCop::ProcessedSource.from_file(file_path, ruby_version)
+        team.inspect_file(source)
+
+        expect(team.errors.empty?).to be(true)
+      end
+    end
+
     context 'when Cop#on_* raises an error' do
       include_context 'mock console output'
       before do


### PR DESCRIPTION
Fixes #8590.

This PR fixes the following error when auto-correcting encoding mismatch file.

```ruby
% cat example.rb
# encoding: Shift_JIS

puts 'Ｔｈｉｓ ｆｉｌｅ ｅｎｃｏｄｉｎｇ ｉｓ ＵＴＦ－８．'
```

## Before

```console
% bundle exec rubocop --cache false -a
(snip)

Cannot extract source from uninitialized Source::Buffer
/Users/koic/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/parser-2.7.1.4/lib/
parser/source/buffer.rb:148:in `source'
/Users/koic/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/parser-2.7.1.4/lib/
parser/source/buffer.rb:297:in `source_range'
/Users/koic/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/parser-2.7.1.4/lib/
parser/source/tree_rewriter.rb:116:in `initialize'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/corrector.rb:18:in
`initialize'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/team.rb:182:in
`new'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/team.rb:182:in
`collate_corrections'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/team.rb:176:in
`autocorrect_report'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/team.rb:121:in
`autocorrect'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/team.rb:79:in
`investigate'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:295:in `inspect_file'
```

## After

```console
% bundle exec rubocop --cache false -a
(snip)

Inspecting 1 file
F

Offenses:

example.rb:1:1: F: Lint/Syntax: "\xef\xbc" from shift_jis to utf-8.

1 file inspected, 1 offense detected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
