### PR TITLE
Tweak spec for Layout/AccessModifierIndentation

### DIFF
--- a/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
     it 'registers an offense and corrects access modifiers ' \
       'in arbitrary blocks' do
       expect_offense(<<~RUBY)
-        Test = func do
+        func do
 
         private
         ^^^^^^^ Indent access modifiers like `private`.
@@ -185,7 +185,7 @@ RSpec.describe RuboCop::Cop::Layout::AccessModifierIndentation do
       RUBY
 
       expect_correction(<<~RUBY)
-        Test = func do
+        func do
 
           private
 


### PR DESCRIPTION
rubocop-hq/rubocop/120 fixes `#macro?` and the proposed PR does not consider `<something> = ...` as an acceptable wrapper, and this spec would no longer pass.

It used to pass because `macro?` considered anything inside a block as ok.

We can either consider that assignments don't change "macro scope" (and tweak the other PR), or tweak this spec as in this PR.