### PR TITLE
Update `Lint/UnmodifiedReduceAccumulator` to handle numblocks and more than 2 arguments.

### DIFF
--- a/changelog/change_update_lintunmodifiedreduceaccumulator.md
+++ b/changelog/change_update_lintunmodifiedreduceaccumulator.md
@@ -1,0 +1,1 @@
+* [#9108](https://github.com/rubocop-hq/rubocop/pull/9108): Update `Lint/UnmodifiedReduceAccumulator` to handle numblocks and more than 2 arguments. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2007,6 +2007,7 @@ Lint/UnmodifiedReduceAccumulator:
   Description: Checks for `reduce` or `inject` blocks that do not update the accumulator each iteration.
   Enabled: pending
   VersionAdded: '1.1'
+  VersionChanged: <<next>>
 
 Lint/UnreachableCode:
   Description: 'Unreachable code.'

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('regexp_parser', '>= 2.0')
   s.add_runtime_dependency('rexml')
-  s.add_runtime_dependency('rubocop-ast', '>= 1.1.1')
+  s.add_runtime_dependency('rubocop-ast', '>= 1.2.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 2.0')
 


### PR DESCRIPTION
Re https://github.com/rubocop-hq/rubocop/pull/9071#issuecomment-733042996

Adds support for numblocks and non-traditional arguments to `Lint/UnmodifiedReduceAccumulator`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
