### PR TITLE
[Fix #8835] Fix an incorrect autocorrect for `Style/RedundantInterpolation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#8807](https://github.com/rubocop-hq/rubocop/pull/8807): Fix a false positive for `Style/RedundantCondition` when using assignment by hash key access. ([@koic][])
 * [#8848](https://github.com/rubocop-hq/rubocop/issues/8848): Fix a false positive for `Style/CombinableLoops` when using the same method with different arguments. ([@dvandersluis][])
 * [#8843](https://github.com/rubocop-hq/rubocop/issues/8843): Fix an incorrect autocorrect for `Lint/AmbiguousRegexpLiteral` when sending method to regexp literal receiver. ([@koic][])
+* [#8835](https://github.com/rubocop-hq/rubocop/issues/8835): Fix an incorrect autocorrect for `Style/RedundantInterpolation` when using string interpolation for non-operator methods. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/redundant_interpolation.rb
+++ b/lib/rubocop/cop/style/redundant_interpolation.rb
@@ -51,7 +51,12 @@ module RuboCop
         end
 
         def single_variable_interpolation?(node)
-          node.children.one? && variable_interpolation?(node.children.first)
+          return false unless node.children.one?
+
+          first_child = node.children.first
+
+          variable_interpolation?(first_child) ||
+            first_child.send_type? && !first_child.operator_method?
         end
 
         def interpolation?(node)

--- a/spec/rubocop/cop/style/redundant_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_interpolation_spec.rb
@@ -157,6 +157,28 @@ RSpec.describe RuboCop::Cop::Style::RedundantInterpolation do
     RUBY
   end
 
+  it 'registers an offense for "#{number}"' do
+    expect_offense(<<~'RUBY')
+      "#{number}"
+      ^^^^^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      number.to_s
+    RUBY
+  end
+
+  it 'registers an offense for "#{do_something(42)}"' do
+    expect_offense(<<~'RUBY')
+      "#{do_something(42)}"
+      ^^^^^^^^^^^^^^^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      do_something(42).to_s
+    RUBY
+  end
+
   it 'registers an offense for "#{var}"' do
     expect_offense(<<~'RUBY')
       var = 1; "#{var}"


### PR DESCRIPTION
Fixes #8835.

This PR fixes an incorrect autocorrect for `Style/RedundantInterpolation` when using string interpolation for non-operator methods.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
