### PR TITLE
Update conservative Gemfile version lock for doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,17 @@ If you'd rather install RuboCop using `bundler`, add a line for it in your `Gemf
 gem 'rubocop', require: false
 ```
 
-RuboCop's development is moving at a very rapid pace and there are
-often backward-incompatible changes between minor releases (since we
-haven't reached version 1.0 yet). To prevent an unwanted RuboCop update you
-might want to use a conservative version lock in your `Gemfile`:
+RuboCop is stable between major versions, both in terms of API and cop configuration.
+We aim the ease the maintenance of RuboCop extensions and the upgrades between RuboCop
+releases. All big changes are reserved for major releases.
+To prevent an unwanted RuboCop update you might want to use a conservative version lock
+in your `Gemfile`:
 
 ```rb
-gem 'rubocop', '~> 1.0.0', require: false
+gem 'rubocop', '~> 1.0', require: false
 ```
+
+See [versioning](https://docs.rubocop.org/rubocop/1.0/versioning.html) for further details.
 
 ## Quickstart
 

--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -14,14 +14,15 @@ If you'd rather install RuboCop using `bundler`, don't require it in your `Gemfi
 gem 'rubocop', require: false
 ----
 
-RuboCop's development is moving at a very rapid pace and there are
-often backward-incompatible changes between minor releases (since we
-haven't reached version 1.0 yet). To prevent an unwanted RuboCop update you
-might want to use a conservative version locking in your `Gemfile`:
+RuboCop is stable between major versions, both in terms of API and cop configuration.
+We aim the ease the maintenance of RuboCop extensions and the upgrades between RuboCop
+releases. All big changes are reserved for major releases.
+To prevent an unwanted RuboCop update you might want to use a conservative version lock
+in your `Gemfile`:
 
 [source,rb]
 ----
-gem 'rubocop', '~> 1.0.0', require: false
+gem 'rubocop', '~> 1.0', require: false
 ----
 
 NOTE: You can check out our progress on the road to version 1.0 https://github.com/rubocop-hq/rubocop/milestone/4[here].

--- a/tasks/cut_release.rake
+++ b/tasks/cut_release.rake
@@ -20,8 +20,8 @@ namespace :cut_release do
 
     File.open('README.md', 'w') do |f|
       f << readme.sub(
-        "gem 'rubocop', '~> #{old_version}', require: false",
-        "gem 'rubocop', '~> #{new_version}', require: false"
+        "gem 'rubocop', '~> #{version_sans_patch(old_version)}', require: false",
+        "gem 'rubocop', '~> #{version_sans_patch(new_version)}', require: false"
       )
     end
   end
@@ -40,8 +40,8 @@ namespace :cut_release do
 
     File.open('docs/modules/ROOT/pages/installation.adoc', 'w') do |f|
       f << installation.sub(
-        "gem 'rubocop', '~> #{old_version}', require: false",
-        "gem 'rubocop', '~> #{new_version}', require: false"
+        "gem 'rubocop', '~> #{version_sans_patch(old_version)}', require: false",
+        "gem 'rubocop', '~> #{version_sans_patch(new_version)}', require: false"
       )
     end
   end


### PR DESCRIPTION
This PR updates conservative Gemfile version lock for doc with RuboCop 1.0's versioning.
https://docs.rubocop.org/rubocop/1.0/versioning.html

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
