### PR TITLE
Show `rubocop -V` output even if the configuration is invalid

### DIFF
--- a/changelog/fix_fix_errors_being_reported_with_rubocop_v.md
+++ b/changelog/fix_fix_errors_being_reported_with_rubocop_v.md
@@ -1,0 +1,1 @@
+* [#9229](https://github.com/rubocop-hq/rubocop/pull/9229): Fix errors being reported with `rubocop -V` with an invalid config. ([@dvandersluis][])

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -33,8 +33,8 @@ module RuboCop
       @validator = ConfigValidator.new(self)
     end
 
-    def self.create(hash, path)
-      new(hash, path).check
+    def self.create(hash, path, check: true)
+      new(hash, path).tap { |config| config.check if check }
     end
 
     def loaded_features

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -25,13 +25,14 @@ module RuboCop
       attr_accessor :debug, :ignore_parent_exclusion,
                     :disable_pending_cops, :enable_pending_cops
       attr_writer :default_configuration, :project_root
+      attr_reader :loaded_features
 
       alias debug? debug
       alias ignore_parent_exclusion? ignore_parent_exclusion
 
       def clear_options
         @debug = nil
-        @loaded_features = []
+        @loaded_features = Set.new
         FileFinder.root_level = nil
       end
 
@@ -174,19 +175,11 @@ module RuboCop
         resolver.merge_with_default(config, config_file, unset_nil: unset_nil)
       end
 
-      def loaded_features
-        @loaded_features.flatten.compact.uniq
-      end
-
       # @api private
       # Used to add features that were required inside a config or from
       # the CLI using `--require`.
       def add_loaded_features(loaded_features)
-        if instance_variable_defined?(:@loaded_features)
-          instance_variable_get(:@loaded_features) << loaded_features
-        else
-          instance_variable_set(:@loaded_features, [loaded_features])
-        end
+        @loaded_features.merge(Array(loaded_features))
       end
 
       private

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -35,7 +35,7 @@ module RuboCop
         FileFinder.root_level = nil
       end
 
-      def load_file(file)
+      def load_file(file, check: true)
         path = file_path(file)
 
         hash = load_yaml_configuration(path)
@@ -52,7 +52,7 @@ module RuboCop
 
         hash.delete('inherit_from')
 
-        Config.create(hash, path)
+        Config.create(hash, path, check: check)
       end
 
       def load_yaml_configuration(absolute_path)
@@ -99,10 +99,10 @@ module RuboCop
           find_user_xdg_config || DEFAULT_FILE
       end
 
-      def configuration_from_file(config_file)
+      def configuration_from_file(config_file, check: true)
         return default_configuration if config_file == DEFAULT_FILE
 
-        config = load_file(config_file)
+        config = load_file(config_file, check: check)
         if ignore_parent_exclusion?
           print 'Ignoring AllCops/Exclude from parent folders' if debug?
         else

--- a/lib/rubocop/config_store.rb
+++ b/lib/rubocop/config_store.rb
@@ -4,6 +4,9 @@ module RuboCop
   # Handles caching of configurations and association of inspected
   # ruby files to configurations.
   class ConfigStore
+    attr_reader :validated
+    alias validated? validated
+
     def initialize
       # @options_config stores a config that is specified in the command line.
       # This takes precedence over configs located in any directories
@@ -17,6 +20,9 @@ module RuboCop
       # @object_cache maps configuration file paths to
       # configuration objects so we only need to load them once.
       @object_cache = {}
+
+      # By default the config is validated before it can be used.
+      @validated = true
     end
 
     def options_config=(options_config)
@@ -27,6 +33,11 @@ module RuboCop
 
     def force_default_config!
       @options_config = ConfigLoader.default_configuration
+    end
+
+    def unvalidated
+      @validated = false
+      self
     end
 
     def for_file(file)
@@ -55,7 +66,7 @@ module RuboCop
       path = @path_cache[dir]
       @object_cache[path] ||= begin
         print "For #{dir}: " if ConfigLoader.debug?
-        ConfigLoader.configuration_from_file(path)
+        ConfigLoader.configuration_from_file(path, check: validated?)
       end
     end
   end

--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -37,7 +37,7 @@ module RuboCop
       features = Util.silence_warnings do
         # Suppress any config issues when loading the config (ie. deprecations,
         # pending cops, etc.).
-        env.config_store.for_pwd.loaded_features.sort
+        env.config_store.unvalidated.for_pwd.loaded_features.sort
       end
 
       features.map do |loaded_feature|

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -177,6 +177,32 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
     end
 
+    context 'when requiring extension cops in multiple layers' do
+      before do
+        create_file('.rubocop-parent.yml', <<~YAML)
+          require:
+            - rubocop-performance
+        YAML
+
+        create_file('.rubocop.yml', <<~YAML)
+          inherit_from: ./.rubocop-parent.yml
+          require:
+            - rubocop-rspec
+        YAML
+      end
+
+      it 'shows with version of extension cops' do
+        # Run in different process that requiring rubocop-performance and rubocop-rspec
+        # does not affect other testing processes.
+        output = `ruby -I . "#{rubocop}" -V --disable-pending-cops`
+        expect(output).to include(RuboCop::Version::STRING)
+        expect(output).to match(/Parser \d+\.\d+\.\d+/)
+        expect(output).to match(/rubocop-ast \d+\.\d+\.\d+/)
+        expect(output).to match(/rubocop-performance \d+\.\d+\.\d+/)
+        expect(output).to match(/rubocop-rspec \d+\.\d+\.\d+/)
+      end
+    end
+
     context 'when requiring redundant extension cop' do
       before do
         create_file('ext.yml', <<~YAML)

--- a/spec/rubocop/config_store_spec.rb
+++ b/spec/rubocop/config_store_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::ConfigStore do
         # The stub returns the same config path for dir and dir/subdir.
         expect(RuboCop::ConfigLoader)
           .to receive(:configuration_from_file)
-          .with('dir/.rubocop.yml').once
+          .with('dir/.rubocop.yml', check: true).once
 
         config_store.for('dir/file2')
         config_store.for('dir/file2')

--- a/spec/rubocop/version_spec.rb
+++ b/spec/rubocop/version_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Version do
+  include FileHelper
+
+  describe '.extension_versions', :isolated_environment, :restore_registry do
+    subject(:extension_versions) { described_class.extension_versions(env) }
+
+    let(:env) { instance_double('RuboCop::CLI::Environment', config_store: config_store) }
+    let(:config_store) { RuboCop::ConfigStore.new }
+
+    before do
+      RuboCop::ConfigLoader.clear_options
+    end
+
+    context 'when no extensions are required' do
+      before do
+        create_file('.rubocop.yml', <<~YAML)
+          AllCops:
+            TargetRubyVersion: 2.4
+        YAML
+      end
+
+      it 'does not return any the extensions' do
+        expect(extension_versions).to eq([])
+      end
+    end
+
+    context 'when extensions are required' do
+      before do
+        create_file('.rubocop.yml', <<~YAML)
+          require:
+            - rubocop-performance
+            - rubocop-rspec
+        YAML
+      end
+
+      it 'returns the extensions' do
+        expect(extension_versions).to contain_exactly(
+          /- rubocop-performance \d+\.\d+\.\d+/,
+          /- rubocop-rspec \d+\.\d+\.\d+/
+        )
+      end
+    end
+
+    context 'when unknown extensions are required' do
+      before do
+        create_file('.rubocop.yml', <<~YAML)
+          require:
+            - ./rubocop-foobarbaz
+        YAML
+
+        create_file('rubocop-foobarbaz.rb', <<~RUBY)
+          module RuboCop
+            module FooBarBaz
+            end
+          end
+        RUBY
+      end
+
+      it 'does not return any the extensions' do
+        expect(extension_versions).to eq([])
+      end
+    end
+
+    context 'with an obsolete config' do
+      before do
+        create_file('.rubocop.yml', <<~YAML)
+          require:
+            - rubocop-performance
+            - rubocop-rspec
+
+          Style/MethodMissing:
+            Enabled: true
+        YAML
+      end
+
+      it 'returns the extensions' do
+        expect do
+          expect(extension_versions).to contain_exactly(
+            /- rubocop-performance \d+\.\d+\.\d+/,
+            /- rubocop-rspec \d+\.\d+\.\d+/
+          )
+        end.not_to raise_error
+      end
+    end
+
+    context 'with an invalid cop in config' do
+      before do
+        create_file('.rubocop.yml', <<~YAML)
+          require:
+            - rubocop-performance
+            - rubocop-rspec
+
+          Style/SomeCop:
+            Enabled: true
+        YAML
+      end
+
+      it 'returns the extensions' do
+        expect do
+          expect(extension_versions).to contain_exactly(
+            /- rubocop-performance \d+\.\d+\.\d+/,
+            /- rubocop-rspec \d+\.\d+\.\d+/
+          )
+        end.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently if the configuration has anything invalid in it (obsolete cops, invalid cops, etc.), `rubocop -V` will output error messages from config validation but not the actual version information.

```shell
$ rubocop -V
Error: The `Style/MethodMissing` cop has been split into `Style/MethodMissingSuper` and `Style/MissingRespondToMissing`.
(obsolete configuration found in .rubocop.yml, please update it)
```

This change allows the config to be loaded without being validated, which allows `rubocop -V` to output properly. Only the version command is affected.

```shell
$ rubocop -V
1.6.1 (using Parser 2.7.2.0, rubocop-ast 1.3.0, running on ruby 2.6.6 x86_64-darwin18)
  - rubocop-performance 1.9.1
  - rubocop-rspec 2.0.1

$ rubocop
Error: The `Style/MethodMissing` cop has been split into `Style/MethodMissingSuper` and `Style/MissingRespondToMissing`.
(obsolete configuration found in .rubocop.yml, please update it)
```

Related to #9228 (will slightly conflict but I'll fix it up once once is merged).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
