### PR TITLE
Fix an error for Layout/EmptyLinesAroundAccessModifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#8913](https://github.com/rubocop-hq/rubocop/pull/8913): Fix an incorrect auto-correct for `Style/RedundantRegexpCharacterClass` due to quantifier. ([@ysakasin][])
 * [#8917](https://github.com/rubocop-hq/rubocop/issues/8917): Fix rubocop comment directives handling of cops with multiple levels in department name. ([@fatkodima][])
 * [#8918](https://github.com/rubocop-hq/rubocop/issues/8918): Fix a false positives for `Bundler/DuplicatedGem` when a gem conditionally duplicated within `if-elsif` or `case-when` statements. ([@fatkodima][])
+* [#8933](https://github.com/rubocop-hq/rubocop/pull/8933): Fix an error for `Layout/EmptyLinesAroundAccessModifier` when the first line is a comment. ([@matthieugendreau][])
 
 ### Changes
 
@@ -5026,3 +5027,4 @@
 [@AllanSiqueira]: https://github.com/allansiqueira
 [@zajn]: https://github.com/zajn
 [@ysakasin]: https://github.com/ysakasin
+[@matthieugendreau]: https://github.com/matthieugendreau

--- a/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
@@ -141,6 +141,7 @@ module RuboCop
         def previous_line_empty?(send_line)
           previous_line = previous_line_ignoring_comments(processed_source,
                                                           send_line)
+          return true unless previous_line
 
           block_start?(send_line) ||
             class_def?(send_line) ||

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -213,6 +213,17 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
         RUBY
       end
 
+      it 'accepts missing blank line when at the beginning of file' \
+         'and preceded by a comment' do
+        expect_no_offenses(<<~RUBY)
+          # comment
+          #{access_modifier}
+
+          def do_something
+          end
+        RUBY
+      end
+
       context 'at the beginning of block' do
         context 'for blocks defined with do' do
           it 'accepts missing blank line' do


### PR DESCRIPTION
Rubocop Layout/EmptyLinesAroundAccessModifier fails with `undefined method blank? for nil:NilClass` when the first line is a comment and the second line is `private`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
