### PR TITLE
Use `Cop::Base` API for `Layout` department [F-M]

### DIFF
--- a/lib/rubocop/cop/correctors/empty_line_corrector.rb
+++ b/lib/rubocop/cop/correctors/empty_line_corrector.rb
@@ -16,8 +16,8 @@ module RuboCop
           end
         end
 
-        def insert_before(node)
-          ->(corrector) { corrector.insert_before(node, "\n") }
+        def insert_before(corrector, node)
+          corrector.insert_before(node, "\n")
         end
       end
     end

--- a/lib/rubocop/cop/correctors/multiline_literal_brace_corrector.rb
+++ b/lib/rubocop/cop/correctors/multiline_literal_brace_corrector.rb
@@ -8,12 +8,17 @@ module RuboCop
       include MultilineLiteralBraceLayout
       include RangeHelp
 
-      def initialize(node, processed_source)
+      def self.correct(corrector, node, processed_source)
+        new(corrector, node, processed_source).call
+      end
+
+      def initialize(corrector, node, processed_source)
+        @corrector = corrector
         @node = node
         @processed_source = processed_source
       end
 
-      def call(corrector)
+      def call
         if closing_brace_on_same_line?(node)
           correct_same_line_brace(corrector)
         else
@@ -29,7 +34,7 @@ module RuboCop
 
       private
 
-      attr_reader :node, :processed_source
+      attr_reader :corrector, :node, :processed_source
 
       def correct_same_line_brace(corrector)
         corrector.insert_before(node.loc.end, "\n")

--- a/lib/rubocop/cop/layout/first_array_element_line_break.rb
+++ b/lib/rubocop/cop/layout/first_array_element_line_break.rb
@@ -18,8 +18,9 @@ module RuboCop
       #       :b]
       #
       # @api private
-      class FirstArrayElementLineBreak < Cop
+      class FirstArrayElementLineBreak < Base
         include FirstElementLineBreak
+        extend AutoCorrector
 
         MSG = 'Add a line break before the first element of a ' \
               'multi-line array.'
@@ -28,10 +29,6 @@ module RuboCop
           return if !node.loc.begin && !assignment_on_same_line?(node)
 
           check_children_line_break(node, node.children)
-        end
-
-        def autocorrect(node)
-          EmptyLineCorrector.insert_before(node)
         end
 
         private

--- a/lib/rubocop/cop/layout/first_hash_element_line_break.rb
+++ b/lib/rubocop/cop/layout/first_hash_element_line_break.rb
@@ -18,8 +18,9 @@ module RuboCop
       #       b: 2 }
       #
       # @api private
-      class FirstHashElementLineBreak < Cop
+      class FirstHashElementLineBreak < Base
         include FirstElementLineBreak
+        extend AutoCorrector
 
         MSG = 'Add a line break before the first element of a ' \
               'multi-line hash.'
@@ -28,10 +29,6 @@ module RuboCop
           # node.loc.begin tells us whether the hash opens with a {
           # If it doesn't, Style/FirstMethodArgumentLineBreak will handle it
           check_children_line_break(node, node.children) if node.loc.begin
-        end
-
-        def autocorrect(node)
-          EmptyLineCorrector.insert_before(node)
         end
       end
     end

--- a/lib/rubocop/cop/layout/first_method_argument_line_break.rb
+++ b/lib/rubocop/cop/layout/first_method_argument_line_break.rb
@@ -22,8 +22,9 @@ module RuboCop
       #       baz
       #
       # @api private
-      class FirstMethodArgumentLineBreak < Cop
+      class FirstMethodArgumentLineBreak < Base
         include FirstElementLineBreak
+        extend AutoCorrector
 
         MSG = 'Add a line break before the first argument of a ' \
               'multi-line method argument list.'
@@ -44,10 +45,6 @@ module RuboCop
         end
         alias on_csend on_send
         alias on_super on_send
-
-        def autocorrect(node)
-          EmptyLineCorrector.insert_before(node)
-        end
       end
     end
   end

--- a/lib/rubocop/cop/layout/first_method_parameter_line_break.rb
+++ b/lib/rubocop/cop/layout/first_method_parameter_line_break.rb
@@ -28,8 +28,9 @@ module RuboCop
       #     end
       #
       # @api private
-      class FirstMethodParameterLineBreak < Cop
+      class FirstMethodParameterLineBreak < Base
         include FirstElementLineBreak
