### PR TITLE
[Fix #8868] Fix false positives for `Lint/RedundantSafeNavigation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#8872](https://github.com/rubocop-hq/rubocop/issues/8872): Fix an error for `Metrics/ClassLength` when multiple assignments to constants. ([@koic][])
 * [#8871](https://github.com/rubocop-hq/rubocop/issues/8871): Fix a false positive for `Style/RedundantBegin` when using `begin` for method argument or part of conditions. ([@koic][])
 * [#8875](https://github.com/rubocop-hq/rubocop/issues/8875): Fix an incorrect auto-correct for `Style/ClassEqualityComparison` when comparing class name. ([@koic][])
+* [#8868](https://github.com/rubocop-hq/rubocop/issues/8868): Fix false positives for `Lint/RedundantSafeNavigation` with `tap`, `yield_self` and `then` methods. ([@tejasbubane][])
 
 ## 0.93.0 (2020-10-08)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1767,6 +1767,9 @@ Lint/RedundantSafeNavigation:
     - public_send
     - send
     - __send__
+    - tap
+    - yield_self
+    - then
 
 Lint/RedundantSplatExpansion:
   Description: 'Checks for splat unnecessarily being called on literals.'

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -2945,7 +2945,7 @@ foo.dup.inspect
 | Name | Default value | Configurable values
 
 | IgnoredMethods
-| `to_c`, `to_f`, `to_i`, `to_r`, `rationalize`, `public_send`, `send`, `__send__`
+| `to_c`, `to_f`, `to_i`, `to_r`, `rationalize`, `public_send`, `send`, `__send__`, `tap`, `yield_self`, `then`
 | Array
 |===
 

--- a/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
@@ -40,14 +40,15 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSafeNavigation, :config do
     RUBY
   end
 
-  context 'when AllowedMethods is set' do
+  context 'when IgnoredMethods is set' do
     let(:cop_config) do
-      { 'IgnoredMethods' => ['to_f'] }
+      { 'IgnoredMethods' => %w[to_f tap] }
     end
 
     it 'does not register an offense when using ignored `nil` method with `.&`' do
       expect_no_offenses(<<~RUBY)
         foo&.to_f
+        foo&.tap { |i| i * 2 }
       RUBY
     end
   end


### PR DESCRIPTION
With `tap`, `yield_self` and `then` methods.

Closes #8868

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/