### PR TITLE
Add test for anonymous module with private method

### DIFF
--- a/lib/rubocop/cop/layout/def_end_alignment.rb
+++ b/lib/rubocop/cop/layout/def_end_alignment.rb
@@ -46,7 +46,7 @@ module RuboCop
         alias on_defs on_def
 
         def on_send(node)
-          return if !node.def_modifier? || node.method?(:using)
+          return unless node.def_modifier?
 
           method_def = node.each_descendant(:def, :defs).first
           expr = node.source_range

--- a/spec/rubocop/cop/layout/def_end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/def_end_alignment_spec.rb
@@ -69,6 +69,17 @@ RSpec.describe RuboCop::Cop::Layout::DefEndAlignment, :config do
         RUBY
       end
     end
+
+    context 'when including an anonymous module containing `private def`' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          include Module.new {
+            private def foo
+            end
+          }
+        RUBY
+      end
+    end
   end
 
   context 'when EnforcedStyleAlignWith is def' do


### PR DESCRIPTION
This already passes on RuboCop AST 1.0.1 (which is required since https://github.com/rubocop-hq/rubocop/pull/8928) via https://github.com/rubocop-hq/rubocop-ast/pull/142, but I think it's worth adding as an integration test anyway, and we can also now drop the refinement-specific check added in https://github.com/rubocop-hq/rubocop/pull/8653.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/