### PR TITLE
[Fix #9089] Fix an incorrect auto-correct for `Style/FormatString`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_format_string.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_format_string.md
@@ -1,0 +1,1 @@
+* [#9089](https://github.com/rubocop-hq/rubocop/issues/9089): Fix an incorrect auto-correct for `Style/FormatString` when using springf with second argument that uses an operator. ([@koic][])

--- a/lib/rubocop/cop/style/format_string.rb
+++ b/lib/rubocop/cop/style/format_string.rb
@@ -111,14 +111,19 @@ module RuboCop
           format = format_arg.source
 
           args = if param_args.one?
-                   arg = param_args.last
-
-                   arg.hash_type? ? "{ #{arg.source} }" : arg.source
+                   format_single_parameter(param_args.last)
                  else
                    "[#{param_args.map(&:source).join(', ')}]"
                  end
 
           corrector.replace(node, "#{format} % #{args}")
+        end
+
+        def format_single_parameter(arg)
+          source = arg.source
+          return "{ #{source} }" if arg.hash_type?
+
+          arg.send_type? && arg.operator_method? && !arg.parenthesized? ? "(#{source})" : source
         end
       end
     end

--- a/spec/rubocop/cop/style/format_string_spec.rb
+++ b/spec/rubocop/cop/style/format_string_spec.rb
@@ -223,6 +223,16 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects when using springf with second argument that uses an operator' do
+      expect_offense(<<~RUBY)
+        format(something, a + 42)
+        ^^^^^^ Favor `String#%` over `format`.
+      RUBY
+      expect_correction(<<~RUBY)
+        something % (a + 42)
+      RUBY
+    end
+
     it 'registers an offense for sprintf with 3 arguments' do
       expect_offense(<<~RUBY)
         format("%d %04x", 123, 123)


### PR DESCRIPTION
Fixes #9089

This PR fixes an incorrect auto-correct for `Style/FormatString` when using springf with second argument that uses an operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
