### PR TITLE
[Fix #9160] Fix an incorrect auto-correct for `Style/SoleNestedConditional`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_sole_nested_conditional.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_sole_nested_conditional.md
@@ -1,0 +1,1 @@
+* [#9160](https://github.com/rubocop-hq/rubocop/issues/9160): Fix an incorrect auto-correct for `Style/IfUnlessModifier` and `Style/SoleNestedConditional` when auto-correction conflicts for guard condition. ([@koic][])

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -46,6 +46,10 @@ module RuboCop
         MSG_USE_NORMAL =
           'Modifier form of `%<keyword>s` makes the line too long.'
 
+        def self.autocorrect_incompatible_with
+          [Style::SoleNestedConditional]
+        end
+
         def on_if(node)
           msg = if single_line_as_modifier?(node) && !named_capture_in_condition?(node)
                   MSG_USE_MODIFIER

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -75,9 +75,8 @@ module RuboCop
             correct_for_guard_condition_style(corrector, node, if_branch, and_operator)
           else
             correct_for_basic_condition_style(corrector, node, if_branch, and_operator)
+            correct_for_comment(corrector, node, if_branch)
           end
-
-          correct_for_comment(corrector, node, if_branch)
         end
 
         def correct_for_guard_condition_style(corrector, node, if_branch, and_operator)
@@ -99,6 +98,8 @@ module RuboCop
         end
 
         def correct_for_comment(corrector, node, if_branch)
+          return if config.for_cop('Style/IfUnlessModifier')['Enabled']
+
           comments = processed_source.comments_before_line(if_branch.source_range.line)
           comment_text = comments.map(&:text).join("\n") << "\n"
 

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -197,6 +197,30 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     RUBY
   end
 
+  it 'corrects `Style/IfUnlessModifier` with `Style/SoleNestedConditional`' do
+    source = <<~RUBY
+      def foo
+        # NOTE: comment
+        if a? && b?
+          puts "looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong message" unless c?
+        end
+      end
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run([
+                     '--auto-correct-all',
+                     '--only', 'Style/IfUnlessModifier,Style/SoleNestedConditional'
+                   ])).to eq(0)
+    expect(IO.read('example.rb')).to eq(<<~RUBY)
+      def foo
+        # NOTE: comment
+        if a? && b? && !c?
+            puts "looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong message"
+          end
+      end
+    RUBY
+  end
+
   describe 'trailing comma cops' do
     let(:source) do
       <<~RUBY

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -198,22 +198,45 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects when using nested conditional and branch contains a comment' do
-    expect_offense(<<~RUBY)
-      if foo
-        # Comment.
-        if bar
-        ^^ Consider merging nested conditions into outer `if` conditions.
-          do_something
+  context 'when disabling `Style/IfUnlessModifier`' do
+    let(:config) do
+      RuboCop::Config.new('Style/IfUnlessModifier' => { 'Enabled' => false })
+    end
+
+    it 'registers an offense and corrects when using nested conditional and branch contains a comment' do
+      expect_offense(<<~RUBY)
+        if foo
+          # Comment.
+          if bar
+          ^^ Consider merging nested conditions into outer `if` conditions.
+            do_something
+          end
         end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # Comment.
+        if foo && bar
+            do_something
+          end
+      RUBY
+    end
+  end
+
+  it 'registers an offense and corrects when using guard conditional with outer comment' do
+    expect_offense(<<~RUBY)
+      # Comment.
+      if foo
+        do_something if bar
+                     ^^ Consider merging nested conditions into outer `if` conditions.
       end
     RUBY
 
     expect_correction(<<~RUBY)
       # Comment.
       if foo && bar
-          do_something
-        end
+        do_something
+      end
     RUBY
   end
 


### PR DESCRIPTION
Fixes #9160.

This PR fixes an incorrect auto-correct for `Style/IfUnlessModifier` and `Style/SoleNestedConditional` when auto-correction conflicts for guard condition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
