### PR TITLE
Use new expect_offense and expect_correction in Layout specs

### DIFF
--- a/spec/rubocop/cop/layout/argument_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/argument_alignment_spec.rb
@@ -244,19 +244,23 @@ RSpec.describe RuboCop::Cop::Layout::ArgumentAlignment do
 
     it "doesn't crash and burn when there are nested issues" do
       # regression test; see GH issue 2441
-      src = <<~RUBY
-        build(:house,
-          :rooms => [
-            build(:bedroom,
-              :bed => build(:bed,
-                :occupants => [],
-                :size => "king"
+      expect do
+        expect_offense(<<~RUBY)
+          build(:house,
+            :rooms => [
+            ^^^^^^^^^^^ Align the arguments of a method call if they span more than one line.
+              build(:bedroom,
+                :bed => build(:bed,
+                ^^^^^^^^^^^^^^^^^^^ Align the arguments of a method call if they span more than one line.
+                  :occupants => [],
+                  ^^^^^^^^^^^^^^^^^ Align the arguments of a method call if they span more than one line.
+                  :size => "king"
+                )
               )
-            )
-          ]
-        )
-      RUBY
-      expect { inspect_source(src) }.not_to raise_error
+            ]
+          )
+        RUBY
+      end.not_to raise_error
     end
 
     context 'assigned methods' do

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -209,46 +209,42 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
     end
   end
 
-  describe '#autocorrect' do
-    context 'when there is a comment in the macro method' do
-      it 'autocorrects the offenses' do
-        new_source = autocorrect_source(<<~RUBY)
-          class Foo
-            # This is a comment for macro method.
-            validates :attr
-            attr_reader :foo
-          end
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          class Foo
-            attr_reader :foo
-            # This is a comment for macro method.
-            validates :attr
-          end
-        RUBY
+  it 'registers an offense and corrects when there is a comment in the macro method' do
+    expect_offense(<<~RUBY)
+      class Foo
+        # This is a comment for macro method.
+        validates :attr
+        attr_reader :foo
+        ^^^^^^^^^^^^^^^^ `attribute_macros` is supposed to appear before `macros`.
       end
-    end
+    RUBY
 
-    context 'literal constant is after method definitions' do
-      it 'autocorrects the offenses' do
-        new_source = autocorrect_source(<<~RUBY)
-          class Foo
-            def name; end
-
-            LIMIT = 10
-          end
-        RUBY
-
-        expect(new_source).to eq(<<~RUBY)
-          class Foo
-            LIMIT = 10
-            def name; end
-
-          end
-        RUBY
+    expect_correction(<<~RUBY)
+      class Foo
+        attr_reader :foo
+        # This is a comment for macro method.
+        validates :attr
       end
-    end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when literal constant is after method definitions' do
+    expect_offense(<<~RUBY)
+      class Foo
+        def name; end
+
+        LIMIT = 10
+        ^^^^^^^^^^ `constants` is supposed to appear before `public_methods`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo
+        LIMIT = 10
+        def name; end
+
+      end
+    RUBY
   end
 
   it 'registers an offense and corrects when str heredoc constant is defined after public method' do

--- a/spec/rubocop/cop/layout/comment_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/comment_indentation_spec.rb
@@ -165,25 +165,31 @@ RSpec.describe RuboCop::Cop::Layout::CommentIndentation do
     end
   end
 
-  it 'auto-corrects' do
-    new_source = autocorrect_source(<<~RUBY)
+  it 'registers an offense and corrects' do
+    # FIXME
+    expect_offense(<<~RUBY)
        # comment
        # comment
        # comment
+       ^^^^^^^^^ Incorrect indentation detected (column 1 instead of 0).
       hash1 = { a: 0,
            # comment
+           ^^^^^^^^^ Incorrect indentation detected (column 5 instead of 10).
                 bb: 1,
                 ccc: 2 }
         if a
         #
+        ^ Incorrect indentation detected (column 2 instead of 4).
           b
         # this is accepted
         elsif aa
           # so is this
         elsif bb
       #
+      ^ Incorrect indentation detected (column 0 instead of 4).
         else
          #
+         ^ Incorrect indentation detected (column 3 instead of 4).
         end
         case a
         # this is accepted
@@ -191,11 +197,12 @@ RSpec.describe RuboCop::Cop::Layout::CommentIndentation do
           # so is this
         when 1
            #
+           ^ Incorrect indentation detected (column 5 instead of 4).
           b
         end
     RUBY
 
-    expect(new_source).to eq(<<~RUBY)
+    expect_correction(<<~RUBY)
       # comment
       # comment
       # comment

--- a/spec/rubocop/cop/layout/first_array_element_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_array_element_line_break_spec.rb
@@ -4,22 +4,16 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
   subject(:cop) { described_class.new }
 
   context 'elements listed on the first line' do
-    it 'registers an offense' do
+    it 'registers and corrects the offense' do
       expect_offense(<<~RUBY)
         a = [:a,
              ^^ Add a line break before the first element of a multi-line array.
              :b]
       RUBY
-    end
 
-    it 'autocorrects the offense' do
-      corrected = autocorrect_source(<<~RUBY)
-        a = [:a,
-             :b]
-      RUBY
       # Alignment for the first element is set by IndentationWidth cop,
       # the rest of the elements should be aligned using the ArrayAlignment cop.
-      expect(corrected).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         a = [
         :a,
              :b]
@@ -28,21 +22,14 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
   end
 
   context 'word arrays' do
-    it 'detects the offense' do
+    it 'registers and corrects the offense' do
       expect_offense(<<~RUBY)
         %w(a b
            ^ Add a line break before the first element of a multi-line array.
            c d)
       RUBY
-    end
 
-    it 'autocorrects the offense' do
-      corrected = autocorrect_source(<<~RUBY)
-        %w(a b
-           c d)
-      RUBY
-
-      expect(corrected).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         %w(
         a b
            c d)
@@ -51,21 +38,14 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
   end
 
   context 'array nested in a method call' do
-    it 'registers ans offense' do
+    it 'registers an corrects the offense' do
       expect_offense(<<~RUBY)
         method([:foo,
                 ^^^^ Add a line break before the first element of a multi-line array.
                 :bar])
       RUBY
-    end
 
-    it 'autocorrects the offense' do
-      corrected = autocorrect_source(<<~RUBY)
-        method([:foo,
-                :bar])
-      RUBY
-
-      expect(corrected).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         method([
         :foo,
                 :bar])
@@ -74,23 +54,15 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
   end
 
   context 'masgn implicit arrays' do
-    it 'detects the offense' do
+    it 'registers and corrects the offense' do
       expect_offense(<<~RUBY)
         a, b,
         c = 1,
             ^ Add a line break before the first element of a multi-line array.
         2, 3
       RUBY
-    end
 
-    it 'autocorrects the offense' do
-      corrected = autocorrect_source(<<~RUBY)
-        a, b,
-        c = 1,
-        2, 3
-      RUBY
-
-      expect(corrected).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         a, b,
         c =#{trailing_whitespace}
         1,
@@ -100,23 +72,15 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
   end
 
   context 'send implicit arrays' do
-    it 'detects the offense' do
+    it 'registers and corrects the offense' do
       expect_offense(<<~RUBY)
         a
         .c = 1,
              ^ Add a line break before the first element of a multi-line array.
         2, 3
       RUBY
-    end
 
-    it 'autocorrects the offense' do
-      new_source = autocorrect_source(<<~RUBY)
-        a
-        .c = 1,
-        2, 3
-      RUBY
-
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY)
         a
         .c =#{trailing_whitespace}
         1,

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -732,13 +732,14 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
     end
 
     it 'fails' do
