### PR TITLE
[Fix #8470] Do not try to autocorrect Style/StringConcatenation if any of the parts are too complex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#8627](https://github.com/rubocop-hq/rubocop/issues/8627): Fix a false positive for `Lint/DuplicateRequire` when same feature argument but different require method. ([@koic][])
 
+### Changes
+
+* [#8470](https://github.com/rubocop-hq/rubocop/issues/8470): Do not autocorrect `Style/StringConcatenation` when parts of the expression are too complex. ([@dvandersluis][])
+
 ## 0.90.0 (2020-09-01)
 
 ### New features

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -9414,6 +9414,11 @@ warn('hello')
 This cop checks for places where string concatenation
 can be replaced with string interpolation.
 
+The cop can autocorrect simple cases but will skip autocorrecting
+more complex cases where the resulting code would be harder to read.
+In those cases, it might be useful to extract statements to local
+variables or methods which you can then interpolate in a string.
+
 === Examples
 
 [source,ruby]

--- a/spec/rubocop/cop/style/string_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/string_concatenation_spec.rb
@@ -41,4 +41,85 @@ RSpec.describe RuboCop::Cop::Style::StringConcatenation do
       user.name + user.email
     RUBY
   end
+
+  context 'multiline' do
+    context 'simple expressions' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<-RUBY)
+          email_with_name = user.name +
+                            ^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+            ' ' +
+            user.email +
+            '\\n'
+        RUBY
+
+        expect_correction(<<-RUBY)
+          email_with_name = "\#{user.name} \#{user.email}\\\\n"
+        RUBY
+      end
+    end
+
+    context 'if condition' do
+      it 'registers an offense but does not correct' do
+        expect_offense(<<~RUBY)
+          "result:" + if condition
+          ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+            "true"
+          else
+            "false"
+          end
+        RUBY
+
+        expect_no_corrections
+      end
+    end
+
+    context 'multiline block' do
+      it 'registers an offense but does not correct' do
+        expect_offense(<<~RUBY)
+          '(' + values.map do |v|
+          ^^^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+              v.titleize
+          end.join(', ') + ')'
+        RUBY
+
+        expect_no_corrections
+      end
+    end
+  end
+
+  context 'nested interpolation' do
+    it 'registers an offense but does not correct' do
+      expect_offense(<<~RUBY)
+        "foo" + "bar: \#{baz}"
+        ^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+      RUBY
+
+      expect_no_corrections
+    end
+  end
+
+  context 'inline block' do
+    it 'registers an offense but does not correct' do
+      expect_offense(<<~RUBY)
+        '(' + values.map { |v| v.titleize }.join(', ') + ')'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+      RUBY
+
+      expect_no_corrections
+    end
+  end
+
+  context 'heredoc' do
+    it 'registers an offense but does not correct' do
+      expect_offense(<<~RUBY)
+        "foo" + <<~STR
+        ^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+          text
+        STR
+      RUBY
+
+      expect_no_corrections
+    end
+  end
 end


### PR DESCRIPTION
Fixes #8470.

If any of the parts in the expression are too complex, an offense will be registered but autocorrection will not take place (ideally the complex expression should be replaced with a variable or method call that could then be interpolated more simply).

The following disable autocorrection:
* multiline statements
* heredocs (which otherwise were autocorrecting into a syntax error)
* nested interpolation
* expressions with blocks (block braces inside interpolation braces)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
