### PR TITLE
Inline and remove spec helper inspect_source_file

### DIFF
--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -9,10 +9,6 @@ module CopHelper
   let(:ruby_version) { 2.4 }
   let(:rails_version) { false }
 
-  def inspect_source_file(source)
-    Tempfile.open('tmp') { |f| inspect_source(source, f) }
-  end
-
   def inspect_source(source, file = nil)
     RuboCop::Formatter::DisabledConfigFormatter.config_to_allow_offenses = {}
     RuboCop::Formatter::DisabledConfigFormatter.detected_styles = {}

--- a/spec/rubocop/cop/layout/end_of_line_spec.rb
+++ b/spec/rubocop/cop/layout/end_of_line_spec.rb
@@ -14,11 +14,19 @@ RSpec.describe RuboCop::Cop::Layout::EndOfLine, :config do
       # be moved somewhere more general ?
       # Also working with encodings is actually the responsibility of
       # 'whitequark/parser' gem, not Rubocop itself so these test really belongs there(?)
-      offenses = inspect_source_file(<<~RUBY)
+
+      encoding = 'iso-8859-15'
+      input = (+<<~RUBY).force_encoding(encoding)
         # coding: ISO-8859-15#{eol}
         # Euro symbol: \xa4#{eol}
       RUBY
-      expect(offenses.size).to eq(1)
+
+      expect do
+        Tempfile.open('tmp', encoding: encoding) { |f| expect_no_offenses(input, f) }
+      end.to raise_error(
+        RSpec::Expectations::ExpectationNotMetError,
+        /Carriage return character (detected|missing)./
+      )
     end
   end
 


### PR DESCRIPTION
Part of https://github.com/rubocop-hq/rubocop/issues/8127

- Inline and remove spec helper inspect_source_file because it is used only in one place

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
