### PR TITLE
Fix a false positive for `Style/RedundantCondition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#8825](https://github.com/rubocop-hq/rubocop/issues/8825): Fix crash in `Style/ExplicitBlockArgument` when code is called outside of a method. ([@ghiculescu][])
 * [#8354](https://github.com/rubocop-hq/rubocop/issues/8354): Detect regexp named captures in `Style/CaseLikeIf` cop. ([@dsavochkin][])
 * [#8830](https://github.com/rubocop-hq/rubocop/issues/8830): Fix bad autocorrect of `Style/StringConcatenation` when string includes double quotes. ([@tleish][])
+* [#8807](https://github.com/rubocop-hq/rubocop/pull/8807): Fix a false positive for `Style/RedundantCondition` when using assignment by hash key access. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/redundant_condition.rb
+++ b/lib/rubocop/cop/style/redundant_condition.rb
@@ -75,7 +75,7 @@ module RuboCop
         def offense?(node)
           condition, if_branch, else_branch = *node
 
-          return false if use_if_branch?(else_branch)
+          return false if use_if_branch?(else_branch) || use_hash_key_assignment?(else_branch)
 
           condition == if_branch && !node.elsif? && (
             node.ternary? ||
@@ -86,6 +86,10 @@ module RuboCop
 
         def use_if_branch?(else_branch)
           else_branch&.if_type?
+        end
+
+        def use_hash_key_assignment?(else_branch)
+          else_branch&.send_type? && else_branch&.method?(:[]=)
         end
 
         def else_source(else_branch)

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition do
         RUBY
       end
 
+      it 'registers an offense and corrects when using assignment by hash key access' do
+        expect_no_offenses(<<~RUBY)
+          if @cache[key]
+            @cache[key]
+          else
+            @cache[key] = heavy_load[key]
+          end
+        RUBY
+      end
+
       it 'registers an offense and corrects when `raise` without argument parentheses in `else`' do
         expect_offense(<<~RUBY)
           if b


### PR DESCRIPTION
This PR fixes the following incorrect autocorrect for `Style/RedundantCondition` when using assignment by hash key access.

### Before

The result of auto-correction is syntax error.

```console
% cat example.rb
if @columns_cache[table_name]
  @columns_cache[table_name]
else
  @columns_cache[table_name] = super(table_name)
end

% bundle exec rubocop -a --only Style/RedundantCondition
(snip)

Inspecting 1 file
C

Offenses:

example.rb:1:1: C: [Corrected] Style/RedundantCondition: Use double
pipes || instead.
if @columns_cache[table_name] ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected

% cat example.rb
@columns_cache[table_name] || []=(table_name, super(table_name))

% ruby -c example.rb
example.rb:1: syntax error, unexpected '=', expecting end-of-input
...olumns_cache[table_name] || []=(table_name, super(table_name...
```

### After

The cop accepts the example case.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
