### PR TITLE
[Proposal] Update formatters to output `[Correctable]` for correctable offenses

### DIFF
--- a/changelog/change_update_formatters_to_output_correctable.md
+++ b/changelog/change_update_formatters_to_output_correctable.md
@@ -1,0 +1,1 @@
+* [#9187](https://github.com/rubocop-hq/rubocop/pull/9187): Update formatters to output `[Correctable]` for correctable offenses. ([@dvandersluis][])

--- a/lib/rubocop/formatter/emacs_style_formatter.rb
+++ b/lib/rubocop/formatter/emacs_style_formatter.rb
@@ -27,6 +27,8 @@ module RuboCop
             "[Todo] #{offense.message}"
           elsif offense.corrected?
             "[Corrected] #{offense.message}"
+          elsif offense.correctable?
+            "[Correctable] #{offense.message}"
           else
             offense.message
           end

--- a/lib/rubocop/formatter/simple_text_formatter.rb
+++ b/lib/rubocop/formatter/simple_text_formatter.rb
@@ -90,6 +90,8 @@ module RuboCop
             green('[Todo] ')
           elsif offense.corrected?
             green('[Corrected] ')
+          elsif offense.correctable?
+            yellow('[Correctable] ')
           else
             ''
           end

--- a/lib/rubocop/formatter/tap_formatter.rb
+++ b/lib/rubocop/formatter/tap_formatter.rb
@@ -71,6 +71,8 @@ module RuboCop
             '[Todo] '
           elsif offense.corrected?
             '[Corrected] '
+          elsif offense.correctable?
+            '[Correctable] '
           else
             ''
           end

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -921,7 +921,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                   ])
       expect(cli.run(%w[--format emacs])).to eq(1)
       expect($stdout.string).to eq(
-        "#{abs('example.rb')}:3:9: C: Style/RegexpLiteral: Use `%r` " \
+        "#{abs('example.rb')}:3:9: C: [Correctable] Style/RegexpLiteral: Use `%r` " \
         "around regular expression.\n"
       )
       expect(cli.run(['--auto-gen-config'])).to eq(0)

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1406,9 +1406,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     expect(IO.read('example.rb')).to eq(corrected)
     expect($stdout.string).to eq(<<~RESULT)
       == example.rb ==
-      C:  1:  8: Style/BlockDelimiters: Prefer {...} over do...end for single-line blocks.
-      C:  2: 34: Style/Semicolon: Do not use semicolons to terminate expressions.
-      W:  3: 27: Lint/UnusedMethodArgument: Unused method argument - bar.
+      C:  1:  8: [Correctable] Style/BlockDelimiters: Prefer {...} over do...end for single-line blocks.
+      C:  2: 34: [Correctable] Style/Semicolon: Do not use semicolons to terminate expressions.
+      W:  3: 27: [Correctable] Lint/UnusedMethodArgument: Unused method argument - bar.
 
       1 file inspected, 3 offenses detected, 3 more offenses can be corrected with `rubocop -A`
     RESULT

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                         'example.rb'])).to eq(1)
         expect($stdout.string)
           .to eq(['== example.rb ==',
-                  'C:  2:  1: Style/IfUnlessModifier: Favor modifier if ' \
+                  'C:  2:  1: [Correctable] Style/IfUnlessModifier: Favor modifier if ' \
                   'usage when having a single-line body. Another good ' \
                   'alternative is the usage of control flow &&/||.',
                   '',
@@ -474,7 +474,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                           'example.rb'])).to eq(1)
           expect($stdout.string)
             .to eq(['== example.rb ==',
-                    'C:  1:  1: Style/IfUnlessModifier: Favor modifier if ' \
+                    'C:  1:  1: [Correctable] Style/IfUnlessModifier: Favor modifier if ' \
                     'usage when having a single-line body. Another good ' \
                     'alternative is the usage of control flow &&/||.',
                     '',
@@ -502,7 +502,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect($stdout.string)
           .to eq(<<~RESULT)
             == example.rb ==
-            C:  1:  6: Layout/TrailingWhitespace: Trailing whitespace detected.
+            C:  1:  6: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
 
             1 file inspected, 1 offense detected, 1 offense auto-correctable
           RESULT
@@ -522,9 +522,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect($stderr.string).to eq('')
         expect($stdout.string).to eq(<<~RESULT)
           == example.rb ==
-          C:  1:  1: Style/IfUnlessModifier: Favor modifier if usage when having a single-line body. Another good alternative is the usage of control flow &&/||.
-          C:  1:  5: Layout/SpaceAroundOperators: Surrounding space missing for operator ==.
-          C:  2:  1: Layout/IndentationStyle: Tab detected in indentation.
+          C:  1:  1: [Correctable] Style/IfUnlessModifier: Favor modifier if usage when having a single-line body. Another good alternative is the usage of control flow &&/||.
+          C:  1:  5: [Correctable] Layout/SpaceAroundOperators: Surrounding space missing for operator ==.
+          C:  2:  1: [Correctable] Layout/IndentationStyle: Tab detected in indentation.
 
           1 file inspected, 3 offenses detected, 3 offenses auto-correctable
         RESULT
@@ -545,8 +545,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           expect($stdout.string)
             .to eq(<<~RESULT)
               == example.rb ==
-              C:  1:  5: Layout/SpaceAroundOperators: Surrounding space missing for operator ==.
-              C:  2:  1: Layout/IndentationStyle: Tab detected in indentation.
+              C:  1:  5: [Correctable] Layout/SpaceAroundOperators: Surrounding space missing for operator ==.
+              C:  2:  1: [Correctable] Layout/IndentationStyle: Tab detected in indentation.
               W:  2:  2: Lint/UselessAssignment: Useless assignment to variable - y.
 
               1 file inspected, 3 offenses detected, 2 offenses auto-correctable
@@ -788,7 +788,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                       '--debug',
                       'example1.rb'])).to eq(1)
       expect($stdout.string.lines.to_a[-1])
