### PR TITLE
Update `Style/MethodDefParentheses` to ignore endless method definitions since parentheses are always required

### DIFF
--- a/changelog/fix_update_stylemethoddefparentheses_to.md
+++ b/changelog/fix_update_stylemethoddefparentheses_to.md
@@ -1,0 +1,1 @@
+* [#9278](https://github.com/rubocop-hq/rubocop/pull/9278): Update `Style/MethodDefParentheses` to ignore endless method definitions since parentheses are always required. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3582,7 +3582,7 @@ Style/MethodDefParentheses:
   StyleGuide: '#method-parens'
   Enabled: true
   VersionAdded: '0.16'
-  VersionChanged: '0.35'
+  VersionChanged: <<next>>
   EnforcedStyle: require_parentheses
   SupportedStyles:
     - require_parentheses

--- a/lib/rubocop/cop/style/method_def_parentheses.rb
+++ b/lib/rubocop/cop/style/method_def_parentheses.rb
@@ -6,6 +6,9 @@ module RuboCop
       # This cop checks for parentheses around the arguments in method
       # definitions. Both instance and class/singleton methods are checked.
       #
+      # This cop does not consider endless methods, since parentheses are
+      # always required for them.
+      #
       # @example EnforcedStyle: require_parentheses (default)
       #   # The `require_parentheses` style requires method definitions
       #   # to always use parentheses
@@ -94,6 +97,8 @@ module RuboCop
                       'parameters.'
 
         def on_def(node)
+          return if node.endless?
+
           args = node.arguments
 
           if require_parentheses?(args)

--- a/spec/rubocop/cop/style/method_def_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_def_parentheses_spec.rb
@@ -1,8 +1,123 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
+  shared_examples 'no parentheses' do
+    # common to require_no_parentheses and
+    # require_no_parentheses_except_multiline
+    it 'reports an offense for def with parameters with parens' do
+      expect_offense(<<~RUBY)
+        def func(a, b)
+                ^^^^^^ Use def without parentheses.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def func a, b
+        end
+      RUBY
+    end
+
+    it 'accepts a def with parameters but no parens' do
+      expect_no_offenses(<<~RUBY)
+        def func a, b
+        end
+      RUBY
+    end
+
+    it 'reports an offense for opposite + correct' do
+      expect_offense(<<~RUBY)
+        def func(a, b)
+                ^^^^^^ Use def without parentheses.
+        end
+        def func a, b
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def func a, b
+        end
+        def func a, b
+        end
+      RUBY
+    end
+
+    it 'reports an offense for class def with parameters with parens' do
+      expect_offense(<<~RUBY)
+        def Test.func(a, b)
+                     ^^^^^^ Use def without parentheses.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def Test.func a, b
+        end
+      RUBY
+    end
+
+    it 'accepts a class def with parameters with parens' do
+      expect_no_offenses(<<~RUBY)
+        def Test.func a, b
+        end
+      RUBY
+    end
+
+    it 'reports an offense for def with no args and parens' do
+      expect_offense(<<~RUBY)
+        def func()
+                ^^ Use def without parentheses.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def func#{trailing_whitespace}
+        end
+      RUBY
+    end
+
+    it 'accepts def with no args and no parens' do
+      expect_no_offenses(<<~RUBY)
+        def func
+        end
+      RUBY
+    end
+
+    it 'auto-removes the parens for defs' do
+      expect_offense(<<~RUBY)
+        def self.test(param); end
+                     ^^^^^^^ Use def without parentheses.
+      RUBY
+      expect_correction(<<~RUBY)
+        def self.test param; end
+      RUBY
+    end
+  end
+
+  shared_examples 'endless methods' do
+    context 'endless methods', :ruby30 do
+      it 'accepts parens without args' do
+        expect_no_offenses(<<~RUBY)
+          def foo() = x
+        RUBY
+      end
+
+      it 'accepts parens with args' do
+        expect_no_offenses(<<~RUBY)
+          def foo(x) = x
+        RUBY
+      end
+
+      it 'accepts parens for method calls inside an endless method' do
+        expect_no_offenses(<<~RUBY)
+          def foo(x) = bar(x)
+        RUBY
+      end
+    end
+  end
+
   context 'require_parentheses' do
     let(:cop_config) { { 'EnforcedStyle' => 'require_parentheses' } }
+
+    it_behaves_like 'endless methods'
 
     it 'reports an offense for def with parameters but no parens' do
       expect_offense(<<~RUBY)
@@ -101,107 +216,19 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
     end
   end
 
-  shared_examples 'no parentheses' do
-    # common to require_no_parentheses and
-    # require_no_parentheses_except_multiline
-    it 'reports an offense for def with parameters with parens' do
-      expect_offense(<<~RUBY)
-        def func(a, b)
-                ^^^^^^ Use def without parentheses.
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        def func a, b
-        end
-      RUBY
-    end
-
-    it 'accepts a def with parameters but no parens' do
-      expect_no_offenses(<<~RUBY)
-        def func a, b
-        end
-      RUBY
-    end
-
-    it 'reports an offense for opposite + correct' do
-      expect_offense(<<~RUBY)
-        def func(a, b)
-                ^^^^^^ Use def without parentheses.
-        end
-        def func a, b
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        def func a, b
-        end
-        def func a, b
-        end
-      RUBY
-    end
-
-    it 'reports an offense for class def with parameters with parens' do
-      expect_offense(<<~RUBY)
-        def Test.func(a, b)
-                     ^^^^^^ Use def without parentheses.
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        def Test.func a, b
-        end
-      RUBY
-    end
-
-    it 'accepts a class def with parameters with parens' do
-      expect_no_offenses(<<~RUBY)
-        def Test.func a, b
-        end
-      RUBY
-    end
-
-    it 'reports an offense for def with no args and parens' do
-      expect_offense(<<~RUBY)
-        def func()
-                ^^ Use def without parentheses.
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        def func#{trailing_whitespace}
-        end
-      RUBY
-    end
-
-    it 'accepts def with no args and no parens' do
-      expect_no_offenses(<<~RUBY)
-        def func
-        end
-      RUBY
-    end
-
-    it 'auto-removes the parens for defs' do
-      expect_offense(<<~RUBY)
-        def self.test(param); end
-                     ^^^^^^^ Use def without parentheses.
-      RUBY
-      expect_correction(<<~RUBY)
-        def self.test param; end
-      RUBY
-    end
-  end
-
   context 'require_no_parentheses' do
     let(:cop_config) { { 'EnforcedStyle' => 'require_no_parentheses' } }
 
     it_behaves_like 'no parentheses'
+    it_behaves_like 'endless methods'
   end
 
   context 'require_no_parentheses_except_multiline' do
     let(:cop_config) do
       { 'EnforcedStyle' => 'require_no_parentheses_except_multiline' }
     end
+
+    it_behaves_like 'endless methods'
 
     context 'when args are all on a single line' do
       it_behaves_like 'no parentheses'


### PR DESCRIPTION
Endless methods require parentheses as part of the definition, or else it is a syntax error. Therefore, `Style/MethodDefParentheses` should never consider endless methods, as rewriting to remove the parens would lead to invalid code.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
