### PR TITLE
[Fix #9105] Fix an incorrect auto-correct for `Style/RedundantCondition`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_redundant_condition.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_redundant_condition.md
@@ -1,0 +1,1 @@
+* [#9105](https://github.com/rubocop-hq/rubocop/issues/9105): Fix an incorrect auto-correct for `Style/RedundantCondition` when using operator method in `else`. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_condition.rb
+++ b/lib/rubocop/cop/style/redundant_condition.rb
@@ -131,7 +131,8 @@ module RuboCop
         end
 
         def without_argument_parentheses_method?(node)
-          node.send_type? && !node.arguments.empty? && !node.parenthesized?
+          node.send_type? &&
+            !node.arguments.empty? && !node.parenthesized? && !node.operator_method?
         end
       end
     end

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -82,6 +82,21 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition do
         RUBY
       end
 
+      it 'registers an offense and corrects when using operator method in `else`' do
+        expect_offense(<<~RUBY)
+          if b
+          ^^^^ Use double pipes `||` instead.
+            b
+          else
+            c + d
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          b || c + d
+        RUBY
+      end
+
       it 'registers an offense and corrects complex one liners' do
         expect_offense(<<~RUBY)
           if b


### PR DESCRIPTION
Fixes #9105

This PR fixes an incorrect auto-correct for `Style/RedundantCondition` when using operator method in `else`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
