### PR TITLE
Remove redundant patch version from default.yml

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1176,7 +1176,7 @@ Layout/SpaceBeforeBlockBraces:
   SupportedStylesForEmptyBraces:
     - space
     - no_space
-  VersionChanged: '0.52.1'
+  VersionChanged: '0.52'
 
 Layout/SpaceBeforeComma:
   Description: 'No spaces before commas.'
@@ -1865,7 +1865,7 @@ Lint/RescueException:
   StyleGuide: '#no-blind-rescues'
   Enabled: true
   VersionAdded: '0.9'
-  VersionChanged: '0.27.1'
+  VersionChanged: '0.27'
 
 Lint/RescueType:
   Description: 'Avoid rescuing from non constants that could result in a `TypeError`.'
@@ -3920,7 +3920,7 @@ Style/PercentLiteralDelimiters:
     '%r': '{}'
     '%w': '[]'
     '%W': '[]'
-  VersionChanged: '0.48.1'
+  VersionChanged: '0.48'
 
 Style/PercentQLiterals:
   Description: 'Checks if uses of %Q/%q match the configured preference.'
@@ -4327,7 +4327,7 @@ Style/StringMethods:
   Description: 'Checks if configured preferred methods are used over non-preferred.'
   Enabled: false
   VersionAdded: '0.34'
-  VersionChanged: '0.34.2'
+  VersionChanged: '0.34'
   # Mapping from undesired method to desired_method
   # e.g. to use `to_sym` over `intern`:
   #

--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -5369,7 +5369,7 @@ a ** b
 | Yes
 | Yes
 | 0.49
-| 0.52.1
+| 0.52
 |===
 
 Checks that block braces have or don't have a space before the opening

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -3689,7 +3689,7 @@ end
 | Yes
 | No
 | 0.9
-| 0.27.1
+| 0.27
 |===
 
 This cop checks for `rescue` blocks targeting the Exception class.

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -7549,7 +7549,7 @@ end
 | Yes
 | Yes
 | 0.19
-| 0.48.1
+| 0.48
 |===
 
 This cop enforces the consistent usage of `%`-literal delimiters.
@@ -10134,7 +10134,7 @@ result = "Tests #{success ? "PASS" : "FAIL"}"
 | Yes
 | Yes
 | 0.34
-| 0.34.2
+| 0.34
 |===
 
 This cop enforces the use of consistent method names

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -37,6 +37,18 @@ RSpec.describe 'RuboCop Project', type: :feature do
       end
     end
 
+    %w[VersionChanged VersionRemoved].each do |version_type|
+      it "requires a nicely formatted `#{version_type}` metadata for all cops" do
+        cop_names.each do |name|
+          version = config[name][version_type]
+          next unless version
+
+          expect(version).to(match(/\A\d+\.\d+\z/),
+                             "#{version} should be format ('X.Y') for #{name}.")
+        end
+      end
+    end
+
     it 'has a period at EOL of description' do
       cop_names.each do |name|
         description = config[name]['Description']


### PR DESCRIPTION
This PR removes redundant patch version of `VersionChanged` from default.yml.

Related PR ... https://github.com/rubocop-hq/rubocop/pull/7802

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
