### PR TITLE
[Fix #8689] Fix exception when Rainbow output passed to warn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#8604](https://github.com/rubocop-hq/rubocop/issues/8604): Fix a false positive for `Bundler/DuplicatedGem` when gem is duplciated in condition. ([@tejasbubane][])
 * [#8671](https://github.com/rubocop-hq/rubocop/issues/8671): Fix an error for `Style/ExplicitBlockArgument` when using safe navigation method call. ([@koic][])
 * [#8682](https://github.com/rubocop-hq/rubocop/pull/8682): Fix a positive for `Style/HashTransformKeys` and `Style/HashTransformValues` when the `each_with_object` hash is used in the transformed key or value. ([@eugeneius][])
+* [#8689](https://github.com/rubocop-hq/rubocop/issues/8689): Fix exception when Rainbow output is passed to warn. ([@aquistech][])
 
 ### Changes
 
@@ -4856,3 +4857,4 @@
 [@jaimerave]: https://github.com/jaimerave
 [@Skipants]: https://github.com/Skipants
 [@sascha-wolf]: https://github.com/sascha-wolf
+[@aquistech]: https://github.com/AquisTech

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -44,7 +44,7 @@ module RuboCop
       warn e.message
       STATUS_ERROR
     rescue RuboCop::Error => e
-      warn Rainbow("Error: #{e.message}").red
+      warn Rainbow("Error: #{e.message}").red.to_s
       STATUS_ERROR
     rescue Finished
       STATUS_SUCCESS

--- a/lib/rubocop/cli/command/execute_runner.rb
+++ b/lib/rubocop/cli/command/execute_runner.rb
@@ -38,7 +38,7 @@ module RuboCop
         def display_warning_summary(warnings)
           return if warnings.empty?
 
-          warn Rainbow("\n#{pluralize(warnings.size, 'warning')}:").yellow
+          warn Rainbow("\n#{pluralize(warnings.size, 'warning')}:").yellow.to_s
 
           warnings.each { |warning| warn warning }
         end
@@ -46,7 +46,7 @@ module RuboCop
         def display_error_summary(errors)
           return if errors.empty?
 
-          warn Rainbow("\n#{pluralize(errors.size, 'error')} occurred:").red
+          warn Rainbow("\n#{pluralize(errors.size, 'error')} occurred:").red.to_s
 
           errors.each { |error| warn error }
 

--- a/lib/rubocop/cli/command/init_dotfile.rb
+++ b/lib/rubocop/cli/command/init_dotfile.rb
@@ -14,7 +14,7 @@ module RuboCop
           path = File.expand_path(DOTFILE)
 
           if File.exist?(DOTFILE)
-            warn Rainbow("#{DOTFILE} already exists at #{path}").red
+            warn Rainbow("#{DOTFILE} already exists at #{path}").red.to_s
 
             STATUS_ERROR
           else

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -151,20 +151,20 @@ module RuboCop
       def warn_on_pending_cops(pending_cops)
         return if pending_cops.empty?
 
-        warn Rainbow(PENDING_BANNER).yellow
+        warn Rainbow(PENDING_BANNER).yellow.to_s
 
         pending_cops.each do |cop|
           warn_pending_cop cop
         end
 
-        warn Rainbow('For more information: https://docs.rubocop.org/rubocop/versioning.html').yellow
+        warn Rainbow('For more information: https://docs.rubocop.org/rubocop/versioning.html').yellow.to_s
       end
 
       def warn_pending_cop(cop)
         version = cop.metadata['VersionAdded'] || 'N/A'
 
-        warn Rainbow("#{cop.name}: # (new in #{version})").yellow
-        warn Rainbow('  Enabled: true').yellow
+        warn Rainbow("#{cop.name}: # (new in #{version})").yellow.to_s
+        warn Rainbow('  Enabled: true').yellow.to_s
       end
 
       # Merges the given configuration with the default one.
@@ -224,7 +224,7 @@ module RuboCop
                     else
                       "#{smart_path}: `#{value}` is concealed by duplicate"
                     end
-          warn Rainbow(message).yellow
+          warn Rainbow(message).yellow.to_s
         end
       end
 

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -128,7 +128,7 @@ module RuboCop
       valid_cop_names.each do |name|
         validate_section_presence(name)
         each_invalid_parameter(name) do |param, supported_params|
-          warn Rainbow(<<~MESSAGE).yellow
+          warn Rainbow(<<~MESSAGE).yellow.to_s
             Warning: #{name} does not support #{param} parameter.
 
             Supported parameters are:

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -422,7 +422,7 @@ module RuboCop
         else
           message = "Warning: Invalid severity '#{severity}'. " \
             "Valid severities are #{Severity::NAMES.join(', ')}."
-          warn(Rainbow(message).red)
+          warn(Rainbow(message).red.to_s)
         end
       end
     end

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -237,7 +237,7 @@ module RuboCop
         message = Rainbow("#{error.message} (from file: #{location})").yellow
 
         @warnings << message
-        warn message
+        warn message.to_s
         puts error.backtrace if debug?
       end
 
@@ -245,7 +245,7 @@ module RuboCop
         message = Rainbow("An error occurred while #{cop.name}" \
                            " cop was inspecting #{location}.").red
         @errors << message
-        warn message
+        warn message.to_s
         if debug?
           puts error.message, error.backtrace
         else


### PR DESCRIPTION
This pull request fixes #8689 
All the places where colored text from Rainbow was passed to warn are converted to string using `to_s`
Before 
```
warn Rainbow('Some text').yellow
```
After
```
warn Rainbow('Some text').yellow.to_s
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [X] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
