### PR TITLE
Add new cop `Lint/UselessTimes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * New option `--cache-root` and support for the `RUBOCOP_CACHE_ROOT` environment variable. Both can be used to override the `AllCops: CacheRootDirectory` config, especially in a CI setting. ([@sascha-wolf][])
 * [#8582](https://github.com/rubocop-hq/rubocop/issues/8582): Add new `Layout/BeginEndAlignment` cop. ([@koic][])
 * [#8699](https://github.com/rubocop-hq/rubocop/pull/8699): Add new `Lint/IdentityComparison` cop. ([@koic][])
+* Add new `Lint/UselessTimes` cop. ([@dvandersluis][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1988,6 +1988,12 @@ Lint/UselessSetterCall:
   VersionChanged: '0.80'
   Safe: false
 
+Lint/UselessTimes:
+  Description: 'Checks for useless `Integer#times` calls.'
+  Enabled: pending
+  VersionAdded: '0.91'
+  Safe: false
+
 Lint/Void:
   Description: 'Possible use of operator/literal/variable in void context.'
   Enabled: true

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -281,6 +281,7 @@ In the following section you find all available cops:
 * xref:cops_lint.adoc#lintuselesselsewithoutrescue[Lint/UselessElseWithoutRescue]
 * xref:cops_lint.adoc#lintuselessmethoddefinition[Lint/UselessMethodDefinition]
 * xref:cops_lint.adoc#lintuselesssettercall[Lint/UselessSetterCall]
+* xref:cops_lint.adoc#lintuselesstimes[Lint/UselessTimes]
 * xref:cops_lint.adoc#lintvoid[Lint/Void]
 
 === Department xref:cops_metrics.adoc[Metrics]

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -4722,6 +4722,40 @@ def something
 end
 ----
 
+== Lint/UselessTimes
+
+|===
+| Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+
+| Pending
+| No
+| Yes (Unsafe)
+| 0.91
+| -
+|===
+
+This cop checks for uses of `Integer#times` that will never yield
+(when the integer <= 0) or that will only ever yield once
+(`1.times`).
+
+This cop is marked as unsafe as `times` returns its receiver, which
+is *usually* OK, but might change behavior.
+
+=== Examples
+
+[source,ruby]
+----
+# bad
+-5.times { do_something }
+0.times { do_something }
+1.times { do_something  }
+1.times { |i| do_something(i) }
+
+# good
+do_something
+do_something(1)
+----
+
 == Lint/Void
 
 |===

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -343,6 +343,7 @@ require_relative 'rubocop/cop/lint/useless_assignment'
 require_relative 'rubocop/cop/lint/useless_else_without_rescue'
 require_relative 'rubocop/cop/lint/useless_method_definition'
 require_relative 'rubocop/cop/lint/useless_setter_call'
+require_relative 'rubocop/cop/lint/useless_times'
 require_relative 'rubocop/cop/lint/void'
 
 require_relative 'rubocop/cop/metrics/utils/iterating_block'

