### PR TITLE
[Fix #8998] Fix an error for `Style/NegatedIfElseCondition`

### DIFF
--- a/changelog/fix_an_error_for_negated_if_else_condition.md
+++ b/changelog/fix_an_error_for_negated_if_else_condition.md
@@ -1,0 +1,1 @@
+* [#8998](https://github.com/rubocop-hq/rubocop/issues/8998): Fix an error for `Style/NegatedIfElseCondition` when using negated condition and `if` branch body is empty. ([@koic][])

--- a/lib/rubocop/cop/style/negated_if_else_condition.rb
+++ b/lib/rubocop/cop/style/negated_if_else_condition.rb
@@ -28,6 +28,7 @@ module RuboCop
       #   x ? do_something_else : do_something
       #
       class NegatedIfElseCondition < Base
+        include RangeHelp
         extend AutoCorrector
 
         MSG = 'Invert the negated condition and swap the %<type>s branches.'
@@ -90,8 +91,12 @@ module RuboCop
         end
 
         def swap_branches(corrector, node)
-          corrector.replace(node.if_branch, node.else_branch.source)
-          corrector.replace(node.else_branch, node.if_branch.source)
+          if node.if_branch.nil?
+            corrector.remove(range_by_whole_lines(node.loc.else, include_final_newline: true))
+          else
+            corrector.replace(node.if_branch, node.else_branch.source)
+            corrector.replace(node.else_branch, node.if_branch.source)
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/negated_if_else_condition_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_else_condition_spec.rb
@@ -115,6 +115,22 @@ RSpec.describe RuboCop::Cop::Style::NegatedIfElseCondition do
     RUBY
   end
 
+  it 'registers an offense when using negated condition and `if` branch body is empty' do
+    expect_offense(<<~RUBY)
+      if !condition.nil?
+      ^^^^^^^^^^^^^^^^^^ Invert the negated condition and swap the if-else branches.
+      else
+        foo = 42
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if condition.nil?
+        foo = 42
+      end
+    RUBY
+  end
+
   it 'does not register an offense when negating condition for `if-elsif`' do
     expect_no_offenses(<<~RUBY)
       if !x


### PR DESCRIPTION
Fixes #8998.

This PR fixes an error for `Style/NegatedIfElseCondition` when using negated condition and `if` branch body is empty.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
