### PR TITLE
Fix `Lint/AmbiguousRegexpLiteral` when regexp is in `=~` expression

### DIFF
--- a/changelog/fix_fix_lintambiguousregexpliteral_when.md
+++ b/changelog/fix_fix_lintambiguousregexpliteral_when.md
@@ -1,0 +1,1 @@
+* [#9245](https://github.com/rubocop-hq/rubocop/pull/9245): Fix `Lint/AmbiguousRegexpLiteral` when regexp is in `=~` expression. ([@h-lame][])

--- a/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
+++ b/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
@@ -53,7 +53,8 @@ module RuboCop
         def find_offense_node(node, regexp_receiver)
           return node unless node.parent
 
-          if (node.parent.send_type? && node.receiver) ||
+          if node.match_with_lvasgn_type? ||
+             (node.parent.send_type? && node.receiver) ||
              method_chain_to_regexp_receiver?(node, regexp_receiver)
             node = find_offense_node(node.parent, regexp_receiver)
           end

--- a/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
@@ -129,6 +129,28 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousRegexpLiteral do
           end
         RUBY
       end
+
+      it 'registers an offense when regexp is in an expression using the match operator' do
+        expect_offense(<<~RUBY)
+          p /pattern/ =~ some_string
+            ^ Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal, or add a whitespace to the right of the `/` if it should be a division.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          p(/pattern/ =~ some_string)
+        RUBY
+      end
+
+      it 'registers an offense when regexp is in an expression using the match operator and there are more arguments' do
+        expect_offense(<<~RUBY)
+          p /pattern/ =~ some_string, some_arg
+            ^ Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal, or add a whitespace to the right of the `/` if it should be a division.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          p(/pattern/ =~ some_string, some_arg)
+        RUBY
+      end
     end
 
     context 'with parentheses' do


### PR DESCRIPTION
## Expected behaviour

Rubocop can run `Lint/AmbiguousRegexpLiteral` cop on code where the regexp literal in the argument list is part of an expression with the `=~` operator.  For example:

```ruby
assert /some pattern/ =~ some_string, "Expected #{some_string} to contain some pattern details but it didn't"
```

## Actual behaviour

Rubocop reports an error when running `Lint/AmbiguousRegexpLiteral` on files with such a construct.

```
$ bundle exec rubocop --only Lint/AmbiguousRegexpLiteral offending_file.rb -d
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.6-compliant syntax, but you are running 2.6.5.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
For /path/to/rubocop: configuration from /path/to/rubocop/.rubocop.yml
configuration from /path/to/rubocop/.bundle/gems/ruby/2.6.0/gems/rubocop-performance-1.9.1/config/default.yml
configuration from /path/to/rubocop/.bundle/gems/ruby/2.6.0/gems/rubocop-performance-1.9.1/config/default.yml
Default configuration from /path/to/rubocop/config/default.yml
configuration from /path/to/rubocop/.bundle/gems/ruby/2.6.0/gems/rubocop-rspec-2.0.1/config/default.yml
configuration from /path/to/rubocop/.bundle/gems/ruby/2.6.0/gems/rubocop-rspec-2.0.1/config/default.yml
Inheriting configuration from /path/to/rubocop/.rubocop_todo.yml
Inspecting 1 file
Scanning /path/to/rubocop/offending_file.rb
An error occurred while Lint/AmbiguousRegexpLiteral cop was inspecting /path/to/rubocop/offending_file.rb.
undefined method `arguments' for #<RuboCop::AST::Node:0x00007fd70cb5b888>
Did you mean?  argument?
/path/to/rubocop/lib/rubocop/cop/util.rb:36:in `add_parentheses'
/path/to/rubocop/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb:38:in `block (2 levels) in on_new_investigation'
/path/to/rubocop/lib/rubocop/cop/base.rb:339:in `correct'
/path/to/rubocop/lib/rubocop/cop/base.rb:126:in `add_offense'
/path/to/rubocop/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb:37:in `block in on_new_investigation'
/path/to/rubocop/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb:32:in `each'
/path/to/rubocop/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb:32:in `on_new_investigation'
/path/to/rubocop/lib/rubocop/cop/commissioner.rb:157:in `block (2 levels) in invoke'
/path/to/rubocop/lib/rubocop/cop/commissioner.rb:166:in `with_cop_error_handling'
/path/to/rubocop/lib/rubocop/cop/commissioner.rb:156:in `block in invoke'
/path/to/rubocop/lib/rubocop/cop/commissioner.rb:155:in `each'
/path/to/rubocop/lib/rubocop/cop/commissioner.rb:155:in `invoke'
/path/to/rubocop/lib/rubocop/cop/commissioner.rb:84:in `investigate'
/path/to/rubocop/lib/rubocop/cop/team.rb:157:in `investigate_partial'
/path/to/rubocop/lib/rubocop/cop/team.rb:83:in `investigate'
/path/to/rubocop/lib/rubocop/runner.rb:315:in `inspect_file'
/path/to/rubocop/lib/rubocop/runner.rb:259:in `block in do_inspection_loop'
/path/to/rubocop/lib/rubocop/runner.rb:293:in `block in iterate_until_no_changes'
/path/to/rubocop/lib/rubocop/runner.rb:286:in `loop'
/path/to/rubocop/lib/rubocop/runner.rb:286:in `iterate_until_no_changes'
/path/to/rubocop/lib/rubocop/runner.rb:255:in `do_inspection_loop'
/path/to/rubocop/lib/rubocop/runner.rb:132:in `block in file_offenses'
/path/to/rubocop/lib/rubocop/runner.rb:157:in `file_offense_cache'
/path/to/rubocop/lib/rubocop/runner.rb:131:in `file_offenses'
/path/to/rubocop/lib/rubocop/runner.rb:122:in `process_file'
/path/to/rubocop/lib/rubocop/runner.rb:101:in `block in each_inspected_file'
/path/to/rubocop/lib/rubocop/runner.rb:100:in `each'
/path/to/rubocop/lib/rubocop/runner.rb:100:in `reduce'
/path/to/rubocop/lib/rubocop/runner.rb:100:in `each_inspected_file'
/path/to/rubocop/lib/rubocop/runner.rb:86:in `inspect_files'
/path/to/rubocop/lib/rubocop/runner.rb:47:in `run'
/path/to/rubocop/lib/rubocop/cli/command/execute_runner.rb:26:in `block in execute_runner'
/path/to/rubocop/lib/rubocop/cli/command/execute_runner.rb:52:in `with_redirect'
/path/to/rubocop/lib/rubocop/cli/command/execute_runner.rb:25:in `execute_runner'
/path/to/rubocop/lib/rubocop/cli/command/execute_runner.rb:17:in `run'
/path/to/rubocop/lib/rubocop/cli/command.rb:11:in `run'
/path/to/rubocop/lib/rubocop/cli/environment.rb:18:in `run'
/path/to/rubocop/lib/rubocop/cli.rb:65:in `run_command'
/path/to/rubocop/lib/rubocop/cli.rb:72:in `execute_runners'
/path/to/rubocop/lib/rubocop/cli.rb:41:in `run'
/path/to/rubocop/exe/rubocop:13:in `block in <top (required)>'
/path/to/.rubies/ruby-2.6.5/lib/ruby/2.6.0/benchmark.rb:308:in `realtime'
/path/to/rubocop/exe/rubocop:12:in `<top (required)>'
/path/to/rubocop/.bundle/gems/ruby/2.6.0/bin/rubocop:23:in `load'
/path/to/rubocop/.bundle/gems/ruby/2.6.0/bin/rubocop:23:in `<top (required)>'
/path/to/.rubies/ruby-2.6.5/lib/ruby/2.6.0/bundler/cli/exec.rb:74:in `load'
/path/to/.rubies/ruby-2.6.5/lib/ruby/2.6.0/bundler/cli/exec.rb:74:in `kernel_load'
/path/to/.rubies/ruby-2.6.5/lib/ruby/2.6.0/bundler/cli/exec.rb:28:in `run'
/path/to/.rubies/ruby-2.6.5/lib/ruby/2.6.0/bundler/cli.rb:463:in `exec'
/path/to/.rubies/ruby-2.6.5/lib/ruby/2.6.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/path/to/.rubies/ruby-2.6.5/lib/ruby/2.6.0/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/path/to/.rubies/ruby-2.6.5/lib/ruby/2.6.0/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/path/to/.rubies/ruby-2.6.5/lib/ruby/2.6.0/bundler/cli.rb:27:in `dispatch'
/path/to/.rubies/ruby-2.6.5/lib/ruby/2.6.0/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/path/to/.rubies/ruby-2.6.5/lib/ruby/2.6.0/bundler/cli.rb:18:in `start'
/path/to/.rubies/ruby-2.6.5/lib/ruby/gems/2.6.0/gems/bundler-1.17.2/exe/bundle:30:in `block in <top (required)>'
/path/to/.rubies/ruby-2.6.5/lib/ruby/2.6.0/bundler/friendly_errors.rb:124:in `with_friendly_errors'
/path/to/.rubies/ruby-2.6.5/lib/ruby/gems/2.6.0/gems/bundler-1.17.2/exe/bundle:22:in `<top (required)>'
/path/to/.rubies/ruby-2.6.5/bin/bundle:23:in `load'
/path/to/.rubies/ruby-2.6.5/bin/bundle:23:in `<main>'
.

1 file inspected, no offenses detected

1 error occurred:
An error occurred while Lint/AmbiguousRegexpLiteral cop was inspecting /path/to/rubocop/offending_file.rb.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop-hq/rubocop/issues

Mention the following information in the issue report:
1.6.1 (using Parser 2.7.2.0, rubocop-ast 1.3.0, running on ruby 2.6.5 x86_64-darwin18)
Finished in 0.3293909999774769 seconds
```

## Steps to reproduce the problem

1. Create a file `offending_file.rb` with contents as follows:

    ```ruby
    assert /some_pattern/ =~ some_string, "Expected #{some_string} to contain some pattern details but it didn't"
    ```

2. Run:

    ```shell
    $ bundle exec rubocop --only Lint/AmbiguousRegexpLiteral offending_file.rb
    ```

3. Observe error instead of offence output.

## RuboCop version

```
$ bundle exec rubocop -V
1.6.1 (using Parser 2.7.2.0, rubocop-ast 1.3.0, running on ruby 2.6.5 x86_64-darwin18)
  - rubocop-performance 1.9.1
  - rubocop-rspec 2.0.1
```

Note - I've provided this output using the master rubocop repo, although I identified it in an app using 1.6.1

## Fix description

The `find_offense_node` method walks up the AST from the regexp node to
find the method call to correct by making sure it has parentheses, but it
doesn't consider that the parent of the regexp node might be an `=~`
operator expression. This doesn't meet the conditions in the method for
continuing the search, so the method returns the `match_with_lvasgn` node
that represents the `=~` expression. As this isn't the kind of node that
the corrector method `add_parentheses` expects it doesn't have an
`arguments` method which `add_parentheses` will call. The solution is to
change the conditions in `find_offense_node` to continue the search if
the node we're looking at is an `match_with_lvasgn` node so we can find a
real `send_type` parent that we can call `arguments` on.

