### PR TITLE
Fix an incorrect auto-correct for `Style/MultilineWhenThen`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#8740](https://github.com/rubocop-hq/rubocop/issues/8740): Fix a false positive for `Style/HashAsLastArrayItem` when the hash is in an implicit array. ([@dvandersluis][])
 * [#8739](https://github.com/rubocop-hq/rubocop/issues/8739): Fix an error for `Lint/UselessTimes` when using empty block argument. ([@koic][])
 * [#8742](https://github.com/rubocop-hq/rubocop/issues/8742): Fix some assignment counts for `Metrics/AbcSize`. ([@marcandre][])
+* [#8750](https://github.com/rubocop-hq/rubocop/pull/8750): Fix an incorrect auto-correct for `Style/MultilineWhenThen` when line break for multiple condidate values of `when` statement. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/multiline_when_then.rb
+++ b/lib/rubocop/cop/style/multiline_when_then.rb
@@ -58,6 +58,7 @@ module RuboCop
         private
 
         def require_then?(when_node)
+          return true if when_node.conditions.count >= 2
           return false unless when_node.body
 
           when_node.loc.line == when_node.body.loc.line

--- a/spec/rubocop/cop/style/multiline_when_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_when_then_spec.rb
@@ -136,4 +136,13 @@ RSpec.describe RuboCop::Cop::Style::MultilineWhenThen do
       end
     RUBY
   end
+
+  it 'does not register an offense when line break for multiple condidate values of `when`' do
+    expect_no_offenses(<<~RUBY)
+      case foo
+      when bar,
+           baz then do_something
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR fixes the following incorrect auto-correct for `Style/MultilineWhenThen` when line break for multiple condidate values of `when` statement.

```console
% cat example.rb
case condition
when :foo,
     :bar then nil
end

% rubocop -a
(snip)

E

Offenses:

example.rb:3:11: E: Lint/Syntax: unexpected token kNIL
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter,
under AllCops)
     :bar nil
          ^^^
example.rb:3:11: C: [Corrected] Style/MultilineWhenThen: Do not use then
for multiline when statement.
     :bar then nil
          ^^^^

1 file inspected, 2 offenses detected, 1 offense corrected

% cat example.rb
case condition
when :foo,
     :bar nil
end

% ruby -c example.rb
example.rb:3: syntax error, unexpected `nil', expecting `then' or ',' or
';' or '\n'
     :bar nil
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
