### PR TITLE
Fix `Style/CaseLikeIf` not properly handling overriden equality methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [#8321](https://github.com/rubocop-hq/rubocop/issues/8321): Enable auto-correction for `Layout/{Def}EndAlignment`, `Lint/EmptyEnsure`. ([@marcandre][])
 * [#8583](https://github.com/rubocop-hq/rubocop/issues/8583): Fix `Style/RedundantRegexpEscape` false positive for line continuations. ([@owst][])
 * [#8593](https://github.com/rubocop-hq/rubocop/issues/8593): Fix `Style/RedundantRegexpCharacterClass` false positive for interpolated multi-line expressions. ([@owst][])
+* [#8624](https://github.com/rubocop-hq/rubocop/pull/8624): Fix an error with the `Style/CaseLikeIf` cop where it does not properly handle overridden equality methods with no arguments. ([@Skipants][])
 
 ### Changes
 
@@ -4821,3 +4822,4 @@
 [@chocolateboy]: https://github.com/chocolateboy
 [@Lykos]: https://github.com/Lykos
 [@jaimerave]: https://github.com/jaimerave
+[@Skipants]: https://github.com/Skipants

--- a/lib/rubocop/cop/style/case_like_if.rb
+++ b/lib/rubocop/cop/style/case_like_if.rb
@@ -116,7 +116,7 @@ module RuboCop
         def find_target_in_equality_node(node)
           argument = node.arguments.first
           receiver = node.receiver
-          return unless receiver
+          return unless argument && receiver
 
           if argument.literal? || const_reference?(argument)
             receiver

--- a/spec/rubocop/cop/style/case_like_if_spec.rb
+++ b/spec/rubocop/cop/style/case_like_if_spec.rb
@@ -336,4 +336,12 @@ RSpec.describe RuboCop::Cop::Style::CaseLikeIf do
       foo if x == 1
     RUBY
   end
+
+  it 'does not register an offense when an object overrides `equal?` with no arity' do
+    expect_no_offenses(<<~RUBY)
+      if x.equal?
+      elsif y
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
If a class overrides one of `#==`, `#eql?`, or `equal?` and the overridden method has no arguments, then `CaseLikeIf#find_target_in_equality_node` would error as it assumes there is at least one argument.

Without the fix, the new spec returns an error:

```shell
➜  rubocop (master) ✔ bundle exec rspec spec/rubocop/cop/style/case_like_if_spec.rb:340
Run options: include {:focus=>true, :locations=>{"./spec/rubocop/cop/style/case_like_if_spec.rb"=>[340]}}

Randomized with seed 42434
F

Failures:

  1) RuboCop::Cop::Style::CaseLikeIf does not register an offense when an object overrides `equal?` with no arity
     Failure/Error: if argument.literal? || const_reference?(argument)

     NoMethodError:
       undefined method `literal?' for nil:NilClass
     # ./lib/rubocop/cop/style/case_like_if.rb:121:in `find_target_in_equality_node'
     # ./lib/rubocop/cop/style/case_like_if.rb:105:in `find_target_in_send_node'
     # ./lib/rubocop/cop/style/case_like_if.rb:95:in `find_target'
     # ./lib/rubocop/cop/style/case_like_if.rb:39:in `on_if'
     # ./lib/rubocop/cop/commissioner.rb:99:in `block (2 levels) in trigger_responding_cops'
     # ./lib/rubocop/cop/commissioner.rb:152:in `with_cop_error_handling'
     # ./lib/rubocop/cop/commissioner.rb:98:in `block in trigger_responding_cops'
     # ./lib/rubocop/cop/commissioner.rb:97:in `each'
     # ./lib/rubocop/cop/commissioner.rb:97:in `trigger_responding_cops'
     # ./lib/rubocop/cop/commissioner.rb:70:in `on_if'
     # ./lib/rubocop/cop/commissioner.rb:85:in `investigate'
     # ./lib/rubocop/cop/team.rb:152:in `investigate_partial'
     # ./lib/rubocop/cop/team.rb:83:in `investigate'
     # ./lib/rubocop/rspec/cop_helper.rb:54:in `_investigate'
     # ./lib/rubocop/rspec/cop_helper.rb:25:in `inspect_source'
     # ./lib/rubocop/rspec/expect_offense.rb:187:in `expect_no_offenses'
     # ./spec/rubocop/cop/style/case_like_if_spec.rb:341:in `block (2 levels) in <top (required)>'

Finished in 0.03323 seconds (files took 1.35 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/rubocop/cop/style/case_like_if_spec.rb:340 # RuboCop::Cop::Style::CaseLikeIf does not register an offense when an object overrides `equal?` with no arity

Randomized with seed 42434
```

I doubt you'll see much of `==` being overridden in the wild, but this particular case was found with `equal?`. An object in my work's app takes in a bunch of data in its constructor and `equal?` is overridden and used to verify some criterion on it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
