### PR TITLE
[Fix #8726] Fix a false positive for `Naming/VariableNumber`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#8720](https://github.com/rubocop-hq/rubocop/issues/8720): Fix an error for `Lint/IdentityComparison` when calling `object_id` method without receiver in LHS or RHS. ([@koic][])
 * [#8710](https://github.com/rubocop-hq/rubocop/issues/8710): Fix a false positive for `Layout/RescueEnsureAlignment` when `Layout/BeginEndAlignment` cop is not enabled status. ([@koic][])
+* [#8726](https://github.com/rubocop-hq/rubocop/issues/8726): Fix a false positive for `Naming/VariableNumber` when naming multibyte character variable name. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/configurable_numbering.rb
+++ b/lib/rubocop/cop/mixin/configurable_numbering.rb
@@ -8,9 +8,9 @@ module RuboCop
       include ConfigurableFormatting
 
       FORMATS = {
-        snake_case:  /(?:[a-z_]|_\d+)$/,
-        normalcase:  /(?:_\D*|[A-Za-z]\d*)$/,
-        non_integer: /[A-Za-z_]$/
+        snake_case:  /(?:[[[:lower:]]_]|_\d+)$/,
+        normalcase:  /(?:_\D*|[[[:upper:]][[:lower:]]]\d*)$/,
+        non_integer: /[[[:upper:]][[:lower:]]_]$/
       }.freeze
     end
   end

--- a/spec/rubocop/cop/naming/variable_number_spec.rb
+++ b/spec/rubocop/cop/naming/variable_number_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
     it_behaves_like 'accepts', 'snake_case', '_foo'
     it_behaves_like 'accepts', 'snake_case', '@foo'
     it_behaves_like 'accepts', 'snake_case', '@__foo__'
+    it_behaves_like 'accepts', 'snake_case', 'emparejó'
 
     it 'registers an offense for normal case numbering in method parameter' do
       expect_offense(<<~RUBY)
@@ -98,6 +99,7 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
     it_behaves_like 'accepts', 'normalcase', '_foo'
     it_behaves_like 'accepts', 'normalcase', '@foo'
     it_behaves_like 'accepts', 'normalcase', '@__foo__'
+    it_behaves_like 'accepts', 'snake_case', 'emparejó'
 
     it 'registers an offense for snake case numbering in method parameter' do
       expect_offense(<<~RUBY)
@@ -139,6 +141,7 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
     it_behaves_like 'accepts', 'non_integer', '_'
     it_behaves_like 'accepts', 'non_integer', '_foo'
     it_behaves_like 'accepts', 'non_integer', '@__foo__'
+    it_behaves_like 'accepts', 'snake_case', 'emparejó'
 
     it 'registers an offense for snake case numbering in method parameter' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #8726.

Fix a false positive for `Naming/VariableNumber` when naming multibyte character variable name.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
