### PR TITLE
[Fix #8782] Mark any condition with defined? as an unsafe autocorrection if it is not parenthesized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#8782](https://github.com/rubocop-hq/rubocop/issues/8782): Fix incorrect autocorrection for `Style/TernaryParentheses` with `defined?`. ([@dvandersluis][])
+
 ## 0.93.0 (2020-10-08)
 
 ### New features

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -192,7 +192,7 @@ module RuboCop
         end
 
         def_node_matcher :method_name, <<~PATTERN
-          {($:defined? (send nil? _) ...)
+          {($:defined? _ ...)
            (send {_ nil?} $_ _ ...)}
         PATTERN
 

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -159,6 +159,50 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
           not (bar) ? a : b
         RUBY
       end
+
+      it 'registers an offense for defined? with variable in condition' do
+        expect_offense(<<~RUBY)
+          foo = defined?(bar) ? a : b
+                ^^^^^^^^^^^^^^^^^^^^^ Use parentheses for ternary conditions.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo = (defined?(bar)) ? a : b
+        RUBY
+      end
+
+      it 'registers an offense for defined? with method chain in condition' do
+        expect_offense(<<~RUBY)
+          foo = defined?(bar.baz) ? a : b
+                ^^^^^^^^^^^^^^^^^^^^^^^^^ Use parentheses for ternary conditions.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo = (defined?(bar.baz)) ? a : b
+        RUBY
+      end
+
+      it 'registers an offense for defined? with class method in condition' do
+        expect_offense(<<~RUBY)
+          foo = defined?(Bar.baz) ? a : b
+                ^^^^^^^^^^^^^^^^^^^^^^^^^ Use parentheses for ternary conditions.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo = (defined?(Bar.baz)) ? a : b
+        RUBY
+      end
+
+      it 'registers an offense for defined? with nested constant in condition' do
+        expect_offense(<<~RUBY)
+          foo = defined?(Bar::BAZ) ? a : b
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use parentheses for ternary conditions.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo = (defined?(Bar::BAZ)) ? a : b
+        RUBY
+      end
     end
 
     context 'with an assignment condition' do
@@ -323,6 +367,42 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
         expect_offense(<<~RUBY)
           foo = (not bar) ? a : b
                 ^^^^^^^^^^^^^^^^^ Omit parentheses for ternary conditions.
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense for defined with variable in condition' do
+        expect_offense(<<~RUBY)
+          foo = (defined? bar) ? a : b
+                ^^^^^^^^^^^^^^^^^^^^^^ Omit parentheses for ternary conditions.
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense for defined with method chain in condition' do
+        expect_offense(<<~RUBY)
+          foo = (defined? bar.baz) ? a : b
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^ Omit parentheses for ternary conditions.
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense for defined with class method in condition' do
+        expect_offense(<<~RUBY)
+          foo = (defined? Bar.baz) ? a : b
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^ Omit parentheses for ternary conditions.
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense for defined with nested constant in condition' do
+        expect_offense(<<~RUBY)
+          foo = (defined? Bar::BAZ) ? a : b
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Omit parentheses for ternary conditions.
         RUBY
 
         expect_no_corrections
@@ -520,6 +600,42 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
 
       it 'accepts boolean expression' do
         expect_no_offenses('foo = (bar && (baz || bar)) ? a : b')
+      end
+
+      it 'registers an offense for defined with variable in condition' do
+        expect_offense(<<~RUBY)
+          foo = (defined? bar) ? a : b
+                ^^^^^^^^^^^^^^^^^^^^^^ Only use parentheses for ternary expressions with complex conditions.
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense for defined with method chain in condition' do
+        expect_offense(<<~RUBY)
+          foo = (defined? bar.baz) ? a : b
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^ Only use parentheses for ternary expressions with complex conditions.
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense for defined with class method in condition' do
+        expect_offense(<<~RUBY)
+          foo = (defined? Bar.baz) ? a : b
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^ Only use parentheses for ternary expressions with complex conditions.
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense for defined with nested constant in condition' do
+        expect_offense(<<~RUBY)
+          foo = (defined? Bar::BAZ) ? a : b
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Only use parentheses for ternary expressions with complex conditions.
+        RUBY
+
+        expect_no_corrections
       end
     end
 


### PR DESCRIPTION
Previously, the check for `defined?` in `unsafe_autocorrect?` only applied when the argument was a single send node with no receiver, but that meant that most times `defined?` was used in a ternary wrapped in parens, it would be autocorrected incorrectly (since `defined?` would then be called on the entire ternary instead of the argument). This change makes `unsafe_autocorrect?` return true if there is any `defined?` call without parentheses.

Fixes #8782.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
