### PR TITLE
[Fix #8842]: Add notification about cache being used to debug mode

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,6 +23,7 @@ Describe here how you expected RuboCop to behave in this particular situation.
 ## Actual behavior
 
 Describe here what actually happened.
+Please use `rubocop --debug` when pasting rubocop output as it contains additional information.
 
 ## Steps to reproduce the problem
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#8796](https://github.com/rubocop-hq/rubocop/pull/8796): Add new `Lint/HashCompareByIdentity` cop. ([@fatkodima][])
 * [#8668](https://github.com/rubocop-hq/rubocop/pull/8668): Add new `Lint/RedundantSafeNavigation` cop. ([@fatkodima][])
+* [#8842](https://github.com/rubocop-hq/rubocop/issues/8842): Add notification about cache being used to debug mode. ([@hatkyinc2][])
 
 ### Bug fixes
 
@@ -4952,3 +4953,4 @@
 [@pbernays]: https://github.com/pbernays
 [@rdunlop]: https://github.com/rdunlop
 [@ghiculescu]: https://github.com/ghiculescu
+[@hatkyinc2]: https://github.com/hatkyinc2

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -95,6 +95,11 @@ module RuboCop
                         context_checksum(team, options),
                         file_checksum(file, config_store))
       @cached_data = CachedData.new(file)
+      @debug = options[:debug]
+    end
+
+    def debug?
+      @debug
     end
 
     def valid?
@@ -102,6 +107,7 @@ module RuboCop
     end
 
     def load
+      puts "Loading cache from #{@path}" if debug?
       @cached_data.from_json(IO.read(@path, encoding: Encoding::UTF_8))
     end
 


### PR DESCRIPTION
* When rubocop is ran in debug mode (`--debug`) and rubocop uses a cache, output the location of cache used. (This is to inform about possible differences between runs..)
* Encourage users submitting bugs to use debug mode.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [X] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
