### PR TITLE
refactor the following layout specs to use 'expect_offense':

### DIFF
--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -113,8 +113,6 @@ module RuboCop
 
       # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def expect_offense(source, file = nil, severity: nil, **replacements)
-        source = "#{source.join("\n")}\n" if source.is_a?(Array)
-
         source = format_offense(source, **replacements)
         RuboCop::Formatter::DisabledConfigFormatter
           .config_to_allow_offenses = {}
@@ -146,8 +144,6 @@ module RuboCop
       end
 
       def expect_correction(correction, loop: true)
-        correction = "#{correction.join("\n")}\n" if correction.is_a?(Array)
-
         raise '`expect_correction` must follow `expect_offense`' unless @processed_source
 
         iteration = 0
@@ -188,8 +184,6 @@ module RuboCop
       end
 
       def expect_no_offenses(source, file = nil)
-        source = "#{source.join("\n")}\n" if source.is_a?(Array)
-
         offenses = inspect_source(source, file)
 
         expected_annotations = AnnotatedSource.parse(source)

--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -113,6 +113,8 @@ module RuboCop
 
       # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def expect_offense(source, file = nil, severity: nil, **replacements)
+        source = "#{source.join("\n")}\n" if source.is_a?(Array)
+
         source = format_offense(source, **replacements)
         RuboCop::Formatter::DisabledConfigFormatter
           .config_to_allow_offenses = {}
@@ -144,6 +146,8 @@ module RuboCop
       end
 
       def expect_correction(correction, loop: true)
+        correction = "#{correction.join("\n")}\n" if correction.is_a?(Array)
+
         raise '`expect_correction` must follow `expect_offense`' unless @processed_source
 
         iteration = 0
@@ -184,6 +188,8 @@ module RuboCop
       end
 
       def expect_no_offenses(source, file = nil)
+        source = "#{source.join("\n")}\n" if source.is_a?(Array)
+
         offenses = inspect_source(source, file)
 
         expected_annotations = AnnotatedSource.parse(source)

--- a/spec/rubocop/cop/layout/end_of_line_spec.rb
+++ b/spec/rubocop/cop/layout/end_of_line_spec.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
-  let(:message)          { 'Carriage return character missing.' }
-  let(:detected_message) { 'Carriage return character detected.' }
-
   shared_examples 'all configurations' do
     it 'accepts an empty file' do
       expect_no_offenses('')
@@ -12,6 +9,11 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
 
   shared_examples 'iso-8859-15' do |eol|
     it 'can inspect non-UTF-8 encoded source with proper encoding comment' do
+      # Weird place to have a test on working with non-utf-8 encodings.
+      # Encodings are not specific to the EndOfLine cop, so the test is better
+      # be moved somewhere more general ?
+      # Also working with encodings is actually the responsibility of
+      # 'whitequark/parser' gem, not Rubocop itself so these test really belongs there(?)
       inspect_source_file(<<~RUBY)
         # coding: ISO-8859-15#{eol}
         # Euro symbol: \xa4#{eol}
@@ -27,7 +29,7 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
       if RuboCop::Platform.windows?
         expect_offense(<<~RUBY)
           x=0
-          ^^^ #{message}
+          ^^^ Carriage return character missing.
 
           y=1\r
         RUBY
@@ -36,7 +38,7 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
           x=0
 
           y=1\r
-          ^^^ #{detected_message}
+          ^^^ Carriage return character detected.
         RUBY
       end
     end
@@ -50,7 +52,7 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
     it 'registers an offense for CR+LF' do
       expect_offense(<<~RUBY)
         x=0
-        ^^^ #{message}
+        ^^^ Carriage return character missing.
 
         y=1\r
       RUBY
@@ -72,7 +74,7 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
       it 'registers only one offense' do
         expect_offense(<<~RUBY)
           x=0
-          ^^^ #{message}
+          ^^^ Carriage return character missing.
 
           y=1
         RUBY
@@ -113,14 +115,14 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
         x=0
 
         y=1\r
-        ^^^ #{detected_message}
+        ^^^ Carriage return character detected.
       RUBY
     end
 
     it 'registers an offense for CR at end of file' do
       expect_offense(<<~RUBY)
         x=0\r
-        ^^^ #{detected_message}
+        ^^^ Carriage return character detected.
       RUBY
     end
 
@@ -136,7 +138,7 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
       it 'registers only one offense' do
         expect_offense(<<~RUBY)
           x=0\r
-          ^^^ #{detected_message}
+          ^^^ Carriage return character detected.
           \r
           y=1
         RUBY

--- a/spec/rubocop/cop/layout/end_of_line_spec.rb
+++ b/spec/rubocop/cop/layout/end_of_line_spec.rb
@@ -1,56 +1,63 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
+  let(:message)          { 'Carriage return character missing.' }
+  let(:detected_message) { 'Carriage return character detected.' }
+
   shared_examples 'all configurations' do
     it 'accepts an empty file' do
-      inspect_source_file('')
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses('')
     end
   end
 
   shared_examples 'iso-8859-15' do |eol|
     it 'can inspect non-UTF-8 encoded source with proper encoding comment' do
-      inspect_source_file(["# coding: ISO-8859-15#{eol}",
-                           "# Euro symbol: \xa4#{eol}"].join("\n"))
+      inspect_source_file(<<~RUBY)
+        # coding: ISO-8859-15#{eol}
+        # Euro symbol: \xa4#{eol}
+      RUBY
       expect(cop.offenses.size).to eq(1)
     end
   end
 
   context 'when EnforcedStyle is native' do
     let(:cop_config) { { 'EnforcedStyle' => 'native' } }
-    let(:messages) do
-      ['Carriage return character ' \
-        "#{RuboCop::Platform.windows? ? 'missing' : 'detected'}."]
-    end
 
     it 'registers an offense for an incorrect EOL' do
