### PR TITLE
[Fix #9251] Fix extracted cop warning when the extension is loaded using `--require`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ InternalAffairs/NodeDestructuring:
 # Offense count: 48
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 192
+  Max: 193
 
 # Offense count: 198
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/changelog/fix_fix_extracted_gem_warning_when_the.md
+++ b/changelog/fix_fix_extracted_gem_warning_when_the.md
@@ -1,0 +1,1 @@
+* [#9251](https://github.com/rubocop-hq/rubocop/issues/9251): Fix extracted cop warning when the extension is loaded using `--require`. ([@dvandersluis][])

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -31,6 +31,7 @@ module RuboCop
 
       def clear_options
         @debug = nil
+        @loaded_features = []
         FileFinder.root_level = nil
       end
 
@@ -177,18 +178,21 @@ module RuboCop
         @loaded_features.flatten.compact
       end
 
-      private
-
-      def file_path(file)
-        File.absolute_path(file.is_a?(RemoteConfig) ? file.file : file)
-      end
-
+      # @api private
+      # Used to add features that were required inside a config or from
+      # the CLI using `--require`.
       def add_loaded_features(loaded_features)
         if instance_variable_defined?(:@loaded_features)
           instance_variable_get(:@loaded_features) << loaded_features
         else
           instance_variable_set(:@loaded_features, [loaded_features])
         end
+      end
+
+      private
+
+      def file_path(file)
+        File.absolute_path(file.is_a?(RemoteConfig) ? file.file : file)
       end
 
       def find_project_dotfile(target_dir)

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -66,7 +66,7 @@ module RuboCop
         add_configuration_options(opts)
         add_formatting_options(opts)
 
-        option(opts, '-r', '--require FILE') { |f| require f }
+        option(opts, '-r', '--require FILE') { |f| require_feature(f) }
 
         add_severity_option(opts)
         add_flags_with_optional_args(opts)
@@ -231,6 +231,13 @@ module RuboCop
       long_opt = args.find { |arg| arg.start_with?('--') }
       long_opt[2..-1].sub('[no-]', '').sub(/ .*/, '')
                      .tr('-', '_').gsub(/[\[\]]/, '').to_sym
+    end
+
+    def require_feature(file)
+      # If any features were added on the CLI from `--require`,
+      # add them to the config.
+      ConfigLoader.add_loaded_features(file)
+      require file
     end
   end
 

--- a/spec/rubocop/config_obsoletion_spec.rb
+++ b/spec/rubocop/config_obsoletion_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe RuboCop::ConfigObsoletion do
         end
       end
 
-      context 'when the extensions are loaded via inherit_gem' do
+      context 'when the extensions are loaded via inherit_gem', :restore_registry do
         let(:resolver) { RuboCop::ConfigLoaderResolver.new }
         let(:gem_root) { File.expand_path('gems') }
 
@@ -285,10 +285,6 @@ RSpec.describe RuboCop::ConfigObsoletion do
             'inherit_gem' => { 'rubocop-includes' => '.rubocop.yml' },
             'Performance/Casecmp' => { 'Enabled': true }
           }
-        end
-
-        around do |example|
-          RuboCop::Cop::Registry.with_temporary_global(RuboCop::Cop::Registry.new) { example.run }
         end
 
         before do


### PR DESCRIPTION
`ConfigObsoletion::ExtractedCop` looks for loaded features in the config, but features added using `--require` were not being added to `ConfigLoader.loaded_features`. Now they are!

Fixes #9251.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
