### PR TITLE
[Fix #9041] Fix a false positive for `Naming/VariableNumber`

### DIFF
--- a/changelog/fix_a_false_positive_for_naming_variable_number.md
+++ b/changelog/fix_a_false_positive_for_naming_variable_number.md
@@ -1,0 +1,1 @@
+* [#9041](https://github.com/rubocop-hq/rubocop/issues/9041): Fix a false positive for `Naming/VariableNumber` when using integer symbols. ([@koic][])

--- a/lib/rubocop/cop/mixin/configurable_numbering.rb
+++ b/lib/rubocop/cop/mixin/configurable_numbering.rb
@@ -8,9 +8,9 @@ module RuboCop
       include ConfigurableFormatting
 
       FORMATS = {
-        snake_case:  /(?:\D|_\d+)$/,
-        normalcase:  /(?:\D|[^_\d]\d+)$/,
-        non_integer: /\D$/
+        snake_case:  /(?:\D|_\d+|\A\d+)\z/,
+        normalcase:  /(?:\D|[^_\d]\d+|\A\d+)\z/,
+        non_integer: /(\D|\A\d+)\z/
       }.freeze
     end
   end

--- a/spec/rubocop/cop/naming/variable_number_spec.rb
+++ b/spec/rubocop/cop/naming/variable_number_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
     end
   end
 
+  shared_examples 'accepts integer symbols' do
+    it 'accepts integer symbol' do
+      expect_no_offenses(':"42"')
+    end
+
+    it 'accepts integer symbol array literal' do
+      expect_no_offenses('%i[1 2 3]')
+    end
+  end
+
   context 'when configured for snake_case' do
     let(:cop_config) { { 'EnforcedStyle' => 'snake_case' } }
 
@@ -59,6 +69,8 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
     it_behaves_like 'accepts', 'snake_case', '@foo'
     it_behaves_like 'accepts', 'snake_case', '@__foo__'
     it_behaves_like 'accepts', 'snake_case', 'emparejó'
+
+    it_behaves_like 'accepts integer symbols'
 
     it 'registers an offense for normal case numbering in symbol' do
       expect_offense(<<~RUBY)
@@ -125,6 +137,8 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
     it_behaves_like 'accepts', 'normalcase', '@__foo__'
     it_behaves_like 'accepts', 'normalcase', 'emparejó'
 
+    it_behaves_like 'accepts integer symbols'
+
     it 'registers an offense for snake case numbering in symbol' do
       expect_offense(<<~RUBY)
         :sym_1
@@ -184,6 +198,8 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
     it_behaves_like 'accepts', 'non_integer', '_foo'
     it_behaves_like 'accepts', 'non_integer', '@__foo__'
     it_behaves_like 'accepts', 'non_integer', 'emparejó'
+
+    it_behaves_like 'accepts integer symbols'
 
     it 'registers an offense for snake case numbering in symbol' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #9041.

This PR fixes a false positive for `Naming/VariableNumber` when using integer symbols.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
