### PR TITLE
[Fix #8621] Helpful Infinite Loop message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [#8617](https://github.com/rubocop-hq/rubocop/issues/8617): Fix `Style/HashAsLastArrayItem` to not register an offense when all items in an array are hashes. ([@dvandersluis][])
 * [#8500](https://github.com/rubocop-hq/rubocop/issues/8500): Add `in?` to AllowedMethods for `Lint/SafeNavigationChain` cop. ([@tejasbubane][])
 * [#8629](https://github.com/rubocop-hq/rubocop/pull/8629): Fix the cache being reusable in CI by using crc32 to calculate file hashes rather than `mtime`, which changes each CI build. ([@dvandersluis][])
+* [#8621](https://github.com/rubocop-hq/rubocop/issues/8621): Add helpful Infinite Loop error message. ([@iSarCasm][])
 
 ## 0.90.0 (2020-09-01)
 
@@ -4862,3 +4863,4 @@
 [@jaimerave]: https://github.com/jaimerave
 [@Skipants]: https://github.com/Skipants
 [@sascha-wolf]: https://github.com/sascha-wolf
+[@iSarCasm]: https://github.com/iSarCasm

--- a/spec/support/cops/a_to_b_cop.rb
+++ b/spec/support/cops/a_to_b_cop.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Test
+      # This cop is only used to test infinite loop detection
+      class AtoB < RuboCop::Cop::Base
+        extend AutoCorrector
+
+        def on_class(node)
+          return unless /A/.match?(node.loc.name.source)
+
+          add_offense(node.loc.name, message: 'A to B') do |corrector|
+            autocorrect(corrector, node)
+          end
+        end
+        alias on_module on_class
+
+        private
+
+        def autocorrect(corrector, node)
+          corrector.replace(node.loc.name, node.loc.name.source.tr('A', 'B'))
+        end
+      end
+    end
+  end
+end

--- a/spec/support/cops/b_to_a_cop.rb
+++ b/spec/support/cops/b_to_a_cop.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Test
+      # This cop is only used to test infinite loop detection
+      class BtoA < RuboCop::Cop::Base
+        extend AutoCorrector
+
+        def on_class(node)
+          return unless /B/.match?(node.loc.name.source)
+
+          add_offense(node.loc.name, message: 'B to A') do |corrector|
+            autocorrect(corrector, node)
+          end
+        end
+        alias on_module on_class
+
+        private
+
+        def autocorrect(corrector, node)
+          corrector.replace(node.loc.name, node.loc.name.source.tr('B', 'A'))
+        end
+      end
+    end
+  end
+end

--- a/spec/support/cops/b_to_c_cop.rb
+++ b/spec/support/cops/b_to_c_cop.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Test
+      # This cop is only used to test infinite loop detection
+      class BtoC < RuboCop::Cop::Base
+        extend AutoCorrector
+
+        def on_class(node)
+          return unless /B/.match?(node.loc.name.source)
+
+          add_offense(node.loc.name, message: 'B to C') do |corrector|
+            autocorrect(corrector, node)
+          end
+        end
+        alias on_module on_class
+
+        private
+
+        def autocorrect(corrector, node)
+          corrector.replace(node.loc.name, node.loc.name.source.tr('B', 'C'))
+        end
+      end
+    end
+  end
+end

--- a/spec/support/cops/c_to_a_cop.rb
+++ b/spec/support/cops/c_to_a_cop.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Test
+      # This cop is only used to test infinite loop detection
+      class CtoA < RuboCop::Cop::Base
+        extend AutoCorrector
+
+        def on_class(node)
+          return unless /C/.match?(node.loc.name.source)
+
+          add_offense(node.loc.name, message: 'C to A') do |corrector|
+            autocorrect(corrector, node)
+          end
+        end
+        alias on_module on_class
+
+        private
+
+        def autocorrect(corrector, node)
+          corrector.replace(node.loc.name, node.loc.name.source.tr('C', 'A'))
+        end
+      end
+    end
+  end
+end

--- a/spec/support/file_helper.rb
+++ b/spec/support/file_helper.rb
@@ -17,6 +17,8 @@ module FileHelper
         file.puts content.join("\n")
       end
     end
+
+    file_path
   end
 
   def create_empty_file(file_path)


### PR DESCRIPTION
Closes #8621

Adds the information about which Cops exactly caused an infinite loop

Tracks the corrected offenses on each iteration. 

In the case of exceeding `MAX_ITERATIONS`, it just returns cop names from the latest iteration.
In the case of duplicated sources, it returns a list of iterations (with cop names) starting from the first time this exact source has already been generated. In most cases, I imagine there would only be 2 or 3 iterations between looped states but it should handle all cases.

Examples:
- `Test/ClassMustBeAModuleCop -> Test/ModuleMustBeAClassCop`
- `Test/ClassMustBeAModuleCop, Test/AtoB -> Test/ModuleMustBeAClassCop, Test/BtoA`
- `Test/AtoB -> Test/BtoC -> Test/CtoA`

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
