### PR TITLE
Use `Cop::Base` API for `Layout` department [N-S]

### DIFF
--- a/lib/rubocop/cop/correctors/punctuation_corrector.rb
+++ b/lib/rubocop/cop/correctors/punctuation_corrector.rb
@@ -5,12 +5,12 @@ module RuboCop
     # This auto-corrects punctuation
     class PunctuationCorrector
       class << self
-        def remove_space(space_before)
-          ->(corrector) { corrector.remove(space_before) }
+        def remove_space(corrector, space_before)
+          corrector.remove(space_before)
         end
 
-        def add_space(token)
-          ->(corrector) { corrector.replace(token.pos, "#{token.pos.source} ") }
+        def add_space(corrector, token)
+          corrector.replace(token.pos, "#{token.pos.source} ")
         end
 
         def swap_comma(corrector, range)

--- a/lib/rubocop/cop/layout/space_after_colon.rb
+++ b/lib/rubocop/cop/layout/space_after_colon.rb
@@ -15,7 +15,9 @@ module RuboCop
       #   def f(a:, b: 2); {a: 3}; end
       #
       # @api private
-      class SpaceAfterColon < Cop
+      class SpaceAfterColon < Base
+        extend AutoCorrector
+
         MSG = 'Space missing after colon.'
 
         def on_pair(node)
@@ -23,7 +25,7 @@ module RuboCop
 
           colon = node.loc.operator
 
-          add_offense(colon, location: colon) unless followed_by_space?(colon)
+          register_offense(colon) unless followed_by_space?(colon)
         end
 
         def on_kwoptarg(node)
@@ -31,14 +33,16 @@ module RuboCop
           # optional keyword argument's name, so must construct one.
           colon = node.loc.name.end.resize(1)
 
-          add_offense(colon, location: colon) unless followed_by_space?(colon)
-        end
-
-        def autocorrect(range)
-          ->(corrector) { corrector.insert_after(range, ' ') }
+          register_offense(colon) unless followed_by_space?(colon)
         end
 
         private
+
+        def register_offense(colon)
+          add_offense(colon) do |corrector|
+            corrector.insert_after(colon, ' ')
+          end
+        end
 
         def followed_by_space?(colon)
           /\s/.match?(colon.source_buffer.source[colon.end_pos])

--- a/lib/rubocop/cop/layout/space_after_comma.rb
+++ b/lib/rubocop/cop/layout/space_after_comma.rb
@@ -16,12 +16,9 @@ module RuboCop
       #   { foo:bar, }
       #
       # @api private
-      class SpaceAfterComma < Cop
+      class SpaceAfterComma < Base
         include SpaceAfterPunctuation
-
-        def autocorrect(comma)
-          PunctuationCorrector.add_space(comma)
-        end
+        extend AutoCorrector
 
         def space_style_before_rcurly
           cfg = config.for_cop('Layout/SpaceInsideHashLiteralBraces')

--- a/lib/rubocop/cop/layout/space_after_method_name.rb
+++ b/lib/rubocop/cop/layout/space_after_method_name.rb
@@ -16,8 +16,9 @@ module RuboCop
       #   def method=(y) end
       #
       # @api private
-      class SpaceAfterMethodName < Cop
+      class SpaceAfterMethodName < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Do not put a space between a method name and the opening ' \
               'parenthesis.'
@@ -31,13 +32,11 @@ module RuboCop
                                                 expr.begin_pos)
           return unless pos_before_left_paren.source.start_with?(' ')
 
-          add_offense(pos_before_left_paren, location: pos_before_left_paren)
+          add_offense(pos_before_left_paren) do |corrector|
+            corrector.remove(pos_before_left_paren)
+          end
         end
         alias on_defs on_def
-
-        def autocorrect(pos_before_left_paren)
-          ->(corrector) { corrector.remove(pos_before_left_paren) }
-        end
       end
     end
   end

--- a/lib/rubocop/cop/layout/space_after_not.rb
+++ b/lib/rubocop/cop/layout/space_after_not.rb
@@ -13,28 +13,26 @@ module RuboCop
       #   !something
       #
       # @api private
-      class SpaceAfterNot < Cop
+      class SpaceAfterNot < Base
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Do not leave space between `!` and its argument.'
 
         def on_send(node)
           return unless node.prefix_bang? && whitespace_after_operator?(node)
 
