### PR TITLE
[Fix #9011] Mark autocorrection for `Lint/Loop` as unsafe

### DIFF
--- a/changelog/change_mark_autocorrection_for_lintloop_as.md
+++ b/changelog/change_mark_autocorrection_for_lintloop_as.md
@@ -1,0 +1,1 @@
+* [#9011](https://github.com/rubocop-hq/rubocop/issues/9011): Mark autocorrection for `Lint/Loop` as unsafe. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1659,7 +1659,8 @@ Lint/Loop:
   StyleGuide: '#loop-with-break'
   Enabled: true
   VersionAdded: '0.9'
-  VersionChanged: '0.89'
+  VersionChanged: '1.3'
+  Safe: false
 
 Lint/MissingCopEnableDirective:
   Description: 'Checks for a `# rubocop:enable` after `# rubocop:disable`.'

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -2351,13 +2351,17 @@ This cop checks for interpolated literals.
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
 | Enabled
-| Yes
-| Yes
+| No
+| Yes (Unsafe)
 | 0.9
-| 0.89
+| 1.3
 |===
 
 This cop checks for uses of `begin...end while/until something`.
+
+The cop is marked as unsafe because behaviour can change in some cases, including
+if a local variable inside the loop body is accessed outside of it, or if the
+loop body raises a `StopIteration` exception (which `Kernel#loop` rescues).
 
 === Examples
 

--- a/lib/rubocop/cop/lint/loop.rb
+++ b/lib/rubocop/cop/lint/loop.rb
@@ -5,6 +5,10 @@ module RuboCop
     module Lint
       # This cop checks for uses of `begin...end while/until something`.
       #
+      # The cop is marked as unsafe because behaviour can change in some cases, including
+      # if a local variable inside the loop body is accessed outside of it, or if the
+      # loop body raises a `StopIteration` exception (which `Kernel#loop` rescues).
+      #
       # @example
       #
       #   # bad


### PR DESCRIPTION
The case in #9011 

```ruby
loop do
  key = generate_key
  break if some_check?
end

puts key
```

cannot be detected by static analysis, so instead I've marked autocorrection for `Lint/Loop` as unsafe and added an explanation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
