### PR TITLE
Add support for endless methods to `Style/SingleLineMethods`.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -87,7 +87,7 @@ desc 'Syntax check for the documentation comments'
 task documentation_syntax_check: :yard_for_generate_documentation do
   require 'parser/ruby25'
   require 'parser/ruby26'
-  require 'parser/ruby27'
+  require 'parser/ruby30'
 
   ok = true
   YARD::Registry.load!
@@ -115,7 +115,7 @@ task documentation_syntax_check: :yard_for_generate_documentation do
                  elsif cop == RuboCop::Cop::Lint::CircularArgumentReference
                    Parser::Ruby26.new(RuboCop::AST::Builder.new)
                  else
-                   Parser::Ruby27.new(RuboCop::AST::Builder.new)
+                   Parser::Ruby30.new(RuboCop::AST::Builder.new)
                  end
         parser.diagnostics.all_errors_are_fatal = true
         parser.parse(buffer)

--- a/changelog/fix_add_support_for_endless_methods_to.md
+++ b/changelog/fix_add_support_for_endless_methods_to.md
@@ -1,0 +1,1 @@
+* [#9276](https://github.com/rubocop-hq/rubocop/pull/9276): Add support for endless methods to `Style/SingleLineMethods`. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4316,7 +4316,7 @@ Style/SingleLineMethods:
   StyleGuide: '#no-single-line-methods'
   Enabled: true
   VersionAdded: '0.9'
-  VersionChanged: '0.19'
+  VersionChanged: <<next>>
   AllowIfMethodIsEmpty: true
 
 Style/SlicingWithRange:

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -6,6 +6,8 @@ module RuboCop
       # This cop checks for single-line method definitions that contain a body.
       # It will accept single-line methods with no body.
       #
+      # Endless methods added in Ruby 3.0 are also accepted by this cop.
+      #
       # @example
       #   # bad
       #   def some_method; body end
@@ -15,6 +17,7 @@ module RuboCop
       #   # good
       #   def self.resource_class=(klass); end
       #   def @table.columns; end
+      #   def some_method() = body
       #
       # @example AllowIfMethodIsEmpty: true (default)
       #   # good
@@ -32,6 +35,7 @@ module RuboCop
 
         def on_def(node)
           return unless node.single_line?
+          return if node.endless?
           return if allow_empty? && !node.body
 
           add_offense(node) do |corrector|

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -149,4 +149,12 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods do
       |  end
     RUBY
   end
+
+  context 'endless methods', :ruby30 do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        def some_method() = x
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
`Style/SingleLineMethods` would raise an error when encountering a Ruby 3.0 endless method. I updated it to ignore single line methods (and I am working on a new cop for endless methods).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
