### PR TITLE
Update RuboCop version of CONTRIBUTING.md when releasing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,5 +36,5 @@ Include the output of `rubocop -V` or `bundle exec rubocop -V` if using Bundler.
 
 ```
 $ [bundle exec] rubocop -V
-1.2.0 (using Parser 2.5.1.2, running on ruby 2.5.1 x86_64-linux)
+1.2.0 (using Parser 2.7.2.0, rubocop-ast 1.1.1, running on ruby 2.7.2 x86_64-linux)
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ do so.
 
 ```
 $ rubocop -V
-0.50.0 (using Parser 2.4.0.0, running on ruby 2.4.2 x86_64-linux)
+1.2.0 (using Parser 2.7.2.0, rubocop-ast 1.1.1, running on ruby 2.7.2 x86_64-linux)
 ```
 
 * Include any relevant code to the issue summary.

--- a/tasks/cut_release.rake
+++ b/tasks/cut_release.rake
@@ -57,6 +57,17 @@ namespace :cut_release do
     end
   end
 
+  def update_contributing_doc(old_version, new_version)
+    contributing_doc = File.read('CONTRIBUTING.md')
+
+    File.open('CONTRIBUTING.md', 'w') do |f|
+      f << contributing_doc.sub(
+        "#{old_version} (using Parser ",
+        "#{new_version} (using Parser "
+      )
+    end
+  end
+
   def add_header_to_changelog(version)
     changelog = File.read('CHANGELOG.md')
     head, tail = changelog.split("## master (unreleased)\n\n", 2)
@@ -101,6 +112,7 @@ namespace :cut_release do
     update_readme(old_version, new_version)
     update_docs(old_version, new_version)
     update_issue_template(old_version, new_version)
+    update_contributing_doc(old_version, new_version)
     add_header_to_changelog(new_version)
     create_release_notes(new_version)
 


### PR DESCRIPTION
This PR updates RuboCop version of CONTRIBUTING.md when releasing and tweaks example of `rubocop -V`.

This PR related to #6342.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
