### PR TITLE
Support auto-correction for `Style/DoubleNegation`

### DIFF
--- a/changelog/new_support_autocorrect_for_style_double_negation.md
+++ b/changelog/new_support_autocorrect_for_style_double_negation.md
@@ -1,0 +1,1 @@
+* [#8984](https://github.com/rubocop-hq/rubocop/pull/8984): Support auto-correction for `Style/DoubleNegation`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2993,7 +2993,7 @@ Style/DoubleNegation:
   StyleGuide: '#no-bang-bang'
   Enabled: true
   VersionAdded: '0.19'
-  VersionChanged: '0.84'
+  VersionChanged: '1.2'
   EnforcedStyle: allowed_in_returns
   SafeAutoCorrect: false
   SupportedStyles:

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -2497,9 +2497,9 @@ end
 
 | Enabled
 | Yes
-| No
+| Yes (Unsafe)
 | 0.19
-| 0.84
+| 1.2
 |===
 
 This cop checks for uses of double negation (`!!`) to convert something to a boolean value.

--- a/lib/rubocop/cop/style/double_negation.rb
+++ b/lib/rubocop/cop/style/double_negation.rb
@@ -34,6 +34,7 @@ module RuboCop
       # this is rarely a problem in practice.
       class DoubleNegation < Base
         include ConfigurableEnforcedStyle
+        extend AutoCorrector
 
         MSG = 'Avoid the use of double negation (`!!`).'
         RESTRICT_ON_SEND = %i[!].freeze
@@ -44,7 +45,11 @@ module RuboCop
           return unless double_negative?(node) && node.prefix_bang?
           return if style == :allowed_in_returns && allowed_in_returns?(node)
 
-          add_offense(node.loc.selector)
+          location = node.loc.selector
+          add_offense(location) do |corrector|
+            corrector.remove(location)
+            corrector.insert_after(node, '.nil?')
+          end
         end
 
         private

--- a/spec/rubocop/cop/style/double_negation_spec.rb
+++ b/spec/rubocop/cop/style/double_negation_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::Cop::Style::DoubleNegation, :config do
   end
 
   shared_examples 'common' do
-    it 'does not register an offense for `!!` when not a return location' do
+    it 'does not register an offense and corrects for `!!` when not a return location' do
       expect_offense(<<~RUBY)
         def foo?
           foo
@@ -17,12 +17,24 @@ RSpec.describe RuboCop::Cop::Style::DoubleNegation, :config do
           bar
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def foo?
+          foo
+          !test.something.nil?
+          bar
+        end
+      RUBY
     end
 
-    it 'registers an offense for `!!`' do
+    it 'registers an offense and corrects for `!!`' do
       expect_offense(<<~RUBY)
         !!test.something
         ^ Avoid the use of double negation (`!!`).
+      RUBY
+
+      expect_correction(<<~RUBY)
+        !test.something.nil?
       RUBY
     end
 
@@ -65,7 +77,7 @@ RSpec.describe RuboCop::Cop::Style::DoubleNegation, :config do
 
     include_examples 'common'
 
-    it 'registers an offense for `!!` when return location' do
+    it 'registers an offense and corrects for `!!` when return location' do
       expect_offense(<<~RUBY)
         def foo?
           bar
@@ -73,9 +85,16 @@ RSpec.describe RuboCop::Cop::Style::DoubleNegation, :config do
           ^ Avoid the use of double negation (`!!`).
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def foo?
+          bar
+          !baz.do_something.nil?
+        end
+      RUBY
     end
 
-    it 'does not register an offense for `!!` when using `return` keyword' do
+    it 'registers an offense and corrects for `!!` when using `return` keyword' do
       expect_offense(<<~RUBY)
         def foo?
           return !!bar.do_something if condition
@@ -83,6 +102,14 @@ RSpec.describe RuboCop::Cop::Style::DoubleNegation, :config do
           baz
           !!bar
           ^ Avoid the use of double negation (`!!`).
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo?
+          return !bar.do_something.nil? if condition
+          baz
+          !bar.nil?
         end
       RUBY
     end


### PR DESCRIPTION
This PR supports auto-correction for `Style/DoubleNegation`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
