### PR TITLE
Make `Style/RedundantBegin` aware of `begin` without `rescue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#8796](https://github.com/rubocop-hq/rubocop/pull/8796): Add new `Lint/HashCompareByIdentity` cop. ([@fatkodima][])
 * [#8668](https://github.com/rubocop-hq/rubocop/pull/8668): Add new `Lint/RedundantSafeNavigation` cop. ([@fatkodima][])
 * [#8842](https://github.com/rubocop-hq/rubocop/issues/8842): Add notification about cache being used to debug mode. ([@hatkyinc2][])
+* [#8822](https://github.com/rubocop-hq/rubocop/pull/8822): Make `Style/RedundantBegin` aware of `begin` without `rescue` or `ensure`. ([@koic][])
 
 ### Bug fixes
 

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -7558,6 +7558,14 @@ rescue StandardError => e
 end
 
 # bad
+begin
+  do_something
+end
+
+# good
+do_something
+
+# bad
 # When using Ruby 2.5 or later.
 do_something do
   begin

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -155,6 +155,55 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using `begin` without `rescue` or `ensure`' do
+    expect_offense(<<~RUBY)
+      begin
+      ^^^^^ Redundant `begin` block detected.
+        do_something
+      end
+    RUBY
+
+    expect_correction("\n  do_something\n\n")
+  end
+
+  it 'does not register an offense when using `begin` with `rescue`' do
+    expect_no_offenses(<<~RUBY)
+      begin
+        do_something
+      rescue
+        handle_exception
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `begin` with `ensure`' do
+    expect_no_offenses(<<~RUBY)
+      begin
+        do_something
+      ensure
+        finalize
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `begin` for assignment' do
+    expect_no_offenses(<<~RUBY)
+      var = begin
+        foo
+        bar
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `begin` for or assignment' do
+    expect_no_offenses(<<~RUBY)
+      var ||= begin
+        foo
+        bar
+      end
+    RUBY
+  end
+
   context '< Ruby 2.5', :ruby24 do
     it 'accepts a do-end block with a begin-end' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This PR makes `Style/RedundantBegin` aware of `begin` without `rescue` or `ensure`.

I got the inspiration below.
https://github.com/faker-ruby/faker/pull/1988

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
