### PR TITLE
Use `Cop::Base` API for `RegexpLiteralHelp`

### DIFF
--- a/lib/rubocop/cop/style/redundant_regexp_escape.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_escape.rb
@@ -32,9 +32,10 @@ module RuboCop
       #
       #   # good
       #   /[+\-]\d/
-      class RedundantRegexpEscape < Cop
+      class RedundantRegexpEscape < Base
         include RangeHelp
         include RegexpLiteralHelp
+        extend AutoCorrector
 
         MSG_REDUNDANT_ESCAPE = 'Redundant escape inside regexp literal'
 
@@ -46,19 +47,9 @@ module RuboCop
           each_escape(node) do |char, index, within_character_class|
             next if allowed_escape?(node, char, within_character_class)
 
-            add_offense(
-              node,
-              location: escape_range_at_index(node, index),
-              message: MSG_REDUNDANT_ESCAPE
-            )
-          end
-        end
+            location = escape_range_at_index(node, index)
 
-        def autocorrect(node)
-          lambda do |corrector|
-            each_escape(node) do |char, index, within_character_class|
-              next if allowed_escape?(node, char, within_character_class)
-
+            add_offense(location, message: MSG_REDUNDANT_ESCAPE) do |corrector|
               corrector.remove_leading(escape_range_at_index(node, index), 1)
             end
           end


### PR DESCRIPTION
Follow #7868.

This PR uses `Cop::Base` API for cops mixing `RegexpLiteralHelp` module.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
