### PR TITLE
Fix a false positive for `Style/SafeNavigation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#8572](https://github.com/rubocop-hq/rubocop/issues/8572): Fix a false positive for `Style/RedundantParentheses` when parentheses are used like method argument parentheses. ([@koic][])
 * [#8653](https://github.com/rubocop-hq/rubocop/pull/8653): Fix a false positive for `Layout/DefEndAlignment` when using refinements and `private def`. ([@koic][])
 * [#8655](https://github.com/rubocop-hq/rubocop/pull/8655): Fix a false positive for `Style/ClassAndModuleChildren` when using cbase class name. ([@koic][])
+* [#8654](https://github.com/rubocop-hq/rubocop/pull/8654): Fix a false positive for `Style/SafeNavigation` when checking `foo&.empty?` in a conditional. ([@koic][])
 
 ### Changes
 

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -8653,6 +8653,10 @@ foo && foo.nil? # method that `nil` responds to
 foo && foo < bar
 foo < bar if foo
 
+# When checking `foo&.empty?` in a conditional, `foo` being `nil` will actually
+# do the opposite of what the author intends.
+foo && foo.empty?
+
 # This could start returning `nil` as well as the return of the method
 foo.nil? || foo.bar
 !foo || foo.bar

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -49,6 +49,10 @@ module RuboCop
       #   foo && foo < bar
       #   foo < bar if foo
       #
+      #   # When checking `foo&.empty?` in a conditional, `foo` being `nil` will actually
+      #   # do the opposite of what the author intends.
+      #   foo && foo.empty?
+      #
       #   # This could start returning `nil` as well as the return of the method
       #   foo.nil? || foo.bar
       #   !foo || foo.bar
@@ -104,6 +108,7 @@ module RuboCop
           # chain greater than 2
           return if chain_size(method_chain, method) > 1
           return if unsafe_method_used?(method_chain, method)
+          return if method_chain.method?(:empty?)
 
           add_offense(node) do |corrector|
             autocorrect(corrector, node)

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1581,6 +1581,24 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     RUBY
   end
 
+  it 'does not crash Lint/SafeNavigationWithEmpty and offenses and accepts Style/SafeNavigation ' \
+     'when checking `foo&.empty?` in a conditional' do
+    create_file('example.rb', <<~RUBY)
+      do_something if ENV['VERSION'] && ENV['VERSION'].empty?
+    RUBY
+    expect(
+      cli.run(
+        [
+          '--auto-correct',
+          '--only', 'Lint/SafeNavigationWithEmpty,Style/SafeNavigation'
+        ]
+      )
+    ).to eq(0)
+    expect(IO.read('example.rb')).to eq(<<~RUBY)
+      do_something if ENV['VERSION'] && ENV['VERSION'].empty?
+    RUBY
+  end
+
   it 'corrects TrailingCommaIn(Array|Hash)Literal and ' \
      'Multiline(Array|Hash)BraceLayout offenses' do
     create_file('.rubocop.yml', <<~YAML)

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -90,6 +90,10 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
     expect_no_offenses('foo && foo.bar !~ /baz/')
   end
 
+  it 'allows an object check before a method call that is used with `empty?`' do
+    expect_no_offenses('foo && foo.empty?')
+  end
+
   it 'allows an object check before a method call that is used in ' \
      'a spaceship comparison' do
     expect_no_offenses('foo && foo.bar <=> baz')


### PR DESCRIPTION
This PR fixes the following error for `Style/SafeNavigation` when checking `foo&.empty?` in a conditional.

```console
% cat example.rb
do_something if ENV['VERSION'] && ENV['VERSION'].empty?

% bunble exec rubocop -a example.rb --only Style/SafeNavigation,Lint/SafeNavigationWithEmpty
(snip)

Inspecting 1 file
W

Offenses:

example.rb:1:17: W: [Corrected] Lint/SafeNavigationWithEmpty: Avoid
calling empty? with the safe navigation operator in conditionals.
do_something if ENV['VERSION']&.empty?
                ^^^^^^^^^^^^^^^^^^^^^^
example.rb:1:17: C: [Corrected] Style/SafeNavigation: Use safe
navigation (&.) instead of checking if an object exists before calling
the method.
do_something if ENV['VERSION'] && ENV['VERSION'].empty?
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

0 files inspected, 2 offenses detected, 2 offenses corrected
Infinite loop detected in
/Users/koic/src/github.com/koic/rubocop-issues/rails/example.rb.
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:289:in
`check_for_infinite_loop'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:272:in
`block in iterate_until_no_changes'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:271:in
`loop'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:271:in
`iterate_until_no_changes'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:242:in
`do_inspection_loop'
```

I found it with the following code.
https://github.com/rails/rails/blob/v6.0.3.2/activerecord/lib/active_record/railties/databases.rake#L120

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
