### PR TITLE
[Fix #9080] Make `Lint/ShadowingOuterVariable` aware of `Ractor`

### DIFF
--- a/changelog/change_make_lintshadowingoutervariable_aware_of.md
+++ b/changelog/change_make_lintshadowingoutervariable_aware_of.md
@@ -1,0 +1,1 @@
+* [#9080](https://github.com/rubocop-hq/rubocop/issues/9080): Make `Lint/ShadowingOuterVariable` aware of `Ractor`. ([@tejasbubane][])

--- a/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
+++ b/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
@@ -8,6 +8,14 @@ module RuboCop
       # given by `ruby -cw` prior to Ruby 2.6:
       # "shadowing outer local variable - foo".
       #
+      # NOTE: Shadowing of variables in block passed to `Ractor.new` is allowed
+      # because `Ractor` should not access outer variables.
+      # eg. following syle is encouraged:
+      #
+      #   worker_id, pipe = env
+      #   Ractor.new(worker_id, pipe) do |worker_id, pipe|
+      #   end
+      #
       # @example
       #
       #   # bad
@@ -34,12 +42,17 @@ module RuboCop
       class ShadowingOuterLocalVariable < Base
         MSG = 'Shadowing outer local variable - `%<variable>s`.'
 
+        def_node_matcher :ractor_block?, <<~PATTERN
+          (block (send (const nil? :Ractor) :new ...) ...)
+        PATTERN
+
         def self.joining_forces
           VariableForce
         end
 
         def before_declaring_variable(variable, variable_table)
           return if variable.should_be_unused?
+          return if ractor_block?(variable.scope.node)
 
           outer_local_variable = variable_table.find_variable(variable.name)
           return unless outer_local_variable

--- a/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
+++ b/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
@@ -172,4 +172,15 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
       RUBY
     end
   end
+
+  context 'with Ractor.new' do
+    it 'does not regiser an offense' do
+      expect_no_offenses(<<~RUBY)
+        def foo(*args)
+          Ractor.new(*args) do |*args|
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Block given to `Ractor.new` should not access outer variables, so shadowing the outer local variables should be encouraged.

Closes #9080 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/