### PR TITLE
Fix a false positive for `Layout/DefEndAlignment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#8627](https://github.com/rubocop-hq/rubocop/issues/8627): Fix a false positive for `Lint/DuplicateRequire` when same feature argument but different require method. ([@koic][])
 * [#8572](https://github.com/rubocop-hq/rubocop/issues/8572): Fix a false positive for `Style/RedundantParentheses` when parentheses are used like method argument parentheses. ([@koic][])
+* [#8653](https://github.com/rubocop-hq/rubocop/pull/8653): Fix a false positive for `Layout/DefEndAlignment` when using refinements and `private def`. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/def_end_alignment.rb
+++ b/lib/rubocop/cop/layout/def_end_alignment.rb
@@ -46,7 +46,7 @@ module RuboCop
         alias on_defs on_def
 
         def on_send(node)
-          return unless node.def_modifier?
+          return if !node.def_modifier? || node.method?(:using)
 
           method_def = node.each_descendant(:def, :defs).first
           expr = node.source_range

--- a/spec/rubocop/cop/layout/def_end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/def_end_alignment_spec.rb
@@ -66,6 +66,21 @@ RSpec.describe RuboCop::Cop::Layout::DefEndAlignment, :config do
         RUBY
       end
     end
+
+    context 'when using refinements and `private def`' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          using Module.new {
+            refine Hash do
+              class << Hash
+                private def _ruby2_keywords_hash(*args)
+                end
+              end
+            end
+          }
+        RUBY
+      end
+    end
   end
 
   context 'when EnforcedStyleAlignWith is def' do


### PR DESCRIPTION
This PR fixes a false positive for `Layout/DefEndAlignment` when using refinements and `private def`.
It prevents the following error when auto-correcting.

```console
% cat example.rb
using Module.new {
  refine Hash do
        class << Hash
      private def _ruby2_keywords_hash(*args)
      end
    end
  end
}

% bundle exec rubocop -a --only Layout/DefEndAlignment example.rb
(snip)

Inspecting 1 file
W

Offenses:

example.rb:5:7: W: [Corrected] Layout/DefEndAlignment: end at 5, 6 is
not aligned with using Module.new {
  refine Hash do
        class << Hash
      private def at 1, 0.
      end
      ^^^

0 files inspected, 1 offense detected, 1 offense corrected
Infinite loop detected in
/Users/koic/src/github.com/koic/rubocop-issues/rails/example.rb.
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:289:in
`check_for_infinite_loop'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:272:in
`block in iterate_until_no_changes'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:271:in
`loop'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:271:in
`iterate_until_no_changes'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:242:in
`do_inspection_loop'
```

I found it with the following code.
https://github.com/rails/rails/blob/v6.0.3.2/activejob/lib/active_job/arguments.rb#L73-L96

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
