### PR TITLE
Support auto-correction for `Style/CommentedKeyword`

### DIFF
--- a/changelog/new_support_autocorrection_for_style_commented_keyword.md
+++ b/changelog/new_support_autocorrection_for_style_commented_keyword.md
@@ -1,0 +1,1 @@
+* [#9243](https://github.com/rubocop-hq/rubocop/pull/9243): Support auto-correction for `Style/CommentedKeyword`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2985,6 +2985,7 @@ Style/CommentedKeyword:
   Description: 'Do not place comments on the same line as certain keywords.'
   Enabled: true
   VersionAdded: '0.51'
+  VersionChanged: <<next>>
 
 Style/ConditionalAssignment:
   Description: >-

--- a/lib/rubocop/cop/style/commented_keyword.rb
+++ b/lib/rubocop/cop/style/commented_keyword.rb
@@ -4,11 +4,14 @@ module RuboCop
   module Cop
     module Style
       # This cop checks for comments put on the same line as some keywords.
-      # These keywords are: `begin`, `class`, `def`, `end`, `module`.
+      # These keywords are: `class`, `module`, `def`, `begin`, `end`.
       #
       # Note that some comments
       # (`:nodoc:`, `:yields:`, `rubocop:disable` and `rubocop:todo`)
       # are allowed.
+      #
+      # Auto-correction removes comments from `end` keyword and keeps comments
+      # for `class`, `module`, `def` and `begin` above the keyword.
       #
       # @example
       #   # bad
@@ -34,16 +37,17 @@ module RuboCop
       #     y
       #   end
       class CommentedKeyword < Base
+        include RangeHelp
+        extend AutoCorrector
+
         MSG = 'Do not place comments on the same line as the ' \
               '`%<keyword>s` keyword.'
 
         def on_new_investigation
           processed_source.comments.each do |comment|
-            next unless (match = line(comment).match(/(?<keyword>\S+).*#/))
+            next unless (match = line(comment).match(/(?<keyword>\S+).*#/)) && offensive?(comment)
 
-            if offensive?(comment)
-              add_offense(comment, message: format(MSG, keyword: match[:keyword]))
-            end
+            register_offense(comment, match[:keyword])
           end
         end
 
@@ -59,6 +63,19 @@ module RuboCop
           rubocop:todo
         ].freeze
         ALLOWED_COMMENT_REGEXES = ALLOWED_COMMENTS.map { |c| /#\s*#{c}/ }.freeze
+
+        def register_offense(comment, matched_keyword)
+          add_offense(comment, message: format(MSG, keyword: matched_keyword)) do |corrector|
+            range = range_with_surrounding_space(range: comment.loc.expression, newlines: false)
+            corrector.remove(range)
+
+            unless matched_keyword == 'end'
+              corrector.insert_before(
+                range.source_buffer.line_range(comment.loc.line), "#{comment.text}\n"
+              )
+            end
+          end
+        end
 
         def offensive?(comment)
           line = line(comment)

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -789,9 +789,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
       def method
         # comment 1
+
         do_some_stuff
       rescue StandardError # comment 2
-        # comment 3
       end
     RUBY
     expect(IO.read('example.rb')).to eq(corrected)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1562,10 +1562,10 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           == example/example1.rb ==
           C:  3: 11: Metrics/ParameterLists: Avoid parameter lists longer than 5 parameters. [6/5]
           C:  3: 39: Naming/MethodParameterName: Method parameter must be at least 3 characters long.
-          C:  3: 46: Style/CommentedKeyword: Do not place comments on the same line as the def keyword.
+          C:  3: 46: [Correctable] Style/CommentedKeyword: Do not place comments on the same line as the def keyword.
           E:  3:121: Layout/LineLength: Line is too long. [130/120]
 
-          1 file inspected, 4 offenses detected
+          1 file inspected, 4 offenses detected, 1 offense auto-correctable
         RESULT
         expect($stderr.string).to eq('')
       end

--- a/spec/rubocop/cop/style/commented_keyword_spec.rb
+++ b/spec/rubocop/cop/style/commented_keyword_spec.rb
@@ -5,52 +5,86 @@ RSpec.describe RuboCop::Cop::Style::CommentedKeyword do
 
   let(:config) { RuboCop::Config.new }
 
-  it 'registers an offense when commenting on the same line as `end`' do
+  it 'registers an offense and corrects when commenting on the same line as `end`' do
     expect_offense(<<~RUBY)
       if x
         y
       end # comment
           ^^^^^^^^^ Do not place comments on the same line as the `end` keyword.
     RUBY
+
+    expect_correction(<<~RUBY)
+      if x
+        y
+      end
+    RUBY
   end
 
-  it 'registers an offense when commenting on the same line as `begin`' do
+  it 'registers an offense and corrects when commenting on the same line as `begin`' do
     expect_offense(<<~RUBY)
       begin # comment
             ^^^^^^^^^ Do not place comments on the same line as the `begin` keyword.
         y
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      # comment
+      begin
+        y
+      end
+    RUBY
   end
 
-  it 'registers an offense when commenting on the same line as `class`' do
+  it 'registers an offense and corrects when commenting on the same line as `class`' do
     expect_offense(<<~RUBY)
       class X # comment
               ^^^^^^^^^ Do not place comments on the same line as the `class` keyword.
         y
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      # comment
+      class X
+        y
+      end
+    RUBY
   end
 
-  it 'registers an offense when commenting on the same line as `module`' do
+  it 'registers an offense and corrects when commenting on the same line as `module`' do
     expect_offense(<<~RUBY)
       module X # comment
                ^^^^^^^^^ Do not place comments on the same line as the `module` keyword.
         y
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      # comment
+      module X
+        y
+      end
+    RUBY
   end
 
-  it 'registers an offense when commenting on the same line as `def`' do
+  it 'registers an offense and corrects when commenting on the same line as `def`' do
     expect_offense(<<~RUBY)
       def x # comment
             ^^^^^^^^^ Do not place comments on the same line as the `def` keyword.
         y
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      # comment
+      def x
+        y
+      end
+    RUBY
   end
 
-  it 'registers an offense when commenting on indented keywords' do
+  it 'registers an offense and corrects when commenting on indented keywords' do
     expect_offense(<<~RUBY)
       module X
         class Y # comment
@@ -59,21 +93,42 @@ RSpec.describe RuboCop::Cop::Style::CommentedKeyword do
         end
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      module X
+      # comment
+        class Y
+          z
+        end
+      end
+    RUBY
   end
 
-  it 'registers an offense when commenting after keyword with spaces' do
+  it 'registers an offense and corrects when commenting after keyword with spaces' do
     expect_offense(<<~RUBY)
       def x(a, b) # comment
                   ^^^^^^^^^ Do not place comments on the same line as the `def` keyword.
         y
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      # comment
+      def x(a, b)
+        y
+      end
+    RUBY
   end
 
-  it 'registers an offense for one-line cases' do
+  it 'registers an offense and corrects for one-line cases' do
     expect_offense(<<~RUBY)
-      def x; end # comment'
-                 ^^^^^^^^^^ Do not place comments on the same line as the `def` keyword.
+      def x; end # comment
+                 ^^^^^^^^^ Do not place comments on the same line as the `def` keyword.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # comment
+      def x; end
     RUBY
   end
 


### PR DESCRIPTION
This PR supports auto-correction for `Style/CommentedKeyword`.

 Auto-correction removes comments from `end` keyword and keeps comments for `class`, `module`, `def` and `begin` above the keyword.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
