### PR TITLE
[Fixes #8626] Fix false negatives for `Lint/UselessMethodDefinition`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#8688](https://github.com/rubocop-hq/rubocop/issues/8688): Mark `Style/GlobalStdStream` as unsafe autocorrection. ([@marcandre][])
 * [#8642](https://github.com/rubocop-hq/rubocop/issues/8642): Fix a false negative for `Style/SpaceInsideHashLiteralBraces` when a correct empty hash precedes the incorrect hash. ([@dvandersluis][])
 * [#8683](https://github.com/rubocop-hq/rubocop/issues/8683): Make naming cops work with non-ascii characters. ([@tejasbubane][])
+* [#8626](https://github.com/rubocop-hq/rubocop/issues/8626): Fix false negatives for `Lint/UselessMethodDefinition`. ([@marcandre][])
 
 ### Changes
 

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -4615,6 +4615,7 @@ an empty constructor just overrides the parent constructor, which is bad anyway.
 ----
 # bad
 def initialize
+  super
 end
 
 def method
@@ -4628,32 +4629,12 @@ end
 
 # good
 def initialize
+  super
   initialize_internals
 end
 
-def method
-  super
-  do_something_else
-end
-----
-
-==== AllowComments: true (default)
-
-[source,ruby]
-----
-# good
-def initialize
-  # Comment.
-end
-----
-
-==== AllowComments: false
-
-[source,ruby]
-----
-# bad
-def initialize
-  # Comment.
+def method(*args)
+  super(:extra_arg, *args)
 end
 ----
 

--- a/spec/rubocop/cop/lint/useless_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/useless_method_definition_spec.rb
@@ -7,18 +7,11 @@ RSpec.describe RuboCop::Cop::Lint::UselessMethodDefinition, :config do
     { 'AllowComments' => true }
   end
 
-  it 'registers an offense and corrects for empty constructor' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense for empty constructor' do
+    expect_no_offenses(<<~RUBY)
       class Foo
         def initialize(arg1, arg2)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Useless method definition detected.
         end
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      class Foo
-       #{trailing_whitespace}
       end
     RUBY
   end
@@ -88,6 +81,11 @@ RSpec.describe RuboCop::Cop::Lint::UselessMethodDefinition, :config do
             super
           end
 
+          def other_class_method_with_parens
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Useless method definition detected.
+            super()
+          end
+
           def other_class_method_with_args(arg)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Useless method definition detected.
             super(arg)
@@ -122,6 +120,8 @@ RSpec.describe RuboCop::Cop::Lint::UselessMethodDefinition, :config do
          #{trailing_whitespace}
 
          #{trailing_whitespace}
+
+         #{trailing_whitespace}
         end
       end
     RUBY
@@ -144,6 +144,10 @@ RSpec.describe RuboCop::Cop::Lint::UselessMethodDefinition, :config do
 
       def method2(foo, bar)
         super(bar, foo)
+      end
+
+      def method3(foo, bar)
+        super()
       end
     RUBY
   end
@@ -170,28 +174,5 @@ RSpec.describe RuboCop::Cop::Lint::UselessMethodDefinition, :config do
         # Comment.
       end
     RUBY
-  end
-
-  context 'when AllowComments is false' do
-    let(:cop_config) do
-      { 'AllowComments' => false }
-    end
-
-    it 'registers an offense when constructor contains only comments' do
-      expect_offense(<<~RUBY)
-        class Foo
-          def initialize
-          ^^^^^^^^^^^^^^ Useless method definition detected.
-            # Comment.
-          end
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        class Foo
-         #{trailing_whitespace}
-        end
-      RUBY
-    end
   end
 end


### PR DESCRIPTION
Note that not calling `super` at all from `initialize` is left to `Lint/MissingSuper` cop.