### PR TITLE
[Fix #9032] Fix an error for `Style/DocumentDynamicEvalDefinition`

### DIFF
--- a/changelog/fix_an_error_for_document_dynamic_eval_definition.md
+++ b/changelog/fix_an_error_for_document_dynamic_eval_definition.md
@@ -1,0 +1,1 @@
+* [#9032](https://github.com/rubocop-hq/rubocop/issues/9032): Fix an error for `Style/DocumentDynamicEvalDefinition` when using eval-type method with interpolated string that is not heredoc without comment doc. ([@koic][])

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -2315,6 +2315,12 @@ class_eval(
     end
   EOT
 )
+
+# bad - interpolated string without comment
+class_eval("def #{unsafe_method}!(*params); end")
+
+# good - with inline comment or replace it with block comment using heredoc
+class_eval("def #{unsafe_method}!(*params); end # def capitalize!(*params); end")
 ----
 
 === References

--- a/lib/rubocop/cop/style/document_dynamic_eval_definition.rb
+++ b/lib/rubocop/cop/style/document_dynamic_eval_definition.rb
@@ -68,6 +68,12 @@ module RuboCop
       #       end
       #     EOT
       #   )
+      #
+      #   # bad - interpolated string without comment
+      #   class_eval("def #{unsafe_method}!(*params); end")
+      #
+      #   # good - with inline comment or replace it with block comment using heredoc
+      #   class_eval("def #{unsafe_method}!(*params); end # def capitalize!(*params); end")
       class DocumentDynamicEvalDefinition < Base
         BLOCK_COMMENT_REGEXP = /^\s*#(?!{)/.freeze
         COMMENT_REGEXP = /\s*#(?!{).*/.freeze
@@ -79,7 +85,8 @@ module RuboCop
           arg_node = node.first_argument
 
           return unless arg_node&.dstr_type? && interpolated?(arg_node)
-          return if inline_comment_docs?(arg_node) || comment_block_docs?(arg_node)
+          return if inline_comment_docs?(arg_node) ||
+                    arg_node.heredoc? && comment_block_docs?(arg_node)
 
           add_offense(node.loc.selector)
         end

--- a/spec/rubocop/cop/style/document_dynamic_eval_definition_spec.rb
+++ b/spec/rubocop/cop/style/document_dynamic_eval_definition_spec.rb
@@ -34,6 +34,21 @@ RSpec.describe RuboCop::Cop::Style::DocumentDynamicEvalDefinition do
     RUBY
   end
 
+  it 'registers an offense when using eval-type method with interpolated string ' \
+     'that is not heredoc without comment doc' do
+    expect_offense(<<~'RUBY')
+      stringio.instance_eval("def original_filename; 'stringio#{n}.txt'; end")
+               ^^^^^^^^^^^^^ Add a comment block showing its appearance if interpolated.
+    RUBY
+  end
+
+  it 'does not register an offense when using eval-type method with interpolated string ' \
+     'that is not heredoc with comment doc' do
+    expect_no_offenses(<<~'RUBY')
+      stringio.instance_eval("def original_filename; 'stringio#{n}.txt'; end # def original_filename; 'stringiofoo.txt'; end")
+    RUBY
+  end
+
   context 'block comment in heredoc' do
     it 'does not register an offense for a matching block comment' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #9032.

This PR fixes an error for `Style/DocumentDynamicEvalDefinition` when using eval-type method with interpolated string that is not heredoc without comment doc.

It may be better to provide an option to accept non-heredoc interpolated-string in future.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
