### PR TITLE
Unification of `IgnoredMethods`

### DIFF
--- a/changelog/change_update_metricsblocklength_and.md
+++ b/changelog/change_update_metricsblocklength_and.md
@@ -1,1 +1,2 @@
 * [#9098](https://github.com/rubocop-hq/rubocop/pull/9098): Update `Metrics/BlockLength` and `Metrics/MethodLength` to use `IgnoredMethods` instead of `ExcludedMethods` in configuration. The previous key is retained for backwards compatibility. ([@dvandersluis][])
+* [#9098](https://github.com/rubocop-hq/rubocop/pull/9098): Update `IgnoredMethods` so that every cop that uses it will accept both strings and regexes in the configuration. ([@dvandersluis][])

--- a/changelog/change_update_metricsblocklength_and.md
+++ b/changelog/change_update_metricsblocklength_and.md
@@ -1,0 +1,1 @@
+* [#9098](https://github.com/rubocop-hq/rubocop/pull/9098): Update `Metrics/BlockLength` and `Metrics/MethodLength` to use `IgnoredMethods` instead of `ExcludedMethods` in configuration. The previous key is retained for backwards compatibility. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2120,11 +2120,12 @@ Metrics/BlockLength:
   Description: 'Avoid long blocks with many lines.'
   Enabled: true
   VersionAdded: '0.44'
-  VersionChanged: '0.87'
+  VersionChanged: <<next>>
   CountComments: false  # count full line comments?
   Max: 25
   CountAsOne: []
-  ExcludedMethods:
+  ExcludedMethods: [] # deprecated, retained for backwards compatibility
+  IgnoredMethods:
     # By default, exclude the `#refine` method, as it tends to have larger
     # associated blocks.
     - refine
@@ -2165,11 +2166,12 @@ Metrics/MethodLength:
   StyleGuide: '#short-methods'
   Enabled: true
   VersionAdded: '0.25'
-  VersionChanged: '0.87'
+  VersionChanged: <<next>>
   CountComments: false  # count full line comments?
   Max: 10
   CountAsOne: []
-  ExcludedMethods: []
+  ExcludedMethods: [] # deprecated, retained for backwards compatibility
+  IgnoredMethods: []
 
 Metrics/ModuleLength:
   Description: 'Avoid modules longer than 100 lines of code.'

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -543,6 +543,22 @@ Style/PerlBackrefs:
   AutoCorrect: false
 ----
 
+== Common configuration parameters
+There are some configuration parameters that are shared by many cops, with the same behavior.
+
+=== IgnoredMethods
+
+Cops that evaluate methods can often be configured to ignore certain methods. Both strings and
+regular expressions can be used. For example:
+
+[source,yaml]
+----
+Metrics/BlockLength:
+  IgnoredMethods:
+    - refine
+    - !ruby/regexp /\b(class|instance)_methods\b/
+----
+
 == Setting the target Ruby version
 
 Some checks are dependent on the version of the Ruby interpreter which the

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -18,6 +18,7 @@ require_relative 'rubocop/ext/regexp_node'
 require_relative 'rubocop/ext/regexp_parser'
 
 require_relative 'rubocop/core_ext/string'
+require_relative 'rubocop/core_ext/hash'
 require_relative 'rubocop/ext/processed_source'
 
 require_relative 'rubocop/path_util'

--- a/lib/rubocop/config_obsoletion.rb
+++ b/lib/rubocop/config_obsoletion.rb
@@ -202,6 +202,12 @@ module RuboCop
         parameters: 'NameWhitelist',
         alternative: '`NameWhitelist` has been renamed to ' \
                      '`AllowedMethods`.'
+      },
+      {
+        cops: %w[Metrics/BlockLength Metrics/MethodLength],
+        parameters: 'ExcludedMethods',
+        alternative: '`ExcludedMethods` has been renamed to `IgnoredMethods`.',
+        severity: :warning
       }
     ].freeze
 

--- a/lib/rubocop/cop/metrics/block_length.rb
+++ b/lib/rubocop/cop/metrics/block_length.rb
@@ -44,7 +44,8 @@ module RuboCop
         LABEL = 'Block'
 
         def on_block(node)
-          return if excluded_method?(node)
+          return if ignored_method?(node.method_name)
+          return if method_receiver_excluded?(node)
           return if node.class_constructor? || node.struct_constructor?
 
           check_code_length(node)
@@ -52,11 +53,13 @@ module RuboCop
 
         private
 
-        def excluded_method?(node)
+        def method_receiver_excluded?(node)
           node_receiver = node.receiver&.source&.gsub(/\s+/, '')
           node_method = String(node.method_name)
 
           ignored_methods.any? do |config|
+            next unless config.is_a?(String)
+
             receiver, method = config.split('.')
 
             unless method

--- a/lib/rubocop/cop/metrics/block_length.rb
+++ b/lib/rubocop/cop/metrics/block_length.rb
@@ -12,6 +12,10 @@ module RuboCop
       # Available are: 'array', 'hash', and 'heredoc'. Each literal
       # will be counted as one line regardless of its actual size.
       #
+      #
+      # NOTE: The `ExcludedMethods` configuration is deprecated and only kept
+      # for backwards compatibility. Please use `IgnoredMethods` instead.
+      #
       # @example CountAsOne: ['array', 'heredoc']
       #
       #   something do
@@ -33,6 +37,9 @@ module RuboCop
       # NOTE: This cop does not apply for `Struct` definitions.
       class BlockLength < Base
         include CodeLength
+        include IgnoredMethods
+
+        ignored_methods deprecated_key: 'ExcludedMethods'
 
         LABEL = 'Block'
 
@@ -49,7 +56,7 @@ module RuboCop
           node_receiver = node.receiver&.source&.gsub(/\s+/, '')
           node_method = String(node.method_name)
 
-          excluded_methods.any? do |config|
+          ignored_methods.any? do |config|
             receiver, method = config.split('.')
 
             unless method
@@ -59,10 +66,6 @@ module RuboCop
 
             method == node_method && receiver == node_receiver
           end
-        end
-
-        def excluded_methods
-          cop_config['ExcludedMethods'] || []
         end
 
         def cop_label

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -41,7 +41,7 @@ module RuboCop
         LABEL = 'Method'
 
         def on_def(node)
-          return if ignored_methods.any? { |m| m.match? String(node.method_name) }
+          return if ignored_method?(node.method_name)
 
           check_code_length(node)
         end

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -11,6 +11,9 @@ module RuboCop
       # Available are: 'array', 'hash', and 'heredoc'. Each literal
       # will be counted as one line regardless of its actual size.
       #
+      # NOTE: The `ExcludedMethods` configuration is deprecated and only kept
+      # for backwards compatibility. Please use `IgnoredMethods` instead.
+      #
       # @example CountAsOne: ['array', 'heredoc']
       #
       #   def m
@@ -31,12 +34,14 @@ module RuboCop
       #
       class MethodLength < Base
         include CodeLength
+        include IgnoredMethods
+
+        ignored_methods deprecated_key: 'ExcludedMethods'
 
         LABEL = 'Method'
 
         def on_def(node)
-          excluded_methods = cop_config['ExcludedMethods']
-          return if excluded_methods.any? { |m| m.match? String(node.method_name) }
+          return if ignored_methods.any? { |m| m.match? String(node.method_name) }
 
           check_code_length(node)
         end

--- a/lib/rubocop/cop/mixin/ignored_methods.rb
+++ b/lib/rubocop/cop/mixin/ignored_methods.rb
@@ -4,6 +4,8 @@ module RuboCop
   module Cop
     # This module encapsulates the ability to ignore certain methods when
     # parsing.
+    # Cops that use `IgnoredMethods` can accept either strings or regexes to match
+    # against.
     module IgnoredMethods
       # Configuration for IgnoredMethods. It is added to classes that include
       # the module so that configuration can be set using the `ignored_methods`
@@ -21,7 +23,14 @@ module RuboCop
       end
 
       def ignored_method?(name)
-        ignored_methods.include?(name.to_s)
+        ignored_methods.any? do |value|
+          case value
+          when Regexp
+            value.match? String(name)
+          else
+            value == String(name)
+          end
+        end
       end
 
       def ignored_methods

--- a/lib/rubocop/cop/mixin/ignored_methods.rb
+++ b/lib/rubocop/cop/mixin/ignored_methods.rb
@@ -5,14 +5,38 @@ module RuboCop
     # This module encapsulates the ability to ignore certain methods when
     # parsing.
     module IgnoredMethods
-      private
+      # Configuration for IgnoredMethods. It is added to classes that include
+      # the module so that configuration can be set using the `ignored_methods`
+      # class macro.
+      module Config
+        attr_accessor :deprecated_key
+
+        def ignored_methods(**config)
+          self.deprecated_key = config[:deprecated_key]
+        end
+      end
+
+      def self.included(base)
+        base.extend(Config)
+      end
 
       def ignored_method?(name)
         ignored_methods.include?(name.to_s)
       end
 
       def ignored_methods
-        cop_config.fetch('IgnoredMethods', [])
+        keys = %w[IgnoredMethods]
+        keys << deprecated_key if deprecated_key
+
+        cop_config.slice(*keys).values.reduce(&:concat)
+      end
+
+      private
+
+      def deprecated_key
+        return unless self.class.respond_to?(:deprecated_key)
+
+        self.class.deprecated_key&.to_s
       end
     end
   end

--- a/lib/rubocop/cop/mixin/method_complexity.rb
+++ b/lib/rubocop/cop/mixin/method_complexity.rb
@@ -11,6 +11,12 @@ module RuboCop
       include Metrics::Utils::RepeatedCsendDiscount
       extend NodePattern::Macros
 
+      # Ensure cops that include `MethodComplexity` have the config
+      # `attr_accessor`s that `ignored_method?` needs.
+      def self.included(base)
+        base.extend(IgnoredMethods::Config)
+      end
+
       def on_def(node)
         return if ignored_method?(node.method_name)
 

--- a/lib/rubocop/core_ext/hash.rb
+++ b/lib/rubocop/core_ext/hash.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Extensions to the core Hash class
+class Hash
+  unless method_defined?(:slice)
+    # Adds `Hash#slice` for Ruby 2.4.
+    # Returns a hash containing a subset of keys. If a given key is not
+    # in the hash, it will not be returned.
+    #
+    # @return [Hash] hash containing only the keys given.
+    #
+    # @example
+    #   { one: 1, two: 2 }.slice(:two, :three) #=> { two: 2 }
+    def slice(*keys)
+      h = {}
+      keys.each { |k| h[k] = self[k] if key?(k) }
+      h
+    end
+  end
+end

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -733,6 +733,7 @@ RSpec.describe RuboCop::ConfigLoader do
               'CountComments' => false,
               'Max' => 5,
               'CountAsOne' => [],
+              'IgnoredMethods' => [],
               'ExcludedMethods' => []
             }
           )

