### PR TITLE
[Fix #8749] Disable `Style/IpAddresses` by default in gemfiles and gemspec files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 * [#8489](https://github.com/rubocop-hq/rubocop/issues/8489): Exclude method `respond_to_missing?` from `OptionalBooleanParameter` cop. ([@em-gazelle][])
 * [#7914](https://github.com/rubocop-hq/rubocop/issues/7914): Style/SafeNavigation marked as having unsafe auto-correction. ([@marcandre][])
+* [#8749](https://github.com/rubocop-hq/rubocop/issues/8749): Disable `Style/IpAddresses` by default in Gemfile and gemspec files. ([@dvandersluis][])
 
 ## 0.91.0 (2020-09-15)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -3283,11 +3283,16 @@ Style/IpAddresses:
   Description: "Don't include literal IP addresses in code."
   Enabled: false
   VersionAdded: '0.58'
-  VersionChanged: '0.77'
+  VersionChanged: '0.91'
   # Allow addresses to be permitted
   AllowedAddresses:
     - "::"
     # :: is a valid IPv6 address, but could potentially be legitimately in code
+  Exclude:
+    - '**/*.gemfile'
+    - '**/Gemfile'
+    - '**/gems.rb'
+    - '**/*.gemspec'
 
 Style/KeywordParametersOrder:
   Description: 'Enforces that optional keyword parameters are placed at the end of the parameters list.'

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -4460,7 +4460,7 @@ end
 | Yes
 | No
 | 0.58
-| 0.77
+| 0.91
 |===
 
 This cop checks for hardcoded IP addresses, which can make code
@@ -4487,6 +4487,10 @@ ip_address = ENV['DEPLOYMENT_IP_ADDRESS']
 
 | AllowedAddresses
 | `::`
+| Array
+
+| Exclude
+| `**/*.gemfile`, `**/Gemfile`, `**/gems.rb`, `**/*.gemspec`
 | Array
 |===
 


### PR DESCRIPTION
Fixes #8749.

Not sure if there's a way to test default exclusions so I didn't try to add tests for it but I am happy to if desired.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
