### PR TITLE
Add style guide link for Lint/ConstantDefinitionInBlock

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1397,6 +1397,7 @@ Lint/CircularArgumentReference:
 
 Lint/ConstantDefinitionInBlock:
   Description: 'Do not define constants within a block.'
+  StyleGuide: '#no-constant-definition-in-block'
   Enabled: pending
   VersionAdded: '0.91'
 

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -393,6 +393,10 @@ describe 'making a request' do
 end
 ----
 
+=== References
+
+* https://rubystyle.guide#no-constant-definition-in-block
+
 == Lint/ConstantResolution
 
 |===


### PR DESCRIPTION
Followup to https://github.com/rubocop-hq/rubocop/pull/8707, https://github.com/rubocop-hq/ruby-style-guide/pull/841.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/