### PR TITLE
Calculate rubocop_checksum by caculating a crc32 for each file rather than using mtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * [#8517](https://github.com/rubocop-hq/rubocop/pull/8517): Make `Style/HashTransformKeys` and `Style/HashTransformValues` aware of `to_h` with block. ([@eugeneius][])
 * [#8529](https://github.com/rubocop-hq/rubocop/pull/8529): Mark `Lint/FrozenStringLiteralComment` as `Safe`, but with unsafe auto-correction. ([@marcandre][])
 * [#8602](https://github.com/rubocop-hq/rubocop/pull/8602): Fix usage of `to_enum(:scan, regexp)` to work on TruffleRuby. ([@jaimerave][])
+* [#8629](https://github.com/rubocop-hq/rubocop/pull/8629): Fix the cache being reusable in CI by using crc32 to calculate file hashes rather than `mtime`, which changes each CI build. ([@dvandersluis][])
 
 ## 0.89.1 (2020-08-10)
 

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -3,6 +3,7 @@
 require 'digest/sha1'
 require 'find'
 require 'etc'
+require 'zlib'
 
 module RuboCop
   # Provides functionality for caching rubocop runs.
@@ -171,7 +172,7 @@ module RuboCop
           rubocop_extra_features
             .select { |path| File.file?(path) }
             .sort!
-            .each { |path| digest << File.mtime(path).to_s }
+            .each { |path| digest << Zlib.crc32(IO.read(path)).to_s }
           digest << RuboCop::Version::STRING << RuboCop::AST::Version::STRING
           digest.hexdigest
         end


### PR DESCRIPTION
Fixes #8629.

`File.mtime` is faster, but inconsistent in CI, because in each CI build the mtime changes, which means that the rubocop cache implicitly cannot be used as-is. It's obviously slower to calculate a hash for each file, but this is still more performant (both in memory consumption and iterations per second) than the original.

I wrote a benchmark to test memory and IPS: https://gist.github.com/dvandersluis/0ddbc936fc858fbbec9cf8fb796ec9a2
```
Calculating -------------------------------------
            original     1.770M memsize (   622.000  retained)
                       587.000  objects (     3.000  retained)
                        50.000  strings (     2.000  retained)
               mtime    27.343k memsize (     0.000  retained)
                       482.000  objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
           file hash     1.586M memsize (     0.000  retained)
                       668.000  objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
               crc32   940.981k memsize (     0.000  retained)
                       480.000  objects (     0.000  retained)
                        50.000  strings (     0.000  retained)

Comparison:
               mtime:      27343 allocated
               crc32:     940981 allocated - 34.41x more
           file hash:    1585783 allocated - 58.00x more
            original:    1769735 allocated - 64.72x more
Warming up --------------------------------------
            original    19.000  i/100ms
               mtime    66.000  i/100ms
           file hash    21.000  i/100ms
               crc32    37.000  i/100ms
Calculating -------------------------------------
            original    246.123  (± 5.3%) i/s -      1.235k in   5.033696s
               mtime      1.143k (± 2.7%) i/s -      5.742k in   5.026275s
           file hash    276.138  (± 2.9%) i/s -      1.386k in   5.023864s
               crc32    406.651  (± 3.2%) i/s -      2.035k in   5.009418s

Comparison:
               mtime:     1143.3 i/s
               crc32:      406.7 i/s - 2.81x  slower
           file hash:      276.1 i/s - 4.14x  slower
            original:      246.1 i/s - 4.65x  slower
```

Obviously just accessing a file stat is going to be best, but that doesn't help when the results are inconsistent. I also tested some other options, such as other non-cryptographic hashes that are supposed to be fast (like mumble hash) and got worse results than using crc32 (plus those involve adding a gem which I think is better to avoid).

If this is too slow still, a thought I had would be to switch how to calculate the checksum based on `ENV['CI']`. Please let me know if you'd like me to make that change, or if there's another strategy to try.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
