### PR TITLE
[Fix #8848] Fix a false positive for `Style/CombinableLoops` when using the same method with different arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#8354](https://github.com/rubocop-hq/rubocop/issues/8354): Detect regexp named captures in `Style/CaseLikeIf` cop. ([@dsavochkin][])
 * [#8830](https://github.com/rubocop-hq/rubocop/issues/8830): Fix bad autocorrect of `Style/StringConcatenation` when string includes double quotes. ([@tleish][])
 * [#8807](https://github.com/rubocop-hq/rubocop/pull/8807): Fix a false positive for `Style/RedundantCondition` when using assignment by hash key access. ([@koic][])
+* [#8848](https://github.com/rubocop-hq/rubocop/issues/8848): Fix a false positive for `Style/CombinableLoops` when using the same method with different arguments. ([@dvandersluis][])
 
 ### Changes
 

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -1437,6 +1437,12 @@ def method
     do_something_else(item)
   end
 end
+
+# good
+def method
+  each_slice(2) { |slice| do_something(slice) }
+  each_slice(3) { |slice| do_something(slice) }
+end
 ----
 
 == Style/CommandLiteral

--- a/lib/rubocop/cop/style/combinable_loops.rb
+++ b/lib/rubocop/cop/style/combinable_loops.rb
@@ -49,6 +49,12 @@ module RuboCop
       #     end
       #   end
       #
+      #   # good
+      #   def method
+      #     each_slice(2) { |slice| do_something(slice) }
+      #     each_slice(3) { |slice| do_something(slice) }
+      #   end
+      #
       class CombinableLoops < Base
         MSG = 'Combine this loop with the previous loop.'
 
@@ -76,7 +82,8 @@ module RuboCop
         def same_collection_looping?(node, sibling)
           sibling&.block_type? &&
             sibling.send_node.method?(node.method_name) &&
-            sibling.send_node.receiver == node.send_node.receiver
+            sibling.send_node.receiver == node.send_node.receiver &&
+            sibling.send_node.arguments == node.send_node.arguments
         end
       end
     end

--- a/spec/rubocop/cop/style/combinable_loops_spec.rb
+++ b/spec/rubocop/cop/style/combinable_loops_spec.rb
@@ -53,6 +53,13 @@ RSpec.describe RuboCop::Cop::Style::CombinableLoops do
         end
       RUBY
     end
+
+    it 'does not register an offense for when the same method with different arguments' do
+      expect_no_offenses(<<~RUBY)
+        each_slice(2) { |slice| do_something(slice) }
+        each_slice(3) { |slice| do_something(slice) }
+      RUBY
+    end
   end
 
   context 'when for loop' do


### PR DESCRIPTION
If the same iterable method is called multiple times with different arguments it is not a combinable loop, and thus a false positive for `Style/CombinableLoops`.

Fixes #8848.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
