### PR TITLE
[Fix #9155] Fix a false positive for `Layout/MultilineMethodCallIndentation`

### DIFF
--- a/changelog/fix_a_false_positive_for_multiline_method_call_indentation.md
+++ b/changelog/fix_a_false_positive_for_multiline_method_call_indentation.md
@@ -1,0 +1,1 @@
+* [#9155](https://github.com/rubocop-hq/rubocop/issues/9155): Fix a false positive for `Layout/MultilineMethodCallIndentation` when multiline method chain has expected indent width and the method is preceded by splat for `EnforcedStyle: indented_relative_to_receiver`. ([@koic][])

--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -77,7 +77,7 @@ module RuboCop
 
           @base = alignment_base(node, rhs, given_style)
           correct_column = if @base
-                             @base.column + extra_indentation(given_style)
+                             @base.column + extra_indentation(given_style, node.parent)
                            else
                              indentation(lhs) + correct_indentation(node)
                            end
@@ -85,9 +85,13 @@ module RuboCop
           rhs if @column_delta.nonzero?
         end
 
-        def extra_indentation(given_style)
+        def extra_indentation(given_style, parent)
           if given_style == :indented_relative_to_receiver
-            configured_indentation_width
+            if parent && (parent.splat_type? || parent.kwsplat_type?)
+              configured_indentation_width - parent.loc.operator.length
+            else
+              configured_indentation_width
+            end
           else
             0
           end

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -693,6 +693,28 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       RUBY
     end
 
+    it 'does not register an offense when multiline method chain has expected indent width and ' \
+       'the method is preceded by splat' do
+      expect_no_offenses(<<~RUBY)
+        [
+          *foo
+            .bar(
+              arg)
+        ]
+      RUBY
+    end
+
+    it 'does not register an offense when multiline method chain has expected indent width and ' \
+       'the method is preceded by double splat' do
+      expect_no_offenses(<<~RUBY)
+        [
+          **foo
+            .bar(
+              arg)
+        ]
+      RUBY
+    end
+
     it 'registers an offense and corrects one space indentation of 2nd line' do
       expect_offense(<<~RUBY)
         a


### PR DESCRIPTION
Fixes #9155.

This PR fixes a false positive for `Layout/MultilineMethodCallIndentation` when multiline method chain has expected indent width and the method is preceded by splat for `EnforcedStyle: indented_relative_to_receiver`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
