### PR TITLE
[Fix #8978] Update `Layout/LineLength` autocorrection to be able to handle method calls with long argument lists

### DIFF
--- a/changelog/change_update_layoutlinelength_autocorrection.md
+++ b/changelog/change_update_layoutlinelength_autocorrection.md
@@ -1,0 +1,1 @@
+* [#8978](https://github.com/rubocop-hq/rubocop/issues/8978): Update `Layout/LineLength` autocorrection to be able to handle method calls with long argument lists. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -891,7 +891,7 @@ Layout/LineLength:
   StyleGuide: '#max-line-length'
   Enabled: true
   VersionAdded: '0.25'
-  VersionChanged: '0.84'
+  VersionChanged: '1.3'
   AutoCorrect: false
   Max: 120
   # To make it possible to copy or click on URIs in the code, we allow lines

--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -3792,7 +3792,7 @@ end
 | Yes
 | Yes
 | 0.25
-| 0.84
+| 1.3
 |===
 
 This cop checks the length of lines in the source code.

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -88,6 +88,10 @@ module RuboCop
           end
         end
 
+        def correctable?
+          super && !breakable_range.nil?
+        end
+
         def autocorrect(range)
           return if range.nil?
 
@@ -97,6 +101,8 @@ module RuboCop
         end
 
         private
+
+        attr_accessor :breakable_range
 
         def check_for_breakable_node(node)
           breakable_node = extract_breakable_node(node, max)
@@ -195,7 +201,8 @@ module RuboCop
         def register_offense(loc, line, line_index)
           message = format(MSG, length: line_length(line), max: max)
 
-          breakable_range = breakable_range_by_line_index[line_index]
+          self.breakable_range = breakable_range_by_line_index[line_index]
+
           add_offense(breakable_range, location: loc, message: message) do
             self.max = line_length(line)
           end

--- a/lib/rubocop/cop/mixin/check_line_breakable.rb
+++ b/lib/rubocop/cop/mixin/check_line_breakable.rb
@@ -103,7 +103,7 @@ module RuboCop
         # hashes wrapped in a set of curly braces like {foo: 1}.
         # That is, not a kwargs hash. For method calls, this ensures
         # the method call is made with parens.
-        starts_with_bracket = node.loc.begin
+        starts_with_bracket = !node.hash_type? || node.loc.begin
 
         # If the call has a second argument, we can insert a line
         # break before the second argument and the rest of the

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             == example.rb ==
             C:  2: 91: Layout/LineLength: Line is too long. [99/90]
 
-            1 file inspected, 1 offense detected, 1 offense auto-correctable
+            1 file inspected, 1 offense detected
           OUTPUT
         end
       end

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -1101,7 +1101,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
               C:  1:  1: Style/FrozenStringLiteralComment: Missing frozen string literal comment.
               C:  1:121: Layout/LineLength: Line is too long. [130/120]
 
-              1 file inspected, 2 offenses detected, 2 offenses auto-correctable
+              1 file inspected, 2 offenses detected, 1 offense auto-correctable
             RESULT
         end
       end
@@ -1249,7 +1249,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             '    end',
             '    ^^^',
             '',
-            '3 files inspected, 15 offenses detected, 13 offenses auto-correctable',
+            '3 files inspected, 15 offenses detected, 12 offenses auto-correctable',
             ''
           ].join("\n"))
         end
@@ -1369,7 +1369,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         C:  1:  1: Style/FrozenStringLiteralComment: Missing frozen string literal comment.
         C:  1:121: Layout/LineLength: Line is too long. [130/120]
 
-        1 file inspected, 2 offenses detected, 2 offenses auto-correctable
+        1 file inspected, 2 offenses detected, 1 offense auto-correctable
       RESULT
 
       expect(File.read('emacs_output.txt'))

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -504,7 +504,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
               == example.rb ==
               C:  1:  3: Layout/LineLength: Line is too long. [5/2]
 
-              1 file inspected, 1 offense detected, 1 offense auto-correctable
+              1 file inspected, 1 offense detected
             RESULT
         end
 
@@ -1291,7 +1291,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         == example/lib/example1.rb ==
         C:  3:121: Layout/LineLength: Line is too long. [130/120]
 
-        2 files inspected, 1 offense detected, 1 offense auto-correctable
+        2 files inspected, 1 offense detected
       RESULT
     end
 
@@ -1347,7 +1347,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         == example/tmp/test/example1.rb ==
         C:  3:121: Layout/LineLength: Line is too long. [130/120]
 
-        1 file inspected, 1 offense detected, 1 offense auto-correctable
+        1 file inspected, 1 offense detected
       RESULT
     end
 
@@ -1556,7 +1556,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           C:  3: 46: Style/CommentedKeyword: Do not place comments on the same line as the def keyword.
           E:  3:121: Layout/LineLength: Line is too long. [130/120]
 
-          1 file inspected, 4 offenses detected, 1 offense auto-correctable
+          1 file inspected, 4 offenses detected
         RESULT
         expect($stderr.string).to eq('')
       end

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -438,11 +438,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
               bar: "10000"}
           RUBY
 
-          expect_correction(<<~RUBY)
-            { # supersupersupersupersupersupersupersupersupersupersupersuperlongcomment
-              baz: "10000",
-              bar: "10000"}
-          RUBY
+          expect_no_corrections
         end
       end
 
