### PR TITLE
Fix a workaround for `Layout/RescueEnsureAlignment`

### DIFF
--- a/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
@@ -191,16 +191,9 @@ module RuboCop
         end
 
         def begin_end_alignment_style
-          # FIXME: Workaround for pending status for `Layout/BeginEndAlignment` cop
-          #        When RuboCop 1.0 is released, please replace it with the following condition.
-          #
-          # config.for_cop('Layout/BeginEndAlignment')['Enabled'] &&
-          #   config.for_cop('Layout/BeginEndAlignment')['EnforcedStyleAlignWith']
-          if config.for_all_cops['NewCops'] == 'enable' ||
-             config.for_cop('Layout/BeginEndAlignment')['Enabled'] &&
-             config.for_cop('Layout/BeginEndAlignment')['Enabled'] != 'pending'
-            config.for_cop('Layout/BeginEndAlignment')['EnforcedStyleAlignWith']
-          end
+          begin_end_alignment_conf = config.for_cop('Layout/BeginEndAlignment')
+
+          begin_end_alignment_conf['Enabled'] && begin_end_alignment_conf['EnforcedStyleAlignWith']
         end
       end
     end


### PR DESCRIPTION
This PR fixes a workaround for `Layout/RescueEnsureAlignment` due to `Layout/BeginEndAlignment` is enabled with RuboCop 1.0 release.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
