### PR TITLE
[Fix #8788] Change `Style/Documentation` to not trigger offense with only macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#8788](https://github.com/rubocop-hq/rubocop/issues/8788): Change `Style/Documentation` to not trigger offense with only macros. ([@tejasbubane][])
+
 ## 1.3.1 (2020-11-16)
 
 ### Bug fixes

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -55,6 +55,11 @@ module RuboCop
       #       Public = Class.new
       #     end
       #
+      #     # Macro calls
+      #     module Namespace
+      #       extend Foo
+      #     end
+      #
       class Documentation < Base
         include DocumentationComment
 
@@ -83,8 +88,14 @@ module RuboCop
           return if documentation_comment?(node) || nodoc_comment?(node)
           return if compact_namespace?(node) &&
                     nodoc_comment?(outer_module(node).first)
+          return if macro_only?(body)
 
           add_offense(node.loc.keyword, message: format(MSG, type: type))
+        end
+
+        def macro_only?(body)
+          body.respond_to?(:macro?) && body.macro? ||
+            body.respond_to?(:children) && body.children&.all? { |child| macro_only?(child) }
         end
 
         def namespace?(node)

--- a/spec/fixtures/html_formatter/expected.html
+++ b/spec/fixtures/html_formatter/expected.html
@@ -367,14 +367,14 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
       <div class="infobox">
         <div class="total">
           3 files inspected,
-          24 offenses detected:
+          23 offenses detected:
         </div>
         <ul class="offenses-list">
           
             
             <li>
               <a href="#offense_app/controllers/application_controller.rb">
-                app/controllers/application_controller.rb - 3 offenses
+                app/controllers/application_controller.rb - 2 offenses
               </a>
             </li>
           
@@ -400,19 +400,8 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
       
       <div class="offense-box" id="offense_app/controllers/application_controller.rb">
         <div class="box-title-placeholder"><h3>&nbsp;</h3></div>
-        <div class="box-title"><h3>app/controllers/application_controller.rb - 3 offenses</h3></div>
+        <div class="box-title"><h3>app/controllers/application_controller.rb - 2 offenses</h3></div>
         <div class="offense-reports">
-          
-          <div class="report">
-            <div class="meta">
-              <span class="location">Line #1</span> –
-              <span class="severity convention">convention:</span>
-              <span class="message">Style/Documentation: Missing top-level class documentation comment.</span>
-            </div>
-            
-            <pre><code><span class="highlight convention">class</span> ApplicationController &lt; ActionController::Base</code></pre>
-            
-          </div>
           
           <div class="report">
             <div class="meta">

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -217,6 +217,38 @@ RSpec.describe RuboCop::Cop::Style::Documentation do
         end
       end
     end
+
+    context 'macro-only class' do
+      it 'does not register offense with single macro' do
+        expect_no_offenses(<<~RUBY)
+          module Foo
+            extend Bar
+          end
+        RUBY
+      end
+
+      it 'does not register offense with multiple macros' do
+        expect_no_offenses(<<~RUBY)
+          module Foo
+            extend A
+            extend B
+            include C
+          end
+        RUBY
+      end
+
+      it 'registers offense for macro with other methods' do
+        expect_offense(<<~RUBY)
+          module Foo
+          ^^^^^^ Missing top-level module documentation comment.
+            extend B
+            include C
+
+            def foo; end
+          end
+        RUBY
+      end
+    end
   end
 
   it 'does not raise an error for an implicit match conditional' do


### PR DESCRIPTION
Closes https://github.com/rubocop-hq/rubocop/issues/8788

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/