### PR TITLE
[Fix #9083] Fix `Style/RedundantArgument` cop raising offense for more than one argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug fixes
 
 * [#9082](https://github.com/rubocop-hq/rubocop/pull/9082): Fix gemspec to include assets directory. ([@javierav][])
+* [#9083](https://github.com/rubocop-hq/rubocop/pull/9083): Fix `Style/RedundantArgument` cop raising offense for more than one argument. ([@tejasbubane][])
 
 ## 1.4.0 (2020-11-23)
 

--- a/lib/rubocop/cop/style/redundant_argument.rb
+++ b/lib/rubocop/cop/style/redundant_argument.rb
@@ -40,6 +40,8 @@ module RuboCop
         MSG = 'Argument %<arg>s is redundant because it is implied by default.'
 
         def on_send(node)
+          return if node.receiver.nil?
+          return if node.arguments.count != 1
           return unless redundant_argument?(node)
 
           add_offense(node, message: format(MSG, arg: node.arguments.first.source))

--- a/spec/rubocop/cop/style/redundant_argument_spec.rb
+++ b/spec/rubocop/cop/style/redundant_argument_spec.rb
@@ -3,100 +3,63 @@
 RSpec.describe RuboCop::Cop::Style::RedundantArgument, :config do
   subject(:cop) { described_class.new(config) }
 
-  context 'join' do
-    let(:cop_config) do
-      { 'Methods' => { 'join' => '' } }
-    end
-
-    it 'registers an offense when using `#join` with empty string argument' do
-      expect_offense(<<~RUBY)
-        foo.join('')
-        ^^^^^^^^^^^^ Argument '' is redundant because it is implied by default.
-      RUBY
-    end
-
-    it 'registers an offense when using `#join` with double quoted string' do
-      expect_offense(<<~RUBY)
-        foo.join("")
-        ^^^^^^^^^^^^ Argument "" is redundant because it is implied by default.
-      RUBY
-    end
-
-    it 'registers an offense when using `#join` on literal arrays' do
-      expect_offense(<<~RUBY)
-        [1, 2, 3].join("")
-        ^^^^^^^^^^^^^^^^^^ Argument "" is redundant because it is implied by default.
-      RUBY
-    end
-
-    it 'does not register an offense when using `#join` with no arguments' do
-      expect_no_offenses(<<~RUBY)
-        foo.join
-      RUBY
-    end
-
-    it 'does not register an offense when using `#join` with array literals' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].join
-      RUBY
-    end
-
-    it 'does not register an offense when using `#join` with separator' do
-      expect_no_offenses(<<~RUBY)
-        foo.join(',')
-      RUBY
-    end
+  let(:cop_config) do
+    { 'Methods' => { 'join' => '', 'split' => ' ' } }
   end
 
-  context 'split' do
-    let(:cop_config) do
-      { 'Methods' => { 'split' => ' ' } }
-    end
+  it 'registers an offense when method called on variable' do
+    expect_offense(<<~RUBY)
+      foo.join('')
+      ^^^^^^^^^^^^ Argument '' is redundant because it is implied by default.
+      foo.split(' ')
+      ^^^^^^^^^^^^^^ Argument ' ' is redundant because it is implied by default.
+    RUBY
+  end
 
-    it 'registers an offense when using `#split` with space' do
-      expect_offense(<<~RUBY)
-        foo.split(' ')
-        ^^^^^^^^^^^^^^ Argument ' ' is redundant because it is implied by default.
-      RUBY
-    end
+  it 'registers an offense when method called on literals' do
+    expect_offense(<<~RUBY)
+      [1, 2, 3].join('')
+      ^^^^^^^^^^^^^^^^^^ Argument '' is redundant because it is implied by default.
+      "first second".split(' ')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Argument ' ' is redundant because it is implied by default.
+    RUBY
+  end
 
-    it 'registers an offense when using `#split` on string literal' do
-      expect_offense(<<~RUBY)
-        "first second".split(' ')
-        ^^^^^^^^^^^^^^^^^^^^^^^^^ Argument ' ' is redundant because it is implied by default.
-      RUBY
-    end
+  it 'works with double-quoted strings when configuration is single-quotes' do
+    expect_offense(<<~RUBY)
+      foo.join("")
+      ^^^^^^^^^^^^ Argument "" is redundant because it is implied by default.
+      "first second".split(" ")
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Argument " " is redundant because it is implied by default.
+    RUBY
+  end
 
-    it 'registers an offense when using `#join` with double quoted string' do
-      expect_offense(<<~RUBY)
-        foo.split(" ")
-        ^^^^^^^^^^^^^^ Argument " " is redundant because it is implied by default.
-      RUBY
-    end
+  it 'does not register an offense when method called with no arguments' do
+    expect_no_offenses(<<~RUBY)
+      foo.join
+      "first second".split
+    RUBY
+  end
 
-    it 'does not register an offense when using `#split` with no arguments' do
-      expect_no_offenses(<<~RUBY)
-        foo.split
-      RUBY
-    end
+  it 'does not register an offense when method called with more than one arguments' do
+    expect_no_offenses(<<~RUBY)
+      foo.join('', 2)
+      [1, 2, 3].split(" ", true, {})
+    RUBY
+  end
 
-    it 'does not register an offense when using `#split` with string literal' do
-      expect_no_offenses(<<~RUBY)
-        "first second".split
-      RUBY
-    end
+  it 'does not register an offense when method called with different argument' do
+    expect_no_offenses(<<~RUBY)
+      foo.join(',')
+      foo.split(',')
+    RUBY
+  end
 
-    it 'does not register an offense when using `#split` with separator' do
-      expect_no_offenses(<<~RUBY)
-        foo.split(',')
-      RUBY
-    end
-
-    it 'does not register an offense when using `#split` with empty string' do
-      expect_no_offenses(<<~RUBY)
-        foo.split('')
-      RUBY
-    end
+  it 'does not register an offense when method called with no receiver' do
+    expect_no_offenses(<<~RUBY)
+      join('')
+      split(' ')
+    RUBY
   end
 
   context 'non-builtin method' do


### PR DESCRIPTION
Also
* Add check for explicit receiver must be present.
* Refactor tests for the cop.

Closes #9083

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/