### PR TITLE
Add `after_<type>` callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#8892](https://github.com/rubocop-hq/rubocop/issues/8892): Fix an error for `Style/StringConcatenation` when correcting nested concatenable parts. ([@fatkodima][])
 * [#8781](https://github.com/rubocop-hq/rubocop/issues/8781): Fix handling of comments in `Style/SafeNavigation` autocorrection. ([@dvandersluis][])
 * [#8907](https://github.com/rubocop-hq/rubocop/pull/8907): Fix an incorrect auto-correct for `Layout/ClassStructure` when heredoc constant is defined after public method. ([@koic][])
+* [#8889](https://github.com/rubocop-hq/rubocop/pull/8889): Cops can use new `after_<type>` callbacks (only for nodes that may have children nodes, like `:send` and unlike `:sym`). ([@marcandre][])
 
 ### Changes
 

--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -248,6 +248,8 @@ module RuboCop
 end
 ----
 
+Note that `on_send` will be called on a given `node` before the callbacks `on_<some type>` for its children are called. There's also a callback `after_send` that is called after the children are processed. There's a similar `after_<some type>` callback for all types, except those that never have children.
+
 Update the spec to cover the expected syntax:
 
 [source,ruby]

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -271,7 +271,7 @@ module RuboCop
       # @api private
       def self.callbacks_needed
         @callbacks_needed ||= public_instance_methods.select do |m|
-          m.match?(/^on_/) &&
+          m.match?(/^on_|^after_/) &&
             !Base.method_defined?(m) # exclude standard "callbacks" like 'on_begin_investigation'
         end
       end

--- a/spec/rubocop/cop/commissioner_spec.rb
+++ b/spec/rubocop/cop/commissioner_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe RuboCop::Cop::Commissioner do
                                     alias_method :on_def, :on_int
                                     alias_method :on_send, :on_int
                                     alias_method :on_csend, :on_int
+                                    alias_method :after_int, :on_int
+                                    alias_method :after_def, :on_int
+                                    alias_method :after_send, :on_int
+                                    alias_method :after_csend, :on_int
                                   end)
     end
     let(:cop) do
@@ -51,6 +55,9 @@ RSpec.describe RuboCop::Cop::Commissioner do
 
     it 'traverses the AST and invoke cops specific callbacks' do
       expect(cop).to receive(:on_def).once
+      expect(cop).to receive(:on_int).once
+      expect(cop).not_to receive(:after_int)
+      expect(cop).to receive(:after_def).once
       offenses
     end
 
@@ -72,7 +79,9 @@ RSpec.describe RuboCop::Cop::Commissioner do
 
         it 'calls on_send for the right method calls' do
           expect(cop).to receive(:on_send).once
+          expect(cop).to receive(:after_send).once
           expect(cop).not_to receive(:on_csend)
+          expect(cop).not_to receive(:after_csend)
           offenses
         end
 
@@ -82,6 +91,8 @@ RSpec.describe RuboCop::Cop::Commissioner do
           it 'calls on_send for the right method calls' do
             expect(cop).to receive(:on_send).once
             expect(cop).to receive(:on_csend).once
+            expect(cop).to receive(:after_send).once
+            expect(cop).to receive(:after_csend).once
             offenses
           end
         end


### PR DESCRIPTION
I double-checked that this has basically no performance impact (less than ~0.1% overall) after #8785 (otherwise that would add ~4-5% overall)