-        .to eq("#{file}:1:7: C: Layout/TrailingWhitespace: Trailing " \
+        .to eq("#{file}:1:7: C: [Correctable] Layout/TrailingWhitespace: Trailing " \
                "whitespace detected.\n")
     end
   end
@@ -824,10 +824,10 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       expect(cli.run(['--format', 'emacs', '--display-cop-names',
                       'example1.rb'])).to eq(1)
       expect($stdout.string).to eq(<<~RESULT)
-        #{file}:1:1: C: Style/FrozenStringLiteralComment: Missing frozen string literal comment.
-        #{file}:1:8: W: Lint/RedundantCopDisableDirective: Unnecessary disabling of `Style/NumericLiterals`.
-        #{file}:1:26: C: Migration/DepartmentName: Department name is missing.
-        #{file}:1:41: C: Layout/TrailingWhitespace: Trailing whitespace detected.
+        #{file}:1:1: C: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
+        #{file}:1:8: W: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of `Style/NumericLiterals`.
+        #{file}:1:26: C: [Correctable] Migration/DepartmentName: Department name is missing.
+        #{file}:1:41: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
       RESULT
     end
 
@@ -836,10 +836,10 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect(cli.run(['--format', 'emacs', '--no-display-cop-names',
                         'example1.rb'])).to eq(1)
         expect($stdout.string).to eq(<<~RESULT)
-          #{file}:1:1: C: Missing frozen string literal comment.
-          #{file}:1:8: W: Unnecessary disabling of `Style/NumericLiterals`.
-          #{file}:1:26: C: Department name is missing.
-          #{file}:1:41: C: Trailing whitespace detected.
+          #{file}:1:1: C: [Correctable] Missing frozen string literal comment.
+          #{file}:1:8: W: [Correctable] Unnecessary disabling of `Style/NumericLiterals`.
+          #{file}:1:26: C: [Correctable] Department name is missing.
+          #{file}:1:41: C: [Correctable] Trailing whitespace detected.
         RESULT
       end
     end
@@ -856,10 +856,10 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect(cli.run(['--format', 'emacs', '--display-cop-names',
                         'example1.rb'])).to eq(1)
         expect($stdout.string).to eq(<<~RESULT)
-          #{file}:1:1: C: Style/FrozenStringLiteralComment: Missing frozen string literal comment.
-          #{file}:1:8: W: Lint/RedundantCopDisableDirective: Unnecessary disabling of `Style/NumericLiterals`.
-          #{file}:1:26: C: Migration/DepartmentName: Department name is missing.
-          #{file}:1:41: C: Layout/TrailingWhitespace: Trailing whitespace detected.
+          #{file}:1:1: C: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
+          #{file}:1:8: W: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of `Style/NumericLiterals`.
+          #{file}:1:26: C: [Correctable] Migration/DepartmentName: Department name is missing.
+          #{file}:1:41: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
         RESULT
       end
 
@@ -867,10 +867,10 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         it 'does not show cop names' do
           expect(cli.run(['--format', 'emacs', 'example1.rb'])).to eq(1)
           expect($stdout.string).to eq(<<~RESULT)
-            #{file}:1:1: C: Missing frozen string literal comment.
-            #{file}:1:8: W: Unnecessary disabling of `Style/NumericLiterals`.
-            #{file}:1:26: C: Department name is missing.
-            #{file}:1:41: C: Trailing whitespace detected.
+            #{file}:1:1: C: [Correctable] Missing frozen string literal comment.
+            #{file}:1:8: W: [Correctable] Unnecessary disabling of `Style/NumericLiterals`.
+            #{file}:1:26: C: [Correctable] Department name is missing.
+            #{file}:1:41: C: [Correctable] Trailing whitespace detected.
           RESULT
         end
       end
@@ -890,9 +890,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       expect(cli.run(['--format', 'emacs', '--extra-details',
                       'example1.rb'])).to eq(1)
       expect($stdout.string).to eq(<<~RESULT)
-        #{file}:1:1: C: Style/FrozenStringLiteralComment: Missing frozen string literal comment.
-        #{file}:1:8: W: Lint/RedundantCopDisableDirective: Unnecessary disabling of `Style/NumericLiterals`.
-        #{file}:1:47: C: Layout/TrailingWhitespace: Trailing whitespace detected. Trailing space is just sloppy.
+        #{file}:1:1: C: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
+        #{file}:1:8: W: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of `Style/NumericLiterals`.
+        #{file}:1:47: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected. Trailing space is just sloppy.
       RESULT
 
       expect($stderr.string).to eq('')
@@ -911,7 +911,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                       '--display-style-guide',
                       'example1.rb'])).to eq(1)
       expect($stdout.string.lines.to_a[-1])
