### PR TITLE
Fix an error when ocurring cop error

### DIFF
--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -18,6 +18,8 @@ module RuboCop
                                       rubocop_ast_version: RuboCop::AST::Version::STRING,
                                       ruby_engine: RUBY_ENGINE, ruby_version: RUBY_VERSION,
                                       ruby_platform: RUBY_PLATFORM)
+        return verbose_version unless env
+
         extension_versions = extension_versions(env)
         return verbose_version if extension_versions.empty?
 


### PR DESCRIPTION
Follow #8908.

This PR fixes the following error when ocurring cop error.

```console
% bundle exec rubocop
(snip)

1 file inspected, no offenses detected

1 error occurred:
An error occurred while Layout/ExtraSpacing cop was inspecting
/Users/koic/src/github.com/koic/rubocop-issues/43/example.rb.
undefined method `config_store' for nil:NilClass
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/version.rb:35:in
`extension_versions'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/version.rb:21:in
`version'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cli/command/execute_runner.rb:62:in
`display_error_summary'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cli/command/execute_runner.rb:27:in
`execute_runner'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cli/command/execute_runner.rb:17:in
`run'
```

It suppresses unexpected `undefined method `config_store' for nil:NilClass`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
