### PR TITLE
Add an option to redirect offence reports to stderr

### DIFF
--- a/changelog/new_redirect_offence_reports_to_stderr_when.md
+++ b/changelog/new_redirect_offence_reports_to_stderr_when.md
@@ -1,0 +1,1 @@
+* [#9043](https://github.com/rubocop-hq/rubocop/pull/9043): Add `--stderr` to write all output to stderr except for the autocorrected source. ([@knu][])

--- a/docs/modules/ROOT/pages/usage/basic_usage.adoc
+++ b/docs/modules/ROOT/pages/usage/basic_usage.adoc
@@ -240,6 +240,9 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | `--show-cops`
 | Shows available cops and their configuration.
 
+| `--stderr`
+| Write all output to stderr except for the autocorrected source. This is especially useful when combined with `--auto-correct` and `--stdin`.
+
 | `-s/--stdin`
 | Pipe source from STDIN. This is useful for editor integration. Takes one argument, a path, relative to the root of the project. RuboCop will use this path to determine which cops are enabled (via eg. Include/Exclude), and so that certain cops like Naming/FileName can be checked.
 

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -195,6 +195,7 @@ module RuboCop
 
       option(opts, '--safe')
 
+      option(opts, '--stderr')
       option(opts, '--[no-]color')
 
       option(opts, '-v', '--version')
@@ -498,6 +499,9 @@ module RuboCop
       extra_details:                    'Display extra details in offense messages.',
       lint:                             'Run only lint cops.',
       safe:                             'Run only safe cops.',
+      stderr:                           ['Write all output to stderr except for the',
+                                         'autocorrected source. This is especially useful',
+                                         'when combined with --auto-correct and --stdin.'],
       list_target_files:                'List all files RuboCop will inspect.',
       auto_correct:                     'Auto-correct offenses (only when it\'s safe).',
       safe_auto_correct:                '(same, deprecated)',

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -1760,6 +1760,31 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
     end
 
+    it 'prints offence reports to stderr and corrected code to stdout if --auto-correct-all and --stderr are used' do
+      begin
+        $stdin = StringIO.new('p $/')
+        argv   = ['--auto-correct-all',
+                  '--only=Style/SpecialGlobalVars',
+                  '--format=simple',
+                  '--stderr',
+                  '--stdin',
+                  'fake.rb']
+        expect(cli.run(argv)).to eq(0)
+        expect($stderr.string).to eq(<<~RESULT)
+          == fake.rb ==
+          C:  1:  3: [Corrected] Style/SpecialGlobalVars: Prefer $INPUT_RECORD_SEPARATOR or $RS from the stdlib 'English' module (don't forget to require it) over $/.
+
+          1 file inspected, 1 offense detected, 1 offense corrected
+          ====================
+        RESULT
+        expect($stdout.string).to eq(<<~RESULT.chomp)
+          p $INPUT_RECORD_SEPARATOR
+        RESULT
+      ensure
+        $stdin = STDIN
+      end
+    end
+
     it 'can parse JSON result when specifying `--format=json` and `--stdin` options' do
       begin
         $stdin = StringIO.new('p $/')

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -131,6 +131,9 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                   --ignore-disable-comments    Run cops even when they are disabled locally
                                                with a comment.
                   --safe                       Run only safe cops.
+                  --stderr                     Write all output to stderr except for the
+                                               autocorrected source. This is especially useful
+                                               when combined with --auto-correct and --stdin.
                   --[no-]color                 Force color output on or off.
               -v, --version                    Display version.
               -V, --verbose-version            Display verbose version.


### PR DESCRIPTION
This adds `--stderr` to make it easier to use `--stdin` in shell scripts, editor integration, CI workflow, etc.

In response to feedbacks, I altered this PR from changing the behavior of `--stdin` to adding a new option. 
<details>
<summary>Here's the original description.</summary>
This makes editor integration much easier to implement by eliminating the need to process the output.

In the short term, existing editor plugins that expect `====================` will be broken, but it should be relatively easy to fix.

For example, [vscode-ruby-rubocop](https://github.com/misogi/vscode-ruby-rubocop/blob/master/src/rubocop.ts) can check if stderr output contains (or ends with) `====================` to see if it needs to delete warnings from stdout output. (to support any version of rubocop)

Eventually, they just need to simply use the stdout output.
</details>

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
