### PR TITLE
Support auto-correction for `Style/FloatDivision`

### DIFF
--- a/changelog/new_support_autocorrection_for_style_float_division.md
+++ b/changelog/new_support_autocorrection_for_style_float_division.md
@@ -1,0 +1,1 @@
+* [#9186](https://github.com/rubocop-hq/rubocop/pull/9186): Support auto-correction for `Style/FloatDivision`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3212,6 +3212,7 @@ Style/FloatDivision:
   Reference: 'https://github.com/rubocop-hq/ruby-style-guide/issues/628'
   Enabled: true
   VersionAdded: '0.72'
+  VersionChanged: <<next>>
   EnforcedStyle: single_coerce
   SupportedStyles:
     - left_coerce

--- a/spec/rubocop/cop/style/float_division_spec.rb
+++ b/spec/rubocop/cop/style/float_division_spec.rb
@@ -4,24 +4,36 @@ RSpec.describe RuboCop::Cop::Style::FloatDivision, :config do
   context 'EnforcedStyle is left_coerce' do
     let(:cop_config) { { 'EnforcedStyle' => 'left_coerce' } }
 
-    it 'registers offense for right coerce' do
+    it 'registers offense and corrects for right coerce' do
       expect_offense(<<~RUBY)
         a / b.to_f
         ^^^^^^^^^^ Prefer using `.to_f` on the left side.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a.to_f / b
+      RUBY
     end
 
-    it 'registers offense for both coerce' do
+    it 'registers offense and corrects for both coerce' do
       expect_offense(<<~RUBY)
         a.to_f / b.to_f
         ^^^^^^^^^^^^^^^ Prefer using `.to_f` on the left side.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a.to_f / b
+      RUBY
     end
 
-    it 'registers offense for right coerce with calculations' do
+    it 'registers offense and corrects for right coerce with calculations' do
       expect_offense(<<~RUBY)
         (a * b) / (c - d / 2).to_f
         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `.to_f` on the left side.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        (a * b).to_f / (c - d / 2)
       RUBY
     end
 
@@ -33,24 +45,36 @@ RSpec.describe RuboCop::Cop::Style::FloatDivision, :config do
   context 'EnforcedStyle is right_coerce' do
     let(:cop_config) { { 'EnforcedStyle' => 'right_coerce' } }
 
-    it 'registers offense for left coerce' do
+    it 'registers offense and corrects for left coerce' do
       expect_offense(<<~RUBY)
         a.to_f / b
         ^^^^^^^^^^ Prefer using `.to_f` on the right side.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a / b.to_f
+      RUBY
     end
 
-    it 'registers offense for both coerce' do
+    it 'registers offense and corrects for both coerce' do
       expect_offense(<<~RUBY)
         a.to_f / b.to_f
         ^^^^^^^^^^^^^^^ Prefer using `.to_f` on the right side.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a / b.to_f
+      RUBY
     end
 
-    it 'registers offense for left coerce with calculations' do
+    it 'registers offense and corrects for left coerce with calculations' do
       expect_offense(<<~RUBY)
         (a - b).to_f / (c * 3 * d / 2)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `.to_f` on the right side.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        (a - b) / (c * 3 * d / 2).to_f
       RUBY
     end
 
@@ -62,17 +86,25 @@ RSpec.describe RuboCop::Cop::Style::FloatDivision, :config do
   context 'EnforcedStyle is single_coerce' do
     let(:cop_config) { { 'EnforcedStyle' => 'single_coerce' } }
 
-    it 'registers offense for both coerce' do
+    it 'registers offense and corrects for both coerce' do
       expect_offense(<<~RUBY)
         a.to_f / b.to_f
         ^^^^^^^^^^^^^^^ Prefer using `.to_f` on one side only.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a.to_f / b
+      RUBY
     end
 
-    it 'registers offense for left coerce with calculations' do
+    it 'registers offense and corrects for left coerce with calculations' do
       expect_offense(<<~RUBY)
         (a - b).to_f / (3 * d / 2).to_f
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `.to_f` on one side only.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        (a - b).to_f / (3 * d / 2)
       RUBY
     end
 
@@ -88,31 +120,47 @@ RSpec.describe RuboCop::Cop::Style::FloatDivision, :config do
   context 'EnforcedStyle is fdiv' do
     let(:cop_config) { { 'EnforcedStyle' => 'fdiv' } }
 
-    it 'registers offense for right coerce' do
+    it 'registers offense and corrects for right coerce' do
       expect_offense(<<~RUBY)
         a / b.to_f
         ^^^^^^^^^^ Prefer using `fdiv` for float divisions.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a.fdiv(b)
+      RUBY
     end
 
-    it 'registers offense for both coerce' do
+    it 'registers offense and corrects for both coerce' do
       expect_offense(<<~RUBY)
         a.to_f / b.to_f
         ^^^^^^^^^^^^^^^ Prefer using `fdiv` for float divisions.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a.fdiv(b)
+      RUBY
     end
 
-    it 'registers offense for left coerce' do
+    it 'registers offense and corrects for left coerce' do
       expect_offense(<<~RUBY)
         a.to_f / b
         ^^^^^^^^^^ Prefer using `fdiv` for float divisions.
       RUBY
+
+      expect_correction(<<~RUBY)
+        a.fdiv(b)
+      RUBY
     end
 
-    it 'registers offense for left coerce with calculations' do
+    it 'registers offense and corrects for left coerce with calculations' do
       expect_offense(<<~RUBY)
         (a - b).to_f / (c * 3 * d / 2)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `fdiv` for float divisions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        (a - b).fdiv(c * 3 * d / 2)
       RUBY
     end
 


### PR DESCRIPTION
This PR supports auto-correction for `Style/FloatDivision`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
