### PR TITLE
Use new expect_offense instead of old inspect_source in all remaining specs

### DIFF
--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -91,15 +91,6 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       RUBY
     end
 
-    it "doesn't fail on unary operators" do
-      expect { inspect_source(<<~RUBY) }.not_to raise_error
-        def foo
-          !0
-          .nil?
-        end
-      RUBY
-    end
-
     it "doesn't crash on unaligned multiline lambdas" do
       expect_no_offenses(<<~RUBY)
         MyClass.(my_args)
@@ -229,6 +220,16 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
 
     include_examples 'common'
     include_examples 'common for aligned and indented'
+
+    it "doesn't fail on unary operators" do
+      expect_offense(<<~RUBY)
+        def foo
+          !0
+          .nil?
+          ^^^^^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
+        end
+      RUBY
+    end
 
     # We call it semantic alignment when a dot is aligned with the first dot in
     # a chain of calls, and that first dot does not begin its line.
@@ -636,6 +637,16 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     include_examples 'common'
     include_examples 'both indented* styles'
 
+    it "doesn't fail on unary operators" do
+      expect_offense(<<~RUBY)
+        def foo
+          !0
+          .nil?
+          ^^^^^ Indent `.nil?` 2 spaces more than `0` on line 2.
+        end
+      RUBY
+    end
+
     it 'accepts correctly indented methods in operation' do
       expect_no_offenses(<<~RUBY)
         1 + a
@@ -787,6 +798,16 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     include_examples 'common'
     include_examples 'common for aligned and indented'
     include_examples 'both indented* styles'
+
+    it "doesn't fail on unary operators" do
+      expect_offense(<<~RUBY)
+        def foo
+          !0
+          .nil?
+          ^^^^^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
+        end
+      RUBY
+    end
 
     it 'accepts correctly indented methods in operation' do
       expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/layout/trailing_empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_empty_lines_spec.rb
@@ -54,24 +54,28 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
     end
 
     it 'registers an offense for no final newline after assignment' do
-      offenses = inspect_source('x = 0')
-
-      expect(offenses.first.message).to eq('Final newline missing.')
+      expect { expect_no_offenses('x = 0') }.to raise_error(
+        RSpec::Expectations::ExpectationNotMetError,
+        /Final newline missing/
+      )
     end
 
     it 'registers an offense for no final newline after block comment' do
-      offenses = inspect_source("#{<<~RUBY}=end")
-        puts 'testing rubocop when final new line is missing
-                                  after block comments'
+      expect do
+        expect_no_offenses(<<~RUBY.chomp)
+          puts 'testing rubocop when final new line is missing
+                                    after block comments'
 
-        =begin
-        first line
-        second line
-        third line
-
-      RUBY
-
-      expect(offenses.first.message).to eq('Final newline missing.')
+          =begin
+          first line
+          second line
+          third line
+          =end
+        RUBY
+      end.to raise_error(
+        RSpec::Expectations::ExpectationNotMetError,
+        /Final newline missing/
+      )
     end
 
     it 'auto-corrects even if some lines have space' do
@@ -91,11 +95,10 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'final_blank_line' } }
 
     it 'registers an offense for final newline' do
-      offenses = inspect_source(<<~RUBY)
-        x = 0
-      RUBY
-
-      expect(offenses.first.message).to eq('Trailing blank line missing.')
+      expect { expect_no_offenses("x = 0\n") }.to raise_error(
+        RSpec::Expectations::ExpectationNotMetError,
+        /Trailing blank line missing./
+      )
     end
 
     it 'registers an offense for multiple trailing blank lines' do
@@ -129,8 +132,10 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
     end
 
     it 'registers an offense for no final newline' do
-      offenses = inspect_source('x = 0')
-      expect(offenses.first.message).to eq('Final newline missing.')
+      expect { expect_no_offenses('x = 0') }.to raise_error(
+        RSpec::Expectations::ExpectationNotMetError,
+        /Final newline missing./
+      )
     end
 
     it 'accepts final blank line' do


### PR DESCRIPTION
Part of https://github.com/rubocop-hq/rubocop/issues/8127

- In trailing empty lines specs use `expect_no_offenses` and `raise_error` for offense message checking.
- In indention specs inline specs from shared example because they have different messages.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
