### PR TITLE
fix wrong example of MultilineOperationIndentation

### DIFF
--- a/lib/rubocop/cop/layout/multiline_operation_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_operation_indentation.rb
@@ -16,14 +16,14 @@ module RuboCop
       #   if a +
       #       b
       #     something &&
-      #     something_else
+      #       something_else
       #   end
       #
       #   # good
       #   if a +
       #      b
       #     something &&
-      #       something_else
+      #     something_else
       #   end
       #
       # @example EnforcedStyle: indented


### PR DESCRIPTION
fix wrong example of MultilineOperationIndentation

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
