### PR TITLE
Update RuboCop/Performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -130,3 +130,8 @@ RSpec/EmptyExampleGroup:
     - 'spec/rubocop/cop/lint/script_permission_spec.rb'
     - 'spec/rubocop/cop/style/empty_else_spec.rb'
     - 'spec/rubocop/result_cache_spec.rb'
+
+Performance/CollectionLiteralInLoop:
+  Exclude:
+    - 'Rakefile'
+    - 'spec/**/*.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -118,3 +118,15 @@ RSpec/MessageSpies:
 
 RSpec/NestedGroups:
   Max: 7
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
+# Buggy cop
+# See https://github.com/rubocop-hq/rubocop-rspec/pull/1018
+RSpec/EmptyExampleGroup:
+  Exclude:
+    - 'spec/rubocop/cli/cli_options_spec.rb'
+    - 'spec/rubocop/cop/lint/script_permission_spec.rb'
+    - 'spec/rubocop/cop/style/empty_else_spec.rb'
+    - 'spec/rubocop/result_cache_spec.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'memory_profiler', platform: :mri
 gem 'pry'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
-gem 'rubocop-performance', '~> 1.7.0'
+gem 'rubocop-performance', '~> 1.8.1'
 gem 'rubocop-rspec', '~> 1.43.2'
 # Workaround for cc-test-reporter with SimpleCov 0.18.
 # Stop upgrading SimpleCov until the following issue will be resolved.

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'pry'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.7.0'
-gem 'rubocop-rspec', '~> 1.39.0'
+gem 'rubocop-rspec', '~> 1.43.2'
 # Workaround for cc-test-reporter with SimpleCov 0.18.
 # Stop upgrading SimpleCov until the following issue will be resolved.
 # https://github.com/codeclimate/test-reporter/issues/418

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -18,6 +18,11 @@ module RuboCop
     # @api private
     NEW_COPS_VALUES = %w[pending disable enable].freeze
 
+    # @api private
+    CONFIG_CHECK_KEYS = %w[Enabled Safe SafeAutoCorrect AutoCorrect].to_set.freeze
+    CONFIG_CHECK_DEPARTMENTS = %w[pending override_department].freeze
+    private_constant :CONFIG_CHECK_KEYS, :CONFIG_CHECK_DEPARTMENTS
+
     def_delegators :@config, :smart_loaded_path, :for_all_cops
 
     def initialize(config)
@@ -202,13 +207,9 @@ module RuboCop
       hash.each do |key, value|
         check_cop_config_value(value, key) if value.is_a?(Hash)
 
-        next unless %w[Enabled
-                       Safe
-                       SafeAutoCorrect
-                       AutoCorrect].include?(key) && value.is_a?(String)
+        next unless CONFIG_CHECK_KEYS.include?(key) && value.is_a?(String)
 
-        next if key == 'Enabled' &&
-                %w[pending override_department].include?(value)
+        next if key == 'Enabled' && CONFIG_CHECK_DEPARTMENTS.include?(value)
 
         raise ValidationError, msg_not_boolean(parent, key, value)
       end

--- a/lib/rubocop/cop/metrics/parameter_lists.rb
+++ b/lib/rubocop/cop/metrics/parameter_lists.rb
@@ -12,6 +12,9 @@ module RuboCop
         MSG = 'Avoid parameter lists longer than %<max>d parameters. ' \
               '[%<count>d/%<max>d]'
 
+        NAMED_KEYWORD_TYPES = %i[kwoptarg kwarg].freeze
+        private_constant :NAMED_KEYWORD_TYPES
+
         def on_args(node)
           count = args_count(node)
           return unless count > max_params
@@ -33,7 +36,7 @@ module RuboCop
           if count_keyword_args?
             node.children.size
           else
-            node.children.count { |a| !%i[kwoptarg kwarg].include?(a.type) }
+            node.children.count { |a| !NAMED_KEYWORD_TYPES.include?(a.type) }
           end
         end
 

--- a/lib/rubocop/cop/style/trailing_underscore_variable.rb
+++ b/lib/rubocop/cop/style/trailing_underscore_variable.rb
@@ -36,6 +36,8 @@ module RuboCop
         MSG = 'Do not use trailing `_`s in parallel assignment. ' \
               'Prefer `%<code>s`.'
         UNDERSCORE = '_'
