### PR TITLE
Remove redundant blank for `Lint/ToJSON`'s offense message

### DIFF
--- a/lib/rubocop/cop/lint/to_json.rb
+++ b/lib/rubocop/cop/lint/to_json.rb
@@ -31,7 +31,7 @@ module RuboCop
       class ToJSON < Base
         extend AutoCorrector
 
-        MSG = ' `#to_json` requires an optional argument to be parsable ' \
+        MSG = '`#to_json` requires an optional argument to be parsable ' \
           'via JSON.generate(obj).'
 
         def on_def(node)

--- a/spec/rubocop/cop/lint/to_json_spec.rb
+++ b/spec/rubocop/cop/lint/to_json_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::Cop::Lint::ToJSON do
   it 'registers an offense and corrects using `#to_json` without arguments' do
     expect_offense(<<~RUBY)
       def to_json
-      ^^^^^^^^^^^  `#to_json` requires an optional argument to be parsable via JSON.generate(obj).
+      ^^^^^^^^^^^ `#to_json` requires an optional argument to be parsable via JSON.generate(obj).
       end
     RUBY
 


### PR DESCRIPTION
This PR removes redundant blank for `Lint/ToJSON`'s offense message.

No similar issues were found.

```console
% git grep "MSG = ' "
(END)
% git grep '\^\^  '
(END)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
