### PR TITLE
Fix crash in Truffleruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * [#8513](https://github.com/rubocop-hq/rubocop/pull/8513): Clarify the ruby warning mentioned in the `Lint/ShadowingOuterLocalVariable` documentation. ([@chocolateboy][])
 * [#8517](https://github.com/rubocop-hq/rubocop/pull/8517): Make `Style/HashTransformKeys` and `Style/HashTransformValues` aware of `to_h` with block. ([@eugeneius][])
 * [#8529](https://github.com/rubocop-hq/rubocop/pull/8529): Mark `Lint/FrozenStringLiteralComment` as `Safe`, but with unsafe auto-correction. ([@marcandre][])
+* [#8602](https://github.com/rubocop-hq/rubocop/pull/8602): Fix usage of `to_enum(:scan, regexp)` to work on TruffleRuby. ([@jaimerave][])
 
 ## 0.89.1 (2020-08-10)
 
@@ -4817,3 +4818,4 @@
 [@nguyenquangminh0711]: https://github.com/nguyenquangminh0711
 [@chocolateboy]: https://github.com/chocolateboy
 [@Lykos]: https://github.com/Lykos
+[@jaimerave]: https://github.com/jaimerave

--- a/lib/rubocop/cop/utils/format_string.rb
+++ b/lib/rubocop/cop/utils/format_string.rb
@@ -111,11 +111,9 @@ module RuboCop
         private
 
         def parse
-          @source.to_enum(:scan, SEQUENCE).map do
-            FormatSequence.new(
-              Regexp.last_match
-            )
-          end
+          matches = []
+          @source.scan(SEQUENCE) { matches << FormatSequence.new(Regexp.last_match) }
+          matches
         end
 
         def mixed_formats?


### PR DESCRIPTION
This adds a workaround for https://github.com/oracle/truffleruby/issues/1484. With this change Rubocop no longer crashes when parsing files, an all the tests pass under Truffleruby 20.2.0 and head. Unfortunately, the tests are still too slow to add it to CI. 

This change also improves performance a little bit:

```
require "benchmark/ips"

Benchmark.ips do |x|
  x.config(time: 5, warmup: 2)

  source = "this is my source"

  x.report("to_enum") { source.to_enum(:scan, /this is/).map { Regexp.last_match } }
  x.report("workaround") do
    match_datas = []
    source.scan(/this is/) { match_datas << Regexp.last_match }
    match_datas
  end

  x.compare!
end
```

With `ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-darwin19]`

```
Warming up --------------------------------------
             to_enum    53.745k i/100ms
          workaround    73.683k i/100ms
Calculating -------------------------------------
             to_enum    542.663k (± 1.4%) i/s -      2.741M in   5.052060s
          workaround    727.989k (± 1.7%) i/s -      3.684M in   5.062231s

Comparison:
          workaround:   727989.4 i/s
             to_enum:   542663.3 i/s - 1.34x  (± 0.00) slower
````
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
