### PR TITLE
[Fix #7966] Enable all pending cops for RuboCop 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 * [#8882](https://github.com/rubocop-hq/rubocop/pull/8882): **(Potentially breaking)** RuboCop assumes that Cop classes do not define new `on_<type>` methods at runtime (e.g. via `extend` in `initialize`). ([@marcandre][])
+* [#7966](https://github.com/rubocop-hq/rubocop/issues/7966): **(Breaking)** Enable all pending cops for RuboCop 1.0. ([@koic][])
 
 ## 0.93.1 (2020-10-12)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -313,7 +313,7 @@ Layout/AssignmentIndentation:
 
 Layout/BeginEndAlignment:
   Description: 'Align ends corresponding to begins correctly.'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.91'
   # The value `start_of_line` means that `end` should be aligned the start of the line
   # where the `begin` keyword is.
@@ -496,7 +496,7 @@ Layout/EmptyLinesAroundArguments:
 Layout/EmptyLinesAroundAttributeAccessor:
   Description: "Keep blank lines around attribute accessors."
   StyleGuide: '#empty-lines-around-attribute-accessor'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.83'
   VersionChanged: '0.84'
   AllowAliasSyntax: true
@@ -1145,7 +1145,7 @@ Layout/SpaceAroundKeyword:
 
 Layout/SpaceAroundMethodCallOperator:
   Description: 'Checks method call operators to not have spaces around them.'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.82'
 
 Layout/SpaceAroundOperators:
@@ -1379,7 +1379,7 @@ Lint/BigDecimalNew:
 
 Lint/BinaryOperatorWithIdenticalOperands:
   Description: 'This cop checks for places where binary operator has identical operands.'
-  Enabled: pending
+  Enabled: true
   Safe: false
   VersionAdded: '0.89'
 
@@ -1398,7 +1398,7 @@ Lint/CircularArgumentReference:
 Lint/ConstantDefinitionInBlock:
   Description: 'Do not define constants within a block.'
   StyleGuide: '#no-constant-definition-in-block'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.91'
 
 Lint/ConstantResolution:
@@ -1423,7 +1423,7 @@ Lint/DeprecatedClassMethods:
 
 Lint/DeprecatedOpenSSLConstant:
   Description: "Don't use algorithm constants for `OpenSSL::Cipher` and `OpenSSL::Digest`."
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.84'
 
 Lint/DisjunctiveAssignmentInConstructor:
@@ -1440,7 +1440,7 @@ Lint/DuplicateCaseCondition:
 
 Lint/DuplicateElsifCondition:
   Description: 'Do not repeat conditions used in if `elsif`.'
-  Enabled: 'pending'
+  Enabled: true
   VersionAdded: '0.88'
 
 Lint/DuplicateHashKey:
@@ -1456,12 +1456,12 @@ Lint/DuplicateMethods:
 
 Lint/DuplicateRequire:
   Description: 'Check for duplicate `require`s and `require_relative`s.'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.90'
 
 Lint/DuplicateRescueException:
   Description: 'Checks that there are no repeated exceptions used in `rescue` expressions.'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.89'
 
 Lint/EachWithObjectArgument:
@@ -1476,7 +1476,7 @@ Lint/ElseLayout:
 
 Lint/EmptyConditionalBody:
   Description: 'This cop checks for the presence of `if`, `elsif` and `unless` branches without a body.'
-  Enabled: 'pending'
+  Enabled: true
   AllowComments: true
   VersionAdded: '0.89'
 
@@ -1493,7 +1493,7 @@ Lint/EmptyExpression:
 
 Lint/EmptyFile:
   Description: 'Enforces that Ruby source files are not empty.'
-  Enabled: pending
+  Enabled: true
   AllowComments: true
   VersionAdded: '0.90'
 
@@ -1531,7 +1531,7 @@ Lint/FlipFlop:
 Lint/FloatComparison:
   Description: 'Checks for the presence of precise comparison of floating point numbers.'
   StyleGuide: '#float-comparison'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.89'
 
 Lint/FloatOutOfRange:
@@ -1549,7 +1549,7 @@ Lint/FormatParameterMismatch:
 Lint/HashCompareByIdentity:
   Description: 'Prefer using `Hash#compare_by_identity` than using `object_id` for keys.'
   StyleGuide: '#identity-comparison'
-  Enabled: pending
+  Enabled: true
   Safe: false
   VersionAdded: '0.93'
 
@@ -1563,7 +1563,7 @@ Lint/HeredocMethodCallPosition:
 
 Lint/IdentityComparison:
   Description: 'Prefer `equal?` over `==` when comparing `object_id`.'
-  Enabled: pending
+  Enabled: true
   StyleGuide: '#identity-comparison'
   VersionAdded: '0.91'
 
@@ -1635,12 +1635,12 @@ Lint/MissingSuper:
   Description: >-
                   This cop checks for the presence of constructors and lifecycle callbacks
                   without calls to `super`'.
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.89'
 
 Lint/MixedRegexpCaptureTypes:
   Description: 'Do not mix named captures and numbered captures in a Regexp literal.'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.85'
 
 Lint/MultipleComparison:
@@ -1692,7 +1692,7 @@ Lint/OrderedMagicComments:
 
 Lint/OutOfRangeRegexpRef:
   Description: 'Checks for out of range reference for Regexp because it always returns nil.'
-  Enabled: pending
+  Enabled: true
   Safe: false
   VersionAdded: '0.89'
 
@@ -1721,7 +1721,7 @@ Lint/PercentSymbolArray:
 Lint/RaiseException:
   Description: Checks for `raise` or `fail` statements which are raising `Exception` class.
   StyleGuide: '#raise-exception'
-  Enabled: pending
+  Enabled: true
   Safe: false
   VersionAdded: '0.81'
   VersionChanged: '0.86'
@@ -1755,7 +1755,7 @@ Lint/RedundantRequireStatement:
 
 Lint/RedundantSafeNavigation:
   Description: 'Checks for redundant safe navigation calls.'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.93'
   AllowedMethods:
     - instance_of?
@@ -1862,7 +1862,7 @@ Lint/ScriptPermission:
 
 Lint/SelfAssignment:
   Description: 'Checks for self-assignments.'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.89'
 
 Lint/SendWithMixinArgument:
@@ -1893,7 +1893,7 @@ Lint/ShadowingOuterLocalVariable:
 
 Lint/StructNewOverride:
   Description: 'Disallow overriding the `Struct` built-in methods via `Struct.new`.'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.81'
 
 Lint/SuppressedException:
@@ -1917,12 +1917,12 @@ Lint/ToJSON:
 
 Lint/TopLevelReturnWithArgument:
   Description: 'This cop detects top level return statements with argument.'
-  Enabled: 'pending'
+  Enabled: true
   VersionAdded: '0.89'
 
 Lint/TrailingCommaInAttributeDeclaration:
   Description: 'This cop checks for trailing commas in attribute declarations.'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.90'
 
 Lint/UnderscorePrefixedVariableName:
@@ -1943,7 +1943,7 @@ Lint/UnreachableCode:
 
 Lint/UnreachableLoop:
   Description: 'This cop checks for loops that will have at most one iteration.'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.89'
 
 Lint/UnusedBlockArgument:
@@ -2002,7 +2002,7 @@ Lint/UselessElseWithoutRescue:
 
 Lint/UselessMethodDefinition:
   Description: 'Checks for useless method definitions.'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.90'
   Safe: false
   AllowComments: true
@@ -2016,7 +2016,7 @@ Lint/UselessSetterCall:
 
 Lint/UselessTimes:
   Description: 'Checks for useless `Integer#times` calls.'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.91'
   Safe: false
 
@@ -2444,7 +2444,7 @@ Style/AccessModifierDeclarations:
 
 Style/AccessorGrouping:
   Description: 'Checks for grouping of accessors in `class` and `module` bodies.'
-  Enabled: 'pending'
+  Enabled: true
   VersionAdded: '0.87'
   EnforcedStyle: grouped
   SupportedStyles:
@@ -2533,7 +2533,7 @@ Style/BisectedAttrAccessor:
   Description: >-
                 Checks for places where `attr_reader` and `attr_writer`
                 for the same method can be combined into single `attr_accessor`.
-  Enabled: 'pending'
+  Enabled: true
   VersionAdded: '0.87'
 
 Style/BlockComments:
@@ -2672,7 +2672,7 @@ Style/CaseEquality:
 Style/CaseLikeIf:
   Description: 'This cop identifies places where `if-elsif` constructions can be replaced with `case-when`.'
   StyleGuide: '#case-vs-if-else'
-  Enabled: 'pending'
+  Enabled: true
   Safe: false
   VersionAdded: '0.88'
 
@@ -2725,7 +2725,7 @@ Style/ClassCheck:
 Style/ClassEqualityComparison:
   Description: 'Enforces the use of `Object#instance_of?` instead of class comparison for equality.'
   StyleGuide: '#instance-of-vs-class-comparison'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.93'
   IgnoredMethods:
     - ==
@@ -2793,7 +2793,7 @@ Style/CombinableLoops:
   Description: >-
                   Checks for places where multiple consecutive loops over the same data
                   can be combined into a single loop.
-  Enabled: pending
+  Enabled: true
   Safe: false
   VersionAdded: '0.90'
 
@@ -3046,7 +3046,7 @@ Style/ExplicitBlockArgument:
                   Consider using explicit block argument to avoid writing block literal
                   that just passes its arguments to another block.
   StyleGuide: '#block-argument'
-  Enabled: pending
+  Enabled: true
   # May change the yielding arity.
   Safe: false
   VersionAdded: '0.89'
@@ -3054,7 +3054,7 @@ Style/ExplicitBlockArgument:
 Style/ExponentialNotation:
   Description: 'When using exponential notation, favor a mantissa between 1 (inclusive) and 10 (exclusive).'
   StyleGuide: '#exponential-notation'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.82'
   EnforcedStyle: scientific
   SupportedStyles:
@@ -3137,7 +3137,7 @@ Style/FrozenStringLiteralComment:
 Style/GlobalStdStream:
   Description: 'Enforces the use of `$stdout/$stderr/$stdin` instead of `STDOUT/STDERR/STDIN`.'
   StyleGuide: '#global-stdout'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.89'
   SafeAutoCorrect: false
 
@@ -3165,7 +3165,7 @@ Style/HashAsLastArrayItem:
                  Checks for presence or absence of braces around hash literal as a last
                  array item depending on configuration.
   StyleGuide: '#hash-literal-as-last-array-item'
-  Enabled: 'pending'
+  Enabled: true
   VersionAdded: '0.88'
   EnforcedStyle: braces
   SupportedStyles:
@@ -3175,7 +3175,7 @@ Style/HashAsLastArrayItem:
 Style/HashEachMethods:
   Description: 'Use Hash#each_key and Hash#each_value.'
   StyleGuide: '#hash-each'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.80'
   Safe: false
 
@@ -3183,7 +3183,7 @@ Style/HashLikeCase:
   Description: >-
                   Checks for places where `case-when` represents a simple 1:1
                   mapping and can be replaced with a hash lookup.
-  Enabled: 'pending'
+  Enabled: true
   VersionAdded: '0.88'
   # `MinBranchesCount` defines the number of branches `case` needs to have
   # to trigger this cop
@@ -3214,14 +3214,14 @@ Style/HashSyntax:
 
 Style/HashTransformKeys:
   Description: 'Prefer `transform_keys` over `each_with_object`, `map`, or `to_h`.'
-  Enabled: 'pending'
+  Enabled: true
   VersionAdded: '0.80'
   VersionChanged: '0.90'
   Safe: false
 
 Style/HashTransformValues:
   Description: 'Prefer `transform_values` over `each_with_object`, `map`, or `to_h`.'
-  Enabled: 'pending'
+  Enabled: true
   VersionAdded: '0.80'
   VersionChanged: '0.90'
   Safe: false
@@ -3328,7 +3328,7 @@ Style/IpAddresses:
 Style/KeywordParametersOrder:
   Description: 'Enforces that optional keyword parameters are placed at the end of the parameters list.'
   StyleGuide: '#keyword-parameters-order'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.90'
 
 Style/Lambda:
@@ -3753,7 +3753,7 @@ Style/OptionalArguments:
 Style/OptionalBooleanParameter:
   Description: 'Use keyword arguments when defining method with boolean argument.'
   StyleGuide: '#boolean-keyword-arguments'
-  Enabled: pending
+  Enabled: true
   Safe: false
   VersionAdded: '0.89'
   AllowedMethods:
@@ -3857,7 +3857,7 @@ Style/RandomWithOffset:
 
 Style/RedundantAssignment:
   Description: 'Checks for redundant assignment before returning.'
-  Enabled: 'pending'
+  Enabled: true
   VersionAdded: '0.87'
 
 Style/RedundantBegin:
@@ -3894,7 +3894,7 @@ Style/RedundantFetchBlock:
                   Use `fetch(key, value)` instead of `fetch(key) { value }`
                   when value has Numeric, Rational, Complex, Symbol or String type, `false`, `true`, `nil` or is a constant.
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#hashfetch-with-argument-vs-hashfetch--block-code'
-  Enabled: 'pending'
+  Enabled: true
   Safe: false
   # If enabled, this cop will autocorrect usages of
   # `fetch` being called with block returning a constant.
@@ -3907,7 +3907,7 @@ Style/RedundantFileExtensionInRequire:
                   Checks for the presence of superfluous `.rb` extension in
                   the filename provided to `require` and `require_relative`.
   StyleGuide: '#no-explicit-rb-to-require'
-  Enabled: 'pending'
+  Enabled: true
   VersionAdded: '0.88'
 
 Style/RedundantFreeze:
@@ -3934,12 +3934,12 @@ Style/RedundantPercentQ:
 
 Style/RedundantRegexpCharacterClass:
   Description: 'Checks for unnecessary single-element Regexp character classes.'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.85'
 
 Style/RedundantRegexpEscape:
   Description: 'Checks for redundant escapes in Regexps.'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.85'
 
 Style/RedundantReturn:
@@ -3960,7 +3960,7 @@ Style/RedundantSelf:
 
 Style/RedundantSelfAssignment:
   Description: 'Checks for places where redundant assignments are made for in place modification methods.'
-  Enabled: pending
+  Enabled: true
   Safe: false
   VersionAdded: '0.90'
 
@@ -4088,7 +4088,7 @@ Style/SignalException:
 
 Style/SingleArgumentDig:
   Description: 'Avoid using single argument dig method.'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.89'
   Safe: false
 
@@ -4115,7 +4115,7 @@ Style/SingleLineMethods:
 
 Style/SlicingWithRange:
   Description: 'Checks array slicing is done with endless ranges when suitable.'
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.83'
   Safe: false
 
@@ -4123,7 +4123,7 @@ Style/SoleNestedConditional:
   Description: >-
                   Finds sole nested conditional nodes
                   which can be merged into outer conditional node.
-  Enabled: pending
+  Enabled: true
   VersionAdded: '0.89'
   AllowModifier: false
 
@@ -4158,7 +4158,7 @@ Style/StderrPuts:
 Style/StringConcatenation:
   Description: 'Checks for places where string concatenation can be replaced with string interpolation.'
   StyleGuide: '#string-interpolation'
-  Enabled: pending
+  Enabled: true
   Safe: false
   VersionAdded: '0.89'
 

--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -266,7 +266,7 @@ value =
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | Yes
 | 0.91
@@ -1606,7 +1606,7 @@ some_method(
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | Yes
 | 0.83
@@ -5220,7 +5220,7 @@ something = 123 if test
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | Yes
 | 0.82

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -218,7 +218,7 @@ BigDecimal(123.456, 3)
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | No
 | No
 | 0.89
@@ -357,7 +357,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | No
 | 0.91
@@ -595,7 +595,7 @@ block_given?
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | Yes
 | 0.84
@@ -723,7 +723,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | No
 | 0.88
@@ -853,7 +853,7 @@ alias bar foo
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | No
 | 0.90
@@ -885,7 +885,7 @@ require_relative 'foo'
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | No
 | 0.89
@@ -999,7 +999,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | No
 | 0.89
@@ -1177,7 +1177,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | No
 | 0.90
@@ -1500,7 +1500,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | No
 | 0.89
@@ -1627,7 +1627,7 @@ format('Numbered format: %1$s and numbered %2$s', a_value, another)
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | No
 | No
 | 0.93
@@ -1710,7 +1710,7 @@ the receiver of the call is a HEREDOC.
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | Yes
 | 0.91
@@ -2131,7 +2131,7 @@ x += 1
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | No
 | 0.89
@@ -2181,7 +2181,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | No
 | 0.85
@@ -2571,7 +2571,7 @@ p [''.frozen?, ''.encoding] #=> [true, #<Encoding:US-ASCII>]
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | No
 | No
 | 0.89
@@ -2701,7 +2701,7 @@ rather than meant to be part of the resulting symbols.
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | No
 | Yes (Unsafe)
 | 0.81
@@ -2910,7 +2910,7 @@ require 'unloaded_feature'
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | No
 | Yes (Unsafe)
 | 0.93
@@ -3520,7 +3520,7 @@ puts 'hello, world'
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | No
 | 0.89
@@ -3786,7 +3786,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | No
 | 0.81
@@ -3973,7 +3973,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | No
 | 0.89
@@ -3997,7 +3997,7 @@ return 1 # 1 is always ignored.
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | Yes
 | 0.90
@@ -4182,7 +4182,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | No
 | 0.89
@@ -4801,7 +4801,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | No
 | Yes (Unsafe)
 | 0.90
@@ -4900,7 +4900,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | No
 | Yes (Unsafe)
 | 0.91

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -109,7 +109,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | Yes
 | 0.87
@@ -551,7 +551,7 @@ BEGIN { test }
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | Yes
 | 0.87
@@ -871,7 +871,7 @@ Array === something
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | No
 | Yes (Unsafe)
 | 0.88
@@ -1057,7 +1057,7 @@ var.kind_of?(String)
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | Yes
 | 0.93
@@ -1425,7 +1425,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | No
 | No
 | 0.90
@@ -3029,7 +3029,7 @@ Pathname.new(__dir__).expand_path
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | No
 | Yes (Unsafe)
 | 0.89
@@ -3081,7 +3081,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | No
 | 0.82
@@ -3576,7 +3576,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | Yes (Unsafe)
 | 0.89
@@ -3743,7 +3743,7 @@ ok
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | Yes
 | 0.88
@@ -3805,7 +3805,7 @@ EnforcedStyle.
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | No
 | Yes (Unsafe)
 | 0.80
@@ -3840,7 +3840,7 @@ hash.each_value { |v| p v }
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | No
 | 0.88
@@ -4011,7 +4011,7 @@ NOTE: Required Ruby version: 2.5
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | No
 | Yes (Unsafe)
 | 0.80
@@ -4050,7 +4050,7 @@ Hash[{a: 1, b: 2}.collect { |k, v| [foo(k), v] }]
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | No
 | Yes (Unsafe)
 | 0.80
@@ -4561,7 +4561,7 @@ ip_address = ENV['DEPLOYMENT_IP_ADDRESS']
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | Yes
 | 0.90
@@ -6942,7 +6942,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | No
 | No
 | 0.89
@@ -7517,7 +7517,7 @@ rand(1...7)
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | Yes
 | 0.87
@@ -7791,7 +7791,7 @@ raise 'message'
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | No
 | Yes (Unsafe)
 | 0.86
@@ -7855,7 +7855,7 @@ ENV.fetch(:key, VALUE)
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | Yes
 | 0.88
@@ -8007,7 +8007,7 @@ question = '"What did you say?"'
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | Yes
 | 0.85
@@ -8041,7 +8041,7 @@ r = /[ab]/
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | Yes
 | 0.85
@@ -8227,7 +8227,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | No
 | Yes (Unsafe)
 | 0.90
@@ -9103,7 +9103,7 @@ explicit_receiver.raise
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | No
 | Yes (Unsafe)
 | 0.89
@@ -9254,7 +9254,7 @@ NOTE: Required Ruby version: 2.6
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | No
 | Yes (Unsafe)
 | 0.83
@@ -9280,7 +9280,7 @@ items[1..]
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | Yes
 | No
 | 0.89
@@ -9515,7 +9515,7 @@ warn('hello')
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Pending
+| Enabled
 | No
 | Yes (Unsafe)
 | 0.89

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -87,17 +87,17 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                    end
         @another = params[:param].map do
                      char_1 = begin
-                                variable_1_1  = 'a'
-                                variable_1_20 = 'b'
+                       variable_1_1  = 'a'
+                       variable_1_20 = 'b'
 
-                                variable_1_300  = 'c'
-                                # A Comment
-                                variable_1_4000 = 'd'
+                       variable_1_300  = 'c'
+                       # A Comment
+                       variable_1_4000 = 'd'
 
-                                variable_1_50000           = 'e'
-                                puts 'a non-assignment statement without a blank line'
-                                some_other_length_variable = 'f'
-                              end
+                       variable_1_50000           = 'e'
+                       puts 'a non-assignment statement without a blank line'
+                       some_other_length_variable = 'f'
+                     end
                      var_2  = 456_123
                    end
 


### PR DESCRIPTION
Fixes #7966.

This PR enables all pending cops for RuboCop 1.0.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
