### PR TITLE
[Fix #8783] Disable `Style/ArrayCoercion` cop by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 * [#8785](https://github.com/rubocop-hq/rubocop/pull/8785): Update TargetRubyVersion 2.8 to 3.0 (experimental). ([@koic][])
 * [#8650](https://github.com/rubocop-hq/rubocop/issues/8650): Faster find of hidden files in `TargetFinder` class which improves rubocop initial startup speed. ([@tleish][])
+* [#8783](https://github.com/rubocop-hq/rubocop/pull/8783): Disable `Style/ArrayCoercion` cop by default. ([@koic][])
 
 ## 0.91.1 (2020-09-23)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -2463,7 +2463,7 @@ Style/ArrayCoercion:
                   with a variable you want to treat as an Array, but you're not certain it's an array.
   StyleGuide: '#array-coercion'
   Safe: false
-  Enabled: 'pending'
+  Enabled: false
   VersionAdded: '0.88'
 
 Style/ArrayJoin:

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -295,7 +295,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Disabled
 | No
 | Yes (Unsafe)
 | 0.88
@@ -303,6 +303,10 @@ end
 |===
 
 This cop enforces the use of `Array()` instead of explicit `Array` check or `[*var]`.
+
+This cop is disabled by default because false positive will occur if
+the argument of `Array()` is not an array (e.g. Hash, Set),
+an array will be returned as an incompatibility result.
 
 === Examples
 

--- a/lib/rubocop/cop/style/array_coercion.rb
+++ b/lib/rubocop/cop/style/array_coercion.rb
@@ -5,6 +5,10 @@ module RuboCop
     module Style
       # This cop enforces the use of `Array()` instead of explicit `Array` check or `[*var]`.
       #
+      # This cop is disabled by default because false positive will occur if
+      # the argument of `Array()` is not an array (e.g. Hash, Set),
+      # an array will be returned as an incompatibility result.
+      #
       # @example
       #   # bad
       #   paths = [paths] unless paths.is_a?(Array)


### PR DESCRIPTION
Fixes #8783, #8391, and #8334.

This PR disables `Style/ArrayCoercion` cop. Because false positive will occur if the argument of `Array()` is not an array (e.g. Hash, Set), an array will be returned as an incompatibility result.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
