### PR TITLE
[Fix #9025] Add `AllowedMethods` to `Lint/ConstantDefinitionInBlock`

### DIFF
--- a/changelog/new_add_allow_methods_to_constant_definition_in_block.md
+++ b/changelog/new_add_allow_methods_to_constant_definition_in_block.md
@@ -1,0 +1,1 @@
+* [#9025](https://github.com/rubocop-hq/rubocop/issues/9025): Add `AllowedMethods` option to `Lint/ConstantDefinitionInBlock`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1400,6 +1400,8 @@ Lint/ConstantDefinitionInBlock:
   StyleGuide: '#no-constant-definition-in-block'
   Enabled: true
   VersionAdded: '0.91'
+  VersionChanged: '1.3'
+  AllowedMethods: []
 
 Lint/ConstantResolution:
   Description: 'Check that constants are fully qualified with `::`.'

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -361,7 +361,7 @@ end
 | Yes
 | No
 | 0.91
-| -
+| 1.3
 |===
 
 Do not define constants within a block, since the block's scope does not
@@ -414,6 +414,28 @@ module M
   end
 end
 ----
+
+==== AllowedMethods: ['enums']
+
+[source,ruby]
+----
+# good
+class TestEnum < T::Enum
+  enums do
+    Foo = new("foo")
+  end
+end
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AllowedMethods
+| `[]`
+| Array
+|===
 
 === References
 


### PR DESCRIPTION
Fixes #9025.

This PR adds `AllowedMethods` option to `Lint/ConstantDefinitionInBlock`.

The following example can be allowed by configuring `AllowedMethods`.

```ruby
class TestEnum < T::Enum
  enums do
    Foo = new("foo")
  end
end
```

Example configuration:

```yaml
# .rubocop.yml
Lint/ConstantDefinitionInBlock:
  AllowedMethods:
    - enums
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
