### PR TITLE
Fix multibyte support in the regexp node handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug fixes
 
+* [#8989](https://github.com/rubocop-hq/rubocop/pull/8989): Fix multibyte support in the regexp node handler that led `Style/RedundantRegexpEscape` to malfunction and corrupt a program in auto-correction. ([@knu][])
 * [#8912](https://github.com/rubocop-hq/rubocop/pull/8912): Fix `Layout/ElseAlignment` for `rescue/else/ensure` inside `do/end` blocks with assignment. ([@miry][])
 * [#8971](https://github.com/rubocop-hq/rubocop/issues/8971): Fix a false alarm for `# rubocop:disable Lint/EmptyBlock` inline comment with `Lint/RedundantCopDisableDirective`. ([@koic][])
 * [#8976](https://github.com/rubocop-hq/rubocop/issues/8976): Fix an incorrect auto-correct for `Style/KeywordParametersOrder` when when `kwoptarg` is before `kwarg` and argument parentheses omitted. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_regexp_escape.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_escape.rb
@@ -82,7 +82,7 @@ module RuboCop
 
         def each_escape(node)
           node.parsed_tree&.traverse&.reduce(0) do |char_class_depth, (event, expr)|
-            yield(expr.text[1], expr.ts, !char_class_depth.zero?) if expr.type == :escape
+            yield(expr.text[1], expr.start_index, !char_class_depth.zero?) if expr.type == :escape
 
             if expr.type == :set
               char_class_depth + (event == :enter ? 1 : -1)

--- a/lib/rubocop/ext/regexp_node.rb
+++ b/lib/rubocop/ext/regexp_node.rb
@@ -19,13 +19,18 @@ module RuboCop
         super
 
         str = with_interpolations_blanked
-        @parsed_tree = begin
-          Regexp::Parser.parse(str, options: options)
+        begin
+          @parsed_tree = Regexp::Parser.parse(str, options: options)
         rescue StandardError
-          nil
+          @parsed_tree = nil
+        else
+          origin = loc.begin.end
+          source = @parsed_tree.to_s
+          @parsed_tree.each_expression(true) do |e|
+            e.origin = origin
+            e.source = source
+          end
         end
-        origin = loc.begin.end
-        @parsed_tree&.each_expression(true) { |e| e.origin = origin }
       end
 
       def each_capture(named: ANY)

--- a/lib/rubocop/ext/regexp_parser.rb
+++ b/lib/rubocop/ext/regexp_parser.rb
@@ -20,11 +20,18 @@ module RuboCop
       module Expression
         # Add `expression` and `loc` to all `regexp_parser` nodes
         module Base
-          attr_accessor :origin
+          attr_accessor :origin, :source
+
+          def start_index
+            # ts is a byte index; convert it to a character index
+            @start_index ||= source.byteslice(0, ts).length
+          end
 
           # Shortcut to `loc.expression`
           def expression
-            @expression ||= origin.adjust(begin_pos: ts, end_pos: ts + full_length)
+            @expression ||= begin
+              origin.adjust(begin_pos: start_index, end_pos: start_index + full_length)
+            end
           end
 
           # @returns a location map like `parser` does, with:

--- a/spec/rubocop/cop/style/redundant_regexp_escape_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_escape_spec.rb
@@ -518,4 +518,21 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpEscape do
       end
     end
   end
+
+  context 'with multibyte characters' do
+    it 'removes the escape character at the right position' do
+      # The indicator should take character widths into account in the
+      # future.
+      expect_offense(<<~'RUBY')
+        x = s[/[一二三四\.]+/]
+                    ^^ Redundant escape inside regexp literal
+        p x
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        x = s[/[一二三四.]+/]
+        p x
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Auto-correction by Style/RedundantRegexpEscape can corrupt a program by removing a character at the wrong index when it deals with a regexp pattern containing multibyte characters.

```console
% cat a.rb
x = s[/[一二\.]+/]
p x
% be rubocop -a a.rb
Inspecting 1 file
F

Offenses:

a.rb:1:7: F: Lint/Syntax: unterminated string meets end of file
(Using Ruby 2.4 parser; configure using TargetRubyVersion parameter, under AllCops)
x = s[/[一二\.]+]
      ^
a.rb:1:15: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
x = s[/[一二\.]+/]
              ^^

1 file inspected, 2 offenses detected, 1 offense corrected
% cat a.rb
x = s[/[一二\.]+]
p x
```

Note that the closing slash is removed instead of the redundant backslash.

The problem is that the cop mixes byte index with character index and results in manipulating source code with the wrong index values.  Regexp::Parser stores byte index in Regexp::Expression#ts and that is the source of confusion.

It can be fixed by converting index values like this, but ideally it should be done in Regexp::Parser.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
