### PR TITLE
Bump RuboCop Performance to 1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'memory_profiler', platform: :mri
 gem 'pry'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
-gem 'rubocop-performance', '~> 1.8.1'
+gem 'rubocop-performance', '~> 1.9.0'
 gem 'rubocop-rspec', '~> 2.0.0'
 # Workaround for cc-test-reporter with SimpleCov 0.18.
 # Stop upgrading SimpleCov until the following issue will be resolved.

--- a/lib/rubocop/cop/internal_affairs/useless_message_assertion.rb
+++ b/lib/rubocop/cop/internal_affairs/useless_message_assertion.rb
@@ -38,7 +38,7 @@ module RuboCop
 
         def assertions_using_described_class_msg
           described_class_msg(processed_source.ast).reject do |node|
-            node.ancestors.any?(&method(:rspec_expectation_on_msg?))
+            node.ancestors.any? { |ancestor| rspec_expectation_on_msg?(ancestor) }
           end
         end
 

--- a/lib/rubocop/cop/layout/empty_line_between_defs.rb
+++ b/lib/rubocop/cop/layout/empty_line_between_defs.rb
@@ -47,7 +47,7 @@ module RuboCop
         def on_begin(node)
           node.children.each_cons(2) do |prev, n|
             nodes = [prev, n]
-            check_defs(nodes) if nodes.all?(&method(:def_node?))
+            check_defs(nodes) if nodes.all? { |def_candidate| def_node?(def_candidate) }
           end
         end
 

--- a/lib/rubocop/cop/mixin/visibility_help.rb
+++ b/lib/rubocop/cop/mixin/visibility_help.rb
@@ -16,9 +16,7 @@ module RuboCop
       end
 
       def find_visibility_start(node)
-        node.left_siblings
-            .reverse
-            .find(&method(:visibility_block?))
+        node.left_siblings.reverse.find { |sibling| visibility_block?(sibling) }
       end
 
       # Navigate to find the last protected method

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -91,7 +91,7 @@ module RuboCop
           return false unless node
 
           if node.begin_type?
-            node.children.all?(&method(:constant_declaration?))
+            node.children.all? { |child| constant_declaration?(child) }
           else
             constant_definition?(node)
           end

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -74,7 +74,7 @@ module RuboCop
             parent &&
               (logical_operator?(parent) ||
               parent.send_type? &&
-              parent.arguments.any?(&method(:logical_operator?)))
+              parent.arguments.any? { |argument| logical_operator?(argument) })
           end
 
           def call_in_optional_arguments?(node)
@@ -110,7 +110,7 @@ module RuboCop
           def hash_literal_in_arguments?(node)
             node.arguments.any? do |n|
               hash_literal?(n) ||
-                n.send_type? && node.descendants.any?(&method(:hash_literal?))
+                n.send_type? && node.descendants.any? { |descendant| hash_literal?(descendant) }
             end
           end
 

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -53,7 +53,7 @@ module RuboCop
       end
 
       def on_node(syms, sexp, excludes = [], &block)
-        return to_enum(:on_node, syms, sexp, excludes) unless block_given?
+        return to_enum(:on_node, syms, sexp, excludes) unless block
 
         yield sexp if Array(syms).include?(sexp.type)
         return if Array(excludes).include?(sexp.type)

--- a/lib/rubocop/cop/variable_force/branch.rb
+++ b/lib/rubocop/cop/variable_force/branch.rb
@@ -78,7 +78,7 @@ module RuboCop
           end
 
           def each_ancestor(include_self: false, &block)
-            return to_enum(__method__, include_self: include_self) unless block_given?
+            return to_enum(__method__, include_self: include_self) unless block
 
             yield self if include_self
             scan_ancestors(&block)

--- a/lib/rubocop/cop/variable_force/scope.rb
+++ b/lib/rubocop/cop/variable_force/scope.rb
@@ -61,7 +61,7 @@ module RuboCop
         end
 
         def each_node(&block)
-          return to_enum(__method__) unless block_given?
+          return to_enum(__method__) unless block
 
           yield node if naked_top_level?
           scan_node(node, &block)

--- a/lib/rubocop/rake_task.rb
+++ b/lib/rubocop/rake_task.rb
@@ -22,7 +22,7 @@ module RuboCop
 
       task(name, *args) do |_, task_args|
         RakeFileUtils.verbose(verbose) do
-          yield(*[self, task_args].slice(0, task_block.arity)) if block_given?
+          yield(*[self, task_args].slice(0, task_block.arity)) if task_block
           run_cli(verbose, full_options)
         end
       end
@@ -66,7 +66,7 @@ module RuboCop
 
         task(:auto_correct, *args) do |_, task_args|
           RakeFileUtils.verbose(verbose) do
-            yield(*[self, task_args].slice(0, task_block.arity)) if block_given?
+            yield(*[self, task_args].slice(0, task_block.arity)) if task_block
             options = full_options.unshift('--auto-correct-all')
             options.delete('--parallel')
             run_cli(verbose, options)

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -64,7 +64,7 @@ module RuboCop
     # instances that each inspects its allotted group of files.
     def warm_cache(target_files)
       puts 'Running parallel inspection' if @options[:debug]
-      Parallel.each(target_files, &method(:file_offenses))
+      Parallel.each(target_files) { |target_file| file_offenses(target_file) }
     end
 
     def find_target_files(paths)


### PR DESCRIPTION
This PR bumps RuboCop Performance to 1.9 and suppresses the new `Performance/BlockGivenWithExplicitBlock` and `Performance/MethodObjectAsBlock` cop's offenses.

```console
% bundle exec rubocop
(snip)

lib/rubocop/rake_task.rb:69:69: C:
Performance/BlockGivenWithExplicitBlock: Check block argument explicitly
instead of using block_given?.
            yield(*[self, task_args].slice(0, task_block.arity)) if
            block_given?
            ^^^^^^^^^^^^
lib/rubocop/runner.rb:67:35: C: Performance/MethodObjectAsBlock: Use
block explicitly instead of block-passing a method object.
      Parallel.each(target_files, &method(:file_offenses))
                                  ^^^^^^^^^^^^^^^^^^^^^^^

1200 files inspected, 12 offenses detected, 5 offenses auto-correctable
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
