### PR TITLE
Added `IgnoredMethods` configuration to `Style/CombinableLoops`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * [#8782](https://github.com/rubocop-hq/rubocop/issues/8782): Fix incorrect autocorrection for `Style/TernaryParentheses` with `defined?`. ([@dvandersluis][])
 * [#8864](https://github.com/rubocop-hq/rubocop/issues/8864): Fix false positive for `Style/RedundantBegin` with a postfix `while` or `until`. ([@dvandersluis][])
 
+### Changes
+* [#8852](https://github.com/rubocop-hq/rubocop/pull/8852): Add `IgnoredMethods` configuration to `Style/CombinableLoops`. ([@dvandersluis][])
+
 ## 0.93.0 (2020-10-08)
 
 ### New features

--- a/config/default.yml
+++ b/config/default.yml
@@ -2797,7 +2797,9 @@ Style/CombinableLoops:
                   can be combined into a single loop.
   Enabled: pending
   Safe: false
+  IgnoredMethods: []
   VersionAdded: '0.90'
+  VersionChanged: '0.94'
 
 Style/CommandLiteral:
   Description: 'Use `` or %x around command literals.'

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -1429,7 +1429,7 @@ end
 | No
 | No
 | 0.90
-| -
+| 0.94
 |===
 
 This cop checks for places where multiple consecutive loops over the same data
@@ -1487,6 +1487,32 @@ def method
   each_slice(3) { |slice| do_something(slice) }
 end
 ----
+
+==== IgnoredMethods: [validates_each]
+
+[source,ruby]
+----
+# good
+class Foo
+  validates_each :attr1, :attr2 do |record, attribute, value|
+    record.errors.add(attribute, :invalid) if invalid?(value)
+  end
+
+  validates_each :attr1, :attr2 do |record, attribute, value|
+    record.errors.add(attribute, :empty) if empty?(value)
+  end
+end
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| IgnoredMethods
+| `[]`
+| Array
+|===
 
 == Style/CommandLiteral
 

--- a/lib/rubocop/cop/style/combinable_loops.rb
+++ b/lib/rubocop/cop/style/combinable_loops.rb
@@ -55,7 +55,21 @@ module RuboCop
       #     each_slice(3) { |slice| do_something(slice) }
       #   end
       #
+      # @example IgnoredMethods: [validates_each]
+      #
+      #   # good
+      #   class Foo
+      #     validates_each :attr1, :attr2 do |record, attribute, value|
+      #       record.errors.add(attribute, :invalid) if invalid?(value)
+      #     end
+      #
+      #     validates_each :attr1, :attr2 do |record, attribute, value|
+      #       record.errors.add(attribute, :empty) if empty?(value)
+      #     end
+      #   end
       class CombinableLoops < Base
+        include IgnoredMethods
+
         MSG = 'Combine this loop with the previous loop.'
 
         def on_block(node)
@@ -76,6 +90,8 @@ module RuboCop
 
         def collection_looping_method?(node)
           method_name = node.send_node.method_name
+          return false if ignored_method?(method_name)
+
           method_name.match?(/^each/) || method_name.match?(/_each$/)
         end
 

--- a/spec/rubocop/cop/style/combinable_loops_spec.rb
+++ b/spec/rubocop/cop/style/combinable_loops_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Style::CombinableLoops do
-  subject(:cop) { described_class.new }
-
+RSpec.describe RuboCop::Cop::Style::CombinableLoops, :config do
   context 'when looping method' do
     it 'registers an offense when looping over the same data as previous loop' do
       expect_offense(<<~RUBY)
@@ -94,6 +92,22 @@ RSpec.describe RuboCop::Cop::Style::CombinableLoops do
           for item in items do do_something(item) end
         else
           for item in items do do_something_else(item, arg) end
+        end
+      RUBY
+    end
+  end
+
+  context 'when IgnoredMethods is set' do
+    let(:cop_config) { { 'IgnoredMethods' => %w[validates_each] } }
+
+    it 'does not register an offense for ignored methods' do
+      expect_no_offenses(<<~RUBY)
+        validates_each :foo, :bar do |record, attribute, value|
+          record.errors.add(attribute, :invalid) if invalid?(value)
+        end
+
+        validates_each :foo, :bar do |record, attribute, value|
+          record.errors.add(attribute, :empty) if empty?(value)
         end
       RUBY
     end


### PR DESCRIPTION
Related to #8848, it probably makes sense to make `Style/CombinableLoops` use `IgnoredMethods`, since it's possible to have a method that matches the method name conditions without being combinable.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
