### PR TITLE
[Fix #9047] Fix deprecating `set-env` for GitHub Actions

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.os == 'windows'
         run: |
           # set TMPDIR, git core.autocrlf
-          echo "::set-env name=TMPDIR::$env:RUNNER_TEMP"
+          echo "TMPDIR=$env:RUNNER_TEMP" >> $GITHUB_ENV
           git config --system core.autocrlf false
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Fixes #9047.

This PR fixes the following GitHub Actions error.

```console
Run # set TMPDIR, git core.autocrlf
Error: Unable to process command '::set-env name=TMPDIR::D:\a\_temp'
successfully.
Error: The `set-env` command is disabled. Please upgrade to using
Environment Files or opt into unsecure command execution by setting the
`ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For
more information see:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

https://github.com/rubocop-hq/rubocop/pull/9062/checks?check_run_id=1409773152

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
