### PR TITLE
Use `RESTRICT_ON_SEND` for `Lint/IdentityComparison`

### DIFF
--- a/lib/rubocop/cop/lint/identity_comparison.rb
+++ b/lib/rubocop/cop/lint/identity_comparison.rb
@@ -20,6 +20,7 @@ module RuboCop
         extend AutoCorrector
 
         MSG = 'Use `equal?` instead `==` when comparing `object_id`.'
+        RESTRICT_ON_SEND = %i[==].freeze
 
         def on_send(node)
           return unless compare_between_object_id_by_double_equal?(node)
@@ -36,8 +37,6 @@ module RuboCop
         private
 
         def compare_between_object_id_by_double_equal?(node)
-          return false unless node.method?(:==)
-
           object_id_method?(node.receiver) && object_id_method?(node.first_argument)
         end
 


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/8699#issuecomment-691098197 and #8606.

This PR uses `RESTRICT_ON_SEND` for `Lint/IdentityComparison`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