-          add_offense(node)
+          add_offense(node) do |corrector|
+            corrector.remove(
+              range_between(node.loc.selector.end_pos, node.receiver.source_range.begin_pos)
+            )
+          end
         end
+
+        private
 
         def whitespace_after_operator?(node)
           node.receiver.loc.column - node.loc.column > 1
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.remove(
-              range_between(node.loc.selector.end_pos,
-                            node.receiver.source_range.begin_pos)
-            )
-          end
         end
       end
     end

--- a/lib/rubocop/cop/layout/space_after_semicolon.rb
+++ b/lib/rubocop/cop/layout/space_after_semicolon.rb
@@ -13,12 +13,9 @@ module RuboCop
       #   x = 1; y = 2
       #
       # @api private
-      class SpaceAfterSemicolon < Cop
+      class SpaceAfterSemicolon < Base
         include SpaceAfterPunctuation
-
-        def autocorrect(semicolon)
-          PunctuationCorrector.add_space(semicolon)
-        end
+        extend AutoCorrector
 
         def space_style_before_rcurly
           cfg = config.for_cop('Layout/SpaceInsideBlockBraces')

--- a/lib/rubocop/cop/layout/space_before_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_before_block_braces.rb
@@ -43,9 +43,10 @@ module RuboCop
       #   7.times{}
       #
       # @api private
-      class SpaceBeforeBlockBraces < Cop
+      class SpaceBeforeBlockBraces < Base
         include ConfigurableEnforcedStyle
         include RangeHelp
+        extend AutoCorrector
 
         MISSING_MSG = 'Space missing to the left of {.'
         DETECTED_MSG = 'Space detected to the left of {.'
@@ -77,29 +78,22 @@ module RuboCop
           end
         end
 
-        def autocorrect(range)
-          lambda do |corrector|
-            case range.source
-            when /\s/ then corrector.remove(range)
-            else           corrector.insert_before(range, ' ')
-            end
-          end
-        end
-
         private
 
         def check_empty(left_brace, space_plus_brace, used_style)
           return if style_for_empty_braces == used_style
 
-          config_to_allow_offenses['EnforcedStyleForEmptyBraces'] =
-            used_style.to_s
+          config_to_allow_offenses['EnforcedStyleForEmptyBraces'] = used_style.to_s
 
           if style_for_empty_braces == :space
-            add_offense(left_brace, location: left_brace, message: MISSING_MSG)
+            add_offense(left_brace, message: MISSING_MSG) do |corrector|
+              autocorrect(corrector, left_brace)
+            end
           else
-            space = range_between(space_plus_brace.begin_pos,
-                                  left_brace.begin_pos)
-            add_offense(space, location: space, message: DETECTED_MSG)
+            space = range_between(space_plus_brace.begin_pos, left_brace.begin_pos)
+            add_offense(space, message: DETECTED_MSG) do |corrector|
+              autocorrect(corrector, space)
+            end
           end
         end
 
@@ -112,16 +106,23 @@ module RuboCop
         end
 
         def space_missing(left_brace)
-          add_offense(left_brace, location: left_brace, message: MISSING_MSG) do
-            opposite_style_detected
+          add_offense(left_brace, message: MISSING_MSG) do |corrector|
+            autocorrect(corrector, left_brace)
           end
         end
 
         def space_detected(left_brace, space_plus_brace)
-          space = range_between(space_plus_brace.begin_pos,
-                                left_brace.begin_pos)
-          add_offense(space, location: space, message: DETECTED_MSG) do
-            opposite_style_detected
+          space = range_between(space_plus_brace.begin_pos, left_brace.begin_pos)
+
+          add_offense(space, message: DETECTED_MSG) do |corrector|
+            autocorrect(corrector, space)
+          end
+        end
+
+        def autocorrect(corrector, range)
+          case range.source
+          when /\s/ then corrector.remove(range)
+          else           corrector.insert_before(range, ' ')
           end
         end
 

--- a/lib/rubocop/cop/layout/space_before_comma.rb
+++ b/lib/rubocop/cop/layout/space_before_comma.rb
@@ -17,12 +17,9 @@ module RuboCop
       #   each { |a, b| }
       #
       # @api private
-      class SpaceBeforeComma < Cop
+      class SpaceBeforeComma < Base
         include SpaceBeforePunctuation
-
-        def autocorrect(space)
-          PunctuationCorrector.remove_space(space)
-        end
+        extend AutoCorrector
 
         def kind(token)
           'comma' if token.comma?

