### PR TITLE
[Fix #7801] Update documentation for `Naming/AccessorMethodName`

### DIFF
--- a/lib/rubocop/cop/naming/accessor_method_name.rb
+++ b/lib/rubocop/cop/naming/accessor_method_name.rb
@@ -3,7 +3,13 @@
 module RuboCop
   module Cop
     module Naming
-      # This cop makes sure that accessor methods are named properly.
+      # This cop makes sure that accessor methods are named properly. Applies
+      # to both instance and class methods.
+      #
+      # NOTE: Offenses are only registered for methods with the expected
+      # arity. Getters (`get_attribute`) must have no arguments to be
+      # registered, and setters (`set_attribute(value)`) must have exactly
+      # one.
       #
       # @example
       #   # bad
@@ -20,6 +26,14 @@ module RuboCop
       #
       #   # good
       #   def attribute
+      #   end
+      #
+      #   # accepted, incorrect arity for getter
+      #   def get_value(attr)
+      #   end
+      #
+      #   # accepted, incorrect arity for setter
+      #   def set_value
       #   end
       class AccessorMethodName < Base
         MSG_READER = 'Do not prefix reader method names with `get_`.'


### PR DESCRIPTION
There was a bit of confusion in #7801 about how `Naming/AccessorMethodName` works so I've updated the documentation. Functionality of the cop has not changed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
