### PR TITLE
Simplify `Style/MixinUsage` and don't depend on broken `Node#macro?`

### DIFF
--- a/lib/rubocop/cop/style/mixin_usage.rb
+++ b/lib/rubocop/cop/style/mixin_usage.rb
@@ -50,39 +50,19 @@ module RuboCop
             const)
         PATTERN
 
-        def_node_matcher :wrapped_macro_scope?, <<~PATTERN
-          {({sclass class module block} ... ({begin if} ...))}
+        def_node_matcher :in_top_level_scope?, <<~PATTERN
+          {
+            root?                        # either at the top level
+            ^[  {kwbegin begin if def}   # or wrapped within one of these
+                #in_top_level_scope? ]   # that is in top level scope
+          }
         PATTERN
 
         def on_send(node)
           include_statement(node) do |statement|
-            return if node.argument? ||
-                      accepted_include?(node) ||
-                      belongs_to_class_or_module?(node)
+            return unless in_top_level_scope?(node)
 
             add_offense(node, message: format(MSG, statement: statement))
-          end
-        end
-
-        private
-
-        def accepted_include?(node)
-          node.parent && (node.macro? || ascend_macro_scope?(node.parent))
-        end
-
-        def ascend_macro_scope?(ancestor)
-          return true if wrapped_macro_scope?(ancestor)
-
-          ancestor.parent && ascend_macro_scope?(ancestor.parent)
-        end
-
-        def belongs_to_class_or_module?(node)
-          if !node.parent
-            false
-          else
-            return true if node.parent.class_type? || node.parent.module_type?
-
-            belongs_to_class_or_module?(node.parent)
           end
         end
       end

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.7')
   s.add_runtime_dependency('rexml')
-  s.add_runtime_dependency('rubocop-ast', '>= 0.4.0', '< 1.0')
+  s.add_runtime_dependency('rubocop-ast', '>= 0.5.0', '< 1.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 2.0')
 


### PR DESCRIPTION
Also bump `rubocop/ast` requirement.
See https://github.com/rubocop-hq/rubocop/issues/8765
