### PR TITLE
Update `VersionChanged` of `Lint/ConstantDefinitionInBlock`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1400,7 +1400,7 @@ Lint/ConstantDefinitionInBlock:
   StyleGuide: '#no-constant-definition-in-block'
   Enabled: true
   VersionAdded: '0.91'
-  VersionChanged: '1.4'
+  VersionChanged: '1.3'
   # `enums` for Typed Enums via T::Enum in Sorbet.
   # https://sorbet.org/docs/tenum
   AllowedMethods:

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -361,7 +361,7 @@ end
 | Yes
 | No
 | 0.91
-| 1.4
+| 1.3
 |===
 
 Do not define constants within a block, since the block's scope does not


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/9033#issuecomment-726588888

`VersionChanged` has been updated to 1.4 by #9036, but if the next release is 1.3.1 it will be 1.3 correctly.
So I think #9036 change can be included in the 1.3.1 bugfix release :-)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
