### PR TITLE
Handle redundant parentheses around an interpolated expression for `Style/RedundantParentheses` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#7944](https://github.com/rubocop-hq/rubocop/issues/7944): Add `MaxUnannotatedPlaceholdersAllowed` option to `Style/FormatStringToken` cop. ([@Tietew][])
+* [#8379](https://github.com/rubocop-hq/rubocop/issues/8379): Handle redundant parentheses around an interpolated expression for `Style/RedundantParentheses` cop. ([@fatkodima][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/correctors/percent_literal_corrector.rb
+++ b/lib/rubocop/cop/correctors/percent_literal_corrector.rb
@@ -89,7 +89,7 @@ module RuboCop
         begin_line_num = previous_line_num - base_line_num + 1
         end_line_num = node.first_line - base_line_num + 1
         lines = source_in_lines[begin_line_num...end_line_num]
-        "\n#{(lines.join("\n").split(node.source).first || '')}"
+        "\n#{lines.join("\n").split(node.source).first || ''}"
       end
 
       def fix_escaped_content(word_node, escape, delimiters)

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -104,8 +104,12 @@ module RuboCop
           return offense(begin_node, 'a variable') if node.variable?
           return offense(begin_node, 'a constant') if node.const_type?
 
+          return offense(begin_node, 'an interpolated expression') if interpolation?(begin_node)
+
           check_send(begin_node, node) if node.call_type?
         end
+
+        def_node_matcher :interpolation?, '[^begin ^^dstr]'
 
         def check_send(begin_node, node)
           return check_unary(begin_node, node) if node.unary_operation?

--- a/spec/rubocop/config_store_spec.rb
+++ b/spec/rubocop/config_store_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::ConfigStore do
       # dir/.rubocop.yml
       # dir/file2
       # dir/subdir/file3
-      "#{(/dir/.match?(arg) ? 'dir' : '.')}/.rubocop.yml"
+      "#{/dir/.match?(arg) ? 'dir' : '.'}/.rubocop.yml"
     end
     allow(RuboCop::ConfigLoader)
       .to receive(:configuration_from_file) { |arg| arg }

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -128,6 +128,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses do
   it_behaves_like 'plausible', '+(1.foo.bar)'
   it_behaves_like 'plausible', '()'
 
+  it 'registers an offense for parens around an interpolated expression' do
+    expect_offense(<<~RUBY)
+      "\#{(foo)}"
+         ^^^^^ Don't use parentheses around an interpolated expression.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      "\#{foo}"
+    RUBY
+  end
+
   it 'registers an offense for parens around a literal in array' do
     expect_offense(<<~RUBY)
       [(1)]


### PR DESCRIPTION
Closes #8379 
cc @marcandre 
