### PR TITLE
[Fix #9012] Allow `AllowedIdentifiers` to be specified for `Naming/VariableNumber`

### DIFF
--- a/changelog/change_allow_allowedidentifiers_to_be_specified.md
+++ b/changelog/change_allow_allowedidentifiers_to_be_specified.md
@@ -1,0 +1,1 @@
+* [#9012](https://github.com/rubocop-hq/rubocop/issues/9012): Allow `AllowedIdentifiers` to be specified for `Naming/VariableNumber`. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2443,7 +2443,7 @@ Naming/VariableNumber:
   StyleGuide: '#snake-case-symbols-methods-vars-with-numbers'
   Enabled: true
   VersionAdded: '0.50'
-  VersionChanged: '1.2'
+  VersionChanged: '1.3'
   EnforcedStyle: normalcase
   SupportedStyles:
     - snake_case
@@ -2451,6 +2451,7 @@ Naming/VariableNumber:
     - non_integer
   CheckMethodNames: true
   CheckSymbols: true
+  AllowedIdentifiers: []
 
 #################### Security ##############################
 

--- a/docs/modules/ROOT/pages/cops_naming.adoc
+++ b/docs/modules/ROOT/pages/cops_naming.adoc
@@ -994,7 +994,7 @@ fooBar = 1
 | Yes
 | No
 | 0.50
-| 1.2
+| 1.3
 |===
 
 This cop makes sure that all numbered variables use the
@@ -1116,6 +1116,14 @@ def some_method_1; end
 :some_sym_1
 ----
 
+==== AllowedIdentifier: [capture3]
+
+[source,ruby]
+----
+# good
+expect(Open3).to receive(:capture3)
+----
+
 === Configurable attributes
 
 |===
@@ -1132,6 +1140,10 @@ def some_method_1; end
 | CheckSymbols
 | `true`
 | Boolean
+
+| AllowedIdentifiers
+| `[]`
+| Array
 |===
 
 === References

--- a/lib/rubocop/cop/naming/variable_number.rb
+++ b/lib/rubocop/cop/naming/variable_number.rb
@@ -92,6 +92,10 @@ module RuboCop
       #   # good
       #   :some_sym_1
       #
+      # @example AllowedIdentifier: [capture3]
+      #   # good
+      #   expect(Open3).to receive(:capture3)
+      #
       class VariableNumber < Base
         include ConfigurableNumbering
 
@@ -108,12 +112,16 @@ module RuboCop
 
         def on_def(node)
           @node = node
+          return if allowed_identifier?(node.method_name)
+
           check_name(node, node.method_name, node.loc.name) if cop_config['CheckMethodNames']
         end
         alias on_defs on_def
 
         def on_sym(node)
           @node = node
+          return if allowed_identifier?(node.value)
+
           check_name(node, node.value, node) if cop_config['CheckSymbols']
         end
 
@@ -128,6 +136,14 @@ module RuboCop
             end
 
           format(MSG, style: style, identifier_type: identifier_type)
+        end
+
+        def allowed_identifier?(name)
+          allowed_identifiers.include?(name.to_s)
+        end
+
+        def allowed_identifiers
+          cop_config.fetch('AllowedIdentifiers', [])
         end
       end
     end

--- a/spec/rubocop/cop/naming/variable_number_spec.rb
+++ b/spec/rubocop/cop/naming/variable_number_spec.rb
@@ -263,4 +263,26 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
       expect_no_offenses(':sym_1')
     end
   end
+
+  context 'when AllowedIdentifiers is set' do
+    let(:cop_config) do
+      {
+        'AllowedIdentifiers' => %w[capture3],
+        'CheckSymbols' => true,
+        'CheckMethodNames' => true,
+        'EnforcedStyle' => 'snake_case'
+      }
+    end
+
+    it 'does not register an offense for a method name that is allowed' do
+      expect_no_offenses(<<~RUBY)
+        def capture3
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for a symbol that is allowed' do
+      expect_no_offenses(':capture3')
+    end
+  end
 end


### PR DESCRIPTION
`AllowedMethods` would have been a good mixin here, but I didn't think that `AllowedMethods` itself made sense as a configuration option (since we are checking for symbols, it's not necessarily methods, so I landed on `AllowedIdentifiers` instead). It'd be good to have a generic version of `AllowedMethods`, but I'll come back to that later.

Fixes #9012.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
