### PR TITLE
[Fix #8774] Fix false positive with `Layout/ArrayAlignment` for parallel assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#8774](https://github.com/rubocop-hq/rubocop/issues/8774): Fix a false positive for `Layout/ArrayAlignment` with parallel assignment. ([@dvandersluis][])
+
 ## 0.91.1 (2020-09-23)
 
 ### Bug fixes

--- a/lib/rubocop/cop/layout/array_alignment.rb
+++ b/lib/rubocop/cop/layout/array_alignment.rb
@@ -44,6 +44,7 @@ module RuboCop
 
         def on_array(node)
           return if node.children.size < 2
+          return if node.parent&.masgn_type?
 
           check_alignment(node.children, base_column(node, node.children))
         end

--- a/spec/rubocop/cop/layout/array_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/array_alignment_spec.rb
@@ -169,6 +169,13 @@ RSpec.describe RuboCop::Cop::Layout::ArrayAlignment do
         ]
       RUBY
     end
+
+    it 'does not register an offense or try to correct parallel assignment' do
+      expect_no_offenses(<<~RUBY)
+        thing, foo =
+          1, 2
+      RUBY
+    end
   end
 
   context 'when aligned with fixed indentation' do
@@ -326,6 +333,13 @@ RSpec.describe RuboCop::Cop::Layout::ArrayAlignment do
           c,
           d
         ]
+      RUBY
+    end
+
+    it 'does not register an offense or try to correct parallel assignment' do
+      expect_no_offenses(<<~RUBY)
+        thing, foo =
+          1, 2
       RUBY
     end
   end


### PR DESCRIPTION
`Layout/ArrayAlignment` was considering parallel assignment as an array, and then getting into a auto-correction loop trying to fix it.

Fixes #8774.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
