### PR TITLE
Add `AllowPercentLiteralArrayArgument` option to `Lint/RedundantSplatExpansion`

### DIFF
--- a/changelog/change_support_allow_percent_literal_array_argument_for_redundant_splat_expansion.md
+++ b/changelog/change_support_allow_percent_literal_array_argument_for_redundant_splat_expansion.md
@@ -1,0 +1,1 @@
+* [#9285](https://github.com/rubocop-hq/rubocop/pull/9285): Add `AllowPercentLiteralArrayArgument` option for `Lint/RedundantSplatExpansion` to enable the option by default. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1858,6 +1858,8 @@ Lint/RedundantSplatExpansion:
   Description: 'Checks for splat unnecessarily being called on literals.'
   Enabled: true
   VersionAdded: '0.76'
+  VersionChanged: <<next>>
+  AllowPercentLiteralArrayArgument: true
 
 Lint/RedundantStringCoercion:
   Description: 'Checks for Object#to_s usage in string interpolation.'

--- a/lib/rubocop/cop/lint/redundant_splat_expansion.rb
+++ b/lib/rubocop/cop/lint/redundant_splat_expansion.rb
@@ -8,17 +8,41 @@ module RuboCop
       # @example
       #
       #   # bad
-      #
       #   a = *[1, 2, 3]
       #   a = *'a'
       #   a = *1
+      #   ['a', 'b', *%w(c d e), 'f', 'g']
       #
+      #   # good
+      #   c = [1, 2, 3]
+      #   a = *c
+      #   a, b = *c
+      #   a, *b = *c
+      #   a = *1..10
+      #   a = ['a']
+      #   ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+      #
+      #   # bad
+      #   do_something(*['foo', 'bar', 'baz'])
+      #
+      #   # good
+      #   do_something('foo', 'bar', 'baz')
+      #
+      #   # bad
       #   begin
       #     foo
       #   rescue *[StandardError, ApplicationError]
       #     bar
       #   end
       #
+      #   # good
+      #   begin
+      #     foo
+      #   rescue StandardError, ApplicationError
+      #     bar
+      #   end
+      #
+      #   # bad
       #   case foo
       #   when *[1, 2, 3]
       #     bar
@@ -26,29 +50,24 @@ module RuboCop
       #     baz
       #   end
       #
-      # @example
-      #
       #   # good
-      #
-      #   c = [1, 2, 3]
-      #   a = *c
-      #   a, b = *c
-      #   a, *b = *c
-      #   a = *1..10
-      #   a = ['a']
-      #
-      #   begin
-      #     foo
-      #   rescue StandardError, ApplicationError
-      #     bar
-      #   end
-      #
       #   case foo
       #   when 1, 2, 3
       #     bar
       #   else
       #     baz
       #   end
+      #
+      # @example AllowPercentLiteralArrayArgument: true (default)
+      #
+      #   # good
+      #   do_something(*%w[foo bar baz])
+      #
+      # @example AllowPercentLiteralArrayArgument: false
+      #
+      #   # bad
+      #   do_something(*%w[foo bar baz])
+      #
       class RedundantSplatExpansion < Base
         extend AutoCorrector
 
@@ -75,6 +94,9 @@ module RuboCop
           redundant_splat_expansion(node) do
             if array_splat?(node) &&
                (method_argument?(node) || part_of_an_array?(node))
+              return if allow_percent_literal_array_argument? &&
+                        use_percent_literal_array_argument?(node)
+
               add_offense(node, message: ARRAY_PARAM_MSG) do |corrector|
                 autocorrect(corrector, node)
               end
@@ -169,6 +191,17 @@ module RuboCop
           else
             elements.join(', ')
           end
+        end
+
+        def use_percent_literal_array_argument?(node)
+          argument = node.children.first
+
+          node.parent.send_type? &&
+            (argument.percent_literal?(:string) || argument.percent_literal?(:symbol))
+        end
+
+        def allow_percent_literal_array_argument?
+          cop_config.fetch('AllowPercentLiteralArrayArgument', true)
         end
       end
     end

--- a/spec/rubocop/cop/lint/redundant_splat_expansion_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_splat_expansion_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Lint::RedundantSplatExpansion do
-  subject(:cop) { described_class.new }
-
+RSpec.describe RuboCop::Cop::Lint::RedundantSplatExpansion, :config do
   it 'allows assigning to a splat' do
     expect_no_offenses('*, rhs = *node')
   end
@@ -77,10 +75,6 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSplatExpansion do
   end
 
   it_behaves_like 'array splat expansion', '[1, 2, 3]', as_args: '1, 2, 3'
-  it_behaves_like 'array splat expansion', '%w(one two three)',
-                  as_args: "'one', 'two', 'three'"
-  it_behaves_like 'array splat expansion', '%W(one #{two} three)',
-                  as_args: '"one", "#{two}", "three"'
   it_behaves_like 'splat expansion', "'a'", as_array: "['a']"
   it_behaves_like 'splat expansion', '"#{a}"', as_array: '["#{a}"]'
   it_behaves_like 'splat expansion', '1', as_array: '[1]'
@@ -333,36 +327,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSplatExpansion do
     end
   end
 
-  it_behaves_like 'array splat expansion', '%i(first second)',
-                  as_args: ':first, :second'
-  it_behaves_like 'array splat expansion', '%I(first second #{third})',
-                  as_args: ':"first", :"second", :"#{third}"'
-
   context 'arrays being expanded with %i variants using splat expansion' do
-    context 'splat expansion of method parameters' do
-      it 'registers an offense and corrects an array literal %i' do
-        expect_offense(<<~RUBY)
-          array.push(*%i(first second))
-                     ^^^^^^^^^^^^^^^^^ Pass array contents as separate arguments.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          array.push(:first, :second)
-        RUBY
-      end
-
-      it 'registers an offense and corrects an array literal %I' do
-        expect_offense(<<~RUBY)
-          array.push(*%I(\#{first} second))
-                     ^^^^^^^^^^^^^^^^^^^^ Pass array contents as separate arguments.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          array.push(:"\#{first}", :"second")
-        RUBY
-      end
-    end
-
     context 'splat expansion inside of an array' do
       it 'registers an offense and corrects %i to a list of symbols' do
         expect_offense(<<~RUBY)
@@ -383,6 +348,74 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSplatExpansion do
 
         expect_correction(<<~'RUBY')
           [:a, :b, :"#{one}", :"two", :e]
+        RUBY
+      end
+    end
+  end
+
+  context 'when `AllowPercentLiteralArrayArgument: true`' do
+    let(:cop_config) do
+      { 'AllowPercentLiteralArrayArgument' => true }
+    end
+
+    it 'does not register an offense when using percent string literal array' do
+      expect_no_offenses(<<~'RUBY')
+        do_something(*%w[foo bar baz])
+      RUBY
+    end
+
+    it 'does not register an offense when using percent symbol literal array' do
+      expect_no_offenses(<<~'RUBY')
+        do_something(*%i[foo bar baz])
+      RUBY
+    end
+  end
+
+  context 'when `AllowPercentLiteralArrayArgument: false`' do
+    let(:cop_config) do
+      { 'AllowPercentLiteralArrayArgument' => false }
+    end
+
+    it_behaves_like 'array splat expansion', '%w(one two three)', as_args: "'one', 'two', 'three'"
+    it_behaves_like 'array splat expansion', '%W(one #{two} three)', as_args: '"one", "#{two}", "three"'
+
+    it 'registers an offense when using percent literal array' do
+      expect_offense(<<~'RUBY')
+        do_something(*%w[foo bar baz])
+                     ^^^^^^^^^^^^^^^^ Pass array contents as separate arguments.
+      RUBY
+    end
+
+    it_behaves_like 'array splat expansion', '%i(first second)', as_args: ':first, :second'
+    it_behaves_like 'array splat expansion', '%I(first second #{third})', as_args: ':"first", :"second", :"#{third}"'
+
+    it 'registers an offense when using percent symbol literal array' do
+      expect_offense(<<~'RUBY')
+        do_something(*%i[foo bar baz])
+                     ^^^^^^^^^^^^^^^^ Pass array contents as separate arguments.
+      RUBY
+    end
+
+    context 'splat expansion of method parameters' do
+      it 'registers an offense and corrects an array literal %i' do
+        expect_offense(<<~RUBY)
+          array.push(*%i(first second))
+                     ^^^^^^^^^^^^^^^^^ Pass array contents as separate arguments.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          array.push(:first, :second)
+        RUBY
+      end
+
+      it 'registers an offense and corrects an array literal %I' do
+        expect_offense(<<~RUBY)
+          array.push(*%I(\#{first} second))
+                     ^^^^^^^^^^^^^^^^^^^^ Pass array contents as separate arguments.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          array.push(:"\#{first}", :"second")
         RUBY
       end
     end


### PR DESCRIPTION
Resolves https://github.com/testdouble/standard/issues/223.

This PR adds `AllowPercentLiteralArrayArgument` option to `Lint/RedundantSplatExpansion.

I think it makes sense to allow the following splat usage.

```ruby
expect(data).to include(*%w[
  id type firstName lastName displayName photo
  phoneNumber publicPhone primaryMobile publicMobile publicEmail
  social primaryFacility facilities
])
```

Therefore this PR defaults to `AllowPercentLiteralArrayArgument: true`.
User can set `AllowPercentLiteralArrayArgument: false` if prefer RuboCop 1.6 or lower behavior.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
