### PR TITLE
[Fix #8761] Read `required_ruby_version` from gemspec file if it exists 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#8761](https://github.com/rubocop-hq/rubocop/issues/8761): Read `required_ruby_version` from gemspec file if it exists #8761. ([@HeroProtagonist][])
+
 ### Bug fixes
 
 * [#8499](https://github.com/rubocop-hq/rubocop/issues/8499): Fix `Style/IfUnlessModifier` and `Style/WhileUntilModifier` to prevent an offense if there are both first-line comment and code after `end` block. ([@dsavochkin][])
@@ -5084,3 +5088,4 @@
 [@miry]: https://github.com/miry
 [@lautis]: https://github.com/lautis
 [@pdobb]: https://github.com/pdobb
+[@HeroProtagonist]: https://github.com/HeroProtagonist

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -559,8 +559,11 @@ AllCops:
   TargetRubyVersion: 2.5
 ----
 
-Otherwise, RuboCop will then check your project for `.ruby-version` and
-use the version specified by it.
+Otherwise, RuboCop will then check your project for a series of files where
+the version may be specified already. The files that will be looked for are
+`.ruby-version`, `Gemfile.lock`, and `*.gemspec`. If Gemspec file has an
+array for `required_ruby_version`, the lowest version will be used.
+If none of the files are found a default version value will be used.
 
 == Automatically Generated Configuration
 

--- a/spec/rubocop/target_ruby_spec.rb
+++ b/spec/rubocop/target_ruby_spec.rb
@@ -256,6 +256,122 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
           expect(target_ruby.version).to eq default_version
         end
       end
+
+      context 'gemspec file' do
+        context 'when file contains `required_ruby_version` as a string' do
+          let(:base_path) { configuration.base_dir_for_path_parameters }
+          let(:gemspec_file_path) { File.join(base_path, 'example.gemspec') }
+
+          it 'sets target_ruby from required_ruby_version from exact version' do
+            content =
+              <<-HEREDOC
+                Gem::Specification.new do |s|
+                  s.name = 'test'
+                  s.required_ruby_version = '2.7.4'
+                  s.licenses = ['MIT']
+                end
+              HEREDOC
+
+            create_file(gemspec_file_path, content)
+            expect(target_ruby.version).to eq 2.7
+          end
+
+          it 'sets target_ruby from required_ruby_version from inclusive range' do
+            content =
+              <<-HEREDOC
+                Gem::Specification.new do |s|
+                  s.name = 'test'
+                  s.required_ruby_version = '>= 3.0.0'
+                  s.licenses = ['MIT']
+                end
+              HEREDOC
+
+            create_file(gemspec_file_path, content)
+            expect(target_ruby.version).to eq 3.0
+          end
+
+          it 'sets default target_ruby from exclusive range' do
+            content =
+              <<-HEREDOC
+                Gem::Specification.new do |s|
+                  s.name = 'test'
+                  s.required_ruby_version = '< 3.0.0'
+                  s.licenses = ['MIT']
+                end
+              HEREDOC
+
+            create_file(gemspec_file_path, content)
+            expect(target_ruby.version).to eq default_version
+          end
+        end
+
+        context 'when file contains `required_ruby_version` as an array' do
+          let(:base_path) { configuration.base_dir_for_path_parameters }
+          let(:gemspec_file_path) { File.join(base_path, 'example.gemspec') }
+
+          it 'sets target_ruby from the lowest value' do
+            content =
+              <<-HEREDOC
+                Gem::Specification.new do |s|
+                  s.name = 'test'
+                  s.required_ruby_version = ['<=2.7.4', '>=2.6.5']
+                  s.licenses = ['MIT']
+                end
+              HEREDOC
+
+            create_file(gemspec_file_path, content)
+            expect(target_ruby.version).to eq 2.6
+          end
+
+          it 'sets target_ruby from required_ruby_version with inclusive range' do
+            content =
+              <<-HEREDOC
+                Gem::Specification.new do |s|
+                  s.name = 'test'
+                  s.required_ruby_version = ['<=2.7.4', '>2.6.5']
+                  s.licenses = ['MIT']
+                end
+              HEREDOC
+
+            create_file(gemspec_file_path, content)
+            expect(target_ruby.version).to eq 2.7
+          end
+
+          it 'sets default target_ruby with all exclusive ranges' do
+            content =
+              <<-HEREDOC
+                Gem::Specification.new do |s|
+                  s.name = 'test'
+                  s.required_ruby_version = ['<2.7.4', '>2.6.5']
+                  s.licenses = ['MIT']
+                end
+              HEREDOC
+
+            create_file(gemspec_file_path, content)
+            expect(target_ruby.version).to eq default_version
+          end
+        end
+
+        context 'when file does not contain `required_ruby_version`' do
+          let(:base_path) { configuration.base_dir_for_path_parameters }
+          let(:gemspec_file_path) { File.join(base_path, 'example.gemspec') }
+
+          it 'sets default target_ruby' do
+            content =
+              <<-HEREDOC
+                Gem::Specification.new do |s|
+                  s.name = 'test'
+                  s.platform = Gem::Platform::RUBY
+                  s.licenses = ['MIT']
+                  s.summary = 'test tool.'
+                end
+              HEREDOC
+
+            create_file(gemspec_file_path, content)
+            expect(target_ruby.version).to eq default_version
+          end
+        end
+      end
     end
 
     context 'when .ruby-version is in a parent directory' do


### PR DESCRIPTION
Closes #8761

- Added `GemspecFile` class to search upwards for `<project_base>.gemspec` and read from `required_ruby_version` if present in the file
- Placed it in the `Sources` array right before `Default`
- Created specs over new class
- Update docs to clarify which files are looked at for ruby version
- Updated changelog

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
