### PR TITLE
Fix #8650 for improved hidden files finder performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 * [#8785](https://github.com/rubocop-hq/rubocop/pull/8785): Update TargetRubyVersion 2.8 to 3.0 (experimental). ([@em-gazelle][])
+* [#8650](https://github.com/rubocop-hq/rubocop/issues/8650): Faster find of hidden files in `TargetFinder` class which improves rubocop initial startup speed. ([@tleish][])
 
 ## 0.91.1 (2020-09-23)
 
@@ -4912,3 +4913,4 @@
 [@fsateler]: https://github.com/fsateler
 [@iSarCasm]: https://github.com/iSarCasm
 [@em-gazelle]: https://github.com/em-gazelle
+[@tleish]: https://github.com/tleish

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -5,6 +5,8 @@ module RuboCop
   # and picking ruby files.
   # @api private
   class TargetFinder
+    HIDDEN_PATH_SUBSTRING = "#{File::SEPARATOR}."
+
     def initialize(config_store, options = {})
       @config_store = config_store
       @options = options
@@ -55,7 +57,8 @@ module RuboCop
       # Support Windows: Backslashes from command-line -> forward slashes
       base_dir = base_dir.gsub(File::ALT_SEPARATOR, File::SEPARATOR) if File::ALT_SEPARATOR
       all_files = find_files(base_dir, File::FNM_DOTMATCH)
-      hidden_files = Set.new(all_files - find_files(base_dir, 0))
+      # use file.include? for performance optimization
+      hidden_files = all_files.select { |file| file.include?(HIDDEN_PATH_SUBSTRING) }
       base_dir_config = @config_store.for(base_dir)
 
       target_files = all_files.select do |file|


### PR DESCRIPTION
Faster find of hidden files in `TargetFinder` class which improves rubocop initial startup speed.

Benchmarks now show a 57x improvement in one large project tested:
```
Comparison:
             select:       50.6 i/s
               glob:        0.9 i/s - 57.38x  (± 0.00) slower
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
