### PR TITLE
[Fix #8862] Fix an error for `Lint/AmbiguousRegexpLiteral`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#8782](https://github.com/rubocop-hq/rubocop/issues/8782): Fix incorrect autocorrection for `Style/TernaryParentheses` with `defined?`. ([@dvandersluis][])
 * [#8864](https://github.com/rubocop-hq/rubocop/issues/8864): Fix false positive for `Style/RedundantBegin` with a postfix `while` or `until`. ([@dvandersluis][])
 * [#8869](https://github.com/rubocop-hq/rubocop/issues/8869): Fix a false positive for `Style/RedundantBegin` when using `begin` for or assignment and method call. ([@koic][])
+* [#8862](https://github.com/rubocop-hq/rubocop/issues/8862): Fix an error for `Lint/AmbiguousRegexpLiteral` when using regexp without method calls in nested structure. ([@koic][])
 
 ## 0.93.0 (2020-10-08)
 

--- a/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
+++ b/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
@@ -53,15 +53,18 @@ module RuboCop
         def find_offense_node(node, regexp_receiver)
           return node unless node.parent
 
-          if node.parent.send_type? || method_chain_to_regexp_receiver?(node)
+          if node.parent.send_type? || method_chain_to_regexp_receiver?(node, regexp_receiver)
             node = find_offense_node(node.parent, regexp_receiver)
           end
 
           node
         end
 
-        def method_chain_to_regexp_receiver?(node)
-          node.parent.parent && node.parent.receiver.receiver == regexp_receiver
+        def method_chain_to_regexp_receiver?(node, regexp_receiver)
+          return false unless (parent = node.parent)
+          return false unless (parent_receiver = parent.receiver)
+
+          parent.parent && parent_receiver.receiver == regexp_receiver
         end
       end
     end

--- a/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
@@ -60,6 +60,25 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousRegexpLiteral do
         RUBY
       end
 
+      it 'registers an offense and corrects when using regexp without method call in a nested structure' do
+        expect_offense(<<~RUBY)
+          class MyTest
+            test '#foo' do
+              assert_match /expected/, actual
+                           ^ Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal, or add a whitespace to the right of the `/` if it should be a division.
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class MyTest
+            test '#foo' do
+              assert_match(/expected/, actual)
+            end
+          end
+        RUBY
+      end
+
       it 'registers an offense and corrects when using block argument' do
         expect_offense(<<~RUBY)
           p /pattern/, foo do |arg|


### PR DESCRIPTION
Fixes #8862.

This PR fixes an error for `Lint/AmbiguousRegexpLiteral` when using regexp without method calls in nested structure.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
