### PR TITLE
Make `Style/RedundantArgument` aware of `String#chomp`

### DIFF
--- a/changelog/change_make_style_redundant_argument_aware_of_string_chomp.md
+++ b/changelog/change_make_style_redundant_argument_aware_of_string_chomp.md
@@ -1,0 +1,1 @@
+* [#9212](https://github.com/rubocop-hq/rubocop/pull/9212): Make `Style/RedundantArgument` aware of `String#chomp` and `String#chomp!`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4026,12 +4026,16 @@ Style/RedundantArgument:
   Enabled: pending
   Safe: false
   VersionAdded: '1.4'
-  VersionChanged: '1.6'
+  VersionChanged: <<next>>
   Methods:
     # Array#join
     join: ''
     # String#split
     split: ' '
+    # String#chomp
+    chomp: "\n"
+    # String#chomp!
+    chomp!: "\n"
 
 Style/RedundantAssignment:
   Description: 'Checks for redundant assignment before returning.'

--- a/lib/rubocop/cop/style/redundant_argument.rb
+++ b/lib/rubocop/cop/style/redundant_argument.rb
@@ -12,7 +12,7 @@ module RuboCop
       # 1. This cop matches for method names only and hence cannot tell apart
       #    methods with same name in different classes.
       # 2. This cop is limited to methods with single parameter.
-      # 3. This cop is unsafe if certain special global variables (e.g. `$;`) are set.
+      # 3. This cop is unsafe if certain special global variables (e.g. `$;`, `$/`) are set.
       #    That depends on the nature of the target methods, of course.
       #
       # Method names and their redundant arguments can be configured like this:
@@ -20,6 +20,8 @@ module RuboCop
       # Methods:
       #   join: ''
       #   split: ' '
+      #   chomp: "\n"
+      #   chomp!: "\n"
       #   foo: 2
       #
       # @example
@@ -28,6 +30,8 @@ module RuboCop
       #   [1, 2, 3].join("")
       #   string.split(" ")
       #   "first\nsecond".split(" ")
+      #   string.chomp("\n")
+      #   string.chomp!("\n")
       #   A.foo(2)
       #
       #   # good
@@ -35,6 +39,8 @@ module RuboCop
       #   [1, 2, 3].join
       #   string.split
       #   "first second".split
+      #   string.chomp
+      #   string.chomp!
       #   A.foo
       class RedundantArgument < Base
         include RangeHelp

--- a/spec/rubocop/cop/style/redundant_argument_spec.rb
+++ b/spec/rubocop/cop/style/redundant_argument_spec.rb
@@ -4,20 +4,26 @@ RSpec.describe RuboCop::Cop::Style::RedundantArgument, :config do
   subject(:cop) { described_class.new(config) }
 
   let(:cop_config) do
-    { 'Methods' => { 'join' => '', 'split' => ' ' } }
+    { 'Methods' => { 'join' => '', 'split' => ' ', 'chomp' => "\n", 'chomp!' => "\n" } }
   end
 
   it 'registers an offense and corrects when method called on variable' do
-    expect_offense(<<~RUBY)
+    expect_offense(<<~'RUBY')
       foo.join('')
       ^^^^^^^^^^^^ Argument '' is redundant because it is implied by default.
       foo.split(' ')
       ^^^^^^^^^^^^^^ Argument ' ' is redundant because it is implied by default.
+      foo.chomp("\n")
+      ^^^^^^^^^^^^^^^ Argument "\n" is redundant because it is implied by default.
+      foo.chomp!("\n")
+      ^^^^^^^^^^^^^^^^ Argument "\n" is redundant because it is implied by default.
     RUBY
 
     expect_correction(<<~RUBY)
       foo.join
       foo.split
+      foo.chomp
+      foo.chomp!
     RUBY
   end
 


### PR DESCRIPTION
This PR makes `Style/RedundantArgument` aware of `String#chomp`.

I was able to notice it in the following suggestion.
https://github.com/rubocop-hq/rubocop/pull/9200#discussion_r539920849

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
