### PR TITLE
Ignore non-integer ranges in Style/RandomWithOffset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#8739](https://github.com/rubocop-hq/rubocop/issues/8739): Fix an error for `Lint/UselessTimes` when using empty block argument. ([@koic][])
 * [#8742](https://github.com/rubocop-hq/rubocop/issues/8742): Fix some assignment counts for `Metrics/AbcSize`. ([@marcandre][])
 * [#8750](https://github.com/rubocop-hq/rubocop/pull/8750): Fix an incorrect auto-correct for `Style/MultilineWhenThen` when line break for multiple condidate values of `when` statement. ([@koic][])
+* [#8754](https://github.com/rubocop-hq/rubocop/pull/8754): Fix an error for `Style/RandomWithOffset` when using a range with non-integer bounds. ([@eugeneius][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/random_with_offset.rb
+++ b/lib/rubocop/cop/style/random_with_offset.rb
@@ -36,7 +36,7 @@ module RuboCop
             (send
               {nil? (const {nil? cbase} :Random) (const {nil? cbase} :Kernel)}
               :rand
-              {int irange erange}))
+              {int (irange int int) (erange int int)}))
         PATTERN
 
         def_node_matcher :rand_op_integer?, <<~PATTERN
@@ -44,7 +44,7 @@ module RuboCop
             (send
               {nil? (const {nil? cbase} :Random) (const {nil? cbase} :Kernel)}
               :rand
-              {int irange erange})
+              {int (irange int int) (erange int int)})
             {:+ :-}
             int)
         PATTERN
@@ -54,7 +54,7 @@ module RuboCop
             (send
               {nil? (const {nil? cbase} :Random) (const {nil? cbase} :Kernel)}
               :rand
-              {int irange erange})
+              {int (irange int int) (erange int int)})
             {:succ :pred :next})
         PATTERN
 

--- a/spec/rubocop/cop/style/random_with_offset_spec.rb
+++ b/spec/rubocop/cop/style/random_with_offset_spec.rb
@@ -258,6 +258,30 @@ RSpec.describe RuboCop::Cop::Style::RandomWithOffset do
     RUBY
   end
 
+  it 'does not register an offense when using rand(irange) + offset with a non-integer range value' do
+    expect_no_offenses(<<~RUBY)
+      rand(0..limit) + 1
+    RUBY
+  end
+
+  it 'does not register an offense when using offset - rand(erange) with a non-integer range value' do
+    expect_no_offenses(<<~RUBY)
+      1 - rand(0...limit)
+    RUBY
+  end
+
+  it 'does not register an offense when using rand(irange).succ with a non-integer range value' do
+    expect_no_offenses(<<~RUBY)
+      rand(0..limit).succ
+    RUBY
+  end
+
+  it 'does not register an offense when using rand(erange).pred with a non-integer range value' do
+    expect_no_offenses(<<~RUBY)
+      rand(0...limit).pred
+    RUBY
+  end
+
   it 'does not register an offense when using range with double dots' do
     expect_no_offenses('rand(1..6)')
   end


### PR DESCRIPTION
This cop only works correctly for ranges with literal integer bounds.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/