### PR TITLE
Fix crash when `expect_corrections` runs into an infinite loop

### DIFF
--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -133,14 +133,14 @@ module RuboCop
             "#{@processed_source.diagnostics.map(&:render).join("\n")}"
         end
 
-        offenses = _investigate(cop, @processed_source)
+        @offenses = _investigate(cop, @processed_source)
         actual_annotations =
-          expected_annotations.with_offense_annotations(offenses)
+          expected_annotations.with_offense_annotations(@offenses)
 
         expect(actual_annotations).to eq(expected_annotations), ''
-        expect(offenses.map(&:severity).uniq).to eq([severity]) if severity
+        expect(@offenses.map(&:severity).uniq).to eq([severity]) if severity
 
-        offenses
+        @offenses
       end
 
       def expect_correction(correction, loop: true)
@@ -157,7 +157,7 @@ module RuboCop
           break corrected_source if corrected_source == @processed_source.buffer.source
 
           if iteration > RuboCop::Runner::MAX_ITERATIONS
-            raise RuboCop::Runner::InfiniteCorrectionLoop.new(@processed_source.path, [])
+            raise RuboCop::Runner::InfiniteCorrectionLoop.new(@processed_source.path, [@offenses])
           end
 
           # Prepare for next loop

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -16,7 +16,11 @@ module RuboCop
         root_cause = offenses_by_iteration[loop_start..-1]
                      .map { |x| x.map(&:cop_name).uniq.join(', ') }
                      .join(' -> ')
-        super "Infinite loop detected in #{path} and caused by #{root_cause}"
+
+        message = 'Infinite loop detected'
+        message += " in #{path}" if path
+        message += " and caused by #{root_cause}" if root_cause
+        super message
       end
     end
 


### PR DESCRIPTION
The message for `InfiniteCorrectionLoop` was changed in #8701, but it now crashes if `expect_corrections` in a spec causes an infinite loop:

```console
Failure/Error:
  root_cause = offenses_by_iteration[loop_start..-1]
               .map { |x| x.map(&:cop_name).uniq.join(', ') }
               .join(' -> ')

NoMethodError:
  undefined method `map' for nil:NilClass
# ./lib/rubocop/runner.rb:18:in `initialize'
# ./lib/rubocop/rspec/expect_offense.rb:160:in `new'
# ./lib/rubocop/rspec/expect_offense.rb:160:in `block in expect_correction'
# ./lib/rubocop/rspec/expect_offense.rb:150:in `loop'
# ./lib/rubocop/rspec/expect_offense.rb:150:in `expect_correction'
```

This fixes that crash by capturing the offenses in `expect_offenses` and passing them into `RuboCop::Runner::InfiniteCorrectionLoop.new`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
