### PR TITLE
[Fix #8627] Fix a false positive for `Lint/DuplicateRequire`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#8627](https://github.com/rubocop-hq/rubocop/issues/8627): Fix a false positive for `Lint/DuplicateRequire` when same feature argument but different require method. ([@koic][])
+
 ## 0.90.0 (2020-09-01)
 
 ### New features

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -805,6 +805,10 @@ require 'foo'
 # good
 require 'foo'
 require 'bar'
+
+# good
+require 'foo'
+require_relative 'foo'
 ----
 
 == Lint/DuplicateRescueException

--- a/lib/rubocop/cop/lint/duplicate_require.rb
+++ b/lib/rubocop/cop/lint/duplicate_require.rb
@@ -15,6 +15,10 @@ module RuboCop
       #   require 'foo'
       #   require 'bar'
       #
+      #   # good
+      #   require 'foo'
+      #   require_relative 'foo'
+      #
       class DuplicateRequire < Base
         MSG = 'Duplicate `%<method>s` detected.'
         REQUIRE_METHODS = %i[require require_relative].freeze
@@ -31,7 +35,7 @@ module RuboCop
 
         def on_send(node)
           return unless REQUIRE_METHODS.include?(node.method_name) && require_call?(node)
-          return if @required[node.parent].add?(node.first_argument)
+          return if @required[node.parent].add?("#{node.method_name}#{node.first_argument}")
 
           add_offense(node, message: format(MSG, method: node.method_name))
         end

--- a/spec/rubocop/cop/lint/duplicate_require_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_require_spec.rb
@@ -73,6 +73,13 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateRequire do
     RUBY
   end
 
+  it 'does not register an offense when same feature argument but different require method' do
+    expect_no_offenses(<<~RUBY)
+      require 'feature'
+      require_relative 'feature'
+    RUBY
+  end
+
   it 'does not register an offense when calling user-defined `require` method' do
     expect_no_offenses(<<~RUBY)
       params.require(:user)


### PR DESCRIPTION
Fixes #8627.

This PR fixes a false positive for `Lint/DuplicateRequire` when same feature argument but different require method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
