### PR TITLE
[Fix #8500] Add `in?` to AllowedMethods for `Lint/SafeNavigationChain` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#8470](https://github.com/rubocop-hq/rubocop/issues/8470): Do not autocorrect `Style/StringConcatenation` when parts of the expression are too complex. ([@dvandersluis][])
 * [#8561](https://github.com/rubocop-hq/rubocop/issues/8561): Fix `Lint/UselessMethodDefinition` to not register an offense when method definition includes optional arguments. ([@fatkodima][])
 * [#8617](https://github.com/rubocop-hq/rubocop/issues/8617): Fix `Style/HashAsLastArrayItem` to not register an offense when all items in an array are hashes. ([@dvandersluis][])
+* [#8500](https://github.com/rubocop-hq/rubocop/issues/8500): Add `in?` to AllowedMethods for `Lint/SafeNavigationChain` cop. ([@tejasbubane][])
 
 ## 0.90.0 (2020-09-01)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1799,6 +1799,7 @@ Lint/SafeNavigationChain:
     - presence
     - try
     - try!
+    - in?
 
 Lint/SafeNavigationConsistency:
   Description: >-

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -3193,7 +3193,7 @@ x&.foo || bar
 | Name | Default value | Configurable values
 
 | AllowedMethods
-| `present?`, `blank?`, `presence`, `try`, `try!`
+| `present?`, `blank?`, `presence`, `try`, `try!`, `in?`
 | Array
 |===
 

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
-  let(:cop_config) do
-    { 'AcceptedMethods' => %w[present? blank? try presence] }
-  end
-
   shared_examples 'accepts' do |name, code|
     it "accepts usages of #{name}" do
       expect_no_offenses(code)
@@ -31,7 +27,8 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
     ['safe navigation with `try` method', 'a&.b.try(:c)'],
     ['safe navigation with assignment method', 'x&.foo = bar'],
     ['safe navigation with self assignment method', 'x&.foo += bar'],
-    ['safe navigation with `to_d` method', 'x&.foo.to_d']
+    ['safe navigation with `to_d` method', 'x&.foo.to_d'],
+    ['safe navigation with `in?` method', 'x&.foo.in?([:baz, :qux])']
   ].each do |name, code|
     include_examples 'accepts', name, code
   end


### PR DESCRIPTION
Closes https://github.com/rubocop-hq/rubocop/issues/8500

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/