### PR TITLE
[Fix #9234] Fix an error for `Style/KeywordParametersOrder`

### DIFF
--- a/changelog/fix_an_error_for_style_keyword_parameters_order.md
+++ b/changelog/fix_an_error_for_style_keyword_parameters_order.md
@@ -1,0 +1,1 @@
+* [#9234](https://github.com/rubocop-hq/rubocop/issues/9234): Fix the error for `Style/KeywordParametersOrder` and make it aware of block keyword parameters. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3495,6 +3495,7 @@ Style/KeywordParametersOrder:
   StyleGuide: '#keyword-parameters-order'
   Enabled: true
   VersionAdded: '0.90'
+  VersionChanged: <<next>>
 
 Style/Lambda:
   Description: 'Use the new lambda literal syntax for single-line blocks.'

--- a/lib/rubocop/cop/style/keyword_parameters_order.rb
+++ b/lib/rubocop/cop/style/keyword_parameters_order.rb
@@ -21,6 +21,16 @@ module RuboCop
       #     # body omitted
       #   end
       #
+      #   # bad
+      #   do_something do |first: false, second:, third: 10|
+      #     # body omitted
+      #   end
+      #
+      #   # good
+      #   do_something do |second:, first: false, third: 10|
+      #     # body omitted
+      #   end
+      #
       class KeywordParametersOrder < Base
         include RangeHelp
         extend AutoCorrector
@@ -35,7 +45,7 @@ module RuboCop
             if node.parent.find(&:kwoptarg_type?) == node
               corrector.insert_before(node, "#{kwarg_nodes.map(&:source).join(', ')}, ")
 
-              arguments = node.each_ancestor(:def, :defs).first.arguments
+              arguments = node.each_ancestor(:def, :defs, :block).first.arguments
               append_newline_to_last_kwoptarg(arguments, corrector) unless parentheses?(arguments)
 
               remove_kwargs(kwarg_nodes, corrector)
@@ -50,7 +60,7 @@ module RuboCop
           return if last_argument.kwrestarg_type? || last_argument.blockarg_type?
 
           last_kwoptarg = arguments.reverse.find(&:kwoptarg_type?)
-          corrector.insert_after(last_kwoptarg, "\n")
+          corrector.insert_after(last_kwoptarg, "\n") unless arguments.parent.block_type?
         end
 
         def remove_kwargs(kwarg_nodes, corrector)

--- a/spec/rubocop/cop/style/keyword_parameters_order_spec.rb
+++ b/spec/rubocop/cop/style/keyword_parameters_order_spec.rb
@@ -101,4 +101,26 @@ RSpec.describe RuboCop::Cop::Style::KeywordParametersOrder do
       end
     RUBY
   end
+
+  context 'when using block keyword parameters' do
+    it 'registers an offense and corrects when `kwoptarg` is before `kwarg`' do
+      expect_offense(<<~RUBY)
+        m(arg) do |block_arg, optional: 1, required:|
+                              ^^^^^^^^^^^ Place optional keyword parameters at the end of the parameters list.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        m(arg) do |block_arg, required:, optional: 1|
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when there are no `kwoptarg`s before `kwarg`s' do
+      expect_no_offenses(<<~RUBY)
+        m(arg) do |block_arg, required:, optional: 1|
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #9234.

This PR fixes the error for `Style/KeywordParametersOrder` and makes it aware of block keyword parameters.
Keyword parameters can be used with block arguments as well as method arguments, but `Style/KeywordParametersOrder` cop were unaware of it.

This PR adds block arguments to the targets for consistency. If the cop need an option to the above customize, I will open a separate PR.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
