### PR TITLE
[Fix #9274] Fix error in `Metrics/ClassLength` when the class only contains comments.

### DIFF
--- a/changelog/fix_fix_error_in_metricsclasslength_when_the.md
+++ b/changelog/fix_fix_error_in_metricsclasslength_when_the.md
@@ -1,0 +1,1 @@
+* [#9274](https://github.com/rubocop-hq/rubocop/issues/9274): Fix error in `Metrics/ClassLength` when the class only contains comments. ([@dvandersluis][])

--- a/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
@@ -124,7 +124,7 @@ module RuboCop
           end
 
           def classlike_node?(node)
-            CLASSLIKE_TYPES.include?(node.type)
+            CLASSLIKE_TYPES.include?(node&.type)
           end
 
           def foldable_node?(node)

--- a/spec/rubocop/cop/metrics/class_length_spec.rb
+++ b/spec/rubocop/cop/metrics/class_length_spec.rb
@@ -134,6 +134,21 @@ RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
     end
   end
 
+  context 'when CountComments is disabled' do
+    it 'accepts classes that only contain comments' do
+      expect_no_offenses(<<~RUBY)
+        class Test
+          # comment
+          # comment
+          # comment
+          # comment
+          # comment
+          # comment
+        end
+      RUBY
+    end
+  end
+
   context 'when CountComments is enabled' do
     before { cop_config['CountComments'] = true }
 
@@ -147,6 +162,20 @@ RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
           #a = 4
           a = 5
           a = 6
+        end
+      RUBY
+    end
+
+    it 'registers an offense for a class that only contains comments' do
+      expect_offense(<<~RUBY)
+        class Test
+        ^^^^^^^^^^ Class has too many lines. [6/5]
+          # comment
+          # comment
+          # comment
+          # comment
+          # comment
+          # comment
         end
       RUBY
     end


### PR DESCRIPTION
Fixes #9274.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
