### PR TITLE
Optimize memory usage

### DIFF
--- a/lib/rubocop/cop/corrector.rb
+++ b/lib/rubocop/cop/corrector.rb
@@ -9,6 +9,8 @@ module RuboCop
     # The nodes modified by the corrections should be part of the
     # AST of the source_buffer.
     class Corrector < ::Parser::Source::TreeRewriter
+      NOOP_CONSUMER = ->(diagnostic) {} # noop
+
       # @param source [Parser::Source::Buffer, or anything
       #                leading to one via `(processed_source.)buffer`]
       #
@@ -23,7 +25,7 @@ module RuboCop
         )
 
         # Don't print warnings to stderr if corrections conflict with each other
-        diagnostics.consumer = ->(diagnostic) {} # noop
+        diagnostics.consumer = NOOP_CONSUMER
       end
 
       alias rewrite process # Legacy

--- a/lib/rubocop/cop/mixin/line_length_help.rb
+++ b/lib/rubocop/cop/mixin/line_length_help.rb
@@ -57,7 +57,7 @@ module RuboCop
       def indentation_difference(line)
         return 0 unless tab_indentation_width
 
-        line.match(/^\t*/)[0].size * (tab_indentation_width - 1)
+        (line.index(/[^\t]/) || 0) * (tab_indentation_width - 1)
       end
 
       def tab_indentation_width

--- a/lib/rubocop/cop/naming/predicate_name.rb
+++ b/lib/rubocop/cop/naming/predicate_name.rb
@@ -67,7 +67,8 @@ module RuboCop
         private
 
         def allowed_method_name?(method_name, prefix)
-          !method_name.match?(/^#{prefix}[^0-9]/) ||
+          !(method_name.start_with?(prefix) && # cheap check to avoid allocating Regexp
+              method_name.match?(/^#{prefix}[^0-9]/)) ||
             method_name == expected_name(method_name, prefix) ||
             method_name.end_with?('=') ||
             allowed_method?(method_name)

--- a/lib/rubocop/cop/style/semicolon.rb
+++ b/lib/rubocop/cop/style/semicolon.rb
@@ -70,6 +70,9 @@ module RuboCop
         private
 
         def check_for_line_terminator_or_opener
+          # Make the obvious check first
+          return unless @processed_source.raw_source.include?(';')
+
           each_semicolon { |line, column| convention_on(line, column, true) }
         end
 

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -99,7 +99,12 @@ module RuboCop
       def self.forces_for(cops)
         needed = Hash.new { |h, k| h[k] = [] }
         cops.each do |cop|
-          Array(cop.class.joining_forces).each { |force| needed[force] << cop }
+          forces = cop.class.joining_forces
+          if forces.is_a?(Array)
+            forces.each { |force| needed[force] << cop }
+          elsif forces
+            needed[forces] << cop
+          end
         end
 
         needed.map do |force_class, joining_cops|

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -62,7 +62,7 @@ module RuboCop
       end
 
       def begins_its_line?(range)
-        (range.source_line =~ /\S/) == range.column
+        range.source_line.index(/\S/) == range.column
       end
 
       # Returns, for example, a bare `if` node if the given node is an `if`

--- a/lib/rubocop/magic_comment.rb
+++ b/lib/rubocop/magic_comment.rb
@@ -194,7 +194,7 @@ module RuboCop
     class SimpleComment < MagicComment
       # Match `encoding` or `coding`
       def encoding
-        extract(/\A\s*\#.*\b(?:en)?coding: (#{TOKEN})/i)
+        extract(/\A\s*\#.*\b(?:en)?coding: (#{TOKEN})/io)
       end
 
       private
@@ -207,7 +207,7 @@ module RuboCop
       # Case-insensitive and dashes/underscores are acceptable.
       # @see https://git.io/vM7Mg
       def extract_frozen_string_literal
-        extract(/\A\s*#\s*frozen[_-]string[_-]literal:\s*(#{TOKEN})\s*\z/i)
+        extract(/\A\s*#\s*frozen[_-]string[_-]literal:\s*(#{TOKEN})\s*\z/io)
       end
     end
   end


### PR DESCRIPTION
```
bin/rubocop-profile --memory lib/rubocop/cop
```

### Before
```
Total allocated: 1.14 GB (16969980 objects)
Total retained:  7.35 MB (54861 objects)
....
allocated memory by file
....
  47.01 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/team.rb   (1)
  23.77 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/util.rb   (2)
  19.01 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/corrector.rb   (3)
  13.81 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/naming/predicate_name.rb   (4)
  11.79 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/mixin/line_length_help.rb   (5)
   7.71 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/style/semicolon.rb   (6)
   7.45 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/magic_comment.rb   (7)
....
```

### After
```
Total allocated: 1.09 GB (16268498 objects)
Total retained:  7.32 MB (54780 objects)
....
allocated memory by file
  37.51 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/team.rb   (1)
  13.77 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/util.rb   (2)
   8.13 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/mixin/line_length_help.rb   (5)
   1.99 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/style/semicolon.rb   (6)
   1.58 MB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/cop/naming/predicate_name.rb   (4)
 612.31 kB  /Users/fatkodima/Desktop/oss/rubocop/lib/rubocop/magic_comment.rb   (7)
```

So, another `5%` of memory savings.