### PR TITLE
Mark `Style/SlicingWithRange` as safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#8892](https://github.com/rubocop-hq/rubocop/issues/8892): Fix an error for `Style/StringConcatenation` when correcting nested concatenable parts. ([@fatkodima][])
 
+### Changes
+
+* [#8890](https://github.com/rubocop-hq/rubocop/pull/8890): Mark `Style/SlicingWithRange` as safe. ([@koic][])
+
 ## 0.93.1 (2020-10-12)
 
 ### Bug fixes

--- a/config/default.yml
+++ b/config/default.yml
@@ -4116,8 +4116,7 @@ Style/SingleLineMethods:
 Style/SlicingWithRange:
   Description: 'Checks array slicing is done with endless ranges when suitable.'
   Enabled: pending
-  VersionAdded: '0.83'
-  Safe: false
+  VersionAdded: '0.94'
 
 Style/SoleNestedConditional:
   Description: >-

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -9255,9 +9255,9 @@ NOTE: Required Ruby version: 2.6
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
 | Pending
-| No
-| Yes (Unsafe)
-| 0.83
+| Yes
+| Yes
+| 0.94
 | -
 |===
 


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/7921.

This PR marks `Style/SlicingWithRange` as safe.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