-      inspect_source_file(['x=0', '', "y=1\r"].join("\n"))
-      expect(cop.messages).to eq(messages)
-      expect(cop.offenses.map(&:line))
-        .to eq([RuboCop::Platform.windows? ? 1 : 3])
+      if RuboCop::Platform.windows?
+        expect_offense(<<~RUBY)
+          x=0
+          ^^^ #{message}
+
+          y=1\r
+        RUBY
+      else
+        expect_offense(<<~RUBY)
+          x=0
+
+          y=1\r
+          ^^^ #{detected_message}
+        RUBY
+      end
     end
   end
 
   context 'when EnforcedStyle is crlf' do
     let(:cop_config) { { 'EnforcedStyle' => 'crlf' } }
-    let(:messages) { ['Carriage return character missing.'] }
 
     include_examples 'all configurations'
 
     it 'registers an offense for CR+LF' do
-      inspect_source_file(['x=0', '', "y=1\r"].join("\n"))
-      expect(cop.messages).to eq(messages)
-      expect(cop.offenses.map(&:line)).to eq([1])
-    end
+      expect_offense(<<~RUBY)
+        x=0
+        ^^^ #{message}
 
-    it 'highlights the whole offending line' do
-      inspect_source_file(['x=0', '', "y=1\r"].join("\n"))
-      expect(cop.highlights).to eq(["x=0\n"])
+        y=1\r
+      RUBY
     end
 
     it 'does not register offense for no CR at end of file' do
-      inspect_source_file('x=0')
-      expect(cop.offenses.empty?).to be(true)
+      expect_no_offenses('x=0')
     end
 
     it 'does not register offenses after __END__' do
@@ -63,8 +70,9 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
 
     context 'and there are many lines ending with LF' do
       it 'registers only one offense' do
-        inspect_source_file(<<~RUBY)
+        expect_offense(<<~RUBY)
           x=0
+          ^^^ #{message}
 
           y=1
         RUBY
@@ -84,22 +92,14 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
       end
 
       it 'does not crash on UTF-8 encoded non-ascii characters' do
-        source = ['class Epd::ReportsController < EpdAreaController',
-                  "  'terecht bij uw ROM-coördinator.'",
-                  'end'].join("\r\n")
-        inspect_source_file(source)
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(<<~RUBY)
+          class Epd::ReportsController < EpdAreaController\r
+            'terecht bij uw ROM-coördinator.'\r
+          end\r
+        RUBY
       end
 
       include_examples 'iso-8859-15', ''
-    end
-
-    context 'and source is a string' do
-      it 'registers an offense' do
-        inspect_source("x=0\ny=1")
-
-        expect(cop.messages).to eq(['Carriage return character missing.'])
-      end
     end
   end
 
@@ -109,19 +109,19 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
     include_examples 'all configurations'
 
     it 'registers an offense for CR+LF' do
-      inspect_source_file(['x=0', '', "y=1\r"].join("\n"))
-      expect(cop.messages).to eq(['Carriage return character detected.'])
-      expect(cop.offenses.map(&:line)).to eq([3])
-    end
+      expect_offense(<<~RUBY)
+        x=0
 
-    it 'highlights the whole offending line' do
-      inspect_source_file(['x=0', '', "y=1\r"].join("\n"))
-      expect(cop.highlights).to eq(["y=1\r"])
+        y=1\r
+        ^^^ #{detected_message}
+      RUBY
     end
 
     it 'registers an offense for CR at end of file' do
-      inspect_source_file("x=0\r")
-      expect(cop.messages).to eq(['Carriage return character detected.'])
+      expect_offense(<<~RUBY)
+        x=0\r
+        ^^^ #{detected_message}
+      RUBY
     end
 
     it 'does not register offenses after __END__' do
@@ -134,8 +134,12 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
 
     context 'and there are many lines ending with CR+LF' do
       it 'registers only one offense' do
-        inspect_source_file(['x=0', '', 'y=1'].join("\r\n"))
-        expect(cop.messages.size).to eq(1)
+        expect_offense(<<~RUBY)
+          x=0\r
+          ^^^ #{detected_message}
+          \r
+          y=1
+        RUBY
       end
 
       include_examples 'iso-8859-15', "\r"
@@ -150,23 +154,14 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
       end
 
       it 'does not crash on UTF-8 encoded non-ascii characters' do
-        source = ['class Epd::ReportsController < EpdAreaController',
-                  "  'terecht bij uw ROM-coördinator.'",
-                  'end'].join("\n")
-        inspect_source_file(source)
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses(<<~RUBY)
+          class Epd::ReportsController < EpdAreaController
+            'terecht bij uw ROM-coördinator.'
+          end
+        RUBY
       end
 
       include_examples 'iso-8859-15', "\r"
-    end
-
-    context 'and source is a string' do
-      it 'registers an offense' do
-        expect_offense(<<~RUBY)
-          x=0\r
-          ^^^ Carriage return character detected.
-        RUBY
-      end
     end
   end
 end

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
-  message = 'Unnecessary spacing detected.'
-
   shared_examples 'common behavior' do
     it 'registers an offense and corrects alignment with token ' \
       'not preceded by space' do
@@ -156,74 +154,74 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
       <<~RUBY,
         website = "example.org"
         name    = "Jill"
-            ^^^ #{message}
+            ^^^ Unnecessary spacing detected.
       RUBY
 
     'lining up assignments with empty lines and comments in between' =>
       <<~RUBY,
         a   += 1
-         ^^ #{message}
+         ^^ Unnecessary spacing detected.
 
         # Comment
         aa   = 2
-          ^^ #{message}
+          ^^ Unnecessary spacing detected.
         bb   = 3
-          ^^ #{message}
+          ^^ Unnecessary spacing detected.
 
         a  ||= 1
