### PR TITLE
Fix `Style/MethodCallWithArgsParentheses` for endless method definitions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,7 +23,7 @@ Metrics/MethodLength:
 # Offense count: 8
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 132
+  Max: 135
 
 # Offense count: 10
 RSpec/AnyInstance:

--- a/changelog/fix_endless_emthod_method_call_with_args_parentheses.md
+++ b/changelog/fix_endless_emthod_method_call_with_args_parentheses.md
@@ -1,0 +1,1 @@
+* [#9279](https://github.com/rubocop-hq/rubocop/pull/9279): Add support for endless methods to `Style/MethodCallWithArgsParentheses`. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3548,7 +3548,7 @@ Style/MethodCallWithArgsParentheses:
   StyleGuide: '#method-invocation-parens'
   Enabled: false
   VersionAdded: '0.47'
-  VersionChanged: '0.61'
+  VersionChanged: <<next>>
   IgnoreMacros: true
   IgnoredMethods: []
   IgnoredPatterns: []

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -40,6 +40,9 @@ module RuboCop
       #     to `true` allows the presence of parentheses in such a method call
       #     even with arguments.
       #
+      # NOTE: Parens are required around a method with arguments when inside an
+      # endless method definition (>= Ruby 3.0).
+      #
       # @example EnforcedStyle: require_parentheses (default)
       #
       #   # bad


### PR DESCRIPTION
When an endless method definition calls another method with arguments, parentheses are required or it will be a syntax error. Therefore, parentheses are required even for the `omit_parentheses` style. If there are no arguments, the method call will continue to be matched to the enforced style as before.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