--- a/lib/rubocop/cop/layout/space_before_comment.rb
+++ b/lib/rubocop/cop/layout/space_before_comment.rb
@@ -14,20 +14,23 @@ module RuboCop
       #   1 + 1 # this operation does ...
       #
       # @api private
-      class SpaceBeforeComment < Cop
+      class SpaceBeforeComment < Base
+        extend AutoCorrector
+
         MSG = 'Put a space before an end-of-line comment.'
 
-        def investigate(processed_source)
+        def on_new_investigation
           processed_source.tokens.each_cons(2) do |token1, token2|
             next unless token2.comment?
             next unless token1.line == token2.line
+            next unless token1.pos.end == token2.pos.begin
 
-            add_offense(token2.pos, location: token2.pos) if token1.pos.end == token2.pos.begin
+            range = token2.pos
+
+            add_offense(range) do |corrector|
+              corrector.insert_before(range, ' ')
+            end
           end
-        end
-
-        def autocorrect(range)
-          ->(corrector) { corrector.insert_before(range, ' ') }
         end
       end
     end

--- a/lib/rubocop/cop/layout/space_before_first_arg.rb
+++ b/lib/rubocop/cop/layout/space_before_first_arg.rb
@@ -22,9 +22,10 @@ module RuboCop
       #   something 'hello'
       #
       # @api private
-      class SpaceBeforeFirstArg < Cop
+      class SpaceBeforeFirstArg < Base
         include PrecedingFollowingAlignment
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Put one space between the method name and ' \
               'the first argument.'
@@ -40,13 +41,11 @@ module RuboCop
           return if space.length == 1
           return unless expect_params_after_method_name?(node)
 
-          add_offense(space, location: space)
+          add_offense(space) do |corrector|
+            corrector.replace(space, ' ')
+          end
         end
         alias on_csend on_send
-
-        def autocorrect(range)
-          ->(corrector) { corrector.replace(range, ' ') }
-        end
 
         private
 

--- a/lib/rubocop/cop/layout/space_before_semicolon.rb
+++ b/lib/rubocop/cop/layout/space_before_semicolon.rb
@@ -13,12 +13,9 @@ module RuboCop
       #   x = 1; y = 2
       #
       # @api private
-      class SpaceBeforeSemicolon < Cop
+      class SpaceBeforeSemicolon < Base
         include SpaceBeforePunctuation
-
-        def autocorrect(space)
-          PunctuationCorrector.remove_space(space)
-        end
+        extend AutoCorrector
 
         def kind(token)
           'semicolon' if token.semicolon?

--- a/lib/rubocop/cop/layout/space_in_lambda_literal.rb
+++ b/lib/rubocop/cop/layout/space_in_lambda_literal.rb
@@ -21,9 +21,10 @@ module RuboCop
       #     a = -> (x, y) { x + y }
       #
       # @api private
-      class SpaceInLambdaLiteral < Cop
+      class SpaceInLambdaLiteral < Base
         include ConfigurableEnforcedStyle
         include RangeHelp
+        extend AutoCorrector
 
         MSG_REQUIRE_SPACE = 'Use a space between `->` and ' \
                             '`(` in lambda literals.'
@@ -33,24 +34,15 @@ module RuboCop
         def on_send(node)
           return unless arrow_lambda_with_args?(node)
 
-          if style == :require_space && !space_after_arrow?(node)
-            add_offense(node,
-                        location: range_of_offense(node),
-                        message: MSG_REQUIRE_SPACE)
-          elsif style == :require_no_space && space_after_arrow?(node)
-            add_offense(node,
-                        location: range_of_offense(node),
-                        message: MSG_REQUIRE_NO_SPACE)
-          end
-        end
+          lambda_node = range_of_offense(node)
 
-        def autocorrect(lambda_node)
-          children = lambda_node.parent.children
-          lambda do |corrector|
-            if style == :require_space
-              corrector.insert_before(children[1], ' ')
-            else
-              corrector.remove(space_after_arrow(lambda_node))
+          if style == :require_space && !space_after_arrow?(node)
+            add_offense(lambda_node, message: MSG_REQUIRE_SPACE) do |corrector|
+              corrector.insert_before(node.parent.children[1], ' ')
+            end
+          elsif style == :require_no_space && space_after_arrow?(node)
+            add_offense(lambda_node, message: MSG_REQUIRE_NO_SPACE) do |corrector|
+              corrector.remove(space_after_arrow(node))
             end
           end
         end

