### PR TITLE
Use `public_send` instead of `send` when public sendable

### DIFF
--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -97,7 +97,7 @@ module RuboCop
       def trigger_responding_cops(callback, node)
         @callbacks[callback]&.each do |cop|
           with_cop_error_handling(cop, node) do
-            cop.send(callback, node)
+            cop.public_send(callback, node)
           end
         end
       end
@@ -133,7 +133,7 @@ module RuboCop
         name = node.method_name
         @restricted_map[event][name]&.each do |cop|
           with_cop_error_handling(cop, node) do
-            cop.send(event, node)
+            cop.public_send(event, node)
           end
         end
       end

--- a/lib/rubocop/cop/force.rb
+++ b/lib/rubocop/cop/force.rb
@@ -31,7 +31,7 @@ module RuboCop
         cops.each do |cop|
           next unless cop.respond_to?(method_name)
 
-          cop.send(method_name, *args)
+          cop.public_send(method_name, *args)
         end
       end
 

--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -255,7 +255,7 @@ module RuboCop
               PATTERN
             end
 
-            send(matcher_name, child)
+            public_send(matcher_name, child)
           end
         end
 
@@ -279,7 +279,7 @@ module RuboCop
               PATTERN
             end
 
-            send(matcher_name, child)
+            public_send(matcher_name, child)
           end
         end
       end

--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -213,7 +213,7 @@ module RuboCop
       #   returns `true` if two offenses contain same attributes
       def ==(other)
         COMPARISON_ATTRIBUTES.all? do |attribute|
-          send(attribute) == other.send(attribute)
+          public_send(attribute) == other.public_send(attribute)
         end
       end
 
@@ -221,7 +221,7 @@ module RuboCop
 
       def hash
         COMPARISON_ATTRIBUTES.reduce(0) do |hash, attribute|
-          hash ^ send(attribute).hash
+          hash ^ public_send(attribute).hash
         end
       end
 
@@ -234,7 +234,7 @@ module RuboCop
       #   comparison result
       def <=>(other)
         COMPARISON_ATTRIBUTES.each do |attribute|
-          result = send(attribute) <=> other.send(attribute)
+          result = public_send(attribute) <=> other.public_send(attribute)
           return result unless result.zero?
         end
         0

--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -30,7 +30,7 @@ module RuboCop
 
       FORMATTER_APIS.each do |method_name|
         define_method(method_name) do |*args|
-          each { |f| f.send(method_name, *args) }
+          each { |f| f.public_send(method_name, *args) }
         end
       end
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1341,7 +1341,7 @@ RSpec.describe RuboCop::ConfigLoader do
           # circumstances.
           it 'does not raise private method load called for SafeYAML:Module' do
             in_its_own_process_with('safe_yaml/load') do
-              SafeYAML.send :private_class_method, :load
+              SafeYAML.public_send :private_class_method, :load
               configuration = described_class.load_file('.rubocop.yml')
 
               word_regexp = configuration['Style/WordArray']['WordRegex']

--- a/spec/rubocop/cop/offense_spec.rb
+++ b/spec/rubocop/cop/offense_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::Cop::Offense do
   %i[severity location message cop_name].each do |a|
     describe "##{a}" do
       it 'is frozen' do
-        expect(offense.send(a).frozen?).to be(true)
+        expect(offense.public_send(a).frozen?).to be(true)
       end
     end
   end

--- a/spec/rubocop/formatter/colorizable_spec.rb
+++ b/spec/rubocop/formatter/colorizable_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe RuboCop::Formatter::Colorizable do
       it "invokes #colorize(string, #{color}" do
         expect(formatter).to receive(:colorize).with('foo', color)
 
-        formatter.send(color, 'foo')
+        formatter.public_send(color, 'foo')
       end
     end
   end


### PR DESCRIPTION
In Ruby, there seems to be a trend to separate `send` into `public_send` and `__send__`.
https://github.com/ruby/ruby/commit/3198e7ab

~RuboCop does not override `send`, so this PR enables `Style/Send` cop to prevent use `send` method.~
~In future, `Style/Send` may be able to move to `Lint/Send`, but for now I think it's good to stay with `Style` department.~
~Also, `Style/Send` remains disabled by default because considering user applications overriding `send` method.~

This PR changes to `public_send` to suppress unnecessary scope to(private, protected) method calls. On the other hand, this PR will not make the change to `__send__` because the change to `__send__` is premature
https://bugs.ruby-lang.org/issues/17100

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
