### PR TITLE
[Fix #8740] Fix a false positive for `Style/HashAsLastArrayItem` when the hash is in an implicit array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#8710](https://github.com/rubocop-hq/rubocop/issues/8710): Fix a false positive for `Layout/RescueEnsureAlignment` when `Layout/BeginEndAlignment` cop is not enabled status. ([@koic][])
 * [#8726](https://github.com/rubocop-hq/rubocop/issues/8726): Fix a false positive for `Naming/VariableNumber` when naming multibyte character variable name. ([@koic][])
 * [#8730](https://github.com/rubocop-hq/rubocop/issues/8730): Fix an error for `Lint/UselessTimes` when there is a blank line in the method definition. ([@koic][])
+* [#8740](https://github.com/rubocop-hq/rubocop/issues/8740): Fix a false positive for `Style/HashAsLastArrayItem` when the hash is in an implicit array. ([@dvandersluis][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/hash_as_last_array_item_spec.rb
+++ b/spec/rubocop/cop/style/hash_as_last_array_item_spec.rb
@@ -83,5 +83,11 @@ RSpec.describe RuboCop::Cop::Style::HashAsLastArrayItem, :config do
         [1, {}]
       RUBY
     end
+
+    it 'does not register an offense when passing an implicit array to a setter' do
+      expect_no_offenses(<<~RUBY)
+        cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] }
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Arrays can be passed implicitly to setters, in which case removing the braces causes a syntax error. For example:

```ruby
config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] } 
```

This change fixes `Style/HashAsLastArrayItem` to not mark the above as an offense or try to correct it.

Fixes #8740.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