--- a/spec/rubocop/config_obsoletion_spec.rb
+++ b/spec/rubocop/config_obsoletion_spec.rb
@@ -289,13 +289,44 @@ RSpec.describe RuboCop::ConfigObsoletion do
         OUTPUT
       end
 
-      it 'prints a warning message' do
+      it 'prints a error message' do
         begin
           config_obsoletion.reject_obsolete_cops_and_parameters
           raise 'Expected a RuboCop::ValidationError'
         rescue RuboCop::ValidationError => e
           expect(expected_message).to eq(e.message)
         end
+      end
+    end
+
+    context 'when the configuration includes any deprecated parameters' do
+      let(:hash) do
+        {
+          'Metrics/BlockLength' => {
+            'ExcludedMethods' => %w[foo bar]
+          },
+          'Metrics/MethodLength' => {
+            'ExcludedMethods' => %w[foo bar]
+          }
+        }
+      end
+
+      let(:warning_message)  { config_obsoletion.warnings.join("\n") }
+
+      let(:expected_message) do
+        <<~OUTPUT.chomp
+          obsolete parameter ExcludedMethods (for Metrics/BlockLength) found in example/.rubocop.yml
+          `ExcludedMethods` has been renamed to `IgnoredMethods`.
+          obsolete parameter ExcludedMethods (for Metrics/MethodLength) found in example/.rubocop.yml
+          `ExcludedMethods` has been renamed to `IgnoredMethods`.
+        OUTPUT
+      end
+
+      it 'prints a warning message' do
+        expect { config_obsoletion.reject_obsolete_cops_and_parameters }
+          .not_to raise_error(RuboCop::ValidationError)
+
+        expect(warning_message).to eq(expected_message)
       end
     end
   end

