### PR TITLE
[Fix #8869] Fix a false positive for `Style/RedundantBegin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#8782](https://github.com/rubocop-hq/rubocop/issues/8782): Fix incorrect autocorrection for `Style/TernaryParentheses` with `defined?`. ([@dvandersluis][])
 * [#8864](https://github.com/rubocop-hq/rubocop/issues/8864): Fix false positive for `Style/RedundantBegin` with a postfix `while` or `until`. ([@dvandersluis][])
+* [#8869](https://github.com/rubocop-hq/rubocop/issues/8869): Fix a false positive for `Style/RedundantBegin` when using `begin` for or assignment and method call. ([@koic][])
 
 ## 0.93.0 (2020-10-08)
 

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -85,8 +85,7 @@ module RuboCop
         end
 
         def on_kwbegin(node)
-          return if node.parent&.assignment?
-          return if node.parent&.post_condition_loop?
+          return if node.each_ancestor.any?(&:assignment?) || node.parent&.post_condition_loop?
 
           first_child = node.children.first
           return if first_child.rescue_type? || first_child.ensure_type?

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -222,6 +222,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
     RUBY
   end
 
+  it 'does not register an offense when using `begin` for or assignment and method call' do
+    expect_no_offenses(<<~RUBY)
+      var ||= begin
+        foo
+        bar
+      end.baz do
+        qux
+      end
+    RUBY
+  end
+
   context '< Ruby 2.5', :ruby24 do
     it 'accepts a do-end block with a begin-end' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #8869.

This PR fixes a false positive for `Style/RedundantBegin` when using `begin` for or assignment and method call.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
