### PR TITLE
[Fix #8583] Allow line continuations in `Style/RedundantRegexpEscape`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [#7705](https://github.com/rubocop-hq/rubocop/issues/7705): Fix `Style/OneLineConditional` cop to handle if/then/elsif/then/else/end cases. Add `AlwaysCorrectToMultiline` config option to this cop to always convert offenses to the multi-line form (false by default). ([@Lykos][], [@dsavochkin][])
 * [#8590](https://github.com/rubocop-hq/rubocop/issues/8590): Fix an error when auto-correcting encoding mismatch file. ([@koic][])
 * [#8321](https://github.com/rubocop-hq/rubocop/issues/8321): Enable auto-correction for `Layout/{Def}EndAlignment`, `Lint/EmptyEnsure`. ([@marcandre][])
+* [#8583](https://github.com/rubocop-hq/rubocop/issues/8583): Fix `Style/RedundantRegexpEscape` false positive for line continuations. ([@owst][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/redundant_regexp_escape.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_escape.rb
@@ -38,7 +38,7 @@ module RuboCop
 
         MSG_REDUNDANT_ESCAPE = 'Redundant escape inside regexp literal'
 
-        ALLOWED_ALWAYS_ESCAPES = ' []^\\#'.chars.freeze
+        ALLOWED_ALWAYS_ESCAPES = " \n[]^\\#".chars.freeze
         ALLOWED_WITHIN_CHAR_CLASS_METACHAR_ESCAPES = '-'.chars.freeze
         ALLOWED_OUTSIDE_CHAR_CLASS_METACHAR_ESCAPES = '.*+?{}()|$'.chars.freeze
 

--- a/spec/rubocop/cop/style/redundant_regexp_escape_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_escape_spec.rb
@@ -16,6 +16,18 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpEscape do
       end
     end
 
+    context 'with a line continuation' do
+      it 'does not register an offense' do
+        expect_no_offenses("foo = /a\\\nb/")
+      end
+    end
+
+    context 'with a line continuation within a character class' do
+      it 'does not register an offense' do
+        expect_no_offenses("foo = /[a\\\nb]/")
+      end
+    end
+
     [
       ('a'..'z').to_a - %w[c n p u x],
       ('A'..'Z').to_a - %w[C M P],
@@ -276,6 +288,9 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpEscape do
           expect_no_offenses("foo = /\\#{char}/")
         end
       end
+
+      # Avoid an empty character class
+      next if char == "\n"
 
       context "with an escaped '#{char}' inside a character class" do
         it 'does not register an offense' do


### PR DESCRIPTION
We should allow line continuations (i.e. an escaped `\n`)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
