### PR TITLE
[Fixes #8742] `Metrics/AbcSize`: Fix assignment counts for various cases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#8730](https://github.com/rubocop-hq/rubocop/issues/8730): Fix an error for `Lint/UselessTimes` when there is a blank line in the method definition. ([@koic][])
 * [#8740](https://github.com/rubocop-hq/rubocop/issues/8740): Fix a false positive for `Style/HashAsLastArrayItem` when the hash is in an implicit array. ([@dvandersluis][])
 * [#8739](https://github.com/rubocop-hq/rubocop/issues/8739): Fix an error for `Lint/UselessTimes` when using empty block argument. ([@koic][])
+* [#8742](https://github.com/rubocop-hq/rubocop/issues/8742): Fix some assignment counts for `Metrics/AbcSize`. ([@marcandre][])
 
 ### Changes
 

--- a/lib/rubocop/cop/metrics/utils/abc_size_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/abc_size_calculator.rb
@@ -102,12 +102,6 @@ module RuboCop
             name && !/^_/.match?(name)
           end
 
-          # Returns true for nodes which otherwise would be counted
-          # as one too many assignment
-          def assignment_doubled_in_ast?(node)
-            node.masgn_type? || node.or_asgn_type? || node.and_asgn_type?
-          end
-
           def branch?(node)
             BRANCH_NODES.include?(node.type)
           end

--- a/spec/rubocop/cop/metrics/utils/abc_size_calculator_spec.rb
+++ b/spec/rubocop/cop/metrics/utils/abc_size_calculator_spec.rb
@@ -16,6 +16,27 @@ RSpec.describe RuboCop::Cop::Metrics::Utils::AbcSizeCalculator do
       it { is_expected.to eq '<0, 3, 0>' }
     end
 
+    context 'with +=' do
+      let(:source) { <<~RUBY }
+        def method_name
+          x = nil
+          x += 1
+        end
+      RUBY
+
+      it { is_expected.to eq '<2, 0, 0>' }
+    end
+
+    context 'with += for setters' do
+      let(:source) { <<~RUBY }
+        def method_name
+          foo.bar += 1
+        end
+      RUBY
+
+      it { is_expected.to eq '<1, 2, 0>' }
+    end
+
     context 'with ||=' do
       let(:source) { <<~RUBY }
         def method_name
@@ -25,6 +46,16 @@ RSpec.describe RuboCop::Cop::Metrics::Utils::AbcSizeCalculator do
       RUBY
 
       it { is_expected.to eq '<2, 0, 1>' }
+    end
+
+    context 'with ||= on a constant' do
+      let(:source) { <<~RUBY }
+        def method_name
+          self::FooModule ||= Mod
+        end
+      RUBY
+
+      it { is_expected.to eq '<1, 0, 1>' }
     end
 
     context 'with &&=' do
@@ -140,6 +171,28 @@ RSpec.describe RuboCop::Cop::Metrics::Utils::AbcSizeCalculator do
       RUBY
 
       it { is_expected.to eq '<3, 1, 0>' }
+    end
+
+    context 'multiple assignment with method setters' do
+      let(:source) { <<~RUBY }
+        def method_name
+          self.a, foo.b, bar[42] = nil
+        end
+      RUBY
+
+      it { is_expected.to eq '<3, 5, 0>' }
+    end
+
+    context 'equivalent to multiple assignment with method setters' do
+      let(:source) { <<~RUBY }
+        def method_name
+          self.a = nil    # 1,  1, 0
+          foo.b = nil     # 1, +2, 0
+          bar[42] = nil   # 1, +2, 0
+        end
+      RUBY
+
+      it { is_expected.to eq '<3, 5, 0>' }
     end
 
     context 'if and arithmetic operations' do


### PR DESCRIPTION
`var += ...` was counted twice
`obj.method += ...` was not counted
`Const ||= ...` was crashing [#8742]
