### PR TITLE
[Fix #8880] Fix an error for `Style/ClassLength`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#8872](https://github.com/rubocop-hq/rubocop/issues/8872): Fix an error for `Metrics/ClassLength` when multiple assignments to constants. ([@koic][])
 * [#8871](https://github.com/rubocop-hq/rubocop/issues/8871): Fix a false positive for `Style/RedundantBegin` when using `begin` for method argument or part of conditions. ([@koic][])
 * [#8875](https://github.com/rubocop-hq/rubocop/issues/8875): Fix an incorrect auto-correct for `Style/ClassEqualityComparison` when comparing class name. ([@koic][])
+* [#8880](https://github.com/rubocop-hq/rubocop/issues/8880): Fix an error for `Style/ClassLength` when overlapping constant assignments. ([@koic][])
 
 ## 0.93.0 (2020-10-08)
 

--- a/lib/rubocop/cop/metrics/class_length.rb
+++ b/lib/rubocop/cop/metrics/class_length.rb
@@ -49,7 +49,9 @@ module RuboCop
             _scope, _name, block_node = *node
           end
 
-          check_code_length(block_node) if block_node.class_definition?
+          return unless block_node.respond_to?(:class_definition?) && block_node.class_definition?
+
+          check_code_length(block_node)
         end
 
         private

--- a/spec/rubocop/cop/metrics/class_length_spec.rb
+++ b/spec/rubocop/cop/metrics/class_length_spec.rb
@@ -202,6 +202,14 @@ RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
     end
   end
 
+  context 'when overlapping constant assignments' do
+    it 'registers an offense' do
+      expect_no_offenses(<<~RUBY)
+        X = Y = Z = do_something
+      RUBY
+    end
+  end
+
   context 'when inspecting a class defined with Struct.new' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #8880.

This PR fixes an error for `Style/ClassLength` when overlapping constant assignments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
