### PR TITLE
Correcting Lint::AmbiguousRegexpLiteral autocorrection to correctly correct my RSpec code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#9067](https://github.com/rubocop-hq/rubocop/pull/9067): Fix an incorrect auto-correct for `Lint::AmbiguousRegexpLiteral` when passing in a regexp to a method with no receiver. ([@amatsuda][])
+
 ### Changes
 
 * [#8788](https://github.com/rubocop-hq/rubocop/issues/8788): Change `Style/Documentation` to not trigger offense with only macros. ([@tejasbubane][])

--- a/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
+++ b/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
@@ -53,7 +53,8 @@ module RuboCop
         def find_offense_node(node, regexp_receiver)
           return node unless node.parent
 
-          if node.parent.send_type? || method_chain_to_regexp_receiver?(node, regexp_receiver)
+          if (node.parent.send_type? && node.receiver) ||
+             method_chain_to_regexp_receiver?(node, regexp_receiver)
             node = find_offense_node(node.parent, regexp_receiver)
           end
 

--- a/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
@@ -79,6 +79,28 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousRegexpLiteral do
         RUBY
       end
 
+      it 'registers an offense and corrects when sending method inside parens without receiver takes a regexp argument' do
+        expect_offense(<<~RUBY)
+          expect('RuboCop').to(match /Cop/)
+                                     ^ Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal, or add a whitespace to the right of the `/` if it should be a division.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          expect('RuboCop').to(match(/Cop/))
+        RUBY
+      end
+
+      it 'registers an offense and corrects when sending method without receiver takes a regexp argument' do
+        expect_offense(<<~RUBY)
+          expect('Rubocop').to match /Robo/
+                                     ^ Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal, or add a whitespace to the right of the `/` if it should be a division.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          expect('Rubocop').to match(/Robo/)
+        RUBY
+      end
+
       it 'registers an offense and corrects when using block argument' do
         expect_offense(<<~RUBY)
           p /pattern/, foo do |arg|


### PR DESCRIPTION
I found that autocorrecting an RSpec code `expect('hello').to match /h/` with `Lint::AmbiguousRegexpLiteral` produces invalid Ruby code that misses an opening paren.

```ruby
# original
expect('hello').to match /h/
# expected
expect('hello').to match(/h/)
# result
expect('hello').to(match /h/))
```

I debugged a little bit, then found that the autocorrector adds the outer parens first, so it rewrites
```ruby
expect('hello').to match /h/
```
to
```ruby
expect('hello').to(match /h/)
```
then internally invokes this same autocorrector again, then fails to properly autocorrect at this second correction.

Attatched the failing specs and a possible fix (I'm not a Rubocop guy, so I'm not at all confident if I'm doing it right, but it seems like this change fixes my problem anyway).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default` and got a Layout/LineLength offense which I really hate but anyway now it executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