+        DISALLOW = %i[lvasgn splat].freeze
+        private_constant :DISALLOW
 
         def on_masgn(node)
           ranges = unneeded_ranges(node)
@@ -64,7 +66,7 @@ module RuboCop
 
         def find_first_possible_offense(variables)
           variables.reduce(nil) do |offense, variable|
-            break offense unless %i[lvasgn splat].include?(variable.type)
+            break offense unless DISALLOW.include?(variable.type)
 
             var, = *variable
             var, = *var

--- a/lib/rubocop/formatter/offense_count_formatter.rb
+++ b/lib/rubocop/formatter/offense_count_formatter.rb
@@ -67,7 +67,7 @@ module RuboCop
       end
 
       def total_offense_count(offense_counts)
-        offense_counts.values.inject(0, :+)
+        offense_counts.values.sum
       end
     end
   end

--- a/lib/rubocop/formatter/worst_offenders_formatter.rb
+++ b/lib/rubocop/formatter/worst_offenders_formatter.rb
@@ -55,7 +55,7 @@ module RuboCop
       end
 
       def total_offense_count(offense_counts)
-        offense_counts.values.inject(0, :+)
+        offense_counts.values.sum
       end
     end
   end

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -242,6 +242,9 @@ module RuboCop
   # @api private
   class OptionsValidator
     class << self
+      SYNTAX_DEPARTMENTS = %w[Syntax Lint/Syntax].freeze
+      private_constant :SYNTAX_DEPARTMENTS
+
       # Cop name validation must be done later than option parsing, so it's not
       # called from within Options.
       def validate_cop_list(names)
@@ -253,7 +256,7 @@ module RuboCop
         names.each do |name|
           next if cop_names.include?(name)
           next if departments.include?(name)
-          next if %w[Syntax Lint/Syntax].include?(name)
+          next if SYNTAX_DEPARTMENTS.include?(name)
 
           raise IncorrectCopNameError, format_message_from(name, cop_names)
         end

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -3,9 +3,9 @@
 require 'timeout'
 
 RSpec.describe RuboCop::CLI, :isolated_environment do
-  include_context 'cli spec behavior'
-
   subject(:cli) { described_class.new }
+
+  include_context 'cli spec behavior'
 
   describe '--auto-gen-config' do
     before do

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::CLI, :isolated_environment do
-  include_context 'cli spec behavior'
-
   subject(:cli) { described_class.new }
+
+  include_context 'cli spec behavior'
 
   before do
     RuboCop::ConfigLoader.default_configuration = nil

--- a/spec/rubocop/cli/cli_disable_uncorrectable_spec.rb
+++ b/spec/rubocop/cli/cli_disable_uncorrectable_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::CLI, :isolated_environment do
-  include_context 'cli spec behavior'
-
   subject(:cli) { described_class.new }
+
+  include_context 'cli spec behavior'
 
   describe '--disable-uncorrectable' do
     let(:exit_code) do

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::CLI, :isolated_environment do
-  include_context 'cli spec behavior'
-
   subject(:cli) { described_class.new }
+
+  include_context 'cli spec behavior'
 
   let(:rubocop) { "#{RuboCop::ConfigLoader::RUBOCOP_HOME}/exe/rubocop" }
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -3,9 +3,9 @@
 require 'timeout'
 
 RSpec.describe RuboCop::CLI, :isolated_environment do
-  include_context 'cli spec behavior'
-
   subject(:cli) { described_class.new }
+
+  include_context 'cli spec behavior'
 
   context 'when interrupted' do
     it 'returns 130' do

--- a/spec/rubocop/runner_formatter_invocation_spec.rb
+++ b/spec/rubocop/runner_formatter_invocation_spec.rb
@@ -2,9 +2,9 @@
 
 RSpec.describe RuboCop::Runner, :isolated_environment do
   describe 'how formatter is invoked' do
-    include_context 'cli spec behavior'
-
     subject(:runner) { described_class.new({}, RuboCop::ConfigStore.new) }
+
+    include_context 'cli spec behavior'
 
     let(:formatter) do
       instance_double(RuboCop::Formatter::BaseFormatter).as_null_object


### PR DESCRIPTION
Builds on #8898 and updates `RuboCop/Performance`

New cop detected arrays that needed to be put into constants, and some places where `sum` can be used. Cop excluded from specs