### PR TITLE
Improve the test output from project_spec when there are missing configuration keys

### DIFF
--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -13,12 +13,29 @@ RSpec.describe 'RuboCop Project', type: :feature do
   version_regexp = /\A\d+\.\d+\z|\A<<next>>\z/
 
   describe 'default configuration file' do
+    matcher :match_all_cops do
+      def expected
+        %w[AllCops] + cop_names
+      end
+
+      match do |actual|
+        (expected.to_set ^ actual.to_set).none?
+      end
+
+      failure_message do
+        diff = RSpec::Support::Differ.new.diff_as_object(expected.sort, actual.sort)
+        "Cop registry does not match configuration keys.\n" \
+          'Check if a new cop is missing configuration, or if cops were accidentally ' \
+          "added to the registry in another test.\n\nDiff:\n#{diff}"
+      end
+    end
+
     subject(:config) { RuboCop::ConfigLoader.load_file('config/default.yml') }
 
     let(:configuration_keys) { config.keys }
 
     it 'has configuration for all cops' do
-      expect(configuration_keys).to match_array(%w[AllCops] + cop_names)
+      expect(configuration_keys).to match_all_cops
     end
 
     it 'has a nicely formatted description for all cops' do


### PR DESCRIPTION
I spent quite a bit of time today trying to debug why tests seemed to be randomly failing in #9197. This change makes the failure message way more clear about what's happening and offers guidance (so that the next time someone accidentally pushes something onto the global registry they'll have an easier time debugging it).

For example:

```
Failure/Error: expect(configuration_keys).to match_all_cops

  Cop registry does not match configuration keys.
  Check if a new cop is missing configuration, or if cops were accidentally added to the registry in another test.

  Diff:

  @@ -237,6 +237,49 @@
    "Naming/RescuedExceptionsVariableName",
    "Naming/VariableName",
    "Naming/VariableNumber",
  + "Performance/AncestorsInclude",
  + "Performance/ArraySemiInfiniteRangeSlice",
  ...
  + "Performance/UriDefaultParser",
    "Security/Eval",
    "Security/JSONLoad",
    "Security/MarshalLoad",
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
