### PR TITLE
Use `Cop::Base` API for `Lint/TopLevelReturnWithArgument`

### DIFF
--- a/lib/rubocop/cop/lint/top_level_return_with_argument.rb
+++ b/lib/rubocop/cop/lint/top_level_return_with_argument.rb
@@ -13,7 +13,7 @@ module RuboCop
       #   return 1 # 1 is always ignored.
       #
       # @api private
-      class TopLevelReturnWithArgument < Cop
+      class TopLevelReturnWithArgument < Base
         # This cop works by validating the ancestors of the return node. A
         # top-level return node's ancestors should not be of block, def, or
         # defs type.


### PR DESCRIPTION
Follow #7868, #8377, and #8395

This PR uses `Cop::Base` API for `Lint/TopLevelReturnWithArgument`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
