### PR TITLE
Fix build error for Ruby 2.4 matrix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,13 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'bump', require: false
-gem 'memory_profiler', platform: :mri
+# memory_profiler 1.0.0 requires Ruby 2.5.0 or higher.
+# Please remove this branch when dropping support for Ruby 2.4.
+if RUBY_VERSION >= '2.5.0'
+  gem 'memory_profiler', platform: :mri
+else
+  gem 'memory_profiler', '<= 1.0.0', platform: :mri
+end
 gem 'pry'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'


### PR DESCRIPTION
This PR fixes the following build error of Ruby 2.4 matrix.

```console
bundle install
(snip)

Gem::RuntimeRequirementNotMetError: memory_profiler requires Ruby
version >=
2.5.0. The current ruby version is 2.4.10.364.
An error occurred while installing memory_profiler (1.0.0), and
Bundler cannot continue.
Make sure that `gem install memory_profiler -v '1.0.0' --source
'https://rubygems.org/'` succeeds before bundling.
```

https://app.circleci.com/pipelines/github/rubocop-hq/rubocop/3451/workflows/35bcf304-ebf8-4fd2-9982-fadba1fde7ec/jobs/159519

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
