### PR TITLE
[Fix #5713] Be more explicit about how Style/CommentAnnotation works

### DIFF
--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -1576,6 +1576,12 @@ folders = %x(find . -type d).split
 This cop checks that comment annotation keywords are written according
 to guidelines.
 
+NOTE: With a multiline comment block (where each line is only a
+comment), only the first line will be able to register an offense, even
+if an annotation keyword starts another line. This is done to prevent
+incorrect registering of keywords (eg. `review`) inside a paragraph as an
+annotation.
+
 === Examples
 
 [source,ruby]

--- a/lib/rubocop/cop/style/comment_annotation.rb
+++ b/lib/rubocop/cop/style/comment_annotation.rb
@@ -6,6 +6,12 @@ module RuboCop
       # This cop checks that comment annotation keywords are written according
       # to guidelines.
       #
+      # NOTE: With a multiline comment block (where each line is only a
+      # comment), only the first line will be able to register an offense, even
+      # if an annotation keyword starts another line. This is done to prevent
+      # incorrect registering of keywords (eg. `review`) inside a paragraph as an
+      # annotation.
+      #
       # @example
       #   # bad
       #   # TODO make better

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -133,4 +133,15 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
       RUBY
     end
   end
+
+  context 'multiline comment' do
+    it 'only registers an offense on the first line' do
+      expect_offense(<<~RUBY)
+        # TODO line 1
+          ^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a colon, and a space, then a note describing the problem.
+        # TODO line 2
+        # TODO line 3
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
The consensus in the issue is that the cop is working as expected, but the documentation does not explain well enough. This change adds an explicit test for comment blocks, as well as a documentation note.

Closes #5713.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
