### PR TITLE
Remove obsolete gem `SafeYAML` compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem 'test-queue'
 gem 'yard', '~> 0.9'
 
 group :test do
-  gem 'safe_yaml', require: false
   gem 'webmock', require: false
 end
 

--- a/changelog/change_remove_obsolete_gem_safeyaml.md
+++ b/changelog/change_remove_obsolete_gem_safeyaml.md
@@ -1,0 +1,1 @@
+* [#9004](https://github.com/rubocop-hq/rubocop/pull/9004): Remove obsolete gem `SafeYAML` compatibility. ([@marcandre][])

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -255,17 +255,18 @@ module RuboCop
               "Configuration file not found: #{absolute_path}"
       end
 
-      def yaml_safe_load(yaml_code, filename)
-        if defined?(SafeYAML) && SafeYAML.respond_to?(:load)
-          SafeYAML.load(yaml_code, filename, whitelisted_tags: %w[!ruby/regexp])
-        # Ruby 2.6+
-        elsif Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0')
+      raise 'SafeYAML is unmaintained, no longer needed and should be removed' if defined?(SafeYAML)
+
+      if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0')
+        def yaml_safe_load(yaml_code, filename)
           YAML.safe_load(yaml_code,
                          permitted_classes: [Regexp, Symbol],
                          permitted_symbols: [],
                          aliases: true,
                          filename: filename)
-        else
+        end
+      else # Ruby < 2.6
+        def yaml_safe_load(yaml_code, filename)
           YAML.safe_load(yaml_code, [Regexp, Symbol], [], true, filename)
         end
       end

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1307,51 +1307,6 @@ RSpec.describe RuboCop::ConfigLoader do
       expect(configuration.to_h).to eq({})
     end
 
-    context 'when SafeYAML is required' do
-      before do
-        create_file(configuration_path, <<~YAML)
-          Style/WordArray:
-            WordRegex: !ruby/regexp '/\\A[\\p{Word}]+\\z/'
-        YAML
-      end
-
-      context 'when it is fully required', broken_on: :ruby_head do
-        it 'de-serializes Regexp class' do
-          in_its_own_process_with('safe_yaml') do
-            configuration = described_class.load_file('.rubocop.yml')
-
-            word_regexp = configuration['Style/WordArray']['WordRegex']
-            expect(word_regexp.is_a?(::Regexp)).to be(true)
-          end
-        end
-      end
-
-      context 'when safe_yaml is required without monkey patching', broken_on: :ruby_head do
-        it 'de-serializes Regexp class' do
-          in_its_own_process_with('safe_yaml/load') do
-            configuration = described_class.load_file('.rubocop.yml')
-
-            word_regexp = configuration['Style/WordArray']['WordRegex']
-            expect(word_regexp.is_a?(::Regexp)).to be(true)
-          end
-        end
-
-        context 'and SafeYAML.load is private' do
-          # According to issue #2935, SafeYAML.load can be private in some
-          # circumstances.
-          it 'does not raise private method load called for SafeYAML:Module' do
-            in_its_own_process_with('safe_yaml/load') do
-              SafeYAML.public_send :private_class_method, :load
-              configuration = described_class.load_file('.rubocop.yml')
-
-              word_regexp = configuration['Style/WordArray']['WordRegex']
-              expect(word_regexp.is_a?(::Regexp)).to be(true)
-            end
-          end
-        end
-      end
-    end
-
     context 'set neither true nor false to value to Enabled' do
       before do
         create_file(configuration_path, <<~YAML)


### PR DESCRIPTION
AFAIK, there is no longer any reason to use `SafeYAML`.

This is what was causing issues on `ruby-head`, the gem is incompatible with keyword parameters.