### PR TITLE
Fix a false positive for `Layout/EmptyLinesAroundAccessModifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#8742](https://github.com/rubocop-hq/rubocop/issues/8742): Fix some assignment counts for `Metrics/AbcSize`. ([@marcandre][])
 * [#8750](https://github.com/rubocop-hq/rubocop/pull/8750): Fix an incorrect auto-correct for `Style/MultilineWhenThen` when line break for multiple condidate values of `when` statement. ([@koic][])
 * [#8754](https://github.com/rubocop-hq/rubocop/pull/8754): Fix an error for `Style/RandomWithOffset` when using a range with non-integer bounds. ([@eugeneius][])
+* [#8756](https://github.com/rubocop-hq/rubocop/issues/8756): Fix an infinite loop error for `Layout/EmptyLinesAroundAccessModifier` with `Layout/EmptyLinesAroundBlockBody` when using access modifier with block argument. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
@@ -84,14 +84,7 @@ module RuboCop
         end
 
         def on_send(node)
-          return unless node.bare_access_modifier?
-
-          case style
-          when :around
-            return if empty_lines_around?(node)
-          when :only_before
-            return if allowed_only_before_style?(node)
-          end
+          return unless register_offense?(node)
 
           message = message(node)
           add_offense(node, message: message) do |corrector|
@@ -104,6 +97,19 @@ module RuboCop
         end
 
         private
+
+        def register_offense?(node)
+          return false unless node.bare_access_modifier? && !node.parent.block_type?
+
+          case style
+          when :around
+            return false if empty_lines_around?(node)
+          when :only_before
+            return false if allowed_only_before_style?(node)
+          end
+
+          true
+        end
 
         def allowed_only_before_style?(node)
           if node.special_modifier?

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1599,6 +1599,36 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     RUBY
   end
 
+  it 'does not crash when using Lint/SafeNavigationWithEmpty and Layout/EmptyLinesAroundBlockBody' do
+    create_file('example.rb', <<~RUBY)
+      FactoryBot.define do
+        factory :model do
+          name { 'value' }
+
+          private { value }
+        end
+      end
+    RUBY
+
+    expect(
+      cli.run(
+        [
+          '--auto-correct',
+          '--only', 'Layout/EmptyLinesAroundAccessModifier,Layout/EmptyLinesAroundBlockBody'
+        ]
+      )
+    ).to eq(0)
+    expect(IO.read('example.rb')).to eq(<<~RUBY)
+      FactoryBot.define do
+        factory :model do
+          name { 'value' }
+
+          private { value }
+        end
+      end
+    RUBY
+  end
+
   it 'corrects TrailingCommaIn(Array|Hash)Literal and ' \
      'Multiline(Array|Hash)BraceLayout offenses' do
     create_file('.rubocop.yml', <<~YAML)

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -105,6 +105,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
         RUBY
       end
 
+      it "ignores #{access_modifier} with block argument" do
+        expect_no_offenses(<<~RUBY)
+          def foo
+            #{access_modifier} { do_something }
+          end
+        RUBY
+      end
+
       it 'autocorrects blank line after #{access_modifier} with comment' do
         expect_offense(<<~RUBY)
           class Test


### PR DESCRIPTION
This PR fixes the following infinite loop error for `Layout/EmptyLinesAroundAccessModifier` with `Layout/EmptyLinesAroundBlockBody` when using access modifier with block argument.

```console
% cat example.rb
FactoryBot.define do
  factory :model do
    name { 'hoge' }

    private { true }
  end
end

% rubocop -a --only Layout/EmptyLinesAroundAccessModifier,Layout/EmptyLinesAroundBlockBody
(snip)

Inspecting 1 file
C

Offenses:

example.rb:5:5: C: [Corrected] Layout/EmptyLinesAroundAccessModifier:
Keep a blank line before and after private.
    private { true }
    ^^^^^^^
example.rb:6:1: C: [Corrected] Layout/EmptyLinesAroundBlockBody: Extra
empty line detected at block body end.

0 files inspected, 2 offenses detected, 2 offenses corrected
Infinite loop detected in
/Users/koic/src/github.com/koic/rubocop-issues/factory_bot/example.rb
and caused by Layout/EmptyLinesAroundAccessModifier -> Layout/EmptyLinesAroundBlockBody
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
