### PR TITLE
[Fix #8642] Fix a false negative for `Style/SpaceInsideHashLiteralBraces` when a correct empty hash precedes the incorrect hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#8671](https://github.com/rubocop-hq/rubocop/issues/8671): Fix an error for `Style/ExplicitBlockArgument` when using safe navigation method call. ([@koic][])
 * [#8682](https://github.com/rubocop-hq/rubocop/pull/8682): Fix a positive for `Style/HashTransformKeys` and `Style/HashTransformValues` when the `each_with_object` hash is used in the transformed key or value. ([@eugeneius][])
 * [#8688](https://github.com/rubocop-hq/rubocop/issues/8688): Mark `Style/GlobalStdStream` as unsafe autocorrection. ([@marcandre][])
+* [#8642](https://github.com/rubocop-hq/rubocop/issues/8642): Fix a false negative for `Style/SpaceInsideHashLiteralBraces` when a correct empty hash precedes the incorrect hash. ([@dvandersluis][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
@@ -126,11 +126,10 @@ module RuboCop
 
         def incorrect_style_detected(token1, token2,
                                      expect_space, is_empty_braces)
+          return unless ambiguous_or_unexpected_style_detected(style, token1.text == token2.text)
+
           brace = (token1.text == '{' ? token1 : token2).pos
           range = expect_space ? brace : space_range(brace)
-
-          style = expect_space ? :no_space : :space
-          return unless ambiguous_or_unexpected_style_detected(style, token1.text == token2.text)
 
           add_offense(range, message: message(brace, is_empty_braces, expect_space)) do |corrector|
             autocorrect(corrector, range)

--- a/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
@@ -216,4 +216,21 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
       expect_no_offenses('{ key: "{" }')
     end
   end
+
+  context 'offending hash following empty hash' do
+    # regression test; see GH issue 8642
+    it 'registers an offense on both sides' do
+      expect_offense(<<~RUBY)
+        {}
+        {key: 1}
+        ^ Space inside { missing.
+               ^ Space inside } missing.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        {}
+        { key: 1 }
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #8642.

I'm not 100% sure I understand what `ConfigurableEnforcedStyle` is doing (it'd be great if it could have more documentation added!), but the problem here is that the detected style was flipping between `space` and `nospace` depending on which hash was being evaluated. The fix is to just pass the defined `style` to `ambiguous_or_unexpected_style_detected` rather than trying to calculate it.

---

Consider the following code (which is also added as a test):
```ruby
{}
{key: 1}
```

1. When the first empty hash is evaluated by the cop, the memoized detected style (in `ConfigurableEnforcedStyle`) is `nil`. Because the spacing for the empty has is correct, `correct_style_detected` is called, which sets [`detected_as_strings` and `updated_list`](https://github.com/rubocop-hq/rubocop/blob/d3f6b097a8fc65a64d050b5844a1a4fe2505d503/lib/rubocop/cop/mixin/configurable_enforced_style.rb#L30-L35) to `['space']` (since that is the `EnforcedStyle` value).
2. When the first brace of the second hash is evaluated by the `check` method, it [detects an offense and runs `incorrect_style_detected`](https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb#L106-L108). At this point, a space is required [`no_space` is passed to `ambiguous_or_unexpected_style_detected`](https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb#L132-L133). Because of this, `updated_list` is set to the intersection of `[space]` and `[no_space]`, which is `[]`, and [`no_acceptable_style!`](https://github.com/rubocop-hq/rubocop/blob/d3f6b097a8fc65a64d050b5844a1a4fe2505d503/lib/rubocop/cop/mixin/configurable_enforced_style.rb#L37) is called. The offense gets registered (and corrected).
3. When further hash braces are encountered, `no_acceptable_style?` returns true, and [`style_detected` short-circuits](https://github.com/rubocop-hq/rubocop/blob/d3f6b097a8fc65a64d050b5844a1a4fe2505d503/lib/rubocop/cop/mixin/configurable_enforced_style.rb#L24). This causes `incorrect_style_detected` to return before adding an offense, and **all further hash spacing issues are ignored in the file**.

My change is to not override style but pass in the style from config on both `correct_style_detected` and `incorrect_style_detected`, which prevents `no_acceptable_style?` from short-circuiting further offense detection. None of the other code or existing tests had to be changed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
