### PR TITLE
Fix a false positive for `Style/ClassAndModuleChildren`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#8627](https://github.com/rubocop-hq/rubocop/issues/8627): Fix a false positive for `Lint/DuplicateRequire` when same feature argument but different require method. ([@koic][])
 * [#8572](https://github.com/rubocop-hq/rubocop/issues/8572): Fix a false positive for `Style/RedundantParentheses` when parentheses are used like method argument parentheses. ([@koic][])
 * [#8653](https://github.com/rubocop-hq/rubocop/pull/8653): Fix a false positive for `Layout/DefEndAlignment` when using refinements and `private def`. ([@koic][])
+* [#8655](https://github.com/rubocop-hq/rubocop/pull/8655): Fix a false positive for `Style/ClassAndModuleChildren` when using cbase class name. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -32,6 +32,7 @@ module RuboCop
                       'nested style.'
 
         def on_class(node)
+          return if node.identifier.children[0]&.cbase_type?
           return if node.parent_class && style != :nested
 
           check_style(node, node.body)

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -60,6 +60,13 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
       RUBY
     end
 
+    it 'accepts cbase class name' do
+      expect_no_offenses(<<~RUBY)
+        class ::Foo
+        end
+      RUBY
+    end
+
     it 'accepts :: in parent class on inheritance' do
       expect_no_offenses(<<~RUBY)
         class FooClass


### PR DESCRIPTION
This PR fixes the following incorrect auto-correct for `Style/ClassAndModuleChildren` when using cbase class name.

```console
% cat example.rb
class ::Foo
end

% bundle exec rubocop -A --only Style/ClassAndModuleChildren
(snip)

Inspecting 1 file
C

Offenses:

example.rb:1:7: C: [Corrected] Style/ClassAndModuleChildren: Use nested
module/class definitions instead of compact style.
class ::Foo
      ^^^^^

1 file inspected, 1 offense detected, 1 offense corrected

% cat example.rb
module
  class Foo
  end
end

% ruby -c example.rb
example.rb:3: syntax error, unexpected '\n', expecting '.' or &. or :: or '['
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
