### PR TITLE
[Fix #9064] Add three new config options for `Layout/EmptyLineBetweenDefs` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### New features
 
 * [#7737](https://github.com/rubocop-hq/rubocop/issues/7737): Add new `Style/RedundantArgument` cop. ([@tejasbubane][])
+* [#9064](https://github.com/rubocop-hq/rubocop/issues/9064): Add `EmptyLineBetweenMethodDefs`, `EmptyLineBetweenClassDefs` and `EmptyLineBetweenModuleDefs` config options for `Layout/EmptyLineBetweenDefs` cop. ([@tejasbubane][])
 
 ## 1.3.1 (2020-11-16)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -463,6 +463,10 @@ Layout/EmptyLineBetweenDefs:
   StyleGuide: '#empty-lines-between-methods'
   Enabled: true
   VersionAdded: '0.49'
+  VersionChanged: <<next>>
+  EmptyLineBetweenMethodDefs: true
+  EmptyLineBetweenClassDefs: true
+  EmptyLineBetweenModuleDefs: true
   # If `true`, this parameter means that single line method definitions don't
   # need an empty line between them.
   AllowAdjacentOneLineDefs: false

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -5,6 +5,7 @@ require 'shellwords'
 
 module RuboCop
   class IncorrectCopNameError < StandardError; end
+
   class OptionArgumentError < StandardError; end
 
   # This class handles command line options.

--- a/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
       class K
         def m
         end
+
         class J
           def n
           end
@@ -15,6 +16,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
           ^^^^^ Use empty lines between method definitions.
           end
         end
+
         # checks something
         def p
         end
@@ -407,6 +409,125 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
 
 
         def o
+        end
+      RUBY
+    end
+  end
+
+  context 'EmptyLineBetweenClassDefs' do
+    it 'registers offense when no empty lines between class and method definitions' do
+      expect_offense(<<~RUBY)
+        class Foo
+        end
+        class Baz
+        ^^^^^^^^^ Use empty lines between class definitions.
+        end
+        def example
+        ^^^^^^^^^^^ Use empty lines between method definitions.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo
+        end
+
+        class Baz
+        end
+
+        def example
+        end
+      RUBY
+    end
+
+    context 'when disabled' do
+      let(:cop_config) { { 'EmptyLineBetweenClassDefs' => false } }
+
+      it 'does not register offense' do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+          end
+          class Baz
+          end
+          def example
+          end
+        RUBY
+      end
+    end
+
+    context 'with AllowAdjacentOneLineDefs enabled' do
+      let(:cop_config) { { 'AllowAdjacentOneLineDefs' => true } }
+
+      it 'does not register offense' do
+        expect_no_offenses(<<~RUBY)
+          class Foo; end
+          class Baz; end
+        RUBY
+      end
+    end
+  end
+
+  context 'EmptyLineBetweenModuleDefs' do
+    it 'registers offense when no empty lines between module and method definitions' do
+      expect_offense(<<~RUBY)
+        module Foo
+        end
+        module Baz
+        ^^^^^^^^^^ Use empty lines between module definitions.
+        end
+        def example
+        ^^^^^^^^^^^ Use empty lines between method definitions.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module Foo
+        end
+
+        module Baz
+        end
+
+        def example
+        end
+      RUBY
+    end
+
+    context 'when disabled' do
+      let(:cop_config) { { 'EmptyLineBetweenModuleDefs' => false } }
+
+      it 'does not register offense' do
+        expect_no_offenses(<<~RUBY)
+          module Foo
+          end
+          module Baz
+          end
+          def example
+          end
+        RUBY
+      end
+    end
+  end
+
+  context 'when empty lines between classes and modules together' do
+    it 'registers offense when no empty lines between module and method definitions' do
+      expect_offense(<<~RUBY)
+        class Foo
+        end
+        module Baz
+        ^^^^^^^^^^ Use empty lines between module definitions.
+        end
+        def example
+        ^^^^^^^^^^^ Use empty lines between method definitions.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo
+        end
+
+        module Baz
+        end
+
+        def example
         end
       RUBY
     end


### PR DESCRIPTION
* EmptyLineBetweenMethodDefs
* EmptyLineBetweenClassDefs
* EmptyLineBetweenModuleDefs

This cop previous had ability to check for empty lines between method
definitions only. This commit allows the cop to check for empty lines between class
and module definitions as well.

All three configs are enabled by default.

Closes #9064

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/