### PR TITLE
[Fix #9235] Allow `--only` and `--except` to be able to properly qualify cops added by require.

### DIFF
--- a/changelog/change_allow_only_and_except_to_be_able_to.md
+++ b/changelog/change_allow_only_and_except_to_be_able_to.md
@@ -1,0 +1,1 @@
+* [#9235](https://github.com/rubocop-hq/rubocop/issues/9235): Allow `--only` and `--except` to be able to properly qualify cops added by require. ([@dvandersluis][])

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -92,14 +92,7 @@ module RuboCop
           raise OptionArgumentError, message
         end
 
-        @options[:"#{option}"] =
-          if list.empty?
-            ['']
-          else
-            list.split(',').map do |c|
-              Cop::Registry.qualified_cop_name(c, "--#{option} option")
-            end
-          end
+        @options[:"#{option}"] = list.empty? ? [''] : list.split(',')
       end
     end
 

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -323,10 +323,15 @@ module RuboCop
       Cop::Team.mobilize(mobilized_cop_classes(config), config, @options)
     end
 
-    def mobilized_cop_classes(config)
+    def mobilized_cop_classes(config) # rubocop:disable Metrics/AbcSize
       @mobilized_cop_classes ||= {}.compare_by_identity
       @mobilized_cop_classes[config] ||= begin
         cop_classes = Cop::Registry.all
+
+        # `@options[:only]` and `@options[:except]` are not qualified until
+        # needed so that the Registry can be fully loaded, including any
+        # cops added by `require`s.
+        qualify_option_cop_names
 
         OptionsValidator.new(@options).validate_cop_options
 
@@ -339,6 +344,16 @@ module RuboCop
         cop_classes.reject! { |c| c.match?(@options[:except]) }
 
         Cop::Registry.new(cop_classes, @options)
+      end
+    end
+
+    def qualify_option_cop_names
+      %i[only except].each do |option|
+        next unless @options[option]
+
+        @options[option].map! do |cop_name|
+          Cop::Registry.qualified_cop_name(cop_name, "--#{option} option")
+        end
       end
     end
 


### PR DESCRIPTION
Previously, cop names passed to `--only` or `--except` were qualified immediately, but because the configuration is not yet loaded when `Options.parse` is called, it could not properly resolve cops that are added by an extension or a local `require`. This was generally not a problem because unresolved cops were accepted, but in the case of a cop that shares a name with a default cop, this resulted in raising a warning that the department name was wrong, and in fact loading the wrong cop.

Instead, qualifying cop names is now done lazily, so that they are only qualified right before they are needed. This ensures that the full registry is present and external cops can be properly detected.

Fixes #9235.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
