### PR TITLE
[Fix #8976] Fix an incorrect auto-correct for `Style/KeywordParametersOrder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#8912](https://github.com/rubocop-hq/rubocop/pull/8912): Fix `Layout/ElseAlignment` for `rescue/else/ensure` inside `do/end` blocks with assignment. ([@miry][])
 * [#8971](https://github.com/rubocop-hq/rubocop/issues/8971): Fix a false alarm for `# rubocop:disable Lint/EmptyBlock` inline comment with `Lint/RedundantCopDisableDirective`. ([@koic][])
+* [#8976](https://github.com/rubocop-hq/rubocop/issues/8976): Fix an incorrect auto-correct for `Style/KeywordParametersOrder` when when `kwoptarg` is before `kwarg` and argument parentheses omitted. ([@koic][])
 
 ## 1.1.0 (2020-10-29)
 

--- a/spec/rubocop/cop/style/keyword_parameters_order_spec.rb
+++ b/spec/rubocop/cop/style/keyword_parameters_order_spec.rb
@@ -16,6 +16,37 @@ RSpec.describe RuboCop::Cop::Style::KeywordParametersOrder do
     RUBY
   end
 
+  it 'registers an offense and corrects when `kwoptarg` is before `kwarg` and argument parentheses omitted' do
+    expect_offense(<<~RUBY)
+      def m arg, optional: 1, required:
+                 ^^^^^^^^^^^ Place optional keyword parameters at the end of the parameters list.
+        do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def m arg, required:, optional: 1
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when multiple `kwoptarg` are before `kwarg` and argument parentheses omitted' do
+    expect_offense(<<~RUBY)
+      def m arg, optional1: 1, optional2: 2, required:
+                               ^^^^^^^^^^^^ Place optional keyword parameters at the end of the parameters list.
+                 ^^^^^^^^^^^^ Place optional keyword parameters at the end of the parameters list.
+        do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def m arg, required:, optional1: 1, optional2: 2
+        do_something
+      end
+    RUBY
+  end
+
   it 'registers an offense and corrects when multiple `kwoptarg`s are interleaved with `kwarg`s' do
     expect_offense(<<~RUBY)
       def m(arg, optional1: 1, required1:, optional2: 2, required2:, **rest, &block)
@@ -26,6 +57,40 @@ RSpec.describe RuboCop::Cop::Style::KeywordParametersOrder do
 
     expect_correction(<<~RUBY)
       def m(arg, required1:, required2:, optional1: 1, optional2: 2, **rest, &block)
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when multiple `kwoptarg`s are interleaved with `kwarg`s' \
+    'and last argument is `kwrestarg` and argument parentheses omitted' do
+    expect_offense(<<~RUBY)
+      def m arg, optional1: 1, required1:, optional2: 2, required2:, **rest
+                 ^^^^^^^^^^^^ Place optional keyword parameters at the end of the parameters list.
+                                           ^^^^^^^^^^^^ Place optional keyword parameters at the end of the parameters list.
+        do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def m arg, required1:, required2:, optional1: 1, optional2: 2, **rest
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when multiple `kwoptarg`s are interleaved with `kwarg`s' \
+    'and last argument is `blockarg` and argument parentheses omitted' do
+    expect_offense(<<~RUBY)
+      def m arg, optional1: 1, required1:, optional2: 2, required2:, **rest, &block
+                 ^^^^^^^^^^^^ Place optional keyword parameters at the end of the parameters list.
+                                           ^^^^^^^^^^^^ Place optional keyword parameters at the end of the parameters list.
+        do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def m arg, required1:, required2:, optional1: 1, optional2: 2, **rest, &block
+        do_something
       end
     RUBY
   end


### PR DESCRIPTION
Fixes #8976.

This PR fixes the following incorrect auto-correct for `Style/KeywordParametersOrder` when `kwoptarg` is before `kwarg` and argument parentheses omitted.

```console
% cat example.rb
def do_something foo: :default_value, bar:
  lvar = 42
end

% bundle exec rubocop --only Style/KeywordParametersOrder -a
Inspecting 1 file
C

Offenses:

example.rb:1:18: C: [Corrected] Style/KeywordParametersOrder: Place
optional keyword parameters at the end of the parameters list.
def do_something foo: :default_value, bar:
                 ^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected

% cat example.rb
def do_something bar:, foo: :default_value  lvar = 42
end

% ruby -c example.rb
example.rb:1: syntax error, unexpected local variable or method,
expecting ';' or '\n'
...bar:, foo: :default_value  lvar = 42
example.rb:2: syntax error, unexpected `end', expecting end-of-input
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
