### PR TITLE
[Fix #8843] Fix an incorrect autocorrect for `Lint/AmbiguousRegexpLiteral`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#8830](https://github.com/rubocop-hq/rubocop/issues/8830): Fix bad autocorrect of `Style/StringConcatenation` when string includes double quotes. ([@tleish][])
 * [#8807](https://github.com/rubocop-hq/rubocop/pull/8807): Fix a false positive for `Style/RedundantCondition` when using assignment by hash key access. ([@koic][])
 * [#8848](https://github.com/rubocop-hq/rubocop/issues/8848): Fix a false positive for `Style/CombinableLoops` when using the same method with different arguments. ([@dvandersluis][])
+* [#8843](https://github.com/rubocop-hq/rubocop/issues/8843): Fix an incorrect autocorrect for `Lint/AmbiguousRegexpLiteral` when sending method to regexp literal receiver. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
+++ b/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
@@ -47,7 +47,21 @@ module RuboCop
             regexp_node.source_range.begin_pos == diagnostic.location.begin_pos
           end
 
-          node.parent
+          find_offense_node(node.parent, node)
+        end
+
+        def find_offense_node(node, regexp_receiver)
+          return node unless node.parent
+
+          if node.parent.send_type? || method_chain_to_regexp_receiver?(node)
+            node = find_offense_node(node.parent, regexp_receiver)
+          end
+
+          node
+        end
+
+        def method_chain_to_regexp_receiver?(node)
+          node.parent.parent && node.parent.receiver.receiver == regexp_receiver
         end
       end
     end

--- a/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
@@ -27,6 +27,39 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousRegexpLiteral do
         RUBY
       end
 
+      it 'registers an offense and corrects when sending method to regexp without argument' do
+        expect_offense(<<~RUBY)
+          p /pattern/.do_something
+            ^ Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal, or add a whitespace to the right of the `/` if it should be a division.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          p(/pattern/.do_something)
+        RUBY
+      end
+
+      it 'registers an offense and corrects when sending method to regexp with argument' do
+        expect_offense(<<~RUBY)
+          p /pattern/.do_something(42)
+            ^ Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal, or add a whitespace to the right of the `/` if it should be a division.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          p(/pattern/.do_something(42))
+        RUBY
+      end
+
+      it 'registers an offense and corrects when sending method chain to regexp' do
+        expect_offense(<<~RUBY)
+          p /pattern/.do_something.do_something
+            ^ Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal, or add a whitespace to the right of the `/` if it should be a division.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          p(/pattern/.do_something.do_something)
+        RUBY
+      end
+
       it 'registers an offense and corrects when using block argument' do
         expect_offense(<<~RUBY)
           p /pattern/, foo do |arg|


### PR DESCRIPTION
Fixes #8843.

This PR fixes an incorrect autocorrect for `Lint/AmbiguousRegexpLiteral` when sending method to regexp literal receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
