### PR TITLE
Allow extensions to disable cop obsoletions

### DIFF
--- a/changelog/change_allow_extensions_to_disable_cop.md
+++ b/changelog/change_allow_extensions_to_disable_cop.md
@@ -1,0 +1,1 @@
+* [#9206](https://github.com/rubocop-hq/rubocop/pull/9206): Allow extensions to disable cop obsoletions. ([@dvandersluis][])

--- a/lib/rubocop/config_obsoletion.rb
+++ b/lib/rubocop/config_obsoletion.rb
@@ -63,9 +63,11 @@ module RuboCop
     # Cop rules are keyed by the name of the original cop
     def load_cop_rules(rules)
       rules.flat_map do |rule_type, data|
-        data.map do |configuration|
-          COP_RULE_CLASSES[rule_type].new(@config, *configuration)
-        end
+        data.map do |cop_name, configuration|
+          next unless configuration # allow configurations to be disabled with `CopName: ~`
+
+          COP_RULE_CLASSES[rule_type].new(@config, cop_name, configuration)
+        end.compact
       end
     end
 

--- a/spec/rubocop/config_obsoletion_spec.rb
+++ b/spec/rubocop/config_obsoletion_spec.rb
@@ -502,5 +502,30 @@ RSpec.describe RuboCop::ConfigObsoletion do
         end
       end
     end
+
+    context 'when extractions are disabled by an external library' do
+      after do
+        described_class.files = [described_class::DEFAULT_RULES_FILE]
+      end
+
+      let(:hash) do
+        {
+          'Performance/CollectionLiteralInLoop' => { 'Enabled': true }
+        }
+      end
+
+      let(:external_obsoletions) do
+        create_file('external/obsoletions.yml', <<~YAML)
+          extracted:
+            Performance/*: ~
+        YAML
+      end
+
+      it 'allows the extracted cops' do
+        described_class.files << external_obsoletions
+
+        expect { config_obsoletion.reject_obsolete! }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
Noticed [this change](https://github.com/rubocop-hq/rubocop-rails/commit/151b8a68c4964c998dad3ffd1a8c67048e2696aa) made to `rubocop-rails`. There needs to be a way for an extension to disable an obsoletion (ie. rubocop-rails should not have `Rails/*` raise an error)

```yaml
extracted:
  Rails/*: ~
```

Follows #9143. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
