### PR TITLE
[Fix #9050] Fix a false positive for `Style/NegatedIfElseCondition`

### DIFF
--- a/changelog/fix_false_negative_for_negated_if_else_condition.md
+++ b/changelog/fix_false_negative_for_negated_if_else_condition.md
@@ -1,0 +1,1 @@
+* [#9050](https://github.com/rubocop-hq/rubocop/issues/9050): Fix a false positive for `Style/NegatedIfElseCondition` when `if` with `!!` condition. ([@koic][])

--- a/lib/rubocop/cop/style/negated_if_else_condition.rb
+++ b/lib/rubocop/cop/style/negated_if_else_condition.rb
@@ -35,6 +35,8 @@ module RuboCop
 
         NEGATED_EQUALITY_METHODS = %i[!= !~].freeze
 
+        def_node_matcher :double_negation?, '(send (send _ :!) :!)'
+
         def self.autocorrect_incompatible_with
           [Style::InverseMethods, Style::Not]
         end
@@ -47,7 +49,7 @@ module RuboCop
           return unless if_else?(node)
 
           condition = node.condition
-          return unless negated_condition?(condition)
+          return if double_negation?(condition) || !negated_condition?(condition)
 
           type = node.ternary? ? 'ternary' : 'if-else'
           add_offense(node, message: format(MSG, type: type)) do |corrector|

--- a/spec/rubocop/cop/style/negated_if_else_condition_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_else_condition_spec.rb
@@ -153,6 +153,16 @@ RSpec.describe RuboCop::Cop::Style::NegatedIfElseCondition do
     RUBY
   end
 
+  it 'does not register an offense when `if` with `!!` condition' do
+    expect_no_offenses(<<~RUBY)
+      if !!x
+        do_something
+      else
+        do_another_thing
+      end
+    RUBY
+  end
+
   it 'does not register an offense when `if` with negated condition has no `else` branch' do
     expect_no_offenses(<<~RUBY)
       if !x


### PR DESCRIPTION
Fixes #9050.

This PR fixes a false positive for `Style/NegatedIfElseCondition` when `if` with `!!` condition'.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