--- a/spec/rubocop/cop/lint/number_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/number_conversion_spec.rb
@@ -158,19 +158,38 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion, :config do
   end
 
   context 'IgnoredMethods' do
-    let(:cop_config) { { 'IgnoredMethods' => %w[minutes] } }
+    context 'with a string' do
+      let(:cop_config) { { 'IgnoredMethods' => %w[minutes] } }
 
-    it 'does not register an offense for an ignored method' do
-      expect_no_offenses(<<~RUBY)
-        10.minutes.to_i
-      RUBY
+      it 'does not register an offense for an ignored method' do
+        expect_no_offenses(<<~RUBY)
+          10.minutes.to_i
+        RUBY
+      end
+
+      it 'registers an offense for other methods' do
+        expect_offense(<<~RUBY)
+          10.hours.to_i
+          ^^^^^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using 10.hours.to_i, use stricter Integer(10.hours, 10).
+        RUBY
+      end
     end
 
-    it 'registers an offense for other methods' do
-      expect_offense(<<~RUBY)
-        10.hours.to_i
-        ^^^^^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using 10.hours.to_i, use stricter Integer(10.hours, 10).
-      RUBY
+    context 'with a regex' do
+      let(:cop_config) { { 'IgnoredMethods' => [/minutes/] } }
+
+      it 'does not register an offense for an ignored method' do
+        expect_no_offenses(<<~RUBY)
+          10.minutes.to_i
+        RUBY
+      end
+
+      it 'registers an offense for other methods' do
+        expect_offense(<<~RUBY)
+          10.hours.to_i
+          ^^^^^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using 10.hours.to_i, use stricter Integer(10.hours, 10).
+        RUBY
+      end
     end
   end
 end

