### PR TITLE
Show extension cop versions when using `--verbose-version` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#8692](https://github.com/rubocop-hq/rubocop/pull/8692): Default changed to disallow `Layout/TrailingWhitespace` in heredoc. ([@marcandre][])
 * [#8894](https://github.com/rubocop-hq/rubocop/issues/8894): Make `Security/Open` aware of `URI.open`. ([@koic][])
 * [#8901](https://github.com/rubocop-hq/rubocop/issues/8901): Fix false positive for `Naming/BinaryOperatorParameterName` when defining `=~`. ([@zajn][])
+* [#8908](https://github.com/rubocop-hq/rubocop/pull/8908): Show extension cop versions when using `--verbose-version` option. ([@koic][])
 
 ## 0.93.1 (2020-10-12)
 

--- a/lib/rubocop/cli/command/version.rb
+++ b/lib/rubocop/cli/command/version.rb
@@ -10,7 +10,7 @@ module RuboCop
 
         def run
           puts RuboCop::Version.version(debug: false) if @options[:version]
-          puts RuboCop::Version.version(debug: true) if @options[:verbose_version]
+          puts RuboCop::Version.version(debug: true, env: env) if @options[:verbose_version]
         end
       end
     end

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -37,6 +37,10 @@ module RuboCop
       new(hash, path).check
     end
 
+    def loaded_features
+      @loaded_features ||= ConfigLoader.loaded_features
+    end
+
     def check
       deprecation_check do |deprecation_message|
         warn("#{loaded_path} - #{deprecation_message}")

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -9,11 +9,13 @@ module RuboCop
   class ConfigLoaderResolver
     def resolve_requires(path, hash)
       config_dir = File.dirname(path)
-      Array(hash.delete('require')).each do |r|
-        if r.start_with?('.')
-          require(File.join(config_dir, r))
-        else
-          require(r)
+      hash.delete('require').tap do |loaded_features|
+        Array(loaded_features).each do |feature|
+          if feature.start_with?('.')
+            require(File.join(config_dir, feature))
+          else
+            require(feature)
+          end
         end
       end
     end

--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -9,15 +9,63 @@ module RuboCop
           'rubocop-ast %<rubocop_ast_version>s, ' \
           'running on %<ruby_engine>s %<ruby_version>s %<ruby_platform>s)'
 
+    CANONICAL_FEATURE_NAMES = { 'Rspec' => 'RSpec' }.freeze
+
     # @api private
-    def self.version(debug: false)
+    def self.version(debug: false, env: nil)
       if debug
-        format(MSG, version: STRING, parser_version: Parser::VERSION,
-                    rubocop_ast_version: RuboCop::AST::Version::STRING,
-                    ruby_engine: RUBY_ENGINE, ruby_version: RUBY_VERSION,
-                    ruby_platform: RUBY_PLATFORM)
+        verbose_version = format(MSG, version: STRING, parser_version: Parser::VERSION,
+                                      rubocop_ast_version: RuboCop::AST::Version::STRING,
+                                      ruby_engine: RUBY_ENGINE, ruby_version: RUBY_VERSION,
+                                      ruby_platform: RUBY_PLATFORM)
+        extension_versions = extension_versions(env)
+        return verbose_version if extension_versions.empty?
+
+        <<~VERSIONS
+          #{verbose_version}
+          #{extension_versions.join("\n")}
+        VERSIONS
       else
         STRING
+      end
+    end
+
+    # @api private
+    def self.extension_versions(env)
+      env.config_store.for_pwd.loaded_features.sort.map do |loaded_feature|
+        next unless (match = loaded_feature.match(/rubocop-(?<feature>.*)/))
+
+        feature = match[:feature]
+        begin
+          require "rubocop/#{feature}/version"
+        rescue LoadError
+          # Not worth mentioning libs that are not installed
+        else
+          next unless (feature_version = feature_version(feature))
+
+          "  - #{loaded_feature} #{feature_version}"
+        end
+      end.compact
+    end
+
+    # Returns feature version in one of two ways:
+    #
+    # * Find by RuboCop core version style (e.g. rubocop-performance, rubocop-rspec)
+    # * Find by `bundle gem` version style (e.g. rubocop-rake)
+    #
+    # @api private
+    def self.feature_version(feature)
+      capitalized_feature = feature.capitalize
+      extension_name = CANONICAL_FEATURE_NAMES.fetch(capitalized_feature, capitalized_feature)
+
+      # Find by RuboCop core version style (e.g. rubocop-performance, rubocop-rspec)
+      RuboCop.const_get(extension_name)::Version::STRING
+    rescue NameError
+      begin
+        # Find by `bundle gem` version style (e.g. rubocop-rake, rubocop-packaging)
+        RuboCop.const_get(extension_name)::VERSION
+      rescue NameError
+        # noop
       end
     end
 

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -152,8 +152,29 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     it 'exits cleanly' do
       expect(cli.run(['-V'])).to eq(0)
       expect($stdout.string).to include(RuboCop::Version::STRING)
-      expect($stdout.string).to match(/Parser \d\.\d\.\d/)
-      expect($stdout.string).to match(/rubocop-ast \d\.\d\.\d/)
+      expect($stdout.string).to match(/Parser \d+\.\d+\.\d+/)
+      expect($stdout.string).to match(/rubocop-ast \d+\.\d+\.\d+/)
+    end
+
+    context 'when requiring extension cops' do
+      before do
+        create_file('.rubocop.yml', <<~YAML)
+          require:
+            - rubocop-performance
+            - rubocop-rspec
+        YAML
+      end
+
+      it 'shows with version of extension cops' do
+        # Run in different process that requiring rubocop-perfmance and rubocop-rspec
+        # does not affect other testing processes.
+        output = `ruby -I . "#{rubocop}" -V --disable-pending-cops`
+        expect(output).to include(RuboCop::Version::STRING)
+        expect(output).to match(/Parser \d+\.\d+\.\d+/)
+        expect(output).to match(/rubocop-ast \d+\.\d+\.\d+/)
+        expect(output).to match(/rubocop-performance \d+\.\d+\.\d+/)
+        expect(output).to match(/rubocop-rspec \d+\.\d+\.\d+/)
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

This PR shows extension cop versions when using `--verbose-version` option.

Before:

```console
% rubocop -V
0.93.1 (using Parser 2.7.2.0, rubocop-ast 0.8.0, running on ruby 2.7.2 x86_64-darwin19)
```

After:

```console
% rubocop -V
0.93.1 (using Parser 2.7.2.0, rubocop-ast 0.8.0, running on ruby 2.7.2 x86_64-darwin19)
  - rubocop-performance 1.8.1
  - rubocop-rspec 1.43.2
```

This information is not shown in `rubocop -v` as it is needed in the bug report, first.

## More Information

It shows extension cop versions named rubocop-feature (e.g. rubocop-performance, rubocop-rspec).
Extention names separated by two or more, such as rubocop-feature-foo, are not supported by this PR. First of all, this is aimed at supporting the extension cop managed by RuboCop Headquarters.

This feature searches for version constant in two ways:

- RuboCop core version style (e.g. `RuboCop::Performance::Version::STRING`)
- `bundle gem` version style (e.g. `RuboCop::Rake::VERSION`)

This enriches the information when reporting bugs from users.

It was inspired by RSpec. Thank you.

```console
% bundle exec rspec --version
RSpec 3.9
  - rspec-core 3.9.3
  - rspec-expectations 3.9.2
  - rspec-mocks 3.9.1
  - rspec-support 3.9.3
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
