### PR TITLE
Add `NOTE` to keywords of `Style/CommentAnnotation`

### DIFF
--- a/changelog/change_add_note_to_keywords_of_comment_annotation.md
+++ b/changelog/change_add_note_to_keywords_of_comment_annotation.md
@@ -1,0 +1,1 @@
+* [#9022](https://github.com/rubocop-hq/rubocop/issues/9022): Add `NOTE` to keywords of `Style/CommentAnnotation`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2898,17 +2898,18 @@ Style/CommandLiteral:
 Style/CommentAnnotation:
   Description: >-
                  Checks formatting of special comments
-                 (TODO, FIXME, OPTIMIZE, HACK, REVIEW).
+                 (TODO, FIXME, OPTIMIZE, HACK, REVIEW, NOTE).
   StyleGuide: '#annotate-keywords'
   Enabled: true
   VersionAdded: '0.10'
-  VersionChanged: '0.31'
+  VersionChanged: '1.3'
   Keywords:
     - TODO
     - FIXME
     - OPTIMIZE
     - HACK
     - REVIEW
+    - NOTE
 
 Style/CommentedKeyword:
   Description: 'Do not place comments on the same line as certain keywords.'

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -1731,7 +1731,7 @@ folders = %x(find . -type d).split
 | Yes
 | Yes
 | 0.10
-| 0.31
+| 1.3
 |===
 
 This cop checks that comment annotation keywords are written according
@@ -1778,7 +1778,7 @@ annotation.
 | Name | Default value | Configurable values
 
 | Keywords
-| `TODO`, `FIXME`, `OPTIMIZE`, `HACK`, `REVIEW`
+| `TODO`, `FIXME`, `OPTIMIZE`, `HACK`, `REVIEW`, `NOTE`
 | Array
 |===
 

--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -138,7 +138,7 @@ module RuboCop
         end
       end
 
-      # Note: mutates `callbacks` in place
+      # NOTE: mutates `callbacks` in place
       def restricted_map(callbacks)
         map = {}
         callbacks&.select! do |cop|

--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -8,7 +8,7 @@ module RuboCop
     # and spec file when given a valid qualified cop name.
     # @api private
     class Generator
-      # Note: RDoc 5.1.0 or lower has the following issue.
+      # NOTE: RDoc 5.1.0 or lower has the following issue.
       # https://github.com/rubocop-hq/rubocop/issues/7043
       #
       # The following `String#gsub` can be replaced with

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -663,7 +663,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect(cli.run(['--format', 'offenses',
                         '--except', 'Style/IfUnlessModifier,Lint',
                         'example.rb'])).to eq(1)
-        # Note: No Lint/UselessAssignment offense.
+        # NOTE: No Lint/UselessAssignment offense.
         expect($stdout.string)
           .to eq(<<~RESULT)
 


### PR DESCRIPTION
This PR adds `# NOTE: ` annotation that is occasionally used to keywords of `Style/CommentAnnotation`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
