### PR TITLE
[Fix #8799] Fix ability to detect/autocorrect multiple offences in a single line.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * [#8810](https://github.com/rubocop-hq/rubocop/pull/8810): Fix multiple offense detection for `Style/RaiseArgs`. ([@pbernays][])
 * [#8809](https://github.com/rubocop-hq/rubocop/pull/8809): Fix multiple offense detection for `Style/For`. ([@pbernays][])
-* [#8801](https://github.com/rubocop-hq/rubocop/pull/8801): Fix `Layout/SpaceAroundEqualsInParameterDefault` only registered once in a line. ([@rdunlop][])
+* [#8801](https://github.com/rubocop-hq/rubocop/issues/8801): Fix `Layout/SpaceAroundEqualsInParameterDefault` only registered once in a line. ([@rdunlop][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/space_inside_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_block_braces.rb
@@ -206,8 +206,6 @@ module RuboCop
 
         def no_space(begin_pos, end_pos, msg)
           if style == :space
-            return unless opposite_style_detected
-
             offense(begin_pos, end_pos, msg)
           else
             correct_style_detected
@@ -216,8 +214,6 @@ module RuboCop
 
         def space(begin_pos, end_pos, msg)
           if style == :no_space
-            return unless opposite_style_detected
-
             offense(begin_pos, end_pos, msg)
           else
             correct_style_detected

--- a/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
@@ -122,6 +122,20 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects both left and right brace without inner space after success' do
+    expect_offense(<<~RUBY)
+      each { puts }
+      each {puts}
+            ^ Space missing inside {.
+                ^ Space missing inside }.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      each { puts }
+      each { puts }
+    RUBY
+  end
+
   it 'register offenses and correct both braces without inner space' do
     expect_offense(<<~RUBY)
       a {}
@@ -281,6 +295,20 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
       RUBY
 
       expect_correction(<<~RUBY)
+        each {puts}
+      RUBY
+    end
+
+    it 'registers an offense and corrects both left and right brace with inner space after success' do
+      expect_offense(<<~RUBY)
+        each {puts}
+        each { puts }
+              ^ Space inside { detected.
+                   ^ Space inside } detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        each {puts}
         each {puts}
       RUBY
     end


### PR DESCRIPTION
SpaceInsideBlockBraces was incorrectly only
detecting the first offense in a single line.

This resulted in requiring running `rubocop -a` multiple times against a file, before all of the corrections were performed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation. (N/A?)

[1]: https://chris.beams.io/posts/git-commit/
