### PR TITLE
Fix a false positive for `Lint/BooleanSymbol` when used within `%i[...]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 * [#8810](https://github.com/rubocop-hq/rubocop/pull/8810): Fix multiple offense detection for `Style/RaiseArgs`. ([@pbernays][])
+* [#8151](https://github.com/rubocop-hq/rubocop/issues/8151): Fix a false positive for `Lint/BooleanSymbol` when used within `%i[...]`. ([@fatkodima][])
 * [#8809](https://github.com/rubocop-hq/rubocop/pull/8809): Fix multiple offense detection for `Style/For`. ([@pbernays][])
 * [#8801](https://github.com/rubocop-hq/rubocop/issues/8801): Fix `Layout/SpaceAroundEqualsInParameterDefault` only registered once in a line. ([@rdunlop][])
 * [#8514](https://github.com/rubocop-hq/rubocop/issues/8514): Correct multiple `Style/MethodDefParentheses` per file. ([@rdunlop][])

--- a/lib/rubocop/cop/lint/boolean_symbol.rb
+++ b/lib/rubocop/cop/lint/boolean_symbol.rb
@@ -32,6 +32,9 @@ module RuboCop
         def on_sym(node)
           return unless boolean_symbol?(node)
 
+          parent = node.parent
+          return if parent&.array_type? && parent&.percent_literal?(:symbol)
+
           add_offense(node, message: format(MSG, boolean: node.value)) do |corrector|
             autocorrect(corrector, node)
           end

--- a/spec/rubocop/cop/lint/boolean_symbol_spec.rb
+++ b/spec/rubocop/cop/lint/boolean_symbol_spec.rb
@@ -76,4 +76,10 @@ RSpec.describe RuboCop::Cop::Lint::BooleanSymbol, :config do
       false
     RUBY
   end
+
+  it 'does not register an offense when used inside percent-literal symbol array' do
+    expect_no_offenses(<<~RUBY)
+      %i[foo false]
+    RUBY
+  end
 end


### PR DESCRIPTION
Closes #8151