### PR TITLE
Whitespace internal

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,9 +59,8 @@ Layout/ClassStructure:
       - protected_methods
       - private_methods
 
-# Trailing white space is meaningful in code examples
 Layout/TrailingWhitespace:
-  AllowInHeredoc: true
+  AllowInHeredoc: false
 
 Lint/AmbiguousBlockAssociation:
   Exclude:

--- a/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
     RUBY
 
     expect_correction(<<~RUBY)
-      def a; end; 
+      def a; end;#{trailing_whitespace}
 
       def b; end
     RUBY

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
             something
 
             #{access_modifier}
- 
+
             def test; end
           end
         RUBY
@@ -339,7 +339,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
 
             #{access_modifier}
             #{'^' * access_modifier.size} Remove a blank line after `#{access_modifier}`.
-            
+
             def test; end
           end
         RUBY

--- a/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBlockBody, :config do
         expect_offense(<<~RUBY)
           some_method #{open}
             do_something
-  
+
           ^{} Extra empty line detected at block body end.
             #{close}
         RUBY

--- a/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBlockBody, :config do
       it 'accepts block body starting with a line with spaces' do
         expect_no_offenses(<<~RUBY)
           some_method #{open}
-            
+           #{trailing_whitespace}
             do_something
           #{close}
         RUBY

--- a/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundMethodBody do
     expect_offense(<<~RUBY)
       def Test.some_method
         do_something
-      
+
       #{end_offense_annotation}
       end
     RUBY

--- a/spec/rubocop/cop/layout/first_array_element_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_array_element_line_break_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
 
       expect(corrected).to eq(<<~RUBY)
         a, b,
-        c = 
+        c =#{trailing_whitespace}
         1,
         2, 3
       RUBY
@@ -118,7 +118,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
 
       expect(new_source).to eq(<<~RUBY)
         a
-        .c = 
+        .c =#{trailing_whitespace}
         1,
         2, 3
       RUBY

--- a/spec/rubocop/cop/layout/first_hash_element_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_hash_element_line_break_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementLineBreak do
     RUBY
 
     expect_correction(<<~RUBY)
