### PR TITLE
[Fix #9104] Preset some stdlib method names for `Naming/VariableNumber`

### DIFF
--- a/changelog/change_preset_ruby_stdlib_api_for_variable_number.md
+++ b/changelog/change_preset_ruby_stdlib_api_for_variable_number.md
@@ -1,0 +1,1 @@
+* [#9104](https://github.com/rubocop-hq/rubocop/issues/9104): Preset some stdlib method names for `Naming/VariableNumber`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2466,7 +2466,13 @@ Naming/VariableNumber:
     - non_integer
   CheckMethodNames: true
   CheckSymbols: true
-  AllowedIdentifiers: []
+  AllowedIdentifiers:
+    - capture3     # Open3.capture3
+    - iso8601      # Time#iso8601
+    - rfc1123_date # CGI.rfc1123_date
+    - rfc822       # Time#rfc822
+    - rfc2822      # Time#rfc2822
+    - rfc3339      # DateTime.rfc3339
 
 #################### Security ##############################
 


### PR DESCRIPTION
Fixes #9104

This PR presets some stdlib method names for `AllowedIdentifiers` of `Naming/VariableNumber`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
