### PR TITLE
Handling trailing whitespace in Heredoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@
 * [#8661](https://github.com/rubocop-hq/rubocop/pull/8661): Fix an incorrect auto-correct for `Style/MultilineTernaryOperator` when returning a multiline ternary operator expression. ([@koic][])
 * [#8526](https://github.com/rubocop-hq/rubocop/pull/8526): Fix a false positive for `Style/CaseEquality` cop when the receiver is not a camel cased constant. ([@koic][])
 * [#8673](https://github.com/rubocop-hq/rubocop/issues/8673): Fix the JSON parse error when specifying `--format=json` and `--stdin` options. ([@koic][])
+* [#8692](https://github.com/rubocop-hq/rubocop/pull/8692): Fix `Layout/TrailingWhitespace` auto-correction in heredoc. ([@marcandre][])
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#8882](https://github.com/rubocop-hq/rubocop/pull/8882): **(Potentially breaking)** RuboCop assumes that Cop classes do not define new `on_<type>` methods at runtime (e.g. via `extend` in `initialize`). ([@marcandre][])
 * [#7966](https://github.com/rubocop-hq/rubocop/issues/7966): **(Breaking)** Enable all pending cops for RuboCop 1.0. ([@koic][])
 * [#8490](https://github.com/rubocop-hq/rubocop/pull/8490): **(Breaking)** Change logic for cop department name computation. Cops inside deep namespaces (5 or more levels deep) now belong to departments with names that are calculated by joining module names starting from the third one with slashes as separators. For example, cop `Rubocop::Cop::Foo::Bar::Baz` now belongs to `Foo/Bar` department (previously it was `Bar`). ([@dsavochkin][])
+* [#8692](https://github.com/rubocop-hq/rubocop/pull/8692): Default changed to disallow `Layout/TrailingWhitespace` in heredoc. ([@marcandre][])
 
 ## 0.93.1 (2020-10-12)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1335,7 +1335,7 @@ Layout/TrailingWhitespace:
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.83'
-  AllowInHeredoc: true
+  AllowInHeredoc: false
 
 #################### Lint ##################################
 ### Warnings

--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -6360,7 +6360,7 @@ x = 0
 x = 0
 ----
 
-==== AllowInHeredoc: false
+==== AllowInHeredoc: false (default)
 
 [source,ruby]
 ----
@@ -6382,7 +6382,7 @@ code = <<~RUBY
 RUBY
 ----
 
-==== AllowInHeredoc: true (default)
+==== AllowInHeredoc: true
 
 [source,ruby]
 ----
@@ -6399,7 +6399,7 @@ RUBY
 | Name | Default value | Configurable values
 
 | AllowInHeredoc
-| `true`
+| `false`
 | Boolean
 |===
 

--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -6369,6 +6369,17 @@ x = 0
 code = <<~RUBY
   x = 0
 RUBY
+
+# ok
+code = <<~RUBY
+  x = 0 #{}
+RUBY
+
+# good
+trailing_whitespace = ' '
+code = <<~RUBY
+  x = 0#{trailing_whitespace}
+RUBY
 ----
 
 ==== AllowInHeredoc: true (default)

--- a/lib/rubocop/cop/layout/trailing_whitespace.rb
+++ b/lib/rubocop/cop/layout/trailing_whitespace.rb
@@ -14,7 +14,7 @@ module RuboCop
       #   # good
       #   x = 0
       #
-      # @example AllowInHeredoc: false
+      # @example AllowInHeredoc: false (default)
       #   # The line in this example contains spaces after the 0.
       #   # bad
       #   code = <<~RUBY
@@ -32,7 +32,7 @@ module RuboCop
       #     x = 0#{trailing_whitespace}
       #   RUBY
       #
-      # @example AllowInHeredoc: true (default)
+      # @example AllowInHeredoc: true
       #   # The line in this example contains spaces after the 0.
       #   # good
       #   code = <<~RUBY

--- a/lib/rubocop/cop/layout/trailing_whitespace.rb
+++ b/lib/rubocop/cop/layout/trailing_whitespace.rb
@@ -21,6 +21,17 @@ module RuboCop
       #     x = 0
       #   RUBY
       #
+      #   # ok
+      #   code = <<~RUBY
+      #     x = 0 #{}
+      #   RUBY
+      #
+      #   # good
+      #   trailing_whitespace = ' '
+      #   code = <<~RUBY
+      #     x = 0#{trailing_whitespace}
+      #   RUBY
+      #
       # @example AllowInHeredoc: true (default)
       #   # The line in this example contains spaces after the 0.
       #   # good
@@ -35,28 +46,36 @@ module RuboCop
         MSG = 'Trailing whitespace detected.'
 
         def on_new_investigation
-          heredoc_ranges = extract_heredoc_ranges(processed_source.ast)
+          @heredoc_ranges = extract_heredoc_ranges(processed_source.ast)
           processed_source.lines.each_with_index do |line, index|
-            lineno = index + 1
-
             next unless line.end_with?(' ', "\t")
-            next if skip_heredoc? && inside_heredoc?(heredoc_ranges, lineno)
 
-            range = offense_range(lineno, line)
-            add_offense(range) do |corrector|
-              corrector.remove(range)
-            end
+            process_line(line, index + 1)
           end
         end
 
         private
 
+        def process_line(line, lineno)
+          in_heredoc = inside_heredoc?(lineno)
+          return if skip_heredoc? && in_heredoc
+
+          range = offense_range(lineno, line)
+          add_offense(range) do |corrector|
+            if in_heredoc
+              corrector.insert_after(range, '#{}') # rubocop:disable Lint/InterpolationCheck
+            else
+              corrector.remove(range)
+            end
+          end
+        end
+
         def skip_heredoc?
           cop_config.fetch('AllowInHeredoc', false)
         end
 
-        def inside_heredoc?(heredoc_ranges, line_number)
-          heredoc_ranges.any? { |r| r.include?(line_number) }
+        def inside_heredoc?(line_number)
+          @heredoc_ranges.any? { |r| r.include?(line_number) }
         end
 
         def extract_heredoc_ranges(ast)

--- a/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
@@ -89,4 +89,25 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
       expect(offenses.size).to eq(1)
     end
   end
+
+  context 'when `AllowInHeredoc` is set to false' do
+    let(:cop_config) { { 'AllowInHeredoc' => false } }
+
+    it 'corrects safely trailing whitespace in a heredoc string' do
+      expect_offense(<<~RUBY)
+        x = <<~EXAMPLE
+          has trailing#{trailing_whitespace}
+                      ^ Trailing whitespace detected.
+          no trailing
+        EXAMPLE
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x = <<~EXAMPLE
+          has trailing \#{}
+          no trailing
+        EXAMPLE
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
@@ -109,5 +109,17 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
         EXAMPLE
       RUBY
     end
+
+    it 'does not correct trailing whitespace in a static heredoc string' do
+      expect_offense(<<~RUBY)
+        x = <<~'EXAMPLE'
+          has trailing#{trailing_whitespace}
+                      ^ Trailing whitespace detected.
+          no trailing
+        EXAMPLE
+      RUBY
+
+      expect_no_corrections
+    end
   end
 end


### PR DESCRIPTION
I extracted #8695 to remove all trailing whitespaces in our own codebase.

This PR fixes `Layout/TrailingWhitespace` auto-correction in Heredocs to be safe. Instead of removing the trailing whitespace (which is never equivalent), it inserts `#{}` after it (which evaluates to an empty string) and thus makes the trailing whitespace no longer trailing. Maybe a more explicit form like `#{ '' }` or `#{ :trailing_whitespace!; '' }` would be better though?

Given the fact that we can now autocorrect correctly trailing whitespaces in heredoc, and that they can be a pain to deal with for Rubyists like me that set their editor to automatically trim their whitesapce, I feel that the default should be changed in general. I assume that most projects have much less occurrences of trailing whitespace in their heredoc anyways.