--- a/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
@@ -68,9 +68,10 @@ module RuboCop
       #   bar = [ ]
       #
       # @api private
-      class SpaceInsideArrayLiteralBrackets < Cop
+      class SpaceInsideArrayLiteralBrackets < Base
         include SurroundingSpace
         include ConfigurableEnforcedStyle
+        extend AutoCorrector
 
         MSG = '%<command>s space inside array brackets.'
         EMPTY_MSG = '%<command>s space inside empty array brackets.'
@@ -87,25 +88,21 @@ module RuboCop
           issue_offenses(node, left, right, start_ok, end_ok)
         end
 
-        def autocorrect(node)
+        private
+
+        def autocorrect(corrector, node)
           left, right = array_brackets(node)
 
-          lambda do |corrector|
-            if empty_brackets?(left, right)
-              SpaceCorrector.empty_corrections(processed_source, corrector,
-                                               empty_config, left, right)
-            elsif style == :no_space
-              SpaceCorrector.remove_space(processed_source, corrector,
-                                          left, right)
-            elsif style == :space
-              SpaceCorrector.add_space(processed_source, corrector, left, right)
-            else
-              compact_corrections(corrector, node, left, right)
-            end
+          if empty_brackets?(left, right)
+            SpaceCorrector.empty_corrections(processed_source, corrector, empty_config, left, right)
+          elsif style == :no_space
+            SpaceCorrector.remove_space(processed_source, corrector, left, right)
+          elsif style == :space
+            SpaceCorrector.add_space(processed_source, corrector, left, right)
+          else
+            compact_corrections(corrector, node, left, right)
           end
         end
-
-        private
 
         def array_brackets(node)
           [left_array_bracket(node), right_array_bracket(node)]

--- a/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
@@ -64,10 +64,11 @@ module RuboCop
       #   foo = {     }
       #
       # @api private
-      class SpaceInsideHashLiteralBraces < Cop
+      class SpaceInsideHashLiteralBraces < Base
         include SurroundingSpace
         include ConfigurableEnforcedStyle
         include RangeHelp
+        extend AutoCorrector
 
         MSG = 'Space inside %<problem>s.'
 
@@ -79,16 +80,6 @@ module RuboCop
             return if begin_index == end_index - 1
 
             check(tokens[end_index - 1], tokens[end_index])
-          end
-        end
-
-        def autocorrect(range)
-          lambda do |corrector|
-            case range.source
-            when /\s/ then corrector.remove(range)
-            when '{' then corrector.insert_after(range, ' ')
-            else corrector.insert_before(range, ' ')
-            end
           end
         end
 
@@ -138,14 +129,20 @@ module RuboCop
                                      expect_space, is_empty_braces)
           brace = (token1.text == '{' ? token1 : token2).pos
           range = expect_space ? brace : space_range(brace)
-          add_offense(
-            range,
-            location: range,
-            message: message(brace, is_empty_braces, expect_space)
-          ) do
-            style = expect_space ? :no_space : :space
-            ambiguous_or_unexpected_style_detected(style,
-                                                   token1.text == token2.text)
+
+          style = expect_space ? :no_space : :space
+          return unless ambiguous_or_unexpected_style_detected(style, token1.text == token2.text)
+
+          add_offense(range, message: message(brace, is_empty_braces, expect_space)) do |corrector|
+            autocorrect(corrector, range)
+          end
+        end
+
+        def autocorrect(corrector, range)
+          case range.source
+          when /\s/ then corrector.remove(range)
+          when '{' then corrector.insert_after(range, ' ')
+          else corrector.insert_before(range, ' ')
           end
         end
 

--- a/lib/rubocop/cop/layout/space_inside_parens.rb
+++ b/lib/rubocop/cop/layout/space_inside_parens.rb
@@ -32,34 +32,29 @@ module RuboCop
       #   y()
       #
       # @api private
-      class SpaceInsideParens < Cop
+      class SpaceInsideParens < Base
         include SurroundingSpace
         include RangeHelp
         include ConfigurableEnforcedStyle
+        extend AutoCorrector
 
         MSG       = 'Space inside parentheses detected.'
         MSG_SPACE = 'No space inside parentheses detected.'
 
