### PR TITLE
[Fix #8897] Change `Style/StringConcatenation` to accept line-end concatenation

### DIFF
--- a/changelog/change_change_stylestringconcatenation_to.md
+++ b/changelog/change_change_stylestringconcatenation_to.md
@@ -1,0 +1,1 @@
+* [#8897](https://github.com/rubocop-hq/rubocop/issues/8897): Change `Style/StringConcatenation` to accept line-end concatenation between two strings so that `Style/LineEndConcatenation` can handle it instead. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4345,6 +4345,7 @@ Style/StringConcatenation:
   Enabled: true
   Safe: false
   VersionAdded: '0.89'
+  VersionChanged: <<next>>
 
 Style/StringHashKeys:
   Description: 'Prefer symbols instead of strings as hash keys.'

--- a/spec/rubocop/cop/style/string_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/string_concatenation_spec.rb
@@ -55,6 +55,16 @@ RSpec.describe RuboCop::Cop::Style::StringConcatenation do
   end
 
   context 'multiline' do
+    context 'string continuation' do
+      it 'does not register an offense' do
+        # handled by `Style/LineEndConcatenation` instead.
+        expect_no_offenses(<<~RUBY)
+          "this is a long string " +
+            "this is a continuation"
+        RUBY
+      end
+    end
+
     context 'simple expressions' do
       it 'registers an offense and corrects' do
         expect_offense(<<-RUBY)


### PR DESCRIPTION
Line end concatenation between two strings is handled by `Style/LineEndConcatenation`.

Fixes #8897.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
