### PR TITLE
`Lint/MissingSuper`: exclude `method_missing` and `respond_to_missing?`

### DIFF
--- a/changelog/change_lintmissingsuper_exclude_method_missing.md
+++ b/changelog/change_lintmissingsuper_exclude_method_missing.md
@@ -1,0 +1,1 @@
+* [#9072](https://github.com/rubocop-hq/rubocop/pull/9072): `Lint/MissingSuper`: exclude `method_missing` and `respond_to_missing?`. ([@marcandre][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1684,6 +1684,7 @@ Lint/MissingSuper:
                   without calls to `super`'.
   Enabled: true
   VersionAdded: '0.89'
+  VersionChanged: '<<next>>'
 
 Lint/MixedRegexpCaptureTypes:
   Description: 'Do not mix named captures and numbered captures in a Regexp literal.'

--- a/lib/rubocop/cop/lint/missing_super.rb
+++ b/lib/rubocop/cop/lint/missing_super.rb
@@ -6,6 +6,11 @@ module RuboCop
       # This cop checks for the presence of constructors and lifecycle callbacks
       # without calls to `super`.
       #
+      # This cop does not consider `method_missing` (and `respond_to_missing?`)
+      # because in some cases it makes sense to overtake what is considered a
+      # missing method. In other cases, the theoretical ideal handling could be
+      # challenging or verbose for no actual gain.
+      #
       # @example
       #   # bad
       #   class Employee < Person
@@ -43,15 +48,13 @@ module RuboCop
 
         STATELESS_CLASSES = %w[BasicObject Object].freeze
 
-        OBJECT_LIFECYCLE_CALLBACKS  = %i[method_missing respond_to_missing?].freeze
         CLASS_LIFECYCLE_CALLBACKS   = %i[inherited].freeze
         METHOD_LIFECYCLE_CALLBACKS  = %i[method_added method_removed method_undefined
                                          singleton_method_added singleton_method_removed
                                          singleton_method_undefined].freeze
 
-        CALLBACKS = (OBJECT_LIFECYCLE_CALLBACKS +
-                      CLASS_LIFECYCLE_CALLBACKS +
-                      METHOD_LIFECYCLE_CALLBACKS).to_set.freeze
+        CALLBACKS = (CLASS_LIFECYCLE_CALLBACKS +
+                     METHOD_LIFECYCLE_CALLBACKS).to_set.freeze
 
         def on_def(node)
           return unless offender?(node)

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+version_regexp = /\A\d+\.\d+\z|\A<<next>>\z/
 
 RSpec.describe 'RuboCop Project', type: :feature do
   let(:cop_names) do
@@ -32,8 +33,8 @@ RSpec.describe 'RuboCop Project', type: :feature do
         version = config[name]['VersionAdded']
         expect(version.nil?).to(be(false),
                                 "VersionAdded is required for #{name}.")
-        expect(version).to(match(/\A\d+\.\d+\z/),
-                           "#{version} should be format ('X.Y') for #{name}.")
+        expect(version).to(match(version_regexp),
+                           "#{version} should be format ('X.Y' or '<<next>>') for #{name}.")
       end
     end
 
@@ -43,8 +44,8 @@ RSpec.describe 'RuboCop Project', type: :feature do
           version = config[name][version_type]
           next unless version
 
-          expect(version).to(match(/\A\d+\.\d+\z/),
-                             "#{version} should be format ('X.Y') for #{name}.")
+          expect(version).to(match(version_regexp),
+                             "#{version} should be format ('X.Y' or '<<next>>') for #{name}.")
         end
       end
     end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-version_regexp = /\A\d+\.\d+\z|\A<<next>>\z/
 
 RSpec.describe 'RuboCop Project', type: :feature do
   let(:cop_names) do
@@ -10,6 +9,8 @@ RSpec.describe 'RuboCop Project', type: :feature do
       .cops
       .map(&:cop_name)
   end
+
+  version_regexp = /\A\d+\.\d+\z|\A<<next>>\z/
 
   describe 'default configuration file' do
     subject(:config) { RuboCop::ConfigLoader.load_file('config/default.yml') }

--- a/spec/rubocop/cop/lint/missing_super_spec.rb
+++ b/spec/rubocop/cop/lint/missing_super_spec.rb
@@ -94,41 +94,11 @@ RSpec.describe RuboCop::Cop::Lint::MissingSuper do
       RUBY
     end
 
-    it 'registers an offense for instance level `method_missing?` with no `super` call' do
-      expect_offense(<<~RUBY)
-        class Foo
-          def method_missing(*args)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^ Call `super` to invoke callback defined in the parent class.
-          end
-        end
-      RUBY
-    end
-
-    it 'registers an offense for class level `method_missing?` with no `super` call' do
-      expect_offense(<<~RUBY)
-        class Foo
-          def self.method_missing(*args)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Call `super` to invoke callback defined in the parent class.
-          end
-        end
-      RUBY
-    end
-
-    it 'does not register an offense when `method_missing?` contains `super` call' do
-      expect_no_offenses(<<~RUBY)
-        class Foo
-          def method_missing(*args)
-            super
-            do_something
-          end
-        end
-      RUBY
-    end
-
     it 'does not register an offense when callback has a `super` call' do
       expect_no_offenses(<<~RUBY)
         class Foo
           def self.inherited(base)
+            do_something
             super
           end
         end


### PR DESCRIPTION
Contrary to the other hooks, these have very valid cases to be completely taken over:

```ruby
# accept everything:
def method_missing(method, *args)
  nil
end

# or delegate all
def method_missing(method, *args)
  delegate_to.send(method, *args)
end
```

While a class has a "right" to expect its other hooks to be called, these hooks aren't necessarily called the same way.

From https://github.com/testdouble/standard/issues/195#issuecomment-729863480