### PR TITLE
Add `Style/PerlBackrefs` targets and change message more detailed

### DIFF
--- a/changelog/change_add_styleperlbackrefs_targets_and_change.md
+++ b/changelog/change_add_styleperlbackrefs_targets_and_change.md
@@ -1,0 +1,1 @@
+* [#9172](https://github.com/rubocop-hq/rubocop/pull/9172): Add `Style/PerlBackrefs` targets and change message more detailed. ([@r7kamura][])

--- a/spec/rubocop/cop/style/perl_backrefs_spec.rb
+++ b/spec/rubocop/cop/style/perl_backrefs_spec.rb
@@ -3,10 +3,10 @@
 RSpec.describe RuboCop::Cop::Style::PerlBackrefs do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for $1' do
+  it 'auto-corrects puts $1 to puts Regexp.last_match(1)' do
     expect_offense(<<~RUBY)
       puts $1
-           ^^ Avoid the use of Perl-style backrefs.
+           ^^ Prefer `Regexp.last_match(1)` over `$1`.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -14,10 +14,10 @@ RSpec.describe RuboCop::Cop::Style::PerlBackrefs do
     RUBY
   end
 
-  it 'registers an offense for $9' do
+  it 'auto-corrects $9 to Regexp.last_match(9)' do
     expect_offense(<<~RUBY)
       $9
-      ^^ Avoid the use of Perl-style backrefs.
+      ^^ Prefer `Regexp.last_match(9)` over `$9`.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -25,14 +25,124 @@ RSpec.describe RuboCop::Cop::Style::PerlBackrefs do
     RUBY
   end
 
-  it 'auto-corrects #$1 to #{Regexp.last_match(1)}' do
+  it 'auto-corrects $& to Regexp.last_match(0)' do
+    expect_offense(<<~RUBY)
+      $&
+      ^^ Prefer `Regexp.last_match(0)` over `$&`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Regexp.last_match(0)
+    RUBY
+  end
+
+  it 'auto-corrects $` to Regexp.last_match.pre_match' do
+    expect_offense(<<~RUBY)
+      $`
+      ^^ Prefer `Regexp.last_match.pre_match` over `$``.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Regexp.last_match.pre_match
+    RUBY
+  end
+
+  it 'auto-corrects $\' to Regexp.last_match.post_match' do
+    expect_offense(<<~RUBY)
+      $'
+      ^^ Prefer `Regexp.last_match.post_match` over `$'`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Regexp.last_match.post_match
+    RUBY
+  end
+
+  it 'auto-corrects $+ to Regexp.last_match(-1)' do
+    expect_offense(<<~RUBY)
+      $+
+      ^^ Prefer `Regexp.last_match(-1)` over `$+`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Regexp.last_match(-1)
+    RUBY
+  end
+
+  it 'auto-corrects $MATCH to Regexp.last_match(0)' do
+    expect_offense(<<~RUBY)
+      $MATCH
+      ^^^^^^ Prefer `Regexp.last_match(0)` over `$MATCH`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Regexp.last_match(0)
+    RUBY
+  end
+
+  it 'auto-corrects $PREMATCH to Regexp.last_match.pre_match' do
+    expect_offense(<<~RUBY)
+      $PREMATCH
+      ^^^^^^^^^ Prefer `Regexp.last_match.pre_match` over `$PREMATCH`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Regexp.last_match.pre_match
+    RUBY
+  end
+
+  it 'auto-corrects $POSTMATCH to Regexp.last_match.post_match' do
+    expect_offense(<<~RUBY)
+      $POSTMATCH
+      ^^^^^^^^^^ Prefer `Regexp.last_match.post_match` over `$POSTMATCH`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Regexp.last_match.post_match
+    RUBY
+  end
+
+  it 'auto-corrects $LAST_PAREN_MATCH to Regexp.last_match(-1)' do
+    expect_offense(<<~RUBY)
+      $LAST_PAREN_MATCH
+      ^^^^^^^^^^^^^^^^^ Prefer `Regexp.last_match(-1)` over `$LAST_PAREN_MATCH`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Regexp.last_match(-1)
+    RUBY
+  end
+
+  it 'auto-corrects "#$1" to "#{Regexp.last_match(1)}"' do
     expect_offense(<<~'RUBY')
       "#$1"
-        ^^ Avoid the use of Perl-style backrefs.
+        ^^ Prefer `Regexp.last_match(1)` over `$1`.
     RUBY
 
     expect_correction(<<~'RUBY')
       "#{Regexp.last_match(1)}"
+    RUBY
+  end
+
+  it 'auto-corrects `#$1` to `#{Regexp.last_match(1)}`' do
+    expect_offense(<<~'RUBY')
+      `#$1`
+        ^^ Prefer `Regexp.last_match(1)` over `$1`.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      `#{Regexp.last_match(1)}`
+    RUBY
+  end
+
+  it 'auto-corrects /#$1/ to /#{Regexp.last_match(1)}/' do
+    expect_offense(<<~'RUBY')
+      /#$1/
+        ^^ Prefer `Regexp.last_match(1)` over `$1`.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      /#{Regexp.last_match(1)}/
     RUBY
   end
 end


### PR DESCRIPTION
As I mentioned at https://github.com/rubocop-hq/rubocop/pull/9166#issuecomment-739158825, it would be better if `Style/PerlBackrefs` corrects some other back-refs and their English aliases like this:

|Bad|Good|
|---|---|
|$&|Regexp.last_match(0)|
|$MATCH|Regexp.last_match(0)|
|$`|Regexp.last_match.pre_match|
|$PREMATCH|Regexp.last_match.pre_match|
|$'|Regexp.last_match.post_match|
|$POSTMATCH|Regexp.last_match.post_match|
|$+|Regexp.last_match(-1)|
|$LAST_PAREN_MATCH|Regexp.last_match(-1)|

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
