### PR TITLE
Prevent Lint/LiteralInInterpolation from removing necessary interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 * [#8933](https://github.com/rubocop-hq/rubocop/pull/8933): Fix an error for `Layout/EmptyLinesAroundAccessModifier` when the first line is a comment. ([@matthieugendreau][])
 * [#8954](https://github.com/rubocop-hq/rubocop/pull/8954): Fix autocorrection for Style/RedundantRegexpCharacterClass with %r. ([@ysakasin][])
 
+### Bug fixes
+
+* [#8921](https://github.com/rubocop-hq/rubocop/pull/8921): Prevent `Lint/LiteralInInterpolation` from removing necessary interpolation in `%W[]` and `%I[]` literals. ([@knu][])
+
 ### Changes
 
 * [#8920](https://github.com/rubocop-hq/rubocop/pull/8920): Remove Capybara's `save_screenshot` from `Lint/Debugger`. ([@ybiquitous][])


### PR DESCRIPTION
%W and %I split the content into words before expansion treating each interpolation as a word component.

For example, the following array literal evaluates to `["-H", "Cookie: a=1; b=2", "https://example.com/"]`.

```ruby
args = %W[-H #{"Cookie: a=1; b=2"} https://example.com/]
```

However, Lint/LiteralInInterpolation will wrongly auto-correct it to this:

```ruby
args = %W[-H Cookie: a=1; b=2 https://example.com/]
```

Which gives a completely different set of elements: `["-H", "Cookie:", "a=1;", "b=2", "https://example.com/"]`.

This fix teaches the cop not to expand an interpolation when the expanded value contains a space character.

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
