### PR TITLE
Fix a false positive for `Layout/SpaceAroundOperators`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#8781](https://github.com/rubocop-hq/rubocop/issues/8781): Fix handling of comments in `Style/SafeNavigation` autocorrection. ([@dvandersluis][])
 * [#8907](https://github.com/rubocop-hq/rubocop/pull/8907): Fix an incorrect auto-correct for `Layout/ClassStructure` when heredoc constant is defined after public method. ([@koic][])
 * [#8889](https://github.com/rubocop-hq/rubocop/pull/8889): Cops can use new `after_<type>` callbacks (only for nodes that may have children nodes, like `:send` and unlike `:sym`). ([@marcandre][])
+* [#8906](https://github.com/rubocop-hq/rubocop/pull/8906): Fix a false positive for `Layout/SpaceAroundOperators` when upward alignment. ([@koic][])
 
 ### Changes
 

--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -5276,6 +5276,8 @@ RuboCop::Cop::Cop
 
 Checks that operators have space around them, except for ** which
 should or shouldn't have surrounding space depending on configuration.
+It allows vertical alignment consisting of one or more whitespace
+around operators.
 
 This cop has `AllowForAlignment` option. When `true`, allows most
 uses of extra spacing if the intent is to align with an operator on

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -5,6 +5,8 @@ module RuboCop
     module Layout
       # Checks that operators have space around them, except for ** which
       # should or shouldn't have surrounding space depending on configuration.
+      # It allows vertical alignment consisting of one or more whitespace
+      # around operators.
       #
       # This cop has `AllowForAlignment` option. When `true`, allows most
       # uses of extra spacing if the intent is to align with an operator on
@@ -207,7 +209,8 @@ module RuboCop
           token            = Token.new(operator, nil, operator.source)
           align_preceding  = aligned_with_preceding_assignment(token)
 
-          return align_preceding == :no unless align_preceding == :none
+          return false if align_preceding == :yes ||
+                          aligned_with_subsequent_assignment(token) == :none
 
           aligned_with_subsequent_assignment(token) != :yes
         end

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -129,6 +129,23 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators do
     expect_no_offenses('x = 0')
   end
 
+  it 'accepts an assignment with the same alignment margins' do
+    expect_no_offenses(<<~RUBY)
+      @integer_message = 12345
+      @output  = StringIO.new
+      @logger  = Logger.new(@output)
+    RUBY
+  end
+
+  it 'accepts an assignment with a blank line' do
+    expect_no_offenses(<<~RUBY)
+      expected = posts(:welcome)
+
+      tagging  = Tagging.all.merge!(includes: :taggable).find(taggings(:welcome_general).id)
+      assert_no_queries { assert_equal expected, tagging.taggable }
+    RUBY
+  end
+
   it 'accepts an assignment by `for` statement' do
     expect_no_offenses(<<~RUBY)
       for a in [] do; end


### PR DESCRIPTION
This PR fixes a false positive for `Layout/SpaceAroundOperators` when upward alignment. Two false positive examples are shown.

1. `@output` and `@logger` assignments are aligned with the same margin

```ruby
@integer_message = 12345
@output  = StringIO.new
@logger  = Logger.new(@output)
```

2. `expected` and `tagging` assignments are aligned with a blank line in between

```ruby
expected = posts(:welcome)

tagging  = Tagging.all.merge!(includes: :taggable).find(taggings(:welcome_general).id)
assert_no_queries { assert_equal expected, tagging.taggable }
```

I got this issue feedback from @kamipo. Thank you!

cf: https://github.com/rails/rails/pull/36943

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
