### PR TITLE
Clean up unused spec setup

### DIFF
--- a/spec/rubocop/config_obsoletion_spec.rb
+++ b/spec/rubocop/config_obsoletion_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe RuboCop::ConfigObsoletion do
   let(:loaded_path) { 'example/.rubocop.yml' }
 
   describe '#validate', :isolated_environment do
-    let(:configuration_path) { '.rubocop.yml' }
-
     context 'when the configuration includes any obsolete cop name' do
       let(:hash) do
         {

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe RuboCop::Cop::Cop, :config do
     end
 
     context 'when the option is not given' do
-      let(:options) { {} }
+      let(:cop_options) { {} }
 
       it { is_expected.to be(false) }
     end

--- a/spec/rubocop/cop/gemspec/ordered_dependencies_spec.rb
+++ b/spec/rubocop/cop/gemspec/ordered_dependencies_spec.rb
@@ -55,16 +55,6 @@ RSpec.describe RuboCop::Cop::Gemspec::OrderedDependencies, :config do
       end
 
       context 'when dependency is separated by multiline comment' do
-        let(:source) { <<~RUBY }
-          Gem::Specification.new do |spec|
-            # For code quality
-            spec.#{add_dependency} 'rubocop'
-            # For
-            # test
-            spec.#{add_dependency} 'rspec'
-          end
-        RUBY
-
         context 'with TreatCommentsAsGroupSeparators: true' do
           let(:treat_comments_as_group_separators) { true }
 

--- a/spec/rubocop/cop/layout/argument_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/argument_alignment_spec.rb
@@ -359,15 +359,6 @@ RSpec.describe RuboCop::Cop::Layout::ArgumentAlignment do
       }
     end
 
-    let(:correct_source) do
-      <<~RUBY
-        create :transaction, :closed,
-          account:     account,
-          open_price:  1.29,
-          close_price: 1.30
-      RUBY
-    end
-
     it 'autocorrects by outdenting when indented too far' do
       expect_offense(<<~RUBY)
         create :transaction, :closed,

--- a/spec/rubocop/cop/layout/def_end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/def_end_alignment_spec.rb
@@ -1,18 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::DefEndAlignment, :config do
-  let(:source) do
-    <<~RUBY
-      foo def a
-        a1
-      end
-
-      foo def b
-            b1
-          end
-    RUBY
-  end
-
   context 'when EnforcedStyleAlignWith is start_of_line' do
     let(:cop_config) do
       { 'EnforcedStyleAlignWith' => 'start_of_line', 'AutoCorrect' => true }

--- a/spec/rubocop/cop/layout/space_inside_array_percent_literal_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_array_percent_literal_spec.rb
@@ -3,10 +3,6 @@
 RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayPercentLiteral do
   subject(:cop) { described_class.new }
 
-  let(:message) do
-    'Use only a single space inside array percent literal.'
-  end
-
   %w[i I w W].each do |type|
     [%w[{ }], %w[( )], %w([ ]), %w[! !]].each do |(ldelim, rdelim)|
       context "for #{type} type and #{[ldelim, rdelim]} delimiters" do

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -4,8 +4,6 @@ require 'rubocop/cop/legacy/corrector'
 
 RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
   describe '.check' do
-    subject(:resulting_offenses) { cop.send(:complete_investigation).offenses }
-
     let(:offenses) { [] }
     let(:cop) { cop_class.new(config, cop_options, offenses) }
 

--- a/spec/rubocop/cop/style/multiline_memoization_spec.rb
+++ b/spec/rubocop/cop/style/multiline_memoization_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::MultilineMemoization, :config do
-  let(:message) { 'Wrap multiline memoization blocks in `begin` and `end`.' }
-
   shared_examples 'with all enforced styles' do
     context 'with a single line memoization' do
       it 'allows expression on first line' do

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -3,11 +3,6 @@
 RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
   let(:cop_config) { { 'ConvertCodeThatCanStartToReturnNil' => false } }
 
-  let(:message) do
-    'Use safe navigation (`&.`) instead of checking if an object ' \
-    'exists before calling the method.'
-  end
-
   it 'allows calls to methods not safeguarded by respond_to' do
     expect_no_offenses('foo.bar')
   end

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -79,8 +79,6 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
   end
 
   context 'when the method has arguments' do
-    let(:source) { 'method(one, 2) { |x| x.test }' }
-
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         method(one, 2) { |x| x.test }
@@ -122,8 +120,6 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
   end
 
   context 'when `super` has arguments' do
-    let(:source) { 'super(one, two) { |x| x.test }' }
-
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         super(one, two) { |x| x.test }
@@ -137,8 +133,6 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
   end
 
   context 'when `super` has no arguments' do
-    let(:source) { 'super { |x| x.test }' }
-
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         super { |x| x.test }

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
     described_class.new(file, team, options, config_store, cache_root)
   end
 
-  let(:cops) { RuboCop::Cop::Registry.all }
   let(:registry) { RuboCop::Cop::Registry.global }
   let(:team) do
     RuboCop::Cop::Team.mobilize(


### PR DESCRIPTION
- Removes various test setup that is no longer in use discovered with [rspectre](https://github.com/dgollahon/rspectre). (Most cases are instances of leftovers from switching to the `expect_` style of tests).
- Fixes cop spec where an `options` `let` was never consumed by anything. I believe this test was meant to test the behavior when `cop_options` was empty.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
