### PR TITLE
[Fix #8514] Correct multiple Style/MethodDefParentheses per file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#8810](https://github.com/rubocop-hq/rubocop/pull/8810): Fix multiple offense detection for `Style/RaiseArgs`. ([@pbernays][])
 * [#8809](https://github.com/rubocop-hq/rubocop/pull/8809): Fix multiple offense detection for `Style/For`. ([@pbernays][])
 * [#8801](https://github.com/rubocop-hq/rubocop/issues/8801): Fix `Layout/SpaceAroundEqualsInParameterDefault` only registered once in a line. ([@rdunlop][])
+* [#8514](https://github.com/rubocop-hq/rubocop/issues/8514): Correct multiple `Style/MethodDefParentheses` per file. ([@rdunlop][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/method_def_parentheses.rb
+++ b/lib/rubocop/cop/style/method_def_parentheses.rb
@@ -140,16 +140,12 @@ module RuboCop
         def missing_parentheses(node)
           location = node.arguments.source_range
 
-          return unless unexpected_style_detected(:require_no_parentheses)
-
           add_offense(location, message: MSG_MISSING) do |corrector|
             correct_definition(node, corrector)
           end
         end
 
         def unwanted_parentheses(args)
-          return unless unexpected_style_detected(:require_parentheses)
-
           add_offense(args, message: MSG_PRESENT) do |corrector|
             # offense is registered on args node when parentheses are unwanted
             correct_arguments(args, corrector)

--- a/spec/rubocop/cop/style/method_def_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_def_parentheses_spec.rb
@@ -65,6 +65,26 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
       RUBY
     end
 
+    it 'auto-adds required parens for a defs after a passing method' do
+      expect_offense(<<~RUBY)
+        def self.fine; end
+
+        def self.test param; end
+                      ^^^^^ Use def with parentheses when there are parameters.
+
+        def self.test2 param; end
+                       ^^^^^ Use def with parentheses when there are parameters.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def self.fine; end
+
+        def self.test(param); end
+
+        def self.test2(param); end
+      RUBY
+    end
+
     it 'auto-adds required parens to argument lists on multiple lines' do
       expect_offense(<<~RUBY)
         def test one,


### PR DESCRIPTION
Fix the ability to correctly identify and auto-correct multiple
MethodDefParentheses violations in a single file.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation. (N/A?)

[1]: https://chris.beams.io/posts/git-commit/
