### PR TITLE
[Fix #9128] Fix an incorrect auto-correct for `Style/ClassAndModuleChildren`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_class_and_module_children.md
+++ b/changelog/fix_incorrect_autocorrect_for_class_and_module_children.md
@@ -1,0 +1,1 @@
+* [#9128](https://github.com/rubocop-hq/rubocop/issues/9128): Fix an incorrect auto-correct for `Style/ClassAndModuleChildren` when namespace is defined as a class in the same file. ([@koic][])

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -55,13 +55,18 @@ module RuboCop
           padding = ((' ' * indent_width) + leading_spaces(node)).to_s
           padding_for_trailing_end = padding.sub(' ' * node.loc.end.column, '')
 
-          replace_keyword_with_module(corrector, node)
+          replace_namespace_keyword(corrector, node)
           split_on_double_colon(corrector, node, padding)
           add_trailing_end(corrector, node, padding_for_trailing_end)
         end
 
-        def replace_keyword_with_module(corrector, node)
-          corrector.replace(node.loc.keyword, 'module')
+        def replace_namespace_keyword(corrector, node)
+          class_definition = node.left_sibling&.each_node(:class)&.find do |class_node|
+            class_node.identifier == node.identifier.namespace
+          end
+          namespace_keyword = class_definition ? 'class' : 'module'
+
+          corrector.replace(node.loc.keyword, namespace_keyword)
         end
 
         def split_on_double_colon(corrector, node, padding)

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -18,6 +18,48 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
       RUBY
     end
 
+    it 'registers an offense for not nested classes when namespace is defined as a class' do
+      expect_offense(<<~RUBY)
+        class FooClass
+        end
+
+        class FooClass::BarClass
+              ^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class FooClass
+        end
+
+        class FooClass
+          class BarClass
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense for not nested classes when namespace is defined as a module' do
+      expect_offense(<<~RUBY)
+        module FooClass
+        end
+
+        class FooClass::BarClass
+              ^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module FooClass
+        end
+
+        module FooClass
+          class BarClass
+          end
+        end
+      RUBY
+    end
+
     it 'registers an offense for not nested classes with explicit superclass' do
       expect_offense(<<~RUBY)
         class FooClass::BarClass < Super


### PR DESCRIPTION
Fixes #9128.

This PR fixes an incorrect auto-correct for `Style/ClassAndModuleChildren` when namespace is defined as a class in the same file.

It is still undetectable when class definition exists in the different file, but it can be detected in the same file. This PR solves the latter.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
