### PR TITLE
Add good examples for `Lint/NestedPercentLiteral`

### DIFF
--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -2448,6 +2448,19 @@ attributes = {
   valid_attributes: %i[name content],
   nested_attributes: %i[name content %i[incorrectly nested]]
 }
+
+# good
+
+# Neither is incompatible with the bad case, but probably the intended code.
+attributes = {
+  valid_attributes: %i[name content],
+  nested_attributes: [:name, :content, %i[incorrectly nested]]
+}
+
+attributes = {
+  valid_attributes: %i[name content],
+  nested_attributes: [:name, :content, [:incorrectly, :nested]]
+}
 ----
 
 == Lint/NextWithoutAccumulator

--- a/lib/rubocop/cop/lint/nested_percent_literal.rb
+++ b/lib/rubocop/cop/lint/nested_percent_literal.rb
@@ -15,6 +15,20 @@ module RuboCop
       #     valid_attributes: %i[name content],
       #     nested_attributes: %i[name content %i[incorrectly nested]]
       #   }
+      #
+      #   # good
+      #
+      #   # Neither is incompatible with the bad case, but probably the intended code.
+      #   attributes = {
+      #     valid_attributes: %i[name content],
+      #     nested_attributes: [:name, :content, %i[incorrectly nested]]
+      #   }
+      #
+      #   attributes = {
+      #     valid_attributes: %i[name content],
+      #     nested_attributes: [:name, :content, [:incorrectly, :nested]]
+      #   }
+      #
       class NestedPercentLiteral < Base
         include PercentLiteral
 


### PR DESCRIPTION
This PR adds good examples for `Lint/NestedPercentLiteral` because complement examples that has only bad example.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
