### PR TITLE
[Fix #8771] Fix an error for `Style/OneLineConditional`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#8754](https://github.com/rubocop-hq/rubocop/pull/8754): Fix an error for `Style/RandomWithOffset` when using a range with non-integer bounds. ([@eugeneius][])
 * [#8756](https://github.com/rubocop-hq/rubocop/issues/8756): Fix an infinite loop error for `Layout/EmptyLinesAroundAccessModifier` with `Layout/EmptyLinesAroundBlockBody` when using access modifier with block argument. ([@koic][])
 * [#8764](https://github.com/rubocop-hq/rubocop/issues/8764): Fix `Layout/CaseIndentation` not showing the cop name in output messages. ([@dvandersluis][])
+* [#8771](https://github.com/rubocop-hq/rubocop/issues/8771): Fix an error for `Style/OneLineConditional` when using `if-then-elsif-then-end`. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/one_line_conditional.rb
+++ b/lib/rubocop/cop/style/one_line_conditional.rb
@@ -89,7 +89,9 @@ module RuboCop
         end
 
         def else_branch_to_multiline(else_branch, indentation)
-          if else_branch.if_type? && else_branch.elsif?
+          if else_branch.nil?
+            'end'
+          elsif else_branch.if_type? && else_branch.elsif?
             multiline_replacement(else_branch, indentation)
           else
             <<~RUBY.chomp

--- a/spec/rubocop/cop/style/one_line_conditional_spec.rb
+++ b/spec/rubocop/cop/style/one_line_conditional_spec.rb
@@ -180,6 +180,22 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional do
     end
 
     it 'registers and corrects an offense with multi-line construct for ' \
+       'if-then-elsif-then-end' do
+      expect_offense(<<~RUBY)
+        if cond1 then run elsif cond2 then maybe end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{if_offense_message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if cond1
+          run
+        elsif cond2
+          maybe
+        end
+      RUBY
+    end
+
+    it 'registers and corrects an offense with multi-line construct for ' \
        'if-then-elsif-then-else-end' do
       expect_offense(<<~RUBY)
         if cond1 then run elsif cond2 then maybe else dont end


### PR DESCRIPTION
Fixes #8771.

This PR fixes an error for `Style/OneLineConditional` when using `if-then-elsif-then-end`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
