### PR TITLE
Fix a false positive for `Lint/ToEnumArguments`

### DIFF
--- a/lib/rubocop/cop/lint/to_enum_arguments.rb
+++ b/lib/rubocop/cop/lint/to_enum_arguments.rb
@@ -33,11 +33,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[to_enum enum_for].freeze
 
         def_node_matcher :enum_conversion_call?, <<~PATTERN
-          (send {nil? self} {:to_enum :enum_for} $_ $...)
-        PATTERN
-
-        def_node_matcher :method_name?, <<~PATTERN
-          {(send nil? :__method__) (sym %1)}
+          (send {nil? self} {:to_enum :enum_for} _ $...)
         PATTERN
 
         def_node_matcher :passing_keyword_arg?, <<~PATTERN
@@ -49,9 +45,8 @@ module RuboCop
           def_node = node.each_ancestor(:def, :defs).first
           return unless def_node
 
-          enum_conversion_call?(node) do |method_node, arguments|
-            add_offense(node) unless method_name?(method_node, def_node.method_name) &&
-                                     arguments_match?(arguments, def_node)
+          enum_conversion_call?(node) do |arguments|
+            add_offense(node) unless arguments_match?(arguments, def_node)
           end
         end
 

--- a/spec/rubocop/cop/lint/to_enum_arguments_spec.rb
+++ b/spec/rubocop/cop/lint/to_enum_arguments_spec.rb
@@ -106,11 +106,10 @@ RSpec.describe RuboCop::Cop::Lint::ToEnumArguments do
     RUBY
   end
 
-  it 'registers an offense when enumerator is created for another method' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when enumerator is created for another method' do
+    expect_no_offenses(<<~RUBY)
       def m(x)
-        return to_enum(:not_m) unless block_given?
-               ^^^^^^^^^^^^^^^ Ensure you correctly provided all the arguments.
+        return to_enum(:not_m, x)
       end
     RUBY
   end


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/8941#discussion_r511770777.

This PR fixes the following false positive for `Lint/ToEnumArguments` when enumerator is created for another method.

```console
% cd path/to/rubocop-performance
% bundle exec rubocop lib/rubocop/cop/performance/redundant_block_call.rb
Inspecting 1 file
W

Offenses:

lib/rubocop/cop/performance/redundant_block_call.rb:83:19: W:
Lint/ToEnumArguments: Ensure you correctly provided all the arguments.
          calls = to_enum(:blockarg_calls, body, argname)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```

The following is a snippet of `Performance/RedundantBlockCall` cop that is a real world use-case.

```ruby
def_node_search :blockarg_calls, <<~PATTERN
  (send (lvar %1) :call ...)
PATTERN

...

def calls_to_report(argname, body)
  return [] if blockarg_assigned?(body, argname)

  calls = to_enum(:blockarg_calls, body, argname)

  return [] if calls.any? { |call| args_include_block_pass?(call) }

  calls
end
```

https://github.com/rubocop-hq/rubocop-performance/blob/v1.8.1/lib/rubocop/cop/performance/redundant_block_call.rb#L80-L88

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