-        def investigate(processed_source)
+        def on_new_investigation
           @processed_source = processed_source
 
           if style == :space
             each_missing_space(processed_source.tokens) do |range|
-              add_offense(range, location: range, message: MSG_SPACE)
+              add_offense(range, message: MSG_SPACE) do |corrector|
+                corrector.insert_before(range, ' ')
+              end
             end
           else
             each_extraneous_space(processed_source.tokens) do |range|
-              add_offense(range, location: range)
-            end
-          end
-        end
-
-        def autocorrect(range)
-          lambda do |corrector|
-            if style == :space
-              corrector.insert_before(range, ' ')
-            else
-              corrector.remove(range)
+              add_offense(range) do |corrector|
+                corrector.remove(range)
+              end
             end
           end
         end

--- a/lib/rubocop/cop/layout/space_inside_range_literal.rb
+++ b/lib/rubocop/cop/layout/space_inside_range_literal.rb
@@ -19,7 +19,9 @@ module RuboCop
       #   'a'..'z'
       #
       # @api private
-      class SpaceInsideRangeLiteral < Cop
+      class SpaceInsideRangeLiteral < Base
+        extend AutoCorrector
+
         MSG = 'Space inside range literal.'
 
         def on_irange(node)
@@ -28,21 +30,6 @@ module RuboCop
 
         def on_erange(node)
           check(node)
