### PR TITLE
Address `frozen_string_literal` no longer applying to interpolated strings

### DIFF
--- a/lib/rubocop/cop/mixin/frozen_string_literal.rb
+++ b/lib/rubocop/cop/mixin/frozen_string_literal.rb
@@ -8,7 +8,7 @@ module RuboCop
 
       FROZEN_STRING_LITERAL = '# frozen_string_literal:'
       FROZEN_STRING_LITERAL_ENABLED = '# frozen_string_literal: true'
-      FROZEN_STRING_LITERAL_TYPES = %i[str dstr].freeze
+      FROZEN_STRING_LITERAL_TYPES = %i[str].freeze
 
       def frozen_string_literal_comment_exists?
         leading_comment_lines.any? do |line|

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
       end
     end
 
-    context 'when the constant is a frozen string literal' do
+    context 'when the constant is a string literal' do
       # TODO : It is not yet decided when frozen string will be the default.
       # It has been abandoned in the Ruby 3.0 period, but may default in
       # the long run. So these tests are left with a provisional value of 4.0.
@@ -166,37 +166,43 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
           let(:ruby_version) { 4.0 }
 
           context 'when the frozen string literal comment is missing' do
-            it_behaves_like 'immutable objects', '"#{a}"'
+            it_behaves_like 'immutable objects', '"#{interpolated}"'
+            it_behaves_like 'immutable objects', '"static"'
           end
 
           context 'when the frozen string literal comment is true' do
             let(:prefix) { '# frozen_string_literal: true' }
 
-            it_behaves_like 'immutable objects', '"#{a}"'
+            it_behaves_like 'immutable objects', '"#{interpolated}"'
+            it_behaves_like 'immutable objects', '"static"'
           end
 
           context 'when the frozen string literal comment is false' do
             let(:prefix) { '# frozen_string_literal: false' }
 
-            it_behaves_like 'immutable objects', '"#{a}"'
+            it_behaves_like 'immutable objects', '"#{interpolated}"'
+            it_behaves_like 'immutable objects', '"static"'
           end
         end
       end
 
       context 'when the frozen string literal comment is missing' do
-        it_behaves_like 'mutable objects', '"#{a}"'
+        it_behaves_like 'mutable objects', '"#{interpolated}"'
+        it_behaves_like 'mutable objects', '"static"'
       end
 
       context 'when the frozen string literal comment is true' do
         let(:prefix) { '# frozen_string_literal: true' }
 
-        it_behaves_like 'immutable objects', '"#{a}"'
+        it_behaves_like 'immutable objects', '"#{interpolated}"'
+        it_behaves_like 'immutable objects', '"static"'
       end
 
       context 'when the frozen string literal comment is false' do
         let(:prefix) { '# frozen_string_literal: false' }
 
-        it_behaves_like 'mutable objects', '"#{a}"'
+        it_behaves_like 'mutable objects', '"#{interpolated}"'
+        it_behaves_like 'mutable objects', '"static"'
       end
     end
   end
@@ -413,19 +419,22 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
     end
 
     context 'when the frozen string literal comment is missing' do
-      it_behaves_like 'mutable objects', '"#{a}"'
+      it_behaves_like 'mutable objects', '"#{interpolated}"'
+      it_behaves_like 'mutable objects', '"static"'
     end
 
     context 'when the frozen string literal comment is true' do
       let(:prefix) { '# frozen_string_literal: true' }
 
-      it_behaves_like 'immutable objects', '"#{a}"'
+      it_behaves_like 'immutable objects', '"#{interpolated}"'
+      it_behaves_like 'immutable objects', '"static"'
     end
 
     context 'when the frozen string literal comment is false' do
       let(:prefix) { '# frozen_string_literal: false' }
 
-      it_behaves_like 'mutable objects', '"#{a}"'
+      it_behaves_like 'mutable objects', '"#{interpolated}"'
+      it_behaves_like 'mutable objects', '"static"'
     end
   end
 end

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -166,21 +166,21 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
           let(:ruby_version) { 4.0 }
 
           context 'when the frozen string literal comment is missing' do
-            it_behaves_like 'immutable objects', '"#{interpolated}"'
+            it_behaves_like 'mutable objects', '"#{interpolated}"'
             it_behaves_like 'immutable objects', '"static"'
           end
 
           context 'when the frozen string literal comment is true' do
             let(:prefix) { '# frozen_string_literal: true' }
 
-            it_behaves_like 'immutable objects', '"#{interpolated}"'
+            it_behaves_like 'mutable objects', '"#{interpolated}"'
             it_behaves_like 'immutable objects', '"static"'
           end
 
           context 'when the frozen string literal comment is false' do
             let(:prefix) { '# frozen_string_literal: false' }
 
-            it_behaves_like 'immutable objects', '"#{interpolated}"'
+            it_behaves_like 'mutable objects', '"#{interpolated}"'
             it_behaves_like 'immutable objects', '"static"'
           end
         end
