### PR TITLE
[Fix #9023] Mark unsafe for `Style/CollectionCompact`.

### DIFF
--- a/changelog/change_mark_unsafe_for_collection_compact.md
+++ b/changelog/change_mark_unsafe_for_collection_compact.md
@@ -1,0 +1,1 @@
+* [#9023](https://github.com/rubocop-hq/rubocop/issues/9023): Mark unsafe for `Style/CollectionCompact`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2833,7 +2833,9 @@ Style/ClassVars:
 Style/CollectionCompact:
   Description: 'Use `{Array,Hash}#{compact,compact!}` instead of custom logic to reject nils.'
   Enabled: pending
+  Safe: false
   VersionAdded: '1.2'
+  VersionChanged: '1.3'
 
 # Align with the style guide.
 Style/CollectionMethods:

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -1367,14 +1367,20 @@ end
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
 | Pending
-| Yes
-| Yes
+| No
+| Yes (Unsafe)
 | 1.2
-| -
+| 1.3
 |===
 
 This cop checks for places where custom logic on rejection nils from arrays
 and hashes can be replaced with `{Array,Hash}#{compact,compact!}`.
+
+It is marked as unsafe by default because false positives may occur in the
+nil check of block arguments to the receiver object.
+For example, `[[1, 2], [3, nil]].reject { |first, second| second.nil? }`
+and `[[1, 2], [3, nil]].compact` are not compatible. This will work fine
+when the receiver is a hash object.
 
 === Examples
 

--- a/lib/rubocop/cop/style/collection_compact.rb
+++ b/lib/rubocop/cop/style/collection_compact.rb
@@ -6,6 +6,12 @@ module RuboCop
       # This cop checks for places where custom logic on rejection nils from arrays
       # and hashes can be replaced with `{Array,Hash}#{compact,compact!}`.
       #
+      # It is marked as unsafe by default because false positives may occur in the
+      # nil check of block arguments to the receiver object.
+      # For example, `[[1, 2], [3, nil]].reject { |first, second| second.nil? }`
+      # and `[[1, 2], [3, nil]].compact` are not compatible. This will work fine
+      # when the receiver is a hash object.
+      #
       # @example
       #   # bad
       #   array.reject { |e| e.nil? }


### PR DESCRIPTION
Fixes #9023.

This PR marks unsafe for `Style/CollectionCompact` by default because false positives may occur in the nil check of block arguments to the receiver object.
For example, `[[1, 2], [3, nil]].reject { |first, second| second.nil? }` and `[[1, 2], [3, nil]].compact` are not compatible. This will work fine when the receiver is a hash object.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
