### PR TITLE
[Fix #9115] Fix a false positive for `Style/FirstArgumentIndentation`

### DIFF
--- a/changelog/fix_false_positive_for_style_first_argument_indentation.md
+++ b/changelog/fix_false_positive_for_style_first_argument_indentation.md
@@ -1,0 +1,1 @@
+* [#9115](https://github.com/rubocop-hq/rubocop/issues/9115): Fix a false positive for `Style/FirstArgumentIndentation` when argument has expected indent width and the method is preceded by splat for `EnforcedStyle: consistent_relative_to_receiver`. ([@koic][])

--- a/lib/rubocop/cop/layout/first_argument_indentation.rb
+++ b/lib/rubocop/cop/layout/first_argument_indentation.rb
@@ -207,8 +207,13 @@ module RuboCop
         PATTERN
 
         def base_range(send_node, arg_node)
-          range_between(send_node.source_range.begin_pos,
-                        arg_node.source_range.begin_pos)
+          parent = send_node.parent
+          start_node = if parent && (parent.splat_type? || parent.kwsplat_type?)
+                         send_node.parent
+                       else
+                         send_node
+                       end
+          range_between(start_node.source_range.begin_pos, arg_node.source_range.begin_pos)
         end
 
         # Returns the column of the given range. For single line ranges, this

--- a/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
@@ -543,6 +543,28 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
         RUBY
       end
 
+      it 'does not register an offense when argument has expected indent width and ' \
+         'the method is preceded by splat' do
+        expect_no_offenses(<<~RUBY)
+          [
+            item,
+            *do_something(
+              arg)
+          ]
+        RUBY
+      end
+
+      it 'does not register an offense when argument has expected indent width and ' \
+         'the method is preceded by double splat' do
+        expect_no_offenses(<<~RUBY)
+          [
+            item,
+            **do_something(
+              arg)
+          ]
+        RUBY
+      end
+
       context 'when the receiver contains a line break' do
         it 'accepts a correctly indented first argument' do
           expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #9115.

This PR fixes a false positive for `Style/FirstArgumentIndentation` when argument has expected indent width and the method is preceded by splat for `EnforcedStyle: consistent_relative_to_receiver`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
