### PR TITLE
[Fix #8683] Make naming cops work with non-ascii characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#8682](https://github.com/rubocop-hq/rubocop/pull/8682): Fix a positive for `Style/HashTransformKeys` and `Style/HashTransformValues` when the `each_with_object` hash is used in the transformed key or value. ([@eugeneius][])
 * [#8688](https://github.com/rubocop-hq/rubocop/issues/8688): Mark `Style/GlobalStdStream` as unsafe autocorrection. ([@marcandre][])
 * [#8642](https://github.com/rubocop-hq/rubocop/issues/8642): Fix a false negative for `Style/SpaceInsideHashLiteralBraces` when a correct empty hash precedes the incorrect hash. ([@dvandersluis][])
+* [#8683](https://github.com/rubocop-hq/rubocop/issues/8683): Make naming cops work with non-ascii characters. ([@tejasbubane][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/configurable_naming.rb
+++ b/lib/rubocop/cop/mixin/configurable_naming.rb
@@ -8,8 +8,8 @@ module RuboCop
       include ConfigurableFormatting
 
       FORMATS = {
-        snake_case: /^@{0,2}[\da-z_]+[!?=]?$/,
-        camelCase:  /^@{0,2}(?:_|_?[a-z][\da-zA-Z]*)[!?=]?$/
+        snake_case: /^@{0,2}[\d[[:lower:]]_]+[!?=]?$/,
+        camelCase:  /^@{0,2}(?:_|_?[[[:lower:]]][\d[[:lower:]][[:upper:]]]*)[!?=]?$/
       }.freeze
     end
   end

--- a/lib/rubocop/cop/naming/file_name.rb
+++ b/lib/rubocop/cop/naming/file_name.rb
@@ -33,7 +33,7 @@ module RuboCop
                             'called `%<namespace>s`.'
         MSG_REGEX = '`%<basename>s` should match `%<regex>s`.'
 
-        SNAKE_CASE = /^[\da-z_.?!]+$/.freeze
+        SNAKE_CASE = /^[\d[[:lower:]]_.?!]+$/.freeze
 
         def on_new_investigation
           file_path = processed_source.file_path

--- a/spec/rubocop/cop/naming/file_name_spec.rb
+++ b/spec/rubocop/cop/naming/file_name_spec.rb
@@ -468,4 +468,12 @@ RSpec.describe RuboCop::Cop::Naming::FileName do
       expect(offenses.empty?).to be(true)
     end
   end
+
+  context 'with non-ascii characters in filename' do
+    let(:filename) { '/some/dir/ünbound_sérvér.rb' }
+
+    it 'reports an offense' do
+      expect(offenses.empty?).to be(true)
+    end
+  end
 end

--- a/spec/rubocop/cop/naming/method_name_spec.rb
+++ b/spec/rubocop/cop/naming/method_name_spec.rb
@@ -344,4 +344,10 @@ RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
     include_examples 'never accepted',  'camelCase'
     include_examples 'multiple attr methods', 'camelCase'
   end
+
+  it 'works for non-ascii characters' do
+    expect_no_offenses(<<~RUBY)
+      def última_vista; end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/naming/variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/variable_name_spec.rb
@@ -213,6 +213,10 @@ RSpec.describe RuboCop::Cop::Naming::VariableName, :config do
       RUBY
     end
 
+    it 'works with non-ascii characters' do
+      expect_no_offenses('léo = 1')
+    end
+
     include_examples 'always accepted'
   end
 end


### PR DESCRIPTION
Closes https://github.com/rubocop-hq/rubocop/issues/8683

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/