### PR TITLE
Enable autocorrection for `Style/DateTime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#8774](https://github.com/rubocop-hq/rubocop/issues/8774): Fix a false positive for `Layout/ArrayAlignment` with parallel assignment. ([@dvandersluis][])
 
+### Changes
+
+* [#8738](https://github.com/rubocop-hq/rubocop/issues/8738): Add autocorrection to `Style/DateTime`. ([@dvandersluis][])
+
 ## 0.91.1 (2020-09-23)
 
 ### Bug fixes

--- a/config/default.yml
+++ b/config/default.yml
@@ -2863,7 +2863,8 @@ Style/DateTime:
   StyleGuide: '#date--time'
   Enabled: false
   VersionAdded: '0.51'
-  VersionChanged: '0.59'
+  VersionChanged: '0.92'
+  SafeAutoCorrect: false
   AllowCoercion: false
 
 Style/DefWithParentheses:

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -1879,9 +1879,9 @@ an offense is reported.
 
 | Disabled
 | Yes
-| No
+| Yes (Unsafe)
 | 0.51
-| 0.59
+| 0.92
 |===
 
 This cop checks for consistent usage of the `DateTime` class over the

--- a/lib/rubocop/cop/style/date_time.rb
+++ b/lib/rubocop/cop/style/date_time.rb
@@ -42,6 +42,8 @@ module RuboCop
       #   # good
       #   something.to_time
       class DateTime < Base
+        extend AutoCorrector
+
         CLASS_MSG = 'Prefer Time over DateTime.'
         COERCION_MSG = 'Do not use #to_datetime.'
 
@@ -63,13 +65,22 @@ module RuboCop
           return if historic_date?(node)
 
           message = to_datetime?(node) ? COERCION_MSG : CLASS_MSG
-          add_offense(node, message: message)
+
+          add_offense(node, message: message) do |corrector|
+            autocorrect(corrector, node)
+          end
         end
 
         private
 
         def disallow_coercion?
           !cop_config['AllowCoercion']
+        end
+
+        def autocorrect(corrector, node)
+          return if to_datetime?(node)
+
+          corrector.replace(node.receiver.loc.name, 'Time')
         end
       end
     end

--- a/spec/rubocop/cop/style/date_time_spec.rb
+++ b/spec/rubocop/cop/style/date_time_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe RuboCop::Cop::Style::DateTime, :config do
       DateTime.now
       ^^^^^^^^^^^^ Prefer Time over DateTime.
     RUBY
+
+    expect_correction(<<~RUBY)
+      Time.now
+    RUBY
   end
 
   it 'registers an offense when using ::DateTime for current time' do
@@ -15,12 +19,20 @@ RSpec.describe RuboCop::Cop::Style::DateTime, :config do
       ::DateTime.now
       ^^^^^^^^^^^^^^ Prefer Time over DateTime.
     RUBY
+
+    expect_correction(<<~RUBY)
+      ::Time.now
+    RUBY
   end
 
   it 'registers an offense when using DateTime for modern date' do
     expect_offense(<<~RUBY)
       DateTime.iso8601('2016-06-29')
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer Time over DateTime.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Time.iso8601('2016-06-29')
     RUBY
   end
 


### PR DESCRIPTION
`Style/DateTime` did not have autocorrection enabled, so I added it to replace `DateTime` with `Time`. I have marked this as unsafe because we are not checking if the date being used is historic or not (unless a `start` parameter is passed in, such as in `iso8601`, in which case an offense isn't registered anyways).

I did not enable autocorrection for `to_datetime` because the message just states to not use it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
