### PR TITLE
Support auto-correction for `Lint/ElseLayout`

### DIFF
--- a/changelog/new_support_autocorrect_for_lint_else_layout.md
+++ b/changelog/new_support_autocorrect_for_lint_else_layout.md
@@ -1,0 +1,1 @@
+* [#8992](https://github.com/rubocop-hq/rubocop/pull/8992): Support auto-correction for `Lint/ElseLayout`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1478,6 +1478,7 @@ Lint/ElseLayout:
   Description: 'Check for odd code arrangement in an else block.'
   Enabled: true
   VersionAdded: '0.17'
+  VersionChanged: '1.2'
 
 Lint/EmptyBlock:
   Description: 'This cop checks for blocks without a body.'

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -991,14 +991,18 @@ sum = numbers.each_with_object(num) { |e, a| a += e }
 
 | Enabled
 | Yes
-| No
+| Yes
 | 0.17
-| -
+| 1.2
 |===
 
-This cop checks for odd else block layout - like
-having an expression on the same line as the else keyword,
+This cop checks for odd `else` block layout - like
+having an expression on the same line as the `else` keyword,
 which is usually a mistake.
+
+Its auto-correction tweaks layout to keep the syntax. So, this auto-correction
+is compatible correction for bad case syntax, but if your code makes a mistake
+with `elsif` and `else`, you will have to correct it manually.
 
 === Examples
 
@@ -1017,10 +1021,19 @@ end
 ----
 # good
 
+# This code is compatible with the bad case. It will be auto-corrected like this.
 if something
   # ...
 else
   do_this
+  do_that
+end
+
+# This code is incompatible with the bad case.
+# If `do_this` is a condition, `elsif` should be used instead of `else`.
+if something
+  # ...
+elsif do_this
   do_that
 end
 ----

--- a/lib/rubocop/cop/lint/else_layout.rb
+++ b/lib/rubocop/cop/lint/else_layout.rb
@@ -3,9 +3,13 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for odd else block layout - like
-      # having an expression on the same line as the else keyword,
+      # This cop checks for odd `else` block layout - like
+      # having an expression on the same line as the `else` keyword,
       # which is usually a mistake.
+      #
+      # Its auto-correction tweaks layout to keep the syntax. So, this auto-correction
+      # is compatible correction for bad case syntax, but if your code makes a mistake
+      # with `elsif` and `else`, you will have to correct it manually.
       #
       # @example
       #
@@ -21,13 +25,25 @@ module RuboCop
       #
       #   # good
       #
+      #   # This code is compatible with the bad case. It will be auto-corrected like this.
       #   if something
       #     # ...
       #   else
       #     do_this
       #     do_that
       #   end
+      #
+      #   # This code is incompatible with the bad case.
+      #   # If `do_this` is a condition, `elsif` should be used instead of `else`.
+      #   if something
+      #     # ...
+      #   elsif do_this
+      #     do_that
+      #   end
       class ElseLayout < Base
+        include RangeHelp
+        extend AutoCorrector
+
         MSG = 'Odd `else` layout detected. Did you mean to use `elsif`?'
 
         def on_if(node)
@@ -58,7 +74,17 @@ module RuboCop
           return unless first_else
           return unless first_else.source_range.line == node.loc.else.line
 
-          add_offense(first_else)
+          add_offense(first_else) do |corrector|
+            autocorrect(corrector, node, first_else)
+          end
+        end
+
+        def autocorrect(corrector, node, first_else)
+          corrector.insert_after(node.loc.else, "\n")
+
+          blank_range = range_between(node.loc.else.end_pos, first_else.loc.expression.begin_pos)
+          indentation = indent(node.else_branch.children[1])
+          corrector.replace(blank_range, indentation)
         end
       end
     end

--- a/spec/rubocop/cop/lint/else_layout_spec.rb
+++ b/spec/rubocop/cop/lint/else_layout_spec.rb
@@ -3,12 +3,22 @@
 RSpec.describe RuboCop::Cop::Lint::ElseLayout do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for expr on same line as else' do
+  it 'registers an offense and corrects for expr on same line as else' do
     expect_offense(<<~RUBY)
       if something
         test
       else ala
            ^^^ Odd `else` layout detected. Did you mean to use `elsif`?
+        something
+        test
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if something
+        test
+      else
+        ala
         something
         test
       end
@@ -35,7 +45,7 @@ RSpec.describe RuboCop::Cop::Lint::ElseLayout do
     RUBY
   end
 
-  it 'can handle elsifs' do
+  it 'registers an offense and corrects for elsifs' do
     expect_offense(<<~RUBY)
       if something
         test
@@ -43,6 +53,18 @@ RSpec.describe RuboCop::Cop::Lint::ElseLayout do
         bala
       else ala
            ^^^ Odd `else` layout detected. Did you mean to use `elsif`?
+        something
+        test
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if something
+        test
+      elsif something
+        bala
+      else
+        ala
         something
         test
       end


### PR DESCRIPTION
This PR supports auto-correction for `Lint/ElseLayout`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
