### PR TITLE
Document syntax for multiple cops named in a command-flag

### DIFF
--- a/docs/modules/ROOT/pages/usage/basic_usage.adoc
+++ b/docs/modules/ROOT/pages/usage/basic_usage.adoc
@@ -121,6 +121,14 @@ For more details check the available command-line options:
 $ rubocop -h
 ----
 
+To specify multiple cops for one flag, separate cops with commas and no spaces:
+
+[source,sh]
+----
+$ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName 
+----
+
+
 |===
 | Command flag | Description
 


### PR DESCRIPTION
Add a line to the Basic Usage page with an example of the syntax required for multiple cops on one flag.
Affects documentation only. No code or test changes.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
