### PR TITLE
[Fix #8673] Fix the JSON parse error when specifying `--format=json` and `--stdin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [#8704](https://github.com/rubocop-hq/rubocop/issues/8704): Fix an error for `Lint/AmbiguousOperator` when using safe navigation operator with a unary operator. ([@koic][])
 * [#8661](https://github.com/rubocop-hq/rubocop/pull/8661): Fix an incorrect auto-correct for `Style/MultilineTernaryOperator` when returning a multiline ternary operator expression. ([@koic][])
 * [#8526](https://github.com/rubocop-hq/rubocop/pull/8526): Fix a false positive for `Style/CaseEquality` cop when the receiver is not a camel cased constant. ([@koic][])
+* [#8673](https://github.com/rubocop-hq/rubocop/issues/8673): Fix the JSON parse error when specifying `--format=json` and `--stdin` options. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cli/command/execute_runner.rb
+++ b/lib/rubocop/cli/command/execute_runner.rb
@@ -8,6 +8,9 @@ module RuboCop
       class ExecuteRunner < Base
         include Formatter::TextUtil
 
+        # Combination of short and long formatter names.
+        INTEGRATION_FORMATTERS = %w[h html j json ju junit].freeze
+
         self.command_name = :execute_runner
 
         def run
@@ -61,6 +64,11 @@ module RuboCop
         end
 
         def maybe_print_corrected_source
+          # Integration tools (like RubyMine) expect to have only the JSON result
+          # when specifying JSON format. Similar HTML and JUnit are targeted as well.
+          # See: https://github.com/rubocop-hq/rubocop/issues/8673
+          return if INTEGRATION_FORMATTERS.include?(@options[:format])
+
           # If we are asked to autocorrect source code read from stdin, the only
           # reasonable place to write it is to stdout
           # Unfortunately, we also write other information to stdout

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -1719,6 +1719,36 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
     end
 
+    it 'can parse JSON result when specifying `--format=json` and `--stdin` options' do
+      begin
+        $stdin = StringIO.new('p $/')
+        argv   = ['--auto-correct-all',
+                  '--only=Style/SpecialGlobalVars',
+                  '--format=json',
+                  '--stdin',
+                  'fake.rb']
+        expect(cli.run(argv)).to eq(0)
+        expect { JSON.parse($stdout.string) }.not_to raise_error(JSON::ParserError)
+      ensure
+        $stdin = STDIN
+      end
+    end
+
+    it 'can parse JSON result when specifying `--format=j` and `--stdin` options' do
+      begin
+        $stdin = StringIO.new('p $/')
+        argv   = ['--auto-correct-all',
+                  '--only=Style/SpecialGlobalVars',
+                  '--format=j',
+                  '--stdin',
+                  'fake.rb']
+        expect(cli.run(argv)).to eq(0)
+        expect { JSON.parse($stdout.string) }.not_to raise_error(JSON::ParserError)
+      ensure
+        $stdin = STDIN
+      end
+    end
+
     it 'detects CR at end of line' do
       begin
         create_file('example.rb', "puts 'hello world'\r")


### PR DESCRIPTION
Fixes #8673.

This PR returns only JSON result when specifying `--format=json` and `--stdin` to fix the JSON parse error.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
