### PR TITLE
Support auto-correction for `Style/MultilineMethodSignature`

### DIFF
--- a/changelog/new_support_autocorrect_for_multiline_method_signature.md
+++ b/changelog/new_support_autocorrect_for_multiline_method_signature.md
@@ -1,0 +1,1 @@
+* [#9260](https://github.com/rubocop-hq/rubocop/pull/9260): Support auto-correction for `Style/MultilineMethodSignature`. ([@koic][])

--- a/lib/rubocop/cop/style/multiline_method_signature.rb
+++ b/lib/rubocop/cop/style/multiline_method_signature.rb
@@ -19,6 +19,9 @@ module RuboCop
       #   end
       #
       class MultilineMethodSignature < Base
+        include RangeHelp
+        extend AutoCorrector
+
         MSG = 'Avoid multi-line method signatures.'
 
         def on_def(node)
@@ -26,11 +29,33 @@ module RuboCop
           return if opening_line(node) == closing_line(node)
           return if correction_exceeds_max_line_length?(node)
 
-          add_offense(node)
+          add_offense(node) do |corrector|
+            autocorrect(corrector, node)
+          end
         end
         alias on_defs on_def
 
         private
+
+        def autocorrect(corrector, node)
+          arguments = node.arguments
+          joined_arguments = arguments.map(&:source).join(', ')
+          last_line_source_of_arguments = processed_source[arguments.last_line - 1].strip
+
+          if last_line_source_of_arguments.start_with?(')')
+            joined_arguments = "#{joined_arguments}#{last_line_source_of_arguments}"
+
+            corrector.remove(range_by_whole_lines(arguments.loc.end, include_final_newline: true))
+          end
+
+          corrector.replace(arguments_range(node), joined_arguments)
+        end
+
+        def arguments_range(node)
+          range_between(
+            node.first_argument.source_range.begin_pos, node.last_argument.source_range.end_pos
+          )
+        end
 
         def opening_line(node)
           node.first_line

--- a/spec/rubocop/cop/style/multiline_method_signature_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_signature_spec.rb
@@ -3,11 +3,16 @@
 RSpec.describe RuboCop::Cop::Style::MultilineMethodSignature, :config do
   context 'when arguments span a single line' do
     context 'when defining an instance method' do
-      it 'registers an offense when closing paren is on the following line' do
+      it 'registers an offense and corrects when closing paren is on the following line' do
         expect_offense(<<~RUBY)
           def foo(bar
           ^^^^^^^^^^^ Avoid multi-line method signatures.
               )
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo(bar)
           end
         RUBY
       end
@@ -31,11 +36,16 @@ RSpec.describe RuboCop::Cop::Style::MultilineMethodSignature, :config do
 
     context 'when defining an class method' do
       context 'when arguments span a single line' do
-        it 'registers an offense when closing paren is on the following line' do
+        it 'registers an offense and corrects when closing paren is on the following line' do
           expect_offense(<<~RUBY)
             def self.foo(bar
             ^^^^^^^^^^^^^^^^ Avoid multi-line method signatures.
                 )
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            def self.foo(bar)
             end
           RUBY
         end
@@ -61,39 +71,83 @@ RSpec.describe RuboCop::Cop::Style::MultilineMethodSignature, :config do
 
   context 'when arguments span multiple lines' do
     context 'when defining an instance method' do
-      it 'registers an offense when `end` is on the following line' do
+      it 'registers an offense and corrects when `end` is on the following line' do
         expect_offense(<<~RUBY)
           def foo(bar,
           ^^^^^^^^^^^^ Avoid multi-line method signatures.
                   baz)
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          def foo(bar, baz)
+          end
+        RUBY
       end
 
-      it 'registers an offense when `end` is on the same line' do
+      it 'registers an offense and corrects when `end` is on the same line with last arguemnt' do
         expect_offense(<<~RUBY)
           def foo(bar,
           ^^^^^^^^^^^^ Avoid multi-line method signatures.
                   baz); end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo(bar, baz); end
+        RUBY
+      end
+
+      it 'registers an offense and corrects when `end` is on the same line with only closing parentheses' do
+        expect_offense(<<~RUBY)
+          def foo(bar,
+          ^^^^^^^^^^^^ Avoid multi-line method signatures.
+                  baz
+                 ); end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo(bar, baz); end
         RUBY
       end
     end
 
     context 'when defining an class method' do
-      it 'registers an offense when `end` is on the following line' do
+      it 'registers an offense and corrects when `end` is on the following line' do
         expect_offense(<<~RUBY)
           def self.foo(bar,
           ^^^^^^^^^^^^^^^^^ Avoid multi-line method signatures.
                   baz)
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          def self.foo(bar, baz)
+          end
+        RUBY
       end
 
-      it 'registers an offense when `end` is on the same line' do
+      it 'registers an offense and corrects when `end` is on the same line' do
         expect_offense(<<~RUBY)
           def self.foo(bar,
           ^^^^^^^^^^^^^^^^^ Avoid multi-line method signatures.
                   baz); end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def self.foo(bar, baz); end
+        RUBY
+      end
+
+      it 'registers an offense and corrects when `end` is on the same line with only closing parentheses' do
+        expect_offense(<<~RUBY)
+          def self.foo(bar,
+          ^^^^^^^^^^^^^^^^^ Avoid multi-line method signatures.
+                  baz
+              ); end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def self.foo(bar, baz); end
         RUBY
       end
     end
@@ -121,11 +175,17 @@ RSpec.describe RuboCop::Cop::Style::MultilineMethodSignature, :config do
         }
       end
 
-      it 'registers an offense' do
+      it 'registers an offense and corrects' do
         expect_offense(<<~RUBY)
           def foo(bar,
           ^^^^^^^^^^^^ Avoid multi-line method signatures.
                   baz)
+            qux.qux
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo(bar, baz)
             qux.qux
           end
         RUBY


### PR DESCRIPTION
This PR supports auto-correction for `Style/MultilineMethodSignature`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
