### PR TITLE
[Fix #9237] Add `IgnoredPatterns` configuration to `Lint/UnreachableLoop`

### DIFF
--- a/changelog/change_add_ignoredpatterns_configuration_to.md
+++ b/changelog/change_add_ignoredpatterns_configuration_to.md
@@ -1,0 +1,1 @@
+* [#9237](https://github.com/rubocop-hq/rubocop/issues/9237): Add `IgnoredPatterns` configuration to `Lint/UnreachableLoop` to allow for block methods that share a name with an `Enumerable` method. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2058,6 +2058,11 @@ Lint/UnreachableLoop:
   Description: 'This cop checks for loops that will have at most one iteration.'
   Enabled: true
   VersionAdded: '0.89'
+  VersionChanged: <<next>>
+  IgnoredPatterns:
+    # RSpec uses `times` in its message expectations
+    # eg. `exactly(2).times`
+    - !ruby/regexp /(exactly|at_least|at_most)\(\d+\)\.times/
 
 Lint/UnusedBlockArgument:
   Description: 'Checks for unused block arguments.'


### PR DESCRIPTION
In #9237:

```
test_spec.rb:7:5: W: Lint/UnreachableLoop: This loop will have at most one iteration.
    SomeClass.should_receive(:test).exactly(2).times { raise StandardError }
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

`Lint/UnreachableLoop` is registering on `times` here because it is an [`enumerator_method`](https://github.com/rubocop-hq/rubocop-ast/blob/master/lib/rubocop/ast/node/mixin/method_identifier_predicates.rb#L10-L13). However, it is actually an RSpec method in this case.

Since we don't know what the receiver is, `IgnoredPatterns` can now be used to have the block receiver be allowed. For instance:

```yaml
Lint/UnreachableLoop:
  IgnoredPatterns:
    - !ruby/regexp /exactly\(\d+\)\.times/
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
