### PR TITLE
Fix `Layout/EmptyLineBetweenDefs` error with endless methods

### DIFF
--- a/changelog/fix_fix_layoutemptylinebetweendefs_error.md
+++ b/changelog/fix_fix_layoutemptylinebetweendefs_error.md
@@ -1,0 +1,1 @@
+* [#9277](https://github.com/rubocop-hq/rubocop/pull/9277): Fix `Layout/EmptyLineBetweenDefs` error with endless method definitions. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -473,7 +473,7 @@ Layout/EmptyLineBetweenDefs:
   StyleGuide: '#empty-lines-between-methods'
   Enabled: true
   VersionAdded: '0.49'
-  VersionChanged: '1.4'
+  VersionChanged: <<next>>
   EmptyLineBetweenMethodDefs: true
   EmptyLineBetweenClassDefs: true
   EmptyLineBetweenModuleDefs: true

--- a/lib/rubocop/cop/layout/empty_line_between_defs.rb
+++ b/lib/rubocop/cop/layout/empty_line_between_defs.rb
@@ -121,8 +121,8 @@ module RuboCop
 
         def autocorrect(corrector, prev_def, node)
           # finds position of first newline
-          end_pos = prev_def.loc.end.end_pos
-          source_buffer = prev_def.loc.end.source_buffer
+          end_pos = end_loc(prev_def).end_pos
+          source_buffer = end_loc(prev_def).source_buffer
           newline_pos = source_buffer.source.index("\n", end_pos)
 
           # Handle the case when multiple one-liners are on the same line.
@@ -206,7 +206,15 @@ module RuboCop
         end
 
         def def_end(node)
-          node.loc.end.line
+          end_loc(node).line
+        end
+
+        def end_loc(node)
+          if node.def_type? && node.endless?
+            node.loc.expression.end
+          else
+            node.loc.end
+          end
         end
 
         def autocorrect_remove_lines(corrector, newline_pos, count)

--- a/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
@@ -532,4 +532,73 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
       RUBY
     end
   end
+
+  context 'endless methods', :ruby30 do
+    context 'between endless and regular methods' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          def foo() = x
+          def bar
+          ^^^^^^^ Use empty lines between method definitions.
+            y
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo() = x
+
+          def bar
+            y
+          end
+        RUBY
+      end
+    end
+
+    context 'between regular and endless  methods' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          def foo
+            x
+          end
+          def bar() = y
+          ^^^^^^^ Use empty lines between method definitions.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo
+            x
+          end
+
+          def bar() = y
+        RUBY
+      end
+    end
+
+    context 'with AllowAdjacentOneLineDefs: false' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          def foo() = x
+          def bar() = y
+          ^^^^^^^ Use empty lines between method definitions.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo() = x
+
+          def bar() = y
+        RUBY
+      end
+    end
+
+    context 'with AllowAdjacentOneLineDefs: true' do
+      let(:cop_config) { { 'AllowAdjacentOneLineDefs' => true } }
+
+      it ' does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          def foo() = x
+          def bar() = y
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
Previously, `Layout/EmptyLineBetweenDefs` would error when encountering an endless method because `node.loc.end` is nil when endless. Now the end position for an endless method can be calculated. If `AllowAdjacentOneLineDefs` is `true`, endless methods are treated like single-line methods.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
