### PR TITLE
Fix `Lint/UselessMethodDefinition` to not register an offense when method definition includes optional arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Changes
 
 * [#8470](https://github.com/rubocop-hq/rubocop/issues/8470): Do not autocorrect `Style/StringConcatenation` when parts of the expression are too complex. ([@dvandersluis][])
+* [#8561](https://github.com/rubocop-hq/rubocop/issues/8561): Fix `Lint/UselessMethodDefinition` to not register an offense when method definition includes optional arguments. ([@fatkodima][])
 * [#8617](https://github.com/rubocop-hq/rubocop/issues/8617): Fix `Style/HashAsLastArrayItem` to not register an offense when all items in an array are hashes. ([@dvandersluis][])
 
 ## 0.90.0 (2020-09-01)

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -4621,6 +4621,11 @@ def method
   super
 end
 
+# good - with default arguments
+def initialize(x = Object.new)
+  super
+end
+
 # good
 def initialize
   initialize_internals

--- a/lib/rubocop/cop/lint/useless_method_definition.rb
+++ b/lib/rubocop/cop/lint/useless_method_definition.rb
@@ -18,6 +18,11 @@ module RuboCop
       #     super
       #   end
       #
+      #   # good - with default arguments
+      #   def initialize(x = Object.new)
+      #     super
+      #   end
+      #
       #   # good
       #   def initialize
       #     initialize_internals
@@ -46,6 +51,7 @@ module RuboCop
         MSG = 'Useless method definition detected.'
 
         def on_def(node)
+          return if optional_args?(node)
           return unless (constructor?(node) && empty_constructor?(node)) ||
                         delegating?(node.body, node)
 
@@ -54,6 +60,10 @@ module RuboCop
         alias on_defs on_def
 
         private
+
+        def optional_args?(node)
+          node.arguments.any? { |arg| arg.optarg_type? || arg.kwoptarg_type? }
+        end
 
         def empty_constructor?(node)
           return false if node.body

--- a/spec/rubocop/cop/lint/useless_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/useless_method_definition_spec.rb
@@ -148,6 +148,22 @@ RSpec.describe RuboCop::Cop::Lint::UselessMethodDefinition, :config do
     RUBY
   end
 
+  it 'does not register an offense when method definition contains optional argument' do
+    expect_no_offenses(<<~RUBY)
+      def method(x = 1)
+        super
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when method definition contains optional keyword argument' do
+    expect_no_offenses(<<~RUBY)
+      def method(x: 1)
+        super
+      end
+    RUBY
+  end
+
   it 'does not register an offense when non-constructor contains only comments' do
     expect_no_offenses(<<~RUBY)
       def non_constructor


### PR DESCRIPTION
Closes #8561