### PR TITLE
AllowedIdentifiers should also check variable assignments.

### DIFF
--- a/changelog/fix_allowed_identifiers_for_naming_variable_number.md
+++ b/changelog/fix_allowed_identifiers_for_naming_variable_number.md
@@ -1,0 +1,1 @@
+* [#9136](https://github.com/rubocop-hq/rubocop/pull/9136): Fix `AllowedIdentifiers` in `Naming/VariableNumber` to include variable assignments. ([@PhilCoggins][])

--- a/lib/rubocop/cop/naming/variable_number.rb
+++ b/lib/rubocop/cop/naming/variable_number.rb
@@ -104,6 +104,8 @@ module RuboCop
         def on_arg(node)
           @node = node
           name, = *node
+          return if allowed_identifier?(name)
+
           check_name(node, name, node.loc.name)
         end
         alias on_lvasgn on_arg
@@ -139,7 +141,7 @@ module RuboCop
         end
 
         def allowed_identifier?(name)
-          allowed_identifiers.include?(name.to_s)
+          allowed_identifiers.include?(name.to_s.gsub('@', ''))
         end
 
         def allowed_identifiers

--- a/spec/rubocop/cop/naming/variable_number_spec.rb
+++ b/spec/rubocop/cop/naming/variable_number_spec.rb
@@ -293,6 +293,24 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
       }
     end
 
+    it 'does not register an offense for a local variable name that is allowed' do
+      expect_no_offenses(<<~RUBY)
+        capture3 = :foo
+      RUBY
+    end
+
+    it 'does not register an offense for a instance variable name that is allowed' do
+      expect_no_offenses(<<~RUBY)
+        @capture3 = :foo
+      RUBY
+    end
+
+    it 'does not register an offense for a class variable name that is allowed' do
+      expect_no_offenses(<<~RUBY)
+        @@capture3 = :foo
+      RUBY
+    end
+
     it 'does not register an offense for a method name that is allowed' do
       expect_no_offenses(<<~RUBY)
         def capture3


### PR DESCRIPTION
https://github.com/rubocop-hq/rubocop/pull/9017 Adds `AllowedIdentifiers` option to allow a preconfigured list of names for symbols and method definitions to ignore for the `Naming/VariableNumber` cop. The cop also checks for variable names, but for whatever reason, does not utilize `AllowedIdentifiers`. It is not intuitive that `AllowedIdentifiers` only checks method names and symbols but ignores variable assignment, so therefore it should be included. Further fixes https://github.com/rubocop-hq/rubocop/issues/9012.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
