### PR TITLE
Update `Lint/UnmodifiedReduceAccumulator` to accept blocks which return in the form `accumulator[element]`

### DIFF
--- a/changelog/change_update_lint_unmodified_reduce_accumulator.md
+++ b/changelog/change_update_lint_unmodified_reduce_accumulator.md
@@ -1,0 +1,1 @@
+* [#9059](https://github.com/rubocop-hq/rubocop/pull/9059): Update `Lint/UnmodifiedReduceAccumulator` to accept blocks which return in the form `accumulator[element]`. ([@dvandersluis][])


### PR DESCRIPTION
Reduce blocks that just return something in the form `accumulator[element]` are now accepted by `Lint/UnmodifiedReduceAccumulator` (the issue asked for all methods on the accumulator to be allowed but this was the only exception previously due to the check for accumulator index). Other accumulator indexes are still offenses.

Fixes #9059.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
