### PR TITLE
Rework `Lint/RedundantSafeNavigation` to be more safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#8782](https://github.com/rubocop-hq/rubocop/issues/8782): Fix incorrect autocorrection for `Style/TernaryParentheses` with `defined?`. ([@dvandersluis][])
+* [#8867](https://github.com/rubocop-hq/rubocop/issues/8867): Rework `Lint/RedundantSafeNavigation` to be more safe. ([@fatkodima][])
 * [#8864](https://github.com/rubocop-hq/rubocop/issues/8864): Fix false positive for `Style/RedundantBegin` with a postfix `while` or `until`. ([@dvandersluis][])
 * [#8869](https://github.com/rubocop-hq/rubocop/issues/8869): Fix a false positive for `Style/RedundantBegin` when using `begin` for or assignment and method call. ([@koic][])
 * [#8862](https://github.com/rubocop-hq/rubocop/issues/8862): Fix an error for `Lint/AmbiguousRegexpLiteral` when using regexp without method calls in nested structure. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1757,16 +1757,14 @@ Lint/RedundantSafeNavigation:
   Description: 'Checks for redundant safe navigation calls.'
   Enabled: pending
   VersionAdded: '0.93'
+  AllowedMethods:
+    - instance_of?
+    - kind_of?
+    - is_a?
+    - eql?
+    - respond_to?
+    - equal?
   Safe: false
-  IgnoredMethods:
-    - to_c
-    - to_f
-    - to_i
-    - to_r
-    - rationalize
-    - public_send
-    - send
-    - __send__
 
 Lint/RedundantSplatExpansion:
   Description: 'Checks for splat unnecessarily being called on literals.'

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -2918,25 +2918,38 @@ require 'unloaded_feature'
 |===
 
 This cop checks for redundant safe navigation calls.
-
-In the example below, the safe navigation operator (`&.`) is unnecessary
-because `NilClass` has methods like `respond_to?` and `dup`.
+`instance_of?`, `kind_of?`, `is_a?`, `eql?`, `respond_to?`, and `equal?` methods
+are checked by default. These are customizable with `AllowedMethods` option.
 
 This cop is marked as unsafe, because auto-correction can change the
 return type of the expression. An offending expression that previously
 could return `nil` will be auto-corrected to never return `nil`.
 
+In the example below, the safe navigation operator (`&.`) is unnecessary
+because `NilClass` has methods like `respond_to?` and `is_a?`.
+
 === Examples
 
 [source,ruby]
 ----
-# bad, because nil has these methods
-attrs&.respond_to?(:[])
-foo&.dup&.inspect
+# bad
+do_something if attrs&.respond_to?(:[])
 
 # good
-attrs.respond_to?(:[])
-foo.dup.inspect
+do_something if attrs.respond_to?(:[])
+
+# bad
+while node&.is_a?(BeginNode)
+  node = node.parent
+end
+
+# good
+while node.is_a?(BeginNode)
+  node = node.parent
+end
+
+# good - without `&.` this will always return `true`
+foo&.respond_to?(:to_a)
 ----
 
 === Configurable attributes
@@ -2944,8 +2957,8 @@ foo.dup.inspect
 |===
 | Name | Default value | Configurable values
 
-| IgnoredMethods
-| `to_c`, `to_f`, `to_i`, `to_r`, `rationalize`, `public_send`, `send`, `__send__`
+| AllowedMethods
+| `instance_of?`, `kind_of?`, `is_a?`, `eql?`, `respond_to?`, `equal?`
 | Array
 |===
 

--- a/lib/rubocop/cop/lint/redundant_safe_navigation.rb
+++ b/lib/rubocop/cop/lint/redundant_safe_navigation.rb
@@ -4,34 +4,52 @@ module RuboCop
   module Cop
     module Lint
       # This cop checks for redundant safe navigation calls.
-      #
-      # In the example below, the safe navigation operator (`&.`) is unnecessary
-      # because `NilClass` has methods like `respond_to?` and `dup`.
+      # `instance_of?`, `kind_of?`, `is_a?`, `eql?`, `respond_to?`, and `equal?` methods
+      # are checked by default. These are customizable with `AllowedMethods` option.
       #
       # This cop is marked as unsafe, because auto-correction can change the
       # return type of the expression. An offending expression that previously
       # could return `nil` will be auto-corrected to never return `nil`.
       #
+      # In the example below, the safe navigation operator (`&.`) is unnecessary
+      # because `NilClass` has methods like `respond_to?` and `is_a?`.
+      #
       # @example
-      #   # bad, because nil has these methods
-      #   attrs&.respond_to?(:[])
-      #   foo&.dup&.inspect
+      #   # bad
+      #   do_something if attrs&.respond_to?(:[])
       #
       #   # good
-      #   attrs.respond_to?(:[])
-      #   foo.dup.inspect
+      #   do_something if attrs.respond_to?(:[])
+      #
+      #   # bad
+      #   while node&.is_a?(BeginNode)
+      #     node = node.parent
+      #   end
+      #
+      #   # good
+      #   while node.is_a?(BeginNode)
+      #     node = node.parent
+      #   end
+      #
+      #   # good - without `&.` this will always return `true`
+      #   foo&.respond_to?(:to_a)
       #
       class RedundantSafeNavigation < Base
-        include IgnoredMethods
+        include AllowedMethods
         include RangeHelp
         extend AutoCorrector
 
         MSG = 'Redundant safe navigation detected.'
 
-        NIL_METHODS = nil.methods.to_set.freeze
+        NIL_SPECIFIC_METHODS = (nil.methods - Object.new.methods).to_set.freeze
+
+        def_node_matcher :respond_to_nil_specific_method?, <<~PATTERN
+          (csend _ :respond_to? (sym %NIL_SPECIFIC_METHODS))
+        PATTERN
 
         def on_csend(node)
-          return unless check_method?(node.method_name)
+          return unless check?(node) && allowed_method?(node.method_name)
+          return if respond_to_nil_specific_method?(node)
 
           range = range_between(node.loc.dot.begin_pos, node.source_range.end_pos)
           add_offense(range) do |corrector|
@@ -41,8 +59,18 @@ module RuboCop
 
         private
 
-        def check_method?(method_name)
-          NIL_METHODS.include?(method_name) && !ignored_method?(method_name)
+        def check?(node)
+          parent = node.parent
+          return false unless parent
+
+          condition?(parent, node) ||
+            parent.and_type? ||
+            parent.or_type? ||
+            (parent.send_type? && parent.negation_method?)
+        end
+
+        def condition?(parent, node)
+          (parent.conditional? || parent.post_condition_loop?) && parent.condition == node
         end
       end
     end

--- a/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
@@ -2,53 +2,97 @@
 
 RSpec.describe RuboCop::Cop::Lint::RedundantSafeNavigation, :config do
   let(:cop_config) do
-    { 'IgnoredMethods' => [] }
+    { 'AllowedMethods' => %w[respond_to?] }
   end
 
-  it 'registers an offense and corrects when `.&` is used for `nil` method' do
+  it 'registers an offense and corrects when `&.` is used inside `if` condition' do
     expect_offense(<<~RUBY)
-      foo&.respond_to?(:bar)
-         ^^^^^^^^^^^^^^^^^^^ Redundant safe navigation detected.
+      if foo&.respond_to?(:bar)
+            ^^^^^^^^^^^^^^^^^^^ Redundant safe navigation detected.
+        do_something
+      elsif foo&.respond_to?(:baz)
+               ^^^^^^^^^^^^^^^^^^^ Redundant safe navigation detected.
+        do_something_else
+      end
     RUBY
 
     expect_correction(<<~RUBY)
-      foo.respond_to?(:bar)
+      if foo.respond_to?(:bar)
+        do_something
+      elsif foo.respond_to?(:baz)
+        do_something_else
+      end
     RUBY
   end
 
-  it 'registers an offense and corrects when multiple `.&` are used for `nil` methods' do
+  it 'registers an offense and corrects when `&.` is used inside `unless` condition' do
     expect_offense(<<~RUBY)
-      foo.do_something&.dup&.inspect
-                      ^^^^^ Redundant safe navigation detected.
-                           ^^^^^^^^^ Redundant safe navigation detected.
+      do_something unless foo&.respond_to?(:bar)
+                             ^^^^^^^^^^^^^^^^^^^ Redundant safe navigation detected.
     RUBY
 
     expect_correction(<<~RUBY)
-      foo.do_something.dup.inspect
+      do_something unless foo.respond_to?(:bar)
     RUBY
   end
 
-  it 'does not register an offense when using non-nil method with `.&`' do
-    expect_no_offenses(<<~RUBY)
-      foo.&do_something
-    RUBY
-  end
+  %i[while until].each do |loop_type|
+    it 'registers an offense and corrects when `&.` is used inside `#{loop_type}` condition' do
+      expect_offense(<<~RUBY, loop_type: loop_type)
+        %{loop_type} foo&.respond_to?(:bar)
+        _{loop_type}    ^^^^^^^^^^^^^^^^^^^ Redundant safe navigation detected.
+          do_something
+        end
 
-  it 'does not register an offense when using `nil` method without `.&`' do
-    expect_no_offenses(<<~RUBY)
-      foo.dup
-    RUBY
-  end
+        begin
+          do_something
+        end %{loop_type} foo&.respond_to?(:bar)
+            _{loop_type}    ^^^^^^^^^^^^^^^^^^^ Redundant safe navigation detected.
+      RUBY
 
-  context 'when AllowedMethods is set' do
-    let(:cop_config) do
-      { 'IgnoredMethods' => ['to_f'] }
-    end
+      expect_correction(<<~RUBY)
+        #{loop_type} foo.respond_to?(:bar)
+          do_something
+        end
 
-    it 'does not register an offense when using ignored `nil` method with `.&`' do
-      expect_no_offenses(<<~RUBY)
-        foo&.to_f
+        begin
+          do_something
+        end #{loop_type} foo.respond_to?(:bar)
       RUBY
     end
+  end
+
+  it 'registers an offense and corrects when `&.` is used inside complex condition' do
+    expect_offense(<<~RUBY)
+      do_something if foo&.respond_to?(:bar) && !foo&.respond_to?(:baz)
+                         ^^^^^^^^^^^^^^^^^^^ Redundant safe navigation detected.
+                                                    ^^^^^^^^^^^^^^^^^^^ Redundant safe navigation detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      do_something if foo.respond_to?(:bar) && !foo.respond_to?(:baz)
+    RUBY
+  end
+
+  it 'does not register an offense when using `&.` outside of conditions' do
+    expect_no_offenses(<<~RUBY)
+      foo&.respond_to?(:bar)
+
+      if condition
+        foo&.respond_to?(:bar)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `&.` with non-allowed method in condition' do
+    expect_no_offenses(<<~RUBY)
+      do_something if foo&.bar?
+    RUBY
+  end
+
+  it 'does not register an offense when using `&.respond_to?` with `nil` specific method as argument in condition' do
+    expect_no_offenses(<<~RUBY)
+      do_something if foo&.respond_to?(:to_a)
+    RUBY
   end
 end


### PR DESCRIPTION
Closes #8867 
Closes #8868 

I reworked this to make an offense only when used inside conditions and only for whitelisted methods.

cc @bbatsov @marcandre @natematykiewicz