### PR TITLE
[Fix-8804] Save actual status to cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#8807](https://github.com/rubocop-hq/rubocop/pull/8807): Fix a false positive for `Style/RedundantCondition` when using assignment by hash key access. ([@koic][])
 * [#8848](https://github.com/rubocop-hq/rubocop/issues/8848): Fix a false positive for `Style/CombinableLoops` when using the same method with different arguments. ([@dvandersluis][])
 * [#8843](https://github.com/rubocop-hq/rubocop/issues/8843): Fix an incorrect autocorrect for `Lint/AmbiguousRegexpLiteral` when sending method to regexp literal receiver. ([@koic][])
+* [#8842](https://github.com/rubocop-hq/rubocop/issues/8842): Save actual status to cache, except corrected. ([@hatkyinc2][])
 
 ### Changes
 
@@ -4952,3 +4953,4 @@
 [@pbernays]: https://github.com/pbernays
 [@rdunlop]: https://github.com/rdunlop
 [@ghiculescu]: https://github.com/ghiculescu
+[@hatkyinc2]: https://github.com/hatkyinc2

--- a/lib/rubocop/cached_data.rb
+++ b/lib/rubocop/cached_data.rb
@@ -21,6 +21,7 @@ module RuboCop
     private
 
     def serialize_offense(offense)
+      status = :uncorrected if %i[corrected corrected_with_todo].include?(offense.status)
       {
         # Calling #to_s here ensures that the serialization works when using
         # other json serializers such as Oj. Some of these gems do not call
@@ -32,7 +33,7 @@ module RuboCop
         },
         message:  message(offense),
         cop_name: offense.cop_name,
-        status:   :uncorrected
+        status:   status || offense.status
       }
     end
 

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -60,25 +60,70 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
     end
 
     # Fixes https://github.com/rubocop-hq/rubocop/issues/6274
-    context 'when offenses are saved by autocorrect run' do
-      let(:corrected_offense) do
-        RuboCop::Cop::Offense.new(
-          :warning, location, 'unused var', 'Lint/UselessAssignment', :corrected
-        )
-      end
-      let(:uncorrected_offense) do
-        RuboCop::Cop::Offense.new(
-          corrected_offense.severity.name,
-          corrected_offense.location,
-          corrected_offense.message,
-          corrected_offense.cop_name,
-          :uncorrected
-        )
+    context 'when offenses are saved' do
+      context 'an offence with status corrected' do
+        let(:offense) do
+          RuboCop::Cop::Offense.new(
+            :warning, location, 'unused var', 'Lint/UselessAssignment', :corrected
+          )
+        end
+
+        it 'serializes them with uncorrected status' do
+          cache.save([offense])
+          expect(cache.load[0].status).to eq(:uncorrected)
+        end
       end
 
-      it 'serializes them with :uncorrected status' do
-        cache.save([corrected_offense])
-        expect(cache.load).to match_array([uncorrected_offense])
+      context 'an offence with status corrected_with_todo' do
+        let(:offense) do
+          RuboCop::Cop::Offense.new(
+            :warning, location, 'unused var', 'Lint/UselessAssignment', :corrected_with_todo
+          )
+        end
+
+        it 'serializes them with uncorrected status' do
+          cache.save([offense])
+          expect(cache.load[0].status).to eq(:uncorrected)
+        end
+      end
+
+      context 'an offence with status uncorrected' do
+        let(:offense) do
+          RuboCop::Cop::Offense.new(
+            :warning, location, 'unused var', 'Lint/UselessAssignment', :uncorrected
+          )
+        end
+
+        it 'serializes them with uncorrected status' do
+          cache.save([offense])
+          expect(cache.load[0].status).to eq(:uncorrected)
+        end
+      end
+
+      context 'an offence with status unsupported' do
+        let(:offense) do
+          RuboCop::Cop::Offense.new(
+            :warning, location, 'unused var', 'Lint/UselessAssignment', :unsupported
+          )
+        end
+
+        it 'serializes them with unsupported status' do
+          cache.save([offense])
+          expect(cache.load[0].status).to eq(:unsupported)
+        end
+      end
+
+      context 'an offence with status new_status' do
+        let(:offense) do
+          RuboCop::Cop::Offense.new(
+            :warning, location, 'unused var', 'Lint/UselessAssignment', :new_status
+          )
+        end
+
+        it 'serializes them with new_status status' do
+          cache.save([offense])
+          expect(cache.load[0].status).to eq(:new_status)
+        end
       end
     end
 


### PR DESCRIPTION
"Unsupported" status should be saved to cache, later to be used by total_correctable_count

This might resolve multiple reports on auto-correct for cops that don't have auto-correct on them

https://github.com/rubocop-hq/rubocop/issues/8804
https://github.com/rubocop-hq/rubocop/issues/8755


-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
