### PR TITLE
[Fix #9225] Fix Style/LambdaCall ignoring further offenses after opposite style is detected

### DIFF
--- a/changelog/fix_bug_in_stylelambdacall.md
+++ b/changelog/fix_bug_in_stylelambdacall.md
@@ -1,0 +1,1 @@
+* [#9225](https://github.com/rubocop-hq/rubocop/issues/9225): Fix Style/LambdaCall ignoring further offenses after opposite style is detected. ([@sswander][])

--- a/lib/rubocop/cop/style/lambda_call.rb
+++ b/lib/rubocop/cop/style/lambda_call.rb
@@ -27,8 +27,9 @@ module RuboCop
         def on_send(node)
           return unless node.receiver
 
-          if offense?(node) && opposite_style_detected
+          if offense?(node)
             add_offense(node) do |corrector|
+              opposite_style_detected
               autocorrect(corrector, node)
             end
           else

--- a/spec/rubocop/cop/style/lambda_call_spec.rb
+++ b/spec/rubocop/cop/style/lambda_call_spec.rb
@@ -27,6 +27,22 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
         x.call(a, b)
       RUBY
     end
+
+    it 'registers an offense for correct + multiple opposite styles' do
+      expect_offense(<<~RUBY)
+        x.call(a, b)
+        x.(a, b)
+        ^^^^^^^^ Prefer the use of `lambda.call(...)` over `lambda.(...)`.
+        x.(a, b)
+        ^^^^^^^^ Prefer the use of `lambda.call(...)` over `lambda.(...)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.call(a, b)
+        x.call(a, b)
+        x.call(a, b)
+      RUBY
+    end
   end
 
   context 'when style is set to braces' do
@@ -51,6 +67,22 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
       RUBY
 
       expect_correction(<<~RUBY)
+        x.(a, b)
+        x.(a, b)
+      RUBY
+    end
+
+    it 'registers an offense for correct + multiple opposite styles' do
+      expect_offense(<<~RUBY)
+        x.call(a, b)
+        ^^^^^^^^^^^^ Prefer the use of `lambda.(...)` over `lambda.call(...)`.
+        x.(a, b)
+        x.call(a, b)
+        ^^^^^^^^^^^^ Prefer the use of `lambda.(...)` over `lambda.call(...)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.(a, b)
         x.(a, b)
         x.(a, b)
       RUBY


### PR DESCRIPTION
- The Style/LambdaCall Cop used to ignore all offenses after encountering an opposite style because during the first encounter, we set `no_acceptable_style!` and in the next iterations we early returned nil for `opposite_style_detected` check. This caused the Cop to never got around to adding the offense
- This PR fixes the behaviour by letting the Cop add the offense first before checking for `opposite_style_detected`
- This PR also updates tests to illustrate the multiple opposite style scenarios

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
