### PR TITLE
Fix calculation of cop department for nested departments

### DIFF
--- a/changelog/fix_fix_calculation_of_cop_department_for.md
+++ b/changelog/fix_fix_calculation_of_cop_department_for.md
@@ -1,0 +1,1 @@
+* [#9258](https://github.com/rubocop-hq/rubocop/pull/9258): Fix calculation of cop department for nested departments. ([@mvz][])

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -292,10 +292,10 @@ module RuboCop
     end
 
     def department_of(qualified_cop_name)
-      cop_department, cop_name = qualified_cop_name.split('/')
-      return nil if cop_name.nil?
+      *cop_department, _ = qualified_cop_name.split('/')
+      return nil if cop_department.empty?
 
-      self[cop_department]
+      self[cop_department.join('/')]
     end
   end
 end

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -781,6 +781,22 @@ RSpec.describe RuboCop::Config do
       end
     end
 
+    context 'when an nested cop department is disabled' do
+      context 'but an individual cop is enabled' do
+        let(:hash) do
+          {
+            'Foo/Bar' => { 'Enabled' => false },
+            'Foo/Bar/BazCop' => { 'Enabled' => true }
+          }
+        end
+
+        it 'still disables the cop' do
+          cop_class = 'Foo/Bar/BazCop'
+          expect(cop_enabled(cop_class)).to be false
+        end
+      end
+    end
+
     context 'when an entire cop department is enabled' do
       context 'but an individual cop is disabled' do
         let(:hash) do


### PR DESCRIPTION
This fixes an issue I ran into with rubocop-i18n. This gem provides two nested departments, I18n/RailsI18n and I18n/GetText. The intent is to enable one and disable the other. However, disabling a department would not disable its cops.

I tracked this issue down to how RuboCop::Config calculates a cops department before looking at that department's configuration: It only considers the part before the first `/`.

This pull request changes this method by considering instead all parts before the last `/`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/