### PR TITLE
Support auto-correction for `Style/RedundantArgument`

### DIFF
--- a/changelog/new_support_autocorrection_for_style_redundant_argument.md
+++ b/changelog/new_support_autocorrection_for_style_redundant_argument.md
@@ -1,0 +1,1 @@
+* [#9182](https://github.com/rubocop-hq/rubocop/pull/9182): Support auto-correction for `Style/RedundantArgument`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4025,6 +4025,7 @@ Style/RedundantArgument:
   Enabled: pending
   Safe: false
   VersionAdded: '1.4'
+  VersionChanged: <<next>>
   Methods:
     # Array#join
     join: ''

--- a/spec/rubocop/cop/style/redundant_argument_spec.rb
+++ b/spec/rubocop/cop/style/redundant_argument_spec.rb
@@ -7,21 +7,56 @@ RSpec.describe RuboCop::Cop::Style::RedundantArgument, :config do
     { 'Methods' => { 'join' => '', 'split' => ' ' } }
   end
 
-  it 'registers an offense when method called on variable' do
+  it 'registers an offense and corrects when method called on variable' do
     expect_offense(<<~RUBY)
       foo.join('')
       ^^^^^^^^^^^^ Argument '' is redundant because it is implied by default.
       foo.split(' ')
       ^^^^^^^^^^^^^^ Argument ' ' is redundant because it is implied by default.
     RUBY
+
+    expect_correction(<<~RUBY)
+      foo.join
+      foo.split
+    RUBY
   end
 
-  it 'registers an offense when method called on literals' do
+  it 'registers an offense and corrects when method called without parenthesis on variable' do
+    expect_offense(<<~RUBY)
+      foo.join ''
+      ^^^^^^^^^^^ Argument '' is redundant because it is implied by default.
+      foo.split ' '
+      ^^^^^^^^^^^^^ Argument ' ' is redundant because it is implied by default.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo.join
+      foo.split
+    RUBY
+  end
+
+  it 'registers an offense and corrects when method called on literals' do
     expect_offense(<<~RUBY)
       [1, 2, 3].join('')
       ^^^^^^^^^^^^^^^^^^ Argument '' is redundant because it is implied by default.
       "first second".split(' ')
       ^^^^^^^^^^^^^^^^^^^^^^^^^ Argument ' ' is redundant because it is implied by default.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3].join
+      "first second".split
+    RUBY
+  end
+
+  it 'registers an offense and corrects when method called without parenthesis on literals' do
+    expect_offense(<<~RUBY)
+      [1, 2, 3].join ''
+      ^^^^^^^^^^^^^^^^^ Argument '' is redundant because it is implied by default.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3].join
     RUBY
   end
 
@@ -31,6 +66,11 @@ RSpec.describe RuboCop::Cop::Style::RedundantArgument, :config do
       ^^^^^^^^^^^^ Argument "" is redundant because it is implied by default.
       "first second".split(" ")
       ^^^^^^^^^^^^^^^^^^^^^^^^^ Argument " " is redundant because it is implied by default.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo.join
+      "first second".split
     RUBY
   end
 
@@ -67,10 +107,14 @@ RSpec.describe RuboCop::Cop::Style::RedundantArgument, :config do
       { 'Methods' => { 'foo' => 2 } }
     end
 
-    it 'registers an offense with configured argument' do
+    it 'registers an offense and corrects with configured argument' do
       expect_offense(<<~RUBY)
         A.foo(2)
         ^^^^^^^^ Argument 2 is redundant because it is implied by default.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        A.foo
       RUBY
     end
 


### PR DESCRIPTION
This PR supports auto-correction for `Style/RedundantArgument`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
