### PR TITLE
Support auto-correction for `Style/SoleNestedConditional`

### DIFF
--- a/changelog/new_support_autocorrect_for_sole_nested_conditional.md
+++ b/changelog/new_support_autocorrect_for_sole_nested_conditional.md
@@ -1,0 +1,1 @@
+* [#9114](https://github.com/rubocop-hq/rubocop/pull/9114): Support auto-correction for `Style/SoleNestedConditional`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4273,6 +4273,7 @@ Style/SoleNestedConditional:
                   which can be merged into outer conditional node.
   Enabled: true
   VersionAdded: '0.89'
+  VersionChanged: '<<next>>'
   AllowModifier: false
 
 Style/SpecialGlobalVars:

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -33,17 +33,22 @@ module RuboCop
       #   end
       #
       class SoleNestedConditional < Base
+        include RangeHelp
+        extend AutoCorrector
+
         MSG = 'Consider merging nested conditions into '\
               'outer `%<conditional_type>s` conditions.'
 
         def on_if(node)
           return if node.ternary? || node.else? || node.elsif?
 
-          branch = node.if_branch
-          return unless offending_branch?(branch)
+          if_branch = node.if_branch
+          return unless offending_branch?(if_branch)
 
           message = format(MSG, conditional_type: node.keyword)
-          add_offense(branch.loc.keyword, message: message)
+          add_offense(if_branch.loc.keyword, message: message) do |corrector|
+            autocorrect(corrector, node, if_branch)
+          end
         end
 
         private
@@ -55,6 +60,47 @@ module RuboCop
             !branch.else? &&
             !branch.ternary? &&
             !(branch.modifier_form? && allow_modifier?)
+        end
+
+        def autocorrect(corrector, node, if_branch)
+          if node.unless?
+            corrector.replace(node.loc.keyword, 'if')
+            corrector.insert_before(node.condition, '!')
+          end
+
+          and_operator = if_branch.unless? ? ' && !' : ' && '
+          if if_branch.modifier_form?
+            correct_for_gurad_condition_style(corrector, node, if_branch, and_operator)
+          else
+            correct_for_basic_condition_style(corrector, node, if_branch, and_operator)
+          end
+
+          correct_for_comment(corrector, node, if_branch)
+        end
+
+        def correct_for_gurad_condition_style(corrector, node, if_branch, and_operator)
+          corrector.insert_after(node.condition, "#{and_operator}#{if_branch.condition.source}")
+
+          range = range_between(
+            if_branch.loc.keyword.begin_pos, if_branch.condition.source_range.end_pos
+          )
+          corrector.remove(range_with_surrounding_space(range: range, newlines: false))
+          corrector.remove(if_branch.loc.keyword)
+        end
+
+        def correct_for_basic_condition_style(corrector, node, if_branch, and_operator)
+          range = range_between(
+            node.condition.source_range.end_pos, if_branch.condition.source_range.begin_pos
+          )
+          corrector.replace(range, and_operator)
+          corrector.remove(range_by_whole_lines(node.loc.end, include_final_newline: true))
+        end
+
+        def correct_for_comment(corrector, node, if_branch)
+          comments = processed_source.comments_before_line(if_branch.source_range.line)
+          comment_text = comments.map(&:text).join("\n") << "\n"
+
+          corrector.insert_before(node.loc.keyword, comment_text) unless comments.empty?
         end
 
         def allow_modifier?

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
     { 'AllowModifier' => false }
   end
 
-  it 'registers an offense when using nested `if` within `if`' do
+  it 'registers an offense and corrects when using nested `if` within `if`' do
     expect_offense(<<~RUBY)
       if foo
         if bar
@@ -14,9 +14,15 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
         end
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      if foo && bar
+          do_something
+        end
+    RUBY
   end
 
-  it 'registers an offense when using nested `unless` within `if`' do
+  it 'registers an offense and corrects when using nested `unless` within `if`' do
     expect_offense(<<~RUBY)
       if foo
         unless bar
@@ -25,9 +31,15 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
         end
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      if foo && !bar
+          do_something
+        end
+    RUBY
   end
 
-  it 'registers an offense when using nested `if` within `unless`' do
+  it 'registers an offense and corrects when using nested `if` within `unless`' do
     expect_offense(<<~RUBY)
       unless foo
         if bar
@@ -36,9 +48,15 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
         end
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      if !foo && bar
+          do_something
+        end
+    RUBY
   end
 
-  it 'registers an offense when using nested `unless` within `unless`' do
+  it 'registers an offense and corrects when using nested `unless` within `unless`' do
     expect_offense(<<~RUBY)
       unless foo
         unless bar
@@ -46,6 +64,12 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
           do_something
         end
       end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if !foo && !bar
+          do_something
+        end
     RUBY
   end
 
@@ -59,16 +83,37 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
     RUBY
   end
 
-  it 'registers an offense when using nested modifier conditional' do
+  it 'registers an offense and corrects when using nested `if` modifier conditional' do
     expect_offense(<<~RUBY)
       if foo
         do_something if bar
                      ^^ Consider merging nested conditions into outer `if` conditions.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      if foo && bar
+        do_something
+      end
+    RUBY
   end
 
-  it 'registers an offense for multiple nested conditionals' do
+  it 'registers an offense and corrects when using nested `unless` modifier conditional' do
+    expect_offense(<<~RUBY)
+      if foo
+        do_something unless bar
+                     ^^^^^^ Consider merging nested conditions into outer `if` conditions.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if foo && !bar
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects for multiple nested conditionals' do
     expect_offense(<<~RUBY)
       if foo
         if bar
@@ -80,9 +125,15 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
         end
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      if foo && bar && baz
+            do_something
+          end
+    RUBY
   end
 
-  it 'registers an offense when using nested conditional and branch contains a comment' do
+  it 'registers an offense and corrects when using nested conditional and branch contains a comment' do
     expect_offense(<<~RUBY)
       if foo
         # Comment.
@@ -91,6 +142,13 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
           do_something
         end
       end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # Comment.
+      if foo && bar
+          do_something
+        end
     RUBY
   end
 


### PR DESCRIPTION
This PR supports auto-correction for `Style/SoleNestedConditional`.

Part of auto-correction of indentation will be left to other `Layout` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
