### PR TITLE
Allow `enums` by default for `Lint/ConstantDefinitionInBlock`

### DIFF
--- a/changelog/change_allow_enums_by_default_for_constant_definition_in_block.md
+++ b/changelog/change_allow_enums_by_default_for_constant_definition_in_block.md
@@ -1,0 +1,1 @@
+* [#9036](https://github.com/rubocop-hq/rubocop/pull/9036): Allow `enums` method by default for `Lint/ConstantDefinitionInBlock`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1400,8 +1400,11 @@ Lint/ConstantDefinitionInBlock:
   StyleGuide: '#no-constant-definition-in-block'
   Enabled: true
   VersionAdded: '0.91'
-  VersionChanged: '1.3'
-  AllowedMethods: []
+  VersionChanged: '1.4'
+  # `enums` for Typed Enums via T::Enum in Sorbet.
+  # https://sorbet.org/docs/tenum
+  AllowedMethods:
+    - enums
 
 Lint/ConstantResolution:
   Description: 'Check that constants are fully qualified with `::`.'

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -361,7 +361,7 @@ end
 | Yes
 | No
 | 0.91
-| 1.3
+| 1.4
 |===
 
 Do not define constants within a block, since the block's scope does not
@@ -415,11 +415,14 @@ module M
 end
 ----
 
-==== AllowedMethods: ['enums']
+==== AllowedMethods: ['enums'] (default)
 
 [source,ruby]
 ----
 # good
+
+# `enums` for Typed Enums via `T::Enum` in Sorbet.
+# https://sorbet.org/docs/tenum
 class TestEnum < T::Enum
   enums do
     Foo = new("foo")
@@ -433,7 +436,7 @@ end
 | Name | Default value | Configurable values
 
 | AllowedMethods
-| `[]`
+| `enums`
 | Array
 |===
 

--- a/lib/rubocop/cop/lint/constant_definition_in_block.rb
+++ b/lib/rubocop/cop/lint/constant_definition_in_block.rb
@@ -50,8 +50,11 @@ module RuboCop
       #     end
       #   end
       #
-      # @example AllowedMethods: ['enums']
+      # @example AllowedMethods: ['enums'] (default)
       #   # good
+      #
+      #   # `enums` for Typed Enums via `T::Enum` in Sorbet.
+      #   # https://sorbet.org/docs/tenum
       #   class TestEnum < T::Enum
       #     enums do
       #       Foo = new("foo")


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/issues/9025#issuecomment-726203458.

This PR allow `enums` method by default for `Lint/ConstantDefinitionInBlock`.

#9027 was worried about false negatives for users who have defined constants in user custom `enums` method's block. But it would be worthwhile to be able to resolve this realistic issue for Sorbet by default rather than not knowing if it would happen or not. And there is not much imagination that the false negatives will occur.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
