### PR TITLE
[Fix #8664] Fix a false positive for `Naming/BinaryOperatorParameterName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#8655](https://github.com/rubocop-hq/rubocop/pull/8655): Fix a false positive for `Style/ClassAndModuleChildren` when using cbase class name. ([@koic][])
 * [#8654](https://github.com/rubocop-hq/rubocop/pull/8654): Fix a false positive for `Style/SafeNavigation` when checking `foo&.empty?` in a conditional. ([@koic][])
 * [#8660](https://github.com/rubocop-hq/rubocop/pull/8660): Fix a false positive for `Style/ClassAndModuleChildren` when using cbase module name. ([@koic][])
+* [#8664](https://github.com/rubocop-hq/rubocop/issues/8664): Fix a false positive for `Naming/BinaryOperatorParameterName` when naming multibyte character method name. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
+++ b/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
@@ -35,7 +35,7 @@ module RuboCop
         def op_method?(name)
           return false if EXCLUDED.include?(name)
 
-          !/\A\w/.match?(name) || OP_LIKE_METHODS.include?(name)
+          !/\A[[:word:]]/.match?(name) || OP_LIKE_METHODS.include?(name)
         end
       end
     end

--- a/spec/rubocop/cop/naming/binary_operator_parameter_name_spec.rb
+++ b/spec/rubocop/cop/naming/binary_operator_parameter_name_spec.rb
@@ -81,6 +81,14 @@ RSpec.describe RuboCop::Cop::Naming::BinaryOperatorParameterName do
     RUBY
   end
 
+  it 'does not register an offense for multibyte character method name' do
+    expect_no_offenses(<<~RUBY)
+      def ｄｏ＿ｓｏｍｅｔｈｉｎｇ(string)
+        string
+      end
+    RUBY
+  end
+
   it 'does not register an offense for non binary operators' do
     expect_no_offenses(<<~RUBY)
       def -@; end


### PR DESCRIPTION
Fixes #8664.

This PR fixes a false positive for `Naming/BinaryOperatorParameterName` when naming multibyte characters method name.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
