### PR TITLE
Fix a false positive for Style/HashTransformKeys and Style/HashTransformValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#8664](https://github.com/rubocop-hq/rubocop/issues/8664): Fix a false positive for `Naming/BinaryOperatorParameterName` when naming multibyte character method name. ([@koic][])
 * [#8604](https://github.com/rubocop-hq/rubocop/issues/8604): Fix a false positive for `Bundler/DuplicatedGem` when gem is duplciated in condition. ([@tejasbubane][])
 * [#8671](https://github.com/rubocop-hq/rubocop/issues/8671): Fix an error for `Style/ExplicitBlockArgument` when using safe navigation method call. ([@koic][])
+* [#8682](https://github.com/rubocop-hq/rubocop/pull/8682): Fix a positive for `Style/HashTransformKeys` and `Style/HashTransformValues` when the `each_with_object` hash is used in the transformed key or value. ([@eugeneius][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/hash_transform_keys.rb
+++ b/lib/rubocop/cop/style/hash_transform_keys.rb
@@ -40,7 +40,7 @@ module RuboCop
                 (arg $_)
                 (arg _val))
               (arg _memo))
-            ({send csend} (lvar _memo) :[]= $_ $(lvar _val)))
+            ({send csend} (lvar _memo) :[]= $!`_memo $(lvar _val)))
         PATTERN
 
         def_node_matcher :on_bad_hash_brackets_map, <<~PATTERN

--- a/lib/rubocop/cop/style/hash_transform_values.rb
+++ b/lib/rubocop/cop/style/hash_transform_values.rb
@@ -37,7 +37,7 @@ module RuboCop
                 (arg _key)
                 (arg $_))
               (arg _memo))
-            ({send csend} (lvar _memo) :[]= $(lvar _key) $_))
+            ({send csend} (lvar _memo) :[]= $(lvar _key) $!`_memo))
         PATTERN
 
         def_node_matcher :on_bad_hash_brackets_map, <<~PATTERN

--- a/spec/rubocop/cop/style/hash_transform_keys_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_keys_spec.rb
@@ -65,6 +65,12 @@ RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
       RUBY
     end
 
+    it 'does not flag `each_with_object` when its argument is used in the key' do
+      expect_no_offenses(<<~RUBY)
+        x.each_with_object({}) { |(k, v), h| h[h[k.to_sym]] = v }
+      RUBY
+    end
+
     it 'does not flag each_with_object when its receiver is array literal' do
       expect_no_offenses(<<~RUBY)
         [1, 2, 3].each_with_object({}) {|(k, v), h| h[foo(k)] = v}

--- a/spec/rubocop/cop/style/hash_transform_values_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_values_spec.rb
@@ -64,6 +64,12 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
     RUBY
   end
 
+  it 'does not flag `each_with_object` when its argument is used in the value' do
+    expect_no_offenses(<<~RUBY)
+      x.each_with_object({}) { |(k, v), h| h[k] = h.count }
+    RUBY
+  end
+
   it 'does not flag each_with_object when receiver is array literal' do
     expect_no_offenses(<<~RUBY)
       [1, 2, 3].each_with_object({}) {|(k, v), h| h[k] = foo(v)}


### PR DESCRIPTION
See also https://github.com/rubocop-hq/rubocop-rails/pull/353.

If the `each_with_object` hash is used in the transformed key or value, `Style/HashTransformKeys` or `Style/HashTransformValues` can't be used.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/