### PR TITLE
[Fix #8993] Allow `ExcludedMethods` config of `Metrics/MethodLength` cop to contain regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [#8788](https://github.com/rubocop-hq/rubocop/issues/8788): Change `Style/Documentation` to not trigger offense with only macros. ([@tejasbubane][])
+* [#8993](https://github.com/rubocop-hq/rubocop/issues/8993): Allow `ExcludedMethods` config of `Metrics/MethodLength` cop to contain regex. ([@tejasbubane][])
 
 ## 1.3.1 (2020-11-16)
 

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -36,7 +36,7 @@ module RuboCop
 
         def on_def(node)
           excluded_methods = cop_config['ExcludedMethods']
-          return if excluded_methods.include?(String(node.method_name))
+          return if excluded_methods.any? { |m| m.match? String(node.method_name) }
 
           check_code_length(node)
         end

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -219,6 +219,37 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
     end
   end
 
+  context 'when regex is defined in `ExcludedMethods`' do
+    before { cop_config['ExcludedMethods'] = [/_name$/] }
+
+    it 'accepts the user_name method' do
+      expect_no_offenses(<<~RUBY)
+        def user_name
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      RUBY
+    end
+
+    it 'raises offense for firstname' do
+      expect_offense(<<~RUBY)
+        def firstname
+        ^^^^^^^^^^^^^ Method has too many lines. [6/5]
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      RUBY
+    end
+  end
+
   context 'when `CountAsOne` is not empty' do
     before { cop_config['CountAsOne'] = ['array'] }
 


### PR DESCRIPTION
Closes #8993

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/