### PR TITLE
Added example for `AllowAdjacentOneLineDefs` config to `Layout/EmptyLineBetweenDefs`

### DIFF
--- a/lib/rubocop/cop/layout/empty_line_between_defs.rb
+++ b/lib/rubocop/cop/layout/empty_line_between_defs.rb
@@ -76,6 +76,14 @@ module RuboCop
       #
       #   def b
       #   end
+      #
+      # @example AllowAdjacentOneLineDefs: true
+      #
+      #   # good
+      #   class ErrorA < BaseError; end
+      #   class ErrorB < BaseError; end
+      #   class ErrorC < BaseError; end
+      #
       class EmptyLineBetweenDefs < Base
         include RangeHelp
         extend AutoCorrector


### PR DESCRIPTION
This is a small documentation-only change to add an example for `Layout/EmptyLineBetweenDefs` for the `AllowAdjacentOneLineDefs` config option. 