### PR TITLE
Fix cache to avoid encoding exception.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [#8642](https://github.com/rubocop-hq/rubocop/issues/8642): Fix a false negative for `Style/SpaceInsideHashLiteralBraces` when a correct empty hash precedes the incorrect hash. ([@dvandersluis][])
 * [#8683](https://github.com/rubocop-hq/rubocop/issues/8683): Make naming cops work with non-ascii characters. ([@tejasbubane][])
 * [#8626](https://github.com/rubocop-hq/rubocop/issues/8626): Fix false negatives for `Lint/UselessMethodDefinition`. ([@marcandre][])
+* [#8698](https://github.com/rubocop-hq/rubocop/pull/8698): Fix cache to avoid encoding exception. ([@marcandre][])
 
 ### Changes
 

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -176,7 +176,10 @@ module RuboCop
           rubocop_extra_features
             .select { |path| File.file?(path) }
             .sort!
-            .each { |path| digest << Zlib.crc32(IO.read(path)).to_s } # mtime not reliable
+            .each do |path|
+              content = File.open(path, 'rb', &:read)
+              digest << Zlib.crc32(content).to_s # mtime not reliable
+            end
           digest << RuboCop::Version::STRING << RuboCop::AST::Version::STRING
           digest.hexdigest
         end


### PR DESCRIPTION
Not too sure how come the CI [sometimes gets](https://app.circleci.com/pipelines/github/rubocop-hq/rubocop/2221/workflows/1bf844cb-7fa5-49cd-9f7a-d0b084e0a2f4/jobs/134769) an encoding error:

```
RuboCop::ResultCache#save when the default internal encoding is UTF-8 writes non UTF-8 encodable data to file with no exception
     Failure/Error:
       rubocop_extra_features
         .select { |path| File.file?(path) }
         .sort!
         .each { |path| digest << Zlib.crc32(IO.read(path)).to_s } # mtime not reliable

     Encoding::InvalidByteSequenceError:
       "\xCE" on US-ASCII
     # ./lib/rubocop/result_cache.rb:179:in `read'
     # ./lib/rubocop/result_cache.rb:179:in `block in rubocop_checksum'
     # ./lib/rubocop/result_cache.rb:179:in `each'
     # ./lib/rubocop/result_cache.rb:179:in `rubocop_checksum'
     # ./lib/rubocop/result_cache.rb:94:in `initialize'
     # ./spec/rubocop/result_cache_spec.rb:7:in `new'
```