### PR TITLE
[Fix #8966] Fix spaces in empty parens.

### DIFF
--- a/changelog/fix_spaces_in_blank_parens.md
+++ b/changelog/fix_spaces_in_blank_parens.md
@@ -1,0 +1,1 @@
+* [#8966](https://github.com/rubocop-hq/rubocop/issues/8966): Fix `Layout/SpaceInsideParens` to enforce no spaces in empty parens for all styles. ([@joshuapinter][])

--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -6017,10 +6017,12 @@ Checks for spaces inside ordinary round parentheses.
 # bad
 f( 3)
 g = (a + 3 )
+f( )
 
 # good
 f(3)
 g = (a + 3)
+f()
 ----
 
 ==== EnforcedStyle: space

--- a/lib/rubocop/cop/layout/space_inside_parens.rb
+++ b/lib/rubocop/cop/layout/space_inside_parens.rb
@@ -11,10 +11,12 @@ module RuboCop
       #   # bad
       #   f( 3)
       #   g = (a + 3 )
+      #   f( )
       #
       #   # good
       #   f(3)
       #   g = (a + 3)
+      #   f()
       #
       # @example EnforcedStyle: space
       #   # The `space` style enforces that parentheses have a space at the
@@ -44,11 +46,7 @@ module RuboCop
           @processed_source = processed_source
 
           if style == :space
-            each_missing_space(processed_source.tokens) do |range|
-              add_offense(range, message: MSG_SPACE) do |corrector|
-                corrector.insert_before(range, ' ')
-              end
-            end
+            process_with_space_style(processed_source)
           else
             each_extraneous_space(processed_source.tokens) do |range|
               add_offense(range) do |corrector|
@@ -59,6 +57,21 @@ module RuboCop
         end
 
         private
+
+        def process_with_space_style(processed_source)
+          processed_source.tokens.each_cons(2) do |token1, token2|
+            each_extraneous_space_in_empty_parens(token1, token2) do |range|
+              add_offense(range) do |corrector|
+                corrector.remove(range)
+              end
+            end
+            each_missing_space(token1, token2) do |range|
+              add_offense(range, message: MSG_SPACE) do |corrector|
+                corrector.insert_before(range, ' ')
+              end
+            end
+          end
+        end
 
         def each_extraneous_space(tokens)
           tokens.each_cons(2) do |token1, token2|
@@ -73,15 +86,21 @@ module RuboCop
           end
         end
 
-        def each_missing_space(tokens)
-          tokens.each_cons(2) do |token1, token2|
-            next if can_be_ignored?(token1, token2)
+        def each_extraneous_space_in_empty_parens(token1, token2)
+          return unless token1.left_parens? && token2.right_parens?
 
-            if token1.left_parens?
-              yield range_between(token2.begin_pos, token2.begin_pos + 1)
-            elsif token2.right_parens?
-              yield range_between(token2.begin_pos, token2.end_pos)
-            end
+          return if range_between(token1.begin_pos, token2.end_pos).source == '()'
+
+          yield range_between(token1.end_pos, token2.begin_pos)
+        end
+
+        def each_missing_space(token1, token2)
+          return if can_be_ignored?(token1, token2)
+
+          if token1.left_parens?
+            yield range_between(token2.begin_pos, token2.begin_pos + 1)
+          elsif token2.right_parens?
+            yield range_between(token2.begin_pos, token2.end_pos)
           end
         end
 
@@ -95,6 +114,9 @@ module RuboCop
 
         def can_be_ignored?(token1, token2)
           return true unless parens?(token1, token2)
+
+          # Ignore empty parentheses.
+          return true if range_between(token1.begin_pos, token2.end_pos).source == '()'
 
           # If the second token is a comment, that means that a line break
           # follows, and that the rules for space inside don't apply.

--- a/spec/rubocop/cop/layout/space_inside_parens_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_parens_spec.rb
@@ -10,11 +10,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideParens, :config do
           ^ Space inside parentheses detected.
         g = (a + 3 )
                   ^ Space inside parentheses detected.
+        f( )
+          ^ Space inside parentheses detected.
       RUBY
 
       expect_correction(<<~RUBY)
         f(3)
         g = (a + 3)
+        f()
       RUBY
     end
 
@@ -65,6 +68,17 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideParens, :config do
       RUBY
     end
 
+    it 'registers an offense for space inside empty parens' do
+      expect_offense(<<~RUBY)
+        f( )
+          ^ Space inside parentheses detected.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        f()
+      RUBY
+    end
+
     it 'registers an offense in block parameter list with no spaces' do
       expect_offense(<<~RUBY)
         list.inject( Tms.new ) { |sum, (label, item)|
@@ -77,6 +91,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideParens, :config do
         list.inject( Tms.new ) { |sum, ( label, item )|
         }
       RUBY
+    end
+
+    it 'accepts empty parentheses without spaces' do
+      expect_no_offenses('f()')
     end
 
     it 'accepts parentheses with spaces' do


### PR DESCRIPTION
According to the docs, empty parens should always have no spaces. However, when `spaces` was set as the `style` for `SpaceInsideParens`, the Cop would register an offence if there was not a space inside the empty parens.

Empty parens should not have spaces.

This commit fixes `SpaceInsideParens` Cop when the `style` is `spaces` so that it doesn't require a space inside the parens. Moreover, it registers an offence when there _is_ a space inside empty parens.

Additionally, a test was added for the default `style` to ensure there are no spaces inside empty parens.

And finally, the docs were updated to show that spaces are not permitted with _either_ `style`.

Note, had to extract out `process_with_space_style` to avoid method length Cop offence.

Fixes https://github.com/rubocop-hq/rubocop/issues/8966.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
