### PR TITLE
Support auto-correction for `Naming/HeredocDelimiterCase`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#8983](https://github.com/rubocop-hq/rubocop/pull/8983): Support auto-correction for `Naming/HeredocDelimiterCase`. ([@koic][])
+
 ### Bug fixes
 
 * [#8912](https://github.com/rubocop-hq/rubocop/pull/8912): Fix `Layout/ElseAlignment` for `rescue/else/ensure` inside `do/end` blocks with assignment. ([@miry][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2287,6 +2287,7 @@ Naming/HeredocDelimiterCase:
   StyleGuide: '#heredoc-delimiters'
   Enabled: true
   VersionAdded: '0.50'
+  VersionChanged: '1.2'
   EnforcedStyle: uppercase
   SupportedStyles:
     - lowercase

--- a/docs/modules/ROOT/pages/cops_naming.adoc
+++ b/docs/modules/ROOT/pages/cops_naming.adoc
@@ -391,9 +391,9 @@ anything/using_snake_case.rake
 
 | Enabled
 | Yes
-| No
+| Yes
 | 0.50
-| -
+| 1.2
 |===
 
 This cop checks that your heredocs are using the configured case.

--- a/lib/rubocop/cop/naming/heredoc_delimiter_case.rb
+++ b/lib/rubocop/cop/naming/heredoc_delimiter_case.rb
@@ -30,13 +30,19 @@ module RuboCop
       class HeredocDelimiterCase < Base
         include Heredoc
         include ConfigurableEnforcedStyle
+        extend AutoCorrector
 
         MSG = 'Use %<style>s heredoc delimiters.'
 
         def on_heredoc(node)
           return if correct_case_delimiters?(node)
 
-          add_offense(node.loc.heredoc_end)
+          add_offense(node.loc.heredoc_end) do |corrector|
+            expr = node.loc.expression
+
+            corrector.replace(expr, correct_delimiters(expr.source))
+            corrector.replace(node.loc.heredoc_end, correct_delimiters(delimiter_string(expr)))
+          end
         end
 
         private
@@ -46,14 +52,14 @@ module RuboCop
         end
 
         def correct_case_delimiters?(node)
-          delimiter_string(node) == correct_delimiters(node)
+          delimiter_string(node) == correct_delimiters(delimiter_string(node))
         end
 
-        def correct_delimiters(node)
+        def correct_delimiters(source)
           if style == :uppercase
-            delimiter_string(node).upcase
+            source.upcase
           else
-            delimiter_string(node).downcase
+            source.downcase
           end
         end
       end

--- a/spec/rubocop/cop/naming/heredoc_delimiter_case_spec.rb
+++ b/spec/rubocop/cop/naming/heredoc_delimiter_case_spec.rb
@@ -14,12 +14,18 @@ RSpec.describe RuboCop::Cop::Naming::HeredocDelimiterCase, :config do
     end
 
     context 'with an interpolated heredoc' do
-      it 'registers an offense with a lowercase delimiter' do
+      it 'registers an offense and corrects with a lowercase delimiter' do
         expect_offense(<<~RUBY)
           <<-sql
             foo
           sql
           ^^^ Use uppercase heredoc delimiters.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          <<-SQL
+            foo
+          SQL
         RUBY
       end
 
@@ -43,21 +49,33 @@ RSpec.describe RuboCop::Cop::Naming::HeredocDelimiterCase, :config do
 
     context 'with a non-interpolated heredoc' do
       context 'when using single quoted delimiters' do
-        it 'registers an offense with a lowercase delimiter' do
+        it 'registers an offense and corrects with a lowercase delimiter' do
           expect_offense(<<~RUBY)
             <<-'sql'
               foo
             sql
             ^^^ Use uppercase heredoc delimiters.
           RUBY
+
+          expect_correction(<<~RUBY)
+            <<-'SQL'
+              foo
+            SQL
+          RUBY
         end
 
-        it 'registers an offense with a camel case delimiter' do
+        it 'registers an offense and corrects with a camel case delimiter' do
           expect_offense(<<~RUBY)
             <<-'Sql'
               foo
             Sql
             ^^^ Use uppercase heredoc delimiters.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            <<-'SQL'
+              foo
+            SQL
           RUBY
         end
 
@@ -71,21 +89,33 @@ RSpec.describe RuboCop::Cop::Naming::HeredocDelimiterCase, :config do
       end
 
       context 'when using double quoted delimiters' do
-        it 'registers an offense with a lowercase delimiter' do
+        it 'registers an offense and corrects with a lowercase delimiter' do
           expect_offense(<<~RUBY)
             <<-"sql"
               foo
             sql
             ^^^ Use uppercase heredoc delimiters.
           RUBY
+
+          expect_correction(<<~RUBY)
+            <<-"SQL"
+              foo
+            SQL
+          RUBY
         end
 
-        it 'registers an offense with a camel case delimiter' do
+        it 'registers an offense and corrects with a camel case delimiter' do
           expect_offense(<<~RUBY)
             <<-"Sql"
               foo
             Sql
             ^^^ Use uppercase heredoc delimiters.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            <<-"SQL"
+              foo
+            SQL
           RUBY
         end
 
@@ -99,21 +129,33 @@ RSpec.describe RuboCop::Cop::Naming::HeredocDelimiterCase, :config do
       end
 
       context 'when using back tick delimiters' do
-        it 'registers an offense with a lowercase delimiter' do
+        it 'registers an offense and corrects with a lowercase delimiter' do
           expect_offense(<<~RUBY)
             <<-`sql`
               foo
             sql
             ^^^ Use uppercase heredoc delimiters.
           RUBY
+
+          expect_correction(<<~RUBY)
+            <<-`SQL`
+              foo
+            SQL
+          RUBY
         end
 
-        it 'registers an offense with a camel case delimiter' do
+        it 'registers an offense and corrects with a camel case delimiter' do
           expect_offense(<<~RUBY)
             <<-`Sql`
               foo
             Sql
             ^^^ Use uppercase heredoc delimiters.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            <<-`SQL`
+              foo
+            SQL
           RUBY
         end
 
@@ -138,21 +180,33 @@ RSpec.describe RuboCop::Cop::Naming::HeredocDelimiterCase, :config do
     end
 
     context 'with a squiggly heredoc' do
-      it 'registers an offense with a lowercase delimiter' do
+      it 'registers an offense and corrects with a lowercase delimiter' do
         expect_offense(<<~RUBY)
           <<~sql
             foo
           sql
           ^^^ Use uppercase heredoc delimiters.
         RUBY
+
+        expect_correction(<<~RUBY)
+          <<~SQL
+            foo
+          SQL
+        RUBY
       end
 
-      it 'registers an offense with a camel case delimiter' do
+      it 'registers an offense and corrects with a camel case delimiter' do
         expect_offense(<<~RUBY)
           <<~Sql
             foo
           Sql
           ^^^ Use uppercase heredoc delimiters.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          <<~SQL
+            foo
+          SQL
         RUBY
       end
 
@@ -183,21 +237,33 @@ RSpec.describe RuboCop::Cop::Naming::HeredocDelimiterCase, :config do
         RUBY
       end
 
-      it 'registers an offense with a camel case delimiter' do
+      it 'registers an offense and corrects with a camel case delimiter' do
         expect_offense(<<~RUBY)
           <<-Sql
             foo
           Sql
           ^^^ Use lowercase heredoc delimiters.
         RUBY
+
+        expect_correction(<<~RUBY)
+          <<-sql
+            foo
+          sql
+        RUBY
       end
 
-      it 'registers an offense with an uppercase delimiter' do
+      it 'registers an offense and corrects with an uppercase delimiter' do
         expect_offense(<<~RUBY)
           <<-SQL
             foo
           SQL
           ^^^ Use lowercase heredoc delimiters.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          <<-sql
+            foo
+          sql
         RUBY
       end
     end
@@ -211,21 +277,33 @@ RSpec.describe RuboCop::Cop::Naming::HeredocDelimiterCase, :config do
         RUBY
       end
 
-      it 'registers an offense with a camel case delimiter' do
+      it 'registers an offense and corrects with a camel case delimiter' do
         expect_offense(<<~RUBY)
           <<-'Sql'
             foo
           Sql
           ^^^ Use lowercase heredoc delimiters.
         RUBY
+
+        expect_correction(<<~RUBY)
+          <<-'sql'
+            foo
+          sql
+        RUBY
       end
 
-      it 'registers an offense with an uppercase delimiter' do
+      it 'registers an offense and corrects with an uppercase delimiter' do
         expect_offense(<<~RUBY)
           <<-'SQL'
             foo
           SQL
           ^^^ Use lowercase heredoc delimiters.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          <<-'sql'
+            foo
+          sql
         RUBY
       end
     end
@@ -239,21 +317,33 @@ RSpec.describe RuboCop::Cop::Naming::HeredocDelimiterCase, :config do
         RUBY
       end
 
-      it 'registers an offense with a camel case delimiter' do
+      it 'registers an offense and corrects with a camel case delimiter' do
         expect_offense(<<~RUBY)
           <<~Sql
             foo
           Sql
           ^^^ Use lowercase heredoc delimiters.
         RUBY
+
+        expect_correction(<<~RUBY)
+          <<~sql
+            foo
+          sql
+        RUBY
       end
 
-      it 'registers an offense with an uppercase delimiter' do
+      it 'registers an offense and corrects with an uppercase delimiter' do
         expect_offense(<<~RUBY)
           <<~SQL
             foo
           SQL
           ^^^ Use lowercase heredoc delimiters.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          <<~sql
+            foo
+          sql
         RUBY
       end
     end


### PR DESCRIPTION
This PR supports auto-correction for `Naming/HeredocDelimiterCase`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
