### PR TITLE
Fix `required_ruby_version` issue when using `Gem::Requirement`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#9037](https://github.com/rubocop-hq/rubocop/pull/9037): Fix `required_ruby_version` issue when using `Gem::Requirement`. ([@cetinajero][])
+
 ## 1.3.0 (2020-11-12)
 
 ### New features

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -141,7 +141,15 @@ module RuboCop
           return versions.compact.min
         end
 
+        return gem_requirement_version(version) if version.send_type?
+
         version_from_str(version.str_content)
+      end
+
+      def gem_requirement_version(version)
+        gem_requirement = version.children.last
+        versions = gem_requirement.children.map { |v| version_from_str(v) }
+        versions.compact.min
       end
 
       def gemspec_filename

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -140,20 +140,11 @@ module RuboCop
         version = version_from_gemspec_file(file)
         return if version.nil?
 
-        if version.array_type?
-          versions = version.children.map { |v| version_from_str(v.str_content) }
-          return versions.compact.min
-        end
-
-        return gem_requirement_version(version) if gem_requirement? version
+        requirement = version.children.last
+        return version_from_array(version) if version.array_type?
+        return version_from_array(requirement) if gem_requirement? version
 
         version_from_str(version.str_content)
-      end
-
-      def gem_requirement_version(version)
-        gem_requirement = version.children.last
-        versions = gem_requirement.children.map { |v| version_from_str(v) }
-        versions.compact.min
       end
 
       def gemspec_filename
@@ -171,6 +162,11 @@ module RuboCop
       def version_from_gemspec_file(file)
         processed_source = ProcessedSource.from_file(file, DEFAULT_VERSION)
         required_ruby_version(processed_source.ast).first
+      end
+
+      def version_from_array(array)
+        versions = array.children.map { |v| version_from_str(v.is_a?(String) ? v : v.str_content) }
+        versions.compact.min
       end
 
       def version_from_str(str)

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -123,6 +123,10 @@ module RuboCop
         (send _ :required_ruby_version= $_)
       PATTERN
 
+      def_node_matcher :gem_requirement?, <<~PATTERN
+        (send (const(const _ :Gem):Requirement) :new $str)
+      PATTERN
+
       def name
         "`required_ruby_version` parameter (in #{gemspec_filename})"
       end
@@ -141,7 +145,7 @@ module RuboCop
           return versions.compact.min
         end
 
-        return gem_requirement_version(version) if version.send_type?
+        return gem_requirement_version(version) if gem_requirement? version
 
         version_from_str(version.str_content)
       end

--- a/spec/rubocop/target_ruby_spec.rb
+++ b/spec/rubocop/target_ruby_spec.rb
@@ -305,6 +305,53 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
           end
         end
 
+        context 'when file contains `required_ruby_version` as a requirement' do
+          let(:base_path) { configuration.base_dir_for_path_parameters }
+          let(:gemspec_file_path) { File.join(base_path, 'example.gemspec') }
+
+          it 'sets target_ruby from required_ruby_version from exact requirement version' do
+            content =
+              <<-HEREDOC
+                Gem::Specification.new do |s|
+                  s.name = 'test'
+                  s.required_ruby_version = Gem::Requirement.new('2.7.4')
+                  s.licenses = ['MIT']
+                end
+              HEREDOC
+
+            create_file(gemspec_file_path, content)
+            expect(target_ruby.version).to eq 2.7
+          end
+
+          it 'sets target_ruby from required_ruby_version from inclusive requirement range' do
+            content =
+              <<-HEREDOC
+                Gem::Specification.new do |s|
+                  s.name = 'test'
+                  s.required_ruby_version = Gem::Requirement.new('>= 3.0.0')
+                  s.licenses = ['MIT']
+                end
+              HEREDOC
+
+            create_file(gemspec_file_path, content)
+            expect(target_ruby.version).to eq 3.0
+          end
+
+          it 'sets default target_ruby from exclusive requirement range' do
+            content =
+              <<-HEREDOC
+                Gem::Specification.new do |s|
+                  s.name = 'test'
+                  s.required_ruby_version = Gem::Requirement.new('< 3.0.0')
+                  s.licenses = ['MIT']
+                end
+              HEREDOC
+
+            create_file(gemspec_file_path, content)
+            expect(target_ruby.version).to eq default_version
+          end
+        end
+
         context 'when file contains `required_ruby_version` as an array' do
           let(:base_path) { configuration.base_dir_for_path_parameters }
           let(:gemspec_file_path) { File.join(base_path, 'example.gemspec') }


### PR DESCRIPTION
This fixes an issue when the `required_ruby_version` uses `Gem::Requirement` to define the Ruby version.

Gemspec:

```
...
s.required_ruby_version = Gem::Requirement.new('< 3.0.0')
...
```

Backtrace using v1.3.0:

```
undefined method `match' for nil:NilClass
296/home/travis/build/grupopv/jekyll-tasks/vendor/bundle/ruby/2.5.0/gems/rubocop-1.3.0/lib/rubocop/target_ruby.rb:165:in `version_from_str'
297/home/travis/build/grupopv/jekyll-tasks/vendor/bundle/ruby/2.5.0/gems/rubocop-1.3.0/lib/rubocop/target_ruby.rb:144:in `find_version'
298/home/travis/build/grupopv/jekyll-tasks/vendor/bundle/ruby/2.5.0/gems/rubocop-1.3.0/lib/rubocop/target_ruby.rb:22:in `initialize'
```

Related to https://github.com/rubocop-hq/rubocop/issues/8761

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
