### PR TITLE
[Fix #9097] Fix a false positive for `Layout/EmptyLinesAroundArguments`

### DIFF
--- a/changelog/fix_false_positive_for_empty_lines_around_arguments.md
+++ b/changelog/fix_false_positive_for_empty_lines_around_arguments.md
@@ -1,0 +1,1 @@
+* [#9097](https://github.com/rubocop-hq/rubocop/issues/9097): Fix a false positive for `Layout/EmptyLinesAroundArguments` when blank line is inserted between method with arguments and receiver. ([@koic][])

--- a/lib/rubocop/cop/layout/empty_lines_around_arguments.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_arguments.rb
@@ -45,7 +45,8 @@ module RuboCop
         MSG = 'Empty line detected around arguments.'
 
         def on_send(node)
-          return if node.single_line? || node.arguments.empty?
+          return if node.single_line? || node.arguments.empty? ||
+                    receiver_and_method_call_on_different_lines?(node)
 
           extra_lines(node) do |range|
             add_offense(range) do |corrector|
@@ -56,6 +57,10 @@ module RuboCop
         alias on_csend on_send
 
         private
+
+        def receiver_and_method_call_on_different_lines?(node)
+          node.receiver && node.receiver.loc.last_line != node.loc.selector.line
+        end
 
         def empty_lines(node)
           lines = processed_lines(node)

--- a/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
@@ -284,6 +284,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
       RUBY
     end
 
+    it 'accepts when blank line is inserted between method with arguments and receiver' do
+      expect_no_offenses(<<~RUBY)
+        foo.
+
+          bar(arg)
+      RUBY
+    end
+
     context 'with one argument' do
       it 'ignores empty lines inside of method arguments' do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #9097.

This PR fixes a false positive for `Layout/EmptyLinesAroundArguments` when blank line is inserted between method with arguments and receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