-      src = <<~RUBY
-        hash = {
-          a: 0,
-          bb: 1
-        }
-      RUBY
-      expect { inspect_source(src) }.to raise_error(RuntimeError)
+      expect do
+        expect_offense(<<~RUBY)
+          hash = {
+            a: 0,
+            bb: 1
+          }
+        RUBY
+      end.to raise_error(RuntimeError)
     end
   end
 

--- a/spec/rubocop/cop/layout/indentation_style_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_style_spec.rb
@@ -16,24 +16,36 @@ RSpec.describe RuboCop::Cop::Layout::IndentationStyle do
   context 'when EnforcedStyle is spaces' do
     let(:cop_config) { { 'EnforcedStyle' => 'spaces' } }
 
-    it 'registers an offense for a line indented with tab' do
+    it 'registers and corrects an offense for a line indented with tab' do
       expect_offense(<<~RUBY)
-        	x = 0
+        \tx = 0
         ^ Tab detected in indentation.
       RUBY
-    end
 
-    it 'registers an offense for a line indented with multiple tabs' do
-      expect_offense(<<~RUBY)
-        			x = 0
-        ^^^ Tab detected in indentation.
+      expect_correction(<<-RUBY.strip_margin('|'))
+        |  x = 0
       RUBY
     end
 
