### PR TITLE
[Fix #8925] Add `--display-time` option for outputting time.

### DIFF
--- a/changelog/new_display_time_command_line_option.md
+++ b/changelog/new_display_time_command_line_option.md
@@ -1,0 +1,1 @@
+* [#8925](https://github.com/rubocop-hq/rubocop/issues/8925): Add `--display-time` option for displaying elapsed time of `rubocop` command. ([@joshuapinter][])

--- a/exe/rubocop
+++ b/exe/rubocop
@@ -13,5 +13,5 @@ time = Benchmark.realtime do
   result = cli.run
 end
 
-puts "Finished in #{time} seconds" if cli.options[:debug]
+puts "Finished in #{time} seconds" if cli.options[:debug] || cli.options[:display_time]
 exit result

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -145,6 +145,7 @@ module RuboCop
         end
       end
 
+      option(opts, '--display-time')
       option(opts, '--display-only-failed')
     end
 
@@ -469,6 +470,7 @@ module RuboCop
                                          'if no format is specified.'],
       fail_level:                       ['Minimum severity (A/R/C/W/E/F) for exit',
                                          'with error code.'],
+      display_time:                     'Display elapsed time in seconds.',
       display_only_failed:              ['Only output offense messages. Omit passing',
                                          'cops. Only valid for --format junit.'],
       display_only_fail_level_offenses:

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -789,6 +789,26 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     end
   end
 
+  describe '--display-time' do
+    before do
+      create_file('example1.rb', '')
+    end
+
+    regex = /Finished in [0-9]*\.[0-9]* seconds/
+
+    context 'without --display-time' do
+      it 'does not display elapsed time in seconds' do
+        expect(`rubocop example1.rb`).not_to match(regex)
+      end
+    end
+
+    context 'with --display-time' do
+      it 'displays elapsed time in seconds' do
+        expect(`rubocop --display-time example1.rb`).to match(regex)
+      end
+    end
+  end
+
   describe '-D/--display-cop-names' do
     before do
       create_file('example1.rb', 'puts 0 # rubocop:disable NumericLiterals ')

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -96,6 +96,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                                                This option applies to the previously
                                                specified --format, or the default format
                                                if no format is specified.
+                  --display-time               Display elapsed time in seconds.
                   --display-only-failed        Only output offense messages. Omit passing
                                                cops. Only valid for --format junit.
               -r, --require FILE               Require Ruby file.


### PR DESCRIPTION
This shows the elapsed time of the Rubocop command without needing to show all of the output of `--debug`.

### Before

```bash
$ rubocop
...
865 files inspected, 218 offenses detected, 148 offenses auto-correctable
$
```

### After

```bash
$ rubocop --display-time
...
865 files inspected, 218 offenses detected, 148 offenses auto-correctable
Finished in 16.146678999997675 seconds
$
```


Fixes #8925.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
  - I tried testing this through the CLI specs but because it occurs outside of the CLI - essentially wrapping the CLI command itself - it wasn't working. Any thoughts or tips on testing this?
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
