### PR TITLE
[Fix #8996] Fix a false positive for `Style/MultipleComparison`

### DIFF
--- a/changelog/fix_false_positive_for_multiple_comparison.md
+++ b/changelog/fix_false_positive_for_multiple_comparison.md
@@ -1,0 +1,1 @@
+* [#8996](https://github.com/rubocop-hq/rubocop/issues/8996): Fix a false positive for `Style/MultipleComparison` when comparing two sides of the disjunction is unrelated. ([@koic][])

--- a/lib/rubocop/cop/style/multiple_comparison.rb
+++ b/lib/rubocop/cop/style/multiple_comparison.rb
@@ -48,6 +48,7 @@ module RuboCop
 
         def on_new_investigation
           @compared_elements = []
+          @allowed_method_comparison = false
         end
 
         def on_or(node)
@@ -55,6 +56,7 @@ module RuboCop
 
           return unless node == root_of_or_node
           return unless nested_variable_comparison?(root_of_or_node)
+          return if @allowed_method_comparison
 
           add_offense(node) do |corrector|
             elements = @compared_elements.join(', ')
@@ -95,8 +97,7 @@ module RuboCop
             return [variable_name(var1), variable_name(var2)]
           end
           if (var, obj = simple_comparison_lhs?(node)) || (obj, var = simple_comparison_rhs?(node))
-            return [] if allow_method_comparison? && obj.send_type?
-
+            @allowed_method_comparison = true if allow_method_comparison? && obj.send_type?
             @compared_elements << obj.source
             return [variable_name(var)]
           end

--- a/spec/rubocop/cop/style/multiple_comparison_spec.rb
+++ b/spec/rubocop/cop/style/multiple_comparison_spec.rb
@@ -177,6 +177,14 @@ RSpec.describe RuboCop::Cop::Style::MultipleComparison, :config do
     end
   end
 
+  it 'does not register an offense when comparing two sides of the disjunction is unrelated' do
+    expect_no_offenses(<<~RUBY)
+      def do_something(foo, bar)
+        bar.do_something == bar || foo == :sym
+      end
+    RUBY
+  end
+
   context 'when `AllowMethodComparison: false`' do
     let(:cop_config) { { 'AllowMethodComparison' => false } }
 


### PR DESCRIPTION
Fixes #8996.

This PR fixes a false positive for `Style/MultipleComparison` when comparing two sides of the disjunction is unrelated.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
