### PR TITLE
Fix crash in Style/ExplicitBlockArgument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#8809](https://github.com/rubocop-hq/rubocop/pull/8809): Fix multiple offense detection for `Style/For`. ([@pbernays][])
 * [#8801](https://github.com/rubocop-hq/rubocop/issues/8801): Fix `Layout/SpaceAroundEqualsInParameterDefault` only registered once in a line. ([@rdunlop][])
 * [#8514](https://github.com/rubocop-hq/rubocop/issues/8514): Correct multiple `Style/MethodDefParentheses` per file. ([@rdunlop][])
+* [#8825](https://github.com/rubocop-hq/rubocop/issues/8825): Fix crash in `Style/ExplicitBlockArgument` when code is called outside of a method. ([@ghiculescu][])
 
 ### Changes
 
@@ -4942,3 +4943,4 @@
 [@tleish]: https://github.com/tleish
 [@pbernays]: https://github.com/pbernays
 [@rdunlop]: https://github.com/rdunlop
+[@ghiculescu]: https://github.com/ghiculescu

--- a/lib/rubocop/cop/style/explicit_block_argument.rb
+++ b/lib/rubocop/cop/style/explicit_block_argument.rb
@@ -57,12 +57,16 @@ module RuboCop
           yielding_block?(block_node) do |send_node, block_args, yield_args|
             return unless yielding_arguments?(block_args, yield_args)
 
+            def_node = block_node.each_ancestor(:def, :defs).first
+            # if `yield` is being called outside of a method context, ignore
+            # this is not a valid ruby pattern, but can happen in haml or erb,
+            # so this can cause crashes in haml_lint
+            return unless def_node
+
             add_offense(block_node) do |corrector|
               corrector.remove(block_body_range(block_node, send_node))
 
               add_block_argument(send_node, corrector)
-
-              def_node = block_node.each_ancestor(:def, :defs).first
               add_block_argument(def_node, corrector) if @def_nodes.add?(def_node)
             end
           end

--- a/spec/rubocop/cop/style/explicit_block_argument_spec.rb
+++ b/spec/rubocop/cop/style/explicit_block_argument_spec.rb
@@ -154,4 +154,12 @@ RSpec.describe RuboCop::Cop::Style::ExplicitBlockArgument do
       end
     RUBY
   end
+
+  it 'does not register an offense when code is called outside of a method' do
+    expect_no_offenses(<<~RUBY)
+      render("partial") do
+        yield
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/rubocop-hq/rubocop/issues/8825