### PR TITLE
Handle attr_accessors on the last line in EmptyLinesAroundAttributeAccessor

### DIFF
--- a/changelog/fix_handle_attr_accessor_on_last_line.md
+++ b/changelog/fix_handle_attr_accessor_on_last_line.md
@@ -1,0 +1,1 @@
+* [#9184](https://github.com/rubocop-hq/rubocop/issues/9184): `Layout/EmptyLinesAroundAttributeAccessor` fails if the attr_accessor is the last line of the file. ([@tas50][])

--- a/lib/rubocop/cop/layout/empty_lines_around_attribute_accessor.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_attribute_accessor.rb
@@ -84,7 +84,7 @@ module RuboCop
         private
 
         def next_line_empty?(line)
-          processed_source[line].blank?
+          processed_source[line].nil? || processed_source[line].blank?
         end
 
         def require_empty_line?(node)

--- a/spec/rubocop/cop/layout/empty_lines_around_attribute_accessor_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_attribute_accessor_spec.rb
@@ -47,6 +47,10 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAttributeAccessor, :config 
     RUBY
   end
 
+  it 'accepts code that where the attr_accessor is the last line' do
+    expect_no_offenses('attr_accessor :foo')
+  end
+
   it 'accepts code that separates attribute accessors from the code ' \
      'with a newline' do
     expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
I figured I should probably push a fix up after writing so many of my own cops. Let me know if I got the process right. I'd like to contribute more fixes for issues we run into at Chef.

The fix:

In Style/EmptyLinesAroundAttributeAccessor we check the line+1 to see if it's empty. That's fine until the attr_accessor is on the last line and then the next line is nil and `blank?` fails. When we're checking the next line and it is nil then there is no next line and the attr_accessor is on the last line. We don't need to pad with an empty line so we're good at that point and we can continue on with life.

Fixes #9184

Signed-off-by: Tim Smith <tsmith@chef.io>