### PR TITLE
[Fix #7338] Handle assignment with []= in MultilineMethodCallIndentation

### DIFF
--- a/changelog/fix_MultilineMethodCallIndentation_indexed_assignment.md
+++ b/changelog/fix_MultilineMethodCallIndentation_indexed_assignment.md
@@ -1,0 +1,2 @@
+* [#7338](https://github.com/rubocop-hq/rubocop/issues/7338): Handle assignment with `[]=` in `MultilineMethodCallIndentation`. ([@jonas054][])
+

--- a/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
+++ b/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
@@ -31,7 +31,7 @@ module RuboCop
       #   b c { block }.            <-- b is indented relative to a
       #   d                         <-- d is indented relative to a
       def left_hand_side(lhs)
-        lhs = lhs.parent while lhs.parent&.send_type?
+        lhs = lhs.parent while lhs.parent&.send_type? && !lhs.parent.method?(:[]=)
         lhs
       end
 

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -910,16 +910,30 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       RUBY
     end
 
-    it 'accepts indentation of assignment' do
-      expect_no_offenses(<<~RUBY)
-        formatted_int = int_part
-          .abs
-          .to_s
-          .reverse
-          .gsub(/...(?=.)/, '&_')
-          .reverse
-      RUBY
+    shared_examples 'assignment' do |lhs|
+      it "accepts indentation of assignment to #{lhs} with rhs on same line" do
+        expect_no_offenses(<<~RUBY)
+          #{lhs} = int_part
+            .abs
+            .to_s
+            .reverse
+            .gsub(/...(?=.)/, '&_')
+            .reverse
+        RUBY
+      end
+
+      it "accepts indentation of assignment to #{lhs} with newline after =" do
+        expect_no_offenses(<<~RUBY)
+          #{lhs} =
+            int_part
+              .abs
+              .to_s
+        RUBY
+      end
     end
+
+    include_examples 'assignment', 'a'
+    include_examples 'assignment', 'a[:key]'
 
     it 'registers an offense and corrects correct + unrecognized style' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
The `[]=` operator is a send node in the AST, which we need to consider while traveling up the ancestor hierarchy of send nodes, looking for the base of alignment.