### PR TITLE
[Fix #8053] Fix an incorrect auto-correct for `Style/AndOr`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_and_or.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_and_or.md
@@ -1,0 +1,1 @@
+* [#8053](https://github.com/rubocop-hq/rubocop/issues/8053): Fix an incorrect auto-correct for `Style/AndOr` when `or` precedes `and`. ([@koic][])

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -72,6 +72,8 @@ module RuboCop
             end
 
             corrector.replace(node.loc.operator, node.alternate_operator)
+
+            keep_operator_precedence(corrector, node)
           end
         end
 
@@ -121,6 +123,14 @@ module RuboCop
           return if node.source_range.begin.is?('(')
 
           corrector.wrap(node, '(', ')')
+        end
+
+        def keep_operator_precedence(corrector, node)
+          if node.or_type? && node.parent&.and_type?
+            corrector.wrap(node, '(', ')')
+          elsif node.and_type? && node.rhs.or_type?
+            corrector.wrap(node.rhs, '(', ')')
+          end
         end
 
         def correctable_send?(node)

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -508,6 +508,60 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
       end
     end
 
+    context 'when `or` precedes `and`' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          foo or bar and baz
+              ^^ Use `||` instead of `or`.
+                     ^^^ Use `&&` instead of `and`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          (foo || bar) && baz
+        RUBY
+      end
+    end
+
+    context 'when `or` precedes `&&`' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          foo or bar && baz
+              ^^ Use `||` instead of `or`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo || bar && baz
+        RUBY
+      end
+    end
+
+    context 'when `and` precedes `or`' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          foo and bar or baz
+              ^^^ Use `&&` instead of `and`.
+                      ^^ Use `||` instead of `or`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo && bar || baz
+        RUBY
+      end
+    end
+
+    context 'when `and` precedes `||`' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          foo and bar || baz
+              ^^^ Use `&&` instead of `and`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo && (bar || baz)
+        RUBY
+      end
+    end
+
     context 'within a nested begin node with one child only' do
       # regression test; see GH issue 2531
       it 'autocorrects "and" with && and adds parens' do


### PR DESCRIPTION
Fixes #8053.

This PR fixes an incorrect auto-correct for `Style/AndOr` when `or` precedes `and`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
