### PR TITLE
Fix a false positive for `Style/RedundantSelfAssignment` when calling coercion methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug fixes
 
 * [#8627](https://github.com/rubocop-hq/rubocop/issues/8627): Fix a false positive for `Lint/DuplicateRequire` when same feature argument but different require method. ([@koic][])
+* [#8658](https://github.com/rubocop-hq/rubocop/pull/8658): Fix a false positive for `Style/RedundantSelfAssignment` when calling coercion methods. ([@fatkodima][])
 * [#8607](https://github.com/rubocop-hq/rubocop/issues/8607): Fix a false positive for `Lint/UnreachableLoop` when conditional branch includes continue statement preceding break statement. ([@fatkodima][])
 * [#8572](https://github.com/rubocop-hq/rubocop/issues/8572): Fix a false positive for `Style/RedundantParentheses` when parentheses are used like method argument parentheses. ([@koic][])
 * [#8653](https://github.com/rubocop-hq/rubocop/pull/8653): Fix a false positive for `Layout/DefEndAlignment` when using refinements and `private def`. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_self_assignment.rb
+++ b/lib/rubocop/cop/style/redundant_self_assignment.rb
@@ -37,8 +37,8 @@ module RuboCop
         METHODS_RETURNING_SELF = %i[
           append clear collect! compare_by_identity concat delete_if
           fill initialize_copy insert keep_if map! merge! prepend push
-          rehash replace reverse! rotate! shuffle! sort! sort_by! to_ary
-          to_hash transform_keys! transform_values! unshift update
+          rehash replace reverse! rotate! shuffle! sort! sort_by!
+          transform_keys! transform_values! unshift update
         ].to_set.freeze
 
         ASSIGNMENT_TYPE_TO_RECEIVER_TYPE = {


### PR DESCRIPTION
Those two returns self, not modifies its receiver in place. So that was my mistake when implementing this cop.