### PR TITLE
Fix wrong offense in Style/SymbolProc

### DIFF
--- a/changelog/fix_a_false_positive_for_style_symbol_proc
+++ b/changelog/fix_a_false_positive_for_style_symbol_proc
@@ -1,0 +1,1 @@
+* [#9232](https://github.com/rubocop-hq/rubocop/pull/9232): Fix `Style/SymbolProc` registering wrong offense when using a symbol numbered block argument greater than 1, i.e. `[[1, 2]].map { _2.succ }`. ([@tdeo][])

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -25,7 +25,7 @@ module RuboCop
         def_node_matcher :symbol_proc?, <<~PATTERN
           ({block numblock}
             ${(send ...) (super ...) zsuper}
-            ${(args (arg _)) %Integer}
+            ${(args (arg _)) 1}
             (send (lvar _var) $_))
         PATTERN
 

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -198,6 +198,10 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
       expect_no_offenses('proc { _1.method }')
     end
 
+    it 'accepts block with only second numeric argument' do
+      expect_no_offenses('something { _2.first }')
+    end
+
     it 'accepts Proc.new with 1 argument' do
       expect_no_offenses('Proc.new { _1.method }')
     end


### PR DESCRIPTION
While upgrading to rubocop `1.6.1`, I noticed that the `Style/SymbolProc` was registering an offense on the following code:
```ruby
array.map { _2.first }
```
And suggesting to autocorrect to `array.map(&:first)`, which is incorrect in such case.

I believe this was introduced in https://github.com/rubocop-hq/rubocop/pull/9127

I suggest changing the cop to only register offenses for the `_1` numbered block argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
