### PR TITLE
[Fix #9026] Update `Style/DocumentDynamicEvalDefinition` to detect comment blocks that document the evaluation

### DIFF
--- a/changelog/change_update.md
+++ b/changelog/change_update.md
@@ -1,0 +1,1 @@
+* [#9026](https://github.com/rubocop-hq/rubocop/issues/9026): Update `Style/DocumentDynamicEvalDefinition` to detect comment blocks that document the evaluation. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3012,6 +3012,7 @@ Style/DocumentDynamicEvalDefinition:
   StyleGuide: '#eval-comment-docs'
   Enabled: pending
   VersionAdded: '1.1'
+  VersionChanged: '1.3'
 
 Style/Documentation:
   Description: 'Document classes and non-namespace modules.'

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -2244,7 +2244,7 @@ end
 | Yes
 | No
 | 1.1
-| -
+| 1.3
 |===
 
 When using `class_eval` (or other `eval`) with string interpolation,
@@ -2272,7 +2272,7 @@ UNSAFE_STRING_METHODS.each do |unsafe_method|
   end
 end
 
-# good
+# good, inline comments in heredoc
 UNSAFE_STRING_METHODS.each do |unsafe_method|
   if 'String'.respond_to?(unsafe_method)
     class_eval <<-EOT, __FILE__, __LINE__ + 1
@@ -2287,6 +2287,34 @@ UNSAFE_STRING_METHODS.each do |unsafe_method|
     EOT
   end
 end
+
+# good, block comments in heredoc
+class_eval <<-EOT, __FILE__, __LINE__ + 1
+  # def capitalize!(*params)
+  #   @dirty = true
+  #   super
+  # end
+
+  def #{unsafe_method}!(*params)
+    @dirty = true
+    super
+  end
+EOT
+
+# good, block comments before heredoc
+class_eval(
+  # def capitalize!(*params)
+  #   @dirty = true
+  #   super
+  # end
+
+  <<-EOT, __FILE__, __LINE__ + 1
+    def #{unsafe_method}!(*params)
+      @dirty = true
+      super
+    end
+  EOT
+)
 ----
 
 === References

--- a/lib/rubocop/cop/style/document_dynamic_eval_definition.rb
+++ b/lib/rubocop/cop/style/document_dynamic_eval_definition.rb
@@ -25,7 +25,7 @@ module RuboCop
       #     end
       #   end
       #
-      #   # good
+      #   # good, inline comments in heredoc
       #   UNSAFE_STRING_METHODS.each do |unsafe_method|
       #     if 'String'.respond_to?(unsafe_method)
       #       class_eval <<-EOT, __FILE__, __LINE__ + 1
@@ -41,25 +41,120 @@ module RuboCop
       #     end
       #   end
       #
+      #   # good, block comments in heredoc
+      #   class_eval <<-EOT, __FILE__, __LINE__ + 1
+      #     # def capitalize!(*params)
+      #     #   @dirty = true
+      #     #   super
+      #     # end
+      #
+      #     def #{unsafe_method}!(*params)
+      #       @dirty = true
+      #       super
+      #     end
+      #   EOT
+      #
+      #   # good, block comments before heredoc
+      #   class_eval(
+      #     # def capitalize!(*params)
+      #     #   @dirty = true
+      #     #   super
+      #     # end
+      #
+      #     <<-EOT, __FILE__, __LINE__ + 1
+      #       def #{unsafe_method}!(*params)
+      #         @dirty = true
+      #         super
+      #       end
+      #     EOT
+      #   )
       class DocumentDynamicEvalDefinition < Base
+        BLOCK_COMMENT_REGEXP = /^\s*#(?!{)/.freeze
+        COMMENT_REGEXP = /\s*#(?!{).*/.freeze
         MSG = 'Add a comment block showing its appearance if interpolated.'
 
         RESTRICT_ON_SEND = %i[eval class_eval module_eval instance_eval].freeze
 
         def on_send(node)
           arg_node = node.first_argument
-          return unless arg_node&.dstr_type?
 
-          add_offense(node.loc.selector) unless comment_docs?(arg_node)
+          return unless arg_node&.dstr_type? && interpolated?(arg_node)
+          return if inline_comment_docs?(arg_node) || comment_block_docs?(arg_node)
+
+          add_offense(node.loc.selector)
         end
 
         private
 
-        def comment_docs?(node)
+        def interpolated?(arg_node)
+          arg_node.each_child_node(:begin).any?
+        end
+
+        def inline_comment_docs?(node)
           node.each_child_node(:begin).all? do |begin_node|
             source_line = processed_source.lines[begin_node.first_line - 1]
-            source_line.match?(/\s*#[^{]+/)
+            source_line.match?(COMMENT_REGEXP)
           end
+        end
+
+        def comment_block_docs?(arg_node)
+          comments = heredoc_comment_blocks(arg_node.loc.heredoc_body.line_span)
+                     .concat(preceding_comment_blocks(arg_node.parent))
+
+          return if comments.none?
+
+          regexp = comment_regexp(arg_node)
+          comments.any? { |comment| regexp.match?(comment) } || regexp.match?(comments.join)
+        end
+
+        def preceding_comment_blocks(node)
+          # Collect comments in the method call, but outside the heredoc
+          comments = processed_source.each_comment_in_lines(node.loc.expression.line_span)
+
+          comments.each_with_object({}) do |comment, hash|
+            merge_adjacent_comments(comment.text, comment.loc.line, hash)
+          end.values
+        end
+
+        def heredoc_comment_blocks(heredoc_body)
+          # Collect comments inside the heredoc
+          line_range = (heredoc_body.begin - 1)..(heredoc_body.end - 1)
+          lines = processed_source.lines[line_range]
+
+          lines.each_with_object({}).with_index(line_range.begin) do |(line, hash), index|
+            merge_adjacent_comments(line, index, hash)
+          end.values
+        end
+
+        def merge_adjacent_comments(line, index, hash)
+          # Combine adjacent comment lines into a single string
+          return unless (line = line.dup.gsub!(BLOCK_COMMENT_REGEXP, ''))
+
+          hash[index] = if hash.keys.last == index - 1
+                          [hash.delete(index - 1), line].join("\n")
+                        else
+                          line
+                        end
+        end
+
+        def comment_regexp(arg_node)
+          # Replace the interpolations with wildcards
+          regexp_parts = arg_node.child_nodes.map do |n|
+            n.begin_type? ? /.+/ : source_to_regexp(n.source)
+          end
+
+          Regexp.new(regexp_parts.join)
+        end
+
+        def source_to_regexp(source)
+          # Get the source in the heredoc being `eval`ed, without any comments
+          # and turn it into a regexp
+          return /\s+/ if source.blank?
+
+          source = source.gsub(COMMENT_REGEXP, '')
+          return if source.blank?
+
+          /\s*#{Regexp.escape(source.strip)}/
         end
       end
     end

--- a/spec/rubocop/cop/style/document_dynamic_eval_definition_spec.rb
+++ b/spec/rubocop/cop/style/document_dynamic_eval_definition_spec.rb
@@ -33,4 +33,229 @@ RSpec.describe RuboCop::Cop::Style::DocumentDynamicEvalDefinition do
       EOT
     RUBY
   end
+
+  context 'block comment in heredoc' do
+    it 'does not register an offense for a matching block comment' do
+      expect_no_offenses(<<~RUBY)
+        class_eval <<-EOT, __FILE__, __LINE__ + 1
+          # def capitalize(*params, &block)
+          #   to_str.capitalize(*params, &block)
+          # end
+
+          def \#{unsafe_method}(*params, &block)
+            to_str.\#{unsafe_method}(*params, &block)
+          end
+        EOT
+      RUBY
+    end
+
+    it 'does not evaluate comments if there is no interpolation' do
+      expect(cop).not_to receive(:comment_block_docs?) # rubocop:disable RSpec/SubjectStub
+
+      expect_no_offenses(<<~RUBY)
+        class_eval <<-EOT, __FILE__, __LINE__ + 1
+          def capitalize(*params, &block)
+            to_str.capitalize(*params, &block)
+          end
+        EOT
+      RUBY
+    end
+
+    it 'handles inline comments' do
+      expect_no_offenses(<<~RUBY)
+        class_eval <<-EOT, __FILE__, __LINE__ + 1
+          # def capitalize(*params, &block)
+          #   to_str.capitalize(*params, &block)
+          # end
+
+          def \#{unsafe_method}(*params, &block)
+            to_str.\#{unsafe_method}(*params, &block) # { note: etc. }
+          end
+        EOT
+      RUBY
+    end
+
+    it 'handles other text' do
+      expect_no_offenses(<<~RUBY)
+        class_eval <<-EOT, __FILE__, __LINE__ + 1
+          # EXAMPLE: def capitalize(*params, &block)
+          #   to_str.capitalize(*params, &block)
+          # end
+
+          def \#{unsafe_method}(*params, &block)
+            to_str.\#{unsafe_method}(*params, &block)
+          end
+        EOT
+      RUBY
+    end
+
+    it 'handles multiple methods' do
+      expect_no_offenses(<<~RUBY)
+        class_eval <<-EOT, __FILE__, __LINE__ + 1
+          # def capitalize(*params, &block)
+          #   to_str.capitalize(*params, &block)
+          # end
+          #
+          # def capitalize!(*params)
+          #   @dirty = true
+          #   super
+          # end
+
+          def \#{unsafe_method}(*params, &block)
+            to_str.\#{unsafe_method}(*params, &block)
+          end
+
+          def \#{unsafe_method}!(*params)
+            @dirty = true
+            super
+          end
+        EOT
+      RUBY
+    end
+
+    it 'handles multiple methods with split comments' do
+      expect_no_offenses(<<~RUBY)
+        class_eval <<-EOT, __FILE__, __LINE__ + 1
+          # def capitalize(*params, &block)
+          #   to_str.capitalize(*params, &block)
+          # end
+          def \#{unsafe_method}(*params, &block)
+            to_str.\#{unsafe_method}(*params, &block)
+          end
+
+          # def capitalize!(*params)
+          #   @dirty = true
+          #   super
+          # end
+          def \#{unsafe_method}!(*params)
+            @dirty = true
+            super
+          end
+        EOT
+      RUBY
+    end
+
+    it 'registers an offense if the comment does not match the method' do
+      expect_offense(<<~RUBY)
+        class_eval <<-EOT, __FILE__, __LINE__ + 1
+        ^^^^^^^^^^ Add a comment block showing its appearance if interpolated.
+          # def capitalize(*params, &block)
+          #   str.capitalize(*params, &block)
+          # end
+
+          def \#{unsafe_method}(*params, &block)
+            to_str.\#{unsafe_method}(*params, &block)
+          end
+        EOT
+      RUBY
+    end
+  end
+
+  context 'block comment outside heredoc' do
+    it 'does not register an offense for a matching block comment before the heredoc' do
+      expect_no_offenses(<<~RUBY)
+        class_eval(
+          # def capitalize(*params, &block)
+          #   to_str.capitalize(*params, &block)
+          # end
+
+          <<-EOT, __FILE__, __LINE__ + 1
+            def \#{unsafe_method}(*params, &block)
+              to_str.\#{unsafe_method}(*params, &block)
+            end
+          EOT
+        )
+      RUBY
+    end
+
+    it 'does not register an offense for a matching block comment after the heredoc' do
+      expect_no_offenses(<<~RUBY)
+        class_eval(
+          <<-EOT, __FILE__, __LINE__ + 1
+            def \#{unsafe_method}(*params, &block)
+              to_str.\#{unsafe_method}(*params, &block)
+            end
+          EOT
+          # def capitalize(*params, &block)
+          #   to_str.capitalize(*params, &block)
+          # end
+        )
+      RUBY
+    end
+
+    it 'handles inline comments' do
+      expect_no_offenses(<<~RUBY)
+        class_eval(
+          # def capitalize(*params, &block)
+          #   to_str.capitalize(*params, &block)
+          # end
+
+          <<-EOT, __FILE__, __LINE__ + 1
+            def \#{unsafe_method}(*params, &block)
+              to_str.\#{unsafe_method}(*params, &block) # { note: etc. }
+            end
+          EOT
+        )
+      RUBY
+    end
+
+    it 'handles other text' do
+      expect_no_offenses(<<~RUBY)
+        class_eval(
+          # EXAMPLE: def capitalize(*params, &block)
+          #   to_str.capitalize(*params, &block)
+          # end
+
+          <<-EOT, __FILE__, __LINE__ + 1
+            def \#{unsafe_method}(*params, &block)
+              to_str.\#{unsafe_method}(*params, &block)
+            end
+          EOT
+        )
+      RUBY
+    end
+
+    it 'registers an offense if the comment does not match the method' do
+      expect_offense(<<~RUBY)
+        class_eval(
+        ^^^^^^^^^^ Add a comment block showing its appearance if interpolated.
+          # def capitalize(*params, &block)
+          #   str.capitalize(*params, &block)
+          # end
+
+          <<-EOT, __FILE__, __LINE__ + 1
+            def \#{unsafe_method}(*params, &block)
+              to_str.\#{unsafe_method}(*params, &block)
+            end
+          EOT
+        )
+      RUBY
+    end
+
+    it 'handles multiple methods' do
+      expect_no_offenses(<<~RUBY)
+        class_eval(
+          # def capitalize(*params, &block)
+          #   to_str.capitalize(*params, &block)
+          # end
+          #
+          # def capitalize!(*params)
+          #   @dirty = true
+          #   super
+          # end
+
+          <<-EOT, __FILE__, __LINE__ + 1
+            def \#{unsafe_method}(*params, &block)
+              to_str.\#{unsafe_method}(*params, &block)
+            end
+
+            def \#{unsafe_method}!(*params)
+              @dirty = true
+              super
+            end
+          EOT
+        )
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Look for comment blocks either inside the heredoc or inside the method call that document the dynamic code. If inline comments are not found, the cop checks for any comment blocks and tries to match it to the source code that will be evaluated, by constructing a regex with wildcards for each interpolation. None of this processing will take place unless necessary (ie. an interpolated heredoc with comment blocks and no matching inline comments).

Fixes #9026.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
