### PR TITLE
Remove back-ref related code from `Style/SpecialGlobalVars`

### DIFF
--- a/changelog/fix_remove_backref_related_code_from.md
+++ b/changelog/fix_remove_backref_related_code_from.md
@@ -1,0 +1,1 @@
+* [#9177](https://github.com/rubocop-hq/rubocop/pull/9177): Remove back-ref related code from `Style/SpecialGlobalVars`. ([@r7kamura][])

--- a/lib/rubocop/cop/style/special_global_vars.rb
+++ b/lib/rubocop/cop/style/special_global_vars.rb
@@ -26,10 +26,6 @@ module RuboCop
       #   puts $LAST_MATCH_INFO
       #   puts $IGNORECASE
       #   puts $ARGV # or ARGV
-      #   puts $MATCH
-      #   puts $PREMATCH
-      #   puts $POSTMATCH
-      #   puts $LAST_PAREN_MATCH
       #
       # @example EnforcedStyle: use_perl_names
       #   # good
@@ -51,10 +47,6 @@ module RuboCop
       #   puts $~
       #   puts $=
       #   puts $*
-      #   puts $&
-      #   puts $`
-      #   puts $'
-      #   puts $+
       #
       class SpecialGlobalVars < Base
         include ConfigurableEnforcedStyle
@@ -85,11 +77,7 @@ module RuboCop
           :$? => [:$CHILD_STATUS],
           :$~ => [:$LAST_MATCH_INFO],
           :$= => [:$IGNORECASE],
-          :$* => %i[$ARGV ARGV],
-          :$& => [:$MATCH],
-          :$` => [:$PREMATCH],
-          :$' => [:$POSTMATCH],
-          :$+ => [:$LAST_PAREN_MATCH]
+          :$* => %i[$ARGV ARGV]
         }
 
         PERL_VARS =


### PR DESCRIPTION
As mentioned in https://github.com/rubocop-hq/rubocop/pull/9166, some unused back-ref related code is written in SpecialGlobalVars.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
