### PR TITLE
Fix autocorrection for `Layout/TrailingWhitespace` in heredocs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [#8889](https://github.com/rubocop-hq/rubocop/pull/8889): Cops can use new `after_<type>` callbacks (only for nodes that may have children nodes, like `:send` and unlike `:sym`). ([@marcandre][])
 * [#8906](https://github.com/rubocop-hq/rubocop/pull/8906): Fix a false positive for `Layout/SpaceAroundOperators` when upward alignment. ([@koic][])
 * [#8585](https://github.com/rubocop-hq/rubocop/pull/8585): Fix false positive in `Style/RedundantSelf` cop with nested `self` access. ([@marcotc][])
+* [#8692](https://github.com/rubocop-hq/rubocop/pull/8692): Fix `Layout/TrailingWhitespace` auto-correction in heredoc. ([@marcandre][])
 
 ### Changes
 
@@ -182,7 +183,6 @@
 * [#8661](https://github.com/rubocop-hq/rubocop/pull/8661): Fix an incorrect auto-correct for `Style/MultilineTernaryOperator` when returning a multiline ternary operator expression. ([@koic][])
 * [#8526](https://github.com/rubocop-hq/rubocop/pull/8526): Fix a false positive for `Style/CaseEquality` cop when the receiver is not a camel cased constant. ([@koic][])
 * [#8673](https://github.com/rubocop-hq/rubocop/issues/8673): Fix the JSON parse error when specifying `--format=json` and `--stdin` options. ([@koic][])
-* [#8692](https://github.com/rubocop-hq/rubocop/pull/8692): Fix `Layout/TrailingWhitespace` auto-correction in heredoc. ([@marcandre][])
 
 ### Changes
 

--- a/changelog/fix_fix_autocorrection_for.md
+++ b/changelog/fix_fix_autocorrection_for.md
@@ -1,0 +1,1 @@
+* [#8914](https://github.com/rubocop-hq/rubocop/pull/8914): Fix autocorrection for `Layout/TrailingWhitespace` in heredocs. ([@marcandre][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1334,7 +1334,7 @@ Layout/TrailingWhitespace:
   StyleGuide: '#no-trailing-whitespace'
   Enabled: true
   VersionAdded: '0.49'
-  VersionChanged: '0.83'
+  VersionChanged: '1.0'
   AllowInHeredoc: false
 
 #################### Lint ##################################

--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -6344,7 +6344,7 @@ class Foo; end
 | Yes
 | Yes
 | 0.49
-| 0.83
+| 1.0
 |===
 
 This cop looks for trailing whitespace in the source code.

--- a/lib/rubocop/cop/layout/trailing_whitespace.rb
+++ b/lib/rubocop/cop/layout/trailing_whitespace.rb
@@ -63,7 +63,7 @@ module RuboCop
           range = offense_range(lineno, line)
           add_offense(range) do |corrector|
             if heredoc
-              corrector.insert_after(range, '#{}') unless static?(heredoc) # rubocop:disable Lint/InterpolationCheck
+              corrector.wrap(range, "\#{'", "'}") unless static?(heredoc)
             else
               corrector.remove(range)
             end

--- a/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
@@ -96,15 +96,15 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
     it 'corrects safely trailing whitespace in a heredoc string' do
       expect_offense(<<~RUBY)
         x = <<~EXAMPLE
-          has trailing#{trailing_whitespace}
-                      ^ Trailing whitespace detected.
+          has trailing   #{trailing_whitespace}
+                      ^^^^ Trailing whitespace detected.
           no trailing
         EXAMPLE
       RUBY
 
       expect_correction(<<~RUBY)
         x = <<~EXAMPLE
-          has trailing \#{}
+          has trailing\#{'    '}
           no trailing
         EXAMPLE
       RUBY


### PR DESCRIPTION
Fix Changelog too, update cop "Changed" attribute

See https://github.com/rubocop-hq/rubocop/pull/8692#issuecomment-713737050