### PR TITLE
[Fix #9207] Fix `can't modify frozen RuboCop::Cop::Registry` when running `bundle exec rake default`.

### DIFF
--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -234,6 +234,10 @@ module RuboCop
         @global = previous
       end
 
+      def self.reset!
+        @global = new
+      end
+
       private
 
       def initialize_copy(reg)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,11 +19,6 @@ require 'rubocop/rspec/support'
 # in ./support/ and its subdirectories.
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
 
-RuboCop::Cop::Registry.global.freeze
-# This insures that there are no side effects from running a particular spec.
-# Use `:restore_registry` / `RuboCop::Cop::Registry.with_temporary_global` if
-# need to modify registry (e.g. with `stub_cop_class`).
-
 RSpec.configure do |config|
   # These two settings work together to allow you to limit a spec run
   # to individual examples or groups you care about by tagging them with
@@ -51,6 +46,17 @@ RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.syntax = :expect # Disable `should_receive` and `stub`
     mocks.verify_partial_doubles = true
+  end
+
+  config.before(:suite) do
+    RuboCop::Cop::Registry.global.freeze
+    # This ensures that there are no side effects from running a particular spec.
+    # Use `:restore_registry` / `RuboCop::Cop::Registry.with_temporary_global` if
+    # need to modify registry (e.g. with `stub_cop_class`).
+  end
+
+  config.after(:suite) do
+    RuboCop::Cop::Registry.reset!
   end
 
   if %w[ruby-head-ascii_spec ruby-head-spec].include? ENV['CIRCLE_STAGE']


### PR DESCRIPTION
Updated spec_helper to freeze the registry inside a `before(:suite)` callback and reset it in `after(:suite)` so that the frozen registry doesn't break the rubocop run after specs complete in `rake default`.

I would have liked to wrap everything in a `Registry.with_temporary_global` block, but rspec doesn't allow for `around(:suite)` unfortunately.

Follows #9204.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
