### PR TITLE
[Fixes #8636] Circumvent treetop's folly

### DIFF
--- a/lib/rubocop/core_ext/string.rb
+++ b/lib/rubocop/core_ext/string.rb
@@ -2,7 +2,7 @@
 
 # Extensions to the core String class
 class String
-  unless method_defined? :blank?
+  unless method_defined?(:blank?) && ' '.blank?
     # Checks whether a string is blank. A string is considered blank if it
     # is either empty or contains only whitespace characters.
     #


### PR DESCRIPTION
Overwrite `treetop`s bad definition of `blank?` if it exists.