### PR TITLE
[Fix #9161] Fix a false positive for `Layout/HeredocArgumentClosingParenthesis`

### DIFF
--- a/changelog/fix_false_positive_for_heredoc_argument_closing_parenthesis.md
+++ b/changelog/fix_false_positive_for_heredoc_argument_closing_parenthesis.md
@@ -1,0 +1,1 @@
+* [#9161](https://github.com/rubocop-hq/rubocop/issues/9161): Fix a false positive for `Layout/HeredocArgumentClosingParenthesis` when using subsequence closing parentheses in the same line. ([@koic][])

--- a/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
+++ b/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
@@ -69,6 +69,7 @@ module RuboCop
           return unless outermost_send
           return unless outermost_send.loc.end
           return unless heredoc_arg.first_line != outermost_send.loc.end.line
+          return if subsequent_closing_parentheses_in_same_line?(outermost_send)
 
           add_offense(outermost_send.loc.end) do |corrector|
             autocorrect(corrector, outermost_send)
@@ -159,6 +160,17 @@ module RuboCop
         end
 
         # Closing parenthesis helpers.
+
+        def subsequent_closing_parentheses_in_same_line?(outermost_send)
+          last_arg_of_outer_send = outermost_send.last_argument
+          return false unless last_arg_of_outer_send&.loc.respond_to?(:end) &&
+                              (end_of_last_arg_of_outer_send = last_arg_of_outer_send.loc.end)
+
+          end_of_outer_send = outermost_send.loc.end
+
+          end_of_outer_send.line == end_of_last_arg_of_outer_send.line &&
+            end_of_outer_send.column == end_of_last_arg_of_outer_send.column + 1
+        end
 
         def fix_closing_parenthesis(node, corrector)
           remove_incorrect_closing_paren(node, corrector)

--- a/spec/rubocop/cop/layout/heredoc_argument_closing_parenthesis_spec.rb
+++ b/spec/rubocop/cop/layout/heredoc_argument_closing_parenthesis_spec.rb
@@ -22,6 +22,29 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
       RUBY
     end
 
+    it 'accepts method chain with heredoc argument correct case' do
+      expect_no_offenses(<<~RUBY)
+        do_something(
+          Model
+            .foo(<<~CODE)
+              code
+            CODE
+            .bar(<<~CODE))
+              code
+            CODE
+      RUBY
+    end
+
+    it 'accepts method with heredoc argument of proc correct case' do
+      expect_no_offenses(<<~RUBY)
+        outer_method(-> {
+          inner_method(<<~CODE)
+            code
+          CODE
+        })
+      RUBY
+    end
+
     it 'accepts double correct case nested' do
       expect_no_offenses(<<~RUBY)
         baz(bar(foo(<<-SQL, <<-NOSQL)))


### PR DESCRIPTION
Fixes #9161.

This PR fixes a false positive for `Layout/HeredocArgumentClosingParenthesis` when using subsequence closing parentheses in the same line.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
