### PR TITLE
Specify the release version of document URL for rubygems.org

### DIFF
--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -20,5 +20,10 @@ module RuboCop
         STRING
       end
     end
+
+    # @api private
+    def self.document_version
+      STRING.match('\d+\.\d+').to_s
+    end
   end
 end

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
     'homepage_uri' => 'https://rubocop.org/',
     'changelog_uri' => 'https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md',
     'source_code_uri' => 'https://github.com/rubocop-hq/rubocop/',
-    'documentation_uri' => 'https://docs.rubocop.org/',
+    'documentation_uri' => "https://docs.rubocop.org/rubocop/#{RuboCop::Version.document_version}/",
     'bug_tracker_uri' => 'https://github.com/rubocop-hq/rubocop/issues'
   }
 


### PR DESCRIPTION
Currently, always links to the latest stable documentation. This PR will link to documents that match each published version.
It will be effective since the next release.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
