### PR TITLE
[Fix #9257] Fix false positive for `Style/SymbolProc` when the block uses a variable from outside the block

### DIFF
--- a/changelog/fix_fix_false_positive_for_stylesymbolproc.md
+++ b/changelog/fix_fix_false_positive_for_stylesymbolproc.md
@@ -1,0 +1,1 @@
+* [#9257](https://github.com/rubocop-hq/rubocop/issues/9257): Fix false positive for `Style/SymbolProc` when the block uses a variable from outside the block. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -22,11 +22,12 @@ module RuboCop
         SUPER_TYPES = %i[super zsuper].freeze
 
         def_node_matcher :proc_node?, '(send (const {nil? cbase} :Proc) :new)'
+        def_node_matcher :symbol_proc_receiver?, '{(send ...) (super ...) zsuper}'
         def_node_matcher :symbol_proc?, <<~PATTERN
-          ({block numblock}
-            ${(send ...) (super ...) zsuper}
-            ${(args (arg _)) 1}
-            (send (lvar _var) $_))
+          {
+            (block $#symbol_proc_receiver? $(args (arg _var)) (send (lvar _var) $_))
+            (numblock $#symbol_proc_receiver? $1 (send (lvar :_1) $_))
+          }
         PATTERN
 
         def self.autocorrect_incompatible_with

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -90,6 +90,17 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
     expect_no_offenses('something { |x,| x.first }')
   end
 
+  it 'accepts a block with an unused argument with an method call' do
+    expect_no_offenses('something { |_x| y.call }')
+  end
+
+  it 'accepts a block with an unused argument with an lvar' do
+    expect_no_offenses(<<~RUBY)
+      y = Y.new
+      something { |_x| y.call }
+    RUBY
+  end
+
   context 'when the method has arguments' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
The changes in #9127 to keep the node pattern DRY accidentally broke the check that the lvar matches the argument name.

Fixes #9257.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
