### PR TITLE
[Fix #8165] Require Parser gem 2.7.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#8774](https://github.com/rubocop-hq/rubocop/issues/8774): Fix a false positive for `Layout/ArrayAlignment` with parallel assignment. ([@dvandersluis][])
 
+### Changes
+
+* [#8785](https://github.com/rubocop-hq/rubocop/pull/8785): Update TargetRubyVersion 2.8 to 3.0 (experimental). ([@em-gazelle][])
+
 ## 0.91.1 (2020-09-23)
 
 ### Bug fixes

--- a/docs/modules/ROOT/pages/compatibility.adoc
+++ b/docs/modules/ROOT/pages/compatibility.adoc
@@ -30,7 +30,7 @@ The following table is the support matrix.
 | 2.5 | -
 | 2.6 | -
 | 2.7 | -
-| 2.8 (experimental) | -
+| 3.0 (experimental) | -
 |===
 
 NOTE: The compatibility xref:configuration.adoc#setting-the-target-ruby-version[target Ruby version mentioned here] is about code analysis (what RuboCop can analyze), not runtime (is RuboCop capable of running on some Ruby or not).

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -4,7 +4,7 @@ module RuboCop
   # The kind of Ruby that code inspected by RuboCop is written in.
   # @api private
   class TargetRuby
-    KNOWN_RUBIES = [2.4, 2.5, 2.6, 2.7, 2.8].freeze
+    KNOWN_RUBIES = [2.4, 2.5, 2.6, 2.7, 3.0].freeze
     DEFAULT_VERSION = KNOWN_RUBIES.first
 
     OBSOLETE_RUBIES = {

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.7')
   s.add_runtime_dependency('rexml')
-  s.add_runtime_dependency('rubocop-ast', '>= 0.4.0', '< 1.0')
+  s.add_runtime_dependency('rubocop-ast', '>= 0.5.0', '< 1.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 2.0')
 

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   }
 
   s.add_runtime_dependency('parallel', '~> 1.10')
-  s.add_runtime_dependency('parser', '>= 2.7.1.1')
+  s.add_runtime_dependency('parser', '>= 2.7.1.5')
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.7')
   s.add_runtime_dependency('rexml')

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1634,14 +1634,14 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       it 'fails with an error message' do
         create_file('.rubocop.yml', <<~YAML)
           AllCops:
-            TargetRubyVersion: 3.0
+            TargetRubyVersion: 4.0
         YAML
         expect(cli.run([])).to eq(2)
         expect($stderr.string.strip).to start_with(
-          'Error: RuboCop found unknown Ruby version 3.0 in `TargetRubyVersion`'
+          'Error: RuboCop found unknown Ruby version 4.0 in `TargetRubyVersion`'
         )
         expect($stderr.string.strip).to match(
-          /Supported versions: 2.4, 2.5, 2.6, 2.7, 2.8/
+          /Supported versions: 2.4, 2.5, 2.6, 2.7, 3.0/
         )
       end
     end


### PR DESCRIPTION
Fixes #8165 and Follows https://github.com/whitequark/parser/pull/729.

Parser 2.7.1.5 includes https://github.com/whitequark/parser/pull/717 and fixes #8165. And this PR updates Ruby 2.8 to Ruby 3.0.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
