### PR TITLE
[Fix #7944] Add `MaxAllowedUnannotated` option to `Style/FormatStringToken` cop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#7944](https://github.com/rubocop-hq/rubocop/issues/7944): Add `MaxUnannotatedPlaceholdersAllowed` option to `Style/FormatStringToken` cop. ([@Tietew][])
+
 ### Bug fixes
 
 * [#8892](https://github.com/rubocop-hq/rubocop/issues/8892): Fix an error for `Style/StringConcatenation` when correcting nested concatenable parts. ([@fatkodima][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3109,8 +3109,12 @@ Style/FormatStringToken:
     # Prefer simple looking "template" style tokens like `%{name}`, `%{age}`
     - template
     - unannotated
+  # `MaxUnannotatedPlaceholdersAllowed` defines the number of `unannotated`
+  # style token in a format string to be allowed when enforced style is not
+  # `unannotated`.
+  MaxUnannotatedPlaceholdersAllowed: 1
   VersionAdded: '0.49'
-  VersionChanged: '0.75'
+  VersionChanged: '1.0'
 
 Style/FrozenStringLiteralComment:
   Description: >-

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -3405,7 +3405,7 @@ puts '%10s' % 'hoge'
 | Yes
 | No
 | 0.49
-| 0.75
+| 1.0
 |===
 
 Use a consistent style for named format string tokens.
@@ -3415,6 +3415,10 @@ which are passed as arguments to those methods:
 `printf`, `sprintf`, `format`, `%`.
 The reason is that _unannotated_ format is very similar
 to encoded URLs or Date/Time formatting strings.
+
+It is allowed to contain unannotated token
+if the number of them is less than or equals to
+`MaxUnannotatedPlaceholdersAllowed`.
 
 === Examples
 
@@ -3454,6 +3458,29 @@ format('%{greeting}', greeting: 'Hello')
 format('%s', 'Hello')
 ----
 
+==== MaxUnannotatedPlaceholdersAllowed: 0
+
+[source,ruby]
+----
+# bad
+format('%06d', 10)
+format('%s %s.', 'Hello', 'world')
+
+# good
+format('%<number>06d', number: 10)
+----
+
+==== MaxUnannotatedPlaceholdersAllowed: 1 (default)
+
+[source,ruby]
+----
+# bad
+format('%s %s.', 'Hello', 'world')
+
+# good
+format('%06d', 10)
+----
+
 === Configurable attributes
 
 |===
@@ -3462,6 +3489,10 @@ format('%s', 'Hello')
 | EnforcedStyle
 | `annotated`
 | `annotated`, `template`, `unannotated`
+
+| MaxUnannotatedPlaceholdersAllowed
+| `1`
+| Integer
 |===
 
 == Style/FrozenStringLiteralComment


### PR DESCRIPTION
This PR adds `MaxAllowedUnannotated` option to `Style/FormatStringToken` cop.

`MaxAllowedUnannotated` defines the number of `unannotated` style token
in a format string to be allowed when enforced style is not `unannotated`.

For example:

MaxAllowedUnannotated: 1
``` ruby
format("%s", foo) # => allowed
format("%s: %d", foo, bar) # => unallowed
```

MaxAllowedUnannotated: 2
``` ruby
format("%s", foo) # => allowed
format("%s: %d", foo, bar) # => allowed
format("%s: %d(%s)", foo, bar, baz) # => unallowed
```

The default value of MaxAllowedUnannotated is 1.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
