### PR TITLE
Fix a false positive for `Style/MethodCallWithoutArgsParentheses`

### DIFF
--- a/changelog/fix_false_positive_for_method_call_without_args_parentheses.md
+++ b/changelog/fix_false_positive_for_method_call_without_args_parentheses.md
@@ -1,0 +1,1 @@
+* [#9113](https://github.com/rubocop-hq/rubocop/pull/9113): Fix a false positive for `Style/MethodCallWithoutArgsParentheses` when assigning to a default argument with the same name. ([@koic][])

--- a/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
@@ -21,19 +21,28 @@ module RuboCop
         def on_send(node)
           return unless !node.arguments? && node.parenthesized?
           return if ineligible_node?(node)
+          return if default_argument?(node)
           return if ignored_method?(node.method_name)
           return if same_name_assignment?(node)
 
+          register_offense(node)
+        end
+
+        private
+
+        def register_offense(node)
           add_offense(offense_range(node)) do |corrector|
             corrector.remove(node.loc.begin)
             corrector.remove(node.loc.end)
           end
         end
 
-        private
-
         def ineligible_node?(node)
           node.camel_case_method? || node.implicit_call? || node.prefix_not?
+        end
+
+        def default_argument?(node)
+          node.parent&.optarg_type?
         end
 
         def same_name_assignment?(node)

--- a/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
@@ -56,6 +56,13 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses, :config do
       expect_no_offenses('test = test()')
     end
 
+    it 'accepts parens in default argument assignment' do
+      expect_no_offenses(<<~RUBY)
+        def foo(test = test())
+        end
+      RUBY
+    end
+
     it 'accepts parens in shorthand assignment' do
       expect_no_offenses('test ||= test()')
     end


### PR DESCRIPTION
This PR fixes the following false positive for `Style/MethodCallWithoutArgsParentheses` when assigning to a default argument with the same name.

```console
% cat example.rb
def foo(test = test())
end

% ruby -c example.rb
Syntax OK

% rubocop --only Style/MethodCallWithoutArgsParentheses -a example.rb
Inspecting 1 file
C

Offenses:

example.rb:1:20: C: [Corrected] Style/MethodCallWithoutArgsParentheses:
Do not use parentheses for method calls with no arguments.
def foo(test = test())
                   ^^

1 file inspected, 1 offense detected, 1 offense corrected

% cat example.rb
def foo(test = test)
end

% ruby -c example.rb
example.rb:1: circular argument reference - test
```

It prevents `example.rb:1: circular argument reference - test`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