-         ^ #{message}
+         ^ Unnecessary spacing detected.
       RUBY
 
     'aligning with the same character' =>
       <<~RUBY,
         y, m = (year * 12 + (mon - 1) + n).divmod(12)
         m,   = (m + 1)                    .divmod(1)
-                      ^^^^^^^^^^^^^^^^^^^ #{message}
-          ^^ #{message}
+                      ^^^^^^^^^^^^^^^^^^^ Unnecessary spacing detected.
+          ^^ Unnecessary spacing detected.
       RUBY
 
     'lining up different kinds of assignments' =>
       <<~RUBY,
         type_name ||= value.class.name if value
         type_name   = type_name.to_s   if type_name
-                                    ^^ #{message}
-                 ^^ #{message}
+                                    ^^ Unnecessary spacing detected.
+                 ^^ Unnecessary spacing detected.
 
         type_name  = value.class.name if     value
-                                        ^^^^ #{message}
-                 ^ #{message}
+                                        ^^^^ Unnecessary spacing detected.
+                 ^ Unnecessary spacing detected.
         type_name += type_name.to_s   unless type_name
-                                   ^^ #{message}
+                                   ^^ Unnecessary spacing detected.
         a  += 1
-         ^ #{message}
+         ^ Unnecessary spacing detected.
         aa -= 2
       RUBY
 
     'aligning comments on non-adjacent lines' =>
       <<~RUBY,
         include_examples 'aligned',   'var = until',  'test'
-                                                    ^ #{message}
-                                   ^^ #{message}
+                                                    ^ Unnecessary spacing detected.
+                                   ^^ Unnecessary spacing detected.
 
         include_examples 'unaligned', "var = if",     'test'
-                                                 ^^^^ #{message}
+                                                 ^^^^ Unnecessary spacing detected.
       RUBY
 
     'aligning tokens with empty line between' =>
       <<~RUBY,
         unless nochdir
           Dir.chdir "/"    # Release old working directory.
-                       ^^^ #{message}
+                       ^^^ Unnecessary spacing detected.
         end
 
         File.umask 0000    # Ensure sensible umask.
-                       ^^^ #{message}
+                       ^^^ Unnecessary spacing detected.
       RUBY
 
     'aligning long assignment expressions that include line breaks' =>
       <<~RUBY,
         size_attribute_name    = FactoryGirl.create(:attribute,
-                           ^^^ #{message}
+                           ^^^ Unnecessary spacing detected.
                                                     name:   'Size',
                                                     values: %w{small large})
         carrier_attribute_name = FactoryGirl.create(:attribute,
@@ -235,25 +233,25 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
       <<~RUBY,
         a_long_var_name = 100 # this is 100
         short_name1     = 2
-                   ^^^^ #{message}
+                   ^^^^ Unnecessary spacing detected.
 
         clear
 
         short_name2     = 2
-                   ^^^^ #{message}
+                   ^^^^ Unnecessary spacing detected.
         a_long_var_name = 100 # this is 100
 
         clear
 
         short_name3     = 2 # this is 2
-                   ^^^^ #{message}
+                   ^^^^ Unnecessary spacing detected.
         a_long_var_name = 100 # this is 100
       RUBY
 
     'aligning trailing comments' =>
       <<~RUBY
         a_long_var_name = 2   # this is 2
-                           ^^ #{message}
+                           ^^ Unnecessary spacing detected.
         a_long_var_name = 100 # this is 100
       RUBY
   }.freeze
@@ -310,7 +308,9 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
       let(:allow_comments) { true }
 
       it 'allows it' do
-        expect_no_offenses(src_with_extra[0])
+        expect_no_offenses(<<~RUBY)
+          object.method(argument)  # this is a comment
+        RUBY
       end
 
       context "doesn't interfere with AllowForAlignment" do
@@ -353,12 +353,16 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
       let(:allow_comments) { false }
 
       it 'regsiters offense' do
-        expect_offense(src_with_extra)
+        expect_offense(<<~RUBY)
+          object.method(argument)  # this is a comment
+                                 ^ Unnecessary spacing detected.
+        RUBY
       end
 
       it 'does not trigger on only one space before comment' do
