### PR TITLE
[#8489] Exclude method respond_to_missing? from OptionalBooleanParameter cop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [#8500](https://github.com/rubocop-hq/rubocop/issues/8500): Add `in?` to AllowedMethods for `Lint/SafeNavigationChain` cop. ([@tejasbubane][])
 * [#8629](https://github.com/rubocop-hq/rubocop/pull/8629): Fix the cache being reusable in CI by using crc32 to calculate file hashes rather than `mtime`, which changes each CI build. ([@dvandersluis][])
 * [#8621](https://github.com/rubocop-hq/rubocop/issues/8621): Add helpful Infinite Loop error message. ([@iSarCasm][])
+* [#8489](https://github.com/rubocop-hq/rubocop/issues/8489):  Exclude method `respond_to_missing?` from `OptionalBooleanParameter` cop. ([@em-gazelle][])
 
 ## 0.90.0 (2020-09-01)
 
@@ -4871,3 +4872,4 @@
 [@Skipants]: https://github.com/Skipants
 [@sascha-wolf]: https://github.com/sascha-wolf
 [@iSarCasm]: https://github.com/iSarCasm
+[@em-gazelle]: https://github.com/em-gazelle

--- a/lib/rubocop/cop/style/optional_boolean_parameter.rb
+++ b/lib/rubocop/cop/style/optional_boolean_parameter.rb
@@ -26,8 +26,11 @@ module RuboCop
       class OptionalBooleanParameter < Base
         MSG = 'Use keyword arguments when defining method with boolean argument.'
         BOOLEAN_TYPES = %i[true false].freeze
+        METHODS_EXCLUDED = %i[respond_to_missing?].freeze
 
         def on_def(node)
+          return if METHODS_EXCLUDED.include?(node.method_name)
+
           node.arguments.each do |arg|
             next unless arg.optarg_type?
 

--- a/spec/rubocop/cop/style/optional_boolean_parameter_spec.rb
+++ b/spec/rubocop/cop/style/optional_boolean_parameter_spec.rb
@@ -42,9 +42,16 @@ RSpec.describe RuboCop::Cop::Style::OptionalBooleanParameter do
     RUBY
   end
 
-  it 'does not register an offense when defining method with optonal non-boolean arg' do
+  it 'does not register an offense when defining method with optional non-boolean arg' do
     expect_no_offenses(<<~RUBY)
       def some_method(bar = 'foo')
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when defining respond_to_missing? method with boolean arg' do
+    expect_no_offenses(<<~RUBY)
+      def respond_to_missing?(arg, bar = false)
       end
     RUBY
   end


### PR DESCRIPTION
This PR stops the OptionalBooleanParameter cop from complaining about code calling Ruby's `respond_to_missing?(arg, private = false)` method in response to issue [8489](https://github.com/rubocop-hq/rubocop/issues/8489).

This is currently non-configurable, but I'm happy to modify it if that'd be useful!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
