### PR TITLE
Support autocorrect for lint useless setter call

### DIFF
--- a/changelog/new_support_autocorrect_for_lint_useless_setter_call.md
+++ b/changelog/new_support_autocorrect_for_lint_useless_setter_call.md
@@ -1,0 +1,1 @@
+* [#8988](https://github.com/rubocop-hq/rubocop/pull/8988): Support auto-correction for `Lint/UselessSetterCall`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2041,8 +2041,9 @@ Lint/UselessMethodDefinition:
 Lint/UselessSetterCall:
   Description: 'Checks for useless setter call to a local variable.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.13'
-  VersionChanged: '0.80'
+  VersionChanged: '1.2'
   Safe: false
 
 Lint/UselessTimes:

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -5174,13 +5174,14 @@ end
 
 | Enabled
 | No
-| No
+| Yes (Unsafe)
 | 0.13
-| 0.80
+| 1.2
 |===
 
 This cop checks for setter call to local variable as the final
 expression of a function definition.
+Its auto-correction is marked as unsafe because return value will be changed.
 
 NOTE: There are edge cases in which the local variable references a
 value that is also accessible outside the local scope. This is not

--- a/lib/rubocop/cop/lint/loop.rb
+++ b/lib/rubocop/cop/lint/loop.rb
@@ -76,10 +76,6 @@ module RuboCop
           conditional_keyword = node.while_post_type? ? 'unless' : 'if'
           "break #{conditional_keyword} #{node.condition.source}\n#{indent(node)}"
         end
-
-        def indent(node)
-          ' ' * node.loc.column
-        end
       end
     end
   end

--- a/lib/rubocop/cop/lint/useless_setter_call.rb
+++ b/lib/rubocop/cop/lint/useless_setter_call.rb
@@ -5,6 +5,7 @@ module RuboCop
     module Lint
       # This cop checks for setter call to local variable as the final
       # expression of a function definition.
+      # Its auto-correction is marked as unsafe because return value will be changed.
       #
       # NOTE: There are edge cases in which the local variable references a
       # value that is also accessible outside the local scope. This is not
@@ -29,6 +30,8 @@ module RuboCop
       #     x
       #   end
       class UselessSetterCall < Base
+        extend AutoCorrector
+
         MSG = 'Useless setter call to local variable `%<variable>s`.'
         ASSIGNMENT_TYPES = %i[lvasgn ivasgn cvasgn gvasgn].freeze
 
@@ -45,7 +48,9 @@ module RuboCop
 
           loc_name = receiver.loc.name
 
-          add_offense(loc_name, message: format(MSG, variable: loc_name.source))
+          add_offense(loc_name, message: format(MSG, variable: loc_name.source)) do |corrector|
+            corrector.insert_after(last_expr, "\n#{indent(last_expr)}#{loc_name.source}")
+          end
         end
         alias on_defs on_def
 

--- a/lib/rubocop/cop/style/bisected_attr_accessor.rb
+++ b/lib/rubocop/cop/style/bisected_attr_accessor.rb
@@ -131,10 +131,6 @@ module RuboCop
             "#{indent(macro)}#{macro.method_name} #{rest_args.map(&:source).join(', ')}"
           end
         end
-
-        def indent(node)
-          ' ' * node.loc.column
-        end
       end
     end
   end

--- a/lib/rubocop/cop/style/case_like_if.rb
+++ b/lib/rubocop/cop/style/case_like_if.rb
@@ -227,10 +227,6 @@ module RuboCop
           range_between(node.parent.loc.keyword.begin_pos, node.loc.expression.end_pos)
         end
 
-        def indent(node)
-          ' ' * node.loc.column
-        end
-
         # Named captures work with `=~` (if regexp is on lhs) and with `match` (both sides)
         def regexp_with_working_captures?(node)
           case node.type

--- a/lib/rubocop/cop/style/mixin_grouping.rb
+++ b/lib/rubocop/cop/style/mixin_grouping.rb
@@ -135,10 +135,6 @@ module RuboCop
 
           "#{node.method_name} #{mixin_names.join(', ')}"
         end
-
-        def indent(node)
-          ' ' * node.loc.column
-        end
       end
     end
   end

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -123,6 +123,10 @@ module RuboCop
           node1.loc.line == node2.loc.line
       end
 
+      def indent(node)
+        ' ' * node.loc.column
+      end
+
       def to_supported_styles(enforced_style)
         enforced_style
           .sub(/^Enforced/, 'Supported')

--- a/spec/rubocop/cop/lint/useless_setter_call_spec.rb
+++ b/spec/rubocop/cop/lint/useless_setter_call_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessSetterCall do
   subject(:cop) { described_class.new }
 
   context 'with method ending with setter call on local object' do
-    it 'registers an offense' do
+    it 'registers an offense and corrects' do
       expect_offense(<<~RUBY)
         def test
           top = Top.new
@@ -12,11 +12,19 @@ RSpec.describe RuboCop::Cop::Lint::UselessSetterCall do
           ^^^ Useless setter call to local variable `top`.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def test
+          top = Top.new
+          top.attr = 5
+          top
+        end
+      RUBY
     end
   end
 
   context 'with singleton method ending with setter call on local object' do
-    it 'registers an offense' do
+    it 'registers an offense and corrects' do
       expect_offense(<<~RUBY)
         def Top.test
           top = Top.new
@@ -24,16 +32,32 @@ RSpec.describe RuboCop::Cop::Lint::UselessSetterCall do
           ^^^ Useless setter call to local variable `top`.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def Top.test
+          top = Top.new
+          top.attr = 5
+          top
+        end
+      RUBY
     end
   end
 
   context 'with method ending with square bracket setter on local object' do
-    it 'registers an offense' do
+    it 'registers an offense and corrects' do
       expect_offense(<<~RUBY)
         def test
           top = Top.new
           top[:attr] = 5
           ^^^ Useless setter call to local variable `top`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def test
+          top = Top.new
+          top[:attr] = 5
+          top
         end
       RUBY
     end
@@ -101,12 +125,20 @@ RSpec.describe RuboCop::Cop::Lint::UselessSetterCall do
 
   context 'when a lvar does not contain any object passed as argument ' \
           'with multiple-assignment at the end of the method' do
-    it 'registers an offense' do
+    it 'registers an offense and corrects' do
       expect_offense(<<~RUBY)
         def test(some_arg)
           _first, some_lvar, _third  = do_something
           some_lvar.attr = 5
           ^^^^^^^^^ Useless setter call to local variable `some_lvar`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def test(some_arg)
+          _first, some_lvar, _third  = do_something
+          some_lvar.attr = 5
+          some_lvar
         end
       RUBY
     end
@@ -127,7 +159,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessSetterCall do
 
   context 'when a lvar does not contain any object passed as argument ' \
           'by binary-operator-assignment at the end of the method' do
-    it 'registers an offense' do
+    it 'registers an offense and corrects' do
       expect_offense(<<~RUBY)
         def test(some_arg)
           some_lvar = some_arg
@@ -136,12 +168,21 @@ RSpec.describe RuboCop::Cop::Lint::UselessSetterCall do
           ^^^^^^^^^ Useless setter call to local variable `some_lvar`.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def test(some_arg)
+          some_lvar = some_arg
+          some_lvar += some_arg
+          some_lvar.attr = 5
+          some_lvar
+        end
+      RUBY
     end
   end
 
   context 'when a lvar declared as an argument ' \
           'is no longer the passed object at the end of the method' do
-    it 'registers an offense for the setter call on the lvar' do
+    it 'registers an offense and corrects for the setter call on the lvar' do
       expect_offense(<<~RUBY)
         def test(some_arg)
           some_arg = Top.new
@@ -149,16 +190,32 @@ RSpec.describe RuboCop::Cop::Lint::UselessSetterCall do
           ^^^^^^^^ Useless setter call to local variable `some_arg`.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def test(some_arg)
+          some_arg = Top.new
+          some_arg.attr = 5
+          some_arg
+        end
+      RUBY
     end
   end
 
   context 'when a lvar contains a local object instantiated with literal' do
-    it 'registers an offense for the setter call on the lvar' do
+    it 'registers an offense and corrects for the setter call on the lvar' do
       expect_offense(<<~RUBY)
         def test
           some_arg = {}
           some_arg[:attr] = 1
           ^^^^^^^^ Useless setter call to local variable `some_arg`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def test
+          some_arg = {}
+          some_arg[:attr] = 1
+          some_arg
         end
       RUBY
     end


### PR DESCRIPTION
This PR supports auto-correction for `Lint/UselessSetterCall`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
