### PR TITLE
Support auto-correction for `Naming/BinaryOperatorParameterName`

### DIFF
--- a/changelog/new_support_autocorrect_for_binary_operator_parameter_name.md
+++ b/changelog/new_support_autocorrect_for_binary_operator_parameter_name.md
@@ -1,0 +1,1 @@
+* [#8982](https://github.com/rubocop-hq/rubocop/pull/8982): Support auto-correction for `Naming/BinaryOperatorParameterName`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2181,6 +2181,7 @@ Naming/BinaryOperatorParameterName:
   StyleGuide: '#other-arg'
   Enabled: true
   VersionAdded: '0.50'
+  VersionChanged: '1.2'
 
 Naming/BlockParameterName:
   Description: >-

--- a/docs/modules/ROOT/pages/cops_naming.adoc
+++ b/docs/modules/ROOT/pages/cops_naming.adoc
@@ -131,9 +131,9 @@ FOÖ = "foo"
 
 | Enabled
 | Yes
-| No
+| Yes
 | 0.50
-| -
+| 1.2
 |===
 
 This cop makes sure that certain binary operator methods have their

--- a/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
+++ b/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
@@ -14,6 +14,8 @@ module RuboCop
       #   # good
       #   def +(other); end
       class BinaryOperatorParameterName < Base
+        extend AutoCorrector
+
         MSG = 'When defining the `%<opr>s` operator, ' \
               'name its argument `other`.'
 
@@ -26,7 +28,15 @@ module RuboCop
 
         def on_def(node)
           op_method_candidate?(node) do |name, arg|
-            add_offense(arg, message: format(MSG, opr: name))
+            add_offense(arg, message: format(MSG, opr: name)) do |corrector|
+              corrector.replace(arg, 'other')
+              node.each_descendant(:lvar, :lvasgn) do |lvar|
+                lvar_location = lvar.loc.name
+                next unless lvar_location.source == arg.source
+
+                corrector.replace(lvar_location, 'other')
+              end
+            end
           end
         end
 

--- a/spec/rubocop/cop/naming/binary_operator_parameter_name_spec.rb
+++ b/spec/rubocop/cop/naming/binary_operator_parameter_name_spec.rb
@@ -3,24 +3,36 @@
 RSpec.describe RuboCop::Cop::Naming::BinaryOperatorParameterName do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for `#+` when argument is not named other' do
+  it 'registers an offense and corrects for `#+` when argument is not named other' do
     expect_offense(<<~RUBY)
       def +(foo); end
             ^^^ When defining the `+` operator, name its argument `other`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      def +(other); end
+    RUBY
   end
 
-  it 'registers an offense for `#eql?` when argument is not named other' do
+  it 'registers an offense and corrects for `#eql?` when argument is not named other' do
     expect_offense(<<~RUBY)
       def eql?(foo); end
                ^^^ When defining the `eql?` operator, name its argument `other`.
     RUBY
+
+    expect_correction(<<~RUBY)
+      def eql?(other); end
+    RUBY
   end
 
-  it 'registers an offense for `#equal?` when argument is not named other' do
+  it 'registers an offense and corrects for `#equal?` when argument is not named other' do
     expect_offense(<<~RUBY)
       def equal?(foo); end
                  ^^^ When defining the `equal?` operator, name its argument `other`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def equal?(other); end
     RUBY
   end
 
@@ -29,6 +41,44 @@ RSpec.describe RuboCop::Cop::Naming::BinaryOperatorParameterName do
       def + another
             ^^^^^^^ When defining the `+` operator, name its argument `other`.
         another
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def + other
+        other
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when argument is referenced in method body' do
+    expect_offense(<<~RUBY)
+      def +(arg)
+            ^^^ When defining the `+` operator, name its argument `other`.
+        lvar = 'lvar'
+        do_something(arg, lvar)
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def +(other)
+        lvar = 'lvar'
+        do_something(other, lvar)
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when assigned to argument in method body' do
+    expect_offense(<<~RUBY)
+      def +(arg)
+            ^^^ When defining the `+` operator, name its argument `other`.
+        arg = do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def +(other)
+        other = do_something
       end
     RUBY
   end


### PR DESCRIPTION
This PR supports auto-correction for `Naming/BinaryOperatorParameterName`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
