### PR TITLE
Fix formatting in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,9 +50,9 @@ $ rubocop -V
 Changelog entries are just files under the `changelog/` folder that will be merged
 into `CHANGELOG.md` at release time. You can create new changelog entries like this:
 
-  $ bundle exec rake changelog:new
-  $ bundle exec rake changelog:fix
-  $ bundle exec rake changelog:change
+    $ bundle exec rake changelog:new
+    $ bundle exec rake changelog:fix
+    $ bundle exec rake changelog:change
 
 Those commands correspond to "new feature", "bug-fix" and "changed" entries in the changelog.
 


### PR DESCRIPTION
Before:
<img width="748" alt="image" src="https://user-images.githubusercontent.com/57964/98898416-95ef5700-247b-11eb-8d39-1ad7fa3bfaf2.png">

After:
<img width="770" alt="image" src="https://user-images.githubusercontent.com/57964/98898432-9f78bf00-247b-11eb-96c2-995b01e89d70.png">

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
