### PR TITLE
Support auto-correct for `Style/SingleLineBlockParams`

### DIFF
--- a/changelog/support_autocorrect_for_style_single_line_block_params.md
+++ b/changelog/support_autocorrect_for_style_single_line_block_params.md
@@ -1,0 +1,1 @@
+* [#9167](https://github.com/rubocop-hq/rubocop/pull/9167): Support auto-correct for `StyleSingleLineBlockParams`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4272,7 +4272,7 @@ Style/SingleLineBlockParams:
   Description: 'Enforces the names of some block params.'
   Enabled: false
   VersionAdded: '0.16'
-  VersionChanged: '0.47'
+  VersionChanged: <<next>>
   Methods:
     - reduce:
         - acc

--- a/spec/rubocop/cop/style/single_line_block_params_spec.rb
+++ b/spec/rubocop/cop/style/single_line_block_params_spec.rb
@@ -26,6 +26,18 @@ RSpec.describe RuboCop::Cop::Style::SingleLineBlockParams, :config do
                    ^^^^^^ Name `test` block params `|x, y|`.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def m
+        [0, 1].reduce { |a, e| a + e }
+        [0, 1].reduce{ |a, e| a + e }
+        [0, 1].reduce(5) { |a, e| a + e }
+        [0, 1].reduce(5){ |a, e| a + e }
+        [0, 1].reduce (5) { |a, e| a + e }
+        [0, 1].reduce(5) { |a, e| a + e }
+        ala.test { |x, y| bala }
+      end
+    RUBY
   end
 
   it 'allows calls with proper argument names' do
@@ -49,7 +61,11 @@ RSpec.describe RuboCop::Cop::Style::SingleLineBlockParams, :config do
   it 'finds incorrectly named parameters with leading underscores' do
     expect_offense(<<~RUBY)
       File.foreach(filename).reduce(0) { |_x, _y| }
-                                         ^^^^^^^^ Name `reduce` block params `|a, e|`.
+                                         ^^^^^^^^ Name `reduce` block params `|_a, _e|`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      File.foreach(filename).reduce(0) { |_a, _e| }
     RUBY
   end
 


### PR DESCRIPTION
This PR supports auto-correct for `Style/SingleLineBlockParams`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
