### PR TITLE
docs: Add Mega-Linter in integration in other tools

### DIFF
--- a/docs/modules/ROOT/pages/integration_with_other_tools.adoc
+++ b/docs/modules/ROOT/pages/integration_with_other_tools.adoc
@@ -84,6 +84,19 @@ https://github.com/yujinakayama/guard-rubocop[guard-rubocop]. It
 allows you to automatically check Ruby code style with RuboCop when
 files are modified.
 
+== Mega-Linter integration
+
+You can use https://nvuillam.github.io/mega-linter/[Mega-Linter]
+to run rubocop automatically on every PR, and also lint all file
+types detected in your repository.
+
+Please follow
+https://nvuillam.github.io/mega-linter/installation[installation instructions]
+to have rubocop activated without additional configuration
+
+https://nvuillam.github.io/mega-linter/flavors/ruby/[Mega-Linter ruby flavor]
+is optimized for ruby linting
+
 == Rake integration
 
 To use RuboCop in your `Rakefile` add the following:


### PR DESCRIPTION
Add Mega-Linter in the list of Other Integration tools

If you have remarks about rubocop page in Mega-Linter documentation, please tell me :)
https://nvuillam.github.io/mega-linter/descriptors/ruby_rubocop/

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

Notes:
- Default Github commit message
- Not added changelog as it is just documentation
- No need tests as it is documentation

[1]: https://chris.beams.io/posts/git-commit/