-        line = src_with_extra[0].gsub(/\s*#/, ' #')
-        expect_no_offenses(line)
+        expect_no_offenses(<<~RUBY)
+          object.method(argument) # this is a comment
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
+  message = 'Unnecessary spacing detected.'
+
   shared_examples 'common behavior' do
     it 'registers an offense and corrects alignment with token ' \
       'not preceded by space' do
@@ -150,79 +152,110 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
   end
 
   sources = {
-    'lining up assignments' => <<~RUBY,
-      website = "example.org"
-      name    = "Jill"
-    RUBY
+    'lining up assignments' =>
+      <<~RUBY,
+        website = "example.org"
+        name    = "Jill"
+            ^^^ #{message}
+      RUBY
 
     'lining up assignments with empty lines and comments in between' =>
-    <<~RUBY,
-      a   += 1
+      <<~RUBY,
+        a   += 1
+         ^^ #{message}
 
-      # Comment
-      aa   = 2
-      bb   = 3
+        # Comment
+        aa   = 2
+          ^^ #{message}
+        bb   = 3
+          ^^ #{message}
 
-      a  ||= 1
-    RUBY
+        a  ||= 1
+         ^ #{message}
+      RUBY
 
-    'aligning with the same character' => <<-RUBY.strip_margin('|'),
-      |      y, m = (year * 12 + (mon - 1) + n).divmod(12)
-      |      m,   = (m + 1)                    .divmod(1)
-    RUBY
+    'aligning with the same character' =>
+      <<~RUBY,
+        y, m = (year * 12 + (mon - 1) + n).divmod(12)
+        m,   = (m + 1)                    .divmod(1)
+                      ^^^^^^^^^^^^^^^^^^^ #{message}
+          ^^ #{message}
+      RUBY
 
-    'lining up different kinds of assignments' => <<~RUBY,
-      type_name ||= value.class.name if value
-      type_name   = type_name.to_s   if type_name
+    'lining up different kinds of assignments' =>
+      <<~RUBY,
+        type_name ||= value.class.name if value
+        type_name   = type_name.to_s   if type_name
+                                    ^^ #{message}
+                 ^^ #{message}
 
-      type_name  = value.class.name if     value
-      type_name += type_name.to_s   unless type_name
+        type_name  = value.class.name if     value
+                                        ^^^^ #{message}
+                 ^ #{message}
+        type_name += type_name.to_s   unless type_name
+                                   ^^ #{message}
+        a  += 1
+         ^ #{message}
+        aa -= 2
+      RUBY
 
-      a  += 1
-      aa -= 2
-    RUBY
+    'aligning comments on non-adjacent lines' =>
+      <<~RUBY,
+        include_examples 'aligned',   'var = until',  'test'
+                                                    ^ #{message}
+                                   ^^ #{message}
 
-    'aligning comments on non-adjacent lines' => <<~RUBY,
-      include_examples 'aligned',   'var = until',  'test'
+        include_examples 'unaligned', "var = if",     'test'
+                                                 ^^^^ #{message}
+      RUBY
 
-      include_examples 'unaligned', "var = if",     'test'
-    RUBY
+    'aligning tokens with empty line between' =>
+      <<~RUBY,
+        unless nochdir
+          Dir.chdir "/"    # Release old working directory.
+                       ^^^ #{message}
+        end
 
-    'aligning = on lines where there are trailing comments' =>
-    <<~RUBY,
-      a_long_var_name = 100 # this is 100
-      short_name1     = 2
-
-      clear
-
-      short_name2     = 2
-      a_long_var_name = 100 # this is 100
-
-      clear
-
-      short_name3     = 2   # this is 2
-      a_long_var_name = 100 # this is 100
-    RUBY
-
-    # WARNING: see mention in tests for AllowBeforeTrailingComments
-    # before modifying this test case, or its name
-    'aligning tokens with empty line between' => <<~RUBY,
-      unless nochdir
-        Dir.chdir "/"    # Release old working directory.
-      end
-
-      File.umask 0000    # Ensure sensible umask.
-    RUBY
+        File.umask 0000    # Ensure sensible umask.
+                       ^^^ #{message}
+      RUBY
 
     'aligning long assignment expressions that include line breaks' =>
-    <<~RUBY
-      size_attribute_name    = FactoryGirl.create(:attribute,
-                                                  name:   'Size',
-                                                  values: %w{small large})
-      carrier_attribute_name = FactoryGirl.create(:attribute,
-                                                  name:   'Carrier',
-                                                  values: %w{verizon})
-    RUBY
+      <<~RUBY,
+        size_attribute_name    = FactoryGirl.create(:attribute,
+                           ^^^ #{message}
+                                                    name:   'Size',
+                                                    values: %w{small large})
+        carrier_attribute_name = FactoryGirl.create(:attribute,
+                                                    name:   'Carrier',
+                                                    values: %w{verizon})
+      RUBY
+
+    'aligning = on lines where there are trailing comments' =>
+      <<~RUBY,
+        a_long_var_name = 100 # this is 100
+        short_name1     = 2
+                   ^^^^ #{message}
+
+        clear
+
+        short_name2     = 2
+                   ^^^^ #{message}
+        a_long_var_name = 100 # this is 100
+
+        clear
+
+        short_name3     = 2 # this is 2
+                   ^^^^ #{message}
+        a_long_var_name = 100 # this is 100
+      RUBY
+
+    'aligning trailing comments' =>
+      <<~RUBY
+        a_long_var_name = 2   # this is 2
+                           ^^ #{message}
+        a_long_var_name = 100 # this is 100
+      RUBY
   }.freeze
 
   context 'when AllowForAlignment is true' do
@@ -236,7 +269,8 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
       sources.each do |reason, src|
         context "such as #{reason}" do
           it 'allows it' do
-            expect_no_offenses(src)
+            src_without_annotations = src.gsub(/^ +\^.+\n/, '')
+            expect_no_offenses(src_without_annotations)
           end
         end
       end
@@ -254,8 +288,7 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
       sources.each do |reason, src|
         context "such as #{reason}" do
           it 'registers offense(s)' do
-            offenses = inspect_source(src)
-            expect(offenses.empty?).to be(false)
+            expect_offense(src)
           end
         end
       end
@@ -268,13 +301,16 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
       { 'AllowForAlignment' => allow_alignment,
         'AllowBeforeTrailingComments' => allow_comments }
     end
-    let(:src_with_extra) { '  object.method(argument)  # this is a comment' }
+    let(:src_with_extra) do
+      ['  object.method(argument)  # this is a comment',
+       '                         ^ Unnecessary spacing detected.']
+    end
 
     context 'true' do
       let(:allow_comments) { true }
 
       it 'allows it' do
-        expect_no_offenses(src_with_extra)
+        expect_no_offenses(src_with_extra[0])
       end
 
       context "doesn't interfere with AllowForAlignment" do
@@ -284,7 +320,8 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
           sources.each do |reason, src|
             context "such as #{reason}" do
               it 'allows it' do
-                expect_no_offenses(src)
+                src_without_annotations = src.gsub(/^ +\^.+\n/, '')
+                expect_no_offenses(src_without_annotations)
               end
             end
           end
@@ -294,15 +331,16 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
           sources.each do |reason, src|
             context "such as #{reason}" do
               it 'registers offense(s)' do
-                offenses = inspect_source(src)
-                # In this one specific test case, the extra space in question
+                # In these specific test cases, the extra space in question
                 # is to align comments, so it would be allowed by EITHER ONE
                 # being true.  Yes, that means technically it interferes a bit,
                 # but specifically in the way it was intended to.
-                if reason == 'aligning tokens with empty line between'
-                  expect(offenses.empty?).to be(true)
+                if ['aligning tokens with empty line between',
+                    'aligning trailing comments'].include?(reason)
+                  src_without_annotations = src.gsub(/^ +\^.+\n/, '')
+                  expect_no_offenses(src_without_annotations)
                 else
-                  expect(offenses.empty?).to be(false)
+                  expect_offense(src)
                 end
               end
             end
@@ -315,13 +353,12 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
       let(:allow_comments) { false }
 
       it 'regsiters offense' do
-        offenses = inspect_source(src_with_extra)
-        expect(offenses.empty?).to be(false)
+        expect_offense(src_with_extra)
       end
 
       it 'does not trigger on only one space before comment' do
-        src_without_extra = src_with_extra.gsub(/\s*#/, ' #')
-        expect_no_offenses(src_without_extra)
+        line = src_with_extra[0].gsub(/\s*#/, ' #')
+        expect_no_offenses(line)
       end
     end
   end

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -1179,7 +1179,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
 
         it 'registers an offense for normal non-indented internal methods ' \
            'indentation' do
-          inspect_source(<<~RUBY)
+          expect_offense(<<~RUBY)
             class Test
               public
 
@@ -1189,22 +1189,21 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
               protected
 
               def f
+              ^{} #{indented_internal_methods_offense_message}
               end
 
               private
 
               def g
+              ^{} #{indented_internal_methods_offense_message}
               end
             end
           RUBY
-          expect(cop.messages)
-            .to eq([indented_internal_methods_offense_message] * 2)
-          expect(cop.offenses.map(&:line)).to eq([9, 14])
         end
 
         it 'registers an offense for normal non-indented internal methods ' \
            'indentation when defined in a singleton class' do
-          inspect_source(<<~RUBY)
+          expect_offense(<<~RUBY)
             class << self
               public
 
@@ -1214,18 +1213,16 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
               protected
 
               def f
+              ^{} #{indented_internal_methods_offense_message}
               end
 
               private
 
               def g
+              ^{} #{indented_internal_methods_offense_message}
               end
             end
           RUBY
-
-          expect(cop.messages)
-            .to eq([indented_internal_methods_offense_message] * 2)
-          expect(cop.offenses.map(&:line)).to eq([9, 14])
         end
       end
     end
@@ -1284,27 +1281,27 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
 
     context 'with begin/rescue/else/ensure/end' do
       it 'registers an offense for bad indentation of bodies' do
-        inspect_source(<<~RUBY)
+        expect_offense(<<~RUBY)
           def my_func
             puts 'do something outside block'
             begin
             puts 'do something error prone'
+            ^{} Use 2 (not 0) spaces for indentation.
             rescue SomeException, SomeOther => e
              puts 'wrongly intended error handling'
+            ^ Use 2 (not 1) spaces for indentation.
             rescue
              puts 'wrongly intended error handling'
+            ^ Use 2 (not 1) spaces for indentation.
             else
                puts 'wrongly intended normal case handling'
+            ^^^ Use 2 (not 3) spaces for indentation.
             ensure
                 puts 'wrongly intended common handling'
+            ^^^^ Use 2 (not 4) spaces for indentation.
             end
           end
         RUBY
-        expect(cop.messages).to eq(['Use 2 (not 0) spaces for indentation.',
-                                    'Use 2 (not 1) spaces for indentation.',
-                                    'Use 2 (not 1) spaces for indentation.',
-                                    'Use 2 (not 3) spaces for indentation.',
-                                    'Use 2 (not 4) spaces for indentation.'])
       end
     end
 
@@ -1345,7 +1342,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
         end
 
         it 'registers an offense for bad indentation in a do/end body' do
-          inspect_source(<<~RUBY)
+          expect_offense(<<~RUBY)
             concern :Authenticatable do
               def foo
                 puts "foo"
@@ -1354,12 +1351,11 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
               private
 
               def bar
+              ^{} #{indented_internal_methods_offense_message}
                 puts "bar"
               end
             end
           RUBY
-          expect(cop.messages)
-            .to eq([indented_internal_methods_offense_message])
         end
       end
 

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -20,9 +20,6 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
   let(:def_end_alignment_config) do
     { 'Enabled' => true, 'EnforcedStyleAlignWith' => 'start_of_line' }
   end
-  let(:indented_internal_methods_offense_message) do
-    'Use 2 (not 0) spaces for indented_internal_methods indentation.'
-  end
 
   context 'with Width set to 4' do
     let(:cop_config) { { 'Width' => 4 } }
@@ -1189,13 +1186,13 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
               protected
 
               def f
-              ^{} #{indented_internal_methods_offense_message}
+              ^{} Use 2 (not 0) spaces for indented_internal_methods indentation.
               end
 
               private
 
               def g
-              ^{} #{indented_internal_methods_offense_message}
+              ^{} Use 2 (not 0) spaces for indented_internal_methods indentation.
               end
             end
           RUBY
@@ -1213,13 +1210,13 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
               protected
 
               def f
-              ^{} #{indented_internal_methods_offense_message}
+              ^{} Use 2 (not 0) spaces for indented_internal_methods indentation.
               end
 
               private
 
               def g
-              ^{} #{indented_internal_methods_offense_message}
+              ^{} Use 2 (not 0) spaces for indented_internal_methods indentation.
               end
             end
           RUBY
@@ -1351,7 +1348,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
               private
 
               def bar
-              ^{} #{indented_internal_methods_offense_message}
+              ^{} Use 2 (not 0) spaces for indented_internal_methods indentation.
                 puts "bar"
               end
             end

--- a/spec/rubocop/cop/layout/trailing_empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_empty_lines_spec.rb
@@ -30,67 +30,60 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
     end
 
     it 'registers an offense for multiple trailing blank lines' do
-      offenses = inspect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
         x = 0
 
+        ^{} 3 trailing blank lines detected.
 
 
       RUBY
-      expect(offenses.size).to eq(1)
-      expect(offenses.first.message).to eq('3 trailing blank lines detected.')
+
+      expect_correction("x = 0\n")
     end
 
     it 'registers an offense for multiple blank lines in an empty file' do
-      offenses = inspect_source(<<~RUBY)
+      expect_offense(<<~RUBY)
 
 
+        ^{} 3 trailing blank lines detected.
 
 
       RUBY
-      expect(offenses.size).to eq(1)
-      expect(offenses.first.message).to eq('3 trailing blank lines detected.')
+
+      expect_correction("\n")
     end
 
     it 'registers an offense for no final newline after assignment' do
       offenses = inspect_source('x = 0')
+
       expect(offenses.first.message).to eq('Final newline missing.')
     end
 
     it 'registers an offense for no final newline after block comment' do
-      offenses = inspect_source("puts 'testing rubocop when final new line is missing " \
-                                "after block comments'\n\n=begin\nfirst line\nsecond " \
-                                "line\nthird line\n=end")
+      offenses = inspect_source("#{<<~RUBY}=end")
+        puts 'testing rubocop when final new line is missing
+                                  after block comments'
+
+        =begin
+        first line
+        second line
+        third line
+
+      RUBY
 
       expect(offenses.first.message).to eq('Final newline missing.')
     end
 
-    it 'auto-corrects unwanted blank lines' do
-      new_source = autocorrect_source(<<~RUBY)
-        x = 0
-
-
-
-
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
-        x = 0
-      RUBY
-    end
-
-    it 'auto-corrects unwanted blank lines in an empty file' do
-      new_source = autocorrect_source(<<~RUBY)
-
-
-
-
-
-      RUBY
-      expect(new_source).to eq("\n")
-    end
-
     it 'auto-corrects even if some lines have space' do
-      new_source = autocorrect_source(['x = 0', '', '  ', '', ''].join("\n"))
-      expect(new_source).to eq(['x = 0', ''].join("\n"))
+      expect_offense(
+        ['x = 0',
+         '',
+         '^{} 4 trailing blank lines detected.',
+         '  ',
+         '',
+         '']
+      )
+      expect_correction("x = 0\n")
     end
   end
 
@@ -106,25 +99,33 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
     end
 
     it 'registers an offense for multiple trailing blank lines' do
-      offenses = inspect_source(<<~RUBY)
+      expect_offense(
+        ['x = 0',
+         '',
+         '^{} 3 trailing blank lines instead of 1 detected.',
+         '',
+         '']
+      )
+
+      expect_correction(<<~RUBY)
         x = 0
 
-
-
       RUBY
-      expect(offenses.size).to eq(1)
-      expect(offenses.first.message).to eq('3 trailing blank lines instead of 1 detected.')
     end
 
     it 'registers an offense for multiple blank lines in an empty file' do
-      offenses = inspect_source(<<~RUBY)
+      expect_offense(
+        ['',
+         '',
+         '^{} 3 trailing blank lines instead of 1 detected.',
+         '',
+         '']
+      )
 
-
+      expect_correction(<<~RUBY)
 
 
       RUBY
-      expect(offenses.size).to eq(1)
-      expect(offenses.first.message).to eq('3 trailing blank lines instead of 1 detected.')
     end
 
     it 'registers an offense for no final newline' do
@@ -134,34 +135,6 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
 
     it 'accepts final blank line' do
       expect_no_offenses("x = 0\n\n")
-    end
-
-    it 'auto-corrects unwanted blank lines' do
-      new_source = autocorrect_source(<<~RUBY)
-        x = 0
-
-
-
-
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
-        x = 0
-
-      RUBY
-    end
-
-    it 'auto-corrects unwanted blank lines in an empty file' do
-      new_source = autocorrect_source(<<~RUBY)
-
-
-
-
-      RUBY
-      expect(new_source).to eq(<<-RUBY)
-
-
-      RUBY
     end
 
     it 'auto-corrects missing blank line' do

--- a/spec/rubocop/cop/layout/trailing_empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_empty_lines_spec.rb
@@ -75,14 +75,14 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
     end
 
     it 'auto-corrects even if some lines have space' do
-      expect_offense(
-        ['x = 0',
-         '',
-         '^{} 4 trailing blank lines detected.',
-         '  ',
-         '',
-         '']
-      )
+      expect_offense(<<~RUBY)
+        x = 0
+
+        ^{} 4 trailing blank lines detected.
+        #{trailing_whitespace}
+
+
+      RUBY
       expect_correction("x = 0\n")
     end
   end
@@ -99,13 +99,13 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
     end
 
     it 'registers an offense for multiple trailing blank lines' do
-      expect_offense(
-        ['x = 0',
-         '',
-         '^{} 3 trailing blank lines instead of 1 detected.',
-         '',
-         '']
-      )
+      expect_offense(<<~RUBY)
+        x = 0
+
+        ^{} 3 trailing blank lines instead of 1 detected.
+
+
+      RUBY
 
       expect_correction(<<~RUBY)
         x = 0
@@ -114,13 +114,13 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
     end
 
     it 'registers an offense for multiple blank lines in an empty file' do
-      expect_offense(
-        ['',
-         '',
-         '^{} 3 trailing blank lines instead of 1 detected.',
-         '',
-         '']
-      )
+      expect_offense(<<~RUBY)
+
+
+        ^{} 3 trailing blank lines instead of 1 detected.
+
+
+      RUBY
 
       expect_correction(<<~RUBY)
 

--- a/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
@@ -4,90 +4,85 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
   let(:cop_config) { { 'AllowInHeredoc' => false } }
 
   it 'registers an offense for a line ending with space' do
-    expect_offense(
-      ['x = 0 ',
-       '     ^ Trailing whitespace detected.']
-    )
+    expect_offense(<<~RUBY)
+      x = 0#{trailing_whitespace}
+           ^ Trailing whitespace detected.
+    RUBY
   end
 
   it 'registers an offense for a blank line with space' do
-    expect_offense(
-      ['  ',
-       "^^ Trailing whitespace detected.\n"]
-    )
+    expect_offense(<<~RUBY)
+      #{trailing_whitespace * 2}
+      ^^ Trailing whitespace detected.
+    RUBY
   end
 
   it 'registers an offense for a line ending with tab' do
-    expect_offense(
-      ["x = 0\t",
-       '     ^ Trailing whitespace detected.']
-    )
+    expect_offense(<<~RUBY)
+      x = 0\t
+           ^ Trailing whitespace detected.
+    RUBY
   end
 
   it 'registers an offense for trailing whitespace in a heredoc string' do
-    expect_offense(
-      [
-        'x = <<RUBY',
-        '  Hi   ',
-        '    ^^^ Trailing whitespace detected.',
-        'RUBY'
-      ]
-    )
+    expect_offense(<<~RUBY)
+      x = <<HEREDOC
+        Hi#{trailing_whitespace * 3}
+          ^^^ Trailing whitespace detected.
+      HEREDOC
+    RUBY
   end
 
   it 'registers offenses before __END__ but not after' do
-    expect_offense(
-      [
-        "x = 0\t",
-        '     ^ Trailing whitespace detected.',
-        ' ',
-        '^ Trailing whitespace detected.',
-        '__END__',
-        "x = 0\t"
-      ]
-    )
-    # expect(offenses.map(&:line)).to eq([1, 2])
+    expect_offense(<<~RUBY)
+      x = 0\t
+           ^ Trailing whitespace detected.
+      #{trailing_whitespace}
+      ^ Trailing whitespace detected.
+      __END__
+      x = 0\t
+    RUBY
   end
 
   it 'is not fooled by __END__ within a documentation comment' do
-    expect_offense(
-      ["x = 0\t",
-       '     ^ Trailing whitespace detected.',
-       '=begin',
-       '__END__',
-       '=end',
-       "x = 0\t",
-       '     ^ Trailing whitespace detected.']
-    )
+    expect_offense(<<~RUBY)
+      x = 0\t
+           ^ Trailing whitespace detected.
+      =begin
+      __END__
+      =end
+      x = 0\t
+           ^ Trailing whitespace detected.
+    RUBY
   end
 
   it 'is not fooled by heredoc containing __END__' do
-    expect_offense(
-      ['x1 = <<RUBY ',
-       '           ^ Trailing whitespace detected.',
-       '__END__',
-       "x2 = 0\t",
-       '      ^ Trailing whitespace detected.',
-       'RUBY',
-       "x3 = 0\t",
-       '      ^ Trailing whitespace detected.']
-    )
+    expect_offense(<<~RUBY)
+      x1 = <<HEREDOC#{trailing_whitespace}
+                    ^ Trailing whitespace detected.
+      __END__
+      x2 = 0\t
+            ^ Trailing whitespace detected.
+      HEREDOC
+      x3 = 0\t
+            ^ Trailing whitespace detected.
+    RUBY
   end
 
   it 'is not fooled by heredoc containing __END__ within a doc comment' do
-    expect_offense(
-      ['x1 = <<RUBY ',
-       '           ^ Trailing whitespace detected.',
-       '=begin  ',
-       '      ^^ Trailing whitespace detected.',
-       '__END__',
-       '=end',
-       "x2 = 0\t",
-       '      ^ Trailing whitespace detected.',
-       'RUBY',
-       "x3 = 0\t",
-       '      ^ Trailing whitespace detected.']
-    )
+    expect_offense(<<~RUBY)
+      x1 = <<HEREDOC#{trailing_whitespace}
+                    ^ Trailing whitespace detected.
+      =begin#{trailing_whitespace * 2}
+            ^^ Trailing whitespace detected.
+      __END__
+      =end
+      x2 = 0\t
+            ^ Trailing whitespace detected.
+      HEREDOC
+      x3 = 0\t
+            ^ Trailing whitespace detected.
+    RUBY
   end
 
   it 'accepts a line without trailing whitespace' do
@@ -95,29 +90,37 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
   end
 
   it 'auto-corrects unwanted space' do
-    expect_offense(['x = 0 ',
-                    '     ^ Trailing whitespace detected.',
-                    "x = 0\t",
-                    '     ^ Trailing whitespace detected.'])
+    expect_offense(<<~RUBY)
+      x = 0#{trailing_whitespace}
+           ^ Trailing whitespace detected.
+      x = 0\t
+           ^ Trailing whitespace detected.
+    RUBY
 
-    expect_correction(['x = 0',
-                       'x = 0'])
+    expect_correction(<<~RUBY)
+      x = 0
+      x = 0
+    RUBY
   end
 
   context 'when `AllowInHeredoc` is set to true' do
     let(:cop_config) { { 'AllowInHeredoc' => true } }
 
     it 'accepts trailing whitespace in a heredoc string' do
-      expect_no_offenses(['x = <<RUBY',
-                          '  Hi   ',
-                          'RUBY'])
+      expect_no_offenses(<<~RUBY)
+        x = <<HEREDOC
+          Hi#{trailing_whitespace * 3}
+        HEREDOC
+      RUBY
     end
 
     it 'registers an offense for trailing whitespace at the heredoc begin' do
-      expect_offense(['x = <<RUBY ',
-                      '          ^ Trailing whitespace detected.',
-                      '  Hi   ',
-                      'RUBY'])
+      expect_offense(<<~RUBY)
+        x = <<HEREDOC#{trailing_whitespace}
+                     ^ Trailing whitespace detected.
+          Hi#{trailing_whitespace * 3}
+        HEREDOC
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
@@ -4,62 +4,90 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
   let(:cop_config) { { 'AllowInHeredoc' => false } }
 
   it 'registers an offense for a line ending with space' do
-    offenses = inspect_source('x = 0 ')
-    expect(offenses.size).to eq(1)
+    expect_offense(
+      ['x = 0 ',
+       '     ^ Trailing whitespace detected.']
+    )
   end
 
   it 'registers an offense for a blank line with space' do
-    offenses = inspect_source('  ')
-    expect(offenses.size).to eq(1)
+    expect_offense(
+      ['  ',
+       "^^ Trailing whitespace detected.\n"]
+    )
   end
 
   it 'registers an offense for a line ending with tab' do
-    offenses = inspect_source("x = 0\t")
-    expect(offenses.size).to eq(1)
+    expect_offense(
+      ["x = 0\t",
+       '     ^ Trailing whitespace detected.']
+    )
   end
 
   it 'registers an offense for trailing whitespace in a heredoc string' do
-    offenses = inspect_source(['x = <<RUBY',
-                               '  Hi   ',
-                               'RUBY'].join("\n"))
-    expect(offenses.size).to eq(1)
+    expect_offense(
+      [
+        'x = <<RUBY',
+        '  Hi   ',
+        '    ^^^ Trailing whitespace detected.',
+        'RUBY'
+      ]
+    )
   end
 
   it 'registers offenses before __END__ but not after' do
-    offenses = inspect_source(["x = 0\t",
-                               ' ',
-                               '__END__',
-                               "x = 0\t"].join("\n"))
-    expect(offenses.map(&:line)).to eq([1, 2])
+    expect_offense(
+      [
+        "x = 0\t",
+        '     ^ Trailing whitespace detected.',
+        ' ',
+        '^ Trailing whitespace detected.',
+        '__END__',
+        "x = 0\t"
+      ]
+    )
+    # expect(offenses.map(&:line)).to eq([1, 2])
   end
 
   it 'is not fooled by __END__ within a documentation comment' do
-    offenses = inspect_source(["x = 0\t",
-                               '=begin',
-                               '__END__',
-                               '=end',
-                               "x = 0\t"].join("\n"))
-    expect(offenses.map(&:line)).to eq([1, 5])
+    expect_offense(
+      ["x = 0\t",
+       '     ^ Trailing whitespace detected.',
+       '=begin',
+       '__END__',
+       '=end',
+       "x = 0\t",
+       '     ^ Trailing whitespace detected.']
+    )
   end
 
   it 'is not fooled by heredoc containing __END__' do
-    offenses = inspect_source(['x1 = <<RUBY ',
-                               '__END__',
-                               "x2 = 0\t",
-                               'RUBY',
-                               "x3 = 0\t"].join("\n"))
-    expect(offenses.map(&:line)).to eq([1, 3, 5])
+    expect_offense(
+      ['x1 = <<RUBY ',
+       '           ^ Trailing whitespace detected.',
+       '__END__',
+       "x2 = 0\t",
+       '      ^ Trailing whitespace detected.',
+       'RUBY',
+       "x3 = 0\t",
+       '      ^ Trailing whitespace detected.']
+    )
   end
 
   it 'is not fooled by heredoc containing __END__ within a doc comment' do
-    offenses = inspect_source(['x1 = <<RUBY ',
-                               '=begin  ',
-                               '__END__',
-                               '=end',
-                               "x2 = 0\t",
-                               'RUBY',
-                               "x3 = 0\t"].join("\n"))
-    expect(offenses.map(&:line)).to eq([1, 2, 5, 7])
+    expect_offense(
+      ['x1 = <<RUBY ',
+       '           ^ Trailing whitespace detected.',
+       '=begin  ',
+       '      ^^ Trailing whitespace detected.',
+       '__END__',
+       '=end',
+       "x2 = 0\t",
+       '      ^ Trailing whitespace detected.',
+       'RUBY',
+       "x3 = 0\t",
+       '      ^ Trailing whitespace detected.']
+    )
   end
 
   it 'accepts a line without trailing whitespace' do
@@ -67,10 +95,13 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
   end
 
   it 'auto-corrects unwanted space' do
-    new_source = autocorrect_source(['x = 0 ',
-                                     "x = 0\t"].join("\n"))
-    expect(new_source).to eq(['x = 0',
-                              'x = 0'].join("\n"))
+    expect_offense(['x = 0 ',
+                    '     ^ Trailing whitespace detected.',
+                    "x = 0\t",
+                    '     ^ Trailing whitespace detected.'])
+
+    expect_correction(['x = 0',
+                       'x = 0'])
   end
 
   context 'when `AllowInHeredoc` is set to true' do
@@ -79,14 +110,14 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
     it 'accepts trailing whitespace in a heredoc string' do
       expect_no_offenses(['x = <<RUBY',
                           '  Hi   ',
-                          'RUBY'].join("\n"))
+                          'RUBY'])
     end
 
     it 'registers an offense for trailing whitespace at the heredoc begin' do
-      offenses = inspect_source(['x = <<RUBY ',
-                                 '  Hi   ',
-                                 'RUBY'].join("\n"))
-      expect(offenses.size).to eq(1)
+      expect_offense(['x = <<RUBY ',
+                      '          ^ Trailing whitespace detected.',
+                      '  Hi   ',
+                      'RUBY'])
     end
   end
 end


### PR DESCRIPTION


Part of #8127
Refactored specs in spec/rubocop/cop/layout/ to use 'expect_offense' matcher :  

- end_of_line_spec.rb, 
- extra_spacing_spec.rb, 
- indentation_width_spec.rb,
- trailing_empty_lines_spec.rb, 
- trailing_whitespace_spec.rb
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
