### PR TITLE
[Fix #8764] Fix `Layout/CaseIndentation` to properly output annotated error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#8750](https://github.com/rubocop-hq/rubocop/pull/8750): Fix an incorrect auto-correct for `Style/MultilineWhenThen` when line break for multiple condidate values of `when` statement. ([@koic][])
 * [#8754](https://github.com/rubocop-hq/rubocop/pull/8754): Fix an error for `Style/RandomWithOffset` when using a range with non-integer bounds. ([@eugeneius][])
 * [#8756](https://github.com/rubocop-hq/rubocop/issues/8756): Fix an infinite loop error for `Layout/EmptyLinesAroundAccessModifier` with `Layout/EmptyLinesAroundBlockBody` when using access modifier with block argument. ([@koic][])
+* [#8764](https://github.com/rubocop-hq/rubocop/issues/8764): Fix `Layout/CaseIndentation` not showing the cop name in output messages. ([@dvandersluis][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/case_indentation.rb
+++ b/lib/rubocop/cop/layout/case_indentation.rb
@@ -105,7 +105,10 @@ module RuboCop
         end
 
         def incorrect_style(when_node)
-          add_offense(when_node.loc.keyword) do |corrector|
+          depth = indent_one_step? ? 'one step more than' : 'as deep as'
+          message = format(MSG, depth: depth, base: style)
+
+          add_offense(when_node.loc.keyword, message: message) do |corrector|
             detect_incorrect_style(when_node)
 
             whitespace = whitespace_range(when_node)
@@ -123,12 +126,6 @@ module RuboCop
           else
             unrecognized_style_detected
           end
-        end
-
-        def find_message(*)
-          depth = indent_one_step? ? 'one step more than' : 'as deep as'
-
-          format(MSG, depth: depth, base: style)
         end
 
         def base_column(case_node, base)


### PR DESCRIPTION
`find_message` is overridden in `Layout::CaseIndentation` but did not actually annotate the message, so the cop name was not being shown in the output.

Fixes #8764.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
