### PR TITLE
Tweak default changelog entry

### DIFF
--- a/spec/tasks/changelog_spec.rb
+++ b/spec/tasks/changelog_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Changelog do
 
         it 'generates correct content' do
           expect(entry.content).to eq <<~MD
-            * [#567](https://github.com/rubocop-hq/rubocop/pull/567): Do something cool. ([@johndoe][])
+            * [#567](https://github.com/rubocop-hq/rubocop/issues/567): Do something cool. ([@johndoe][])
           MD
         end
       end

--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -21,9 +21,10 @@ class Changelog
 
   # New entry
   Entry = Struct.new(:type, :body, :ref_type, :ref_id, :user, keyword_init: true) do
-    def initialize(type:, body: last_commit_title, ref_type: :pull, ref_id: nil, user: github_user)
+    def initialize(type:, body: last_commit_title, ref_type: nil, ref_id: nil, user: github_user)
       id, body = extract_id(body)
       ref_id ||= id || 'x'
+      ref_type ||= id ? :issues : :pull
       super
     end
 


### PR DESCRIPTION
Uses `issues` in link instead of `pull` when the commit refers to an issue.