### PR TITLE
[Fix #7495] Documentation for `Lint/AmbiguousBlockAssociation` cop is confusing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#8843](https://github.com/rubocop-hq/rubocop/issues/8843): Fix an incorrect autocorrect for `Lint/AmbiguousRegexpLiteral` when sending method to regexp literal receiver. ([@koic][])
 * [#8842](https://github.com/rubocop-hq/rubocop/issues/8842): Save actual status to cache, except corrected. ([@hatkyinc2][])
 * [#8835](https://github.com/rubocop-hq/rubocop/issues/8835): Fix an incorrect autocorrect for `Style/RedundantInterpolation` when using string interpolation for non-operator methods. ([@koic][])
+* [#7495](https://github.com/rubocop-hq/rubocop/issues/7495): Example for `Lint/AmbiguousBlockAssociation` cop. ([@AllanSiqueira][])
 
 ### Changes
 
@@ -4956,3 +4957,4 @@
 [@rdunlop]: https://github.com/rdunlop
 [@ghiculescu]: https://github.com/ghiculescu
 [@hatkyinc2]: https://github.com/hatkyinc2
+[@AllanSiqueira]: https://github.com/allansiqueira

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -27,6 +27,8 @@ some_method a { |val| puts val }
 ----
 # good
 # With parentheses, there's no ambiguity.
+some_method(a { |val| puts val })
+# or (different meaning)
 some_method(a) { |val| puts val }
 
 # good

--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -15,6 +15,8 @@ module RuboCop
       #
       #   # good
       #   # With parentheses, there's no ambiguity.
+      #   some_method(a { |val| puts val })
+      #   # or (different meaning)
       #   some_method(a) { |val| puts val }
       #
       #   # good


### PR DESCRIPTION
Fixes: #7495 
Add an example in the documentation for `Lint/AmbiguousBlockAssociation` to illustrate both good solutions for this cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
