### PR TITLE
Fix an infinite loop when autocorrecting `Layout/TrailingWhitespace` + `Lint/LiteralInInterpolation`

### DIFF
--- a/changelog/fix_literal_in_interpolation_infinite_loop.md
+++ b/changelog/fix_literal_in_interpolation_infinite_loop.md
@@ -1,0 +1,1 @@
+* [#8975](https://github.com/rubocop-hq/rubocop/issues/8975): Fix an infinite loop when autocorrecting `Layout/TrailingWhitespace` + `Lint/LiteralInInterpolation`. ([@fatkodima][])

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -283,6 +283,14 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
     RUBY
   end
 
+  it 'does not register an offense when space literal at the end of heredoc line' do
+    expect_no_offenses(<<~RUBY)
+      <<~HERE
+        Line with explicit space literal at the end. \#{'  '}
+      HERE
+    RUBY
+  end
+
   context 'in string-like contexts' do
     let(:literal) { '42' }
     let(:expected) { '42' }


### PR DESCRIPTION
Closes #8975

cc @marcandre 