### PR TITLE
[Fix #9244] When a cop defined in an extension is explicitly enabled, ensure that it remains enabled.

### DIFF
--- a/changelog/fix_when_a_cop_defined_in_an_extension_is.md
+++ b/changelog/fix_when_a_cop_defined_in_an_extension_is.md
@@ -1,0 +1,1 @@
+* [#9244](https://github.com/rubocop-hq/rubocop/issues/9244): When a cop defined in an extension is explicitly enabled, ensure that it remains enabled. ([@dvandersluis][])

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -50,8 +50,8 @@ module RuboCop
       self
     end
 
-    def_delegators :@hash, :[], :[]=, :delete, :each, :key?, :keys, :each_key,
-                   :fetch, :map, :merge, :to_h, :to_hash, :transform_values
+    def_delegators :@hash, :[], :[]=, :delete, :dig, :each, :key?, :keys, :each_key,
+                   :fetch, :map, :merge, :replace, :to_h, :to_hash, :transform_values
     def_delegators :@validator, :validate, :target_ruby_version
 
     def to_s
@@ -281,6 +281,9 @@ module RuboCop
     end
 
     def enable_cop?(qualified_cop_name, cop_options)
+      # If the cop is explicitly enabled, the other checks can be skipped.
+      return true if cop_options['Enabled'] == true
+
       department = department_of(qualified_cop_name)
       cop_enabled = cop_options.fetch('Enabled') do
         !for_all_cops['DisabledByDefault']

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -774,9 +774,9 @@ RSpec.describe RuboCop::Config do
           }
         end
 
-        it 'still disables the cop' do
+        it 'the cop setting overrides the department' do
           cop_class = RuboCop::Cop::Layout::TrailingWhitespace
-          expect(cop_enabled(cop_class)).to be false
+          expect(cop_enabled(cop_class)).to be true
         end
       end
     end
@@ -790,7 +790,20 @@ RSpec.describe RuboCop::Config do
           }
         end
 
-        it 'still disables the cop' do
+        it 'the cop setting overrides the department' do
+          cop_class = 'Foo/Bar/BazCop'
+          expect(cop_enabled(cop_class)).to be true
+        end
+      end
+
+      context 'and an individual cop is not specified' do
+        let(:hash) do
+          {
+            'Foo/Bar' => { 'Enabled' => false }
+          }
+        end
+
+        it 'the cop setting overrides the department' do
           cop_class = 'Foo/Bar/BazCop'
           expect(cop_enabled(cop_class)).to be false
         end


### PR DESCRIPTION
With `DisabledByDefault: true` in a config, `Enabled: false` is automatically added to every key in the default configuration.

In normal operation, the configuration from any config files (including via inheritence) is then merged into that default configuration, so that if a cop is explicitly enabled it overrides the default disable (in `ConfigLoaderResolver#merge_with_default`). This works even if `inherit_from` or `inherit_gem` are specified.

However, extensions inject their configuration in when they are required, and the injection code that extensions use also calls `merge_with_default`. In that case, the **extension's** configuration gets merged into rubocop's default, which then becomes the default configuration (note, depending on how many extensions are `require`d by the user, this process may happen multiple times). When that configuration gets the local config merged into it with `DisabledByDefault: true`, if that extension's configuration had a department config key, it would get `Enabled: false` set on it. Then, when the specific cop is checked for if it's enabled, the department value would override the local value, and the cop would be disabled.

In order to fix this, cops with `Enabled: true` in their configuration after all the merging happens are always considered to be enabled, and the department is not checked. To facilitate this, when config files are being merged (either through inheritence or through `merge_with_default`), if a department is disabled any previously defined cops that are Enabled are flipped to be disabled (as expected, since configurations are meant to override other configurations they inherit from).

--- 

Example:

```yaml
# .rubocop.yml
require:
  - rubocop-rspec
  
AllCops:
  DisabledByDefault: true

RSpec/Focus:
  Enabled: true
```

Before:
```
$ rubocop test_spec.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
```

After:
```
$ rubocop test_spec.rb
Inspecting 1 file
C

Offenses:

test_spec.rb:31:3: C: RSpec/Focus: Focused spec found.
  fit 'does something' do
  ^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```

Fixes #9244.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
