### PR TITLE
Suppress any config warnings for `rubocop -V`.

### DIFF
--- a/changelog/change_suppress_any_config_warnings_for_rubocop.md
+++ b/changelog/change_suppress_any_config_warnings_for_rubocop.md
@@ -1,0 +1,1 @@
+* [#9228](https://github.com/rubocop-hq/rubocop/pull/9228): Suppress any config warnings for `rubocop -V`. ([@dvandersluis][])

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -28,6 +28,7 @@ require_relative 'rubocop/name_similarity'
 require_relative 'rubocop/string_interpreter'
 require_relative 'rubocop/error'
 require_relative 'rubocop/warning'
+require_relative 'rubocop/util'
 
 require_relative 'rubocop/cop/util'
 require_relative 'rubocop/cop/offense'

--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -106,23 +106,13 @@ module RuboCop
           error && error.ancestors[1] == SystemCallError
         end
 
-        def silence_warnings
-          # Replaces Kernel::silence_warnings since it hides any warnings,
-          # including the RuboCop ones
-          old_verbose = $VERBOSE
-          $VERBOSE = nil
-          yield
-        ensure
-          $VERBOSE = old_verbose
-        end
-
         def evaluate_exceptions(group)
           rescued_exceptions = group.exceptions
 
           if rescued_exceptions.any?
             rescued_exceptions.each_with_object([]) do |exception, converted|
               begin
-                silence_warnings do
+                RuboCop::Util.silence_warnings do
                   # Avoid printing deprecation warnings about constants
                   converted << Kernel.const_get(exception.source)
                 end

--- a/lib/rubocop/util.rb
+++ b/lib/rubocop/util.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module RuboCop
+  # This module contains a collection of useful utility methods.
+  module Util
+    def self.silence_warnings
+      # Replaces Kernel::silence_warnings since it hides any warnings,
+      # including the RuboCop ones
+      old_verbose = $VERBOSE
+      $VERBOSE = nil
+      yield
+    ensure
+      $VERBOSE = old_verbose
+    end
+  end
+end

--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -34,7 +34,13 @@ module RuboCop
 
     # @api private
     def self.extension_versions(env)
-      env.config_store.for_pwd.loaded_features.sort.map do |loaded_feature|
+      features = Util.silence_warnings do
+        # Suppress any config issues when loading the config (ie. deprecations,
+        # pending cops, etc.).
+        env.config_store.for_pwd.loaded_features.sort
+      end
+
+      features.map do |loaded_feature|
         next unless (match = loaded_feature.match(/rubocop-(?<feature>.*)/))
 
         feature = match[:feature]


### PR DESCRIPTION
Because `rubocop -V` now loads the config in order to show versions of extensions, any config warnings (such as pending cops) are shown as well, which makes the output too dirty. This change suppresses any warnings as to only output the version information.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
