### PR TITLE
Update doc for `Lint/FlipFlop`

### DIFF
--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -1534,8 +1534,14 @@ end
 | -
 |===
 
-This cop looks for uses of flip-flop operator.
-flip-flop operator is deprecated since Ruby 2.6.0.
+This cop looks for uses of flip-flop operator
+based on the Ruby Style Guide.
+
+Here is the history of flip-flops in Ruby.
+flip-flop operator is deprecated in Ruby 2.6.0 and
+the deprecation has been reverted by Ruby 2.7.0 and
+backported to Ruby 2.6.
+See: https://bugs.ruby-lang.org/issues/5400
 
 === Examples
 

--- a/lib/rubocop/cop/lint/flip_flop.rb
+++ b/lib/rubocop/cop/lint/flip_flop.rb
@@ -3,8 +3,14 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop looks for uses of flip-flop operator.
-      # flip-flop operator is deprecated since Ruby 2.6.0.
+      # This cop looks for uses of flip-flop operator
+      # based on the Ruby Style Guide.
+      #
+      # Here is the history of flip-flops in Ruby.
+      # flip-flop operator is deprecated in Ruby 2.6.0 and
+      # the deprecation has been reverted by Ruby 2.7.0 and
+      # backported to Ruby 2.6.
+      # See: https://bugs.ruby-lang.org/issues/5400
       #
       # @example
       #   # bad


### PR DESCRIPTION
This PR updates doc for `Lint/FlipFlop` based on the change to flip-flop in Ruby 2.7.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
