### PR TITLE
Update reference for `Style/FloatDivision`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -3209,7 +3209,7 @@ Style/ExponentialNotation:
 Style/FloatDivision:
   Description: 'For performing float division, coerce one side only.'
   StyleGuide: '#float-division'
-  Reference: 'https://github.com/rubocop-hq/ruby-style-guide/issues/628'
+  Reference: 'https://blog.rubystyle.guide/ruby/2019/06/21/float-division.html'
   Enabled: true
   VersionAdded: '0.72'
   VersionChanged: <<next>>


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/9186#issuecomment-740405392.

This PR updates the reference for `Style/FloatDivision`.

The new link is a comprehensive reference that includes the old link address, so this PR is replacing the URL rather than adding new link.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
