### PR TITLE
Fix Style/MultilineWhenThen cop to correct when one line has multiple condidate values

### DIFF
--- a/changelog/fix_an_incorrect_for_multiline_when_then.md
+++ b/changelog/fix_an_incorrect_for_multiline_when_then.md
@@ -1,0 +1,1 @@
+* [#9261](https://github.com/rubocop-hq/rubocop/pull/9261): Fix an incorrect auto-correct for `Style/MultilineWhenThen` when one line for multiple condidate values of `when` statement. ([@makicamel][])

--- a/lib/rubocop/cop/style/multiline_when_then.rb
+++ b/lib/rubocop/cop/style/multiline_when_then.rb
@@ -58,7 +58,9 @@ module RuboCop
         private
 
         def require_then?(when_node)
-          return true if when_node.conditions.count >= 2
+          unless when_node.conditions.first.first_line == when_node.conditions.last.last_line
+            return true
+          end
           return false unless when_node.body
 
           when_node.loc.line == when_node.body.loc.line

--- a/spec/rubocop/cop/style/multiline_when_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_when_then_spec.rb
@@ -137,6 +137,21 @@ RSpec.describe RuboCop::Cop::Style::MultilineWhenThen do
     RUBY
   end
 
+  it 'registers an offense when one line for multiple condidate values of `when`' do
+    expect_offense(<<~RUBY)
+      case foo
+      when bar, baz then
+                    ^^^^ Do not use `then` for multiline `when` statement.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      case foo
+      when bar, baz
+      end
+    RUBY
+  end
+
   it 'does not register an offense when line break for multiple condidate values of `when`' do
     expect_no_offenses(<<~RUBY)
       case foo


### PR DESCRIPTION
I found not autocorrecting with Style/MultilineWhenThen cop.

```ruby
# original
case foo
when bar, baz then

# expected
case foo
when bar, baz

# actually
case foo
when bar, baz then
```

In version 0.91.0 correctly corrected, in version 0.91.1 not corrected, from #8750.
Multiple condition values may be in one line, so fixed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
