### PR TITLE
Deprecate `EnforceSuperclass` module`

### DIFF
--- a/changelog/change_deprecate_enforce_superclass_module.md
+++ b/changelog/change_deprecate_enforce_superclass_module.md
@@ -1,0 +1,1 @@
+* [#9087](https://github.com/rubocop-hq/rubocop/pull/9087): Deprecate `EnforceSuperclass` module. ([@koic][])

--- a/lib/rubocop/cop/mixin/enforce_superclass.rb
+++ b/lib/rubocop/cop/mixin/enforce_superclass.rb
@@ -2,7 +2,15 @@
 
 module RuboCop
   module Cop
-    # Common functionality for enforcing a specific superclass
+    # Common functionality for enforcing a specific superclass.
+    #
+    # IMPORTANT: RuboCop core depended on this module when it supported Rails department.
+    # Rails department has been extracted to RuboCop Rails gem.
+    # This module is deprecated and will be removed by RuboCop 2.0.
+    # It will not be updated to `RuboCop::Cop::Base` v1 API to maintain compatibility
+    # with existing RuboCop Rails 2.8 or lower.
+    #
+    # @api private
     module EnforceSuperclass
       def self.included(base)
         base.def_node_matcher :class_definition, <<~PATTERN


### PR DESCRIPTION
RuboCop core depended on this module when it supported Rails department. Rails department has been extracted to RuboCop Rails gem. I forgot to remove it when extracting Rails department from the core.

rubocop-hq/rubocop-rails#390 is ready to be removed from RuboCop core.
First of all, as soft deprecation, the document only indicates that it is a deprecation warning.
After releasing RuboCop Rails several times, I will display a deprecation warning and will remove it in RuboCop 2.0.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