-        .to eq("#{file}:1:7: C: Layout/TrailingWhitespace: " \
+        .to eq("#{file}:1:7: C: [Correctable] Layout/TrailingWhitespace: " \
                "Trailing whitespace detected. (#{url})\n")
     end
 
@@ -926,7 +926,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                       '--display-style-guide',
                       'example1.rb'])).to eq(1)
 
-      output = "#{file}:1:6: C: Security/JSONLoad: " \
+      output = "#{file}:1:6: C: [Correctable] Security/JSONLoad: " \
                "Prefer `JSON.parse` over `JSON.load`. (#{url})"
       expect($stdout.string.lines.to_a[-1])
         .to eq([output, ''].join("\n"))
@@ -1102,7 +1102,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           expect($stdout.string)
             .to include(<<~RESULT)
               == #{target_file} ==
-              C:  1:  1: Style/FrozenStringLiteralComment: Missing frozen string literal comment.
+              C:  1:  1: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
               C:  1:121: Layout/LineLength: Line is too long. [130/120]
 
               1 file inspected, 2 offenses detected, 1 offense auto-correctable
@@ -1186,15 +1186,15 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                           'example2.rb', 'example3.rb']))
             .to eq(1)
           expect($stdout.string).to eq([
-            'example1.rb:1:1: C: Style/FrozenStringLiteralComment: ' \
+            'example1.rb:1:1: C: [Correctable] Style/FrozenStringLiteralComment: ' \
             'Missing frozen string literal comment.',
             'x= 0 ',
             '^',
-            'example1.rb:1:2: C: Layout/SpaceAroundOperators: ' \
+            'example1.rb:1:2: C: [Correctable] Layout/SpaceAroundOperators: ' \
             'Surrounding space missing for operator =.',
             'x= 0 ',
             ' ^',
-            'example1.rb:1:5: C: Layout/TrailingWhitespace: ' \
+            'example1.rb:1:5: C: [Correctable] Layout/TrailingWhitespace: ' \
             'Trailing whitespace detected.',
             'x= 0 ',
             '    ^',
@@ -1206,31 +1206,31 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             '                                                   ' \
             '                                                   ' \
             '                  ^^^^^^^^^^',
-            'example1.rb:3:2: C: Layout/TrailingWhitespace: ' \
+            'example1.rb:3:2: C: [Correctable] Layout/TrailingWhitespace: ' \
             'Trailing whitespace detected.',
             'y ',
             ' ^',
-            'example2.rb:1:1: C: Layout/CommentIndentation: ' \
+            'example2.rb:1:1: C: [Correctable] Layout/CommentIndentation: ' \
             'Incorrect indentation detected (column 0 instead of 1).',
             '# frozen_string_literal: true',
             '^^^^^^^^^^^^^^^^^^^^^^^^^^^^^',
-            'example2.rb:3:1: C: Layout/IndentationStyle: '\
+            'example2.rb:3:1: C: [Correctable] Layout/IndentationStyle: '\
             'Tab detected in indentation.',
             "\tx",
             '^',
-            'example2.rb:3:2: C: Layout/InitialIndentation: ' \
+            'example2.rb:3:2: C: [Correctable] Layout/InitialIndentation: ' \
             'Indentation of first line in file detected.',
             "\tx",
             ' ^',
-            'example2.rb:4:1: C: Layout/IndentationConsistency: ' \
+            'example2.rb:4:1: C: [Correctable] Layout/IndentationConsistency: ' \
             'Inconsistent indentation detected.',
             'def a ...',
             '^^^^^',
-            'example2.rb:5:1: C: Layout/IndentationWidth: ' \
+            'example2.rb:5:1: C: [Correctable] Layout/IndentationWidth: ' \
             'Use 2 (not 3) spaces for indentation.',
             '   puts',
             '^^^',
-            'example3.rb:1:1: C: Style/FrozenStringLiteralComment: ' \
+            'example3.rb:1:1: C: [Correctable] Style/FrozenStringLiteralComment: ' \
             'Missing frozen string literal comment.',
             'def badName',
             '^',
@@ -1243,12 +1243,12 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             'wrapping the code inside a conditional expression.',
             '  if something',
             '  ^^',
-            'example3.rb:2:3: C: Style/IfUnlessModifier: ' \
+            'example3.rb:2:3: C: [Correctable] Style/IfUnlessModifier: ' \
             'Favor modifier if usage when having a single-line body. ' \
             'Another good alternative is the usage of control flow &&/||.',
             '  if something',
             '  ^^',
-            'example3.rb:4:5: W: Layout/EndAlignment: ' \
+            'example3.rb:4:5: W: [Correctable] Layout/EndAlignment: ' \
             'end at 4, 4 is not aligned with if at 2, 2.',
             '    end',
             '    ^^^',
@@ -1275,13 +1275,13 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           expect(cli.run(['--format', 'emacs', 'example1.rb',
                           'example2.rb'])).to eq(1)
           expected_output = <<~RESULT
-            #{abs('example1.rb')}:3:2: C: Layout/SpaceAroundOperators: Surrounding space missing for operator `=`.
-            #{abs('example1.rb')}:3:5: C: Layout/TrailingWhitespace: Trailing whitespace detected.
-            #{abs('example1.rb')}:4:2: C: Layout/TrailingWhitespace: Trailing whitespace detected.
-            #{abs('example2.rb')}:1:1: C: Layout/CommentIndentation: Incorrect indentation detected (column 0 instead of 1).
-            #{abs('example2.rb')}:3:1: C: Layout/IndentationStyle: Tab detected in indentation.
-            #{abs('example2.rb')}:3:2: C: Layout/InitialIndentation: Indentation of first line in file detected.
-            #{abs('example2.rb')}:4:1: C: Layout/IndentationConsistency: Inconsistent indentation detected.
+            #{abs('example1.rb')}:3:2: C: [Correctable] Layout/SpaceAroundOperators: Surrounding space missing for operator `=`.
+            #{abs('example1.rb')}:3:5: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
+            #{abs('example1.rb')}:4:2: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
+            #{abs('example2.rb')}:1:1: C: [Correctable] Layout/CommentIndentation: Incorrect indentation detected (column 0 instead of 1).
+            #{abs('example2.rb')}:3:1: C: [Correctable] Layout/IndentationStyle: Tab detected in indentation.
+            #{abs('example2.rb')}:3:2: C: [Correctable] Layout/InitialIndentation: Indentation of first line in file detected.
+            #{abs('example2.rb')}:4:1: C: [Correctable] Layout/IndentationConsistency: Inconsistent indentation detected.
           RESULT
           expect($stdout.string).to eq(expected_output)
         end
@@ -1343,9 +1343,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       cli.run(['--format', 'simple', '--format', 'emacs', 'example.rb'])
       expect($stdout.string).to include(<<~RESULT)
         == #{target_file} ==
-        C:  1:  1: Style/FrozenStringLiteralComment: Missing frozen string literal comment.
+        C:  1:  1: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
         C:  1:121: Layout/LineLength: Line is too long. [130/120]
-        #{abs(target_file)}:1:1: C: Style/FrozenStringLiteralComment: Missing frozen string literal comment.
+        #{abs(target_file)}:1:1: C: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
         #{abs(target_file)}:1:121: C: Layout/LineLength: Line is too long. [130/120]
       RESULT
     end
@@ -1370,7 +1370,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
       expect($stdout.string).to eq(<<~RESULT)
         == #{target_file} ==
-        C:  1:  1: Style/FrozenStringLiteralComment: Missing frozen string literal comment.
+        C:  1:  1: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
         C:  1:121: Layout/LineLength: Line is too long. [130/120]
 
         1 file inspected, 2 offenses detected, 1 offense auto-correctable
@@ -1378,7 +1378,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
       expect(File.read('emacs_output.txt'))
         .to eq(<<~RESULT)
-          #{abs(target_file)}:1:1: C: Style/FrozenStringLiteralComment: Missing frozen string literal comment.
+          #{abs(target_file)}:1:1: C: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
           #{abs(target_file)}:1:121: C: Layout/LineLength: Line is too long. [130/120]
       RESULT
     end
@@ -1703,7 +1703,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect(cli.run(argv)).to eq(1)
         expect($stdout.string).to eq(<<~RESULT)
           == fake.rb ==
-          C:  1:  3: Style/SpecialGlobalVars: Prefer $INPUT_RECORD_SEPARATOR or $RS from the stdlib 'English' module (don't forget to require it) over $/.
+          C:  1:  3: [Correctable] Style/SpecialGlobalVars: Prefer $INPUT_RECORD_SEPARATOR or $RS from the stdlib 'English' module (don't forget to require it) over $/.
 
           1 file inspected, 1 offense detected, 1 offense auto-correctable
         RESULT

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         .to eq(<<~RESULT)
           == example.rb ==
           C:  1:  1: Layout/EndOfLine: Carriage return character detected.
-          C:  1:  1: Style/FrozenStringLiteralComment: Missing frozen string literal comment.
+          C:  1:  1: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
 
           1 file inspected, 2 offenses detected, 1 offense auto-correctable
       RESULT
@@ -143,7 +143,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     expect($stdout.string)
       .to eq <<~RESULT
         == example.rb ==
-        C:  3:  6: Layout/TrailingWhitespace: Trailing whitespace detected.
+        C:  3:  6: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
 
         1 file inspected, 1 offense detected, 1 offense auto-correctable
     RESULT
@@ -170,11 +170,11 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     aggregate_failures('CLI output') do
       expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)
       expect($stdout.string)
-        .to eq(["#{abs('example.rb')}:3:6: W: Lint/AmbiguousOperator: " \
+        .to eq(["#{abs('example.rb')}:3:6: W: [Correctable] Lint/AmbiguousOperator: " \
                 'Ambiguous splat operator. Parenthesize the method arguments ' \
                 "if it's surely a splat operator, or add a whitespace to the " \
                 'right of the `*` if it should be a multiplication.',
-                "#{abs('example.rb')}:4:1: C: Style/OneLineConditional: " \
+                "#{abs('example.rb')}:4:1: C: [Correctable] Style/OneLineConditional: " \
                 'Favor the ternary operator (`?:`) or multi-line constructs over ' \
                 'single-line `if/then/else/end` constructs.',
                 ''].join("\n"))
@@ -226,7 +226,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       # should get 2 offenses reported.
       expect($stdout.string).to eq(<<~RESULT)
         #{abs('example.rb')}:7:121: C: Layout/LineLength: Line is too long. [132/120]
-        #{abs('example.rb')}:9:5: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
+        #{abs('example.rb')}:9:5: C: [Correctable] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
       RESULT
     end
 
@@ -313,9 +313,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       # 2 real cops were disabled, and 1 that was incorrect
       # 2 real cops was enabled, but only 1 had been disabled correctly
       expect($stdout.string).to eq(<<~RESULT)
-        #{abs('example.rb')}:8:21: W: Lint/RedundantCopEnableDirective: Unnecessary enabling of Layout/LineLength.
+        #{abs('example.rb')}:8:21: W: [Correctable] Lint/RedundantCopEnableDirective: Unnecessary enabling of Layout/LineLength.
         #{abs('example.rb')}:9:121: C: Layout/LineLength: Line is too long. [132/120]
-        #{abs('example.rb')}:11:5: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
+        #{abs('example.rb')}:11:5: C: [Correctable] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
       RESULT
     end
 
@@ -355,9 +355,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         OUTPUT
         expect($stdout.string)
           .to eq(<<~RESULT)
-            #{abs('example.rb')}:3:150: C: Migration/DepartmentName: Department name is missing.
+            #{abs('example.rb')}:3:150: C: [Correctable] Migration/DepartmentName: Department name is missing.
             #{abs('example.rb')}:4:121: C: Layout/LineLength: Line is too long. [130/120]
-            #{abs('example.rb')}:5:28: C: Migration/DepartmentName: Department name is missing.
+            #{abs('example.rb')}:5:28: C: [Correctable] Migration/DepartmentName: Department name is missing.
         RESULT
       end
     end
@@ -377,9 +377,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect($stderr.string).to eq('')
         expect($stdout.string).to eq(<<~RESULT)
           #{abs('example.rb')}:3:121: C: Layout/LineLength: Line is too long. [130/120]
-          #{abs('example.rb')}:4:1: W: Lint/RedundantCopDisableDirective: Unnecessary disabling of all cops.
-          #{abs('example.rb')}:5:12: W: Lint/RedundantCopDisableDirective: Unnecessary disabling of `Layout/LineLength`, `Metrics/ClassLength`.
-          #{abs('example.rb')}:6:8: W: Lint/RedundantCopDisableDirective: Unnecessary disabling of all cops.
+          #{abs('example.rb')}:4:1: W: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of all cops.
+          #{abs('example.rb')}:5:12: W: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of `Layout/LineLength`, `Metrics/ClassLength`.
+          #{abs('example.rb')}:6:8: W: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of all cops.
         RESULT
       end
 
@@ -744,8 +744,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           expect($stdout.string)
             .to eq(<<~RESULT)
               == example.rb ==
-              C:  9:  3: Layout/IndentationWidth: Use 2 (not 0) spaces for indented_internal_methods indentation.
-              C: 15:  3: Layout/IndentationWidth: Use 2 (not 0) spaces for indented_internal_methods indentation.
+              C:  9:  3: [Correctable] Layout/IndentationWidth: Use 2 (not 0) spaces for indented_internal_methods indentation.
+              C: 15:  3: [Correctable] Layout/IndentationWidth: Use 2 (not 0) spaces for indented_internal_methods indentation.
 
               1 file inspected, 2 offenses detected, 2 offenses auto-correctable
           RESULT
@@ -834,7 +834,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           expect($stdout.string)
             .to eq(<<~RESULT)
               == example.rb ==
-              C:  3:  6: Layout/TrailingWhitespace: Trailing whitespace detected.
+              C:  3:  6: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
 
               1 file inspected, 1 offense detected, 1 offense auto-correctable
             RESULT
@@ -872,9 +872,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       expect(cli.run(%w[--format simple])).to eq(1)
       expect($stdout.string).to eq(<<~RESULT)
         == dir/example2.rb ==
-        C:  3:  6: Trailing whitespace detected.
+        C:  3:  6: [Correctable] Trailing whitespace detected.
         == example1.rb ==
-        C:  3:  6: Layout/TrailingWhitespace: Trailing whitespace detected.
+        C:  3:  6: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
 
         2 files inspected, 2 offenses detected, 2 offenses auto-correctable
       RESULT
@@ -898,9 +898,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       expect(cli.run(%w[--format simple])).to eq(1)
       expect($stdout.string).to eq(<<~RESULT)
         == dir/example2.rb ==
-        C:  3:  6: Layout/TrailingWhitespace: Trailing whitespace detected. (#{url})
+        C:  3:  6: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected. (#{url})
         == example1.rb ==
-        C:  3:  6: Layout/TrailingWhitespace: Trailing whitespace detected.
+        C:  3:  6: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
 
         2 files inspected, 2 offenses detected, 2 offenses auto-correctable
       RESULT
@@ -1048,7 +1048,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       expect(cli.run(%w[--format simple .])).to eq(1)
       expect($stdout.string).to eq(<<~RESULT)
         == special.dsl ==
-        C:  3:  9: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
+        C:  3:  9: [Correctable] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
 
         1 file inspected, 1 offense detected, 1 offense auto-correctable
       RESULT
@@ -1088,7 +1088,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       expect($stdout.string)
         .to eq(<<~RESULT)
           == example1.rb ==
-          C:  3:  7: Layout/TrailingWhitespace: Trailing whitespace detected.
+          C:  3:  7: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
 
           1 file inspected, 1 offense detected, 1 offense auto-correctable
         RESULT
@@ -1111,7 +1111,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect($stdout.string)
           .to eq(<<~RESULT)
             == example1.rb ==
-            C:  3:  7: Layout/TrailingWhitespace: Trailing whitespace detected.
+            C:  3:  7: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
 
             1 file inspected, 1 offense detected, 1 offense auto-correctable
           RESULT
@@ -1169,9 +1169,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       cli.run(['--format', 'simple', '-c', 'rubocop.yml', 'example1.rb'])
       expect($stdout.string).to eq(<<~RESULT)
         == example1.rb ==
-        C:  3:  6: Style/PercentLiteralDelimiters: %w-literals should be delimited by [ and ].
-        C:  4:  6: Style/PercentLiteralDelimiters: %q-literals should be delimited by ( and ).
-        C:  4:  6: Style/RedundantPercentQ: Use %q only for strings that contain both single quotes and double quotes.
+        C:  3:  6: [Correctable] Style/PercentLiteralDelimiters: %w-literals should be delimited by [ and ].
+        C:  4:  6: [Correctable] Style/PercentLiteralDelimiters: %q-literals should be delimited by ( and ).
+        C:  4:  6: [Correctable] Style/RedundantPercentQ: Use %q only for strings that contain both single quotes and double quotes.
 
         1 file inspected, 3 offenses detected, 3 offenses auto-correctable
       RESULT
@@ -1201,8 +1201,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       expect($stdout.string)
         .to eq(<<~RESULT)
           == example1.rb ==
-          C:  1:  5: Style/CollectionMethods: Prefer find_all over select.
-          C:  1: 26: Style/CollectionMethods: Prefer map over collect.
+          C:  1:  5: [Correctable] Style/CollectionMethods: Prefer find_all over select.
+          C:  1: 26: [Correctable] Style/CollectionMethods: Prefer map over collect.
 
           1 file inspected, 2 offenses detected, 2 offenses auto-correctable
         RESULT
@@ -1227,7 +1227,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                         '-c', 'rubocop.yml', 'example1.rb'])
       expect($stdout.string).to eq(<<~RESULT)
         == example1.rb ==
-        C:  3:  1: Style/IfUnlessModifier: Favor modifier if usage when having a single-line body. Another good alternative is the usage of control flow &&/||.
+        C:  3:  1: [Correctable] Style/IfUnlessModifier: Favor modifier if usage when having a single-line body. Another good alternative is the usage of control flow &&/||.
 
         1 file inspected, 1 offense detected, 1 offense auto-correctable
       RESULT
@@ -1250,7 +1250,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       expect($stdout.string)
         .to eq(<<~RESULT)
           == example_src/example1.rb ==
-          C:  3:  7: Layout/TrailingWhitespace: Trailing whitespace detected.
+          C:  3:  7: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
 
           1 file inspected, 1 offense detected, 1 offense auto-correctable
         RESULT

--- a/spec/rubocop/formatter/clang_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/clang_style_formatter_spec.rb
@@ -95,12 +95,22 @@ RSpec.describe RuboCop::Formatter::ClangStyleFormatter, :config do
     end
 
     context 'when the offense is not corrected' do
-      let(:status) { :uncorrected }
+      let(:status) { :unsupported }
 
       it 'prints message as-is' do
         formatter.report_file(file, [offense])
         expect(output.string)
           .to include(': This is a message.')
+      end
+    end
+
+    context 'when the offense is correctable' do
+      let(:status) { :uncorrected }
+
+      it 'prints message as-is' do
+        formatter.report_file(file, [offense])
+        expect(output.string)
+          .to include(': [Correctable] This is a message.')
       end
     end
 

--- a/spec/rubocop/formatter/emacs_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/emacs_style_formatter_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe RuboCop::Formatter::EmacsStyleFormatter, :config do
       it 'strips newlines out of the error message' do
         formatter.file_finished(file, [offense])
         expect(output.string).to eq(
-          '/path/to/file:1:1: E: unmatched close parenthesis: /    ' \
+          '/path/to/file:1:1: E: [Correctable] unmatched close parenthesis: /    ' \
           "world # Some comment containing a ) /\n"
         )
       end

--- a/spec/rubocop/formatter/progress_formatter_spec.rb
+++ b/spec/rubocop/formatter/progress_formatter_spec.rb
@@ -153,13 +153,13 @@ RSpec.describe RuboCop::Formatter::ProgressFormatter do
         expect(output.string).to include(<<~OUTPUT)
           Offenses:
 
-          lib/rubocop.rb:2:3: C: foo
+          lib/rubocop.rb:2:3: C: [Correctable] foo
           This is line 2.
             ^
-          exe/rubocop:5:2: E: bar
+          exe/rubocop:5:2: E: [Correctable] bar
           This is line 5.
            ^
-          exe/rubocop:6:1: C: foo
+          exe/rubocop:6:1: C: [Correctable] foo
           This is line 6.
           ^
         OUTPUT

--- a/spec/rubocop/formatter/quiet_formatter_spec.rb
+++ b/spec/rubocop/formatter/quiet_formatter_spec.rb
@@ -55,11 +55,20 @@ RSpec.describe RuboCop::Formatter::QuietFormatter do
     end
 
     context 'when the offense is not corrected' do
-      let(:status) { :uncorrected }
+      let(:status) { :unsupported }
 
       it 'prints message as-is' do
         expect(output.string)
           .to include(': This is a message with colored text.')
+      end
+    end
+
+    context 'when the offense is correctable' do
+      let(:status) { :uncorrected }
+
+      it 'prints message as-is' do
+        expect(output.string)
+          .to include(': [Correctable] This is a message with colored text.')
       end
     end
 

--- a/spec/rubocop/formatter/simple_text_formatter_spec.rb
+++ b/spec/rubocop/formatter/simple_text_formatter_spec.rb
@@ -55,11 +55,20 @@ RSpec.describe RuboCop::Formatter::SimpleTextFormatter do
     end
 
     context 'when the offense is not corrected' do
-      let(:status) { :uncorrected }
+      let(:status) { :unsupported }
 
       it 'prints message as-is' do
         expect(output.string)
           .to include(': This is a message with colored text.')
+      end
+    end
+
+    context 'when the offense is correctable' do
+      let(:status) { :uncorrected }
+
+      it 'prints message as-is' do
+        expect(output.string)
+          .to include(': [Correctable] This is a message with colored text.')
       end
     end
 

--- a/spec/rubocop/formatter/tap_formatter_spec.rb
+++ b/spec/rubocop/formatter/tap_formatter_spec.rb
@@ -114,15 +114,15 @@ RSpec.describe RuboCop::Formatter::TapFormatter do
         expect(output.string).to include(<<~OUTPUT)
           1..3
           not ok 1 - lib/rubocop.rb
-          # lib/rubocop.rb:2:3: C: foo
+          # lib/rubocop.rb:2:3: C: [Correctable] foo
           # This is line 2.
           #   ^
           ok 2 - spec/spec_helper.rb
           not ok 3 - exe/rubocop
-          # exe/rubocop:5:2: E: bar
+          # exe/rubocop:5:2: E: [Correctable] bar
           # This is line 5.
           #  ^
-          # exe/rubocop:6:1: C: foo
+          # exe/rubocop:6:1: C: [Correctable] foo
           # This is line 6.
           # ^
         OUTPUT


### PR DESCRIPTION
Some cops only are able to correct in specific situations, but it is unclear from the output which offenses are auto-correctable and which aren't (I kept running into this while working on #9176 and found it confusing). This adds a tag to the output for offenses which are correctable but not corrected yet:

```
Offenses:

test.rb:5:41: C: [Correctable] Layout/LineLength: Line is too long. [123/40]
  attr_accessor :name, :unit_number, :street_name, :city, :province, :postal_code, :location, :direction, :country, :region
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
test.rb:11:41: C: [Correctable] Layout/LineLength: Line is too long. [113/40]
    Model.where(username: username, email: email, first_name: first_name, last_name: last_name, country: country)
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
test.rb:15:41: C: Layout/LineLength: Line is too long. [82/40]
    # this is a really long comment that is longer than `Layout/LineLength` allows
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
test.rb:16:41: C: Layout/LineLength: Line is too long. [76/40]
    here.is.a.long.chain.of.methods.that.exceeds.the.max.allowed.line.length
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 4 offenses detected, 2 offenses auto-correctable
```

I updated all the formatters that were already reporting `[Corrected]`. Interesting, the json formatter already exposes `correctable` so this would be a good parallel.

I think this would be useful to show what can be automatically corrected, especially like in my above example where with just `2 offenses auto-correctable` it's impossible to know which 2 of the 4 will be corrected.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
