### PR TITLE
[Fix #9205] Update `Naming/MemoizedInstanceVariableName` to handle dynamically defined methods

### DIFF
--- a/changelog/change_update.md
+++ b/changelog/change_update.md
@@ -1,0 +1,1 @@
+* [#9205](https://github.com/rubocop-hq/rubocop/issues/9205): Update `Naming/MemoizedInstanceVariableName` to handle dynamically defined methods. ([@dvandersluis][])

--- a/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
+++ b/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
@@ -4,7 +4,9 @@ module RuboCop
   module Cop
     module Naming
       # This cop checks for memoized methods whose instance variable name
-      # does not match the method name.
+      # does not match the method name. Applies to both regular methods
+      # (defined with `def`) and dynamic methods (defined with
+      # `define_method` or `define_singleton_method`).
       #
       # This cop can be configured with the EnforcedStyleForLeadingUnderscores
       # directive. It can be configured to allow for memoized instance variables
@@ -48,6 +50,17 @@ module RuboCop
       #     @foo ||= calculate_expensive_thing(helper_variable)
       #   end
       #
+      #   # good
+      #   define_method(:foo) do
+      #     @foo ||= calculate_expensive_thing
+      #   end
+      #
+      #   # good
+      #   define_method(:foo) do
+      #     return @foo if defined?(@foo)
+      #     @foo = calculate_expensive_thing
+      #   end
+      #
       # @example EnforcedStyleForLeadingUnderscores: required
       #   # bad
       #   def foo
@@ -79,6 +92,17 @@ module RuboCop
       #     @_foo = calculate_expensive_thing
       #   end
       #
+      #   # good
+      #   define_method(:foo) do
+      #     @_foo ||= calculate_expensive_thing
+      #   end
+      #
+      #   # good
+      #   define_method(:foo) do
+      #     return @_foo if defined?(@_foo)
+      #     @_foo = calculate_expensive_thing
+      #   end
+      #
       # @example EnforcedStyleForLeadingUnderscores :optional
       #   # bad
       #   def foo
@@ -105,6 +129,16 @@ module RuboCop
       #     return @_foo if defined?(@_foo)
       #     @_foo = calculate_expensive_thing
       #   end
+      #
+      #   # good
+      #   define_method(:foo) do
+      #     @foo ||= calculate_expensive_thing
+      #   end
+      #
+      #   # good
+      #   define_method(:foo) do
+      #     @_foo ||= calculate_expensive_thing
+      #   end
       class MemoizedInstanceVariableName < Base
         include ConfigurableEnforcedStyle
 
@@ -112,17 +146,27 @@ module RuboCop
           'method name `%<method>s`. Use `@%<suggested_var>s` instead.'
         UNDERSCORE_REQUIRED = 'Memoized variable `%<var>s` does not start ' \
           'with `_`. Use `@%<suggested_var>s` instead.'
+        DYNAMIC_DEFINE_METHODS = %i[define_method define_singleton_method].to_set.freeze
+
+        def_node_matcher :method_definition?, <<~PATTERN
+          ${
+            (block (send _ %DYNAMIC_DEFINE_METHODS ({sym str} $_)) ...)
+            (def $_ ...)
+            (defs _ $_ ...)
+          }
+        PATTERN
 
         # rubocop:disable Metrics/AbcSize
         def on_or_asgn(node)
           lhs, _value = *node
           return unless lhs.ivasgn_type?
-          return unless (method_node = node.each_ancestor(:def, :defs).first)
+
+          method_node, method_name = find_definition(node)
+          return unless method_node
 
           body = method_node.body
           return unless body == node || body.children.last == node
 
-          method_name = method_node.method_name
           return if matches?(method_name, lhs)
 
           msg = format(
@@ -147,11 +191,10 @@ module RuboCop
           arg = node.arguments.first
           return unless arg.ivar_type?
 
-          method_node = node.each_ancestor(:def, :defs).first
+          method_node, method_name = find_definition(node)
           return unless method_node
 
           var_name = arg.children.first
-          method_name = method_node.method_name
           defined_memoized?(method_node.body, var_name) do |defined_ivar, return_ivar, ivar_assign|
             return if matches?(method_name, ivar_assign)
 
@@ -172,6 +215,17 @@ module RuboCop
 
         def style_parameter_name
           'EnforcedStyleForLeadingUnderscores'
+        end
+
+        def find_definition(node)
+          # Methods can be defined in a `def` or `defs`,
+          # or dynamically via a `block` node.
+          node.each_ancestor(:def, :defs, :block).each do |ancestor|
+            method_node, method_name = method_definition?(ancestor)
+            return [method_node, method_name] if method_node
+          end
+
+          nil
         end
 
         def matches?(method_name, ivar_assign)


### PR DESCRIPTION
`Naming/MemoizedInstanceVariableName` was previously not aware of dynamically defined methods, and when defined inside another method (such as a module's `inherited` callback), it used the wrong value as the method name.

Fix to be able to find `define_method` and `define_singleton_method` and use that as the node to check against, so that the recommended ivar name is correct.

Fixes #9205.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