-    it 'registers an offense for a line indented with mixed whitespace' do
-      expect_offense(<<~'RUBY')
-         	x = 0
+    it 'registers and corrects an offense for a line indented with multiple tabs' do
+      expect_offense(<<~RUBY)
+        \t\t\tx = 0
+        ^^^ Tab detected in indentation.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_margin('|'))
+        |      x = 0
+      RUBY
+    end
+
+    it 'registers and corrects an offense for a line indented with mixed whitespaces' do
+      expect_offense(<<~RUBY)
+         \tx = 0
         ^^ Tab detected in indentation.
+      RUBY
+
+      expect_correction(<<-RUBY.strip_margin('|'))
+        |   x = 0
       RUBY
     end
 
@@ -70,29 +82,15 @@ RSpec.describe RuboCop::Cop::Layout::IndentationStyle do
       expect_no_offenses("x = <<HELLO\n\thello\n\t\n\t\t\nhello\nHELLO")
     end
 
-    it 'auto-corrects a line indented with tab' do
-      new_source = autocorrect_source("\tx = 0")
-      expect(new_source).to eq('  x = 0')
-    end
+    it 'registers and corrects an offense for a line with tab in a string indented with tab' do
+      expect_offense(<<~RUBY)
+        \t(x = \"\t\")
+        ^ Tab detected in indentation.
+      RUBY
 
-    it 'auto-corrects a line indented with multiple tabs' do
-      new_source = autocorrect_source("\t\t\tx = 0")
-      expect(new_source).to eq('      x = 0')
-    end
-
-    it 'auto-corrects a line indented with mixed whitespace' do
-      new_source = autocorrect_source(" \tx = 0")
-      expect(new_source).to eq('   x = 0')
-    end
-
-    it 'auto-corrects a line with tab in a string indented with tab' do
-      new_source = autocorrect_source("\t(x = \"\t\")")
-      expect(new_source).to eq("  (x = \"\t\")")
-    end
-
-    it 'does not auto-correct a line with tab other than indentation' do
-      new_source = autocorrect_source("foo \t bar")
-      expect(new_source).to eq("foo \t bar")
+      expect_correction(<<-RUBY.strip_margin('|'))
+        |  (x = \"\t\")
+      RUBY
     end
 
     context 'custom indentation width' do
@@ -101,9 +99,14 @@ RSpec.describe RuboCop::Cop::Layout::IndentationStyle do
       end
 
       it 'uses the configured number of spaces to replace a tab' do
-        new_source = autocorrect_source("\tx = 0")
+        expect_offense(<<~RUBY)
+          \tx = 0
+          ^ Tab detected in indentation.
+        RUBY
 
-        expect(new_source).to eq('   x = 0')
+        expect_correction(<<-RUBY.strip_margin('|'))
+          |   x = 0
+        RUBY
       end
     end
   end
@@ -111,23 +114,31 @@ RSpec.describe RuboCop::Cop::Layout::IndentationStyle do
   context 'when EnforcedStyle is tabs' do
     let(:cop_config) { { 'EnforcedStyle' => 'tabs' } }
 
-    it 'registers an offense for a line indented with space' do
+    it 'registers and corrects an offense for a line indented with space' do
       expect_offense(<<~RUBY)
           x = 0
         ^^ Space detected in indentation.
       RUBY
+
+      expect_correction(<<~RUBY)
+        \tx = 0
+      RUBY
     end
 
-    it 'registers an offense for a line indented with multiple spaces' do
+    it 'registers and corrects an offense for a line indented with multiple spaces' do
       expect_offense(<<~RUBY)
               x = 0
         ^^^^^^ Space detected in indentation.
       RUBY
+
+      expect_correction(<<~RUBY)
+        \t\t\tx = 0
+      RUBY
     end
 
     it 'registers an offense for a line indented with mixed whitespace' do
-      expect_offense(<<~'RUBY')
-         	x = 0
+      expect_offense(<<~RUBY)
+         \tx = 0
         ^ Space detected in indentation.
       RUBY
     end
@@ -165,35 +176,27 @@ RSpec.describe RuboCop::Cop::Layout::IndentationStyle do
       expect_no_offenses("x = <<HELLO\n\thello\n\t\n\t\t\nhello\nHELLO")
     end
 
-    it 'auto-corrects a line indented with space' do
-      new_source = autocorrect_source('  x = 0')
-      expect(new_source).to eq("\tx = 0")
-    end
-
-    it 'auto-corrects a line indented with multiple spaces' do
-      new_source = autocorrect_source('      x = 0')
-      expect(new_source).to eq("\t\t\tx = 0")
-    end
-
-    it 'auto-corrects a line indented with fractional number of'\
+    it 'registers and corrects an offense for a line indented with fractional number of'\
       'indentation groups by rounding down' do
-      new_source = autocorrect_source('   x = 0')
-      expect(new_source).to eq("\tx = 0")
+      expect_offense(<<~RUBY)
+           x = 0
+        ^^^ Space detected in indentation.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        \tx = 0
+      RUBY
     end
 
-    it 'auto-corrects a line indented with mixed whitespace' do
-      new_source = autocorrect_source(" \tx = 0")
-      expect(new_source).to eq("\tx = 0")
-    end
+    it 'registers and corrects an offense for a line with tab in a string indented with space' do
+      expect_offense(<<~RUBY)
+          (x = \"\t\")
+        ^^ Space detected in indentation.
+      RUBY
 
-    it 'auto-corrects a line with tab in a string indented with space' do
-      new_source = autocorrect_source("  (x = \"\t\")")
-      expect(new_source).to eq("\t(x = \"\t\")")
-    end
-
-    it 'does not auto-corrects a line with tab other than indentation' do
-      new_source = autocorrect_source("\tfoo \t bar")
-      expect(new_source).to eq("\tfoo \t bar")
+      expect_correction(<<~RUBY)
+        \t(x = \"\t\")
+      RUBY
     end
 
     context 'custom indentation width' do
@@ -202,9 +205,14 @@ RSpec.describe RuboCop::Cop::Layout::IndentationStyle do
       end
 
       it 'uses the configured number of spaces to replace with a tab' do
-        new_source = autocorrect_source('      x = 0')
+        expect_offense(<<~RUBY)
+                x = 0
+          ^^^^^^ Space detected in indentation.
+        RUBY
 
-        expect(new_source).to eq("\t\tx = 0")
+        expect_correction(<<~RUBY)
+          \t\tx = 0
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -132,8 +132,9 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
 
       it 'does not crash' do
         expect do
-          inspect_source(<<~RUBY)
+          expect_offense(<<~RUBY)
             xxxxxxxxxxxxxxxxxxxxxxxxxxxxzxxxxxxxxxxx = LDAP::DEFAULT_GROUP_UNIQUE_MEMBER_LIST_KEY
+                                                                                            ^^^^^ Line is too long. [85/80]
           RUBY
         end.not_to raise_error
       end
@@ -196,7 +197,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
     context 'when the source has no AST' do
       it 'does not crash' do
         expect do
-          inspect_source('# this results in AST being nil')
+          expect_no_offenses('# this results in AST being nil')
         end.not_to raise_error
       end
     end

--- a/spec/rubocop/cop/layout/space_around_method_call_operator_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_method_call_operator_spec.rb
@@ -5,15 +5,11 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundMethodCallOperator do
 
   let(:config) { RuboCop::Config.new }
 
-  shared_examples 'offense' do |name, code, offense, correction|
-    it "registers an offense when #{name}" do
+  # FIXME: Remove unused vars
+  shared_examples 'offense' do |name, _code, offense, correction|
+    it "registers an offense and corrects when #{name}" do
       expect_offense(offense)
-    end
-
-    it "autocorrects offense when #{name}" do
-      corrected = autocorrect_source(code)
-
-      expect(corrected).to eq(correction)
+      expect_correction(correction)
     end
   end
 
@@ -100,7 +96,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundMethodCallOperator do
       CODE
         foo .
            ^ Avoid using spaces around a method call operator.
-            bar
+          bar
       OFFENSE
         foo.
           bar
@@ -284,7 +280,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundMethodCallOperator do
       CODE
         foo &.
            ^ Avoid using spaces around a method call operator.
-            bar
+          bar
       OFFENSE
         foo&.
           bar

--- a/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
     let(:cop_config) { { 'EnforcedStyleForEmptyBraces' => 'unknown' } }
 
     it 'fails with an error' do
-      expect { inspect_source('each {}') }
+      expect { expect_no_offenses('each {}') }
         .to raise_error('Unknown EnforcedStyleForEmptyBraces selected!')
     end
   end

--- a/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     let(:cop_config) { { 'EnforcedStyleForEmptyBraces' => 'unknown' } }
 
     it 'fails with an error' do
-      expect { inspect_source('each { }') }
+      expect { expect_no_offenses('each { }') }
         .to raise_error('Unknown EnforcedStyleForEmptyBraces selected!')
     end
   end


### PR DESCRIPTION
Part of https://github.com/rubocop-hq/rubocop/issues/8127

- Replace old `inspect_source` and `autocorrect_source` with `expect_offense` and `expect_correction`.
- Merge split specs for registering and corrections same offenses.
- Remove useless correction checks when we check for `expect no offenses`.

Except files:
spec/rubocop/cop/layout/end_of_line_spec.rb
spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
spec/rubocop/cop/layout/trailing_empty_lines_spec.rb

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
