### PR TITLE
Add callback for `rubocop/ast`

### DIFF
--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -8,11 +8,12 @@ require 'set'
 require 'forwardable'
 require 'regexp_parser'
 require 'unicode/display_width/no_string_ext'
-require 'rubocop-ast'
-require_relative 'rubocop/ast_aliases'
-require_relative 'rubocop/ext/regexp_node'
 
 require_relative 'rubocop/version'
+require 'rubocop-ast'
+
+require_relative 'rubocop/ast_aliases'
+require_relative 'rubocop/ext/regexp_node'
 
 require_relative 'rubocop/core_ext/string'
 require_relative 'rubocop/ext/processed_source'
@@ -636,3 +637,4 @@ require_relative 'rubocop/yaml_duplication_checker'
 unless File.exist?("#{__dir__}/../rubocop.gemspec") # Check if we are a gem
   RuboCop::ResultCache.rubocop_required_features = $LOADED_FEATURES - before_us
 end
+RuboCop::AST.rubocop_loaded if RuboCop::AST.respond_to?(:rubocop_loaded)

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.7')
   s.add_runtime_dependency('rexml')
-  s.add_runtime_dependency('rubocop-ast', '>= 0.5.0', '< 1.0')
+  s.add_runtime_dependency('rubocop-ast', '>= 0.5.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 2.0')
 


### PR DESCRIPTION
Loading the version first also gives an opportunity for `rubocop/ast` to react.
Removing handling of rubocop-ast <1.0 in gemspec no longer needed

See also: rubocop-hq/rubocop-ast#123