### PR TITLE
Enable RSpec/StubbedMock

### DIFF
--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
       context 'when team external_dependency_checksum changes' do
         it 'is invalid' do
           cache.save(offenses)
-          expect(team).to(
+          allow(team).to(
             receive(:external_dependency_checksum).and_return('bar')
           )
           cache2 = described_class.new(
@@ -188,7 +188,7 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
       context 'when team external_dependency_checksum is the same' do
         it 'is valid' do
           cache.save(offenses)
-          expect(team).to(
+          allow(team).to(
             receive(:external_dependency_checksum).and_return('foo')
           )
           cache2 = described_class.new(
@@ -329,8 +329,8 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
       end
 
       it 'doesn\'t raise an exception' do
-        expect(FileUtils).to receive(:mkdir_p).with(start_with(cache_root))
-                                              .and_raise(error)
+        allow(FileUtils).to receive(:mkdir_p).with(start_with(cache_root))
+                                             .and_raise(error)
         expect { cache.save([]) }.not_to raise_error
         expect($stderr.string).to eq(<<~WARN)
           Couldn't create cache directory. Continuing without cache.


### PR DESCRIPTION
I know this cop can be controversial, and maybe we don't want to *always* enforce its recommended style.

But in all three cases found in our spec suite, the mock (defined by `expect`) is entirely unnecessary - using a stub (with `allow`) is enough. If any of the stubs are changed, other expectations in each example will fail.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
