### PR TITLE
[Fix #9262] Update `Style/CollectionMethods` to be handle additional arguments and methods that accept a symbol instead of a block

### DIFF
--- a/changelog/change_update_stylecollectionmethods_to_be.md
+++ b/changelog/change_update_stylecollectionmethods_to_be.md
@@ -1,0 +1,1 @@
+* [#9262](https://github.com/rubocop-hq/rubocop/issues/9262): Update `Style/CollectionMethods` to be handle additional arguments and methods that accept a symbol instead of a block. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2916,7 +2916,7 @@ Style/CollectionMethods:
   StyleGuide: '#map-find-select-reduce-include-size'
   Enabled: false
   VersionAdded: '0.9'
-  VersionChanged: '0.27'
+  VersionChanged: <<next>>
   Safe: false
   # Mapping from undesired method to desired method
   # e.g. to use `detect` over `find`:
@@ -2931,6 +2931,11 @@ Style/CollectionMethods:
     detect: 'find'
     find_all: 'select'
     member?: 'include?'
+  # Methods in this array accept a final symbol as an implicit block
+  # eg. `inject(:+)`
+  MethodsAcceptingSymbol:
+    - inject
+    - reduce
 
 Style/ColonMethodCall:
   Description: 'Do not use :: for method call.'

--- a/lib/rubocop/cop/style/collection_methods.rb
+++ b/lib/rubocop/cop/style/collection_methods.rb
@@ -48,7 +48,7 @@ module RuboCop
         end
 
         def on_send(node)
-          return unless node.arguments.one? && node.first_argument.block_pass_type?
+          return unless implicit_block?(node)
 
           check_method_node(node)
         end
@@ -64,8 +64,21 @@ module RuboCop
           end
         end
 
+        def implicit_block?(node)
+          return false unless node.arguments.any?
+
+          node.last_argument.block_pass_type? ||
+            node.last_argument.sym_type? && methods_accepting_symbol.include?(node.method_name.to_s)
+        end
+
         def message(node)
           format(MSG, prefer: preferred_method(node.method_name), current: node.method_name)
+        end
+
+        # Some enumerable methods accept a bare symbol (ie. _not_ Symbol#to_proc) instead
+        # of a block.
+        def methods_accepting_symbol
+          Array(cop_config['MethodsAcceptingSymbol'])
         end
       end
     end

--- a/spec/rubocop/cop/style/collection_methods_spec.rb
+++ b/spec/rubocop/cop/style/collection_methods_spec.rb
@@ -36,15 +36,58 @@ RSpec.describe RuboCop::Cop::Style::CollectionMethods, :config do
       RUBY
     end
 
-    it "accepts #{method} with more than 1 param" do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].#{method}(other, &:test)
+    it "registers an offense for #{method} with an argument and proc param" do
+      expect_offense(<<~RUBY, method: method)
+        [1, 2, 3].%{method}(0, &:test)
+                  ^{method} Prefer `#{preferred_method}` over `#{method}`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [1, 2, 3].#{preferred_method}(0, &:test)
       RUBY
     end
 
     it "accepts #{method} without a block" do
       expect_no_offenses(<<~RUBY)
         [1, 2, 3].#{method}
+      RUBY
+    end
+  end
+
+  context 'for methods that accept a symbol as implicit block' do
+    it 'registers an offense with a final symbol param' do
+      expect_offense(<<~RUBY)
+        [1, 2, 3].inject(:+)
+                  ^^^^^^ Prefer `reduce` over `inject`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [1, 2, 3].reduce(:+)
+      RUBY
+    end
+
+    it 'registers an offense with an argument and final symbol param' do
+      expect_offense(<<~RUBY)
+        [1, 2, 3].inject(0, :+)
+                  ^^^^^^ Prefer `reduce` over `inject`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [1, 2, 3].reduce(0, :+)
+      RUBY
+    end
+  end
+
+  context 'for methods that do not accept a symbol as implicit block' do
+    it 'does not register an offense for a final symbol param' do
+      expect_no_offenses(<<~RUBY)
+        [1, 2, 3].collect(:+)
+      RUBY
+    end
+
+    it 'does not register an offense for a final symbol param with extra args' do
+      expect_no_offenses(<<~RUBY)
+        [1, 2, 3].collect(0, :+)
       RUBY
     end
   end


### PR DESCRIPTION
The `Style/CollectionMethods` cop previously was not accepting anything that had additional arguments (since the first iteration it seems), so this is now a bit more permissive (we should watch for false positives). Additionally, some methods accept a symbol instead of a block/proc argument. For example, `inject`/`reduce` have accepted a final symbol since 1.9.0.

Fixes #9262.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
