### PR TITLE
[Fix #9140] Fix an error for `Layout/EmptyLinesAroundArguments`

### DIFF
--- a/changelog/fix_an_error_for_layout_empty_lines_around_arguments.md
+++ b/changelog/fix_an_error_for_layout_empty_lines_around_arguments.md
@@ -1,0 +1,1 @@
+* [#9140](https://github.com/rubocop-hq/rubocop/issues/9140): Fix an error for `Layout/EmptyLinesAroundArguments` when multiline style argument for method call without selector. ([@koic][])

--- a/lib/rubocop/cop/layout/empty_lines_around_arguments.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_arguments.rb
@@ -59,7 +59,7 @@ module RuboCop
         private
 
         def receiver_and_method_call_on_different_lines?(node)
-          node.receiver && node.receiver.loc.last_line != node.loc.selector.line
+          node.receiver && node.receiver.loc.last_line != node.loc.selector&.line
         end
 
         def empty_lines(node)

--- a/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
@@ -292,6 +292,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
       RUBY
     end
 
+    it 'accepts multiline style argument for method call without selector' do
+      expect_no_offenses(<<~RUBY)
+        foo.(
+          arg
+        )
+      RUBY
+    end
+
     context 'with one argument' do
       it 'ignores empty lines inside of method arguments' do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #9140.

This PR fixes an error for `Layout/EmptyLinesAroundArguments` when multiline style argument for method call without selector.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
