### PR TITLE
[Fix #8708] Fix bad regexp recognition in `Lint/OutOfRangeRegexpRef` when there are multiple regexps

### DIFF
--- a/changelog/fix_fix_8708_fix_bad_regexp_recognition_in.md
+++ b/changelog/fix_fix_8708_fix_bad_regexp_recognition_in.md
@@ -1,0 +1,1 @@
+* [#8708](https://github.com/rubocop-hq/rubocop/pull/8708): Fix bad regexp recognition in `Lint/OutOfRangeRegexpRef` when there are multiple regexps. ([@dvandersluis][])

--- a/lib/rubocop/cop/lint/out_of_range_regexp_ref.rb
+++ b/lib/rubocop/cop/lint/out_of_range_regexp_ref.rb
@@ -35,14 +35,13 @@ module RuboCop
           check_regexp(node.children.first)
         end
 
-        def on_send(node)
+        def after_send(node)
           @valid_ref = nil
 
-          if node.receiver&.regexp_type?
-            check_regexp(node.receiver)
-          elsif node.first_argument&.regexp_type? \
-            && REGEXP_ARGUMENT_METHODS.include?(node.method_name)
+          if regexp_first_argument?(node)
             check_regexp(node.first_argument)
+          elsif regexp_receiver?(node)
+            check_regexp(node.receiver)
           end
         end
 
@@ -79,6 +78,19 @@ module RuboCop
                        else
                          node.each_capture(named: false).count
                        end
+        end
+
+        def regexp_first_argument?(send_node)
+          send_node.first_argument&.regexp_type? \
+            && REGEXP_ARGUMENT_METHODS.include?(send_node.method_name)
+        end
+
+        def regexp_receiver?(send_node)
+          send_node.receiver&.regexp_type?
+        end
+
+        def nth_ref_receiver?(send_node)
+          send_node.receiver&.nth_ref_type?
         end
       end
     end

--- a/spec/rubocop/cop/lint/out_of_range_regexp_ref_spec.rb
+++ b/spec/rubocop/cop/lint/out_of_range_regexp_ref_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef do
 
   let(:config) { RuboCop::Config.new }
 
-  it 'registers an offense when references are used before any Regexp' do
+  it 'registers an offense when references are used before any regexp' do
     expect_offense(<<~RUBY)
       puts $3
-           ^^ Do not use out of range reference for the Regexp.
+           ^^ $3 is out of range (no regexp capture groups detected).
     RUBY
   end
 
@@ -16,7 +16,7 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef do
     expect_offense(<<~RUBY)
       /(?<foo>FOO)(?<bar>BAR)/ =~ "FOOBAR"
       puts $3
-           ^^ Do not use out of range reference for the Regexp.
+           ^^ $3 is out of range (2 regexp capture groups detected).
     RUBY
   end
 
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef do
     expect_offense(<<~RUBY)
       /(foo)(bar)/ =~ "foobar"
       puts $3
-           ^^ Do not use out of range reference for the Regexp.
+           ^^ $3 is out of range (2 regexp capture groups detected).
     RUBY
   end
 
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef do
     expect_offense(<<~RUBY)
       /(?<foo>FOO)(BAR)/ =~ "FOOBAR"
       puts $2
-           ^^ Do not use out of range reference for the Regexp.
+           ^^ $2 is out of range (1 regexp capture group detected).
     RUBY
   end
 
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef do
     expect_offense(<<~RUBY)
       /bar/ =~ 'foo'
       puts $1
-           ^^ Do not use out of range reference for the Regexp.
+           ^^ $1 is out of range (no regexp capture groups detected).
     RUBY
   end
 
@@ -70,7 +70,7 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef do
   # RuboCop does not know a value of variables that it will contain in the regexp literal.
   # For example, `/(?<foo>#{var}*)` is interpreted as `/(?<foo>*)`.
   # So it does not offense when variables are used in regexp literals.
-  it 'does not register an offence Regexp containing non literal' do
+  it 'does not register an offence regexp containing non literal' do
     expect_no_offenses(<<~'RUBY')
       var = '(\d+)'
       /(?<foo>#{var}*)/ =~ "12"
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef do
     expect_offense(<<~RUBY)
       "foobar" =~ /(foo)(bar)/
       puts $3
-           ^^ Do not use out of range reference for the Regexp.
+           ^^ $3 is out of range (2 regexp capture groups detected).
     RUBY
   end
 
@@ -91,7 +91,7 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef do
     expect_offense(<<~RUBY)
       /(foo)(bar)/ === "foobar"
       puts $3
-           ^^ Do not use out of range reference for the Regexp.
+           ^^ $3 is out of range (2 regexp capture groups detected).
     RUBY
   end
 
@@ -99,7 +99,7 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef do
     expect_offense(<<~RUBY)
       /(foo)(bar)/.match("foobar")
       puts $3
-           ^^ Do not use out of range reference for the Regexp.
+           ^^ $3 is out of range (2 regexp capture groups detected).
     RUBY
   end
 
@@ -108,7 +108,7 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef do
       /(foo)(bar)/.match("foobar")
       /(foo)(bar)(baz)/.match?("foobarbaz")
       puts $3
-           ^^ Do not use out of range reference for the Regexp.
+           ^^ $3 is out of range (2 regexp capture groups detected).
     RUBY
   end
 
@@ -148,7 +148,7 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef do
       case "foobar"
       when /(foo)(bar)/
         $3
-        ^^ Do not use out of range reference for the Regexp.
+        ^^ $3 is out of range (2 regexp capture groups detected).
       end
     RUBY
   end
@@ -165,7 +165,7 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef do
       case "foobarbaz"
       when /(foo)(bar)/, /(bar)baz/
         $3
-        ^^ Do not use out of range reference for the Regexp.
+        ^^ $3 is out of range (2 regexp capture groups detected).
       end
     RUBY
   end
@@ -184,7 +184,7 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef do
       case "foobarbaz"
       when /(foo)(bar)/, /#{var}/
         $3
-        ^^ Do not use out of range reference for the Regexp.
+        ^^ $3 is out of range (2 regexp capture groups detected).
       end
     RUBY
   end
@@ -199,7 +199,7 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef do
     it 'registers an offense when out of range references are used' do
       expect_offense(<<~RUBY)
         %w[foo foobar].grep(/(foo)/) { $2 }
-                                       ^^ Do not use out of range reference for the Regexp.
+                                       ^^ $2 is out of range (1 regexp capture group detected).
       RUBY
     end
 
@@ -222,7 +222,7 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef do
       expect_offense(<<~RUBY)
         "foobar"[/(foo)(bar)/]
         puts $3
-             ^^ Do not use out of range reference for the Regexp.
+             ^^ $3 is out of range (2 regexp capture groups detected).
       RUBY
     end
 
@@ -245,7 +245,7 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef do
       it 'registers an offense when out of range references are used' do
         expect_offense(<<~RUBY, method: method)
           "foobar".%{method}(/(foo)(bar)/) { $3 }
-                   _{method}                 ^^ Do not use out of range reference for the Regexp.
+                   _{method}                 ^^ $3 is out of range (2 regexp capture groups detected).
         RUBY
       end
 
@@ -270,7 +270,7 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef do
         expect_offense(<<~RUBY)
           "foobar".#{method}(/(foo)(bar)/)
           puts $3
-               ^^ Do not use out of range reference for the Regexp.
+               ^^ $3 is out of range (2 regexp capture groups detected).
         RUBY
       end
 


### PR DESCRIPTION
`Lint/OutOfRangeRegexpRef` was using the wrong regexp to determine how many capturing groups there are, in a few cases, that are now fixed. I also updated the error message to be a bit more straightforward because I found it hard to understand, but please let me know if you'd like me to reword or revert.

Also I have no idea what the plural of `regexp` should be. 😅 

Fixes #8708.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
