### PR TITLE
[Fix #8781] Change how comments are determined for `Style/SafeNavigation` autocorrection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 * [#8892](https://github.com/rubocop-hq/rubocop/issues/8892): Fix an error for `Style/StringConcatenation` when correcting nested concatenable parts. ([@fatkodima][])
+* [#8781](https://github.com/rubocop-hq/rubocop/issues/8781): Fix handling of comments in `Style/SafeNavigation` autocorrection. ([@dvandersluis][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -160,6 +160,32 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
     RUBY
   end
 
+  # See https://github.com/rubocop-hq/rubocop/issues/8781
+  it 'does not move comments that are inside an inner block' do
+    expect_offense(<<~RUBY)
+      # Comment 1
+      if x
+      ^^^^ Use safe navigation (`&.`) instead of checking if an object exists before calling the method.
+        # Comment 2
+        x.each do
+          # Comment 3
+          # Comment 4
+        end
+        # Comment 5
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # Comment 1
+      # Comment 2
+      # Comment 5
+      x&.each do
+          # Comment 3
+          # Comment 4
+        end
+    RUBY
+  end
+
   shared_examples 'all variable types' do |variable|
     context 'modifier if' do
       shared_examples 'safe guarding logical break keywords' do |keyword|


### PR DESCRIPTION
Previously, every comment within the source range of the `if` being auto-corrected was captured and moved above the rewritten line. This resulted in comment duplication, as some comments belonged to internal blocks within the if. This change only considers line ranges between internal if blocks as entry points for comments that are allowed to be moved.

I had tried looking into `Parser::Source::Comment.associate_locations` as a way to determine what node each comment belonged to, but this does not associate comments in the way we're expecting for this cop.

Fixes #8781.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
