### PR TITLE
Add `AllowMethodComparison` option for `Lint/MultipleComparison`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#7549](https://github.com/rubocop-hq/rubocop/issues/7549): Add new `Style/ArgumentsForwarding` cop. ([@koic][])
 * [#8859](https://github.com/rubocop-hq/rubocop/issues/8859): Add new `Lint/UnmodifiedReduceAccumulator` cop. ([@dvandersluis][])
 * [#8951](https://github.com/rubocop-hq/rubocop/pull/8951): Support auto-correction for `Style/MultipleComparison`. ([@koic][])
+* [#8953](https://github.com/rubocop-hq/rubocop/pull/8953): Add `AllowMethodComparison` option for `Lint/MultipleComparison`. ([@koic][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1659,6 +1659,7 @@ Lint/MultipleComparison:
   Enabled: true
   VersionAdded: '0.47'
   VersionChanged: '1.1'
+  AllowMethodComparison: true
 
 Lint/NestedMethodDefinition:
   Description: 'Do not use nested method definitions.'

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -2338,6 +2338,16 @@ x < y && y < z
 10 <= x && x <= 20
 ----
 
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AllowMethodComparison
+| `true`
+| Boolean
+|===
+
 == Lint/NestedMethodDefinition
 
 |===

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -6017,7 +6017,8 @@ end
 
 This cop checks against comparing a variable with multiple items, where
 `Array#include?` could be used instead to avoid code repetition.
-It accepts comparisons of multiple method calls to avoid unnecessary method calls.
+It accepts comparisons of multiple method calls to avoid unnecessary method calls
+by default. It can be configured by `AllowMethodComparison` option.
 
 === Examples
 
@@ -6031,6 +6032,25 @@ foo if a == 'a' || a == 'b' || a == 'c'
 a = 'a'
 foo if ['a', 'b', 'c'].include?(a)
 foo if a == b.lightweight || a == b.heavyweight
+----
+
+==== AllowMethodComparison: true (default)
+
+[source,ruby]
+----
+# good
+foo if a == b.lightweight || a == b.heavyweight
+----
+
+==== AllowMethodComparison: false
+
+[source,ruby]
+----
+# bad
+foo if a == b.lightweight || a == b.heavyweight
+
+# good
+foo if [b.lightweight, b.heavyweight].include?(a)
 ----
 
 == Style/MutableConstant


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/8939#issuecomment-717021466.

This PR adds `AllowMethodComparison` option for `Lint/MultipleComparison`.

```ruby
# @example AllowMethodComparison: true (default)
#   # good
#   foo if a == b.lightweight || a == b.heavyweight
#
# @example AllowMethodComparison: false
#   # bad
#   foo if a == b.lightweight || a == b.heavyweight
#
#   # good
#   foo if [b.lightweight, b.heavyweight].include?(a)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
