### PR TITLE
Use `Cop::Base` API for `PercentArray`

### DIFF
--- a/lib/rubocop/cop/correctors/percent_literal_corrector.rb
+++ b/lib/rubocop/cop/correctors/percent_literal_corrector.rb
@@ -13,23 +13,18 @@ module RuboCop
         @preferred_delimiters = preferred_delimiters
       end
 
-      def correct(node, char)
+      def correct(corrector, node, char)
         escape = escape_words?(node)
         char = char.upcase if escape
         delimiters = delimiters_for("%#{char}")
         contents = new_contents(node, escape, delimiters)
-        wrap_contents(node, contents, char, delimiters)
+        wrap_contents(corrector, node, contents, char, delimiters)
       end
 
       private
 
-      def wrap_contents(node, contents, char, delimiters)
-        lambda do |corrector|
-          corrector.replace(
-            node,
-            "%#{char}#{delimiters[0]}#{contents}#{delimiters[1]}"
-          )
-        end
+      def wrap_contents(corrector, node, contents, char, delimiters)
+        corrector.replace(node, "%#{char}#{delimiters[0]}#{contents}#{delimiters[1]}")
       end
 
       def escape_words?(node)

--- a/lib/rubocop/cop/mixin/percent_array.rb
+++ b/lib/rubocop/cop/mixin/percent_array.rb
@@ -34,14 +34,25 @@ module RuboCop
 
       def check_percent_array(node)
         array_style_detected(:percent, node.values.size)
-        add_offense(node) if style == :brackets
+
+        return unless style == :brackets
+
+        add_offense(node) do |corrector|
+          correct_bracketed(corrector, node)
+        end
       end
 
-      def check_bracketed_array(node)
+      def check_bracketed_array(node, literal_prefix)
         return if allowed_bracket_array?(node)
 
         array_style_detected(:brackets, node.values.size)
-        add_offense(node) if style == :percent
+
+        return unless style == :percent
+
+        add_offense(node) do |corrector|
+          percent_literal_corrector = PercentLiteralCorrector.new(@config, @preferred_delimiters)
+          percent_literal_corrector.correct(corrector, node, literal_prefix)
+        end
       end
     end
   end

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -29,11 +29,12 @@ module RuboCop
       #   %w[foo bar baz]
       #
       # @api private
-      class WordArray < Cop
+      class WordArray < Base
         include ArrayMinSize
         include ArraySyntax
         include ConfigurableEnforcedStyle
         include PercentArray
+        extend AutoCorrector
 
         PERCENT_MSG = 'Use `%w` or `%W` for an array of words.'
         ARRAY_MSG = 'Use `[]` for an array of words.'
@@ -46,30 +47,13 @@ module RuboCop
           if bracketed_array_of?(:str, node)
             return if complex_content?(node.values)
 
-            check_bracketed_array(node)
+            check_bracketed_array(node, 'w')
           elsif node.percent_literal?(:string)
             check_percent_array(node)
           end
         end
 
-        def autocorrect(node)
-          if style == :percent
-            PercentLiteralCorrector
-              .new(@config, @preferred_delimiters)
-              .correct(node, 'w')
-          else
-            correct_bracketed(node)
-          end
-        end
-
         private
-
-        def check_bracketed_array(node)
-          return if allowed_bracket_array?(node)
-
-          array_style_detected(:brackets, node.values.size)
-          add_offense(node) if style == :percent
-        end
 
         def complex_content?(strings)
           strings.any? do |s|
@@ -83,7 +67,7 @@ module RuboCop
           Regexp.new(cop_config['WordRegex'])
         end
 
-        def correct_bracketed(node)
+        def correct_bracketed(corrector, node)
           words = node.children.map do |word|
             if word.dstr_type?
               string_literal = to_string_literal(word.source)
@@ -94,9 +78,7 @@ module RuboCop
             end
           end
 
-          lambda do |corrector|
-            corrector.replace(node, "[#{words.join(', ')}]")
-          end
+          corrector.replace(node, "[#{words.join(', ')}]")
         end
       end
     end


### PR DESCRIPTION
Follow #7868.

This PR uses `Cop::Base` API for cops mixing `PercentArray` module.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