--- a/spec/rubocop/cop/metrics/abc_size_spec.rb
+++ b/spec/rubocop/cop/metrics/abc_size_spec.rb
@@ -78,30 +78,60 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
     end
 
     context 'when method is in list of ignored methods' do
-      let(:cop_config) { { 'Max' => 0, 'IgnoredMethods' => ['foo'] } }
+      context 'when given a string' do
+        let(:cop_config) { { 'Max' => 0, 'IgnoredMethods' => ['foo'] } }
 
-      it 'does not register an offense when defining an instance method' do
-        expect_no_offenses(<<~RUBY)
-          def foo
-            bar.baz(:qux)
-          end
-        RUBY
+        it 'does not register an offense when defining an instance method' do
+          expect_no_offenses(<<~RUBY)
+            def foo
+              bar.baz(:qux)
+            end
+          RUBY
+        end
+
+        it 'does not register an offense when defining a class method' do
+          expect_no_offenses(<<~RUBY)
+            def self.foo
+              bar.baz(:qux)
+            end
+          RUBY
+        end
+
+        it 'does not register an offense when using `define_method`' do
+          expect_no_offenses(<<~RUBY)
+            define_method :foo do
+              bar.baz(:qux)
+            end
+          RUBY
+        end
       end
 
-      it 'does not register an offense when defining a class method' do
-        expect_no_offenses(<<~RUBY)
-          def self.foo
-            bar.baz(:qux)
-          end
-        RUBY
-      end
+      context 'when given a regex' do
+        let(:cop_config) { { 'Max' => 0, 'IgnoredMethods' => [/foo/] } }
 
-      it 'does not register an offense when using `define_method`' do
-        expect_no_offenses(<<~RUBY)
-          define_method :foo do
-            bar.baz(:qux)
-          end
-        RUBY
+        it 'does not register an offense when defining an instance method' do
+          expect_no_offenses(<<~RUBY)
+            def foo
+              bar.baz(:qux)
+            end
+          RUBY
+        end
+
+        it 'does not register an offense when defining a class method' do
+          expect_no_offenses(<<~RUBY)
+            def self.foo
+              bar.baz(:qux)
+            end
+          RUBY
+        end
+
+        it 'does not register an offense when using `define_method`' do
+          expect_no_offenses(<<~RUBY)
+            define_method :foo do
+              bar.baz(:qux)
+            end
+          RUBY
+        end
       end
     end
   end

--- a/spec/rubocop/cop/metrics/block_length_spec.rb
+++ b/spec/rubocop/cop/metrics/block_length_spec.rb
@@ -249,5 +249,32 @@ RSpec.describe RuboCop::Cop::Metrics::BlockLength, :config do
         end
       end
     end
