### PR TITLE
[Fix #9245] Fix `Lint/AmbiguousRegexpLiteral` when given a `match_with_lvasgn` node

### DIFF
--- a/changelog/fix_fix_lintambiguousregexpliteral_when.md
+++ b/changelog/fix_fix_lintambiguousregexpliteral_when.md
@@ -1,0 +1,1 @@
+* [#9245](https://github.com/rubocop-hq/rubocop/issues/9245): Fix `Lint/AmbiguousRegexpLiteral` when given a `match_with_lvasgn` node. ([@dvandersluis][])

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -33,7 +33,9 @@ module RuboCop
       end
 
       def add_parentheses(node, corrector)
-        if node.arguments.empty?
+        if !node.respond_to?(:arguments)
+          corrector.wrap(node, '(', ')')
+        elsif node.arguments.empty?
           corrector.insert_after(node, '()')
         else
           corrector.replace(args_begin(node), '(')

--- a/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
@@ -136,5 +136,37 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousRegexpLiteral do
         expect_no_offenses('p(/pattern/)')
       end
     end
+
+    context 'with `match_with_lvasgn` node' do
+      context 'with parentheses' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            assert(/some pattern/ =~ some_string)
+          RUBY
+        end
+      end
+
+      context 'with different parentheses' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            assert(/some pattern/) =~ some_string
+          RUBY
+        end
+      end
+
+      context 'without parentheses' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            assert /some pattern/ =~ some_string
+                   ^ Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal, or add a whitespace to the right of the `/` if it should be a division.
+          RUBY
+
+          # Spacing will be fixed by `Lint/ParenthesesAsGroupedExpression`.
+          expect_correction(<<~RUBY)
+            assert (/some pattern/ =~ some_string)
+          RUBY
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
`Cop::Util#add_parentheses` expected every node to have arguments, but `match_with_lvasgn` does not. This will not correct spaces properly (see the tests), but it will be picked up by `Lint/ParenthesesAsGroupedExpression`.

Fixes #9245.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
