### PR TITLE
Fix an incorrect auto-correct for `Style/RedundantRegexpCharacterClass` due to quantifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 * [#8920](https://github.com/rubocop-hq/rubocop/pull/8920): Remove Capybara's `save_screenshot` from `Lint/Debugger`. ([@ybiquitous][])
 
+### Bug fixes
+
+* [#8913](https://github.com/rubocop-hq/rubocop/pull/8913): Fix an incorrect auto-correct for `Style/RedundantRegexpCharacterClass` due to quantifier. ([@ysakasin][])
+
 ## 1.0.0 (2020-10-21)
 
 ### New features
@@ -5018,3 +5022,4 @@
 [@hatkyinc2]: https://github.com/hatkyinc2
 [@AllanSiqueira]: https://github.com/allansiqueira
 [@zajn]: https://github.com/zajn
+[@ysakasin]: https://github.com/ysakasin

--- a/lib/rubocop/cop/style/redundant_regexp_character_class.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_character_class.rb
@@ -48,7 +48,9 @@ module RuboCop
           each_single_element_character_class(node) do |char_class|
             next unless redundant_single_element_character_class?(node, char_class)
 
-            yield node.loc.begin.adjust(begin_pos: 1 + char_class.ts, end_pos: char_class.te)
+            begin_pos = 1 + char_class.ts
+            end_pos = begin_pos + char_class.expressions.first.text.length + 1
+            yield node.loc.begin.adjust(begin_pos: begin_pos, end_pos: end_pos)
           end
         end
 

--- a/spec/rubocop/cop/style/redundant_regexp_character_class_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_character_class_spec.rb
@@ -43,6 +43,32 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpCharacterClass do
     end
   end
 
+  context 'with a character class containing a single character before `+` quantifier' do
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        foo = /[a]+/
+               ^^^ Redundant single-element character class, `[a]` can be replaced with `a`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo = /a+/
+      RUBY
+    end
+  end
+
+  context 'with a character class containing a single character before `{n,m}` quantifier' do
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        foo = /[a]{2,10}/
+               ^^^ Redundant single-element character class, `[a]` can be replaced with `a`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo = /a{2,10}/
+      RUBY
+    end
+  end
+
   context 'with a character class containing a single range' do
     it 'does not register an offense' do
       expect_no_offenses('foo = /[a-z]/')


### PR DESCRIPTION
Fix following incorrect behavior.

```console
% cat example.rb
/[a]+/
/[a]{2,10}/

% bundle exec rubocop --only Style/RedundantRegexpCharacterClass -a
(snip)

% cat example.rb
/a]/
/a]{2,10/
```

The cause of this bug is that Regexp::Expression::CharacterSet#te contains quantifier. Regexp::Expression::CharacterSet has quantifier attribute.

```ruby
[15] pry(RuboCop)> Regexp::Parser.parse("[a]{2,10}").expressions.first
=> #<Regexp::Expression::CharacterSet:0x00007faa945d8090
 @closed=true,
 @conditional_level=0,
 @expressions=
  [#<Regexp::Expression::Literal:0x00007faa945cfa08
    @conditional_level=0,
    @level=0,
    @nesting_level=2,
    @options={},
    @quantifier=nil,
    @set_level=1,
    @text="a",
    @token=:literal,
    @ts=1,
    @type=:literal>],
 @level=0,
 @negative=false,
 @nesting_level=1,
 @options={},
 @quantifier=
  #<Regexp::Expression::Quantifier:0x00007faa945cf738 @max=10, @min=2, @mode=:greedy, @text="{2,10}", @token=:interval>,
 @set_level=0,
 @text="[",
 @token=:character,
 @ts=0,
 @type=:set>
[16] pry(RuboCop)> _.te
=> 9
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