@@ -194,7 +194,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
       context 'when the frozen string literal comment is true' do
         let(:prefix) { '# frozen_string_literal: true' }
 
-        it_behaves_like 'immutable objects', '"#{interpolated}"'
+        it_behaves_like 'mutable objects', '"#{interpolated}"'
         it_behaves_like 'immutable objects', '"static"'
       end
 
@@ -426,7 +426,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
     context 'when the frozen string literal comment is true' do
       let(:prefix) { '# frozen_string_literal: true' }
 
-      it_behaves_like 'immutable objects', '"#{interpolated}"'
+      it_behaves_like 'mutable objects', '"#{interpolated}"'
       it_behaves_like 'immutable objects', '"static"'
     end
 

--- a/spec/rubocop/cop/style/redundant_freeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_freeze_spec.rb
@@ -62,21 +62,21 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze do
         let(:ruby_version) { 4.0 }
 
         context 'when the frozen string literal comment is missing' do
-          it_behaves_like 'immutable objects', '"#{interpolated}"'
+          it_behaves_like 'mutable objects', '"#{interpolated}"'
           it_behaves_like 'immutable objects', '"static"'
         end
 
         context 'when the frozen string literal comment is true' do
           let(:prefix) { '# frozen_string_literal: true' }
 
-          it_behaves_like 'immutable objects', '"#{interpolated}"'
+          it_behaves_like 'mutable objects', '"#{interpolated}"'
           it_behaves_like 'immutable objects', '"static"'
         end
 
         context 'when the frozen string literal comment is false' do
           let(:prefix) { '# frozen_string_literal: false' }
 
-          it_behaves_like 'immutable objects', '"#{interpolated}"'
+          it_behaves_like 'mutable objects', '"#{interpolated}"'
           it_behaves_like 'immutable objects', '"static"'
         end
       end
@@ -90,7 +90,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze do
     context 'when the frozen string literal comment is true' do
       let(:prefix) { '# frozen_string_literal: true' }
 
-      it_behaves_like 'immutable objects', '"#{interpolated}"'
+      it_behaves_like 'mutable objects', '"#{interpolated}"'
       it_behaves_like 'immutable objects', '"static"'
     end
 

--- a/spec/rubocop/cop/style/redundant_freeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_freeze_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze do
     expect_no_offenses('TOP_TEST = Something.new.freeze')
   end
 
-  context 'when the receiver is a frozen string literal' do
+  context 'when the receiver is a string literal' do
     # TODO : It is not yet decided when frozen string will be the default.
     # It has been abandoned in the Ruby 3.0 period, but may default in
     # the long run. So these tests are left with a provisional value of 4.0.
@@ -62,37 +62,43 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze do
         let(:ruby_version) { 4.0 }
 
         context 'when the frozen string literal comment is missing' do
-          it_behaves_like 'immutable objects', '"#{a}"'
+          it_behaves_like 'immutable objects', '"#{interpolated}"'
+          it_behaves_like 'immutable objects', '"static"'
         end
 
         context 'when the frozen string literal comment is true' do
           let(:prefix) { '# frozen_string_literal: true' }
 
-          it_behaves_like 'immutable objects', '"#{a}"'
+          it_behaves_like 'immutable objects', '"#{interpolated}"'
+          it_behaves_like 'immutable objects', '"static"'
         end
 
         context 'when the frozen string literal comment is false' do
           let(:prefix) { '# frozen_string_literal: false' }
 
-          it_behaves_like 'immutable objects', '"#{a}"'
+          it_behaves_like 'immutable objects', '"#{interpolated}"'
+          it_behaves_like 'immutable objects', '"static"'
         end
       end
     end
 
     context 'when the frozen string literal comment is missing' do
-      it_behaves_like 'mutable objects', '"#{a}"'
+      it_behaves_like 'mutable objects', '"#{interpolated}"'
+      it_behaves_like 'mutable objects', '"static"'
     end
 
     context 'when the frozen string literal comment is true' do
       let(:prefix) { '# frozen_string_literal: true' }
 
-      it_behaves_like 'immutable objects', '"#{a}"'
+      it_behaves_like 'immutable objects', '"#{interpolated}"'
+      it_behaves_like 'immutable objects', '"static"'
     end
 
     context 'when the frozen string literal comment is false' do
       let(:prefix) { '# frozen_string_literal: false' }
 
-      it_behaves_like 'mutable objects', '"#{a}"'
+      it_behaves_like 'mutable objects', '"#{interpolated}"'
+      it_behaves_like 'mutable objects', '"static"'
     end
   end
 end


### PR DESCRIPTION
As per [Ruby Feature #17104](https://bugs.ruby-lang.org/issues/17104), interpolated string literals will no longer be frozen when frozen string literals are enabled.

Therefore, two changes must happen to how we treat **interpolated** literals

- `Style/MutableConstant` should enforce freezing them
- `Style/RedundantFreeze` should not consider it redundant to freeze them

This PR makes those changes.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/

----

Fixes #8703
