### PR TITLE
Fix bug where `Style/SpecialGlobalVars` doesn't register offences for some variables

### DIFF
--- a/changelog/fix_fix_bug_where_stylespecialglobalvars.md
+++ b/changelog/fix_fix_bug_where_stylespecialglobalvars.md
@@ -1,0 +1,1 @@
+* [#9166](https://github.com/rubocop-hq/rubocop/pull/9166): Fix bug where `Style/SpecialGlobalVars` doesn't register offences for `$&`, `$+`, `$'`, and ``$` ``. ([@r7kamura][])

--- a/lib/rubocop/cop/style/special_global_vars.rb
+++ b/lib/rubocop/cop/style/special_global_vars.rb
@@ -112,6 +112,10 @@ module RuboCop
                                      ARGV
                                    ]).freeze
 
+        def on_back_ref(node)
+          on_gvar(node)
+        end
+
         def on_gvar(node)
           global_var, = *node
 

--- a/spec/rubocop/cop/style/special_global_vars_spec.rb
+++ b/spec/rubocop/cop/style/special_global_vars_spec.rb
@@ -4,6 +4,171 @@ RSpec.describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
   context 'when style is use_english_names' do
     let(:cop_config) { { 'EnforcedStyle' => 'use_english_names' } }
 
+    it 'registers an offense for $@' do
+      expect_offense(<<~RUBY)
+        puts $@
+             ^^ Prefer `$ERROR_POSITION` from the stdlib 'English' module (don't forget to require it) over `$@`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        puts $ERROR_POSITION
+      RUBY
+    end
+
+    it 'registers an offense for $;' do
+      expect_offense(<<~RUBY)
+        puts $;
+             ^^ Prefer `$FIELD_SEPARATOR` or `$FS` from the stdlib 'English' module (don't forget to require it) over `$;`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        puts $FIELD_SEPARATOR
+      RUBY
+    end
+
+    it 'registers an offense for $,' do
+      expect_offense(<<~RUBY)
+        puts $,
+             ^^ Prefer `$OUTPUT_FIELD_SEPARATOR` or `$OFS` from the stdlib 'English' module (don't forget to require it) over `$,`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        puts $OUTPUT_FIELD_SEPARATOR
+      RUBY
+    end
+
+    it 'registers an offense for $\\' do
+      expect_offense(<<~RUBY)
+        puts $\\
+             ^^ Prefer `$OUTPUT_RECORD_SEPARATOR` or `$ORS` from the stdlib 'English' module (don't forget to require it) over `$\\`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        puts $OUTPUT_RECORD_SEPARATOR
+      RUBY
+    end
+
+    it 'registers an offense for $.' do
+      expect_offense(<<~RUBY)
+        puts $.
+             ^^ Prefer `$INPUT_LINE_NUMBER` or `$NR` from the stdlib 'English' module (don't forget to require it) over `$.`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        puts $INPUT_LINE_NUMBER
+      RUBY
+    end
+
+    it 'registers an offense for $_' do
+      expect_offense(<<~RUBY)
+        puts $_
+             ^^ Prefer `$LAST_READ_LINE` from the stdlib 'English' module (don't forget to require it) over `$_`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        puts $LAST_READ_LINE
+      RUBY
+    end
+
+    it 'registers an offense for $>' do
+      expect_offense(<<~RUBY)
+        puts $>
+             ^^ Prefer `$DEFAULT_OUTPUT` from the stdlib 'English' module (don't forget to require it) over `$>`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        puts $DEFAULT_OUTPUT
+      RUBY
+    end
+
+    it 'registers an offense for $<' do
+      expect_offense(<<~RUBY)
+        puts $<
+             ^^ Prefer `$DEFAULT_INPUT` from the stdlib 'English' module (don't forget to require it) over `$<`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        puts $DEFAULT_INPUT
+      RUBY
+    end
+
+    it 'registers an offense for $?' do
+      expect_offense(<<~RUBY)
+        puts $?
+             ^^ Prefer `$CHILD_STATUS` from the stdlib 'English' module (don't forget to require it) over `$?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        puts $CHILD_STATUS
+      RUBY
+    end
+
+    it 'registers an offense for $~' do
+      expect_offense(<<~RUBY)
+        puts $~
+             ^^ Prefer `$LAST_MATCH_INFO` from the stdlib 'English' module (don't forget to require it) over `$~`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        puts $LAST_MATCH_INFO
+      RUBY
+    end
+
+    it 'registers an offense for $=' do
+      expect_offense(<<~RUBY)
+        puts $=
+             ^^ Prefer `$IGNORECASE` from the stdlib 'English' module (don't forget to require it) over `$=`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        puts $IGNORECASE
+      RUBY
+    end
+
+    it 'registers an offense for $&' do
+      expect_offense(<<~RUBY)
+        puts $&
+             ^^ Prefer `$MATCH` from the stdlib 'English' module (don't forget to require it) over `$&`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        puts $MATCH
+      RUBY
+    end
+
+    it 'registers an offense for $`' do
+      expect_offense(<<~RUBY)
+        puts $`
+             ^^ Prefer `$PREMATCH` from the stdlib 'English' module (don't forget to require it) over `$``.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        puts $PREMATCH
+      RUBY
+    end
+
+    it 'registers an offense for $\'' do
+      expect_offense(<<~RUBY)
+        puts $'
+             ^^ Prefer `$POSTMATCH` from the stdlib 'English' module (don't forget to require it) over `$'`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        puts $POSTMATCH
+      RUBY
+    end
+
+    it 'registers an offense for $+' do
+      expect_offense(<<~RUBY)
+        puts $+
+             ^^ Prefer `$LAST_PAREN_MATCH` from the stdlib 'English' module (don't forget to require it) over `$+`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        puts $LAST_PAREN_MATCH
+      RUBY
+    end
+
     it 'registers an offense for $:' do
       expect_offense(<<~RUBY)
         puts $:


### PR DESCRIPTION
As the following`ruby-parse` result shows, some special variables are treated as `back-ref` rather than `gvar`.

```
(begin
  (gvar :$:)
  (gvar :$")
  (gvar :$0)
  (gvar :$!)
  (gvar :$@)
  (gvar :$;)
  (gvar :$,)
  (gvar :$/)
  (gvar :$\)
  (gvar :$.)
  (gvar :$_)
  (gvar :$>)
  (gvar :$<)
  (gvar :$$)
  (gvar :$?)
  (gvar :$~)
  (gvar :$=)
  (gvar :$*)
  (back-ref :$&)
  (back-ref :$`)
  (back-ref :$')
  (back-ref :$+))
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
