### PR TITLE
Fix an example for `Style/FormatStringToken`

### DIFF
--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -3405,7 +3405,7 @@ format('%{greeting}', greeting: 'Hello')
 ----
 # bad
 format('%<greeting>s', greeting: 'Hello')
-format('%{greeting}', 'Hello')
+format('%{greeting}', greeting: 'Hello')
 
 # good
 format('%s', 'Hello')

--- a/lib/rubocop/cop/style/format_string_token.rb
+++ b/lib/rubocop/cop/style/format_string_token.rb
@@ -33,7 +33,7 @@ module RuboCop
       #
       #   # bad
       #   format('%<greeting>s', greeting: 'Hello')
-      #   format('%{greeting}', 'Hello')
+      #   format('%{greeting}', greeting: 'Hello')
       #
       #   # good
       #   format('%s', 'Hello')


### PR DESCRIPTION
This PR fixes an example for `Style/FormatStringToken`.
It seems that kwarg to `format` method has been forgotten.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
