### PR TITLE
[Fix #8985] Fix `Style/StringConcatenation` autocorrect generating invalid ruby

### DIFF
--- a/changelog/fix_fix_stylestringconcatenation_autocorrect.md
+++ b/changelog/fix_fix_stylestringconcatenation_autocorrect.md
@@ -1,0 +1,1 @@
+* [#8985](https://github.com/rubocop-hq/rubocop/issues/8985): Fix `Style/StringConcatenation` autocorrect generating invalid ruby. ([@tejasbubane][])

--- a/lib/rubocop/cop/style/string_concatenation.rb
+++ b/lib/rubocop/cop/style/string_concatenation.rb
@@ -106,7 +106,13 @@ module RuboCop
               end
             end
 
-          "\"#{interpolated_parts.join}\""
+          "\"#{handle_quotes(interpolated_parts).join}\""
+        end
+
+        def handle_quotes(parts)
+          parts.map do |part|
+            part == '"' ? '\"' : part
+          end
         end
 
         def single_quoted?(str_node)

--- a/spec/rubocop/cop/style/string_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/string_concatenation_spec.rb
@@ -158,4 +158,26 @@ RSpec.describe RuboCop::Cop::Style::StringConcatenation do
       RUBY
     end
   end
+
+  context 'empty quotes' do
+    it 'registers offense and corrects' do
+      expect_offense(<<-RUBY)
+        '"' + "foo" + '"'
+        ^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+        '"' + "foo" + "'"
+        ^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+        "'" + "foo" + '"'
+        ^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+        "'" + "foo" + '"' + "bar"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+      RUBY
+
+      expect_correction(<<-RUBY)
+        "\\\"foo\\\""
+        "\\\"foo'"
+        "'foo\\\""
+        "'foo\\\"bar"
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
When single quoted strings

Closes #8985 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/