### PR TITLE
Allow simple math for `Lint/BinaryOperatorWithIdenticalOperands` cop

### DIFF
--- a/changelog/change_simple_math_bin_op_with_ident_ops.md
+++ b/changelog/change_simple_math_bin_op_with_ident_ops.md
@@ -1,0 +1,1 @@
+* [#8482](https://github.com/rubocop-hq/rubocop/issues/8482): Allow simple math for `Lint/BinaryOperatorWithIdenticalOperands` cop. ([@fatkodima][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1396,6 +1396,7 @@ Lint/BinaryOperatorWithIdenticalOperands:
   Enabled: true
   Safe: false
   VersionAdded: '0.89'
+  VersionChanged: <<next>>
 
 Lint/BooleanSymbol:
   Description: 'Check for `:true` and `:false` symbols.'

--- a/lib/rubocop/cop/lint/binary_operator_with_identical_operands.rb
+++ b/lib/rubocop/cop/lint/binary_operator_with_identical_operands.rb
@@ -17,6 +17,7 @@ module RuboCop
       #
       # @example
       #   # bad
+      #   x / x
       #   x.top >= x.top
       #
       #   if a.x != 0 && a.x != 0
@@ -27,15 +28,19 @@ module RuboCop
       #     left_child || left_child
       #   end
       #
+      #   # good
+      #   x + x
+      #   1 << 1
+      #
       class BinaryOperatorWithIdenticalOperands < Base
         MSG = 'Binary operator `%<op>s` has identical operands.'
-        MATH_OPERATORS = %i[+ - * / % ** << >> | ^].to_set.freeze
+        ALLOWED_MATH_OPERATORS = %i[+ * ** << >>].to_set.freeze
 
         def on_send(node)
           return unless node.binary_operation?
 
           lhs, operation, rhs = *node
-          return if MATH_OPERATORS.include?(node.method_name) && lhs.basic_literal?
+          return if ALLOWED_MATH_OPERATORS.include?(node.method_name)
 
           add_offense(node, message: format(MSG, op: operation)) if lhs == rhs
         end

--- a/spec/rubocop/cop/lint/binary_operator_with_identical_operands_spec.rb
+++ b/spec/rubocop/cop/lint/binary_operator_with_identical_operands_spec.rb
@@ -3,19 +3,21 @@
 RSpec.describe RuboCop::Cop::Lint::BinaryOperatorWithIdenticalOperands do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense when binary operator has identical nodes' do
-    expect_offense(<<~RUBY)
-      x == x
-      ^^^^^^ Binary operator `==` has identical operands.
-      y = x && x
-          ^^^^^^ Binary operator `&&` has identical operands.
-      y = a.x + a.x
-          ^^^^^^^^^ Binary operator `+` has identical operands.
-      a.x(arg) > a.x(arg)
-      ^^^^^^^^^^^^^^^^^^^ Binary operator `>` has identical operands.
-      a.(x) > a.(x)
-      ^^^^^^^^^^^^^ Binary operator `>` has identical operands.
-    RUBY
+  %i[== != === <=> =~ && || - > >= < <= / % | ^].each do |operator|
+    it "registers an offense for `#{operator}` with duplicate operands" do
+      expect_offense(<<~RUBY, operator: operator)
+        y = a.x(arg) %{operator} a.x(arg)
+            ^^^^^^^^^^{operator}^^^^^^^^^ Binary operator `%{operator}` has identical operands.
+      RUBY
+    end
+  end
+
+  %i[+ * ** << >>].each do |operator|
+    it "does not register an offense for `#{operator}` with duplicate operands" do
+      expect_no_offenses(<<~RUBY)
+        y = a.x(arg) #{operator} a.x(arg)
+      RUBY
+    end
   end
 
   it 'does not register an offense when using binary operator with different operands' do


### PR DESCRIPTION
Fixes #8482 

I have removed several operators (`-`, `/`, `%`, `|` and `^`) from the ignore list, because each of them makes no sense with identical operands and looks like a bug (for example, `whatever` `-` `whatever` is always `0`, etc).

```ruby
# good
x * x
x + x
...

# bad
x / x
x % x
...
```