### PR TITLE
Upgrade regexp_parser to 2.0

### DIFF
--- a/changelog/change_upgrade_regexp_parser_to_20.md
+++ b/changelog/change_upgrade_regexp_parser_to_20.md
@@ -1,0 +1,1 @@
+* [#9102](https://github.com/rubocop-hq/rubocop/pull/9102): Upgrade regexp_parser to 2.0. ([@knu][])

--- a/lib/rubocop/cop/style/redundant_regexp_escape.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_escape.rb
@@ -82,7 +82,7 @@ module RuboCop
 
         def each_escape(node)
           node.parsed_tree&.traverse&.reduce(0) do |char_class_depth, (event, expr)|
-            yield(expr.text[1], expr.start_index, !char_class_depth.zero?) if expr.type == :escape
+            yield(expr.text[1], expr.ts, !char_class_depth.zero?) if expr.type == :escape
 
             if expr.type == :set
               char_class_depth + (event == :enter ? 1 : -1)

--- a/lib/rubocop/ext/regexp_node.rb
+++ b/lib/rubocop/ext/regexp_node.rb
@@ -19,18 +19,13 @@ module RuboCop
         super
 
         str = with_interpolations_blanked
-        begin
-          @parsed_tree = Regexp::Parser.parse(str, options: options)
+        @parsed_tree = begin
+          Regexp::Parser.parse(str, options: options)
         rescue StandardError
-          @parsed_tree = nil
-        else
-          origin = loc.begin.end
-          source = @parsed_tree.to_s
-          @parsed_tree.each_expression(true) do |e|
-            e.origin = origin
-            e.source = source
-          end
+          nil
         end
+        origin = loc.begin.end
+        @parsed_tree&.each_expression(true) { |e| e.origin = origin }
       end
 
       def each_capture(named: ANY)

--- a/lib/rubocop/ext/regexp_parser.rb
+++ b/lib/rubocop/ext/regexp_parser.rb
@@ -20,18 +20,11 @@ module RuboCop
       module Expression
         # Add `expression` and `loc` to all `regexp_parser` nodes
         module Base
-          attr_accessor :origin, :source
-
-          def start_index
-            # ts is a byte index; convert it to a character index
-            @start_index ||= source.byteslice(0, ts).length
-          end
+          attr_accessor :origin
 
           # Shortcut to `loc.expression`
           def expression
-            @expression ||= begin
-              origin.adjust(begin_pos: start_index, end_pos: start_index + full_length)
-            end
+            @expression ||= origin.adjust(begin_pos: ts, end_pos: ts + full_length)
           end
 
           # @returns a location map like `parser` does, with:

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('parallel', '~> 1.10')
   s.add_runtime_dependency('parser', '>= 2.7.1.5')
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
-  s.add_runtime_dependency('regexp_parser', '>= 1.8')
+  s.add_runtime_dependency('regexp_parser', '>= 2.0')
   s.add_runtime_dependency('rexml')
   s.add_runtime_dependency('rubocop-ast', '>= 1.1.1')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')


### PR DESCRIPTION
regexp_parser 2.0 is out, which introduced char-based indices we wanted.

https://github.com/ammar/regexp_parser/issues/72
https://github.com/ammar/regexp_parser/pull/73

Methods we use that used to return byte-based indices now return char-based indices, so we can revert the changes made in #8989.

https://github.com/ammar/regexp_parser/blob/master/CHANGELOG.md#200---2020-11-25---janosch-m%C3%BCller

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
