### PR TITLE
Ruby 3.0's Regexp and Range literals will be frozen

### DIFF
--- a/changelog/new_frozen_ragexp_and_range_literals.md
+++ b/changelog/new_frozen_ragexp_and_range_literals.md
@@ -1,0 +1,1 @@
+* [#9282](https://github.com/rubocop-hq/rubocop/pull/9282): Make `Style/RedundantFreeze` and `Style/MutableConstant` cops aware of frozen regexp and range literals when using Ruby 3.0. ([@koic][])

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -14,6 +14,8 @@ module RuboCop
       # positives. Luckily, there is no harm in freezing an already
       # frozen object.
       #
+      # NOTE: Regexp and Range literals are frozen objects since Ruby 3.0.
+      #
       # @example EnforcedStyle: literals (default)
       #   # bad
       #   CONST = [1, 2, 3]
@@ -94,7 +96,8 @@ module RuboCop
           range_enclosed_in_parentheses = range_enclosed_in_parentheses?(value)
 
           return unless mutable_literal?(value) ||
-                        range_enclosed_in_parentheses
+                        target_ruby_version <= 2.7 && range_enclosed_in_parentheses
+
           return if FROZEN_STRING_LITERAL_TYPES.include?(value.type) &&
                     frozen_string_literals_enabled?
 
@@ -119,16 +122,23 @@ module RuboCop
         end
 
         def mutable_literal?(value)
-          value&.mutable_literal?
+          return false if value.nil?
+          return false if frozen_regexp_or_range_literals?(value)
+
+          value.mutable_literal?
         end
 
         def immutable_literal?(node)
-          node.nil? || node.immutable_literal?
+          node.nil? || frozen_regexp_or_range_literals?(node) || node.immutable_literal?
         end
 
         def frozen_string_literal?(node)
           FROZEN_STRING_LITERAL_TYPES.include?(node.type) &&
             frozen_string_literals_enabled?
+        end
+
+        def frozen_regexp_or_range_literals?(node)
+          target_ruby_version >= 3.0 && (node.regexp_type? || node.range_type?)
         end
 
         def requires_parentheses?(node)

--- a/lib/rubocop/cop/style/redundant_freeze.rb
+++ b/lib/rubocop/cop/style/redundant_freeze.rb
@@ -3,7 +3,9 @@
 module RuboCop
   module Cop
     module Style
-      # This cop check for uses of Object#freeze on immutable objects.
+      # This cop check for uses of `Object#freeze` on immutable objects.
+      #
+      # NOTE: Regexp and Range literals are frozen objects since Ruby 3.0.
       #
       # @example
       #   # bad
@@ -37,8 +39,10 @@ module RuboCop
 
           return true if node.immutable_literal?
 
-          FROZEN_STRING_LITERAL_TYPES.include?(node.type) &&
-            frozen_string_literals_enabled?
+          return true if FROZEN_STRING_LITERAL_TYPES.include?(node.type) &&
+                         frozen_string_literals_enabled?
+
+          target_ruby_version >= 3.0 && (node.regexp_type? || node.range_type?)
         end
 
         def strip_parenthesis(node)

--- a/spec/rubocop/cop/style/redundant_freeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_freeze_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Style::RedundantFreeze do
-  subject(:cop) { described_class.new }
-
+RSpec.describe RuboCop::Cop::Style::RedundantFreeze, :config do
   let(:prefix) { nil }
 
   shared_examples 'immutable objects' do |o|
@@ -42,9 +40,6 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze do
   it_behaves_like 'mutable objects', '{ a: 1, b: 2 }'
   it_behaves_like 'mutable objects', "'str'"
   it_behaves_like 'mutable objects', '"top#{1 + 2}"'
-  it_behaves_like 'mutable objects', '/./'
-  it_behaves_like 'mutable objects', '(1..5)'
-  it_behaves_like 'mutable objects', '(1...5)'
   it_behaves_like 'mutable objects', "('a' + 'b')"
   it_behaves_like 'mutable objects', "('a' * 20)"
   it_behaves_like 'mutable objects', '(a + b)'
@@ -94,6 +89,24 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze do
       let(:prefix) { '# frozen_string_literal: false' }
 
       it_behaves_like 'mutable objects', '"#{a}"'
+    end
+
+    describe 'Regexp and Range literals' do
+      # Ruby 3.0's Regexp and Range literals are frozen.
+      #
+      # https://bugs.ruby-lang.org/issues/15504
+      # https://bugs.ruby-lang.org/issues/16377
+      context 'Ruby 3.0 or higher', :ruby30 do
+        it_behaves_like 'immutable objects', '/./'
+        it_behaves_like 'immutable objects', '(1..5)'
+        it_behaves_like 'immutable objects', '(1...5)'
+      end
+
+      context 'Ruby 2.7 or lower', :ruby27 do
+        it_behaves_like 'mutable objects', '/./'
+        it_behaves_like 'mutable objects', '(1..5)'
+        it_behaves_like 'mutable objects', '(1...5)'
+      end
     end
   end
 end


### PR DESCRIPTION
This PR makes `Style/RedundantFreeze` and `Style/MutableConstant` cops aware of frozen regexp and range literals when using Ruby 3.0.

- https://bugs.ruby-lang.org/issues/15504
- https://bugs.ruby-lang.org/issues/16377

```console
% ruby -ve 'p(/regexp/.frozen?); p (0..42).frozen?'
ruby 3.0.0dev (2020-12-23T03:25:41Z master 02233ed024) [x86_64-darwin19]
true
true
```

```console
% ruby -ve 'p(/regexp/.frozen?); p (0..42).frozen?'
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin19]
false
false
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
