### PR TITLE
[Fix #8372] Fix `Lint/RedundantCopDisableDirective` autocorrection removing a preceding newline incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#8750](https://github.com/rubocop-hq/rubocop/pull/8750): Fix an incorrect auto-correct for `Style/MultilineWhenThen` when line break for multiple condidate values of `when` statement. ([@koic][])
 * [#8754](https://github.com/rubocop-hq/rubocop/pull/8754): Fix an error for `Style/RandomWithOffset` when using a range with non-integer bounds. ([@eugeneius][])
 * [#8756](https://github.com/rubocop-hq/rubocop/issues/8756): Fix an infinite loop error for `Layout/EmptyLinesAroundAccessModifier` with `Layout/EmptyLinesAroundBlockBody` when using access modifier with block argument. ([@koic][])
+* [#8372](https://github.com/rubocop-hq/rubocop/issues/8372): Fix `Lint/RedundantCopDisableDirective` autocorrection. ([@dvandersluis][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -56,19 +56,29 @@ module RuboCop
 
         private
 
+        def previous_line_blank?(range)
+          processed_source.buffer.source_line(range.line - 1).blank?
+        end
+
         def comment_range_with_surrounding_space(range)
-          # Eat the entire comment, the preceding space, and the preceding
-          # newline if there is one.
-          original_begin = range.begin_pos
-          range = range_with_surrounding_space(range: range,
-                                               side: :left,
-                                               newlines: true)
-          range_with_surrounding_space(range: range,
-                                       side: :right,
-                                       # Special for a comment that
-                                       # begins the file: remove
-                                       # the newline at the end.
-                                       newlines: original_begin.zero?)
+          if previous_line_blank?(range)
+            # When the previous line is blank, it should be retained
+            range_with_surrounding_space(range: range, side: :right)
+          else
+            # Eat the entire comment, the preceding space, and the preceding
+            # newline if there is one.
+            original_begin = range.begin_pos
+            range = range_with_surrounding_space(range: range,
+                                                 side: :left,
+                                                 newlines: true)
+
+            range_with_surrounding_space(range: range,
+                                         side: :right,
+                                         # Special for a comment that
+                                         # begins the file: remove
+                                         # the newline at the end.
+                                         newlines: original_begin.zero?)
+          end
         end
 
         def directive_range_in_list(range, ranges)


### PR DESCRIPTION
First fix for #8372 (I split it into two PRs since it touches two cops), fixes `Lint/RedundantCopDisableDirective` autocorrection so that it doesn't clobber blank lines. There were no tests previously for autocorrection, so this change also adds tests to ensure whitespace is managed correctly.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
