### PR TITLE
[Fix #7408] Make `Gemspec/RequiredRubyVersion` cop aware of `Gem::Requirement`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 * [#8646](https://github.com/rubocop-hq/rubocop/issues/8646): Faster find of all files in `TargetFinder` class which improves initial startup speed. ([@tleish][])
 * [#8102](https://github.com/rubocop-hq/rubocop/issues/8102): Consider class length instead of block length for `Struct.new`. ([@tejasbubane][])
+* [#7408](https://github.com/rubocop-hq/rubocop/issues/7408): Make `Gemspec/RequiredRubyVersion` cop aware of `Gem::Requirement`. ([@tejasbubane][])
 
 ## 0.92.0 (2020-09-25)
 

--- a/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
+++ b/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
@@ -20,6 +20,24 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
       RUBY
     end
 
+    it 'registers an offense when `required_ruby_version` is specified in array and is lower than `TargetRubyVersion`' do
+      expect_offense(<<~RUBY, '/path/to/foo.gemspec')
+        Gem::Specification.new do |spec|
+          spec.required_ruby_version = ['>= 2.6.0', '< 3.0.0']
+                                       ^^^^^^^^^^^^^^^^^^^^^^^ `required_ruby_version` (2.6, declared in foo.gemspec) and `TargetRubyVersion` (2.7, which may be specified in .rubocop.yml) should be equal.
+        end
+      RUBY
+    end
+
+    it 'recognizes Gem::Requirement and registers offense' do
+      expect_offense(<<~RUBY, '/path/to/foo.gemspec')
+        Gem::Specification.new do |spec|
+          spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
+                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `required_ruby_version` (2.6, declared in foo.gemspec) and `TargetRubyVersion` (2.7, which may be specified in .rubocop.yml) should be equal.
+        end
+      RUBY
+    end
+
     describe 'false negatives' do
       it 'does not register an offense when `required_ruby_version` ' \
          'is assigned as a variable (string literal)' do


### PR DESCRIPTION
Closes https://github.com/rubocop-hq/rubocop/issues/7408

In the process, also make the cop work with array of versions.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/