### PR TITLE
Fix documentation markup in auto_correct.adoc

### DIFF
--- a/docs/modules/ROOT/pages/usage/auto_correct.adoc
+++ b/docs/modules/ROOT/pages/usage/auto_correct.adoc
@@ -80,7 +80,7 @@ str << 'world' # => now fails because `str` is frozen
 
 str = +'hello' # => We want an unfrozen string literal here...
 str << 'world' # => ok
----
+----
 
 This diagnostic is valid since the magic comment is indeed missing (thus `Safe: true`),
 but the auto-correction is not; some string literals need to be prefixed with `+` to avoid


### PR DESCRIPTION
A forgotten dash leads to wrong html output, as seen here, in the bottom of the page: https://docs.rubocop.org/rubocop/0.90/usage/auto_correct.html

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
