### PR TITLE
Fix multiple offense detection for Style/For

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 * [#8810](https://github.com/rubocop-hq/rubocop/pull/8810): Fix multiple offense detection for Style/RaiseArgs. ([@pbernays][])
+* [#8809](https://github.com/rubocop-hq/rubocop/pull/8809): Fix multiple offense detection for Style/For. ([@pbernays][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/for.rb
+++ b/lib/rubocop/cop/style/for.rb
@@ -49,8 +49,6 @@ module RuboCop
 
         def on_for(node)
           if style == :each
-            return unless opposite_style_detected
-
             add_offense(node, message: PREFER_EACH) do |corrector|
               ForToEachCorrector.new(node).call(corrector)
             end
@@ -63,8 +61,6 @@ module RuboCop
           return unless suspect_enumerable?(node)
 
           if style == :for
-            return unless opposite_style_detected
-
             add_offense(node, message: PREFER_FOR) do |corrector|
               EachToForCorrector.new(node).call(corrector)
             end

--- a/spec/rubocop/cop/style/for_spec.rb
+++ b/spec/rubocop/cop/style/for_spec.rb
@@ -48,6 +48,34 @@ RSpec.describe RuboCop::Cop::Style::For, :config do
       RUBY
     end
 
+    it 'registers multiple offenses' do
+      expect_offense(<<~RUBY)
+        for n in [1, 2, 3] do
+        ^^^^^^^^^^^^^^^^^^^^^ Prefer `each` over `for`.
+          puts n
+        end
+        [1, 2, 3].each do |n|
+          puts n
+        end
+        for n in [1, 2, 3] do
+        ^^^^^^^^^^^^^^^^^^^^^ Prefer `each` over `for`.
+          puts n
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [1, 2, 3].each do |n|
+          puts n
+        end
+        [1, 2, 3].each do |n|
+          puts n
+        end
+        [1, 2, 3].each do |n|
+          puts n
+        end
+      RUBY
+    end
+
     context 'auto-correct' do
       context 'with range' do
         let(:expected_each_with_range) do
@@ -245,6 +273,34 @@ RSpec.describe RuboCop::Cop::Style::For, :config do
           for n in [1, 2, 3] do
             puts n
           end
+        end
+      RUBY
+    end
+
+    it 'registers multiple offenses' do
+      expect_offense(<<~RUBY)
+        for n in [1, 2, 3] do
+          puts n
+        end
+        [1, 2, 3].each do |n|
+        ^^^^^^^^^^^^^^^^^^^^^ Prefer `for` over `each`.
+          puts n
+        end
+        [1, 2, 3].each do |n|
+        ^^^^^^^^^^^^^^^^^^^^^ Prefer `for` over `each`.
+          puts n
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        for n in [1, 2, 3] do
+          puts n
+        end
+        for n in [1, 2, 3] do
+          puts n
+        end
+        for n in [1, 2, 3] do
+          puts n
         end
       RUBY
     end


### PR DESCRIPTION
The use of `opposite_style_detected` prevents cops from detecting
subsequent offenses once the first correct style has been detected.

Related to #8802, #8800, and #8759 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
