### PR TITLE
[Fix #8950] Add `IgnoredMethods` and `IgnoredClasses` to `Lint/NumberConversion`

### DIFF
--- a/changelog/change_add_ignoredmethods_and_ignoredclasses_to.md
+++ b/changelog/change_add_ignoredmethods_and_ignoredclasses_to.md
@@ -1,0 +1,1 @@
+* [#8950](https://github.com/rubocop-hq/rubocop/issues/8950): Add `IgnoredMethods` and `IgnoredClasses` to `Lint/NumberConversion`. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1693,8 +1693,12 @@ Lint/NumberConversion:
   Description: 'Checks unsafe usage of number conversion methods.'
   Enabled: false
   VersionAdded: '0.53'
-  VersionChanged: '0.70'
+  VersionChanged: '1.1'
   SafeAutoCorrect: false
+  IgnoredMethods: []
+  IgnoredClasses:
+    - Time
+    - DateTime
 
 Lint/OrderedMagicComments:
   Description: 'Checks the proper ordering of magic comments and whether a magic comment is not placed before a shebang.'

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -2601,12 +2601,23 @@ end
 | Yes
 | Yes (Unsafe)
 | 0.53
-| 0.70
+| 1.1
 |===
 
 This cop warns the usage of unsafe number conversions. Unsafe
 number conversion can cause unexpected error if auto type conversion
 fails. Cop prefer parsing with number class instead.
+
+Conversion with `Integer`, `Float`, etc. will raise an `ArgumentError`
+if given input that is not numeric (eg. an empty string), whereas
+`to_i`, etc. will try to convert regardless of input (`''.to_i => 0`).
+As such, this cop is disabled by default because it's not necessarily
+always correct to raise if a value is not numeric.
+
+NOTE: Some values cannot be converted properly using one of the `Kernel`
+method (for instance, `Time` and `DateTime` values are allowed by this
+cop by default). Similarly, Rails' duration methods do not work well
+with `Integer()` and can be ignored with `IgnoredMethods`.
 
 === Examples
 
@@ -2624,6 +2635,36 @@ Integer('10', 10)
 Float('10.2')
 Complex('10')
 ----
+
+==== IgnoredMethods: [minutes]
+
+[source,ruby]
+----
+# good
+10.minutes.to_i
+----
+
+==== IgnoredClasses: [Time, DateTime] (default)
+
+[source,ruby]
+----
+# good
+Time.now.to_datetime.to_i
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| IgnoredMethods
+| `[]`
+| Array
+
+| IgnoredClasses
+| `Time`, `DateTime`
+| Array
+|===
 
 == Lint/OrderedMagicComments
 


### PR DESCRIPTION
Fixes #8950, to an extent. There are going to inherently be a number of false positives possible from this cop since it applies to basically any receiver of `to_i`, etc. other than `Time` and `DateTime`, which were hardcoded. Since this cop is disabled by default we probably don't have a lot of external coverage here (searching github for Lint/NumberConversion returns a lot of inline disables though!)

Instead, the classes to ignore are now configurable, and `IgnoredMethods` was added as well (so the rails duration helpers could be allowed in configuration). This of course isn't going to help when assigned to a variable, because those are checked as well:

```ruby
x = 10.minutes
x.to_i # will be registered
```

Another potential issue is that `Integer(10.minutes)` will work but `Integer(10.minutes, 10)`, which is the default suggestion/correction, does not work when the first argument is not a string. Should I change that as well to only add the base if the first arg is a known string?

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