+        extend AutoCorrector
 
         MSG = 'Add a line break before the first parameter of a ' \
               'multi-line method parameter list.'
@@ -38,10 +39,6 @@ module RuboCop
           check_method_line_break(node, node.arguments)
         end
         alias on_defs on_def
-
-        def autocorrect(node)
-          EmptyLineCorrector.insert_before(node)
-        end
       end
     end
   end

--- a/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
+++ b/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
@@ -51,11 +51,16 @@ module RuboCop
       #      )
       #
       # @api private
-      class HeredocArgumentClosingParenthesis < Cop
+      class HeredocArgumentClosingParenthesis < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Put the closing parenthesis for a method call with a ' \
         'HEREDOC parameter on the same line as the HEREDOC opening.'
+
+        def self.autocorrect_incompatible_with
+          [Style::TrailingCommaInArguments]
+        end
 
         def on_send(node)
           heredoc_arg = extract_heredoc_argument(node)
@@ -66,8 +71,12 @@ module RuboCop
           return unless outermost_send.loc.end
           return unless heredoc_arg.first_line != outermost_send.loc.end.line
 
-          add_offense(outermost_send, location: :end)
+          add_offense(outermost_send.loc.end) do |corrector|
+            autocorrect(corrector, outermost_send)
+          end
         end
+
+        private
 
         # Autocorrection note:
         #
@@ -95,21 +104,13 @@ module RuboCop
         #   SQL
         #   third_array_value,
         # ]
-        def autocorrect(node)
-          lambda do |corrector|
-            fix_closing_parenthesis(node, corrector)
+        def autocorrect(corrector, node)
+          fix_closing_parenthesis(node, corrector)
 
-            remove_internal_trailing_comma(node, corrector) if internal_trailing_comma?(node)
+          remove_internal_trailing_comma(node, corrector) if internal_trailing_comma?(node)
 
-            fix_external_trailing_comma(node, corrector) if external_trailing_comma?(node)
-          end
+          fix_external_trailing_comma(node, corrector) if external_trailing_comma?(node)
         end
-
-        def self.autocorrect_incompatible_with
-          [Style::TrailingCommaInArguments]
-        end
-
-        private
 
         def outermost_send_on_same_line(heredoc)
           previous = heredoc

--- a/lib/rubocop/cop/layout/initial_indentation.rb
+++ b/lib/rubocop/cop/layout/initial_indentation.rb
@@ -18,19 +18,18 @@ module RuboCop
       #   end
       #
       # @api private
-      class InitialIndentation < Cop
+      class InitialIndentation < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Indentation of first line in file detected.'
 
-        def investigate(_processed_source)
+        def on_new_investigation
           space_before(first_token) do |space|
-            add_offense(space, location: first_token.pos)
+            add_offense(first_token.pos) do |corrector|
+              corrector.remove(space)
+            end
           end
-        end
-
-        def autocorrect(range)
-          ->(corrector) { corrector.remove(range) }
         end
 
         private

--- a/lib/rubocop/cop/layout/leading_comment_space.rb
+++ b/lib/rubocop/cop/layout/leading_comment_space.rb
@@ -50,30 +50,32 @@ module RuboCop
       #   #ruby-gemset=myproject
       #
       # @api private
-      class LeadingCommentSpace < Cop
+      class LeadingCommentSpace < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Missing space after `#`.'
 
-        def investigate(processed_source)
+        def on_new_investigation
           processed_source.comments.each do |comment|
             next unless /\A#+[^#\s=:+-]/.match?(comment.text)
             next if comment.loc.line == 1 && allowed_on_first_line?(comment)
             next if doxygen_comment_style?(comment)
             next if gemfile_ruby_comment?(comment)
 
-            add_offense(comment)
+            add_offense(comment) do |corrector|
+              expr = comment.loc.expression
+
+              corrector.insert_after(hash_mark(expr), ' ')
+            end
           end
         end
 
-        def autocorrect(comment)
-          expr = comment.loc.expression
-          hash_mark = range_between(expr.begin_pos, expr.begin_pos + 1)
-
-          ->(corrector) { corrector.insert_after(hash_mark, ' ') }
-        end
-
         private
+
+        def hash_mark(expr)
+          range_between(expr.begin_pos, expr.begin_pos + 1)
+        end
 
         def allowed_on_first_line?(comment)
           shebang?(comment) || rackup_config_file? && rackup_options?(comment)

