### PR TITLE
[Fix #9145] Fix issues with SuggestExtensions when bundler is not available, or when there is no gemfile

### DIFF
--- a/changelog/fix_fix_issues_with_suggestextensions_when.md
+++ b/changelog/fix_fix_issues_with_suggestextensions_when.md
@@ -1,0 +1,1 @@
+* [#9145](https://github.com/rubocop-hq/rubocop/issues/9145): Fix issues with SuggestExtensions when bundler is not available, or when there is no gemfile. ([@dvandersluis][])

--- a/lib/rubocop/cli/command/suggest_extensions.rb
+++ b/lib/rubocop/cli/command/suggest_extensions.rb
@@ -12,8 +12,12 @@ module RuboCop
         self.command_name = :suggest_extensions
 
         def self.dependent_gems
+          return [] unless defined?(Bundler)
+
           # This only includes gems in Gemfile, not in lockfile
           Bundler.load.dependencies.map(&:name)
+        rescue Bundler::GemfileNotFound
+          []
         end
 
         def run
@@ -54,6 +58,8 @@ module RuboCop
         end
 
         def extensions
+          return [] unless dependent_gems.any?
+
           @extensions ||= begin
             extensions = @config_store.for_pwd.for_all_cops['SuggestExtensions'] || {}
             extensions.select { |_, v| (Array(v) & dependent_gems).any? }.keys - dependent_gems
@@ -66,7 +72,7 @@ module RuboCop
         end
 
         def dependent_gems
-          self.class.dependent_gems
+          @dependent_gems ||= self.class.dependent_gems
         end
       end
     end


### PR DESCRIPTION
This fixes #9145 (and #9148). `SuggestExtensions` relies on Bundler to enumerate gems, but Bundler is not guaranteed to be present.

Fixes two issues:
1. Bundler is not required (`uninitialized constant RuboCop::CLI::Command::SuggestExtensions::Bundler`)
2. Bundler is required but there is no Gemfile  (`Could not locate Gemfile or .bundle/ directory`)

I'm not exactly sure how to write tests for this since bundler _is_ a development dependency and I can't add and remove a Gemfile on the fly. Any suggestions?

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
