### PR TITLE
Test multi-offenses for Layout/DotPosition cop

### DIFF
--- a/lib/rubocop/cop/layout/dot_position.rb
+++ b/lib/rubocop/cop/layout/dot_position.rb
@@ -29,17 +29,14 @@ module RuboCop
         def on_send(node)
           return unless node.dot? || ampersand_dot?(node)
 
-          if proper_dot_position?(node)
-            correct_style_detected
-          else
-            return unless opposite_style_detected
+          return correct_style_detected if proper_dot_position?(node)
 
-            dot = node.loc.dot
-            message = message(dot)
+          opposite_style_detected
+          dot = node.loc.dot
+          message = message(dot)
 
-            add_offense(dot, message: message) do |corrector|
-              autocorrect(corrector, dot, node)
-            end
+          add_offense(dot, message: message) do |corrector|
+            autocorrect(corrector, dot, node)
           end
         end
         alias on_csend on_send

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1693,41 +1693,4 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     expect(status).to eq(0)
     expect(source_file.read).to eq(source)
   end
-
-  it 'corrects multiple Layout/DotPosition offenses' do
-    create_file('.rubocop.yml', <<~YAML)
-      Layout/DotPosition:
-        EnforcedStyle: leading
-    YAML
-
-    source_file = Pathname('example.rb')
-    source = <<~RUBY
-      @objects = @objects.where(type: :a)
-
-      @objects = @objects.
-        with_relation.
-        paginate
-    RUBY
-    create_file(source_file, source)
-
-    status = cli.run(
-      [
-        '--auto-correct',
-        '--only',
-        [
-          'Layout/DotPosition',
-        ].join(',')
-      ]
-    )
-    expect(status).to eq(0)
-
-    corrected = <<~RUBY
-      @objects = @objects.where(type: :a)
-
-      @objects = @objects
-        .with_relation
-        .paginate
-    RUBY
-    expect(source_file.read).to eq(corrected)
-  end
 end

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1693,4 +1693,41 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     expect(status).to eq(0)
     expect(source_file.read).to eq(source)
   end
+
+  it 'corrects multiple Layout/DotPosition offenses' do
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/DotPosition:
+        EnforcedStyle: leading
+    YAML
+
+    source_file = Pathname('example.rb')
+    source = <<~RUBY
+      @objects = @objects.where(type: :a)
+
+      @objects = @objects.
+        with_relation.
+        paginate
+    RUBY
+    create_file(source_file, source)
+
+    status = cli.run(
+      [
+        '--auto-correct',
+        '--only',
+        [
+          'Layout/DotPosition',
+        ].join(',')
+      ]
+    )
+    expect(status).to eq(0)
+
+    corrected = <<~RUBY
+      @objects = @objects.where(type: :a)
+
+      @objects = @objects
+        .with_relation
+        .paginate
+    RUBY
+    expect(source_file.read).to eq(corrected)
+  end
 end

--- a/spec/rubocop/cop/layout/dot_position_spec.rb
+++ b/spec/rubocop/cop/layout/dot_position_spec.rb
@@ -107,6 +107,20 @@ RSpec.describe RuboCop::Cop::Layout::DotPosition, :config do
         RUBY
       end
     end
+
+    context 'with multiple offenses' do
+      it 'registers all of them' do
+        expect_offense(<<~RUBY)
+          @objects = @objects.where(type: :a)
+
+          @objects = @objects.
+                             ^ Place the . on the next line, together with the method name.
+            with_relation.
+                         ^ Place the . on the next line, together with the method name.
+            paginate
+        RUBY
+      end
+    end
   end
 
   context 'Trailing dots style' do

--- a/spec/rubocop/cop/layout/dot_position_spec.rb
+++ b/spec/rubocop/cop/layout/dot_position_spec.rb
@@ -119,6 +119,14 @@ RSpec.describe RuboCop::Cop::Layout::DotPosition, :config do
                          ^ Place the . on the next line, together with the method name.
             paginate
         RUBY
+
+        expect_correction(<<~RUBY)
+          @objects = @objects.where(type: :a)
+
+          @objects = @objects
+            .with_relation
+            .paginate
+        RUBY
       end
     end
   end


### PR DESCRIPTION
Hi,

I'd like to show an issue I've been having with multi-offenses autocorrect for the `Layout/DotPosition` cop, I have a potential fix coming in a second commit.

In some cases, when having multiple offenses for this cop, it only autocorrects the first it finds and exits, which is very painful when relying on auto-correct to change from one style to another.

I'm not familiar with the `ConfigurableEnforcedStyle`, but my guess is that it is used for guessing the best style to use when auto-generating a config file.

I've found accross the code multiple use of both the pattern `return unless opposite_style_detected` and simple calls to `opposite_style_detected`:
```
$ git grep opposite_style_detected
lib/rubocop/cop/layout/access_modifier_indentation.rb:74:                opposite_style_detected
lib/rubocop/cop/layout/case_indentation.rb:125:            opposite_style_detected
lib/rubocop/cop/layout/dot_position.rb:34:          opposite_style_detected
lib/rubocop/cop/layout/space_around_equals_in_parameter_default.rb:65:            return unless opposite_style_detected
lib/rubocop/cop/layout/space_inside_block_braces.rb:168:                opposite_style_detected
lib/rubocop/cop/layout/space_inside_block_braces.rb:185:                opposite_style_detected
lib/rubocop/cop/layout/space_inside_block_braces.rb:209:            return unless opposite_style_detected
lib/rubocop/cop/layout/space_inside_block_braces.rb:219:            return unless opposite_style_detected
lib/rubocop/cop/mixin/configurable_enforced_style.rb:7:      def opposite_style_detected
lib/rubocop/cop/mixin/multiline_expression_indentation.rb:99:            opposite_style_detected
lib/rubocop/cop/mixin/string_help.rb:17:          add_offense(node) { opposite_style_detected }
lib/rubocop/cop/style/access_modifier_declarations.rb:90:            add_offense(node.loc.selector) if opposite_style_detected
lib/rubocop/cop/style/character_literal.rb:45:        def opposite_style_detected; end
lib/rubocop/cop/style/for.rb:52:            return unless opposite_style_detected
lib/rubocop/cop/style/for.rb:66:            return unless opposite_style_detected
lib/rubocop/cop/style/hash_syntax.rb:163:                opposite_style_detected
lib/rubocop/cop/style/ip_addresses.rb:42:        def opposite_style_detected; end
lib/rubocop/cop/style/lambda_call.rb:30:          if offense?(node) && opposite_style_detected
lib/rubocop/cop/style/raise_args.rb:87:            return unless opposite_style_detected
lib/rubocop/cop/style/raise_args.rb:106:          return unless opposite_style_detected
lib/rubocop/cop/style/special_global_vars.rb:123:            opposite_style_detected
```

Is there a practice that should be enforced for using `opposite_style_detected` ?

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
