### PR TITLE
[Fix #8593] Ignore multi-line interpolations in `Style/RedundantRegexpCharacterClass`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [#8590](https://github.com/rubocop-hq/rubocop/issues/8590): Fix an error when auto-correcting encoding mismatch file. ([@koic][])
 * [#8321](https://github.com/rubocop-hq/rubocop/issues/8321): Enable auto-correction for `Layout/{Def}EndAlignment`, `Lint/EmptyEnsure`. ([@marcandre][])
 * [#8583](https://github.com/rubocop-hq/rubocop/issues/8583): Fix `Style/RedundantRegexpEscape` false positive for line continuations. ([@owst][])
+* [#8593](https://github.com/rubocop-hq/rubocop/issues/8593): Fix `Style/RedundantRegexpCharacterClass` false positive for interpolated multi-line expressions. ([@owst][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/regexp_literal_help.rb
+++ b/lib/rubocop/cop/mixin/regexp_literal_help.rb
@@ -27,7 +27,7 @@ module RuboCop
         # part of the pattern source, but need to preserve their width, to allow offsets to
         # correctly line up with the original source: spaces have no effect, and preserve width.
         if child.begin_type?
-          replace_match_with_spaces(source, /.*/) # replace all content
+          replace_match_with_spaces(source, /.*/m) # replace all content
         elsif freespace_mode
           replace_match_with_spaces(source, /(?<!\\)#.*/) # replace any comments
         else

--- a/spec/rubocop/cop/style/redundant_regexp_character_class_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_character_class_spec.rb
@@ -224,6 +224,16 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpCharacterClass do
     end
   end
 
+  context 'with a multi-line interpolation' do
+    it 'ignores offenses in the interpolated expression' do
+      expect_no_offenses(<<~'RUBY')
+        /#{Regexp.union(
+          %w"( ) { } [ ] < > $ ! ^ ` ... + * ? ,"
+        )}/o
+      RUBY
+    end
+  end
+
   context 'with a character class containing a space' do
     context 'when not using free-spaced mode' do
       it 'registers an offense and corrects' do


### PR DESCRIPTION

I agree with @marcandre's comment in #8593 that this cop (and `Style/RedundantRegexpEscape`) should use a Regexp parser rather than the hacky "blank-out interpolations" approach fixed here. However, for now, this fix seemed straightforward - I'll try and take a look at the parser suggestion over the weekend.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
