### PR TITLE
[Fix #9151] Don't suggest extensions that are installed but not direct dependencies

### DIFF
--- a/changelog/fix_dont_suggest_extensions_that_are.md
+++ b/changelog/fix_dont_suggest_extensions_that_are.md
@@ -1,0 +1,1 @@
+* [#9151](https://github.com/rubocop-hq/rubocop/issues/9151): Fix `SuggestExtensions` to not suggest extensions that are installed but not direct dependencies. ([@dvandersluis][])


### PR DESCRIPTION
`SuggestExtensions` checks against your gemfile for installed gems in order to make suggestions, but it did not account for rubocop extensions that were installed as dependencies of dependencies (ie. in Gemfile.lock but not Gemfile). This changes that so that it continues to look at only `Gemfile` to determine what to suggest, but it's filtered down by all activated gems.

Also I figured out a way that I could test without having to mock out bundler, so it uses bundler to ensure this works (and also I added some test cases that were missing from #9149).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
