### PR TITLE
Docs: RedundantSafeNavigation

### DIFF
--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -2918,14 +2918,19 @@ require 'unloaded_feature'
 |===
 
 This cop checks for redundant safe navigation calls.
-It is marked as unsafe, because it can produce code that returns
-non `nil` while `nil` result is expected on `nil` receiver.
+
+In the example below, the safe navigation operator (`&.`) is unnecessary
+because `NilClass` has methods like `respond_to?` and `dup`.
+
+This cop is marked as unsafe, because auto-correction can change the
+return type of the expression. An offending expression that previously
+could return `nil` will be auto-corrected to never return `nil`.
 
 === Examples
 
 [source,ruby]
 ----
-# bad
+# bad, because nil has these methods
 attrs&.respond_to?(:[])
 foo&.dup&.inspect
 

--- a/lib/rubocop/cop/lint/redundant_safe_navigation.rb
+++ b/lib/rubocop/cop/lint/redundant_safe_navigation.rb
@@ -4,11 +4,16 @@ module RuboCop
   module Cop
     module Lint
       # This cop checks for redundant safe navigation calls.
-      # It is marked as unsafe, because it can produce code that returns
-      # non `nil` while `nil` result is expected on `nil` receiver.
+      #
+      # In the example below, the safe navigation operator (`&.`) is unnecessary
+      # because `NilClass` has methods like `respond_to?` and `dup`.
+      #
+      # This cop is marked as unsafe, because auto-correction can change the
+      # return type of the expression. An offending expression that previously
+      # could return `nil` will be auto-corrected to never return `nil`.
       #
       # @example
-      #   # bad
+      #   # bad, because nil has these methods
       #   attrs&.respond_to?(:[])
       #   foo&.dup&.inspect
       #


### PR DESCRIPTION
Improves explanation re: purpose of cop

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [N/A] Added tests.
* [N/A] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
