### PR TITLE
[Fix #8901] Fix a false positive for `Naming/BinaryOperatorParameterName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#8490](https://github.com/rubocop-hq/rubocop/pull/8490): **(Breaking)** Change logic for cop department name computation. Cops inside deep namespaces (5 or more levels deep) now belong to departments with names that are calculated by joining module names starting from the third one with slashes as separators. For example, cop `Rubocop::Cop::Foo::Bar::Baz` now belongs to `Foo/Bar` department (previously it was `Bar`). ([@dsavochkin][])
 * [#8692](https://github.com/rubocop-hq/rubocop/pull/8692): Default changed to disallow `Layout/TrailingWhitespace` in heredoc. ([@marcandre][])
 * [#8894](https://github.com/rubocop-hq/rubocop/issues/8894): Make `Security/Open` aware of `URI.open`. ([@koic][])
+* [#8901](https://github.com/rubocop-hq/rubocop/issues/8901): Fix false positive for `Naming/BinaryOperatorParameterName` when defining `=~`. ([@zajn][])
 
 ## 0.93.1 (2020-10-12)
 
@@ -4998,3 +4999,4 @@
 [@ghiculescu]: https://github.com/ghiculescu
 [@hatkyinc2]: https://github.com/hatkyinc2
 [@AllanSiqueira]: https://github.com/allansiqueira
+[@zajn]: https://github.com/zajn

--- a/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
+++ b/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
@@ -18,7 +18,7 @@ module RuboCop
               'name its argument `other`.'
 
         OP_LIKE_METHODS = %i[eql? equal?].freeze
-        EXCLUDED = %i[+@ -@ [] []= << === `].freeze
+        EXCLUDED = %i[+@ -@ [] []= << === ` =~].freeze
 
         def_node_matcher :op_method_candidate?, <<~PATTERN
           (def [#op_method? $_] (args $(arg [!:other !:_other])) _)

--- a/spec/rubocop/cop/naming/binary_operator_parameter_name_spec.rb
+++ b/spec/rubocop/cop/naming/binary_operator_parameter_name_spec.rb
@@ -99,4 +99,10 @@ RSpec.describe RuboCop::Cop::Naming::BinaryOperatorParameterName do
       def `(cmd); end
     RUBY
   end
+
+  it 'does not register an offense for the match operator' do
+    expect_no_offenses(<<~RUBY)
+      def =~(regexp); end
+    RUBY
+  end
 end


### PR DESCRIPTION
Defining the match operator `=~` triggered a false positive for
`Naming/BinaryOperatorParameterName`, which should not be triggered
for pattern/matchable relations according to the [Ruby style guide](https://rubystyle.guide/#other-arg).

The method which triggered this false positive for me was as follows:

```ruby
def =~(re)
  re.match?(to_s)
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
