### PR TITLE
[Fix #8855] Fix an error when using only access modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#8842](https://github.com/rubocop-hq/rubocop/issues/8842): Save actual status to cache, except corrected. ([@hatkyinc2][])
 * [#8835](https://github.com/rubocop-hq/rubocop/issues/8835): Fix an incorrect autocorrect for `Style/RedundantInterpolation` when using string interpolation for non-operator methods. ([@koic][])
 * [#7495](https://github.com/rubocop-hq/rubocop/issues/7495): Example for `Lint/AmbiguousBlockAssociation` cop. ([@AllanSiqueira][])
+* [#8855](https://github.com/rubocop-hq/rubocop/issues/8855): Fix an error for `Layout/EmptyLinesAroundAccessModifier` and `Style/AccessModifierDeclarations` when using only access modifier. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
@@ -84,7 +84,8 @@ module RuboCop
         end
 
         def on_send(node)
-          return unless register_offense?(node)
+          return unless node.bare_access_modifier? && !node.parent&.block_type?
+          return if expected_empty_lines?(node)
 
           message = message(node)
           add_offense(node, message: message) do |corrector|
@@ -98,17 +99,15 @@ module RuboCop
 
         private
 
-        def register_offense?(node)
-          return false unless node.bare_access_modifier? && !node.parent.block_type?
-
+        def expected_empty_lines?(node)
           case style
           when :around
-            return false if empty_lines_around?(node)
+            return true if empty_lines_around?(node)
           when :only_before
-            return false if allowed_only_before_style?(node)
+            return true if allowed_only_before_style?(node)
           end
 
-          true
+          false
         end
 
         def allowed_only_before_style?(node)

--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -83,8 +83,8 @@ module RuboCop
 
         def on_send(node)
           return unless node.access_modifier?
-          return if node.parent.pair_type?
-          return if cop_config['AllowModifiersOnSymbols'] && access_modifier_with_symbol?(node)
+          return if node.parent&.pair_type?
+          return if allow_modifiers_on_symbols?(node)
 
           if offense?(node)
             add_offense(node.loc.selector) if opposite_style_detected
@@ -94,6 +94,10 @@ module RuboCop
         end
 
         private
+
+        def allow_modifiers_on_symbols?(node)
+          cop_config['AllowModifiersOnSymbols'] && access_modifier_with_symbol?(node)
+        end
 
         def offense?(node)
           (group_style? && access_modifier_is_inlined?(node)) ||

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -322,6 +322,12 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
           end\r
         RUBY
       end
+
+      it 'accepts only using access modifier' do
+        expect_no_offenses(<<~RUBY)
+          #{access_modifier}
+        RUBY
+      end
     end
   end
 

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -64,6 +64,12 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
         RUBY
       end
 
+      it 'accepts when using only #{access_modifier}' do
+        expect_no_offenses(<<~RUBY)
+          #{access_modifier}
+        RUBY
+      end
+
       it "does not offend when #{access_modifier} is not inlined and " \
          'has a comment' do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #8855.

This PR fixes an error for `Layout/EmptyLinesAroundAccessModifier` and `Style/AccessModifierDeclarations` when using only access modifier.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