--- a/lib/rubocop/cop/lint/useless_times.rb
+++ b/lib/rubocop/cop/lint/useless_times.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Lint
+      # This cop checks for uses of `Integer#times` that will never yield
+      # (when the integer <= 0) or that will only ever yield once
+      # (`1.times`).
+      #
+      # This cop is marked as unsafe as `times` returns its receiver, which
+      # is *usually* OK, but might change behavior.
+      #
+      # @example
+      #   # bad
+      #   -5.times { do_something }
+      #   0.times { do_something }
+      #   1.times { do_something  }
+      #   1.times { |i| do_something(i) }
+      #
+      #   # good
+      #   do_something
+      #   do_something(1)
+      class UselessTimes < Base
+        include RangeHelp
+        extend AutoCorrector
+
+        MSG = 'Useless call to `%<count>i.times` detected.'
+        RESTRICT_ON_SEND = %i[times].freeze
+
+        def_node_matcher :times_call?, <<~PATTERN
+          (send (int $_) :times (block-pass (sym $_))?)
+        PATTERN
+
+        def_node_matcher :block_arg, <<~PATTERN
+          (block _ (args (arg $_)) ...)
+        PATTERN
+
+        def_node_search :block_reassigns_arg?, <<~PATTERN
+          (lvasgn %)
+        PATTERN
+
+        def on_send(node)
+          return unless (count, proc_name = times_call?(node))
+          return if count > 1
+
+          # Get the block node if applicable
+          node = node.block_node if node.block_literal?
+
+          add_offense(node, message: format(MSG, count: count)) do |corrector|
+            next unless own_line?(node)
+
+            if count < 1
+              remove_node(corrector, node)
+            elsif !proc_name.empty?
+              autocorrect_block_pass(corrector, node, proc_name)
+            else
+              autocorrect_block(corrector, node)
+            end
+          end
+        end
+
+        private
+
+        def remove_node(corrector, node)
+          corrector.remove(range_by_whole_lines(node.loc.expression, include_final_newline: true))
+        end
+
+        def autocorrect_block_pass(corrector, node, proc_name)
+          corrector.replace(node, proc_name)
+        end
+
+        def autocorrect_block(corrector, node)
+          block_arg = block_arg(node)
+          return if block_reassigns_arg?(node, block_arg)
+
+          source = node.body.source
+          source.gsub!(/\b#{block_arg}\b/, '1') if block_arg
+
+          corrector.replace(node, fix_indentation(source, node.loc.column...node.body.loc.column))
+        end
+
+        def fix_indentation(source, range)
+          # Cleanup indentation in a multiline block
+          source_lines = source.split("\n")
+          source_lines[1..-1].each { |line| line[range] = '' }
+          source_lines.join("\n")
+        end
+
+        def own_line?(node)
+          # If there is anything else on the line other than whitespace,
+          # don't try to autocorrect
+          processed_source.buffer.source_line(node.loc.line)[0...node.loc.column] !~ /\S/
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/lint/useless_times_spec.rb
+++ b/spec/rubocop/cop/lint/useless_times_spec.rb
@@ -1,0 +1,252 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Lint::UselessTimes do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense and corrects with 0.times' do
+    expect_offense(<<~RUBY)
+      0.times { something }
+      ^^^^^^^^^^^^^^^^^^^^^ Useless call to `0.times` detected.
+    RUBY
+
+    expect_correction('')
+  end
+
+  it 'registers an offense and corrects with 0.times with block arg' do
+    expect_offense(<<~RUBY)
+      0.times { |i| something(i) }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Useless call to `0.times` detected.
+    RUBY
+
+    expect_correction('')
+  end
+
+  it 'registers an offense and corrects with negative times' do
+    expect_offense(<<~RUBY)
+      -1.times { something }
+      ^^^^^^^^^^^^^^^^^^^^^^ Useless call to `-1.times` detected.
+    RUBY
+
+    expect_correction('')
+  end
+
+  it 'registers an offense and corrects with negative times with block arg' do
+    expect_offense(<<~RUBY)
+      -1.times { |i| something(i) }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Useless call to `-1.times` detected.
+    RUBY
+
+    expect_correction('')
+  end
+
+  it 'registers an offense and corrects with 1.times' do
+    expect_offense(<<~RUBY)
+      1.times { something }
+      ^^^^^^^^^^^^^^^^^^^^^ Useless call to `1.times` detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      something
+    RUBY
+  end
+
+  it 'registers an offense and corrects with 1.times with block arg' do
+    expect_offense(<<~RUBY)
+      1.times { |i| something(i) }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Useless call to `1.times` detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      something(1)
+    RUBY
+  end
+
+  it 'does not register an offense for an integer > 1' do
+    expect_no_offenses(<<~RUBY)
+      2.times { |i| puts i }
+    RUBY
+  end
+
+  context 'short-form method' do
+    it 'registers an offense and corrects with 0.times' do
+      expect_offense(<<~RUBY)
+        0.times(&:something)
+        ^^^^^^^^^^^^^^^^^^^^ Useless call to `0.times` detected.
+      RUBY
+
+      expect_correction('')
+    end
+
+    it 'registers an offense and corrects with negative times' do
+      expect_offense(<<~RUBY)
+        -1.times(&:something)
+        ^^^^^^^^^^^^^^^^^^^^^ Useless call to `-1.times` detected.
+      RUBY
+
+      expect_correction('')
+    end
+
+    it 'registers an offense and corrects with 1.times' do
+      expect_offense(<<~RUBY)
+        1.times(&:something)
+        ^^^^^^^^^^^^^^^^^^^^ Useless call to `1.times` detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        something
+      RUBY
+    end
+
+    it 'does not register an offense for an integer > 1' do
+      expect_no_offenses(<<~RUBY)
+        2.times(&:something)
+      RUBY
+    end
+
+    it 'does not adjust surrounding space' do
+      expect_offense(<<~RUBY)
+        precondition
+        0.times(&:something)
+        ^^^^^^^^^^^^^^^^^^^^ Useless call to `0.times` detected.
+        postcondition
+      RUBY
+
+      expect_correction(<<~RUBY)
+        precondition
+        postcondition
+      RUBY
+    end
+  end
+
+  context 'multiline block' do
+    it 'correctly handles a multiline block with 1.times' do
+      expect_offense(<<~RUBY)
+        1.times do |i|
+        ^^^^^^^^^^^^^^ Useless call to `1.times` detected.
+          do_something(i)
+          do_something_else(i)
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something(1)
+        do_something_else(1)
+      RUBY
+    end
+
+    it 'does not try to correct a block if the block arg is changed' do
+      expect_offense(<<~RUBY)
+        1.times do |i|
+        ^^^^^^^^^^^^^^ Useless call to `1.times` detected.
+          do_something(i)
+          i += 1
+          do_something_else(i)
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'does not try to correct a block if the block arg is changed in parallel assignment' do
+      expect_offense(<<~RUBY)
+        1.times do |i|
+        ^^^^^^^^^^^^^^ Useless call to `1.times` detected.
+          do_something(i)
+          i, j = i * 2, i * 3
+          do_something_else(i)
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'corrects a block that changes another lvar' do
+      expect_offense(<<~RUBY)
+        1.times do |i|
+        ^^^^^^^^^^^^^^ Useless call to `1.times` detected.
+          do_something(i)
+          j = 1
+          do_something_else(j)
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something(1)
+        j = 1
+        do_something_else(j)
+      RUBY
+    end
+  end
+
+  context 'within indentation' do
+    it 'corrects properly when removing single line' do
+      expect_offense(<<~RUBY)
+        def my_method
+          0.times { do_something }
+          ^^^^^^^^^^^^^^^^^^^^^^^^ Useless call to `0.times` detected.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def my_method
+        end
+      RUBY
+    end
+
+    it 'corrects properly when removing multiline' do
+      expect_offense(<<~RUBY)
+        def my_method
+          0.times do
+          ^^^^^^^^^^ Useless call to `0.times` detected.
+            do_something
+            do_something_else
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def my_method
+        end
+      RUBY
+    end
+
+    it 'corrects properly when replacing' do
+      expect_offense(<<~RUBY)
+        def my_method
+          1.times do
+          ^^^^^^^^^^ Useless call to `1.times` detected.
+            do_something
+            do_something_else
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def my_method
+          do_something
+          do_something_else
+        end
+      RUBY
+    end
+
+    context 'inline `Integer#times` calls' do
+      it 'does not try to correct `0.times`' do
+        expect_offense(<<~RUBY)
+          foo(0.times { do_something })
+              ^^^^^^^^^^^^^^^^^^^^^^^^ Useless call to `0.times` detected.
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'does not try to correct `1.times`' do
+        expect_offense(<<~RUBY)
+          foo(1.times { do_something })
+              ^^^^^^^^^^^^^^^^^^^^^^^^ Useless call to `1.times` detected.
+        RUBY
+
+        expect_no_corrections
+      end
+    end
+  end
+end


### PR DESCRIPTION
This cop looks for pointless uses of `Integer#times` and replaces or removes them as necessary (I found some of these in my codebase at work, sadly). When the integer is <= 0, the block will never be yielded to, so the entire thing can be removed. When the integer is 1, the block will only ever yield once, so the `1.times` call can (generally) be replaced with the block body.

Auto-correction is enabled in most cases, but because `Integer#times` returns its receiver (and the replacement won't), I've marked it as unsafe.

The cop will remove `0.times` and `-5.times` (etc.) calls, since they will never do anything. The cop will replace `1.times` with its block, and if the block arg is used at all, replace it with 1.

Auto-correction will not be attempted in a couple more complex cases, such as mutating the block arg within the block, or calling `Integer#times` not on its own line. See the tests for more details.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