--- a/lib/rubocop/cop/layout/leading_empty_lines.rb
+++ b/lib/rubocop/cop/layout/leading_empty_lines.rb
@@ -29,23 +29,18 @@ module RuboCop
       #   # a comment
       #
       # @api private
-      class LeadingEmptyLines < Cop
+      class LeadingEmptyLines < Base
+        extend AutoCorrector
+
         MSG = 'Unnecessary blank line at the beginning of the source.'
 
-        def investigate(processed_source)
+        def on_new_investigation
           token = processed_source.tokens[0]
           return unless token && token.line > 1
 
-          add_offense(processed_source.tokens[0],
-                      location: processed_source.tokens[0].pos)
-        end
+          add_offense(token.pos) do |corrector|
+            range = Parser::Source::Range.new(processed_source.buffer, 0, token.begin_pos)
 
-        def autocorrect(node)
-          range = Parser::Source::Range.new(processed_source.buffer,
-                                            0,
-                                            node.begin_pos)
-
-          lambda do |corrector|
             corrector.remove(range)
           end
         end

--- a/lib/rubocop/cop/layout/multiline_array_brace_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_array_brace_layout.rb
@@ -90,8 +90,9 @@ module RuboCop
       #       :b ]
       #
       # @api private
-      class MultilineArrayBraceLayout < Cop
+      class MultilineArrayBraceLayout < Base
         include MultilineLiteralBraceLayout
+        extend AutoCorrector
 
         SAME_LINE_MESSAGE = 'The closing array brace must be on the same ' \
           'line as the last array element when the opening brace is on the ' \
@@ -109,10 +110,6 @@ module RuboCop
 
         def on_array(node)
           check_brace_layout(node)
-        end
-
-        def autocorrect(node)
-          MultilineLiteralBraceCorrector.new(node, processed_source)
         end
       end
     end

--- a/lib/rubocop/cop/layout/multiline_array_line_breaks.rb
+++ b/lib/rubocop/cop/layout/multiline_array_line_breaks.rb
@@ -22,18 +22,15 @@ module RuboCop
       #   ]
       #
       # @api private
-      class MultilineArrayLineBreaks < Cop
+      class MultilineArrayLineBreaks < Base
         include MultilineElementLineBreaks
+        extend AutoCorrector
 
         MSG = 'Each item in a multi-line array must start ' \
           'on a separate line.'
 
         def on_array(node)
           check_line_breaks(node, node.children)
-        end
-
-        def autocorrect(node)
-          EmptyLineCorrector.insert_before(node)
         end
       end
     end

--- a/lib/rubocop/cop/layout/multiline_assignment_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_assignment_layout.rb
@@ -33,10 +33,11 @@ module RuboCop
       #   end
       #
       # @api private
-      class MultilineAssignmentLayout < Cop
+      class MultilineAssignmentLayout < Base
         include CheckAssignment
         include ConfigurableEnforcedStyle
         include RangeHelp
+        extend AutoCorrector
 
         NEW_LINE_OFFENSE = 'Right hand side of multi-line assignment is on ' \
           'the same line as the assignment operator `=`.'
@@ -65,24 +66,19 @@ module RuboCop
         def check_new_line_offense(node, rhs)
           return unless node.loc.operator.line == rhs.first_line
 
-          add_offense(node, message: NEW_LINE_OFFENSE)
+          add_offense(node, message: NEW_LINE_OFFENSE) do |corrector|
+            corrector.insert_after(node.loc.operator, "\n")
+          end
         end
 
         def check_same_line_offense(node, rhs)
           return unless node.loc.operator.line != rhs.first_line
 
-          add_offense(node, message: SAME_LINE_OFFENSE)
-        end
-
-        def autocorrect(node)
-          case style
-          when :new_line
-            ->(corrector) { corrector.insert_after(node.loc.operator, "\n") }
-          when :same_line
-            range = range_between(node.loc.operator.end_pos,
-                                  extract_rhs(node).source_range.begin_pos)
-
-            ->(corrector) { corrector.replace(range, ' ') }
+          add_offense(node, message: SAME_LINE_OFFENSE) do |corrector|
+            range = range_between(
+              node.loc.operator.end_pos, extract_rhs(node).source_range.begin_pos
+            )
+            corrector.replace(range, ' ')
           end
         end
 

