### PR TITLE
Have `cut_release` handle "config/default" and generate cops doc.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,9 +234,6 @@ jobs:
       - run:
           name: Check documentation syntax
           command: bundle exec rake documentation_syntax_check
-      - run:
-          name: Build documentation and verify that doc files are in sync
-          command: bundle exec rake verify_cops_documentation
 
 workflows:
   version: 2

--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,7 @@ RuboCop::RakeTask.new(:internal_investigation).tap do |task|
 end
 
 task default: %i[
-  documentation_syntax_check generate_cops_documentation
+  documentation_syntax_check
   spec ascii_spec
   internal_investigation
 ]

--- a/changelog/change_have_cut_release_handle_configdefault.md
+++ b/changelog/change_have_cut_release_handle_configdefault.md
@@ -1,0 +1,1 @@
+* [#9045](https://github.com/rubocop-hq/rubocop/pull/9045): Have `cut_release` handle "config/default" and generate cops doc. ([@marcandre][])

--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -439,9 +439,6 @@ keys being in alphabetical order, the `(default)` being specified, and one empty
 before `class YourCop`. While not all examples in the codebase follow this exact format,
 we strive to make this consistent. PRs improving RuboCop documentation are very welcome.
 
-Run `rake generate_cops_documentation` to apply your `yard` documentation into the manual.
-CI will fail if the manual and `yard` comments do not match exactly. `rake default` will also generate the new documentation.
-
 == Testing your cop in a real codebase
 
 Generally, is a good practice to check if your cop is working properly over a
@@ -462,6 +459,3 @@ To make it fast and do not get confused with other cops in action,  you can use
 ----
 $ rubocop --only Style/SimplifyNotEmptyWithAny
 ----
-
-In the end, do not forget to run `rake generate_cops_documentation` to update
-the docs.

--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -17,7 +17,6 @@ module RuboCop
       SOURCE_TEMPLATE = <<-RUBY.gsub(/^ {8}/, '')
         # frozen_string_literal: true
 
-        # TODO: when finished, run `rake generate_cops_documentation` to update the docs
         module RuboCop
           module Cop
             module %<department>s
@@ -134,7 +133,7 @@ module RuboCop
       end
 
       def inject_config(config_file_path: 'config/default.yml',
-                        version_added: bump_minor_version)
+                        version_added: '<<next>>')
         injector =
           ConfigurationInjector.new(configuration_file_path: config_file_path,
                                     badge: badge,
@@ -212,12 +211,6 @@ module RuboCop
           .gsub(/([^A-Z])([A-Z]+)/, '\1_\2')
           .gsub(/([A-Z])([A-Z][^A-Z\d]+)/, '\1_\2')
           .downcase
-      end
-
-      def bump_minor_version
-        versions = RuboCop::Version::STRING.split('.')
-
-        "#{versions[0]}.#{versions[1].succ}"
       end
     end
   end

--- a/lib/rubocop/cop/generator/configuration_injector.rb
+++ b/lib/rubocop/cop/generator/configuration_injector.rb
@@ -14,7 +14,7 @@ module RuboCop
             VersionAdded: '%<version_added>s'
         YAML
 
-        def initialize(configuration_file_path:, badge:, version_added:)
+        def initialize(configuration_file_path:, badge:, version_added: '<<next>>')
           @configuration_file_path = configuration_file_path
           @badge = badge
           @version_added = version_added

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe RuboCop::Cop::Generator do
       generated_source = <<~RUBY
         # frozen_string_literal: true
 
-        # TODO: when finished, run `rake generate_cops_documentation` to update the docs
         module RuboCop
           module Cop
             module Style
@@ -194,8 +193,6 @@ RSpec.describe RuboCop::Cop::Generator do
         Style/SpecialGlobalVars:
           Enabled: true
       YAML
-
-      stub_const('RuboCop::Version::STRING', '0.58.2')
     end
 
     context 'when it is the middle in alphabetical order' do
@@ -207,7 +204,7 @@ RSpec.describe RuboCop::Cop::Generator do
           Style/FakeCop:
             Description: 'TODO: Write a description of the cop.'
             Enabled: pending
-            VersionAdded: '0.59'
+            VersionAdded: '<<next>>'
 
           Style/Lambda:
             Enabled: true
@@ -232,7 +229,7 @@ RSpec.describe RuboCop::Cop::Generator do
           Style/Aaa:
             Description: 'TODO: Write a description of the cop.'
             Enabled: pending
-            VersionAdded: '0.59'
+            VersionAdded: '<<next>>'
 
           Style/Alias:
             Enabled: true
@@ -269,7 +266,7 @@ RSpec.describe RuboCop::Cop::Generator do
           Style/Zzz:
             Description: 'TODO: Write a description of the cop.'
             Enabled: pending
-            VersionAdded: '0.59'
+            VersionAdded: '<<next>>'
         YAML
 
         generator.inject_config(config_file_path: path)
@@ -289,7 +286,7 @@ RSpec.describe RuboCop::Cop::Generator do
           Style/FakeCop:
             Description: 'TODO: Write a description of the cop.'
             Enabled: pending
-            VersionAdded: '1.52'
+            VersionAdded: '<<next>>'
 
           Style/Lambda:
             Enabled: true
@@ -298,7 +295,7 @@ RSpec.describe RuboCop::Cop::Generator do
             Enabled: true
         YAML
 
-        generator.inject_config(config_file_path: path, version_added: '1.52')
+        generator.inject_config(config_file_path: path)
       end
     end
   end

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -9,23 +9,12 @@ YARD::Rake::YardocTask.new(:yard_for_generate_documentation) do |task|
   task.options = ['--no-output']
 end
 
-desc 'Generate docs of all cops departments'
-task generate_cops_documentation: :yard_for_generate_documentation do
+task update_cops_documentation: :yard_for_generate_documentation do
   deps = %w[Bundler Gemspec Layout Lint Metrics Migration Naming Security Style]
   CopsDocumentationGenerator.new(departments: deps).call
 end
 
-desc 'Verify that documentation is up to date'
-task verify_cops_documentation: :generate_cops_documentation do
-  # Do not print diff and yield whether exit code was zero
-  sh('git diff --quiet docs') do |outcome, _|
-    exit if outcome
-
-    # Output diff before raising error
-    sh('GIT_PAGER=cat git diff docs')
-
-    warn 'The docs directory is out of sync. ' \
-      'Run `rake generate_cops_documentation` and commit the results.'
-    exit!
-  end
+desc 'Generate docs of all cops departments (obsolete)'
+task :generate_cops_documentation do
+  puts 'Updating the documentation is now done automatically!'
 end


### PR DESCRIPTION
* task `cut_release` will replace the string "<<next_version>>" in the default.yml file with the version being cut (matching is permissive: quoted or unquoted, with "-" or "_", etc.)
* task `generate_cops_documentation` now does nothing and only prints out that doc generation is now automatic
* processing code moved to new task `update_cops_documentation` (no public description) that is triggered by `cut_release`
* new cop generator uses this by default instead of the next minor version

Did I forget anything?