### PR TITLE
Fix an error for `Lint/UselessTimes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#8726](https://github.com/rubocop-hq/rubocop/issues/8726): Fix a false positive for `Naming/VariableNumber` when naming multibyte character variable name. ([@koic][])
 * [#8730](https://github.com/rubocop-hq/rubocop/issues/8730): Fix an error for `Lint/UselessTimes` when there is a blank line in the method definition. ([@koic][])
 * [#8740](https://github.com/rubocop-hq/rubocop/issues/8740): Fix a false positive for `Style/HashAsLastArrayItem` when the hash is in an implicit array. ([@dvandersluis][])
+* [#8739](https://github.com/rubocop-hq/rubocop/issues/8739): Fix an error for `Lint/UselessTimes` when using empty block argument. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/useless_times.rb
+++ b/lib/rubocop/cop/lint/useless_times.rb
@@ -49,7 +49,7 @@ module RuboCop
           add_offense(node, message: format(MSG, count: count)) do |corrector|
             next unless own_line?(node)
 
-            if count < 1
+            if never_process?(count, node)
               remove_node(corrector, node)
             elsif !proc_name.empty?
               autocorrect_block_pass(corrector, node, proc_name)
@@ -60,6 +60,10 @@ module RuboCop
         end
 
         private
+
+        def never_process?(count, node)
+          count < 1 || node.block_type? && node.body.nil?
+        end
 
         def remove_node(corrector, node)
           corrector.remove(range_by_whole_lines(node.loc.expression, include_final_newline: true))

--- a/spec/rubocop/cop/lint/useless_times_spec.rb
+++ b/spec/rubocop/cop/lint/useless_times_spec.rb
@@ -61,6 +61,21 @@ RSpec.describe RuboCop::Cop::Lint::UselessTimes do
     RUBY
   end
 
+  it 'registers an offense and corrects when 1.times with empty block argument' do
+    expect_offense(<<~RUBY)
+      def foo
+        1.times do
+        ^^^^^^^^^^ Useless call to `1.times` detected.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+      end
+    RUBY
+  end
+
   it 'registers an offense and corrects when there is a blank line in the method definition' do
     expect_offense(<<~RUBY)
       def foo


### PR DESCRIPTION
This PR fixes the following error for `Lint/UselessTimes` when using empty block argument.

```console
% cat example.rb
def foo
  1.times do
  end
end

% rubocop --only Lint/UselessTimes -d
(snip)

Inspecting 1 file
Scanning /Users/koic/src/github.com/koic/rubocop-issues/bar/example.rb
An error occurred while Lint/UselessTimes cop was inspecting
/Users/koic/src/github.com/koic/rubocop-issues/bar/example.rb:2:2.
undefined method `source' for nil:NilClass
/Users/koic/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rubocop-0.91.0/lib/rubocop/cop/lint/useless_times.rb:76:in `autocorrect_block'
/Users/koic/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rubocop-0.91.0/lib/rubocop/cop/lint/useless_times.rb:57:in `block in on_send'
/Users/koic/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rubocop-0.91.0/lib/rubocop/cop/base.rb:333:in `correct'
/Users/koic/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rubocop-0.91.0/lib/rubocop/cop/base.rb:126:in `add_offense'
/Users/koic/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rubocop-0.91.0/lib/rubocop/cop/lint/useless_times.rb:49:in `on_send'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
