### PR TITLE
Add source to `expect_correction` as dependency

### DIFF
--- a/spec/rubocop/cop/layout/trailing_empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_empty_lines_spec.rb
@@ -143,18 +143,14 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
     end
 
     it 'auto-corrects missing blank line' do
-      new_source = autocorrect_source(<<~RUBY)
-        x = 0
-      RUBY
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY, source: "x = 0\n")
         x = 0
 
       RUBY
     end
 
     it 'auto-corrects missing newline' do
-      new_source = autocorrect_source('x = 0')
-      expect(new_source).to eq(<<~RUBY)
+      expect_correction(<<~RUBY, source: 'x = 0')
         x = 0
 
       RUBY


### PR DESCRIPTION
Part of https://github.com/rubocop-hq/rubocop/issues/8127

Add source to `expect_correction` as dependency when there is no `expect_offense` before. It useful for testing examples where we don't able to specify source using `expect_offense`. For example in specs with missing newline.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
