### PR TITLE
Fix test that breaks in ascii_spec

### DIFF
--- a/spec/rubocop/cop/style/redundant_regexp_escape_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_escape_spec.rb
@@ -523,9 +523,9 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpEscape do
     it 'removes the escape character at the right position' do
       # The indicator should take character widths into account in the
       # future.
-      expect_offense(<<~'RUBY')
+      expect_offense(<<~'RUBY', prefix: '一二三四')
         x = s[/[一二三四\.]+/]
-                    ^^ Redundant escape inside regexp literal
+                _{prefix}^^ Redundant escape inside regexp literal
         p x
       RUBY
 


### PR DESCRIPTION
We are getting this in CI:

```
 1) RuboCop::Cop::Style::RedundantRegexpEscape with multibyte characters removes the escape character at the right position
     Failure/Error: expect(actual_annotations).to eq(expected_annotations), ''

       Diff:
       @@ -1,4 +1,4 @@
        x = s[/[????\.]+/]
       -            ^^ Redundant escape inside regexp literal
       +          ^^ Redundant escape inside regexp literal
```

This change attempts to fix the spacing issue when running in ascii mode.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
