### PR TITLE
Fix Layout/ElseAlignment for rescue/else/ensure inside do/end blocks with assignment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#8912](https://github.com/rubocop-hq/rubocop/pull/8912): Fix `Layout/ElseAlignment` for `rescue/else/ensure` inside `do/end` blocks with assignment. ([@miry][])
+
 ## 1.1.0 (2020-10-29)
 
 ### New features
@@ -5041,3 +5045,4 @@
 [@zajn]: https://github.com/zajn
 [@ysakasin]: https://github.com/ysakasin
 [@matthieugendreau]: https://github.com/matthieugendreau
+[@miry]: https://github.com/miry

--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -1096,7 +1096,7 @@ something.
 |===
 
 This cop checks the alignment of else keywords. Normally they should
-be aligned with an if/unless/while/until/begin/def keyword, but there
+be aligned with an if/unless/while/until/begin/def/rescue keyword, but there
 are special cases when they should follow the same rules as the
 alignment of end.
 

--- a/lib/rubocop/cop/layout/else_alignment.rb
+++ b/lib/rubocop/cop/layout/else_alignment.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Layout
       # This cop checks the alignment of else keywords. Normally they should
-      # be aligned with an if/unless/while/until/begin/def keyword, but there
+      # be aligned with an if/unless/while/until/begin/def/rescue keyword, but there
       # are special cases when they should follow the same rules as the
       # alignment of end.
       #
@@ -93,7 +93,13 @@ module RuboCop
           case parent.type
           when :def, :defs then base_for_method_definition(parent)
           when :kwbegin then parent.loc.begin
-          when :block then parent.send_node.source_range
+          when :block
+            assignment_node = assignment_node(parent)
+            if same_line?(parent, assignment_node)
+              assignment_node.source_range
+            else
+              parent.send_node.source_range
+            end
           else node.loc.keyword
           end
         end
@@ -135,6 +141,13 @@ module RuboCop
             base_range: base_range.source[/^\S*/]
           )
           add_offense(else_range, location: else_range, message: message)
+        end
+
+        def assignment_node(node)
+          assignment_node = node.ancestors.first
+          return unless assignment_node&.assignment?
+
+          assignment_node
         end
       end
     end

--- a/spec/rubocop/cop/layout/else_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/else_alignment_spec.rb
@@ -589,6 +589,20 @@ RSpec.describe RuboCop::Cop::Layout::ElseAlignment do
       RUBY
     end
 
+    it 'accepts a correctly aligned else with assignment' do
+      expect_no_offenses(<<~RUBY)
+        result = array_like.each do |n|
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+        rescue
+          puts 'error handling'
+        else
+          puts 'normal handling'
+        end
+      RUBY
+    end
+
     it 'registers an offense for misaligned else' do
       expect_offense(<<~RUBY)
         array_like.each do |n|


### PR DESCRIPTION
Fix the problem of broken indent of else iniside block with rescue:

```ruby
# bad
var = array.map do |i|
  code
rescue
  code
      else
        code
end

# good
var = array.map do |i|
  code
rescue
  code
else
  code
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/