### PR TITLE
Improve the gemspec to load only the necessary files without the git utility

### DIFF
--- a/changelog/change_improve_gemspec_files_attribute.md
+++ b/changelog/change_improve_gemspec_files_attribute.md
@@ -1,0 +1,1 @@
+* [#9079](https://github.com/rubocop-hq/rubocop/pull/9079): Improve the gemspec to load only the necessary files without the git utility. ([@piotrmurach][])

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path('lib', __dir__)
-require 'rubocop/version'
-require 'English'
+require_relative 'lib/rubocop/version'
 
 Gem::Specification.new do |s|
   s.name = 'rubocop'
@@ -16,8 +14,7 @@ Gem::Specification.new do |s|
   DESCRIPTION
 
   s.email = 'rubocop@googlegroups.com'
-  s.files = `git ls-files assets bin config lib LICENSE.txt README.md`
-            .split($RS)
+  s.files = Dir.glob('{config,lib}/**/*', File::FNM_DOTMATCH)
   s.bindir = 'exe'
   s.executables = ['rubocop']
   s.extra_rdoc_files = ['LICENSE.txt', 'README.md']


### PR DESCRIPTION
This makes the gemspec independent of the git utility by replacing the
files attribute value with Ruby Dir for listing all the required files.
In addition, we exclude bin folder as these files are strictly development
concerns and can cause issues when distributed. The same goes for the
assets which are unnecessary for the distributed package. Both the README.txt
and LICENSE.txt are no longer mentioned as well as they are automatically
included in the generated file list via the extra_rdoc_files attribute.
This change reduces the overall package size from 440K down to 432K.

The version file is now loaded with the require_relative method to
increase performance and skip unnecessary lookup.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
