### PR TITLE
[Fix #9070] Fix `Lint/UnmodifiedReduceAccumulator` when there aren't enough block arguments

### DIFF
--- a/changelog/fix_updated_lintunmodifiedreduceaccumulator.md
+++ b/changelog/fix_updated_lintunmodifiedreduceaccumulator.md
@@ -1,0 +1,1 @@
+* [#9070](https://github.com/rubocop-hq/rubocop/issues/9070): Fix `Lint/UnmodifiedReduceAccumulator` error when the block does not have enough arguments. ([@dvandersluis][])

--- a/lib/rubocop/cop/lint/unmodified_reduce_accumulator.rb
+++ b/lib/rubocop/cop/lint/unmodified_reduce_accumulator.rb
@@ -12,7 +12,8 @@ module RuboCop
       # could be rewritten as such without a loop.
       #
       # Also catches instances where an index of the accumulator is returned, as
-      # this may change the type of object being retained.
+      # this may change the type of object being retained. As well, detects when
+      # fewer than 2 block arguments are specified.
       #
       # NOTE: For the purpose of reducing false positives, this cop only flags
       # returns in `reduce` blocks where the element is the only variable in
@@ -67,7 +68,7 @@ module RuboCop
         MSG_INDEX = 'Do not return an element of the accumulator in `%<method>s`.'
 
         def_node_matcher :reduce_with_block?, <<~PATTERN
-          (block (send _recv {:reduce :inject} ...) (args arg+) ...)
+          (block (send _recv {:reduce :inject} ...) args ...)
         PATTERN
 
         def_node_matcher :accumulator_index?, <<~PATTERN
@@ -106,6 +107,7 @@ module RuboCop
 
         def on_block(node)
           return unless reduce_with_block?(node)
+          return unless node.arguments.length >= 2
 
           check_return_values(node)
         end

--- a/spec/rubocop/cop/lint/unmodified_reduce_accumulator_spec.rb
+++ b/spec/rubocop/cop/lint/unmodified_reduce_accumulator_spec.rb
@@ -578,6 +578,14 @@ RSpec.describe RuboCop::Cop::Lint::UnmodifiedReduceAccumulator do
           end
         RUBY
       end
+
+      context 'argument count' do
+        it 'ignores when there are not enough block arguments' do
+          expect_no_offenses(<<~RUBY, method: method)
+            (1..4).#{method}(0) { |acc| acc.foo }
+          RUBY
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Handle cases in `Lint/UnmodifiedReduceAccumulator` when there are fewer block elements than expected. Fixes #9070.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