+
+    context 'when given a regex' do
+      before { cop_config['IgnoredMethods'] = [/baz/] }
+
+      it 'does not report an offense' do
+        expect_no_offenses(<<~RUBY)
+          Foo::Bar.baz do
+            a = 1
+            a = 2
+            a = 3
+          end
+        RUBY
+      end
+
+      context 'that does not match' do
+        it 'reports an offense' do
+          expect_offense(<<~RUBY)
+            Foo::Bar.bar do
+            ^^^^^^^^^^^^^^^ Block has too many lines. [3/2]
+              a = 1
+              a = 2
+              a = 3
+            end
+          RUBY
+        end
+      end
+    end
   end
 end

--- a/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
@@ -292,31 +292,61 @@ RSpec.describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     end
   end
 
-  context 'when method is in list of ignored methods' do
-    let(:cop_config) { { 'Max' => 0, 'IgnoredMethods' => ['foo'] } }
+  context 'when IgnoredMethods is set' do
+    context 'with a string' do
+      let(:cop_config) { { 'Max' => 0, 'IgnoredMethods' => ['foo'] } }
 
-    it 'does not register an offense when defining an instance method' do
-      expect_no_offenses(<<~RUBY)
-        def foo
-          bar.baz(:qux)
-        end
-      RUBY
+      it 'does not register an offense when defining an instance method' do
+        expect_no_offenses(<<~RUBY)
+          def foo
+            bar.baz(:qux)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when defining a class method' do
+        expect_no_offenses(<<~RUBY)
+          def self.foo
+            bar.baz(:qux)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when using `define_method`' do
+        expect_no_offenses(<<~RUBY)
+          define_method :foo do
+            bar.baz(:qux)
+          end
+        RUBY
+      end
     end
 
-    it 'does not register an offense when defining a class method' do
-      expect_no_offenses(<<~RUBY)
-        def self.foo
-          bar.baz(:qux)
-        end
-      RUBY
-    end
+    context 'with a regex' do
+      let(:cop_config) { { 'Max' => 0, 'IgnoredMethods' => [/foo/] } }
 
-    it 'does not register an offense when using `define_method`' do
-      expect_no_offenses(<<~RUBY)
-        define_method :foo do
-          bar.baz(:qux)
-        end
-      RUBY
+      it 'does not register an offense when defining an instance method' do
+        expect_no_offenses(<<~RUBY)
+          def foo
+            bar.baz(:qux)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when defining a class method' do
+        expect_no_offenses(<<~RUBY)
+          def self.foo
+            bar.baz(:qux)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when using `define_method`' do
+        expect_no_offenses(<<~RUBY)
+          define_method :foo do
+            bar.baz(:qux)
+          end
+        RUBY
+      end
     end
   end
 

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       'EnforcedStyle' => 'semantic',
       'ProceduralMethods' => %w[tap],
       'FunctionalMethods' => %w[let],
-      'IgnoredMethods' => %w[lambda]
+      'IgnoredMethods' => ['lambda', /test/]
     }
 
     let(:cop_config) { cop_config }
@@ -168,10 +168,17 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       RUBY
     end
 
-    it 'accepts a multi-line functional block with do-end if it is ' \
-       'an ignored method' do
+    it 'accepts a multi-line functional block with do-end if it is an ignored method' do
       expect_no_offenses(<<~RUBY)
         foo = lambda do
+          puts 42
+        end
+      RUBY
+    end
+
+    it 'accepts a multi-line functional block with do-end if it is an ignored method by regex' do
+      expect_no_offenses(<<~RUBY)
+        foo = test_method do
           puts 42
         end
       RUBY
@@ -303,7 +310,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
   context 'line count-based style' do
     cop_config = {
       'EnforcedStyle' => 'line_count_based',
-      'IgnoredMethods' => %w[proc]
+      'IgnoredMethods' => ['proc', /test/]
     }
 
     let(:cop_config) { cop_config }
@@ -383,6 +390,14 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
         RUBY
       end
 
+      it 'accepts a multi-line functional block with {} if it is an ignored method by regex' do
+        expect_no_offenses(<<~RUBY)
+          foo = test_method {
+            puts 42
+          }
+        RUBY
+      end
+
       it 'registers an offense for braces if do-end would not change ' \
          'the meaning' do
         expect_offense(<<~RUBY)
