### PR TITLE
[Fix #8604] Fix a false positive for `Bundler/DuplicatedGem` when gem is duplicated in condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#8654](https://github.com/rubocop-hq/rubocop/pull/8654): Fix a false positive for `Style/SafeNavigation` when checking `foo&.empty?` in a conditional. ([@koic][])
 * [#8660](https://github.com/rubocop-hq/rubocop/pull/8660): Fix a false positive for `Style/ClassAndModuleChildren` when using cbase module name. ([@koic][])
 * [#8664](https://github.com/rubocop-hq/rubocop/issues/8664): Fix a false positive for `Naming/BinaryOperatorParameterName` when naming multibyte character method name. ([@koic][])
+* [#8604](https://github.com/rubocop-hq/rubocop/issues/8604): Fix a false positive for `Bundler/DuplicatedGem` when gem is duplciated in condition. ([@tejasbubane][])
 
 ### Changes
 

--- a/lib/rubocop/cop/bundler/duplicated_gem.rb
+++ b/lib/rubocop/cop/bundler/duplicated_gem.rb
@@ -53,7 +53,11 @@ module RuboCop
           gem_declarations(processed_source.ast)
             .group_by(&:first_argument)
             .values
-            .select { |nodes| nodes.size > 1 }
+            .select { |nodes| nodes.size > 1 && !condition?(nodes) }
+        end
+
+        def condition?(nodes)
+          nodes[0].parent&.if_type? && nodes[0].parent == nodes[1].parent
         end
 
         def register_offense(node, gem_name, line_of_first_occurrence)

--- a/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
+++ b/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
@@ -51,5 +51,17 @@ RSpec.describe RuboCop::Cop::Bundler::DuplicatedGem, :config do
         GEM
       end
     end
+
+    context 'and the gem is conditionally duplicated' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-GEM, 'Gemfile')
+          if Dir.exist? local
+            gem 'rubocop', path: local
+          else
+            gem 'rubocop', '~> 0.90.0'
+          end
+        GEM
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes https://github.com/rubocop-hq/rubocop/issues/8604

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/