### PR TITLE
Renamed `Naming/VariableNumber` cop to `Naming/IdentifierNumber`. Extended this cop to handle symbols and method names

### DIFF
--- a/changelog/change_variable_number.md
+++ b/changelog/change_variable_number.md
@@ -1,0 +1,1 @@
+* [#8964](https://github.com/rubocop-hq/rubocop/pull/8964): Extend `Naming/VariableNumber` cop to handle method names and symbols. ([@fatkodima][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2411,14 +2411,18 @@ Naming/VariableName:
     - camelCase
 
 Naming/VariableNumber:
-  Description: 'Use the configured style when numbering variables.'
+  Description: 'Use the configured style when numbering symbols, methods and variables.'
+  StyleGuide: '#snake-case-symbols-methods-vars-with-numbers'
   Enabled: true
   VersionAdded: '0.50'
+  VersionChanged: '1.2'
   EnforcedStyle: normalcase
   SupportedStyles:
     - snake_case
     - normalcase
     - non_integer
+  CheckMethodNames: true
+  CheckSymbols: true
 
 #################### Security ##############################
 

--- a/docs/modules/ROOT/pages/cops_naming.adoc
+++ b/docs/modules/ROOT/pages/cops_naming.adoc
@@ -973,12 +973,16 @@ fooBar = 1
 | Yes
 | No
 | 0.50
-| -
+| 1.2
 |===
 
 This cop makes sure that all numbered variables use the
 configured style, snake_case, normalcase, or non_integer,
 for their numbering.
+
+Additionally, `CheckMethodNames` and `CheckSymbols` configuration options
+can be used to specify whether method names and symbols should be checked.
+Both are enabled by default.
 
 === Examples
 
@@ -987,12 +991,20 @@ for their numbering.
 [source,ruby]
 ----
 # bad
-
+:some_sym1
 variable1 = 1
 
-# good
+def some_method1; end
 
+def some_method_1(arg1); end
+
+# good
+:some_sym_1
 variable_1 = 1
+
+def some_method_1; end
+
+def some_method_1(arg_1); end
 ----
 
 ==== EnforcedStyle: normalcase (default)
@@ -1000,12 +1012,20 @@ variable_1 = 1
 [source,ruby]
 ----
 # bad
-
+:some_sym_1
 variable_1 = 1
 
-# good
+def some_method_1; end
 
+def some_method1(arg_1); end
+
+# good
+:some_sym1
 variable1 = 1
+
+def some_method1; end
+
+def some_method1(arg1); end
 ----
 
 ==== EnforcedStyle: non_integer
@@ -1013,16 +1033,66 @@ variable1 = 1
 [source,ruby]
 ----
 # bad
+:some_sym1
+:some_sym_1
 
 variable1 = 1
-
 variable_1 = 1
 
+def some_method1; end
+
+def some_method_1; end
+
+def some_methodone(arg1); end
+def some_methodone(arg_1); end
+
 # good
+:some_symone
+:some_sym_one
 
 variableone = 1
-
 variable_one = 1
+
+def some_methodone; end
+
+def some_method_one; end
+
+def some_methodone(argone); end
+def some_methodone(arg_one); end
+
+# In the following examples, we assume `EnforcedStyle: normalcase` (default).
+----
+
+==== CheckMethodNames: true (default)
+
+[source,ruby]
+----
+# bad
+def some_method_1; end
+----
+
+==== CheckMethodNames: false
+
+[source,ruby]
+----
+# good
+def some_method_1; end
+----
+
+==== CheckSymbols: true (default)
+
+[source,ruby]
+----
+# bad
+:some_sym_1
+----
+
+==== CheckSymbols: false
+
+[source,ruby]
+----
+# good
+:some_sym_1
 ----
 
 === Configurable attributes
@@ -1033,4 +1103,16 @@ variable_one = 1
 | EnforcedStyle
 | `normalcase`
 | `snake_case`, `normalcase`, `non_integer`
+
+| CheckMethodNames
+| `true`
+| Boolean
+
+| CheckSymbols
+| `true`
+| Boolean
 |===
+
+=== References
+
+* https://rubystyle.guide#snake-case-symbols-methods-vars-with-numbers

--- a/lib/rubocop/cop/mixin/configurable_formatting.rb
+++ b/lib/rubocop/cop/mixin/configurable_formatting.rb
@@ -10,7 +10,7 @@ module RuboCop
         if valid_name?(node, name)
           correct_style_detected
         else
-          add_offense(name_range, message: message(style)) do
+          add_offense(name_range, message: message(node, style)) do
             report_opposing_styles(node, name)
           end
         end

--- a/lib/rubocop/cop/mixin/configurable_numbering.rb
+++ b/lib/rubocop/cop/mixin/configurable_numbering.rb
@@ -8,9 +8,9 @@ module RuboCop
       include ConfigurableFormatting
 
       FORMATS = {
-        snake_case:  /(?:[[[:lower:]]_]|_\d+)$/,
-        normalcase:  /(?:_\D*|[[[:upper:]][[:lower:]]]\d*)$/,
-        non_integer: /[[[:upper:]][[:lower:]]_]$/
+        snake_case:  /(?:\D|_\d+)$/,
+        normalcase:  /(?:\D|[^_\d]\d+)$/,
+        non_integer: /\D$/
       }.freeze
     end
   end

--- a/lib/rubocop/cop/naming/method_name.rb
+++ b/lib/rubocop/cop/naming/method_name.rb
@@ -70,7 +70,7 @@ module RuboCop
           range_between(selector_end_pos, expr_end_pos)
         end
 
-        def message(style)
+        def message(_node, style)
           format(MSG, style: style)
         end
       end

--- a/lib/rubocop/cop/naming/variable_name.rb
+++ b/lib/rubocop/cop/naming/variable_name.rb
@@ -43,7 +43,7 @@ module RuboCop
 
         private
 
-        def message(style)
+        def message(_node, style)
           format(MSG, style: style)
         end
       end

--- a/lib/rubocop/cop/naming/variable_number.rb
+++ b/lib/rubocop/cop/naming/variable_number.rb
@@ -7,40 +7,95 @@ module RuboCop
       # configured style, snake_case, normalcase, or non_integer,
       # for their numbering.
       #
+      # Additionally, `CheckMethodNames` and `CheckSymbols` configuration options
+      # can be used to specify whether method names and symbols should be checked.
+      # Both are enabled by default.
+      #
       # @example EnforcedStyle: snake_case
       #   # bad
-      #
+      #   :some_sym1
       #   variable1 = 1
       #
-      #   # good
+      #   def some_method1; end
       #
+      #   def some_method_1(arg1); end
+      #
+      #   # good
+      #   :some_sym_1
       #   variable_1 = 1
+      #
+      #   def some_method_1; end
+      #
+      #   def some_method_1(arg_1); end
       #
       # @example EnforcedStyle: normalcase (default)
       #   # bad
-      #
+      #   :some_sym_1
       #   variable_1 = 1
       #
-      #   # good
+      #   def some_method_1; end
       #
+      #   def some_method1(arg_1); end
+      #
+      #   # good
+      #   :some_sym1
       #   variable1 = 1
+      #
+      #   def some_method1; end
+      #
+      #   def some_method1(arg1); end
       #
       # @example EnforcedStyle: non_integer
       #   # bad
+      #   :some_sym1
+      #   :some_sym_1
       #
       #   variable1 = 1
-      #
       #   variable_1 = 1
       #
+      #   def some_method1; end
+      #
+      #   def some_method_1; end
+      #
+      #   def some_methodone(arg1); end
+      #   def some_methodone(arg_1); end
+      #
       #   # good
+      #   :some_symone
+      #   :some_sym_one
       #
       #   variableone = 1
-      #
       #   variable_one = 1
+      #
+      #   def some_methodone; end
+      #
+      #   def some_method_one; end
+      #
+      #   def some_methodone(argone); end
+      #   def some_methodone(arg_one); end
+      #
+      #   # In the following examples, we assume `EnforcedStyle: normalcase` (default).
+      #
+      # @example CheckMethodNames: true (default)
+      #   # bad
+      #   def some_method_1; end
+      #
+      # @example CheckMethodNames: false
+      #   # good
+      #   def some_method_1; end
+      #
+      # @example CheckSymbols: true (default)
+      #   # bad
+      #   :some_sym_1
+      #
+      # @example CheckSymbols: false
+      #   # good
+      #   :some_sym_1
+      #
       class VariableNumber < Base
         include ConfigurableNumbering
 
-        MSG = 'Use %<style>s for variable numbers.'
+        MSG = 'Use %<style>s for %<identifier_type>s numbers.'
 
         def on_arg(node)
           name, = *node
@@ -50,10 +105,26 @@ module RuboCop
         alias on_ivasgn on_arg
         alias on_cvasgn on_arg
 
+        def on_def(node)
+          check_name(node, node.method_name, node.loc.name) if cop_config['CheckMethodNames']
+        end
+        alias on_defs on_def
+
+        def on_sym(node)
+          check_name(node, node.value, node) if cop_config['CheckSymbols']
+        end
+
         private
 
-        def message(style)
-          format(MSG, style: style)
+        def message(node, style)
+          identifier_type =
+            case node.type
+            when :def, :defs then 'method name'
+            when :sym        then 'symbol'
+            else                  'variable'
+            end
+
+          format(MSG, style: style, identifier_type: identifier_type)
         end
       end
     end

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1045,7 +1045,7 @@ RSpec.describe RuboCop::ConfigLoader do
     context 'when a file inherits from a url inheriting from another file' do
       let(:file_path) { '.rubocop.yml' }
       let(:cache_file) { '.rubocop-http---example-com-rubocop-yml' }
-      let(:cache_file_2) { '.rubocop-http---example-com-inherit-yml' }
+      let(:cache_file2) { '.rubocop-http---example-com-inherit-yml' }
 
       before do
         stub_request(:get, %r{example.com/rubocop})
@@ -1058,7 +1058,7 @@ RSpec.describe RuboCop::ConfigLoader do
       end
 
       after do
-        [cache_file, cache_file_2].each do |f|
+        [cache_file, cache_file2].each do |f|
           File.unlink f if File.exist? f
         end
       end
@@ -1066,7 +1066,7 @@ RSpec.describe RuboCop::ConfigLoader do
       it 'downloads the inherited file from the same url and caches it' do
         configuration_from_file
         expect(File.exist?(cache_file)).to be true
-        expect(File.exist?(cache_file_2)).to be true
+        expect(File.exist?(cache_file2)).to be true
       end
     end
 

--- a/spec/rubocop/cop/naming/variable_number_spec.rb
+++ b/spec/rubocop/cop/naming/variable_number_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
+  let(:cop_config) do
+    { 'CheckMethodNames' => true, 'CheckSymbols' => true }
+  end
+
   shared_examples 'offense' do |style, variable, style_to_allow_offenses|
     it "registers an offense for #{variable} in #{style}" do
       expect_offense(<<~RUBY, variable: variable)
@@ -56,6 +60,19 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
     it_behaves_like 'accepts', 'snake_case', '@__foo__'
     it_behaves_like 'accepts', 'snake_case', 'emparejó'
 
+    it 'registers an offense for normal case numbering in symbol' do
+      expect_offense(<<~RUBY)
+        :sym1
+        ^^^^^ Use snake_case for symbol numbers.
+      RUBY
+    end
+
+    it 'does not register an offense for snake case numbering in symbol' do
+      expect_no_offenses(<<~RUBY)
+        :sym_1
+      RUBY
+    end
+
     it 'registers an offense for normal case numbering in method parameter' do
       expect_offense(<<~RUBY)
         def method(arg1); end
@@ -68,6 +85,13 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
       expect_offense(<<~RUBY)
         def method(funnyArg1); end
                    ^^^^^^^^^ Use snake_case for variable numbers.
+      RUBY
+    end
+
+    it 'registers an offense for normal case numbering in method name' do
+      expect_offense(<<~RUBY)
+        def method1; end
+            ^^^^^^^ Use snake_case for method name numbers.
       RUBY
     end
   end
@@ -101,6 +125,17 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
     it_behaves_like 'accepts', 'normalcase', '@__foo__'
     it_behaves_like 'accepts', 'snake_case', 'emparejó'
 
+    it 'registers an offense for snake case numbering in symbol' do
+      expect_offense(<<~RUBY)
+        :sym_1
+        ^^^^^^ Use normalcase for symbol numbers.
+      RUBY
+    end
+
+    it 'does not register an offense for normal case numbering in symbol' do
+      expect_no_offenses(':sym1')
+    end
+
     it 'registers an offense for snake case numbering in method parameter' do
       expect_offense(<<~RUBY)
         def method(arg_1); end
@@ -113,6 +148,13 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
       expect_offense(<<~RUBY)
         def method(funnyArg_1); end
                    ^^^^^^^^^^ Use normalcase for variable numbers.
+      RUBY
+    end
+
+    it 'registers an offense for snake case numbering in method name' do
+      expect_offense(<<~RUBY)
+        def method_1; end
+            ^^^^^^^^ Use normalcase for method name numbers.
       RUBY
     end
   end
@@ -143,6 +185,20 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
     it_behaves_like 'accepts', 'non_integer', '@__foo__'
     it_behaves_like 'accepts', 'snake_case', 'emparejó'
 
+    it 'registers an offense for snake case numbering in symbol' do
+      expect_offense(<<~RUBY)
+        :sym_1
+        ^^^^^^ Use non_integer for symbol numbers.
+      RUBY
+    end
+
+    it 'registers an offense for normal case numbering in symbol' do
+      expect_offense(<<~RUBY)
+        :sym1
+        ^^^^^ Use non_integer for symbol numbers.
+      RUBY
+    end
+
     it 'registers an offense for snake case numbering in method parameter' do
       expect_offense(<<~RUBY)
         def method(arg_1); end
@@ -171,6 +227,40 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
         def method(myArg1); end
                    ^^^^^^ Use non_integer for variable numbers.
       RUBY
+    end
+
+    it 'registers an offense for snake case numbering in method name' do
+      expect_offense(<<~RUBY)
+        def method_1; end
+            ^^^^^^^^ Use non_integer for method name numbers.
+      RUBY
+    end
+
+    it 'registers an offense for normal case numbering in method name' do
+      expect_offense(<<~RUBY)
+        def method1; end
+            ^^^^^^^ Use non_integer for method name numbers.
+      RUBY
+    end
+  end
+
+  context 'when CheckMethodNames is false' do
+    let(:cop_config) do
+      { 'CheckMethodNames' => false, 'EnforcedStyle' => 'normalcase' }
+    end
+
+    it 'does not register an offense for snake case numbering in method name' do
+      expect_no_offenses('def method_1; end')
+    end
+  end
+
+  context 'when CheckSymbols is false' do
+    let(:cop_config) do
+      { 'CheckSymbols' => false, 'EnforcedStyle' => 'normalcase' }
+    end
+
+    it 'does not register an offense for snake case numbering in symbol' do
+      expect_no_offenses(':sym_1')
     end
   end
 end


### PR DESCRIPTION
This PR renames and extends an existing cop to also handle symbols and method names, as in the style guide https://rubystyle.guide/#snake-case-symbols-methods-vars-with-numbers