### PR TITLE
Fix gemspec to include assets directory

### DIFF
--- a/changelog/fix_fix_gemspec_to_include_assets_directory.md
+++ b/changelog/fix_fix_gemspec_to_include_assets_directory.md
@@ -1,0 +1,1 @@
+* [#9082](https://github.com/rubocop-hq/rubocop/pull/9082): Fix gemspec to include assets directory. ([@javierav][])

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   DESCRIPTION
 
   s.email = 'rubocop@googlegroups.com'
-  s.files = Dir.glob('{config,lib}/**/*', File::FNM_DOTMATCH)
+  s.files = Dir.glob('{assets,config,lib}/**/*', File::FNM_DOTMATCH)
   s.bindir = 'exe'
   s.executables = ['rubocop']
   s.extra_rdoc_files = ['LICENSE.txt', 'README.md']


### PR DESCRIPTION
Fix current release of rubocop 1.4.0 that not includes the assets directory used by html report.

```
rubocop --format html --out tmp/rubocop.html
```

```
No such file or directory @ rb_sysopen - /Users/javierav/.asdf/installs/ruby/2.5.0/lib/ruby/gems/2.5.0/gems/rubocop-1.4.0/assets/output.html.erb
```