### PR TITLE
Fix stack level too deep error if target directory contains `**`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#9037](https://github.com/rubocop-hq/rubocop/pull/9037): Fix `required_ruby_version` issue when using `Gem::Requirement`. ([@cetinajero][])
+* [#9039](https://github.com/rubocop-hq/rubocop/pull/9039): Fix stack level too deep error if target directory contains `**`. ([@unasuke][])
 
 ## 1.3.0 (2020-11-12)
 

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -94,7 +94,7 @@ module RuboCop
     end
 
     def wanted_dir_patterns(base_dir, exclude_pattern, flags)
-      dirs = Dir.glob(File.join(base_dir, '*/'), flags)
+      dirs = Dir.glob(File.join(base_dir.gsub('/**/', '/\**/'), '*/'), flags)
                 .reject do |dir|
                   dir.end_with?('/./', '/../') || File.fnmatch?(exclude_pattern, dir, flags)
                 end

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -440,6 +440,21 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       expect(found_basenames).to include('ruby3.rb')
       expect(found_basenames).to include('ruby4.rb')
     end
+
+    # Cannot create a directory with containing `*` character on Windows.
+    # https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
+    unless RuboCop::Platform.windows?
+      it 'works also if a folder is named "**"' do
+        create_empty_file('**/ruby5.rb')
+
+        config = instance_double(RuboCop::Config)
+        exclude_property = { 'Exclude' => [File.expand_path('dir1/**/*')] }
+        allow(config).to receive(:for_all_cops).and_return(exclude_property)
+        allow(config_store).to receive(:for).and_return(config)
+
+        expect(found_basenames).to include('ruby5.rb')
+      end
+    end
   end
 
   describe '#target_files_in_dir' do


### PR DESCRIPTION
RuboCop exits with `SystemStackError` because "stack level too deep" if the target directory has the "**" directory.

```
foo
└── **
    └── bar.rb
```

```
Traceback (most recent call last):
        9197: from exe/rubocop:12:in `<main>'
        9196: from /Users/unasuke/.rbenv/versions/2.7.1/lib/ruby/2.7.0/benchmark.rb:308:in `realtime'
        9195: from exe/rubocop:13:in `block in <main>'
        9194: from /Users/unasuke/src/github.com/rubocop-hq/rubocop/lib/rubocop/cli.rb:41:in `run'
        9193: from /Users/unasuke/src/github.com/rubocop-hq/rubocop/lib/rubocop/cli.rb:72:in `execute_runners'
        9192: from /Users/unasuke/src/github.com/rubocop-hq/rubocop/lib/rubocop/cli.rb:65:in `run_command'
        9191: from /Users/unasuke/src/github.com/rubocop-hq/rubocop/lib/rubocop/cli/environment.rb:18:in `run'
        9190: from /Users/unasuke/src/github.com/rubocop-hq/rubocop/lib/rubocop/cli/command.rb:11:in `run'
         ... 9185 levels...
           4: from /Users/unasuke/src/github.com/rubocop-hq/rubocop/lib/rubocop/target_finder.rb:101:in `wanted_dir_patterns'
           3: from /Users/unasuke/src/github.com/rubocop-hq/rubocop/lib/rubocop/target_finder.rb:101:in `flat_map'
           2: from /Users/unasuke/src/github.com/rubocop-hq/rubocop/lib/rubocop/target_finder.rb:101:in `each'
           1: from /Users/unasuke/src/github.com/rubocop-hq/rubocop/lib/rubocop/target_finder.rb:101:in `block in wanted_dir_patterns'
/Users/unasuke/src/github.com/rubocop-hq/rubocop/lib/rubocop/target_finder.rb:97:in `wanted_dir_patterns': stack level too deep (SystemStackError)
```

If directory name end with `/**/`, escape dir name to `/\**\` to inspect files under the `**/` directory.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
