### PR TITLE
`Metrics/ParameterLists` supports `MaxOptionalParameters` config parameter

### DIFF
--- a/changelog/new_add_max_optional_parameters_to_parameter_lists_cop.md
+++ b/changelog/new_add_max_optional_parameters_to_parameter_lists_cop.md
@@ -1,0 +1,1 @@
+* [#9010](https://github.com/rubocop-hq/rubocop/pull/9010): `Metrics/ParameterLists` supports `MaxOptionalParameters` config parameter. ([@fatkodima][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2185,8 +2185,10 @@ Metrics/ParameterLists:
   StyleGuide: '#too-many-params'
   Enabled: true
   VersionAdded: '0.25'
+  VersionChanged: '<<next>>'
   Max: 5
   CountKeywordArgs: true
+  MaxOptionalParameters: 3
 
 Metrics/PerceivedComplexity:
   Description: >-

--- a/lib/rubocop/cop/metrics/parameter_lists.rb
+++ b/lib/rubocop/cop/metrics/parameter_lists.rb
@@ -36,14 +36,43 @@ module RuboCop
       #   # good (assuming Max is 3)
       #   def foo(a, b, c, d: 1)
       #   end
+      #
+      # This cop also checks for the maximum number of optional parameters.
+      # This can be configured using the `MaxOptionalParameters` config option.
+      #
+      # @example MaxOptionalParameters: 3 (default)
+      #   # good
+      #   def foo(a = 1, b = 2, c = 3)
+      #   end
+      #
+      # @example MaxOptionalParameters: 2
+      #   # bad
+      #   def foo(a = 1, b = 2, c = 3)
+      #   end
+      #
       class ParameterLists < Base
         include ConfigurableMax
 
         MSG = 'Avoid parameter lists longer than %<max>d parameters. ' \
               '[%<count>d/%<max>d]'
+        OPTIONAL_PARAMETERS_MSG = 'Method has too many optional parameters. [%<count>d/%<max>d]'
 
         NAMED_KEYWORD_TYPES = %i[kwoptarg kwarg].freeze
         private_constant :NAMED_KEYWORD_TYPES
+
+        def on_def(node)
+          optargs = node.arguments.select(&:optarg_type?)
+          return if optargs.count <= max_optional_parameters
+
+          message = format(
+            OPTIONAL_PARAMETERS_MSG,
+            max: max_optional_parameters,
+            count: optargs.count
+          )
+
+          add_offense(node, message: message)
+        end
+        alias on_defs on_def
 
         def on_args(node)
           count = args_count(node)
@@ -72,6 +101,10 @@ module RuboCop
 
         def max_params
           cop_config['Max']
+        end
+
+        def max_optional_parameters
+          cop_config['MaxOptionalParameters']
         end
 
         def count_keyword_args?

--- a/spec/rubocop/cop/metrics/parameter_lists_spec.rb
+++ b/spec/rubocop/cop/metrics/parameter_lists_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe RuboCop::Cop::Metrics::ParameterLists, :config do
   let(:cop_config) do
     {
       'Max' => 4,
-      'CountKeywordArgs' => true
+      'CountKeywordArgs' => true,
+      'MaxOptionalParameters' => 3
     }
   end
 
@@ -61,5 +62,20 @@ RSpec.describe RuboCop::Cop::Metrics::ParameterLists, :config do
         end
       RUBY
     end
+  end
+
+  it 'registers an offense when optargs count exceeds the maximum' do
+    expect_offense(<<~RUBY)
+      def foo(a = 1, b = 2, c = 3, d = 4)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method has too many optional parameters. [4/3]
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when method has allowed amount of optargs' do
+    expect_no_offenses(<<~RUBY)
+      def foo(a, b = 2, c = 3, d = 4)
+      end
+    RUBY
   end
 end


### PR DESCRIPTION
This is an implementation of https://rubystyle.guide/#keyword-arguments-vs-optional-arguments

Not sure if something like `IgnoredMethods` should be added - like for this https://github.com/rubocop-hq/rubocop/compare/master...fatkodima:too_many_default_arguments-cop?expand=1#diff-3b2d7d0e5589b3568a72de6447fa1095b2e9bae437f299ab43196979d0d50c01R36