### PR TITLE
[Fix #8617] Style/HashAsLastArrayItem no longer flags hashes if all elements in an array are hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changes
 
 * [#8470](https://github.com/rubocop-hq/rubocop/issues/8470): Do not autocorrect `Style/StringConcatenation` when parts of the expression are too complex. ([@dvandersluis][])
+* [#8617](https://github.com/rubocop-hq/rubocop/issues/8617): Fix `Style/HashAsLastArrayItem` to not register an offense when all items in an array are hashes. ([@dvandersluis][])
 
 ## 0.90.0 (2020-09-01)
 

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -3691,6 +3691,9 @@ ok
 Checks for presence or absence of braces around hash literal as a last
 array item depending on configuration.
 
+NOTE: This cop will ignore arrays where all items are hashes, regardless of
+EnforcedStyle.
+
 === Examples
 
 ==== EnforcedStyle: braces (default)
@@ -3702,6 +3705,9 @@ array item depending on configuration.
 
 # good
 [1, 2, { one: 1, two: 2 }]
+
+# good
+[{ one: 1 }, { two: 2 }]
 ----
 
 ==== EnforcedStyle: no_braces
@@ -3713,6 +3719,9 @@ array item depending on configuration.
 
 # good
 [1, 2, one: 1, two: 2]
+
+# good
+[{ one: 1 }, { two: 2 }]
 ----
 
 === Configurable attributes

--- a/spec/rubocop/cop/style/hash_as_last_array_item_spec.rb
+++ b/spec/rubocop/cop/style/hash_as_last_array_item_spec.rb
@@ -30,6 +30,12 @@ RSpec.describe RuboCop::Cop::Style::HashAsLastArrayItem, :config do
         foo(one: 1, two: 2)
       RUBY
     end
+
+    it 'does not register an offense when the array is all hashes' do
+      expect_no_offenses(<<~RUBY)
+        [{ one: 1 }, { two: 2 }]
+      RUBY
+    end
   end
 
   context 'when EnforcedStyle is no_braces' do
@@ -57,6 +63,12 @@ RSpec.describe RuboCop::Cop::Style::HashAsLastArrayItem, :config do
     it 'does not register an offense when hash is not inside array' do
       expect_no_offenses(<<~RUBY)
         foo({ one: 1, two: 2 })
+      RUBY
+    end
+
+    it 'does not register an offense when the array is all hashes' do
+      expect_no_offenses(<<~RUBY)
+        [{ one: 1 }, { two: 2 }]
       RUBY
     end
   end


### PR DESCRIPTION
Fixes #8617.

`Style/HashAsLastArrayItem` currently changes arrays of hashes so that the final hash has no braces (if `EnforcedStyle: no_braces` is set). This PR changes that behaviour so that an array of all hashes is ignored.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
