### PR TITLE
Freeze global registry when testing

### DIFF
--- a/lib/rubocop/cop/gemspec/required_ruby_version.rb
+++ b/lib/rubocop/cop/gemspec/required_ruby_version.rb
@@ -36,12 +36,13 @@ module RuboCop
       #     spec.required_ruby_version = '>= 2.5'
       #   end
       #
-      #   # good
+      #   # accepted but not recommended
       #   Gem::Specification.new do |spec|
       #     spec.required_ruby_version = ['>= 2.5.0', '< 2.7.0']
       #   end
       #
-      #   # good
+      #   # accepted but not recommended, since
+      #   # Ruby does not really follow semantic versionning
       #   Gem::Specification.new do |spec|
       #     spec.required_ruby_version = '~> 2.5'
       #   end

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -204,6 +204,12 @@ module RuboCop
         to_h[cop_name].first
       end
 
+      def freeze
+        clear_enrollment_queue
+        unqualified_cop_names # build cache
+        super
+      end
+
       @global = new
 
       class << self

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environment do
+RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environment,
+               :restore_registry do
   include FileHelper
 
   subject(:formatter) { described_class.new(output) }
@@ -16,8 +17,8 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
   end
 
   let(:offenses) do
-    [RuboCop::Cop::Offense.new(:convention, location, 'message', 'Cop1'),
-     RuboCop::Cop::Offense.new(:convention, location, 'message', 'Cop2')]
+    [RuboCop::Cop::Offense.new(:convention, location, 'message', 'Test/Cop1'),
+     RuboCop::Cop::Offense.new(:convention, location, 'message', 'Test/Cop2')]
   end
 
   let(:location) { OpenStruct.new(line: 1, column: 5) }
@@ -52,6 +53,8 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
   end
 
   before do
+    stub_cop_class('Test::Cop1')
+    stub_cop_class('Test::Cop2')
     # Avoid intermittent failure when another test set ConfigLoader options
     RuboCop::ConfigLoader.clear_options
 
@@ -71,13 +74,13 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
     let(:expected_rubocop_todo) do
       [heading,
        '# Offense count: 2',
-       'Cop1:',
+       'Test/Cop1:',
        '  Exclude:',
        "    - 'test_a.rb'",
        "    - 'test_b.rb'",
        '',
        '# Offense count: 1',
-       'Cop2:',
+       'Test/Cop2:',
        '  Exclude:',
        "    - 'test_a.rb'",
        ''].join("\n")
@@ -92,10 +95,10 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
   context "when there's .rubocop.yml" do
     before do
       create_file('.rubocop.yml', <<~YAML)
-        Cop1:
+        Test/Cop1:
           Exclude:
             - Gemfile
-        Cop2:
+        Test/Cop2:
           Exclude:
             - "**/*.blah"
             - !ruby/regexp /.*/bar/*/foo\.rb$/
@@ -107,8 +110,6 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
       formatter.file_started('test_b.rb', {})
       formatter.file_finished('test_b.rb', [offenses.first])
 
-      # Cop1 and Cop2 are unknown cops and would raise an validation error
-      allow(RuboCop::Cop::Registry.global).to receive(:contains_cop_matching?).and_return(true)
       allow(RuboCop::ConfigLoader.default_configuration).to receive(:[]).and_return({})
       formatter.finished(['test_a.rb', 'test_b.rb'])
     end
@@ -116,14 +117,14 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
     let(:expected_rubocop_todo) do
       [heading,
        '# Offense count: 2',
-       'Cop1:',
+       'Test/Cop1:',
        '  Exclude:',
        "    - 'Gemfile'",
        "    - 'test_a.rb'",
        "    - 'test_b.rb'",
        '',
        '# Offense count: 1',
-       'Cop2:',
+       'Test/Cop2:',
        '  Exclude:',
        "    - '**/*.blah'",
        "    - !ruby/regexp /.*/bar/*/foo\.rb$/",
@@ -160,11 +161,11 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
     let(:expected_rubocop_todo) do
       [heading,
        '# Offense count: 16',
-       'Cop1:',
+       'Test/Cop1:',
        '  Enabled: false',
        '',
        '# Offense count: 15',
-       'Cop2:',
+       'Test/Cop2:',
        '  Exclude:',
        "    - 'test_01.rb'",
        "    - 'test_02.rb'",
@@ -219,11 +220,11 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
     let(:expected_rubocop_todo) do
       [heading,
        '# Offense count: 6',
-       'Cop1:',
+       'Test/Cop1:',
        '  Enabled: false',
        '',
        '# Offense count: 5',
-       'Cop2:',
+       'Test/Cop2:',
        '  Exclude:',
        "    - 'test_01.rb'",
        "    - 'test_02.rb'",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,11 @@ require 'rubocop/rspec/support'
 # in ./support/ and its subdirectories.
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
 
+RuboCop::Cop::Registry.global.freeze
+# This insures that there are no side effects from running a particular spec.
+# Use `:restore_registry` / `RuboCop::Cop::Registry.with_temporary_global` if
+# need to modify registry (e.g. with `stub_cop_class`).
+
 RSpec.configure do |config|
   # These two settings work together to allow you to limit a spec run
   # to individual examples or groups you care about by tagging them with


### PR DESCRIPTION
This insures that there are no side effects from running a particular spec.
Use `:restore_registry` / `RuboCop::Cop::Registry.with_temporary_global` if
need to modify registry (e.g. with `stub_cop_class`).

See also https://github.com/rubocop-hq/rubocop/pull/9197#issuecomment-742325730
