### PR TITLE
[Fix #8759] Fix multiple offense detection for Style/RaiseArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#8796](https://github.com/rubocop-hq/rubocop/pull/8796): Add new `Lint/HashCompareByIdentity` cop. ([@fatkodima][])
 
+### Bug fixes
+
+* [#8810](https://github.com/rubocop-hq/rubocop/pull/8810): Fix multiple offense detection for Style/RaiseArgs. ([@pbernays][])
+
 ### Changes
 
 * [#8646](https://github.com/rubocop-hq/rubocop/issues/8646): Faster find of all files in `TargetFinder` class which improves rubocop initial startup speed. ([@tleish][])
@@ -4932,3 +4936,4 @@
 [@iSarCasm]: https://github.com/iSarCasm
 [@em-gazelle]: https://github.com/em-gazelle
 [@tleish]: https://github.com/tleish
+[@pbernays]: https://github.com/pbernays

--- a/lib/rubocop/cop/style/raise_args.rb
+++ b/lib/rubocop/cop/style/raise_args.rb
@@ -84,8 +84,6 @@ module RuboCop
 
         def check_compact(node)
           if node.arguments.size > 1
-            return unless opposite_style_detected
-
             add_offense(node, message: format(COMPACT_MSG, method: node.method_name)) do |corrector|
               replacement = correction_exploded_to_compact(node)
 
@@ -103,7 +101,6 @@ module RuboCop
 
           return unless first_arg.send_type? && first_arg.method?(:new)
           return if acceptable_exploded_args?(first_arg.arguments)
-          return unless opposite_style_detected
 
           add_offense(node, message: format(EXPLODED_MSG, method: node.method_name)) do |corrector|
             replacement = correction_compact_to_exploded(node)

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -75,6 +75,30 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
           end
         RUBY
       end
+
+      it 'reports multiple offenses' do
+        expect_offense(<<~RUBY)
+          if a
+            raise RuntimeError, msg
+            ^^^^^^^^^^^^^^^^^^^^^^^ Provide an exception object as an argument to `raise`.
+          elsif b
+            raise Ex.new(msg)
+          else
+            raise ArgumentError, msg
+            ^^^^^^^^^^^^^^^^^^^^^^^^ Provide an exception object as an argument to `raise`.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          if a
+            raise RuntimeError.new(msg)
+          elsif b
+            raise Ex.new(msg)
+          else
+            raise ArgumentError.new(msg)
+          end
+        RUBY
+      end
     end
 
     context 'with a raise with 3 args' do
@@ -107,8 +131,6 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
             raise Ex.new(msg)
             ^^^^^^^^^^^^^^^^^ Provide an exception class and message as arguments to `raise`.
           RUBY
-          expect(cop.config_to_allow_offenses)
-            .to eq('EnforcedStyle' => 'compact')
 
           expect_correction(<<~RUBY)
             raise Ex, msg
@@ -122,8 +144,6 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
             raise Ex.new
             ^^^^^^^^^^^^ Provide an exception class and message as arguments to `raise`.
           RUBY
-          expect(cop.config_to_allow_offenses)
-            .to eq('EnforcedStyle' => 'compact')
 
           expect_correction(<<~RUBY)
             raise Ex
@@ -181,13 +201,36 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
             ^^^^^^^^^^^^^^^^^ Provide an exception class and message as arguments to `raise`.
           end
         RUBY
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
 
         expect_correction(<<~RUBY)
           if a
             raise RuntimeError, msg
           else
             raise Ex, msg
+          end
+        RUBY
+      end
+
+      it 'reports multiple offenses' do
+        expect_offense(<<~RUBY)
+          if a
+            raise RuntimeError, msg
+          elsif b
+            raise Ex.new(msg)
+            ^^^^^^^^^^^^^^^^^ Provide an exception class and message as arguments to `raise`.
+          else
+            raise ArgumentError.new(msg)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Provide an exception class and message as arguments to `raise`.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          if a
+            raise RuntimeError, msg
+          elsif b
+            raise Ex, msg
+          else
+            raise ArgumentError, msg
           end
         RUBY
       end


### PR DESCRIPTION
The use of opposite_style_detected prevents cops from detecting
subsequent offenses once the first correct style has been detected.

Related to #8809, #8802, and #8800.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
