### PR TITLE
[Fix #8843] Fix invalid `Lint/AmbiguousRegexpLiteral` autocorrect when the original node had internal parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#8354](https://github.com/rubocop-hq/rubocop/issues/8354): Detect regexp named captures in `Style/CaseLikeIf` cop. ([@dsavochkin][])
 * [#8830](https://github.com/rubocop-hq/rubocop/issues/8830): Fix bad autocorrect of `Style/StringConcatenation` when string includes double quotes. ([@tleish][])
 * [#8807](https://github.com/rubocop-hq/rubocop/pull/8807): Fix a false positive for `Style/RedundantCondition` when using assignment by hash key access. ([@koic][])
+* [#8843](https://github.com/rubocop-hq/rubocop/issues/8843): Fix invalid `Lint/AmbiguousRegexpLiteral` autocorrect when the original node had internal parentheses. ([@dvandersluis][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
+++ b/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
@@ -35,7 +35,8 @@ module RuboCop
             offense_node = find_offense_node_by(diagnostic)
 
             add_offense(diagnostic.location, severity: diagnostic.level) do |corrector|
-              add_parentheses(offense_node, corrector)
+              corrector.replace(diagnostic.location.begin.adjust(begin_pos: -1), '(')
+              corrector.insert_after(offense_node, ')')
             end
           end
         end

--- a/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
@@ -55,6 +55,17 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousRegexpLiteral do
           end
         RUBY
       end
+
+      it 'correctly handles inner parentheses' do
+        expect_offense(<<~RUBY)
+          assert /foobar/.match('foo')
+                 ^ Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal, or add a whitespace to the right of the `/` if it should be a division.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          assert(/foobar/.match('foo'))
+        RUBY
+      end
     end
 
     context 'with parentheses' do


### PR DESCRIPTION
This previously used `Util#add_parentheses` to do correction, but this does not handle send nodes properly, so I changed it to just edit the node in place.

Fixes #8843.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
