### PR TITLE
[Fix #8704] Fix an error for `Lint/AmbiguousOperator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#8683](https://github.com/rubocop-hq/rubocop/issues/8683): Make naming cops work with non-ascii characters. ([@tejasbubane][])
 * [#8626](https://github.com/rubocop-hq/rubocop/issues/8626): Fix false negatives for `Lint/UselessMethodDefinition`. ([@marcandre][])
 * [#8698](https://github.com/rubocop-hq/rubocop/pull/8698): Fix cache to avoid encoding exception. ([@marcandre][])
+* [#8704](https://github.com/rubocop-hq/rubocop/issues/8704): Fix an error for `Lint/AmbiguousOperator` when using safe navigation operator with a unary operator. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/ambiguous_operator.rb
+++ b/lib/rubocop/cop/lint/ambiguous_operator.rb
@@ -43,6 +43,8 @@ module RuboCop
             next unless diagnostic.reason == :ambiguous_prefix
 
             offense_node = find_offense_node_by(diagnostic)
+            next unless offense_node
+
             message = message(diagnostic)
 
             add_offense(

--- a/spec/rubocop/cop/lint/ambiguous_operator_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_operator_spec.rb
@@ -194,4 +194,12 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousOperator do
       end
     end
   end
+
+  context 'when using safe navigation operator with a unary operator' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        do_something&.* -1
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #8704.

This PR fixes an error for `Lint/AmbiguousOperator` when using safe navigation operator with a unary operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
