### PR TITLE
Add `IgnoreLiteralBranches` and `IgnoreConstantBranches` options to `Lint/DuplicateBranch`

### DIFF
--- a/changelog/change_add_ignoreliteralbranches_option_to.md
+++ b/changelog/change_add_ignoreliteralbranches_option_to.md
@@ -1,1 +1,1 @@
-* [#9193](https://github.com/rubocop-hq/rubocop/pull/9193): Add `IgnoreLiteralBranches` option to `Lint/DuplicateBranch`. ([@dvandersluis][])
+* [#9193](https://github.com/rubocop-hq/rubocop/pull/9193): Add `IgnoreLiteralBranches` and `IgnoreConstantBranches` options to `Lint/DuplicateBranch`. ([@dvandersluis][])

--- a/changelog/change_add_ignoreliteralbranches_option_to.md
+++ b/changelog/change_add_ignoreliteralbranches_option_to.md
@@ -1,0 +1,1 @@
+* [#9193](https://github.com/rubocop-hq/rubocop/pull/9193): Add `IgnoreLiteralBranches` option to `Lint/DuplicateBranch`. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1472,6 +1472,8 @@ Lint/DuplicateBranch:
   Description: Checks that there are no repeated bodies within `if/unless`, `case-when` and `rescue` constructs.
   Enabled: pending
   VersionAdded: '1.3'
+  VersionChanged: <<next>>
+  IgnoreLiteralBranches: false
 
 Lint/DuplicateCaseCondition:
   Description: 'Do not repeat values in case conditionals.'

--- a/config/default.yml
+++ b/config/default.yml
@@ -1474,6 +1474,7 @@ Lint/DuplicateBranch:
   VersionAdded: '1.3'
   VersionChanged: <<next>>
   IgnoreLiteralBranches: false
+  IgnoreConstantBranches: false
 
 Lint/DuplicateCaseCondition:
   Description: 'Do not repeat values in case conditionals.'

--- a/lib/rubocop/cop/lint/duplicate_branch.rb
+++ b/lib/rubocop/cop/lint/duplicate_branch.rb
@@ -12,6 +12,9 @@ module RuboCop
       # return an array, hash, regexp or range that only contains one of
       # the above basic literal values.
       #
+      # With `IgnoreConstantBranches: true`, branches are not registered
+      # as offenses if they return a constant value.
+      #
       # @example
       #   # bad
       #   if foo
@@ -71,6 +74,15 @@ module RuboCop
       #   else 250
       #   end
       #
+      # @example IgnoreLiteralBranches: true
+      #   # good
+      #   case size
+      #   when "small" then SMALL_SIZE
+      #   when "medium" then MEDIUM_SIZE
+      #   when "large" then LARGE_SIZE
+      #   else MEDIUM_SIZE
+      #   end
+      #
       class DuplicateBranch < Base
         include RescueNode
 
@@ -109,20 +121,33 @@ module RuboCop
         end
 
         def consider_branch?(branch)
-          return true unless ignore_literal_branches?
-          return true unless branch.literal?
-          return false if branch.basic_literal?
-          return true if branch.xstr_type?
+          return false if ignore_literal_branches? && literal_branch?(branch)
+          return false if ignore_constant_branches? && const_branch?(branch)
 
-          branch.each_descendant.any? do |node|
-            next if node.pair_type? # hash keys and values are contained within a `pair` node
-
-            !node.basic_literal?
-          end
+          true
         end
 
         def ignore_literal_branches?
           cop_config.fetch('IgnoreLiteralBranches', false)
+        end
+
+        def ignore_constant_branches?
+          cop_config.fetch('IgnoreConstantBranches', false)
+        end
+
+        def literal_branch?(branch) # rubocop:disable Metrics/CyclomaticComplexity
+          return false if !branch.literal? || branch.xstr_type?
+          return true if branch.basic_literal?
+
+          branch.each_descendant.all? do |node|
+            node.basic_literal? ||
+              node.pair_type? || # hash keys and values are contained within a `pair` node
+              (node.const_type? && ignore_constant_branches?)
+          end
+        end
+
+        def const_branch?(branch)
+          branch.const_type?
         end
       end
     end

--- a/spec/rubocop/cop/lint/duplicate_branch_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_branch_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Lint::DuplicateBranch do
-  subject(:cop) { described_class.new }
-
+RSpec.describe RuboCop::Cop::Lint::DuplicateBranch, :config do
   it 'registers an offense when `if` has duplicate `else` branch' do
     expect_offense(<<~RUBY)
       if foo
@@ -244,5 +242,144 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateBranch do
         handle_bar_error(x)
       end
     RUBY
+  end
+
+  context 'with IgnoreLiteralBranches: true' do
+    let(:cop_config) { { 'IgnoreLiteralBranches' => true } }
+
+    shared_examples_for 'literal if allowed' do |type, value|
+      context "when returning a #{type} in multiple branches" do
+        it 'allows branches to be duplicated' do
+          expect_no_offenses(<<~RUBY)
+            if x
+              #{value}
+            elsif y
+              #{value}
+            else
+              #{value}
+            end
+          RUBY
+        end
+      end
+    end
+
+    shared_examples_for 'literal if disallowed' do |type, value|
+      context "when returning a #{type} in multiple branches" do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            if x
+              #{value}
+            elsif y
+            ^^^^^^^ Duplicate branch body detected.
+              #{value}
+            else
+            ^^^^ Duplicate branch body detected.
+              #{value}
+            end
+          RUBY
+        end
+      end
+    end
+
+    shared_examples_for 'literal case allowed' do |type, value|
+      context "when returning a #{type} in multiple branches" do
+        it 'allows branches to be duplicated' do
+          expect_no_offenses(<<~RUBY)
+            case foo
+            when x then #{value}
+            when y then #{value}
+            else #{value}
+            end
+          RUBY
+        end
+      end
+    end
+
+    shared_examples_for 'literal case disallowed' do |type, value|
+      context "when returning a #{type} in multiple branches" do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY, value: value)
+            case foo
+            when x then #{value}
+            when y then #{value}
+            ^^^^^^^^^^^^^{value} Duplicate branch body detected.
+            else #{value}
+            ^^^^ Duplicate branch body detected.
+            end
+          RUBY
+        end
+      end
+    end
+
+    shared_examples_for 'literal rescue allowed' do |type, value|
+      context "when returning a #{type} in multiple branches" do
+        it 'allows branches to be duplicated' do
+          expect_no_offenses(<<~RUBY)
+            begin
+              foo
+            rescue FooError
+              #{value}
+            rescue BarError
+              #{value}
+            else
+              #{value}
+            end
+          RUBY
+        end
+      end
+    end
+
+    shared_examples_for 'literal rescue disallowed' do |type, value|
+      context "when returning a #{type} in multiple branches" do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            begin
+              foo
+            rescue FooError
+              #{value}
+            rescue BarError
+            ^^^^^^^^^^^^^^^ Duplicate branch body detected.
+              #{value}
+            else
+            ^^^^ Duplicate branch body detected.
+              #{value}
+            end
+          RUBY
+        end
+      end
+    end
+
+    %w[if case rescue].each do |keyword|
+      context "with `#{keyword}`" do
+        it_behaves_like "literal #{keyword} allowed", 'integer', '5'
+        it_behaves_like "literal #{keyword} allowed", 'float', '5.0'
+        it_behaves_like "literal #{keyword} allowed", 'rational', '5r'
+        it_behaves_like "literal #{keyword} allowed", 'complex', '5i'
+        it_behaves_like "literal #{keyword} allowed", 'string', '"string"'
+        it_behaves_like "literal #{keyword} allowed", 'symbol', ':symbol'
+        it_behaves_like "literal #{keyword} allowed", 'true', 'true'
+        it_behaves_like "literal #{keyword} allowed", 'false', 'false'
+        it_behaves_like "literal #{keyword} allowed", 'nil', 'nil'
+        it_behaves_like "literal #{keyword} allowed", 'regexp', '/foo/'
+        it_behaves_like "literal #{keyword} allowed", 'regexp with modifier', '/foo/i'
+        it_behaves_like "literal #{keyword} allowed", 'simple irange', '1..5'
+        it_behaves_like "literal #{keyword} allowed", 'simple erange', '1...5'
+        it_behaves_like "literal #{keyword} allowed", 'empty array', '[]'
+        it_behaves_like "literal #{keyword} allowed", 'array of literals', '[1, 2, 3]'
+        it_behaves_like "literal #{keyword} allowed", 'empty hash', '{}'
+        it_behaves_like "literal #{keyword} allowed", 'hash of literals', '{ foo: 1, bar: 2 }'
+
+        it_behaves_like "literal #{keyword} disallowed", 'dstr', '"#{foo}"'
+        it_behaves_like "literal #{keyword} disallowed", 'dsym', ':"#{foo}"'
+        it_behaves_like "literal #{keyword} disallowed", 'xstr', '`foo bar`'
+        it_behaves_like "literal #{keyword} disallowed", 'complex array', '[foo, bar, baz]'
+        it_behaves_like "literal #{keyword} disallowed", 'complex hash', '{ foo: foo, bar: bar }'
+        it_behaves_like "literal #{keyword} disallowed", 'complex irange', '1..foo'
+        it_behaves_like "literal #{keyword} disallowed", 'complex erange', '1...foo'
+        it_behaves_like "literal #{keyword} disallowed", 'complex regexp', '/#{foo}/i'
+        it_behaves_like "literal #{keyword} disallowed", 'variable', 'foo'
+        it_behaves_like "literal #{keyword} disallowed", 'method call', 'foo(bar)'
+      end
+    end
   end
 end

--- a/spec/rubocop/cop/lint/duplicate_branch_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_branch_spec.rb
@@ -1,6 +1,108 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::DuplicateBranch, :config do
+  shared_examples_for 'literal if allowed' do |type, value|
+    context "when returning a #{type} in multiple branches" do
+      it 'allows branches to be duplicated' do
+        expect_no_offenses(<<~RUBY)
+          if x
+            #{value}
+          elsif y
+            #{value}
+          else
+            #{value}
+          end
+        RUBY
+      end
+    end
+  end
+
+  shared_examples_for 'literal if disallowed' do |type, value|
+    context "when returning a #{type} in multiple branches" do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          if x
+            #{value}
+          elsif y
+          ^^^^^^^ Duplicate branch body detected.
+            #{value}
+          else
+          ^^^^ Duplicate branch body detected.
+            #{value}
+          end
+        RUBY
+      end
+    end
+  end
+
+  shared_examples_for 'literal case allowed' do |type, value|
+    context "when returning a #{type} in multiple branches" do
+      it 'allows branches to be duplicated' do
+        expect_no_offenses(<<~RUBY)
+          case foo
+          when x then #{value}
+          when y then #{value}
+          else #{value}
+          end
+        RUBY
+      end
+    end
+  end
+
+  shared_examples_for 'literal case disallowed' do |type, value|
+    context "when returning a #{type} in multiple branches" do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY, value: value)
+          case foo
+          when x then #{value}
+          when y then #{value}
+          ^^^^^^^^^^^^^{value} Duplicate branch body detected.
+          else #{value}
+          ^^^^ Duplicate branch body detected.
+          end
+        RUBY
+      end
+    end
+  end
+
+  shared_examples_for 'literal rescue allowed' do |type, value|
+    context "when returning a #{type} in multiple branches" do
+      it 'allows branches to be duplicated' do
+        expect_no_offenses(<<~RUBY)
+          begin
+            foo
+          rescue FooError
+            #{value}
+          rescue BarError
+            #{value}
+          else
+            #{value}
+          end
+        RUBY
+      end
+    end
+  end
+
+  shared_examples_for 'literal rescue disallowed' do |type, value|
+    context "when returning a #{type} in multiple branches" do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          begin
+            foo
+          rescue FooError
+            #{value}
+          rescue BarError
+          ^^^^^^^^^^^^^^^ Duplicate branch body detected.
+            #{value}
+          else
+          ^^^^ Duplicate branch body detected.
+            #{value}
+          end
+        RUBY
+      end
+    end
+  end
+
   it 'registers an offense when `if` has duplicate `else` branch' do
     expect_offense(<<~RUBY)
       if foo
@@ -247,108 +349,6 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateBranch, :config do
   context 'with IgnoreLiteralBranches: true' do
     let(:cop_config) { { 'IgnoreLiteralBranches' => true } }
 
-    shared_examples_for 'literal if allowed' do |type, value|
-      context "when returning a #{type} in multiple branches" do
-        it 'allows branches to be duplicated' do
-          expect_no_offenses(<<~RUBY)
-            if x
-              #{value}
-            elsif y
-              #{value}
-            else
-              #{value}
-            end
-          RUBY
-        end
-      end
-    end
-
-    shared_examples_for 'literal if disallowed' do |type, value|
-      context "when returning a #{type} in multiple branches" do
-        it 'registers an offense' do
-          expect_offense(<<~RUBY)
-            if x
-              #{value}
-            elsif y
-            ^^^^^^^ Duplicate branch body detected.
-              #{value}
-            else
-            ^^^^ Duplicate branch body detected.
-              #{value}
-            end
-          RUBY
-        end
-      end
-    end
-
-    shared_examples_for 'literal case allowed' do |type, value|
-      context "when returning a #{type} in multiple branches" do
-        it 'allows branches to be duplicated' do
-          expect_no_offenses(<<~RUBY)
-            case foo
-            when x then #{value}
-            when y then #{value}
-            else #{value}
-            end
-          RUBY
-        end
-      end
-    end
-
-    shared_examples_for 'literal case disallowed' do |type, value|
-      context "when returning a #{type} in multiple branches" do
-        it 'registers an offense' do
-          expect_offense(<<~RUBY, value: value)
-            case foo
-            when x then #{value}
-            when y then #{value}
-            ^^^^^^^^^^^^^{value} Duplicate branch body detected.
-            else #{value}
-            ^^^^ Duplicate branch body detected.
-            end
-          RUBY
-        end
-      end
-    end
-
-    shared_examples_for 'literal rescue allowed' do |type, value|
-      context "when returning a #{type} in multiple branches" do
-        it 'allows branches to be duplicated' do
-          expect_no_offenses(<<~RUBY)
-            begin
-              foo
-            rescue FooError
-              #{value}
-            rescue BarError
-              #{value}
-            else
-              #{value}
-            end
-          RUBY
-        end
-      end
-    end
-
-    shared_examples_for 'literal rescue disallowed' do |type, value|
-      context "when returning a #{type} in multiple branches" do
-        it 'registers an offense' do
-          expect_offense(<<~RUBY)
-            begin
-              foo
-            rescue FooError
-              #{value}
-            rescue BarError
-            ^^^^^^^^^^^^^^^ Duplicate branch body detected.
-              #{value}
-            else
-            ^^^^ Duplicate branch body detected.
-              #{value}
-            end
-          RUBY
-        end
-      end
-    end
-
     %w[if case rescue].each do |keyword|
       context "with `#{keyword}`" do
         it_behaves_like "literal #{keyword} allowed", 'integer', '5'
@@ -379,6 +379,32 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateBranch, :config do
         it_behaves_like "literal #{keyword} disallowed", 'complex regexp', '/#{foo}/i'
         it_behaves_like "literal #{keyword} disallowed", 'variable', 'foo'
         it_behaves_like "literal #{keyword} disallowed", 'method call', 'foo(bar)'
+
+        context 'and IgnoreConstBranches: true' do
+          let(:cop_config) { super().merge('IgnoreConstantBranches' => true) }
+
+          it_behaves_like "literal #{keyword} allowed", 'array of constants', '[CONST1, CONST2]'
+          it_behaves_like "literal #{keyword} allowed", 'hash of constants', '{ foo: CONST1, bar: CONST2 }'
+        end
+
+        context 'and IgnoreConstBranches: false' do
+          let(:cop_config) { super().merge('IgnoreConstantBranches' => false) }
+
+          it_behaves_like "literal #{keyword} disallowed", 'array of constants', '[CONST1, CONST2]'
+          it_behaves_like "literal #{keyword} disallowed", 'hash of constants', '{ foo: CONST1, bar: CONST2 }'
+        end
+      end
+    end
+  end
+
+  context 'with IgnoreConstantBranches: true' do
+    let(:cop_config) { { 'IgnoreConstantBranches' => true } }
+
+    %w[if case rescue].each do |keyword|
+      context "with `#{keyword}`" do
+        it_behaves_like "literal #{keyword} allowed", 'constant', 'MY_CONST'
+
+        it_behaves_like "literal #{keyword} disallowed", 'object', 'Object.new'
       end
     end
   end


### PR DESCRIPTION
I noticed that the standard gem [disabled `Lint/DuplicateBranch`](https://github.com/testdouble/standard/pull/228) and the straw that broke the camel's back for them was that this kind of case layout registered an offense:

```ruby
case size
when "small" then 100
when "medium" then 250
when "large" then 1000
else 250
end
```

While it's true that the `medium` case and the `else` case are duplicates, I'd argue that this duplication is beneficial because it clearly outlines what possible values are expected.

Introduced a new configuration, `IgnoreLiteralBranches`, which when true will not consider any branches that just return a basic literal value, or a composite literal (array, hash, etc.) that only contains basic literals (see test for examples). As well, added `IgnoreConstantBranches` to allow branches that just return a constant to be ignored.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
