### PR TITLE
[Fix #9208] Use Array#bsearch instead of Array#include? to detect hid…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5267,3 +5267,4 @@
 [@ThomasKoppensteiner]: https://github.com/ThomasKoppensteiner
 [@PhilCoggins]: https://github.com/PhilCoggins
 [@tas50]: https://github.com/tas50
+[@dark-panda]: https://github.com/dark-panda

--- a/changelog/change_use_arraybsearch_instead_of_arrayinclude.md
+++ b/changelog/change_use_arraybsearch_instead_of_arrayinclude.md
@@ -1,0 +1,1 @@
+* [#9208](https://github.com/rubocop-hq/rubocop/issues/9208): Use Array#bsearch instead of Array#include? to detect hidden files. ([@dark-panda][])

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -58,7 +58,7 @@ module RuboCop
       base_dir = base_dir.gsub(File::ALT_SEPARATOR, File::SEPARATOR) if File::ALT_SEPARATOR
       all_files = find_files(base_dir, File::FNM_DOTMATCH)
       # use file.include? for performance optimization
-      hidden_files = all_files.select { |file| file.include?(HIDDEN_PATH_SUBSTRING) }
+      hidden_files = all_files.select { |file| file.include?(HIDDEN_PATH_SUBSTRING) }.sort
       base_dir_config = @config_store.for(base_dir)
 
       target_files = all_files.select do |file|
@@ -70,7 +70,9 @@ module RuboCop
 
     def to_inspect?(file, hidden_files, base_dir_config)
       return false if base_dir_config.file_to_exclude?(file)
-      return true if !hidden_files.include?(file) && ruby_file?(file)
+      return true if !hidden_files.bsearch do |hidden_file|
+        file <=> hidden_file
+      end && ruby_file?(file)
 
       base_dir_config.file_to_include?(file)
     end


### PR DESCRIPTION
Finding hidden files can have a performance impact when there are hidden
directories in the working directory that contain many files, as the
`hidden_files` array can become rather large, resulting in a long
start-up time while the target files are determined. Using a binary search
can cut down on this start-up time considerably. 

As an example, on my machine, I have a `.bundle` directory containing my local 
bundle, which contains tens of thousands of files. This causes the `target_files`
array to be quite large as a result. Scanning on these using `Array#include?` 
becomes at worst O(n), while using a binary search will be on average O(log n).
This change reduced the start-up time on my Rubocop scans from around 
100 seconds to around 15 seconds when analyzed using `Benchmark`.
