### PR TITLE
Revert "Specify Code Climate Test Reporter 0.7.0 as a workaround"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,12 +196,9 @@ jobs:
     steps:
       - run:
           name: Download Code Climate test-reporter
-          # Specify Code Climate Test Reporter 0.7.0 as a workaround to prevent
-          # `cannot execute binary file: Exec format error`.
-          # See: https://github.com/codeclimate/test-reporter/issues/449
           command: |
             mkdir -p tmp/
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-0.7.0-linux-amd64 > ./tmp/cc-test-reporter
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./tmp/cc-test-reporter
             chmod +x ./tmp/cc-test-reporter
       - persist_to_workspace:
           root: tmp


### PR DESCRIPTION
This reverts commit e476dbbab182ead247f09793f50defb7a2f8c6f4.

https://github.com/codeclimate/test-reporter/issues/449 has been resolved.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
