### PR TITLE
Updated 5 cops to inherit from `Base` instead of `Cop`

### DIFF
--- a/lib/rubocop/cop/correctors/string_literal_corrector.rb
+++ b/lib/rubocop/cop/correctors/string_literal_corrector.rb
@@ -7,16 +7,14 @@ module RuboCop
       extend Util
 
       class << self
-        def correct(node, style)
+        def correct(corrector, node, style)
           return if node.dstr_type?
 
-          lambda do |corrector|
-            str = node.str_content
-            if style == :single_quotes
-              corrector.replace(node, to_string_literal(str))
-            else
-              corrector.replace(node, str.inspect)
-            end
+          str = node.str_content
+          if style == :single_quotes
+            corrector.replace(node, to_string_literal(str))
+          else
+            corrector.replace(node, str.inspect)
           end
         end
       end

--- a/lib/rubocop/cop/mixin/string_help.rb
+++ b/lib/rubocop/cop/mixin/string_help.rb
@@ -14,7 +14,10 @@ module RuboCop
         return if part_of_ignored_node?(node)
 
         if offense?(node)
-          add_offense(node) { opposite_style_detected }
+          add_offense(node) do |corrector|
+            opposite_style_detected
+            autocorrect(corrector, node) if respond_to?(:autocorrect, true)
+          end
         else
           correct_style_detected
         end

--- a/lib/rubocop/cop/style/character_literal.rb
+++ b/lib/rubocop/cop/style/character_literal.rb
@@ -14,8 +14,9 @@ module RuboCop
       #
       #   # good
       #   ?\C-\M-d
-      class CharacterLiteral < Cop
+      class CharacterLiteral < Base
         include StringHelp
+        extend AutoCorrector
 
         MSG = 'Do not use the character literal - ' \
               'use string literal instead.'
@@ -26,17 +27,15 @@ module RuboCop
             node.source.size.between?(2, 3)
         end
 
-        def autocorrect(node)
-          lambda do |corrector|
-            string = node.source[1..-1]
+        def autocorrect(corrector, node)
+          string = node.source[1..-1]
 
-            # special character like \n
-            # or ' which needs to use "" or be escaped.
-            if string.length == 2 || string == "'"
-              corrector.replace(node, %("#{string}"))
-            elsif string.length == 1 # normal character
-              corrector.replace(node, "'#{string}'")
-            end
+          # special character like \n
+          # or ' which needs to use "" or be escaped.
+          if string.length == 2 || string == "'"
+            corrector.replace(node, %("#{string}"))
+          elsif string.length == 1 # normal character
+            corrector.replace(node, "'#{string}'")
           end
         end
 

--- a/lib/rubocop/cop/style/ip_addresses.rb
+++ b/lib/rubocop/cop/style/ip_addresses.rb
@@ -18,7 +18,7 @@ module RuboCop
       #
       #   # good
       #   ip_address = ENV['DEPLOYMENT_IP_ADDRESS']
-      class IpAddresses < Cop
+      class IpAddresses < Base
         include StringHelp
 
         IPV6_MAX_SIZE = 45 # IPv4-mapped IPv6 is the longest

--- a/lib/rubocop/cop/style/string_literals_in_interpolation.rb
+++ b/lib/rubocop/cop/style/string_literals_in_interpolation.rb
@@ -19,12 +19,13 @@ module RuboCop
       #
       #   # good
       #   result = "Tests #{success ? "PASS" : "FAIL"}"
-      class StringLiteralsInInterpolation < Cop
+      class StringLiteralsInInterpolation < Base
         include ConfigurableEnforcedStyle
         include StringLiteralsHelp
+        extend AutoCorrector
 
-        def autocorrect(node)
-          StringLiteralCorrector.correct(node, style)
+        def autocorrect(corrector, node)
+          StringLiteralCorrector.correct(corrector, node, style)
         end
 
         private


### PR DESCRIPTION
Extracted from #9176, follows #7868.

* `Layout/LineLength`
* `Style/CharacterLiteral`
* `Style/IpAddresses`
* `Style/StringLiterals`
* `Style/StringLiteralsInInterpolation`

Also Updated `StringHelp` and `StringLiteralCorrector` for use with `Base` instead of `Cop`.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