@@ -455,7 +470,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
   context 'braces for chaining style' do
     cop_config = {
       'EnforcedStyle' => 'braces_for_chaining',
-      'IgnoredMethods' => %w[proc]
+      'IgnoredMethods' => ['proc', /test/]
     }
 
     let(:cop_config) { cop_config }
@@ -479,6 +494,14 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
        'an ignored method' do
       expect_no_offenses(<<~RUBY)
         foo = proc {
+          puts 42
+        }
+      RUBY
+    end
+
+    it 'accepts a multi-line functional block with {} if it is an ignored method by regex' do
+      expect_no_offenses(<<~RUBY)
+        foo = test_method {
           puts 42
         }
       RUBY
@@ -574,7 +597,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
   context 'always braces' do
     cop_config = {
       'EnforcedStyle' => 'always_braces',
-      'IgnoredMethods' => %w[proc]
+      'IgnoredMethods' => ['proc', /test/]
     }
 
     let(:cop_config) { cop_config }
@@ -644,6 +667,15 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
        'an ignored method' do
       expect_no_offenses(<<~RUBY)
         foo = proc do
+          puts 42
+        end
+      RUBY
+    end
+
+    it 'accepts a multi-line functional block with do-end if it is ' \
+       'an ignored method by regex' do
+      expect_no_offenses(<<~RUBY)
+        foo = test_method do
           puts 42
         end
       RUBY

--- a/spec/rubocop/cop/style/class_equality_comparison_spec.rb
+++ b/spec/rubocop/cop/style/class_equality_comparison_spec.rb
@@ -67,17 +67,34 @@ RSpec.describe RuboCop::Cop::Style::ClassEqualityComparison, :config do
   end
 
   context 'when IgnoredMethods is specified' do
-    let(:cop_config) do
-      { 'IgnoredMethods' => ['=='] }
+    context 'with a string' do
+      let(:cop_config) do
+        { 'IgnoredMethods' => ['=='] }
+      end
+
+      it 'does not register an offense when comparing class for equality' do
+        expect_no_offenses(<<~RUBY)
+          def ==(other)
+            self.class == other.class &&
+              name == other.name
+          end
+        RUBY
+      end
     end
 
-    it 'does not register an offense when comparing class for equality' do
-      expect_no_offenses(<<~RUBY)
-        def ==(other)
-          self.class == other.class &&
-            name == other.name
-        end
-      RUBY
+    context 'with a regex' do
+      let(:cop_config) do
+        { 'IgnoredMethods' => [/equal/] }
+      end
+
+      it 'does not register an offense when comparing class for equality' do
+        expect_no_offenses(<<~RUBY)
+          def equal?(other)
+            self.class == other.class &&
+              name == other.name
+          end
+        RUBY
+      end
     end
   end
 end

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -2,10 +2,6 @@
 
 RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
   context 'when EnforcedStyle is require_parentheses (default)' do
-    let(:cop_config) do
-      { 'IgnoredMethods' => %w[puts] }
-    end
-
     it 'accepts no parens in method call without args' do
       expect_no_offenses('top.test')
     end
@@ -256,8 +252,22 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
-    it 'ignores method listed in IgnoredMethods' do
-      expect_no_offenses('puts :test')
+    context 'with IgnoredMethods' do
+      context 'with a string' do
+        let(:cop_config) { { 'IgnoredMethods' => %w[puts] } }
+
+        it 'ignores method listed in IgnoredMethods' do
+          expect_no_offenses('puts :test')
+        end
+      end
+
+      context 'with a regex' do
+        let(:cop_config) { { 'IgnoredMethods' => [/puts/] } }
+
+        it 'ignores method listed in IgnoredMethods' do
+          expect_no_offenses('puts :test')
+        end
+      end
     end
 
     context 'when inspecting macro methods' do

--- a/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses, :config do
-  let(:cop_config) do
-    { 'IgnoredMethods' => %w[s] }
-  end
-
   it 'registers an offense for parens in method call without args' do
     expect_offense(<<~RUBY)
       top.test()
@@ -33,8 +29,26 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses, :config do
     expect_no_offenses('not(something)')
   end
 
