### PR TITLE
[Fix #8710] Fix a false positive for `Layout/RescueEnsureAlignment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#8720](https://github.com/rubocop-hq/rubocop/issues/8720): Fix an error for `Lint/IdentityComparison` when calling `object_id` method without receiver in LHS or RHS. ([@koic][])
+* [#8710](https://github.com/rubocop-hq/rubocop/issues/8710): Fix a false positive for `Layout/RescueEnsureAlignment` when `Layout/BeginEndAlignment` cop is not enabled status. ([@koic][])
 
 ## 0.91.0 (2020-09-15)
 

--- a/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
@@ -191,7 +191,16 @@ module RuboCop
         end
 
         def begin_end_alignment_style
-          config.for_cop('Layout/BeginEndAlignment')['EnforcedStyleAlignWith']
+          # FIXME: Workaround for pending status for `Layout/BeginEndAlignment` cop
+          #        When RuboCop 1.0 is released, please replace it with the following condition.
+          #
+          # config.for_cop('Layout/BeginEndAlignment')['Enabled'] &&
+          #   config.for_cop('Layout/BeginEndAlignment')['EnforcedStyleAlignWith']
+          if config.for_all_cops['NewCops'] == 'enable' ||
+             config.for_cop('Layout/BeginEndAlignment')['Enabled'] &&
+             config.for_cop('Layout/BeginEndAlignment')['Enabled'] != 'pending'
+            config.for_cop('Layout/BeginEndAlignment')['EnforcedStyleAlignWith']
+          end
         end
       end
     end

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -30,6 +30,58 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
         { 'EnforcedStyle' => 'require_parentheses' }
       end
 
+      context '`Layout/BeginEndAlignment` cop is not enabled' do
+        let(:other_cops) do
+          {
+            'Layout/BeginEndAlignment' => {
+              'Enabled' => false,
+              'EnforcedStyleAlignWith' => 'start_of_line'
+            }
+          }
+        end
+
+        it 'accepts multi-line, aligned' do
+          expect_no_offenses(<<~RUBY)
+            x ||= begin
+                    1
+                  rescue
+                    2
+                  end
+          RUBY
+        end
+
+        it 'accepts multi-line, indented' do
+          expect_no_offenses(<<~RUBY)
+            x ||=
+              begin
+                1
+              rescue
+                2
+              end
+          RUBY
+        end
+
+        it 'registers an offense and corrects for incorrect alignment' do
+          expect_offense(<<~RUBY)
+            x ||= begin
+              1
+            rescue
+            ^^^^^^ `rescue` at 3, 0 is not aligned with `begin` at 1, 6.
+              2
+            end
+          RUBY
+
+          # Except for `rescue`, it will be aligned by `Layout/BeginEndAlignment` auto-correction.
+          expect_correction(<<~RUBY)
+            x ||= begin
+              1
+                  rescue
+              2
+            end
+          RUBY
+        end
+      end
+
       context 'when `EnforcedStyleAlignWith: start_of_line` of `Layout/BeginEndAlignment` cop' do
         let(:other_cops) do
           {


### PR DESCRIPTION
Fixes #8710 and #8717.

This PR fixes a false positive for `Layout/RescueEnsureAlignment` when `Layout/BeginEndAlignment` cop is not enabled status (e.g. pending, disabled).

This patch includes workaround for pending status until RuboCop 1.0 is released.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
