### PR TITLE
[Fix #8820] Fixes `IfWithSemicolon` autocorrection when `elsif` is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5178,3 +5178,4 @@
 [@HeroProtagonist]: https://github.com/HeroProtagonist
 [@piotrmurach]: https://github.com/piotrmurach
 [@javierav]: https://github.com/javierav
+[@adrian-rivera]: https://github.com/adrian-rivera

--- a/changelog/fix_if_with_semicolon_correction.md
+++ b/changelog/fix_if_with_semicolon_correction.md
@@ -1,0 +1,1 @@
+* [#8820](https://github.com/rubocop-hq/rubocop/issues/8820): Fixes `IfWithSemicolon` autocorrection when `elsif` is present. ([@adrian-rivera][], [@dvandersluis][])

--- a/lib/rubocop/cop/style/if_with_semicolon.rb
+++ b/lib/rubocop/cop/style/if_with_semicolon.rb
@@ -17,25 +17,60 @@ module RuboCop
         include OnNormalIfUnless
         extend AutoCorrector
 
-        MSG = 'Do not use if x; Use the ternary operator instead.'
+        MSG_IF_ELSE = 'Do not use `if %<expr>s;` - use `if/else` instead.'
+        MSG_TERNARY = 'Do not use `if %<expr>s;` - use a ternary operator instead.'
 
         def on_normal_if_unless(node)
           return unless node.else_branch
+          return if node.parent&.if_type?
 
           beginning = node.loc.begin
           return unless beginning&.is?(';')
 
-          add_offense(node) do |corrector|
-            corrector.replace(node, correct_to_ternary(node))
+          message = node.else_branch.if_type? ? MSG_IF_ELSE : MSG_TERNARY
+
+          add_offense(node, message: format(message, expr: node.condition.source)) do |corrector|
+            corrector.replace(node, autocorrect(node))
           end
         end
 
         private
 
-        def correct_to_ternary(node)
+        def autocorrect(node)
+          return correct_elsif(node) if node.else_branch.if_type?
+
           else_code = node.else_branch ? node.else_branch.source : 'nil'
 
           "#{node.condition.source} ? #{node.if_branch.source} : #{else_code}"
+        end
+
+        def correct_elsif(node)
+          <<~RUBY.chop
+            if #{node.condition.source}
+              #{node.if_branch.source}
+            #{build_else_branch(node.else_branch).chop}
+            end
+          RUBY
+        end
+
+        def build_else_branch(second_condition)
+          result = <<~RUBY
+            elsif #{second_condition.condition.source}
+              #{second_condition.if_branch.source}
+          RUBY
+
+          if second_condition.else_branch
+            result += if second_condition.else_branch.if_type?
+                        build_else_branch(second_condition.else_branch)
+                      else
+                        <<~RUBY
+                          else
+                            #{second_condition.else_branch.source}
+                        RUBY
+                      end
+          end
+
+          result
         end
       end
     end

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon do
   it 'registers an offense and corrects for one line if/;/end' do
     expect_offense(<<~RUBY)
       if cond; run else dont end
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use if x; Use the ternary operator instead.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if cond;` - use a ternary operator instead.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -27,5 +27,58 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon do
       class Hash
       end if RUBY_VERSION < "1.8.7"
     RUBY
+  end
+
+  context 'when elsif is present' do
+    it 'accepts without `else` branch' do
+      expect_offense(<<~RUBY)
+        if cond; run elsif cond2; run2 end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if cond;` - use `if/else` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if cond
+          run
+        elsif cond2
+          run2
+        end
+      RUBY
+    end
+
+    it 'accepts second elsif block' do
+      expect_offense(<<~RUBY)
+        if cond; run elsif cond2; run2 elsif cond3; run3 else dont end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if cond;` - use `if/else` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if cond
+          run
+        elsif cond2
+          run2
+        elsif cond3
+          run3
+        else
+          dont
+        end
+      RUBY
+    end
+
+    it 'accepts with `else` branch' do
+      expect_offense(<<~RUBY)
+        if cond; run elsif cond2; run2 else dont end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if cond;` - use `if/else` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if cond
+          run
+        elsif cond2
+          run2
+        else
+          dont
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Continuation of #8831.

This change fixes autocorrection for Style/IfWithSemicolon when elsif present.

In case of one of more elsif conditions present, the autocorrector will create a full if, elsif, else structure.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
