### PR TITLE
Allow specifying a pull request ID when calling `rake changelog:*`

### DIFF
--- a/changelog/change_allow_specifying_a_pull_request_id_when.md
+++ b/changelog/change_allow_specifying_a_pull_request_id_when.md
@@ -1,0 +1,1 @@
+* [#9074](https://github.com/rubocop-hq/rubocop/pull/9074): Allow specifying a pull request ID when calling `rake changelog:*`. ([@marcandre][])

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -5,8 +5,9 @@ autoload :Changelog, "#{__dir__}/changelog"
 namespace :changelog do
   %i[new fix change].each do |type|
     desc "Create a Changelog entry (#{type})"
-    task type do
-      path = Changelog::Entry.new(type: type).write
+    task type, [:id] do |_task, args|
+      ref_type = :pull if args[:id]
+      path = Changelog::Entry.new(type: type, ref_id: args[:id], ref_type: ref_type).write
       cmd = "git add #{path}"
       system cmd
       puts "Entry '#{path}' created and added to git index"


### PR DESCRIPTION
Currently:

```sh
rake changelog:fix # => issue#666 if commit contains "[Fixes #666]", otherwise pull#x (amend manually later)
```

This PR adds the possibility to create the PR first, then specify the ID, amend commit and force push:

```sh
git push
<create PR> 
rake changelog:fix[42] # => pull#42
git commit -a --amend
git push --force
```