### PR TITLE
[Fix #9174] Handle send nodes with unparenthesized arguments in `Style/SoleNestedConditional`

### DIFF
--- a/changelog/fix_handle_send_nodes_with_unparenthesized.md
+++ b/changelog/fix_handle_send_nodes_with_unparenthesized.md
@@ -1,0 +1,1 @@
+* [#9174](https://github.com/rubocop-hq/rubocop/issues/9174): Handle send nodes with unparenthesized arguments in `Style/SoleNestedConditional`. ([@dvandersluis][])

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -266,6 +266,82 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
     RUBY
   end
 
+  context 'when the inner condition has a send node without parens' do
+    context 'in guard style' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          if foo
+            do_something if ok? bar
+                         ^^ Consider merging nested conditions into outer `if` conditions.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          if foo && (ok? bar)
+            do_something
+          end
+        RUBY
+      end
+    end
+
+    context 'in modifier style' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          if foo
+            if ok? bar
+            ^^ Consider merging nested conditions into outer `if` conditions.
+              do_something
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          if foo && (ok? bar)
+              do_something
+            end
+        RUBY
+      end
+    end
+  end
+
+  context 'when the inner condition has a send node with parens' do
+    context 'in guard style' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          if foo
+            do_something if ok?(bar)
+                         ^^ Consider merging nested conditions into outer `if` conditions.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          if foo && ok?(bar)
+            do_something
+          end
+        RUBY
+      end
+    end
+
+    context 'in modifier style' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          if foo
+            if ok?(bar)
+            ^^ Consider merging nested conditions into outer `if` conditions.
+              do_something
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          if foo && ok?(bar)
+              do_something
+            end
+        RUBY
+      end
+    end
+  end
+
   context 'when AllowModifier is true' do
     let(:cop_config) do
       { 'AllowModifier' => true }


### PR DESCRIPTION
If a condition is rewritten by `Style/SoleNestedConditional` that was an unparenthesized send node, it would be rewritten to a syntax error. This changes it to wrap the send node in parens.

Fixes #9174.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