@@ -455,11 +451,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
               bar: "10000"}
           RUBY
 
-          expect_correction(<<~RUBY)
-            {supersupersupersupersupersupersupersupersupersupersupersuperfirstarg: 10,
-              baz: "10000",
-              bar: "10000"}
-          RUBY
+          expect_no_corrections
         end
       end
 
@@ -474,13 +466,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
               bar: "10000"}
           RUBY
 
-          expect_correction(<<~RUBY)
-            {
-              baz0: "10000",
-              baz1: "10000",
-              baz2: "10000", baz2: "10000", baz3: "10000", baz4: "10000",
-              bar: "10000"}
-          RUBY
+          expect_no_corrections
         end
       end
 
@@ -492,7 +478,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           RUBY
 
           expect_correction(<<~RUBY)
-            {abc: "100000", def: "100000",\s
+            {abc: "100000", def: "100000",#{trailing_whitespace}
             ghi: "100000", jkl: "100000", mno: "100000"}
           RUBY
         end
@@ -506,7 +492,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           RUBY
 
           expect_correction(<<~RUBY)
-            {"abc" => "100000", "def" => "100000",\s
+            {"abc" => "100000", "def" => "100000",#{trailing_whitespace}
             "casd" => "100000", "asdf" => "100000"}
           RUBY
         end
@@ -520,7 +506,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           RUBY
 
           expect_correction(<<~RUBY)
-            {:abc => "100000", :asd => "100000",\s
+            {:abc => "100000", :asd => "100000",#{trailing_whitespace}
             :asd => "100000", :fds => "100000"}
           RUBY
         end
@@ -534,7 +520,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           RUBY
 
           expect_correction(<<~RUBY)
-            {abc: "100000", def: "100000",\s
+            {abc: "100000", def: "100000",#{trailing_whitespace}
             ghi: {abc: "100000"}, jkl: "100000", mno: "100000"}
           RUBY
         end
@@ -553,7 +539,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           expect_correction(<<~RUBY)
             get(
               :index,
-              params: {driver_id: driver.id,\s
+              params: {driver_id: driver.id,#{trailing_whitespace}
             from_date: "2017-08-18T15:09:04.000Z", to_date: "2017-09-19T15:09:04.000Z"},
               xhr: true)
           RUBY
@@ -631,9 +617,20 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [70/40]
           RUBY
 
+          expect_no_corrections
+        end
+      end
+
+      context 'with long argument list' do
+        it 'registers an offense and autocorrects it' do
+          expect_offense(<<~RUBY)
+            attr_reader :first_name, :last_name, :email, :username, :country, :state, :city, :postal_code
+                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [93/40]
+          RUBY
+
           expect_correction(<<~RUBY)
-            get(1000000,
-            foo(44440000, 30000, 39999, 1992), foo(44440000, 30000, 39999, 12093))
+            attr_reader :first_name, :last_name,#{trailing_whitespace}
+            :email, :username, :country, :state, :city, :postal_code
           RUBY
         end
       end
@@ -694,11 +691,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
             100, 100]
           RUBY
 
-          expect_correction(<<~RUBY)
-            [1000000, 3912312312999,
-              [44440000, 3912312312999, 3912312312999, 1992912031231232131312093],
-            100, 100]
-          RUBY
+          expect_no_corrections
         end
       end
     end
@@ -712,11 +705,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           456
         RUBY
 
-        expect_correction(<<~RUBY)
-          10000003912312312999
-            # 444400003912312312999391231231299919929120312312321313120933333333
-          456
-        RUBY
+        expect_no_corrections
       end
     end
 
@@ -885,9 +874,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
                                                     ^ Line is too long. [41/40]
           RUBY
 
-          expect_correction(<<~RUBY)
-            a = 400000000000 + 500000000000000000000;
-          RUBY
+          expect_no_corrections
         end
       end
 
@@ -899,9 +886,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
                                                     ^^^^^^^ Line is too long. [47/40]
           RUBY
 
-          expect_correction(<<~RUBY)
-            a = 400000000000 + 500000000000000000000;;;;;;;
-          RUBY
+          expect_no_corrections
         end
       end
 
@@ -947,11 +932,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
             SQL
           RUBY
 
-          expect_correction(<<~RUBY)
-            foo = <<-SQL
-              SELECT a b c d a b FROM c d a b c d ; COUNT(*) a b
-            SQL
-          RUBY
+          expect_no_corrections
         end
       end
     end
@@ -964,9 +945,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
                                                     ^^^^^^^^^^^^^ Line is too long. [53/40]
           RUBY
 
-          expect_correction(<<~RUBY)
-            # a b c d a b c d a b c d ; a b c d a b c d a b c d a
-          RUBY
+          expect_no_corrections
         end
       end
     end


### PR DESCRIPTION
Added the ability to autocorrect a long argument list when it's not a hash.

I think part of the confusion in #8978 is that `Layout/LineLength` marks every offense as correctable even though only a subset are. I'm not 100% sure if inheriting from `Base` instead of `Cop` would help here, but because `autocorrect` is defined on the cop, it's considered to be always autocorrectable. In order to try to get around this, I added a second commit which overrides `correctable?` so that only offense the cop can actually correct are marked. I'm happy to remove this if it's too much of a hack or not desirable!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