--- a/lib/rubocop/cop/layout/multiline_block_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_block_layout.rb
@@ -50,8 +50,9 @@ module RuboCop
       #   }
       #
       # @api private
-      class MultilineBlockLayout < Cop
+      class MultilineBlockLayout < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Block body expression is on the same line as ' \
               'the block start.'
@@ -70,23 +71,6 @@ module RuboCop
           return unless node.body && node.loc.begin.line == node.body.first_line
 
           add_offense_for_expression(node, node.body, MSG)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            unless args_on_beginning_line?(node)
-              autocorrect_arguments(corrector, node)
-              expr_before_body = node.arguments.source_range.end
-            end
-
-            return unless node.body
-
-            expr_before_body ||= node.loc.begin
-
-            if expr_before_body.line == node.body.first_line
-              autocorrect_body(corrector, node, node.body)
-            end
-          end
         end
 
         private
@@ -118,7 +102,25 @@ module RuboCop
         def add_offense_for_expression(node, expr, msg)
           expression = expr.source_range
           range = range_between(expression.begin_pos, expression.end_pos)
-          add_offense(node, location: range, message: msg)
+
+          add_offense(range, message: msg) do |corrector|
+            autocorrect(corrector, node)
+          end
+        end
+
+        def autocorrect(corrector, node)
+          unless args_on_beginning_line?(node)
+            autocorrect_arguments(corrector, node)
+            expr_before_body = node.arguments.source_range.end
+          end
+
+          return unless node.body
+
+          expr_before_body ||= node.loc.begin
+
+          return unless expr_before_body.line == node.body.first_line
+
+          autocorrect_body(corrector, node, node.body)
         end
 
         def autocorrect_arguments(corrector, node)

--- a/lib/rubocop/cop/layout/multiline_hash_brace_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_hash_brace_layout.rb
@@ -90,8 +90,9 @@ module RuboCop
       #       b: 2 }
       #
       # @api private
-      class MultilineHashBraceLayout < Cop
+      class MultilineHashBraceLayout < Base
         include MultilineLiteralBraceLayout
+        extend AutoCorrector
 
         SAME_LINE_MESSAGE = 'Closing hash brace must be on the same line as ' \
           'the last hash element when opening brace is on the same line as ' \
@@ -109,10 +110,6 @@ module RuboCop
 
         def on_hash(node)
           check_brace_layout(node)
-        end
-
-        def autocorrect(node)
-          MultilineLiteralBraceCorrector.new(node, processed_source)
         end
       end
     end

--- a/lib/rubocop/cop/layout/multiline_hash_key_line_breaks.rb
+++ b/lib/rubocop/cop/layout/multiline_hash_key_line_breaks.rb
@@ -22,8 +22,9 @@ module RuboCop
       #   }
       #
       # @api private
-      class MultilineHashKeyLineBreaks < Cop
+      class MultilineHashKeyLineBreaks < Base
         include MultilineElementLineBreaks
+        extend AutoCorrector
 
         MSG = 'Each key in a multi-line hash must start on a ' \
           'separate line.'
@@ -35,10 +36,6 @@ module RuboCop
           return unless starts_with_curly_brace?(node)
 
           check_line_breaks(node, node.children) if node.loc.begin
-        end
-
-        def autocorrect(node)
-          EmptyLineCorrector.insert_before(node)
         end
 
         private

--- a/lib/rubocop/cop/layout/multiline_method_argument_line_breaks.rb
+++ b/lib/rubocop/cop/layout/multiline_method_argument_line_breaks.rb
@@ -21,8 +21,9 @@ module RuboCop
       #   )
       #
       # @api private
-      class MultilineMethodArgumentLineBreaks < Cop
-        include(MultilineElementLineBreaks)
+      class MultilineMethodArgumentLineBreaks < Base
+        include MultilineElementLineBreaks
+        extend AutoCorrector
 
         MSG = 'Each argument in a multi-line method call must start ' \
           'on a separate line.'
@@ -42,10 +43,6 @@ module RuboCop
           args = args[0...-1] + last_arg.children if last_arg&.hash_type? && !last_arg&.braces?
 
           check_line_breaks(node, args)
-        end
-
-        def autocorrect(node)
-          EmptyLineCorrector.insert_before(node)
         end
       end
     end

--- a/lib/rubocop/cop/layout/multiline_method_call_brace_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_brace_layout.rb
@@ -90,8 +90,9 @@ module RuboCop
       #     b)
       #
       # @api private
