### PR TITLE
[Fix #8801] Fix Layouts/SpaceAroundEqualsInParameterDefault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#8810](https://github.com/rubocop-hq/rubocop/pull/8810): Fix multiple offense detection for Style/RaiseArgs. ([@pbernays][])
 * [#8809](https://github.com/rubocop-hq/rubocop/pull/8809): Fix multiple offense detection for Style/For. ([@pbernays][])
+* [#8801](https://github.com/rubocop-hq/rubocop/pull/8801): Fix `Layout/SpaceAroundEqualsInParameterDefault` only registered once in a line. ([@rdunlop][])
 
 ### Changes
 
@@ -4938,3 +4939,4 @@
 [@em-gazelle]: https://github.com/em-gazelle
 [@tleish]: https://github.com/tleish
 [@pbernays]: https://github.com/pbernays
+[@rdunlop]: https://github.com/rdunlop

--- a/lib/rubocop/cop/layout/space_around_equals_in_parameter_default.rb
+++ b/lib/rubocop/cop/layout/space_around_equals_in_parameter_default.rb
@@ -51,21 +51,12 @@ module RuboCop
              style == :no_space && no_surrounding_space
             correct_style_detected
           else
-            incorrect_style_detected(arg, value, space_on_both_sides,
-                                     no_surrounding_space)
+            incorrect_style_detected(arg, value)
           end
         end
 
-        def incorrect_style_detected(arg, value, space_on_both_sides,
-                                     no_surrounding_space)
+        def incorrect_style_detected(arg, value)
           range = range_between(arg.end_pos, value.begin_pos)
-
-          if style == :space && no_surrounding_space ||
-             style == :no_space && space_on_both_sides
-            return unless opposite_style_detected
-          else
-            return unless unrecognized_style_detected
-          end
 
           add_offense(range) do |corrector|
             autocorrect(corrector, range)

--- a/spec/rubocop/cop/layout/space_around_equals_in_parameter_default_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_equals_in_parameter_default_spec.rb
@@ -19,6 +19,21 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :confi
       RUBY
     end
 
+    it 'registers an offense and corrects default value assignment where first is partially right ' \
+      'without space' do
+      expect_offense(<<~RUBY)
+        def f(x, y= 0, z=1)
+                  ^^ Surrounding space missing in default value assignment.
+                        ^ Surrounding space missing in default value assignment.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def f(x, y = 0, z = 1)
+        end
+      RUBY
+    end
+
     it 'registers an offense and corrects assigning empty string ' \
       'without space' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
This cop is only being handled once per line, due to a
mis-use of the 'opposite_style_detected'/'unrecognized_style_detected'
methods.

Very similar to the issue in #8800

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation. (N/A?)

[1]: https://chris.beams.io/posts/git-commit/
