### PR TITLE
Accept method calls for `Style/MultipleComparison`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 * [#8920](https://github.com/rubocop-hq/rubocop/pull/8920): Remove Capybara's `save_screenshot` from `Lint/Debugger`. ([@ybiquitous][])
 * [#8919](https://github.com/rubocop-hq/rubocop/issues/8919): Require RuboCop AST to 1.0.1 or higher. ([@koic][])
+* [#8939](https://github.com/rubocop-hq/rubocop/pull/8939): Accept comparisons of multiple method calls for `Style/MultipleComparison`. ([@koic][])
 
 ## 1.0.0 (2020-10-21)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1653,7 +1653,7 @@ Lint/MultipleComparison:
   Description: "Use `&&` operator to compare multiple values."
   Enabled: true
   VersionAdded: '0.47'
-  VersionChanged: '0.77'
+  VersionChanged: '1.1'
 
 Lint/NestedMethodDefinition:
   Description: 'Do not use nested method definitions.'

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -2275,7 +2275,7 @@ named captures.
 | Yes
 | Yes
 | 0.47
-| 0.77
+| 1.1
 |===
 
 In math and Python, we can use `x < y < z` style comparison to compare

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -6017,6 +6017,7 @@ end
 
 This cop checks against comparing a variable with multiple items, where
 `Array#include?` could be used instead to avoid code repetition.
+It accepts comparisons of multiple method calls to avoid unnecessary method calls.
 
 === Examples
 
@@ -6029,6 +6030,7 @@ foo if a == 'a' || a == 'b' || a == 'c'
 # good
 a = 'a'
 foo if ['a', 'b', 'c'].include?(a)
+foo if a == b.lightweight || a == b.heavyweight
 ----
 
 == Style/MutableConstant

--- a/lib/rubocop/cop/layout/extra_spacing.rb
+++ b/lib/rubocop/cop/layout/extra_spacing.rb
@@ -56,8 +56,7 @@ module RuboCop
           aligned = Set[locs.first.line, locs.last.line]
           locs.each_cons(3) do |before, loc, after|
             col = loc.column
-            aligned << loc.line if col == before.column || # rubocop:disable Style/MultipleComparison
-                                   col == after.column
+            aligned << loc.line if col == before.column || col == after.column
           end
           aligned
         end

--- a/lib/rubocop/cop/style/multiple_comparison.rb
+++ b/lib/rubocop/cop/style/multiple_comparison.rb
@@ -5,6 +5,7 @@ module RuboCop
     module Style
       # This cop checks against comparing a variable with multiple items, where
       # `Array#include?` could be used instead to avoid code repetition.
+      # It accepts comparisons of multiple method calls to avoid unnecessary method calls.
       #
       # @example
       #   # bad
@@ -14,6 +15,7 @@ module RuboCop
       #   # good
       #   a = 'a'
       #   foo if ['a', 'b', 'c'].include?(a)
+      #   foo if a == b.lightweight || a == b.heavyweight
       class MultipleComparison < Base
         MSG = 'Avoid comparing a variable with multiple items ' \
           'in a conditional, use `Array#include?` instead.'
@@ -31,8 +33,8 @@ module RuboCop
 
         def_node_matcher :simple_double_comparison?, '(send $lvar :== $lvar)'
         def_node_matcher :simple_comparison?, <<~PATTERN
-          {(send $lvar :== _)
-           (send _ :== $lvar)}
+          {(send $lvar :== !send)
+           (send !send :== $lvar)}
         PATTERN
 
         def nested_variable_comparison?(node)

--- a/spec/rubocop/cop/style/multiple_comparison_spec.rb
+++ b/spec/rubocop/cop/style/multiple_comparison_spec.rb
@@ -66,6 +66,15 @@ RSpec.describe RuboCop::Cop::Style::MultipleComparison do
     RUBY
   end
 
+  it 'does not register an offense and corrects when using multiple method calls' do
+    expect_no_offenses(<<~RUBY)
+      col = loc.column
+      if col == before.column || col == after.column
+        do_something
+      end
+    RUBY
+  end
+
   it 'does not register an offense for comparing multiple literal strings' do
     expect_no_offenses(<<~RUBY)
       if "a" == "a" || "a" == "c"


### PR DESCRIPTION
This PR accepts comparisons of multiple method calls for `Style/MultipleComparison` to avoid unnecessary method calls.

```ruby
# also good
foo if a == b.lightweight || a == b.heavyweight
```

This change can reduce RuboCop's own disable comment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
