### PR TITLE
[Fix #9175] Fix status for offenses that are not correctable.

### DIFF
--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -288,13 +288,6 @@ module RuboCop
         @current_corrector&.merge!(corrector) if corrector
       end
 
-      def correction_strategy
-        return :unsupported unless correctable?
-        return :uncorrected unless autocorrect?
-
-        :attempt_correction
-      end
-
       ### Reserved for Commissioner:
 
       def current_offense_locations
@@ -341,33 +334,42 @@ module RuboCop
 
       # @return [Symbol, Corrector] offense status
       def correct(range)
-        status = correction_strategy
-
         if block_given?
           corrector = Corrector.new(self)
           yield corrector
-          if !corrector.empty? && !self.class.support_autocorrect?
+          if corrector.empty?
+            corrector = nil
+          elsif !self.class.support_autocorrect?
             raise "The Cop #{name} must `extend AutoCorrector` to be able to autocorrect"
           end
         end
 
-        status = attempt_correction(range, corrector) if status == :attempt_correction
+        [use_corrector(range, corrector), corrector]
+      end
 
-        [status, corrector]
+      # @return [Symbol] offense status
+      def use_corrector(range, corrector)
+        if autocorrect?
+          attempt_correction(range, corrector)
+        elsif corrector
+          :uncorrected
+        else
+          :unsupported
+        end
       end
 
       # @return [Symbol] offense status
       def attempt_correction(range, corrector)
-        if corrector && !corrector.empty?
+        if corrector
           status = :corrected
         elsif disable_uncorrectable?
           corrector = disable_uncorrectable(range)
           status = :corrected_with_todo
         else
-          return :uncorrected
+          return :unsupported
         end
 
-        apply_correction(corrector) if corrector
+        apply_correction(corrector)
         status
       end
 

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -27,7 +27,7 @@ module RuboCop
       def add_offense(node_or_range, location: :expression, message: nil, severity: nil, &block)
         @v0_argument = node_or_range
         range = find_location(node_or_range, location)
-        if block.nil? && !autocorrect?
+        if block.nil? && !support_autocorrect?
           super(range, message: message, severity: severity)
         else
           super(range, message: message, severity: severity) do |corrector|
@@ -136,7 +136,7 @@ module RuboCop
       end
 
       def correction_lambda
-        return unless correction_strategy == :attempt_correction && support_autocorrect?
+        return unless support_autocorrect?
 
         dedup_on_node(@v0_argument) do
           autocorrect(@v0_argument)

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1410,7 +1410,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       C:  2: 34: Style/Semicolon: Do not use semicolons to terminate expressions.
       W:  3: 27: Lint/UnusedMethodArgument: Unused method argument - bar.
 
-      1 file inspected, 3 offenses detected, 3 more offenses can be corrected with `rubocop -A`
+      1 file inspected, 3 offenses detected
     RESULT
   end
 


### PR DESCRIPTION
This addresses a few things:
1) Calling `add_offense` or `add_offense { |corrector| # don't auto-correct }` should be handled the same way. An empty corrector is now replaced by `nil`.
2) Tweaks how the status is handled. Status `:uncorrected` is reserved for cases where there is a corrector but it is not applied.
3) Old style cops' `auto_correct` method is now called even when run without auto-correction. This way we can know if they can auto-correct or not. It also simplifies logic.

I should have done 3) during my refactor (I don't see how it could be incompatible)