### PR TITLE
[Fix #7670] Handle offenses inside heredocs for --disable-uncorrectable

### DIFF
--- a/changelog/fix_infinite_disable_uncorrectable.md
+++ b/changelog/fix_infinite_disable_uncorrectable.md
@@ -1,0 +1,1 @@
+* [#7670](https://github.com/rubocop-hq/rubocop/issues/7670): Handle offenses inside heredocs for `-a --disable-uncorrectable`. ([@jonas054][])

--- a/lib/rubocop/cop/autocorrect_logic.rb
+++ b/lib/rubocop/cop/autocorrect_logic.rb
@@ -57,16 +57,11 @@ module RuboCop
         # The empty offense range is an edge case that can be reached from the Lint/Syntax cop.
         return nil if offense_range.empty?
 
-        @heredoc_ranges ||= begin
-          ranges = []
-          processed_source.ast.each_descendant do |node|
-            if node.respond_to?(:heredoc?) && node.heredoc?
-              ranges << node.loc.expression.join(node.loc.heredoc_end)
-            end
-          end
-          ranges
+        heredoc_nodes = processed_source.ast.each_descendant.select do |node|
+          node.respond_to?(:heredoc?) && node.heredoc?
         end
-        @heredoc_ranges.find { |range| range.contains?(offense_range) }
+        heredoc_nodes.map { |node| node.loc.expression.join(node.loc.heredoc_end) }
+                     .find { |range| range.contains?(offense_range) }
       end
 
       def range_of_first_line(range)

--- a/spec/rubocop/cli/cli_disable_uncorrectable_spec.rb
+++ b/spec/rubocop/cli/cli_disable_uncorrectable_spec.rb
@@ -228,6 +228,40 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           # last line
         RUBY
       end
+
+      context 'and the offense is inside a heredoc' do
+        it 'adds before-and-after disable statement around the heredoc' do
+          create_file('example.rb', <<~'RUBY')
+            # frozen_string_literal: true
+
+            def our_function
+              ourVariable = "foo"
+              script = <<~JS
+                <script>
+                  window.stuff = "#{ourVariable}"
+                </script>
+              JS
+              puts(script)
+            end
+          RUBY
+          expect(exit_code).to eq(0)
+          expect(IO.read('example.rb')).to eq(<<~'RUBY')
+            # frozen_string_literal: true
+
+            def our_function
+              ourVariable = 'foo' # rubocop:todo Naming/VariableName
+              # rubocop:todo Naming/VariableName
+              script = <<~JS
+                <script>
+                  window.stuff = "#{ourVariable}"
+                </script>
+              JS
+              # rubocop:enable Naming/VariableName
+              puts(script)
+            end
+          RUBY
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The `# rubocop:todo` and `# rubocop:enable` must be placed outside the heredoc. Otherwise they won't have any effect and we will just add more and more comments until we crash.