### PR TITLE
Support regexp_parser 1.8 and 2.x series

### DIFF
--- a/lib/rubocop/cop/style/redundant_regexp_escape.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_escape.rb
@@ -80,14 +80,30 @@ module RuboCop
           delimiters.include?(char)
         end
 
-        def each_escape(node)
-          node.parsed_tree&.traverse&.reduce(0) do |char_class_depth, (event, expr)|
-            yield(expr.text[1], expr.ts, !char_class_depth.zero?) if expr.type == :escape
+        if Gem::Version.new(Regexp::Parser::VERSION) >= Gem::Version.new('2.0')
+          def each_escape(node)
+            node.parsed_tree&.traverse&.reduce(0) do |char_class_depth, (event, expr)|
+              yield(expr.text[1], expr.ts, !char_class_depth.zero?) if expr.type == :escape
 
-            if expr.type == :set
-              char_class_depth + (event == :enter ? 1 : -1)
-            else
-              char_class_depth
+              if expr.type == :set
+                char_class_depth + (event == :enter ? 1 : -1)
+              else
+                char_class_depth
+              end
+            end
+          end
+        # Please remove this `else` branch when support for regexp_parser 1.8 will be dropped.
+        # It's for compatibility with regexp_arser 1.8 and will never be maintained.
+        else
+          def each_escape(node)
+            node.parsed_tree&.traverse&.reduce(0) do |char_class_depth, (event, expr)|
+              yield(expr.text[1], expr.start_index, !char_class_depth.zero?) if expr.type == :escape
+
+              if expr.type == :set
+                char_class_depth + (event == :enter ? 1 : -1)
+              else
+                char_class_depth
+              end
             end
           end
         end

--- a/lib/rubocop/ext/regexp_node.rb
+++ b/lib/rubocop/ext/regexp_node.rb
@@ -15,17 +15,39 @@ module RuboCop
       # see `ext/regexp_parser`.
       attr_reader :parsed_tree
 
-      def assign_properties(*)
-        super
+      if Gem::Version.new(Regexp::Parser::VERSION) >= Gem::Version.new('2.0')
+        def assign_properties(*)
+          super
 
-        str = with_interpolations_blanked
-        @parsed_tree = begin
-          Regexp::Parser.parse(str, options: options)
-        rescue StandardError
-          nil
+          str = with_interpolations_blanked
+          @parsed_tree = begin
+            Regexp::Parser.parse(str, options: options)
+          rescue StandardError
+            nil
+          end
+          origin = loc.begin.end
+          @parsed_tree&.each_expression(true) { |e| e.origin = origin }
         end
-        origin = loc.begin.end
-        @parsed_tree&.each_expression(true) { |e| e.origin = origin }
+      # Please remove this `else` branch when support for regexp_parser 1.8 will be dropped.
+      # It's for compatibility with regexp_arser 1.8 and will never be maintained.
+      else
+        def assign_properties(*)
+          super
+
+          str = with_interpolations_blanked
+          begin
+            @parsed_tree = Regexp::Parser.parse(str, options: options)
+          rescue StandardError
+            @parsed_tree = nil
+          else
+            origin = loc.begin.end
+            source = @parsed_tree.to_s
+            @parsed_tree.each_expression(true) do |e|
+              e.origin = origin
+              e.source = source
+            end
+          end
+        end
       end
 
       def each_capture(named: ANY)

--- a/lib/rubocop/ext/regexp_parser.rb
+++ b/lib/rubocop/ext/regexp_parser.rb
@@ -22,9 +22,27 @@ module RuboCop
         module Base
           attr_accessor :origin
 
-          # Shortcut to `loc.expression`
-          def expression
-            @expression ||= origin.adjust(begin_pos: ts, end_pos: ts + full_length)
+          if Gem::Version.new(Regexp::Parser::VERSION) >= Gem::Version.new('2.0')
+            # Shortcut to `loc.expression`
+            def expression
+              @expression ||= origin.adjust(begin_pos: ts, end_pos: ts + full_length)
+            end
+          # Please remove this `else` branch when support for regexp_parser 1.8 will be dropped.
+          # It's for compatibility with regexp_arser 1.8 and will never be maintained.
+          else
+            attr_accessor :source
+
+            def start_index
+              # ts is a byte index; convert it to a character index
+              @start_index ||= source.byteslice(0, ts).length
+            end
+
+            # Shortcut to `loc.expression`
+            def expression
+              @expression ||= begin
+                origin.adjust(begin_pos: start_index, end_pos: start_index + full_length)
+              end
+            end
           end
 
           # @returns a location map like `parser` does, with:


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/9154, https://github.com/rubocop-hq/rubocop/issues/9155, and https://github.com/rubocop-hq/rubocop/pull/9102.

This is a step towards the widespread use of regexp_parser 2.0.

RuboCop core accepts regexp_parser 1.8 (#9154) , but several code is already incompatible with regexp_parser 1.8. It can cause issue because these combination of versions.

Therefore, this PR ports code for regexp_parser 1.8 that will never be maintained from https://github.com/rubocop-hq/rubocop/pull/9102.

Implementation of this patch, code is intentionally duplicated because it is evaluated only when the class is defined. Also, since obsoleted code for regexp_parser 1.8 is assumed to never be maintained, the target to be removed is clear.

To be honest, it's ugly as implementation, but I think it has the least impact for RuboCop 1.x series users.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
