### PR TITLE
Fix an incorrect auto-correct for `Style/MultilineTernaryOperator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#8626](https://github.com/rubocop-hq/rubocop/issues/8626): Fix false negatives for `Lint/UselessMethodDefinition`. ([@marcandre][])
 * [#8698](https://github.com/rubocop-hq/rubocop/pull/8698): Fix cache to avoid encoding exception. ([@marcandre][])
 * [#8704](https://github.com/rubocop-hq/rubocop/issues/8704): Fix an error for `Lint/AmbiguousOperator` when using safe navigation operator with a unary operator. ([@koic][])
+* [#8661](https://github.com/rubocop-hq/rubocop/pull/8661): Fix an incorrect auto-correct for `Style/MultilineTernaryOperator` when returning a multiline ternary operator expression. ([@koic][])
 
 ### Changes
 

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -5757,6 +5757,9 @@ end
 
 This cop checks for multi-line ternary op expressions.
 
+NOTE: `return if ... else ... end` is syntax error. If `return` is used before
+multiline ternary operator expression, it cannot be auto-corrected.
+
 === Examples
 
 [source,ruby]

--- a/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
@@ -53,6 +53,17 @@ RSpec.describe RuboCop::Cop::Style::MultilineTernaryOperator do
     RUBY
   end
 
+  it 'register an offense and does not auto-correct when returning a multiline ternary operator expression' do
+    expect_offense(<<~RUBY)
+      return cond ?
+             ^^^^^^ Avoid multi-line ternary operators, use `if` or `unless` instead.
+             foo :
+             bar
+    RUBY
+
+    expect_no_corrections
+  end
+
   it 'accepts a single line ternary operator expression' do
     expect_no_offenses('a = cond ? b : c')
   end


### PR DESCRIPTION
This PR fixes the following incorrect auto-correct for `Style/MultilineTernaryOperator` when returning a multiline ternary operator expression.

```console
% cat example.rb
return distance_in_minutes == 0 ?
       locale.t(:less_than_x_minutes, count: 1) :
       locale.t(:x_minutes, count: distance_in_minutes)

% bundle exec rubocop -a --only Style/MultilineTernaryOperator
(snip)

Inspecting 2 files
C.

Offenses:

example.rb:1:8: C: [Corrected] Style/MultilineTernaryOperator: Avoid
multi-line ternary operators, use if or unless instead.
return distance_in_minutes == 0 ? ...
       ^^^^^^^^^^^^^^^^^^^^^^^^^^

2 files inspected, 1 offense detected, 1 offense corrected

% cat example.rb
return if distance_in_minutes == 0
  locale.t(:less_than_x_minutes, count: 1)
else
  locale.t(:x_minutes, count: distance_in_minutes)
end

% ruby -c example.rb
example.rb:3: syntax error, unexpected `else', expecting end-of-input
```

I found it with the following code.
https://github.com/rails/rails/blob/v6.0.3.2/actionview/lib/action_view/helpers/date_helper.rb#L109-L111

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
