### PR TITLE
[Fix #9175] Don't count autocorrects that will not be performed

### DIFF
--- a/changelog/fix_fix_layoutlinelength_autocorrection.md
+++ b/changelog/fix_fix_layoutlinelength_autocorrection.md
@@ -1,0 +1,1 @@
+* [#9175](https://github.com/rubocop-hq/rubocop/issues/9175): Fix autocorrection reporting when autocorrection is not always possible. ([@dvandersluis][])

--- a/lib/rubocop/cop/correctors/string_literal_corrector.rb
+++ b/lib/rubocop/cop/correctors/string_literal_corrector.rb
@@ -7,16 +7,14 @@ module RuboCop
       extend Util
 
       class << self
-        def correct(node, style)
+        def correct(corrector, node, style)
           return if node.dstr_type?
 
-          lambda do |corrector|
-            str = node.str_content
-            if style == :single_quotes
-              corrector.replace(node, to_string_literal(str))
-            else
-              corrector.replace(node, str.inspect)
-            end
+          str = node.str_content
+          if style == :single_quotes
+            corrector.replace(node, to_string_literal(str))
+          else
+            corrector.replace(node, str.inspect)
           end
         end
       end

--- a/lib/rubocop/cop/mixin/string_help.rb
+++ b/lib/rubocop/cop/mixin/string_help.rb
@@ -14,7 +14,10 @@ module RuboCop
         return if part_of_ignored_node?(node)
 
         if offense?(node)
-          add_offense(node) { opposite_style_detected }
+          add_offense(node) do |corrector|
+            opposite_style_detected
+            autocorrect(corrector, node) if respond_to?(:autocorrect, true)
+          end
         else
           correct_style_detected
         end

--- a/lib/rubocop/cop/style/character_literal.rb
+++ b/lib/rubocop/cop/style/character_literal.rb
@@ -14,8 +14,9 @@ module RuboCop
       #
       #   # good
       #   ?\C-\M-d
-      class CharacterLiteral < Cop
+      class CharacterLiteral < Base
         include StringHelp
+        extend AutoCorrector
 
         MSG = 'Do not use the character literal - ' \
               'use string literal instead.'
@@ -26,17 +27,15 @@ module RuboCop
             node.source.size.between?(2, 3)
         end
 
-        def autocorrect(node)
-          lambda do |corrector|
-            string = node.source[1..-1]
+        def autocorrect(corrector, node)
+          string = node.source[1..-1]
 
-            # special character like \n
-            # or ' which needs to use "" or be escaped.
-            if string.length == 2 || string == "'"
-              corrector.replace(node, %("#{string}"))
-            elsif string.length == 1 # normal character
-              corrector.replace(node, "'#{string}'")
-            end
+          # special character like \n
+          # or ' which needs to use "" or be escaped.
+          if string.length == 2 || string == "'"
+            corrector.replace(node, %("#{string}"))
+          elsif string.length == 1 # normal character
+            corrector.replace(node, "'#{string}'")
           end
         end
 

--- a/lib/rubocop/cop/style/ip_addresses.rb
+++ b/lib/rubocop/cop/style/ip_addresses.rb
@@ -18,7 +18,7 @@ module RuboCop
       #
       #   # good
       #   ip_address = ENV['DEPLOYMENT_IP_ADDRESS']
-      class IpAddresses < Cop
+      class IpAddresses < Base
         include StringHelp
 
         IPV6_MAX_SIZE = 45 # IPv4-mapped IPv6 is the longest

--- a/lib/rubocop/cop/style/string_literals_in_interpolation.rb
+++ b/lib/rubocop/cop/style/string_literals_in_interpolation.rb
@@ -19,12 +19,13 @@ module RuboCop
       #
       #   # good
       #   result = "Tests #{success ? "PASS" : "FAIL"}"
-      class StringLiteralsInInterpolation < Cop
+      class StringLiteralsInInterpolation < Base
         include ConfigurableEnforcedStyle
         include StringLiteralsHelp
+        extend AutoCorrector
 
-        def autocorrect(node)
-          StringLiteralCorrector.correct(node, style)
+        def autocorrect(corrector, node)
+          StringLiteralCorrector.correct(corrector, node, style)
         end
 
         private

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1377,7 +1377,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       RUBY
   end
 
-  it 'does not say [Corrected] if correction was avoided' do
+  it 'does not say [Corrected] if is not possible' do
     src = <<~RUBY
       func a do b end
       Signal.trap('TERM') { system(cmd); exit }
@@ -1410,7 +1410,37 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       C:  2: 34: Style/Semicolon: Do not use semicolons to terminate expressions.
       W:  3: 27: Lint/UnusedMethodArgument: Unused method argument - bar.
 
-      1 file inspected, 3 offenses detected, 3 more offenses can be corrected with `rubocop -A`
+      1 file inspected, 3 offenses detected
+    RESULT
+  end
+
+  it 'does not say [Corrected] if is unsafe' do
+    src = <<~RUBY
+      var = :false
+      %w('foo', "bar")
+    RUBY
+    corrected = <<~RUBY
+      var = :false
+      %w('foo', "bar")
+    RUBY
+    create_file('.rubocop.yml', <<~YAML)
+      AllCops:
+        TargetRubyVersion: 2.4
+    YAML
+    create_file('example.rb', src)
+    exit_status = cli.run(
+      %w[-a -f simple
+         --only Lint/BooleanSymbol,Lint/PercentStringArray]
+    )
+    expect(exit_status).to eq(1)
+    expect($stderr.string).to eq('')
+    expect(IO.read('example.rb')).to eq(corrected)
+    expect($stdout.string).to eq(<<~RESULT)
+      == example.rb ==
+      W:  1:  7: Lint/BooleanSymbol: Symbol with a boolean name - you probably meant to use false.
+      W:  2:  1: Lint/PercentStringArray: Within %w/%W, quotes and ',' are unnecessary and may be unwanted in the resulting strings.
+
+      1 file inspected, 2 offenses detected, 2 more offenses can be corrected with `rubocop -A`
     RESULT
   end
 


### PR DESCRIPTION
In #9031, in order to try to stop `Layout/LineLength` from reporting potential corrections that could not be made, I overrode `correctable?` to only return true if there is a range that can be broken. However, I was not aware that `correctable?` is also called before any cops are run to partition cops into autocorrectable and not:

https://github.com/rubocop-hq/rubocop/blob/291aec7f04775dbe8aaff0c6a2d7328aaca0427b/lib/rubocop/cop/team.rb#L66-L91

My overridden `correctable?` was therefore causing `Layout/LineLength` to not actually autocorrect, ie. #9175.

I have changed it now to override `correction_strategy` instead and return `:unsupported` if no correction can be made for the code.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
