### PR TITLE
[Fix #8971] Fix a false alarm for `# rubocop:disable Lint/EmptyBlock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#8912](https://github.com/rubocop-hq/rubocop/pull/8912): Fix `Layout/ElseAlignment` for `rescue/else/ensure` inside `do/end` blocks with assignment. ([@miry][])
+* [#8971](https://github.com/rubocop-hq/rubocop/issues/8971): Fix a false alarm for `# rubocop:disable Lint/EmptyBlock` inline comment with `Lint/RedundantCopDisableDirective`. ([@koic][])
 
 ## 1.1.0 (2020-10-29)
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -390,6 +390,24 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         end
       end
 
+      context 'when using `rubocop:disable` line comment for `Lint/EmptyBlock`' do
+        it 'does not register an offense for `Lint/RedundantCopDisableDirective`' do
+          create_file('.rubocop.yml', <<~YAML)
+            Lint/EmptyBlock:
+              Enabled: true
+            Lint/RedundantCopDisableDirective:
+              Enabled: true
+          YAML
+          create_file('example.rb', <<~RUBY)
+            # frozen_string_literal: true
+
+            assert_equal nil, combinator {}.call # rubocop:disable Lint/EmptyBlock'
+          RUBY
+          expect(cli.run(['example.rb'])).to eq(0)
+          expect($stdout.string).to include('1 file inspected, no offenses detected')
+        end
+      end
+
       shared_examples 'RedundantCopDisableDirective not run' do |state, config|
         context "and RedundantCopDisableDirective is #{state}" do
           it 'does not report RedundantCopDisableDirective offenses' do


### PR DESCRIPTION
Fixes #8971.

This PR fixes the following false alarm for `# rubocop:disable Lint/EmptyBlock` inline comment with `Lint/RedundantCopDisableDirective`.

```ruby
% cat example.rb
# frozen_string_literal: true

assert_equal nil, combinator {}.call # rubocop:disable Lint/EmptyBlock

% bundle exec rubocop example.rb
Inspecting 1 file
W

Offenses:

example.rb:3:38: W: Lint/RedundantCopDisableDirective: Unnecessary
disabling of Lint/EmptyBlock.
assert_equal nil, combinator {}.call # rubocop:disable Lint/EmptyBlock
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense auto-correctabl
```

`Lint/EmptyBlock` is `AllowComments: true` by default. `Lint/RedundantCopDisableDirective` was occurring because
`# rubocop:disable Lint/EmptyBlock` inline comment was treated as an allowed comment by `Lint/EmptyBlock`.

This PR does not treat `# rubocop:disable` as a comment allowed by `AllowComment`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
