### PR TITLE
[Fix #8730] Fix an error for `Lint/UselessTimes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#8720](https://github.com/rubocop-hq/rubocop/issues/8720): Fix an error for `Lint/IdentityComparison` when calling `object_id` method without receiver in LHS or RHS. ([@koic][])
 * [#8710](https://github.com/rubocop-hq/rubocop/issues/8710): Fix a false positive for `Layout/RescueEnsureAlignment` when `Layout/BeginEndAlignment` cop is not enabled status. ([@koic][])
 * [#8726](https://github.com/rubocop-hq/rubocop/issues/8726): Fix a false positive for `Naming/VariableNumber` when naming multibyte character variable name. ([@koic][])
+* [#8730](https://github.com/rubocop-hq/rubocop/issues/8730): Fix an error for `Lint/UselessTimes` when there is a blank line in the method definition. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/useless_times.rb
+++ b/lib/rubocop/cop/lint/useless_times.rb
@@ -82,7 +82,12 @@ module RuboCop
         def fix_indentation(source, range)
           # Cleanup indentation in a multiline block
           source_lines = source.split("\n")
-          source_lines[1..-1].each { |line| line[range] = '' }
+
+          source_lines[1..-1].each do |line|
+            next if line.empty?
+
+            line[range] = ''
+          end
           source_lines.join("\n")
         end
 

--- a/spec/rubocop/cop/lint/useless_times_spec.rb
+++ b/spec/rubocop/cop/lint/useless_times_spec.rb
@@ -61,6 +61,27 @@ RSpec.describe RuboCop::Cop::Lint::UselessTimes do
     RUBY
   end
 
+  it 'registers an offense and corrects when there is a blank line in the method definition' do
+    expect_offense(<<~RUBY)
+      def foo
+        1.times do
+        ^^^^^^^^^^ Useless call to `1.times` detected.
+          bar
+
+          baz
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        bar
+
+        baz
+      end
+    RUBY
+  end
+
   it 'does not register an offense for an integer > 1' do
     expect_no_offenses(<<~RUBY)
       2.times { |i| puts i }


### PR DESCRIPTION
Fixes #8730.

This PR fixes an error for `Lint/UselessTimes` when there is a blank line in the method definition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