-  it 'ignores method listed in IgnoredMethods' do
-    expect_no_offenses('s()')
+  context 'with IgnoredMethods' do
+    context 'with a string' do
+      let(:cop_config) do
+        { 'IgnoredMethods' => %w[s] }
+      end
+
+      it 'ignores method listed in IgnoredMethods' do
+        expect_no_offenses('s()')
+      end
+    end
+
+    context 'with a regex' do
+      let(:cop_config) do
+        { 'IgnoredMethods' => [/test/] }
+      end
+
+      it 'ignores method listed in IgnoredMethods' do
+        expect_no_offenses('my_test()')
+      end
+    end
   end
 
   context 'assignment to a variable with the same name' do

--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
       {
         'EnforcedStyle' => 'predicate',
         'AutoCorrect' => true,
-        'IgnoredMethods' => %w[where]
+        'IgnoredMethods' => ['where', /order/]
       }
     end
 
@@ -262,12 +262,24 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
 
     context 'in argument' do
       context 'ignored method' do
-        it 'allows checking if a number is positive' do
-          expect_no_offenses('where(Sequel[:number] > 0)')
+        context 'with a string' do
+          it 'allows checking if a number is positive' do
+            expect_no_offenses('where(Sequel[:number] > 0)')
+          end
+
+          it 'allows checking if a number is negative' do
+            expect_no_offenses('where(Sequel[:number] < 0)')
+          end
         end
 
-        it 'allows checking if a number is negative' do
-          expect_no_offenses('where(Sequel[:number] < 0)')
+        context 'with a regex' do
+          it 'allows checking if a number is positive' do
+            expect_no_offenses('order(Sequel[:number] > 0)')
+          end
+
+          it 'allows checking if a number is negative' do
+            expect_no_offenses('order(Sequel[:number] < 0)')
+          end
         end
       end
 
@@ -296,12 +308,24 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
 
     context 'in block' do
       context 'ignored method' do
-        it 'allows checking if a number is positive' do
-          expect_no_offenses('where { table[number] > 0 }')
+        context 'with a string' do
+          it 'allows checking if a number is positive' do
+            expect_no_offenses('where { table[number] > 0 }')
+          end
+
+          it 'allows checking if a number is negative' do
+            expect_no_offenses('where { table[number] < 0 }')
+          end
         end
 
-        it 'allows checking if a number is negative' do
-          expect_no_offenses('where { table[number] < 0 }')
+        context 'with a regex' do
+          it 'allows checking if a number is positive' do
+            expect_no_offenses('order { table[number] > 0 }')
+          end
+
+          it 'allows checking if a number is negative' do
+            expect_no_offenses('order { table[number] < 0 }')
+          end
         end
       end
 

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
-  let(:cop_config) { { 'IgnoredMethods' => %w[respond_to] } }
-
   it 'registers an offense for a block with parameterless method call on ' \
      'param' do
     expect_offense(<<~RUBY)
@@ -46,8 +44,22 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
     expect_no_offenses('::Proc.new { |x| x.method }')
   end
 
-  it 'accepts ignored method' do
-    expect_no_offenses('respond_to { |format| format.xml }')
+  context 'with IgnoredMethods' do
+    context 'when given a string' do
+      let(:cop_config) { { 'IgnoredMethods' => %w[respond_to] } }
+
+      it 'accepts ignored method' do
+        expect_no_offenses('respond_to { |format| format.xml }')
+      end
+    end
+
+    context 'when given a regex' do
+      let(:cop_config) { { 'IgnoredMethods' => [/respond_/] } }
+
+      it 'accepts ignored method' do
+        expect_no_offenses('respond_to { |format| format.xml }')
+      end
+    end
   end
 
   it 'accepts block with no arguments' do


### PR DESCRIPTION
As mentioned by @bbatsov at https://github.com/rubocop-hq/rubocop/pull/9058#issuecomment-729918462

1. The two cops that were configured using `ExcludedMethods` instead of `IgnoredMethods` (`Metrics/BlockLength` and `Metrics/MethodLength`) have been changed to use `IgnoredMethods` going forward. I changed the `IgnoredMethods` mixin so that it can be configured to allow for those two cops to continue accepting `ExcludedMethods` without adding that config key to the reset of the cops.
2. All cops that use the `IgnoredMethods` mixin now can accept an array of both strings and regexes, and both are applied.

Questions:
* ~Is there a good way to document this so that users will know they can use regexes for `IgnoredMethods` everywhere now?~ I added a new section to configuration.adoc.
* Is there a way to add a deprecation warning when running rubocop with `ExcludedMethods` in the configuration so that users can update their config?

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
