### PR TITLE
Allow Metrics/AbcSize skip wide array/hash literals with nested method calls

### DIFF
--- a/changelog/new_add_count_as_one_for_abc_size.md
+++ b/changelog/new_add_count_as_one_for_abc_size.md
@@ -1,0 +1,1 @@
+* [#8986](https://github.com/rubocop-hq/rubocop/pull/8986): Add new `CountAsOne` option for `Metric/AbcSize` cop. ([@razum2um][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2072,6 +2072,7 @@ Metrics/AbcSize:
   # The ABC size is a calculated magnitude, so this number can be an Integer or
   # a Float.
   IgnoredMethods: []
+  CountAsOne: []
   Max: 17
 
 Metrics/BlockLength:

--- a/docs/modules/ROOT/pages/cops_metrics.adoc
+++ b/docs/modules/ROOT/pages/cops_metrics.adoc
@@ -17,12 +17,40 @@ configured maximum. The ABC size is based on assignments, branches
 (method calls), and conditions. See http://c2.com/cgi/wiki?AbcMetric
 and https://en.wikipedia.org/wiki/ABC_Software_Metric.
 
+You can set literals you want to fold with `CountAsOne`.
+Available are: 'array', 'hash'. Each literal
+will be counted as one branch regardless of its values branch counts,
+but only if any value has branches (e.g. is/includes a method call)
+
+=== Examples
+
+==== CountAsOne: ['array', 'hash']
+
+[source,ruby]
+----
+def m
+  Klass.new([
+    private_m.foo,
+    private_m.bar
+  ]) # 1 (construstor) + 1 (array includes calls)
+
+  Klass.new(
+    key: private_m.foo,
+    bar: private_m.bar
+  ) # 1 (construstor) + 1 (hash values includes calls)
+end
+----
+
 === Configurable attributes
 
 |===
 | Name | Default value | Configurable values
 
 | IgnoredMethods
+| `[]`
+| Array
+
+| CountAsOne
 | `[]`
 | Array
 

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -358,6 +358,7 @@ require_relative 'rubocop/cop/lint/void'
 require_relative 'rubocop/cop/metrics/utils/iterating_block'
 require_relative 'rubocop/cop/metrics/cyclomatic_complexity'
 # relies on cyclomatic_complexity
+require_relative 'rubocop/cop/metrics/abc_size_result'
 require_relative 'rubocop/cop/metrics/utils/abc_size_calculator'
 require_relative 'rubocop/cop/metrics/utils/code_length_calculator'
 require_relative 'rubocop/cop/metrics/abc_size'

--- a/lib/rubocop/cop/metrics/abc_size.rb
+++ b/lib/rubocop/cop/metrics/abc_size.rb
@@ -7,6 +7,26 @@ module RuboCop
       # configured maximum. The ABC size is based on assignments, branches
       # (method calls), and conditions. See http://c2.com/cgi/wiki?AbcMetric
       # and https://en.wikipedia.org/wiki/ABC_Software_Metric.
+      #
+      # You can set literals you want to fold with `CountAsOne`.
+      # Available are: 'array', 'hash'. Each literal
+      # will be counted as one branch regardless of its values branch counts,
+      # but only if any value has branches (e.g. is/includes a method call)
+      #
+      # @example CountAsOne: ['array', 'hash']
+      #
+      #   def m
+      #     Klass.new([
+      #       private_m.foo,
+      #       private_m.bar
+      #     ]) # 1 (construstor) + 1 (array includes calls)
+      #
+      #     Klass.new(
+      #       key: private_m.foo,
+      #       bar: private_m.bar
+      #     ) # 1 (construstor) + 1 (hash values includes calls)
+      #   end
+      #
       class AbcSize < Base
         include MethodComplexity
 
@@ -16,7 +36,11 @@ module RuboCop
         private
 
         def complexity(node)
-          Utils::AbcSizeCalculator.calculate(node)
+          Utils::AbcSizeCalculator.calculate(node, foldable_types: count_as_one)
+        end
+
+        def count_as_one
+          Array(cop_config['CountAsOne']).map(&:to_sym)
         end
       end
     end

--- a/lib/rubocop/cop/metrics/abc_size_result.rb
+++ b/lib/rubocop/cop/metrics/abc_size_result.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Metrics
+      module Utils
+        # Tiny wrapper to replace string explanation result of AbcSizeCalculator
+        class AbcSizeResult
+          attr_reader :assignment, :branch, :condition
+
+          def initialize(assignment, branch, condition)
+            @assignment = assignment
+            @branch = branch
+            @condition = condition
+          end
+
+          def quadratic
+            Math.sqrt(@assignment**2 + @branch**2 + @condition**2).round(2)
+          end
+
+          def to_s
+            "<#{@assignment}, #{@branch}, #{@condition}>"
+          end
+          alias inspect to_s
+
+          def eql?(other)
+            case other
+            when AbcSizeResult
+              @assignment == other.assignment &&
+                @branch == branch.assignment &&
+                @condition == other.condition
+            else
+              to_s == other.to_s
+            end
+          end
+          alias == eql?
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We had code pieces like 

```
def builder_meth
  ActiveRecordModel.new(
    attr1: x.attr1,
    attr2: x.attr2,
    attr3: y.attr3,
    attr4: y.attr4
  )
end
```

The current defaults for `Metrics/AbcSize` grows at double speed along with column count. 
Now some alternative approaches:

- You may advise rewriting using `merge` + extract methods for getting `attr1` / `attr2` together,
   but really, the code looks very clean, there's nothing more **simple** than a hash declaration, isn't it?

- You may advise increasing AbcSize's limit,
   but for a non-declarative, **imperative** code is really good, so we'd rather not

I think this is very similar to what they done in https://github.com/rubocop-hq/rubocop/pull/8159

p.s. but still, I think even declarations should contribute at least something to branches, if not empty, hence added `@branches += 1` for every `folded` thing - but this is questionable, maybe it makes sense not completely `-=` but `-= (.. / 2).ceil` - what do you think?