### PR TITLE
Fix an incorrect auto-correct for `Layout/ClassStructure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * [#8892](https://github.com/rubocop-hq/rubocop/issues/8892): Fix an error for `Style/StringConcatenation` when correcting nested concatenable parts. ([@fatkodima][])
 * [#8781](https://github.com/rubocop-hq/rubocop/issues/8781): Fix handling of comments in `Style/SafeNavigation` autocorrection. ([@dvandersluis][])
+* [#8907](https://github.com/rubocop-hq/rubocop/pull/8907): Fix an incorrect auto-correct for `Layout/ClassStructure` when heredoc constant is defined after public method. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -265,6 +265,9 @@ module RuboCop
         end
 
         def end_position_for(node)
+          heredoc = find_heredoc(node)
+          return heredoc.location.heredoc_end.end_pos + 1 if heredoc
+
           end_line = buffer.line_for_position(node.loc.expression.end_pos)
           buffer.line_range(end_line).end_pos
         end
@@ -282,6 +285,10 @@ module RuboCop
 
         def start_line_position(node)
           buffer.line_range(node.loc.line).begin_pos - 1
+        end
+
+        def find_heredoc(node)
+          node.each_node(:str, :dstr, :xstr).find(&:heredoc?)
         end
 
         def buffer

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -214,4 +214,79 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
       end
     end
   end
+
+  it 'registers an offense and corrects when str heredoc constant is defined after public method' do
+    expect_offense(<<~RUBY)
+      class Foo
+        def do_something
+        end
+
+        CONSTANT = <<~EOS
+        ^^^^^^^^^^^^^^^^^ `constants` is supposed to appear before `public_methods`.
+          str
+        EOS
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo
+        CONSTANT = <<~EOS
+          str
+        EOS
+
+        def do_something
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when dstr heredoc constant is defined after public method' do
+    expect_offense(<<~'RUBY')
+      class Foo
+        def do_something
+        end
+
+        CONSTANT = <<~EOS
+        ^^^^^^^^^^^^^^^^^ `constants` is supposed to appear before `public_methods`.
+          #{str}
+        EOS
+      end
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      class Foo
+        CONSTANT = <<~EOS
+          #{str}
+        EOS
+
+        def do_something
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when xstr heredoc constant is defined after public method' do
+    expect_offense(<<~'RUBY')
+      class Foo
+        def do_something
+        end
+
+        CONSTANT = <<~`EOS`
+        ^^^^^^^^^^^^^^^^^^^ `constants` is supposed to appear before `public_methods`.
+          str
+        EOS
+      end
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      class Foo
+        CONSTANT = <<~`EOS`
+          str
+        EOS
+
+        def do_something
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR fixes the following incorrect auto-correct for `Layout/ClassStructure` when heredoc constant is defined after public method.

```console
% cat example.rb
class Foo
  def foo
  end

  CONSTANT = <<~EOS.freeze
    str
  EOS
end

% bundle exec rubocop --only Layout/ClassStructure -a
(snip)

% cat example.rb
class Foo
  CONSTANT = <<~EOS.freeze
  def foo
  end

    str
  EOS
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
