### PR TITLE
Support auto-correction for `Style/IfInsideElse`

### DIFF
--- a/changelog/new_support_autocorrect_for_style_if_inside_else.md
+++ b/changelog/new_support_autocorrect_for_style_if_inside_else.md
@@ -1,0 +1,1 @@
+* [#9014](https://github.com/rubocop-hq/rubocop/pull/9014): Support auto-correction for `Style/IfInsideElse`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3330,6 +3330,7 @@ Style/IfInsideElse:
   Enabled: true
   AllowIfModifier: false
   VersionAdded: '0.36'
+  VersionChanged: '1.3'
 
 Style/IfUnlessModifier:
   Description: >-

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -4370,9 +4370,9 @@ end
 
 | Enabled
 | Yes
-| No
+| Yes
 | 0.36
-| -
+| 1.3
 |===
 
 If the `else` branch of a conditional consists solely of an `if` node,

--- a/lib/rubocop/cop/style/if_inside_else.rb
+++ b/lib/rubocop/cop/style/if_inside_else.rb
@@ -59,6 +59,9 @@ module RuboCop
       #   end
       #
       class IfInsideElse < Base
+        include RangeHelp
+        extend AutoCorrector
+
         MSG = 'Convert `if` nested inside `else` to `elsif`.'
 
         def on_if(node)
@@ -69,10 +72,43 @@ module RuboCop
           return unless else_branch&.if_type? && else_branch&.if?
           return if allow_if_modifier_in_else_branch?(else_branch)
 
-          add_offense(else_branch.loc.keyword)
+          add_offense(else_branch.loc.keyword) do |corrector|
+            autocorrect(corrector, else_branch)
+          end
         end
 
         private
+
+        def autocorrect(corrector, node)
+          if node.modifier_form?
+            correct_to_elsif_from_modifier_form(corrector, node)
+            end_range = node.parent.loc.end
+          else
+            correct_to_elsif_from_if_inside_else_form(corrector, node, node.condition)
+            end_range = node.loc.end
+          end
+          corrector.remove(range_by_whole_lines(end_range, include_final_newline: true))
+          corrector.remove(
+            range_by_whole_lines(node.if_branch.source_range, include_final_newline: true)
+          )
+        end
+
+        def correct_to_elsif_from_modifier_form(corrector, node)
+          corrector.replace(node.parent.loc.else, <<~RUBY.chop)
+            elsif #{node.condition.source}
+            #{indent(node.if_branch)}#{node.if_branch.source}
+            end
+          RUBY
+        end
+
+        def correct_to_elsif_from_if_inside_else_form(corrector, node, condition)
+          corrector.replace(node.parent.loc.else, "elsif #{condition.source}")
+          if_condition_range = range_between(
+            node.loc.keyword.begin_pos, condition.source_range.end_pos
+          )
+          corrector.replace(if_condition_range, node.if_branch.source)
+          corrector.remove(condition)
+        end
 
         def allow_if_modifier_in_else_branch?(else_branch)
           allow_if_modifier? && else_branch&.modifier_form?

--- a/spec/rubocop/cop/style/if_inside_else_spec.rb
+++ b/spec/rubocop/cop/style/if_inside_else_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe RuboCop::Cop::Style::IfInsideElse, :config do
         end
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      if a
+        blah
+      elsif b
+        foo
+      end
+    RUBY
   end
 
   it 'catches an if..else nested inside an else' do
@@ -26,9 +34,52 @@ RSpec.describe RuboCop::Cop::Style::IfInsideElse, :config do
         if b
         ^^ Convert `if` nested inside `else` to `elsif`.
           foo
-        else
+        else # This is expected to be auto-corrected by `Layout/IndentationWidth`.
           bar
         end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if a
+        blah
+      elsif b
+        foo
+        else # This is expected to be auto-corrected by `Layout/IndentationWidth`.
+          bar
+      end
+    RUBY
+  end
+
+  it 'catches an if..elsif..else nested inside an else' do
+    expect_offense(<<~RUBY)
+      if a
+        blah
+      else
+        if b
+        ^^ Convert `if` nested inside `else` to `elsif`.
+          foo
+        elsif c # This is expected to be auto-corrected by `Layout/IndentationWidth`.
+            bar
+        elsif d
+          baz
+        else
+          qux
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if a
+        blah
+      elsif b
+        foo
+        elsif c # This is expected to be auto-corrected by `Layout/IndentationWidth`.
+            bar
+        elsif d
+          baz
+        else
+          qux
       end
     RUBY
   end
@@ -41,6 +92,14 @@ RSpec.describe RuboCop::Cop::Style::IfInsideElse, :config do
         else
           foo if b
               ^^ Convert `if` nested inside `else` to `elsif`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if a
+          blah
+        elsif b
+          foo
         end
       RUBY
     end


### PR DESCRIPTION
This PR supports auto-correction for `Style/IfInsideElse`.
Existing `elsif` and (not inside) `else` indentation is expected to be auto-corrected by `Layout/IndentationWidth`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
