### PR TITLE
Change SafeYAML raise to a warn

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ InternalAffairs/NodeDestructuring:
 # Offense count: 48
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 186
+  Max: 187
 
 # Offense count: 198
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -255,7 +255,9 @@ module RuboCop
               "Configuration file not found: #{absolute_path}"
       end
 
-      raise 'SafeYAML is unmaintained, no longer needed and should be removed' if defined?(SafeYAML)
+      if defined?(SafeYAML)
+        warn Rainbow('SafeYAML is unmaintained, no longer needed and should be removed').yellow
+      end
 
       if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0')
         def yaml_safe_load(yaml_code, filename)


### PR DESCRIPTION
Change SafeYAML from a raise to a warn to prevent breaking other dependencies that require it during the build steps before testing (e.g. Jekyll)

This change was added very recently in this PR: https://github.com/rubocop-hq/rubocop/pull/9004

With the latest update to RuboCop (1.3.0), it raises an exception when `SafeYAML` exists. 

I use `Jekyll` to build my website which depends on `SafeYAML`.  In my testing phase I check for both linting errors and other issues with my site build. However, because RuboCop is in these steps, it finds my `SafeYAML` executable and fails with the raised exception.

My proposal is that we change this from a raised exception to a warning instead. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
