### PR TITLE
Make `Security/Open` aware of `URI.open`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#7966](https://github.com/rubocop-hq/rubocop/issues/7966): **(Breaking)** Enable all pending cops for RuboCop 1.0. ([@koic][])
 * [#8490](https://github.com/rubocop-hq/rubocop/pull/8490): **(Breaking)** Change logic for cop department name computation. Cops inside deep namespaces (5 or more levels deep) now belong to departments with names that are calculated by joining module names starting from the third one with slashes as separators. For example, cop `Rubocop::Cop::Foo::Bar::Baz` now belongs to `Foo/Bar` department (previously it was `Bar`). ([@dsavochkin][])
 * [#8692](https://github.com/rubocop-hq/rubocop/pull/8692): Default changed to disallow `Layout/TrailingWhitespace` in heredoc. ([@marcandre][])
+* [#8894](https://github.com/rubocop-hq/rubocop/issues/8894): Make `Security/Open` aware of `URI.open`. ([@koic][])
 
 ## 0.93.1 (2020-10-12)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -2415,9 +2415,10 @@ Security/MarshalLoad:
   VersionAdded: '0.47'
 
 Security/Open:
-  Description: 'The use of Kernel#open represents a serious security risk.'
+  Description: 'The use of `Kernel#open` and `URI.open` represent a serious security risk.'
   Enabled: true
   VersionAdded: '0.53'
+  VersionChanged: '0.94'
   Safe: false
 
 Security/YAMLLoad:

--- a/docs/modules/ROOT/pages/cops_security.adoc
+++ b/docs/modules/ROOT/pages/cops_security.adoc
@@ -117,16 +117,16 @@ Marshal.load(Marshal.dump({}))
 | No
 | No
 | 0.53
-| -
+| 0.94
 |===
 
-This cop checks for the use of `Kernel#open`.
+This cop checks for the use of `Kernel#open` and `URI.open`.
 
-`Kernel#open` enables not only file access but also process invocation
-by prefixing a pipe symbol (e.g., `open("| ls")`). So, it may lead to
-a serious security risk by using variable input to the argument of
-`Kernel#open`. It would be better to use `File.open`, `IO.popen` or
-`URI#open` explicitly.
+`Kernel#open` and `URI.open` enable not only file access but also process
+invocation by prefixing a pipe symbol (e.g., `open("| ls")`).
+So, it may lead to a serious security risk by using variable input to
+the argument of `Kernel#open` and `URI.open`. It would be better to use
+`File.open`, `IO.popen` or `URI.parse#open` explicitly.
 
 === Examples
 
@@ -134,6 +134,7 @@ a serious security risk by using variable input to the argument of
 ----
 # bad
 open(something)
+URI.open(something)
 
 # good
 File.open(something)

--- a/lib/rubocop/cop/security/open.rb
+++ b/lib/rubocop/cop/security/open.rb
@@ -3,35 +3,37 @@
 module RuboCop
   module Cop
     module Security
-      # This cop checks for the use of `Kernel#open`.
+      # This cop checks for the use of `Kernel#open` and `URI.open`.
       #
-      # `Kernel#open` enables not only file access but also process invocation
-      # by prefixing a pipe symbol (e.g., `open("| ls")`). So, it may lead to
-      # a serious security risk by using variable input to the argument of
-      # `Kernel#open`. It would be better to use `File.open`, `IO.popen` or
-      # `URI#open` explicitly.
+      # `Kernel#open` and `URI.open` enable not only file access but also process
+      # invocation by prefixing a pipe symbol (e.g., `open("| ls")`).
+      # So, it may lead to a serious security risk by using variable input to
+      # the argument of `Kernel#open` and `URI.open`. It would be better to use
+      # `File.open`, `IO.popen` or `URI.parse#open` explicitly.
       #
       # @example
       #   # bad
       #   open(something)
+      #   URI.open(something)
       #
       #   # good
       #   File.open(something)
       #   IO.popen(something)
       #   URI.parse(something).open
       class Open < Base
-        MSG = 'The use of `Kernel#open` is a serious security risk.'
+        MSG = 'The use of `%<receiver>sopen` is a serious security risk.'
         RESTRICT_ON_SEND = %i[open].freeze
 
         def_node_matcher :open?, <<~PATTERN
-          (send nil? :open $!str ...)
+          (send ${nil? (const {nil? cbase} :URI)} :open $!str ...)
         PATTERN
 
         def on_send(node)
-          open?(node) do |code|
+          open?(node) do |receiver, code|
             return if safe?(code)
 
-            add_offense(node.loc.selector)
+            message = format(MSG, receiver: receiver ? "#{receiver.source}." : 'Kernel#')
+            add_offense(node.loc.selector, message: message)
           end
         end
 

--- a/spec/rubocop/cop/security/open_spec.rb
+++ b/spec/rubocop/cop/security/open_spec.rb
@@ -31,6 +31,20 @@ RSpec.describe RuboCop::Cop::Security::Open do
     RUBY
   end
 
+  it 'registers an offense for `URI.open` with string that starts with a pipe' do
+    expect_offense(<<~'RUBY')
+      URI.open("| #{foo}")
+          ^^^^ The use of `URI.open` is a serious security risk.
+    RUBY
+  end
+
+  it 'registers an offense for `::URI.open` with string that starts with a pipe' do
+    expect_offense(<<~'RUBY')
+      ::URI.open("| #{foo}")
+            ^^^^ The use of `::URI.open` is a serious security risk.
+    RUBY
+  end
+
   it 'accepts open as variable' do
     expect_no_offenses('open = something')
   end


### PR DESCRIPTION
This PR makes `Security/Open` aware of `URI.open` and tweaks the doc.
`URI.open` has the same security risk as `Kernel#open`.

## `Kernel#open`

```console
% ruby -ve "p open('| ls').read"
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin19]
"CHANGELOG.md\nCODE_OF_CONDUCT.md\nCONTRIBUTING.md\n...
```

## `URI.open`

```console
% ruby -ropen-uri -ve "p URI.open('| ls').read"
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin19]
"CHANGELOG.md\nCODE_OF_CONDUCT.md\nCONTRIBUTING.md\n...
```

I got this issue feedback from @amatsuda. Thank you!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
