### PR TITLE
Add "did you mean" message when failing due to invalid cops in configuration

### DIFF
--- a/changelog/change_add_did_you_mean_message_when_warning.md
+++ b/changelog/change_add_did_you_mean_message_when_warning.md
@@ -1,0 +1,1 @@
+* [#9171](https://github.com/rubocop-hq/rubocop/pull/9171): Add "did you mean" message when failing due to invalid cops in configuration. ([@dvandersluis][])

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -106,10 +106,17 @@ module RuboCop
         # to do so than to pass the value around to various methods.
         next if name == 'inherit_mode'
 
-        unknown_cops << "unrecognized cop #{name} found in " \
-          "#{smart_loaded_path}"
+        suggestions = NameSimilarity.find_similar_names(name, Cop::Registry.global.map(&:cop_name))
+        suggestion = "Did you mean `#{suggestions.join('`, `')}`?" if suggestions.any?
+
+        message = <<~MESSAGE.rstrip
+          unrecognized cop #{name} found in #{smart_loaded_path}
+          #{suggestion}
+        MESSAGE
+
+        unknown_cops << message
       end
-      raise ValidationError, unknown_cops.join(', ') if unknown_cops.any?
+      raise ValidationError, unknown_cops.join("\n") if unknown_cops.any?
     end
 
     def validate_syntax_cop

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1445,16 +1445,25 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       create_file('example/example1.rb', '#' * 90)
 
       create_file('example/.rubocop.yml', <<~YAML)
-        Style/LyneLenth:
+        Layout/LyneLenth:
           Enabled: true
           Max: 100
+        Lint/LiteralInCondition:
+          Enabled: true
+        Style/AlignHash:
+          Enabled: true
       YAML
 
       expect(cli.run(%w[--format simple example])).to eq(2)
       expect($stderr.string)
-        .to eq(['Error: unrecognized cop Style/LyneLenth found in ' \
-                'example/.rubocop.yml',
-                ''].join("\n"))
+        .to eq(<<~OUTPUT)
+          Error: unrecognized cop Layout/LyneLenth found in example/.rubocop.yml
+          Did you mean `Layout/LineLength`?
+          unrecognized cop Lint/LiteralInCondition found in example/.rubocop.yml
+          Did you mean `Lint/LiteralAsCondition`?
+          unrecognized cop Style/AlignHash found in example/.rubocop.yml
+          Did you mean `Style/Alias`, `Style/OptionHash`?
+        OUTPUT
     end
 
     it 'prints a warning for an unrecognized configuration parameter' do


### PR DESCRIPTION
Try to suggest a replacement cop when an invalid cop name is found in the config.

eg:

```
Error: unrecognized cop Layout/LyneLenth found in .rubocop.yml
Did you mean `Layout/LineLength`?
unrecognized cop Lint/LiteralInCondition found in .rubocop.yml
Did you mean `Lint/LiteralAsCondition`?
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
