### PR TITLE
Update `Style/SymbolProc` to be aware of numblocks.

### DIFF
--- a/changelog/change_update_stylesymbolproc_to_be_aware_of.md
+++ b/changelog/change_update_stylesymbolproc_to_be_aware_of.md
@@ -1,0 +1,1 @@
+* [#9127](https://github.com/rubocop-hq/rubocop/pull/9127): Update `Style/SymbolProc` to be aware of numblocks. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4423,7 +4423,7 @@ Style/SymbolProc:
   Enabled: true
   Safe: false
   VersionAdded: '0.26'
-  VersionChanged: '0.64'
+  VersionChanged: <<next>>
   # A list of method names to be ignored by the check.
   # The names should be fairly unique, otherwise you'll end up ignoring lots of code.
   IgnoredMethods:

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
     expect_no_offenses('something { |x| y.method }')
   end
 
-  it 'accepts block with a block argument ' do
+  it 'accepts block with a block argument' do
     expect_no_offenses('something { |&x| x.call }')
   end
 
@@ -172,5 +172,38 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
         subject: 'bar', &:text
       )
     RUBY
+  end
+
+  context 'numblocks', :ruby27 do
+    it 'registers an offense for a block with a single numeric argument' do
+      expect_offense(<<~RUBY)
+        something { _1.foo }
+                  ^^^^^^^^^^ Pass `&:foo` as an argument to `something` instead of a block.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        something(&:foo)
+      RUBY
+    end
+
+    it 'accepts block with multiple numeric argumnets' do
+      expect_no_offenses('something { _1 + _2 }')
+    end
+
+    it 'accepts lambda with 1 argument' do
+      expect_no_offenses('-> { _1.method }')
+    end
+
+    it 'accepts proc with 1 argument' do
+      expect_no_offenses('proc { _1.method }')
+    end
+
+    it 'accepts Proc.new with 1 argument' do
+      expect_no_offenses('Proc.new { _1.method }')
+    end
+
+    it 'accepts ::Proc.new with 1 argument' do
+      expect_no_offenses('::Proc.new { _1.method }')
+    end
   end
 end


### PR DESCRIPTION
Follows https://github.com/rubocop-hq/rubocop/pull/9101#issuecomment-734036252

> Independently, I think SymbolProc should be fixed to catch { _1.foo }

Adds numblock awareness to `Style/SymbolProc`, with autocorrection.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
