### PR TITLE
Update `ConfigObsoletion` so that parameters can be deprecated but still accepted

### DIFF
--- a/changelog/change_update_configobsoletion_so_that.md
+++ b/changelog/change_update_configobsoletion_so_that.md
@@ -1,0 +1,1 @@
+* [#9100](https://github.com/rubocop-hq/rubocop/pull/9100): Update `ConfigObsoletion` so that parameters can be deprecated but still accepted. ([@dvandersluis][])

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -42,7 +42,7 @@ module RuboCop
         ConfigLoader.default_configuration.key?(key)
       end
 
-      @config_obsoletion.reject_obsolete_cops_and_parameters
+      check_obsoletions
 
       alert_about_unrecognized_cops(invalid_cop_names)
       check_target_ruby
@@ -67,6 +67,13 @@ module RuboCop
     private
 
     attr_reader :target_ruby
+
+    def check_obsoletions
+      @config_obsoletion.reject_obsolete_cops_and_parameters
+      return unless @config_obsoletion.warnings.any?
+
+      warn Rainbow("Warning: #{@config_obsoletion.warnings.join("\n")}").yellow
+    end
 
     def check_target_ruby
       return if target_ruby.supported?


### PR DESCRIPTION
In #9098 it was desired to change some parameters and have a deprecation warning be shown but still accept the old parameters. `ConfigObsoletion` previously would just error if anything was obsolete; this adds a new `severity: :warning` option to the `OBSOLETE_PARAMETERS` hash, for which issues will be warned about but rubocop will still complete.

I don't have any more tests for this because there is nothing to add to the hash until #9098 is merged, so I'll add them in there once this is accepted.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
