### PR TITLE
[Fix #9152] Fix an incorrect auto-correct for `Style/SoleNestedCondional`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_sole_nested_conditional.md
+++ b/changelog/fix_incorrect_autocorrect_for_sole_nested_conditional.md
@@ -1,0 +1,1 @@
+* [#9152](https://github.com/rubocop-hq/rubocop/issues/9152): Fix an incorrect auto-correct for `Style/SoleNestedConditional` when nested `||` operator modifier condition. ([@koic][])

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -113,6 +113,71 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when nested `||` operator condition' do
+    expect_offense(<<~RUBY)
+      if foo
+        if bar || baz
+        ^^ Consider merging nested conditions into outer `if` conditions.
+          do_something
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if foo && (bar || baz)
+          do_something
+        end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when nested `||` operator modifier condition' do
+    expect_offense(<<~RUBY)
+      if foo
+        do_something if bar || baz
+                     ^^ Consider merging nested conditions into outer `if` conditions.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if foo && (bar || baz)
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using `||` in the outer condition' do
+    expect_offense(<<~RUBY)
+      if foo || bar
+        if baz || qux
+        ^^ Consider merging nested conditions into outer `if` conditions.
+          do_something
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if (foo || bar) && (baz || qux)
+          do_something
+        end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using `||` in the outer condition' \
+     'and nested modifier condition ' do
+    expect_offense(<<~RUBY)
+      if foo || bar
+        do_something if baz || qux
+                     ^^ Consider merging nested conditions into outer `if` conditions.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if (foo || bar) && (baz || qux)
+        do_something
+      end
+    RUBY
+  end
+
   it 'registers an offense and corrects for multiple nested conditionals' do
     expect_offense(<<~RUBY)
       if foo


### PR DESCRIPTION
Fixes #9152.

This PR fixes an incorrect auto-correct for `Style/SoleNestedConditional` when nested `||` operator modifier condition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
