### PR TITLE
[Fix #8875] Fix incorrect autocorrect for `Style/ClassEqualityComparison`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#8862](https://github.com/rubocop-hq/rubocop/issues/8862): Fix an error for `Lint/AmbiguousRegexpLiteral` when using regexp without method calls in nested structure. ([@koic][])
 * [#8872](https://github.com/rubocop-hq/rubocop/issues/8872): Fix an error for `Metrics/ClassLength` when multiple assignments to constants. ([@koic][])
 * [#8871](https://github.com/rubocop-hq/rubocop/issues/8871): Fix a false positive for `Style/RedundantBegin` when using `begin` for method argument or part of conditions. ([@koic][])
+* [#8875](https://github.com/rubocop-hq/rubocop/issues/8875): Fix an incorrect auto-correct for `Style/ClassEqualityComparison` when comparing class name. ([@koic][])
 
 ## 0.93.0 (2020-10-08)
 

--- a/lib/rubocop/cop/style/class_equality_comparison.rb
+++ b/lib/rubocop/cop/style/class_equality_comparison.rb
@@ -36,12 +36,21 @@ module RuboCop
           return if def_node && ignored_method?(def_node.method_name)
 
           class_comparison_candidate?(node) do |receiver_node, class_node|
-            range = range_between(receiver_node.loc.selector.begin_pos, node.source_range.end_pos)
+            range = offense_range(receiver_node, node)
 
             add_offense(range) do |corrector|
-              corrector.replace(range, "instance_of?(#{class_node.source})")
+              class_name = class_node.source
+              class_name = class_name.delete('"').delete("'") if node.children.first.method?(:name)
+
+              corrector.replace(range, "instance_of?(#{class_name})")
             end
           end
+        end
+
+        private
+
+        def offense_range(receiver_node, node)
+          range_between(receiver_node.loc.selector.begin_pos, node.source_range.end_pos)
         end
       end
     end

--- a/spec/rubocop/cop/style/class_equality_comparison_spec.rb
+++ b/spec/rubocop/cop/style/class_equality_comparison_spec.rb
@@ -5,21 +5,58 @@ RSpec.describe RuboCop::Cop::Style::ClassEqualityComparison, :config do
     { 'IgnoredMethods' => [] }
   end
 
-  it 'registers an offense and corrects when comparing class for equality' do
+  it 'registers an offense and corrects when comparing class using `==` for equality' do
     expect_offense(<<~RUBY)
       var.class == Date
           ^^^^^^^^^^^^^ Use `Object.instance_of?` instead of comparing classes.
-      var.class.equal?(Date)
-          ^^^^^^^^^^^^^^^^^^ Use `Object.instance_of?` instead of comparing classes.
-      var.class.eql?(Date)
-          ^^^^^^^^^^^^^^^^ Use `Object.instance_of?` instead of comparing classes.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      var.instance_of?(Date)
     RUBY
   end
 
-  it 'registers an offense and corrects when comparing class name for equality' do
+  it 'registers an offense and corrects when comparing class using `equal?` for equality' do
+    expect_offense(<<~RUBY)
+      var.class.equal?(Date)
+          ^^^^^^^^^^^^^^^^^^ Use `Object.instance_of?` instead of comparing classes.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      var.instance_of?(Date)
+    RUBY
+  end
+
+  it 'registers an offense and corrects when comparing class using `eql?` for equality' do
+    expect_offense(<<~RUBY)
+      var.class.eql?(Date)
+          ^^^^^^^^^^^^^^^^ Use `Object.instance_of?` instead of comparing classes.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      var.instance_of?(Date)
+    RUBY
+  end
+
+  it 'registers an offense and corrects when comparing single quoted class name for equality' do
+    expect_offense(<<~RUBY)
+      var.class.name == 'Date'
+          ^^^^^^^^^^^^^^^^^^^^ Use `Object.instance_of?` instead of comparing classes.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      var.instance_of?(Date)
+    RUBY
+  end
+
+  it 'registers an offense and corrects when comparing double quoted class name for equality' do
     expect_offense(<<~RUBY)
       var.class.name == "Date"
           ^^^^^^^^^^^^^^^^^^^^ Use `Object.instance_of?` instead of comparing classes.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      var.instance_of?(Date)
     RUBY
   end
 

--- a/spec/rubocop/cop/style/class_equality_comparison_spec.rb
+++ b/spec/rubocop/cop/style/class_equality_comparison_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::Cop::Style::ClassEqualityComparison, :config do
   it 'registers an offense and corrects when comparing class using `==` for equality' do
     expect_offense(<<~RUBY)
       var.class == Date
-          ^^^^^^^^^^^^^ Use `Object.instance_of?` instead of comparing classes.
+          ^^^^^^^^^^^^^ Use `instance_of?(Date)` instead of comparing classes.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::Style::ClassEqualityComparison, :config do
   it 'registers an offense and corrects when comparing class using `equal?` for equality' do
     expect_offense(<<~RUBY)
       var.class.equal?(Date)
-          ^^^^^^^^^^^^^^^^^^ Use `Object.instance_of?` instead of comparing classes.
+          ^^^^^^^^^^^^^^^^^^ Use `instance_of?(Date)` instead of comparing classes.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Style::ClassEqualityComparison, :config do
   it 'registers an offense and corrects when comparing class using `eql?` for equality' do
     expect_offense(<<~RUBY)
       var.class.eql?(Date)
-          ^^^^^^^^^^^^^^^^ Use `Object.instance_of?` instead of comparing classes.
+          ^^^^^^^^^^^^^^^^ Use `instance_of?(Date)` instead of comparing classes.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::Style::ClassEqualityComparison, :config do
   it 'registers an offense and corrects when comparing single quoted class name for equality' do
     expect_offense(<<~RUBY)
       var.class.name == 'Date'
-          ^^^^^^^^^^^^^^^^^^^^ Use `Object.instance_of?` instead of comparing classes.
+          ^^^^^^^^^^^^^^^^^^^^ Use `instance_of?(Date)` instead of comparing classes.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Cop::Style::ClassEqualityComparison, :config do
   it 'registers an offense and corrects when comparing double quoted class name for equality' do
     expect_offense(<<~RUBY)
       var.class.name == "Date"
-          ^^^^^^^^^^^^^^^^^^^^ Use `Object.instance_of?` instead of comparing classes.
+          ^^^^^^^^^^^^^^^^^^^^ Use `instance_of?(Date)` instead of comparing classes.
     RUBY
 
     expect_correction(<<~RUBY)


### PR DESCRIPTION
Fixes #8875.

This PR fixes an incorrect auto-correct for `Style/ClassEqualityComparison` when comparing string class name, and it tweaks the offense message.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