-        end
-
-        def autocorrect(node)
-          expression = node.source
-          operator = node.loc.operator.source
-          operator_escaped = operator.gsub(/\./, '\.')
-
-          lambda do |corrector|
-            corrector.replace(
-              node,
-              expression
-                .sub(/\s+#{operator_escaped}/, operator)
-                .sub(/#{operator_escaped}\s+/, operator)
-            )
-          end
         end
 
         private
@@ -57,7 +44,11 @@ module RuboCop
 
           return unless /(\s#{escaped_op})|(#{escaped_op}\s)/.match?(expression)
 
-          add_offense(node)
+          add_offense(node) do |corrector|
+            corrector.replace(
+              node, expression.sub(/\s+#{escaped_op}/, op).sub(/#{escaped_op}\s+/, op)
+            )
+          end
         end
       end
     end

--- a/lib/rubocop/cop/layout/space_inside_reference_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_reference_brackets.rb
@@ -54,9 +54,10 @@ module RuboCop
       #   foo[ ]
       #
       # @api private
-      class SpaceInsideReferenceBrackets < Cop
+      class SpaceInsideReferenceBrackets < Base
         include SurroundingSpace
         include ConfigurableEnforcedStyle
+        extend AutoCorrector
 
         MSG = '%<command>s space inside reference brackets.'
         EMPTY_MSG = '%<command>s space inside empty reference brackets.'
@@ -84,23 +85,19 @@ module RuboCop
           end
         end
 
-        def autocorrect(node)
-          lambda do |corrector|
-            left, right = reference_brackets(node)
+        private
 
-            if empty_brackets?(left, right)
-              SpaceCorrector.empty_corrections(processed_source, corrector,
-                                               empty_config, left, right)
-            elsif style == :no_space
-              SpaceCorrector.remove_space(processed_source, corrector,
-                                          left, right)
-            else
-              SpaceCorrector.add_space(processed_source, corrector, left, right)
-            end
+        def autocorrect(corrector, node)
+          left, right = reference_brackets(node)
+
+          if empty_brackets?(left, right)
+            SpaceCorrector.empty_corrections(processed_source, corrector, empty_config, left, right)
+          elsif style == :no_space
+            SpaceCorrector.remove_space(processed_source, corrector, left, right)
+          else
+            SpaceCorrector.add_space(processed_source, corrector, left, right)
           end
         end
-
-        private
 
         def reference_brackets(node)
           tokens = tokens(node)

--- a/lib/rubocop/cop/layout/space_inside_string_interpolation.rb
+++ b/lib/rubocop/cop/layout/space_inside_string_interpolation.rb
@@ -20,11 +20,12 @@ module RuboCop
       #      var = "This is the #{ space } example"
       #
       # @api private
-      class SpaceInsideStringInterpolation < Cop
+      class SpaceInsideStringInterpolation < Base
         include Interpolation
         include SurroundingSpace
         include ConfigurableEnforcedStyle
         include RangeHelp
+        extend AutoCorrector
 
         NO_SPACE_MSG = 'Space inside string interpolation detected.'
         SPACE_MSG = 'Missing space inside string interpolation detected.'
@@ -42,19 +43,17 @@ module RuboCop
           end
         end
 
-        def autocorrect(begin_node)
-          lambda do |corrector|
-            delims = delimiters(begin_node)
+        private
 
-            if style == :no_space
-              SpaceCorrector.remove_space(processed_source, corrector, *delims)
-            else
-              SpaceCorrector.add_space(processed_source, corrector, *delims)
-            end
+        def autocorrect(corrector, begin_node)
+          delims = delimiters(begin_node)
+
+          if style == :no_space
+            SpaceCorrector.remove_space(processed_source, corrector, *delims)
+          else
+            SpaceCorrector.add_space(processed_source, corrector, *delims)
           end
         end
-
-        private
 
         def delimiters(begin_node)
           left = processed_source.tokens[index_of_first_token(begin_node)]

--- a/lib/rubocop/cop/mixin/space_after_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_after_punctuation.rb
@@ -7,10 +7,11 @@ module RuboCop
     module SpaceAfterPunctuation
       MSG = 'Space missing after %<token>s.'
 
-      def investigate(processed_source)
+      def on_new_investigation
         each_missing_space(processed_source.tokens) do |token|
-          add_offense(token, location: token.pos,
-                             message: format(MSG, token: kind(token)))
+          add_offense(token.pos, message: format(MSG, token: kind(token))) do |corrector|
+            PunctuationCorrector.add_space(corrector, token)
+          end
         end
       end
 

--- a/lib/rubocop/cop/mixin/space_before_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_before_punctuation.rb
@@ -9,10 +9,11 @@ module RuboCop
 
       MSG = 'Space found before %<token>s.'
 
-      def investigate(processed_source)
+      def on_new_investigation
         each_missing_space(processed_source.tokens) do |token, pos_before|
-          add_offense(pos_before, location: pos_before,
-                                  message: format(MSG, token: kind(token)))
+          add_offense(pos_before, message: format(MSG, token: kind(token))) do |corrector|
+            PunctuationCorrector.remove_space(corrector, pos_before)
+          end
         end
       end
 

--- a/lib/rubocop/cop/mixin/surrounding_space.rb
+++ b/lib/rubocop/cop/mixin/surrounding_space.rb
@@ -81,8 +81,11 @@ module RuboCop
 
       def space_offense(node, token, side, message, command)
         range = side_space_range(range: token.pos, side: side)
-        add_offense(node, location: range,
-                          message: format(message, command: command))
+        add_offense(range, message: format(message, command: command)) do |corrector|
+          autocorrect(corrector, node) unless ignored_node?(node)
+
+          ignore_node(node)
+        end
       end
 
       def empty_offenses(node, left, right, message)
@@ -96,8 +99,9 @@ module RuboCop
       end
 
       def empty_offense(node, range, message, command)
-        add_offense(node, location: range,
-                          message: format(message, command: command))
+        add_offense(range, message: format(message, command: command)) do |corrector|
+          autocorrect(corrector, node)
+        end
       end
 
       def empty_brackets?(left_bracket_token, right_bracket_token)

--- a/spec/rubocop/formatter/junit_formatter_spec.rb
+++ b/spec/rubocop/formatter/junit_formatter_spec.rb
@@ -12,18 +12,16 @@ RSpec.describe RuboCop::Formatter::JUnitFormatter, :config do
   describe '#file_finished' do
     before do
       cop.add_offense(
-        nil,
-        location: Parser::Source::Range.new(source_buffer, 0, 1),
+        Parser::Source::Range.new(source_buffer, 0, 1),
         message: 'message 1'
       )
-      cop.add_offense(
-        nil,
-        location: Parser::Source::Range.new(source_buffer, 9, 10),
+      offenses = cop.add_offense(
+        Parser::Source::Range.new(source_buffer, 9, 10),
         message: 'message 2'
       )
 
-      formatter.file_finished('test_1', cop.offenses)
-      formatter.file_finished('test_2', cop.offenses)
+      formatter.file_finished('test_1', offenses)
+      formatter.file_finished('test_2', offenses)
 
       formatter.finished(nil)
     end


### PR DESCRIPTION
Follow #7868.

This PR uses `Cop::Base` API for almost `Layout` department's cops.
It targets cop that names begin between N and S. And several N-S cops will be excluded from this PR target and addressed separately.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
