### PR TITLE
Fix an error for `Layout/EmptyLineAfterMultilineCondition` when conditional is at the top level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug fixes
 
 * [#8627](https://github.com/rubocop-hq/rubocop/issues/8627): Fix a false positive for `Lint/DuplicateRequire` when same feature argument but different require method. ([@koic][])
+* [#8674](https://github.com/rubocop-hq/rubocop/issues/8674): Fix an error for `Layout/EmptyLineAfterMultilineCondition` when conditional is at the top level. ([@fatkodima][])
 * [#8658](https://github.com/rubocop-hq/rubocop/pull/8658): Fix a false positive for `Style/RedundantSelfAssignment` when calling coercion methods. ([@fatkodima][])
 * [#8607](https://github.com/rubocop-hq/rubocop/issues/8607): Fix a false positive for `Lint/UnreachableLoop` when conditional branch includes continue statement preceding break statement. ([@fatkodima][])
 * [#8572](https://github.com/rubocop-hq/rubocop/issues/8572): Fix a false positive for `Style/RedundantParentheses` when parentheses are used like method argument parentheses. ([@koic][])

--- a/lib/rubocop/cop/layout/empty_line_after_multiline_condition.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_multiline_condition.rb
@@ -62,7 +62,7 @@ module RuboCop
           return if node.ternary?
 
           if node.modifier_form?
-            check_condition(node.condition) unless next_sibling_empty?(node)
+            check_condition(node.condition) if right_sibling(node)
           else
             check_condition(node.condition)
           end
@@ -74,7 +74,7 @@ module RuboCop
         alias on_until on_while
 
         def on_while_post(node)
-          return if next_sibling_empty?(node)
+          return unless right_sibling(node)
 
           check_condition(node.condition)
         end
@@ -116,9 +116,10 @@ module RuboCop
           processed_source[line].blank?
         end
 
-        def next_sibling_empty?(node)
-          next_sibling = node.parent.children[node.sibling_index + 1]
-          next_sibling.nil?
+        def right_sibling(node)
+          return unless node.parent
+
+          node.parent.children[node.sibling_index + 1]
         end
 
         def multiline_when_condition?(when_node)

--- a/spec/rubocop/cop/layout/empty_line_after_multiline_condition_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_multiline_condition_spec.rb
@@ -59,6 +59,12 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMultilineCondition do
     RUBY
   end
 
+  it 'does not register an offense when `if` at the top level' do
+    expect_no_offenses(<<~RUBY)
+      do_something if condition
+    RUBY
+  end
+
   it 'registers an offense when no new line after `elsif` with multiline condition' do
     expect_offense(<<~RUBY)
       if condition


### PR DESCRIPTION
Closes #8674
