### PR TITLE
Fix #8820 autocorrection for Style/IfWithSemicolon

### DIFF
--- a/changelog/fix_if_with_semicolon_correction.md
+++ b/changelog/fix_if_with_semicolon_correction.md
@@ -1,0 +1,1 @@
+* [#8820](https://github.com/rubocop-hq/rubocop/issues/8820): Fixes `IfWithSemicolon` autocorrection when `elsif` is present. ([@adrian-rivera][])

--- a/lib/rubocop/cop/style/if_with_semicolon.rb
+++ b/lib/rubocop/cop/style/if_with_semicolon.rb
@@ -17,25 +17,55 @@ module RuboCop
         include OnNormalIfUnless
         extend AutoCorrector
 
-        MSG = 'Do not use if x; Use the ternary operator instead.'
+        MSG = 'Do not use if x; Use the ternary operator instead or if else structure.'
 
         def on_normal_if_unless(node)
           return unless node.else_branch
+          return if node.parent&.if_type?
 
           beginning = node.loc.begin
           return unless beginning&.is?(';')
 
           add_offense(node) do |corrector|
-            corrector.replace(node, correct_to_ternary(node))
+            corrector.replace(node, correct_to_structure(node))
           end
         end
 
         private
 
-        def correct_to_ternary(node)
+        def correct_to_structure(node)
+          return correct_elsif_structure(node) if node.else_branch.if_type?
+
           else_code = node.else_branch ? node.else_branch.source : 'nil'
 
           "#{node.condition.source} ? #{node.if_branch.source} : #{else_code}"
+        end
+
+        def correct_elsif_structure(node)
+          <<~RUBY.chop
+            if #{node.condition.source}
+              #{node.if_branch.source}
+            #{build_second_condition_structure(node.else_branch).chop}
+            end
+          RUBY
+        end
+
+        def build_second_condition_structure(second_condition)
+          result = <<~RUBY
+            elsif #{second_condition.condition.source}
+              #{second_condition.if_branch.source}
+          RUBY
+          if second_condition.else_branch
+            result += if second_condition.else_branch.if_type?
+                        build_second_condition_structure(second_condition.else_branch)
+                      else
+                        <<~RUBY
+                          else
+                            #{second_condition.else_branch.source}
+                        RUBY
+                      end
+          end
+          result
         end
       end
     end

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon do
   it 'registers an offense and corrects for one line if/;/end' do
     expect_offense(<<~RUBY)
       if cond; run else dont end
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use if x; Use the ternary operator instead.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use if x; Use the ternary operator instead or if else structure.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -27,5 +27,58 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon do
       class Hash
       end if RUBY_VERSION < "1.8.7"
     RUBY
+  end
+
+  context 'when elsif is present' do
+    it 'accepts without `else` branch' do
+      expect_offense(<<~RUBY)
+        if cond; run elsif cond2; run2 end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use if x; Use the ternary operator instead or if else structure.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if cond
+          run
+        elsif cond2
+          run2
+        end
+      RUBY
+    end
+
+    it 'accepts second elsif block' do
+      expect_offense(<<~RUBY)
+        if cond; run elsif cond2; run2 elsif cond3; run3 else dont end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use if x; Use the ternary operator instead or if else structure.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if cond
+          run
+        elsif cond2
+          run2
+        elsif cond3
+          run3
+        else
+          dont
+        end
+      RUBY
+    end
+
+    it 'accepts with `else` branch' do
+      expect_offense(<<~RUBY)
+        if cond; run elsif cond2; run2 else dont end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use if x; Use the ternary operator instead or if else structure.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if cond
+          run
+        elsif cond2
+          run2
+        else
+          dont
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
This change fixes autocorrection for Style/IfWithSemicolon when elsif present, which was reported on #8820 

In case of one of more elsif conditions present, the autocorrector will create a full if, elsif, else structure.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
