### PR TITLE
[Fix #9060] Fix an error for `Layout/SpaceAroundMethodCallOperator`

### DIFF
--- a/changelog/fix_an_error_for_space_around_method_call_operator.md
+++ b/changelog/fix_an_error_for_space_around_method_call_operator.md
@@ -1,0 +1,1 @@
+* [#9060](https://github.com/rubocop-hq/rubocop/issues/9060): Fix an error for `Layout/SpaceAroundMethodCallOperator` when using `__ENCODING__`. ([@koic][])

--- a/lib/rubocop/cop/layout/space_around_method_call_operator.rb
+++ b/lib/rubocop/cop/layout/space_around_method_call_operator.rb
@@ -51,7 +51,7 @@ module RuboCop
         alias on_csend on_send
 
         def on_const(node)
-          return unless node.loc.double_colon
+          return unless node.loc.respond_to?(:double_colon) && node.loc.double_colon
 
           check_space_after_double_colon(node)
         end

--- a/spec/rubocop/cop/layout/space_around_method_call_operator_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_method_call_operator_spec.rb
@@ -511,4 +511,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundMethodCallOperator do
       'foo' + 'bar'
     RUBY
   end
+
+  it 'does not register an offense when using `__ENCODING__`' do
+    expect_no_offenses(<<~RUBY)
+      __ENCODING__
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #9060.

This PR fixes the following error for `Layout/SpaceAroundMethodCallOperator` when using `__ENCODING__`.

```console
% cat example.rb
__ENCODING__

% bundle exec rubocop --only Layout/SpaceAroundMethodCallOperator -d example.rb
(snip)

An error occurred while Layout/SpaceAroundMethodCallOperator cop was
inspecting
/Users/koic/src/github.com/koic/rubocop-issues/9060/example.rb:1:0.
undefined method `double_colon' for
#<Parser::Source::Map:0x00007f8f12a3fae0>
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/layout/space_around_method_call_operator.rb:54:in
`on_const'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/commissioner.rb:100:in
`public_send'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/commissioner.rb:100:in
`block (2 levels) in trigger_responding_cops'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
