### PR TITLE
Remove `save_screenshot` from `Lint/Debugger` (revival)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#8895](https://github.com/rubocop-hq/rubocop/pull/8895): Add new `Lint/EmptyBlock` cop. ([@fatkodima][])
 
+### Changes
+
+* [#8920](https://github.com/rubocop-hq/rubocop/pull/8920): Remove Capybara's `save_screenshot` from `Lint/Debugger`. ([@ybiquitous][])
+
 ## 1.0.0 (2020-10-21)
 
 ### New features

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -37,7 +37,7 @@ module RuboCop
 
         RESTRICT_ON_SEND = %i[
           debugger byebug remote_byebug pry remote_pry pry_remote console rescue
-          save_and_open_page save_and_open_screenshot save_screenshot irb
+          save_and_open_page save_and_open_screenshot irb
         ].freeze
 
         def_node_matcher :kernel?, <<~PATTERN
@@ -53,8 +53,7 @@ module RuboCop
              {:pry :remote_pry :pry_remote :console} ...)
            (send (const {nil? (cbase)} :Pry) :rescue ...)
            (send nil? {:save_and_open_page
-                      :save_and_open_screenshot
-                      :save_screenshot} ...)}
+                      :save_and_open_screenshot} ...)}
         PATTERN
 
         def_node_matcher :binding_irb_call?, <<~PATTERN

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -51,13 +51,6 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
       RUBY
     end
 
-    it 'reports an offense for save_screenshot' do
-      expect_offense(<<~RUBY)
-        save_screenshot
-        ^^^^^^^^^^^^^^^ Remove debugger entry point `save_screenshot`.
-      RUBY
-    end
-
     context 'with an argument' do
       it 'reports an offense for save_and_open_page' do
         expect_offense(<<~RUBY)
@@ -70,13 +63,6 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
         expect_offense(<<~RUBY)
           save_and_open_screenshot foo
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove debugger entry point `save_and_open_screenshot foo`.
-        RUBY
-      end
-
-      it 'reports an offense for save_screenshot' do
-        expect_offense(<<~RUBY)
-          save_screenshot foo
-          ^^^^^^^^^^^^^^^^^^^ Remove debugger entry point `save_screenshot foo`.
         RUBY
       end
     end
@@ -161,7 +147,7 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
   end
 
   %w[debugger byebug console pry remote_pry pry_remote irb save_and_open_page
-     save_and_open_screenshot save_screenshot remote_byebug].each do |src|
+     save_and_open_screenshot remote_byebug].each do |src|
     it "does not report an offense for a #{src} in comments" do
       expect_no_offenses("# #{src}")
     end


### PR DESCRIPTION
This PR is a revival of PR #7853. Please see the PR #7853 description for details.

Closes #7853

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