-      a = { 
+      a = {#{trailing_whitespace}
       a: 1,
             b: 2 }
     RUBY
@@ -25,7 +25,7 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementLineBreak do
     RUBY
 
     expect_correction(<<~RUBY)
-      method({ 
+      method({#{trailing_whitespace}
       foo: 1,
                bar: 2 })
     RUBY

--- a/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
     RUBY
 
     expect_correction(<<~RUBY)
-      test do 
+      test do#{trailing_whitespace}
         foo
       end
     RUBY
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
     RUBY
 
     expect_correction(<<~RUBY)
-      test { 
+      test {#{trailing_whitespace}
         foo
       }
     RUBY
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
     RUBY
 
     expect_correction(<<~RUBY)
-      test do |x| 
+      test do |x|#{trailing_whitespace}
         foo
       end
     RUBY
@@ -56,7 +56,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
     RUBY
 
     expect_correction(<<~RUBY)
-      test { |x| 
+      test { |x|#{trailing_whitespace}
         foo
       }
     RUBY
@@ -150,7 +150,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
     RUBY
 
     expect_correction(<<~RUBY)
-      -> (x) do 
+      -> (x) do#{trailing_whitespace}
         foo
         bar
       end
@@ -166,7 +166,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
     RUBY
 
     expect_correction(<<~RUBY)
-      -> x do 
+      -> x do#{trailing_whitespace}
         foo
         bar
       end
@@ -226,7 +226,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
     RUBY
 
     expect_correction(<<~RUBY)
-      test do |foo| 
+      test do |foo|#{trailing_whitespace}
         bar
         test
       end
@@ -243,7 +243,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
     RUBY
 
     expect_correction(<<~RUBY)
-      x = -> (y) { 
+      x = -> (y) {#{trailing_whitespace}
             foo
         bar
       }
@@ -260,7 +260,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
     RUBY
 
     expect_correction(<<~RUBY)
-      foo do |o| 
+      foo do |o|#{trailing_whitespace}
         (
           bar
         )

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -202,12 +202,12 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
                  ^^^^^^ Literal interpolation detected.
     RUBY
 
-    expect_correction(<<~'RUBY')
-      "this is 
+    expect_correction(<<~RUBY)
+      "this is#{trailing_whitespace}
        silly"
-      "this is 
+      "this is#{trailing_whitespace}
        silly"
-      "this is 
+      "this is#{trailing_whitespace}
        silly"
     RUBY
   end

--- a/spec/rubocop/cop/lint/useless_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/useless_method_definition_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessMethodDefinition, :config do
 
     expect_correction(<<~RUBY)
       class Foo
-        
+       #{trailing_whitespace}
       end
     RUBY
   end
@@ -102,26 +102,26 @@ RSpec.describe RuboCop::Cop::Lint::UselessMethodDefinition, :config do
           do_something
         end
 
-        
+       #{trailing_whitespace}
 
-        
+       #{trailing_whitespace}
 
         def self.useful_class_method
           do_something
         end
 
-        
+       #{trailing_whitespace}
 
-        
+       #{trailing_whitespace}
 
         class << self
           def self.other_useful_class_method
             do_something
           end
 
-          
+         #{trailing_whitespace}
 
-          
+         #{trailing_whitespace}
         end
       end
     RUBY
@@ -189,7 +189,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessMethodDefinition, :config do
 
       expect_correction(<<~RUBY)
         class Foo
-          
+         #{trailing_whitespace}
         end
       RUBY
     end

--- a/spec/rubocop/cop/style/bisected_attr_accessor_spec.rb
+++ b/spec/rubocop/cop/style/bisected_attr_accessor_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe RuboCop::Cop::Style::BisectedAttrAccessor do
     expect_correction(<<~RUBY)
       class Foo
         attr_accessor :bar
-        
+       #{trailing_whitespace}
         other_macro :something
       end
     RUBY
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::Style::BisectedAttrAccessor do
     expect_correction(<<~RUBY)
       class Foo
         attr_accessor :bar
-        
+       #{trailing_whitespace}
         other_macro :something
       end
     RUBY
@@ -59,7 +59,7 @@ RSpec.describe RuboCop::Cop::Style::BisectedAttrAccessor do
       class Foo
         ATTRIBUTES = %i[foo bar]
         attr_accessor *ATTRIBUTES
-        
+       #{trailing_whitespace}
         other_macro :something
       end
     RUBY
@@ -106,11 +106,11 @@ RSpec.describe RuboCop::Cop::Style::BisectedAttrAccessor do
     expect_correction(<<~RUBY)
       class Foo
         attr_accessor :bar
-        
+       #{trailing_whitespace}
 
         private
 
-        
+       #{trailing_whitespace}
         attr_accessor :baz
       end
     RUBY
@@ -140,7 +140,7 @@ RSpec.describe RuboCop::Cop::Style::BisectedAttrAccessor do
 
         class << self
           attr_accessor :baz
-          
+         #{trailing_whitespace}
 
           private
 

--- a/spec/rubocop/cop/style/class_methods_definitions_spec.rb
+++ b/spec/rubocop/cop/style/class_methods_definitions_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::Style::ClassMethodsDefinitions, :config do
 
       expect_correction(<<~RUBY)
         class A
-          
+         #{trailing_whitespace}
             def self.three
             end
 
@@ -49,7 +49,7 @@ RSpec.describe RuboCop::Cop::Style::ClassMethodsDefinitions, :config do
 
       expect_correction(<<~RUBY)
         class A
-          
+         #{trailing_whitespace}
             # Multiline
             # comment.
             def self.two

--- a/spec/rubocop/cop/style/line_end_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/line_end_concatenation_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
   # whitespace in this cop.
   it 'autocorrects a + with trailing whitespace to \\' do
     expect_offense(<<~RUBY)
-      top = "test" + 
+      top = "test" +#{trailing_whitespace}
                    ^ Use `\\` instead of `+` or `<<` to concatenate those strings.
       "top"
     RUBY

--- a/spec/rubocop/cop/style/method_def_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_def_parentheses_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
       RUBY
 
       expect_correction(<<~RUBY)
-        def func 
+        def func#{trailing_whitespace}
         end
       RUBY
     end

--- a/spec/rubocop/cop/style/mixin_grouping_spec.rb
+++ b/spec/rubocop/cop/style/mixin_grouping_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe RuboCop::Cop::Style::MixinGrouping, :config do
           class Foo
             prepend Qux, Baz, Bar
             do_something_else
-            
+           #{trailing_whitespace}
           end
         RUBY
       end
@@ -229,7 +229,7 @@ RSpec.describe RuboCop::Cop::Style::MixinGrouping, :config do
             prepend Qux, Bar
             Other.prepend Baz
             do_something_else
-            
+           #{trailing_whitespace}
           end
         RUBY
       end

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -189,7 +189,6 @@ RSpec.describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
 
   context 'parentheses in multiline conditions are not allowed' do
     let(:cop_config) { { 'AllowInMultilineConditions' => false } }
-    let(:trailing_whitespace) { ' ' }
 
     it 'registers an offense for parentheses around multiline condition' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/redundant_assignment_spec.rb
+++ b/spec/rubocop/cop/style/redundant_assignment_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantAssignment do
       def func
         some_preceding_statements
         something
-        
+       #{trailing_whitespace}
       end
     RUBY
   end
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantAssignment do
           some_preceding_statements
           begin
             something
-            
+           #{trailing_whitespace}
           end
         end
       RUBY
@@ -69,11 +69,11 @@ RSpec.describe RuboCop::Cop::Style::RedundantAssignment do
         def func
           1
           2
-          
+         #{trailing_whitespace}
         rescue SomeException
           3
           4
-          
+         #{trailing_whitespace}
         rescue AnotherException
           5
         end
@@ -117,12 +117,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantAssignment do
           some_preceding_statements
           if x
             1
-            
+           #{trailing_whitespace}
           elsif y
             2
           else
             3
-            
+           #{trailing_whitespace}
           end
         end
       RUBY
@@ -156,13 +156,13 @@ RSpec.describe RuboCop::Cop::Style::RedundantAssignment do
           case x
           when y
             1
-            
+           #{trailing_whitespace}
           when z
             2
           when q
           else
             3
-            
+           #{trailing_whitespace}
           end
         end
       RUBY

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
-  let(:trailing_whitespace) { ' ' }
-
   it 'reports an offense for single line def with redundant begin block' do
     expect_offense(<<~RUBY)
       def func; begin; x; y; rescue; z end; end

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods do
                         'Layout/IndentationWidth' => { 'Width' => 2 })
   end
   let(:cop_config) { { 'AllowIfMethodIsEmpty' => true } }
-  let(:trailing_whitespace) { ' ' }
 
   it 'registers an offense for a single-line method' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/trailing_body_on_class_spec.rb
+++ b/spec/rubocop/cop/style/trailing_body_on_class_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnClass do
   let(:config) do
     RuboCop::Config.new('Layout/IndentationWidth' => { 'Width' => 2 })
   end
-  let(:trailing_whitespace) { ' ' }
 
   it 'registers an offense when body trails after class definition' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/trailing_body_on_method_definition_spec.rb
+++ b/spec/rubocop/cop/style/trailing_body_on_method_definition_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnMethodDefinition do
   let(:config) do
     RuboCop::Config.new('Layout/IndentationWidth' => { 'Width' => 2 })
   end
-  let(:trailing_whitespace) { ' ' }
 
   it 'registers an offense when body trails after method definition' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/trailing_body_on_module_spec.rb
+++ b/spec/rubocop/cop/style/trailing_body_on_module_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnModule do
   let(:config) do
     RuboCop::Config.new('Layout/IndentationWidth' => { 'Width' => 2 })
   end
-  let(:trailing_whitespace) { ' ' }
 
   it 'registers an offense when body trails after module definition' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/trailing_comma_in_block_args_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_block_args_spec.rb
@@ -65,12 +65,12 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInBlockArgs do
       expect_offense(<<~RUBY)
         test do |a, b,|
                      ^ Useless trailing comma present in block arguments.
-          a + b 
+          a + b
         end
       RUBY
       expect_correction(<<~RUBY)
         test do |a, b|
-          a + b 
+          a + b
         end
       RUBY
     end
@@ -78,7 +78,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInBlockArgs do
     it 'does not register an offense when a trailing comma is required' do
       expect_no_offenses(<<~RUBY)
         test do |a,|
-          a 
+          a
         end
       RUBY
     end
@@ -86,7 +86,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInBlockArgs do
     it 'does not register an offense when no arguments are present' do
       expect_no_offenses(<<~RUBY)
         test do
-          a 
+          a
         end
       RUBY
     end
@@ -125,15 +125,15 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInBlockArgs do
 
     it 'ignores commas in default argument strings' do
       expect_no_offenses(<<~RUBY)
-        add do |foo, bar = ','| 
-          foo + bar 
+        add do |foo, bar = ','|
+          foo + bar
         end
       RUBY
     end
 
     it 'preserves semicolons in block/local variables' do
       expect_no_offenses(<<~RUBY)
-        add do |foo, bar,; baz| 
+        add do |foo, bar,; baz|
           foo + bar
         end
       RUBY

--- a/spec/rubocop/cop/style/trailing_method_end_statement_spec.rb
+++ b/spec/rubocop/cop/style/trailing_method_end_statement_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe RuboCop::Cop::Style::TrailingMethodEndStatement do
   let(:config) do
     RuboCop::Config.new('Layout/IndentationWidth' => { 'Width' => 2 })
   end
-  let(:trailing_whitespace) { ' ' }
 
   it 'register offense with trailing end on 2 line method' do
     expect_offense(<<~RUBY)

--- a/spec/support/misc_helper.rb
+++ b/spec/support/misc_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+def trailing_whitespace
+  ' '
+end


### PR DESCRIPTION
The "internal-use" part of #8692 I'm confident enough to merge:

* adds a `trailing_whitespace` helper for RuboCop
* removes 10 useless trailing whitespaces in out codebase
* uses `trailing_whitespace` wherever needed
* disallows trailing whitespaces in heredocs in our codebase.