### PR TITLE
[Fix #7726] Handle method call chains inside square brackets

### DIFF
--- a/changelog/fix_MultilineMethodCallIndentation_inside_brackets.md
+++ b/changelog/fix_MultilineMethodCallIndentation_inside_brackets.md
@@ -1,0 +1,1 @@
+* [#7726](https://github.com/rubocop-hq/rubocop/issues/7726): Fix `MultilineMethodCallIndentation` indentation inside square brackets. ([@jonas054][])

--- a/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
+++ b/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
@@ -31,7 +31,7 @@ module RuboCop
       #   b c { block }.            <-- b is indented relative to a
       #   d                         <-- d is indented relative to a
       def left_hand_side(lhs)
-        lhs = lhs.parent while lhs.parent&.send_type? && !lhs.parent.method?(:[]=)
+        lhs = lhs.parent while lhs.parent&.send_type? && lhs.parent.loc.dot
         lhs
       end
 

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -798,6 +798,23 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       RUBY
     end
 
+    it 'registers an offense and corrects 0 space indentation inside square brackets' do
+      expect_offense(<<~RUBY)
+        foo[
+          bar
+          .baz
+          ^^^^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
+        ]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo[
+          bar
+            .baz
+        ]
+      RUBY
+    end
+
     it 'registers an offense and corrects aligned methods in if condition' do
       expect_offense(<<~RUBY)
         if a.


### PR DESCRIPTION
Searching for the root of a method call chain should only consider method calls with a dot operator. We should stop if it's another kind of send node.

This is an improvement on a recent fix for the same cop. That commit only fixed the problem for the `[]=` operator. This solution is more comprehensive.