### PR TITLE
[Fix #8720] Fix an error for `Lint/IdentityComparison`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#8720](https://github.com/rubocop-hq/rubocop/issues/8720): Fix an error for `Lint/IdentityComparison` when calling `object_id` method without receiver in LHS or RHS. ([@koic][])
+
 ## 0.91.0 (2020-09-15)
 
 ### New features

--- a/lib/rubocop/cop/lint/identity_comparison.rb
+++ b/lib/rubocop/cop/lint/identity_comparison.rb
@@ -26,9 +26,11 @@ module RuboCop
           return unless compare_between_object_id_by_double_equal?(node)
 
           add_offense(node) do |corrector|
-            receiver = node.receiver.receiver.source
-            argument = node.first_argument.receiver.source
-            replacement = "#{receiver}.equal?(#{argument})"
+            receiver = node.receiver.receiver
+            argument = node.first_argument.receiver
+            return unless receiver && argument
+
+            replacement = "#{receiver.source}.equal?(#{argument.source})"
 
             corrector.replace(node, replacement)
           end

--- a/spec/rubocop/cop/lint/identity_comparison_spec.rb
+++ b/spec/rubocop/cop/lint/identity_comparison_spec.rb
@@ -31,4 +31,16 @@ RSpec.describe RuboCop::Cop::Lint::IdentityComparison, :config do
       foo.equal(bar)
     RUBY
   end
+
+  it 'does not register an offense when lhs is `object_id` without receiver' do
+    expect_no_offenses(<<~RUBY)
+      object_id == bar.object_id
+    RUBY
+  end
+
+  it 'does not register an offense when rhs is `object_id` without receiver' do
+    expect_no_offenses(<<~RUBY)
+      foo.object_id == object_id
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #8720.

This PR fixes an error for `IdentityComparison` when calling `object_id` method without receiver in LHS or RHS.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
