### PR TITLE
Prevent broken changelog

### DIFF
--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -18,6 +18,7 @@ class Changelog
   MAX_LENGTH = 40
   CONTRIBUTOR = '[@%<user>s]: https://github.com/%<user>s'
   SIGNATURE = Regexp.new(format(Regexp.escape("([@%<user>s][])\n"), user: '(\w+)'))
+  EOF = "\n"
 
   # New entry
   Entry = Struct.new(:type, :body, :ref_type, :ref_id, :user, keyword_init: true) do
@@ -111,12 +112,14 @@ class Changelog
   end
 
   def merge_content
-    [
+    merged_content = [
       @header,
       unreleased_content,
-      @rest,
+      @rest.chomp,
       *new_contributor_lines
     ].join("\n")
+
+    merged_content << EOF
   end
 
   def self.pending?


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/commit/905e3632fb662ec8a22f5be7aae0edfd6f6ca501#commitcomment-44955820.

This PR removes the last line break (EOL) from existing contributor line and adds it to the end of new contributor line.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
