### PR TITLE
[Fix #8872] Fix an error for `Metrics/ClassLength`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#8864](https://github.com/rubocop-hq/rubocop/issues/8864): Fix false positive for `Style/RedundantBegin` with a postfix `while` or `until`. ([@dvandersluis][])
 * [#8869](https://github.com/rubocop-hq/rubocop/issues/8869): Fix a false positive for `Style/RedundantBegin` when using `begin` for or assignment and method call. ([@koic][])
 * [#8862](https://github.com/rubocop-hq/rubocop/issues/8862): Fix an error for `Lint/AmbiguousRegexpLiteral` when using regexp without method calls in nested structure. ([@koic][])
+* [#8872](https://github.com/rubocop-hq/rubocop/issues/8872): Fix an error for `Metrics/ClassLength` when multiple assignments to constants. ([@koic][])
 
 ## 0.93.0 (2020-10-08)
 

--- a/lib/rubocop/cop/metrics/class_length.rb
+++ b/lib/rubocop/cop/metrics/class_length.rb
@@ -39,8 +39,12 @@ module RuboCop
         end
 
         def on_casgn(node)
-          if node.parent&.assignment?
-            block_node = node.parent.children[1]
+          parent = node.parent
+
+          if parent&.assignment?
+            block_node = parent.children[1]
+          elsif parent&.parent&.masgn_type?
+            block_node = parent.parent.children[1]
           else
             _scope, _name, block_node = *node
           end

--- a/spec/rubocop/cop/metrics/class_length_spec.rb
+++ b/spec/rubocop/cop/metrics/class_length_spec.rb
@@ -230,5 +230,20 @@ RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
         end
       RUBY
     end
+
+    it 'registers an offense when multiple assignments to constants' do
+      # `Bar` is always nil, but syntax is valid.
+      expect_offense(<<~RUBY)
+        Foo, Bar = Struct.new(:foo, :bar) do
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^ Class has too many lines. [6/5]
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Fixes #8872.

This PR fixes an error for `Metrics/ClassLength` when multiple assignments to constants.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
