### PR TITLE
[Fix #8919] Require RuboCop AST to 1.0.1 or higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changes
 
 * [#8920](https://github.com/rubocop-hq/rubocop/pull/8920): Remove Capybara's `save_screenshot` from `Lint/Debugger`. ([@ybiquitous][])
+* [#8919](https://github.com/rubocop-hq/rubocop/issues/8919): Require RuboCop AST to 1.0.1 or higher. ([@koic][])
 
 ### Bug fixes
 

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 1.8')
   s.add_runtime_dependency('rexml')
-  s.add_runtime_dependency('rubocop-ast', '>= 0.6.0')
+  s.add_runtime_dependency('rubocop-ast', '>= 1.0.1')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 2.0')
 

--- a/spec/rubocop/cop/layout/indentation_consistency_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_consistency_spec.rb
@@ -527,6 +527,42 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
           end
         RUBY
       end
+
+      it 'accepts different indentation in different visibility sections when using `Struct.new`' do
+        expect_no_offenses(<<~RUBY)
+          Foo = Struct.new(:foo) do
+            def meow
+              puts('Meow!')
+            end
+
+            protected
+
+              def can_we_be_friends?(another_cat)
+                # some logic
+              end
+
+              def related_to?(another_cat)
+                # some logic
+              end
+
+            private
+
+                        # Here we go back an indentation level again. This is a
+                        # violation of the indented_internal_methods style,
+                        # but it's not for this cop to report.
+                        # Layout/IndentationWidth will handle it.
+            def meow_at_3am?
+              rand < 0.8
+            end
+
+                        # As long as the indentation of this method is
+                        # consistent with that of the last one, we're fine.
+            def meow_at_4am?
+              rand < 0.8
+            end
+          end
+        RUBY
+      end
     end
 
     context 'with normal style configured' do


### PR DESCRIPTION
Fixes #8919 and follow https://github.com/rubocop-hq/rubocop-ast/pull/141.

This PR requires rubocop-ast 1.0.1 to awaken of struct constructor. And it will also add a reproduction test for #8919

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