-      class MultilineMethodCallBraceLayout < Cop
+      class MultilineMethodCallBraceLayout < Base
         include MultilineLiteralBraceLayout
+        extend AutoCorrector
 
         SAME_LINE_MESSAGE = 'Closing method call brace must be on the ' \
           'same line as the last argument when opening brace is on the same ' \
@@ -109,10 +110,6 @@ module RuboCop
 
         def on_send(node)
           check_brace_layout(node)
-        end
-
-        def autocorrect(node)
-          MultilineLiteralBraceCorrector.new(node, processed_source)
         end
 
         private

--- a/lib/rubocop/cop/layout/multiline_method_definition_brace_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_method_definition_brace_layout.rb
@@ -102,8 +102,9 @@ module RuboCop
       #   end
       #
       # @api private
-      class MultilineMethodDefinitionBraceLayout < Cop
+      class MultilineMethodDefinitionBraceLayout < Base
         include MultilineLiteralBraceLayout
+        extend AutoCorrector
 
         SAME_LINE_MESSAGE = 'Closing method definition brace must be on the ' \
           'same line as the last parameter when opening brace is on the same ' \
@@ -123,10 +124,6 @@ module RuboCop
           check_brace_layout(node.arguments)
         end
         alias on_defs on_def
-
-        def autocorrect(node)
-          MultilineLiteralBraceCorrector.new(node, processed_source)
-        end
       end
     end
   end

--- a/lib/rubocop/cop/mixin/first_element_line_break.rb
+++ b/lib/rubocop/cop/mixin/first_element_line_break.rb
@@ -31,7 +31,9 @@ module RuboCop
         max = last_by_line(children)
         return if line == max.last_line
 
-        add_offense(min)
+        add_offense(min) do |corrector|
+          EmptyLineCorrector.insert_before(corrector, min)
+        end
       end
 
       def first_by_line(nodes)

--- a/lib/rubocop/cop/mixin/multiline_element_line_breaks.rb
+++ b/lib/rubocop/cop/mixin/multiline_element_line_breaks.rb
@@ -16,7 +16,9 @@ module RuboCop
         last_seen_line = -1
         children.each do |child|
           if last_seen_line >= child.first_line
-            add_offense(child)
+            add_offense(child) do |corrector|
+              EmptyLineCorrector.insert_before(corrector, child)
+            end
           else
             last_seen_line = child.last_line
           end

--- a/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
+++ b/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
@@ -43,30 +43,32 @@ module RuboCop
       def check_new_line(node)
         return unless closing_brace_on_same_line?(node)
 
-        add_offense(node,
-                    location: :end,
-                    message: self.class::ALWAYS_NEW_LINE_MESSAGE)
+        add_offense(node.loc.end, message: self.class::ALWAYS_NEW_LINE_MESSAGE) do |corrector|
+          MultilineLiteralBraceCorrector.correct(corrector, node, processed_source)
+        end
       end
 
       def check_same_line(node)
         return if closing_brace_on_same_line?(node)
 
-        add_offense(node,
-                    location: :end,
-                    message: self.class::ALWAYS_SAME_LINE_MESSAGE)
+        add_offense(node.loc.end, message: self.class::ALWAYS_SAME_LINE_MESSAGE) do |corrector|
+          MultilineLiteralBraceCorrector.correct(corrector, node, processed_source)
+        end
       end
 
       def check_symmetrical(node)
         if opening_brace_on_same_line?(node)
           return if closing_brace_on_same_line?(node)
 
-          add_offense(node, location: :end,
-                            message: self.class::SAME_LINE_MESSAGE)
+          add_offense(node.loc.end, message: self.class::SAME_LINE_MESSAGE) do |corrector|
+            MultilineLiteralBraceCorrector.correct(corrector, node, processed_source)
+          end
         else
           return unless closing_brace_on_same_line?(node)
 
-          add_offense(node, location: :end,
-                            message: self.class::NEW_LINE_MESSAGE)
+          add_offense(node.loc.end, message: self.class::NEW_LINE_MESSAGE) do |corrector|
+            MultilineLiteralBraceCorrector.correct(corrector, node, processed_source)
+          end
         end
       end
 


### PR DESCRIPTION
Follow #7868.

This PR uses `Cop::Base` API for almost `Style` department's cops.
It targets cop that names begin between F and M. And some F-M cops will be excluded from this PR target and addressed separately.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
