### PR TITLE
Fix #8830 bad autocorrect of `Style/StringConcatenation` when string includes double quotes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#8514](https://github.com/rubocop-hq/rubocop/issues/8514): Correct multiple `Style/MethodDefParentheses` per file. ([@rdunlop][])
 * [#8825](https://github.com/rubocop-hq/rubocop/issues/8825): Fix crash in `Style/ExplicitBlockArgument` when code is called outside of a method. ([@ghiculescu][])
 * [#8354](https://github.com/rubocop-hq/rubocop/issues/8354): Detect regexp named captures in `Style/CaseLikeIf` cop. ([@dsavochkin][])
+* [#8830](https://github.com/rubocop-hq/rubocop/issues/8830): Fix bad autocorrect of `Style/StringConcatenation` when string includes double quotes. ([@tleish][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/string_concatenation.rb
+++ b/lib/rubocop/cop/style/string_concatenation.rb
@@ -87,7 +87,7 @@ module RuboCop
                 if single_quoted?(part)
                   part.value.gsub('\\') { '\\\\' }
                 else
-                  escape_string(part.value)
+                  part.value.inspect[1..-2]
                 end
               else
                 "\#{#{part.source}}"

--- a/spec/rubocop/cop/style/string_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/string_concatenation_spec.rb
@@ -122,4 +122,28 @@ RSpec.describe RuboCop::Cop::Style::StringConcatenation do
       expect_no_corrections
     end
   end
+
+  context 'double quotes inside string' do
+    it 'registers an offense and corrects with double quotes' do
+      expect_offense(<<-RUBY)
+        email_with_name = "He said " + "\\\"Arrest that man!\\\"."
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+      RUBY
+
+      expect_correction(<<-RUBY)
+        email_with_name = "He said \\\"Arrest that man!\\\"."
+      RUBY
+    end
+
+    it 'registers an offense and corrects with percentage quotes' do
+      expect_offense(<<-RUBY)
+        email_with_name = %(He said ) + %("Arrest that man!".)
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+      RUBY
+
+      expect_correction(<<-RUBY)
+        email_with_name = "He said \\\"Arrest that man!\\\"."
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
`Style/StringConcatenation` autocorrect combines strings into a single string, but currently does not escape double quotes.  The autocorrect creates an invalid string.

### Current:
Before:
```ruby
"He said " + "\"Arrest that man!\"."
```
Autocorrect: (quotes not escaped)
```ruby
"He said "Arrest that man!"."
#=> syntax error, unexpected tCONSTANT, expecting end-of-input
```

### Fix:
Before:
```ruby
"He said " + "\"Arrest that man!\"."
```
Autocorrect: (quotes escaped)
```ruby
"He said \"Arrest that man!\"."
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
