### PR TITLE
[Fix #8046] Fix an error for `Layout/HeredocArgumentClosingParenthesis`

### DIFF
--- a/changelog/fix_error_for_heredoc_argument_closing_parenthesis.md
+++ b/changelog/fix_error_for_heredoc_argument_closing_parenthesis.md
@@ -1,0 +1,1 @@
+* [#8046](https://github.com/rubocop-hq/rubocop/issues/8046): Fix an error for `Layout/HeredocArgumentClosingParenthesis` when there is an argument between a heredoc argument and the closing paretheses. ([@koic][])

--- a/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
+++ b/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
@@ -70,6 +70,7 @@ module RuboCop
           return unless outermost_send.loc.end
           return unless heredoc_arg.first_line != outermost_send.loc.end.line
           return if subsequent_closing_parentheses_in_same_line?(outermost_send)
+          return if exist_argument_between_heredoc_end_and_closing_parentheses?(node)
 
           add_offense(outermost_send.loc.end) do |corrector|
             autocorrect(corrector, outermost_send)
@@ -213,6 +214,19 @@ module RuboCop
           else
             end_pos
           end
+        end
+
+        def exist_argument_between_heredoc_end_and_closing_parentheses?(node)
+          return false unless (heredoc_end = find_most_bottom_of_heredoc_end(node.arguments))
+
+          heredoc_end < node.loc.end.begin_pos &&
+            range_between(heredoc_end, node.loc.end.begin_pos).source.strip != ''
+        end
+
+        def find_most_bottom_of_heredoc_end(arguments)
+          arguments.map do |argument|
+            argument.loc.heredoc_end.end_pos if argument.loc.respond_to?(:heredoc_end)
+          end.compact.max
         end
 
         # Internal trailing comma helpers.

--- a/spec/rubocop/cop/layout/heredoc_argument_closing_parenthesis_spec.rb
+++ b/spec/rubocop/cop/layout/heredoc_argument_closing_parenthesis_spec.rb
@@ -66,6 +66,18 @@ RSpec.describe RuboCop::Cop::Layout::HeredocArgumentClosingParenthesis do
       RUBY
     end
 
+    it 'accepts when there is an argument between a heredoc argument and the closing paretheses' do
+      expect_no_offenses(<<~RUBY)
+        foo(<<~TEXT,
+            Lots of
+            Lovely
+            Text
+          TEXT
+          some_arg: { foo: "bar" }
+        )
+      RUBY
+    end
+
     it 'accepts correct case with other param after' do
       expect_no_offenses(<<~RUBY)
         foo(<<-SQL, 123)


### PR DESCRIPTION
Fixes #8046.

This PR fixes an error for `Layout/HeredocArgumentClosingParenthesis` when existing an argument between heredoc of end and closing parentheses.

`Layout/HeredocArgumentClosingParenthesis` alone reproduced an error without being affected by other cops.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
