### PR TITLE
Mark `Style/InfiniteLoop` as unsafe

### DIFF
--- a/changelog/fix_mark_styleinfiniteloop_as_unsafe.md
+++ b/changelog/fix_mark_styleinfiniteloop_as_unsafe.md
@@ -1,0 +1,1 @@
+* [#9008](https://github.com/rubocop-hq/rubocop/pull/9008): Mark `Style/InfiniteLoop` as unsafe. ([@marcandre][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3356,12 +3356,14 @@ Style/ImplicitRuntimeError:
   VersionAdded: '0.41'
 
 Style/InfiniteLoop:
-  Description: 'Use Kernel#loop for infinite loops.'
+  Description: >-
+                 Use Kernel#loop for infinite loops.
+                 This cop is unsafe in the body may raise a `StopIteration` exception.
+  Safe: false
   StyleGuide: '#infinite-loop'
   Enabled: true
   VersionAdded: '0.26'
   VersionChanged: '0.61'
-  SafeAutoCorrect: true
 
 Style/InlineComment:
   Description: 'Avoid trailing inline comments.'

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -4602,13 +4602,17 @@ raise ArgumentError, 'Error message here'
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
 | Enabled
-| Yes
-| Yes
+| No
+| Yes (Unsafe)
 | 0.26
 | 0.61
 |===
 
 Use `Kernel#loop` for infinite loops.
+
+This cop is marked as unsafe as the rule does not necessarily
+apply if the body might raise a `StopIteration` exception; contrary to
+other infinite loops, `Kernel#loop` silently rescues that and returns `nil`.
 
 === Examples
 

--- a/lib/rubocop/cop/style/infinite_loop.rb
+++ b/lib/rubocop/cop/style/infinite_loop.rb
@@ -5,6 +5,10 @@ module RuboCop
     module Style
       # Use `Kernel#loop` for infinite loops.
       #
+      # This cop is marked as unsafe as the rule does not necessarily
+      # apply if the body might raise a `StopIteration` exception; contrary to
+      # other infinite loops, `Kernel#loop` silently rescues that and returns `nil`.
+      #
       # @example
       #   # bad
       #   while true


### PR DESCRIPTION
I noticed this while backporting `Ractor`. In particular `Ractor::ClosedError` and `CloseQueueError` are `StopIteration`