### PR TITLE
Fix changelog item generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3079,7 +3079,7 @@
 * [#2146](https://github.com/rubocop-hq/rubocop/pull/2146): Add STDIN support. ([@caseywebdev][])
 * [#2175](https://github.com/rubocop-hq/rubocop/pull/2175): Files that are excluded from a cop (e.g. using the `Exclude:` config option) are no longer being processed by that cop. ([@bquorning][])
 * `Rails/ActionFilter` now handles complete list of methods found in the Rails 4.2 [release notes](https://github.com/rails/rails/blob/4115a12da1409c753c747fd4bab6e612c0c6e51a/guides/source/4_2_release_notes.md#notable-changes-1). ([@MGerrior][])
-* [*2138](https://github.com/rubocop-hq/rubocop/issues/2138): Change the offense in `Style/Next` to highlight the condition instead of the iteration. ([@rrosenblum][])
+* [#2138](https://github.com/rubocop-hq/rubocop/issues/2138): Change the offense in `Style/Next` to highlight the condition instead of the iteration. ([@rrosenblum][])
 * `Style/EmptyLineBetweenDefs` now handles class methods as well. ([@unmanbearpig][])
 * Improve handling of `super` in `Style/SymbolProc`. ([@lumeet][])
 * `Style/SymbolProc` is applied to methods receiving arguments. ([@lumeet][])

--- a/changelog/fix_fix_changelog_task_to_build_a_correct.md
+++ b/changelog/fix_fix_changelog_task_to_build_a_correct.md
@@ -1,0 +1,1 @@
+* [#8945](https://github.com/rubocop-hq/rubocop/pull/8945): Fix changelog task to build a correct changelog item when `Fix #123` is encountered. ([@dvandersluis][])

--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -51,7 +51,7 @@ class Changelog
     end
 
     def extract_id(body)
-      /^\[Fixes #(\d+)\] (.*)/.match(body)&.captures || [nil, body]
+      /^\[Fix(?:es)? #(\d+)\] (.*)/.match(body)&.captures || [nil, body]
     end
 
     def str_to_filename(str)


### PR DESCRIPTION
Re #8930. I found a couple issues when using `rake changelog:fix` to write a changelog item for another PR. Foremost, `[Fix #xxxx]` as requested in the contributing guidelines was not being parsed properly (it was only looking for `Fixes`, now it accepts both). `tasks/changelog.rb` did not have a spec, so I added a basic one that just covers this issue but is not exhaustive.

I also updated the tests in `project_spec.rb`:
* Only links at the start of a changelog item are evaluated (eg. 7th item here: https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#bug-fixes-18)
* Issues on other rubocop-hq repos are accepted (eg. last item here: https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#bug-fixes-18)
* Ensures that a changelog item does not have `[Fix #xxxx]` in it.
* Flag `[#x]` as invalid in a changelog item

The last item is potentially contentious because the rake task prefaces items with `* [#x](https://github.com/rubocop-hq/rubocop/pull/x):` if a ref ID cannot be found, which will then cause `bundle exec rake default` to fail. This is kind of a paradox if there isn't already an issue to refer to (ie. sometimes in practice the link is to the PR that merges the change, which doesn't exist before `rake default` is run), so I'm not 100% sure about this, but I think the test is valuable in general to ensure we don't end up with `[#x]` in the changelog.

/cc @marcandre 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
