### PR TITLE
Add tests and documentation for SuggestExtensions

### DIFF
--- a/changelog/change_added_notification_if_any_gems_are.md
+++ b/changelog/change_added_notification_if_any_gems_are.md
@@ -1,0 +1,1 @@
+* [#9122](https://github.com/rubocop-hq/rubocop/issues/9122): Added tip message if any gems are loaded that have RuboCop extensions. ([@dvandersluis][])

--- a/docs/modules/ROOT/pages/extensions.adoc
+++ b/docs/modules/ROOT/pages/extensions.adoc
@@ -20,6 +20,31 @@ extension file is not in `$LOAD_PATH`, you need to specify the path as
 relative path prefixed with `./` explicitly or absolute path. Paths
 starting with a `.` are resolved relative to `.rubocop.yml`.
 
+== Extension Suggestions
+
+Depending on what gems you have in your bundle, RuboCop might suggest extensions
+that can be added to provide further functionality. For instance, if you are using
+`rspec` without the corresponding `rubocop-rspec` extension, RuboCop will suggest
+enabling it.
+
+This message can be disabled by adding the following to your configuration:
+
+[source,yaml]
+----
+AllCops:
+  SuggestExtensions: false
+----
+
+You can also opt-out of suggestions for a particular extension library as so (unspecified
+extensions will continue to be notified, as appropriate):
+
+[source,yaml]
+----
+AllCops:
+  SuggestExtensions:
+    rubocop-rake: false
+----
+
 == Custom Cops
 
 You can configure the custom cops in your `.rubocop.yml` just like any


### PR DESCRIPTION
Follows #9130.

Also allows individual extensions to be disabled instead of disabling everything:

```yaml
AllCops:
  SuggestExtensions:
    rubocop-rake: false
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
