### PR TITLE
Fix a build error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5315,3 +5315,4 @@
 [@dark-panda]: https://github.com/dark-panda
 [@sswander]: https://github.com/sswander
 [@makicamel]: https://github.com/makicamel
+[@h-lame]: https://github.com/h-lame

--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -17,7 +17,7 @@ class Changelog
   REF_URL = 'https://github.com/rubocop-hq/rubocop'
   MAX_LENGTH = 40
   CONTRIBUTOR = '[@%<user>s]: https://github.com/%<user>s'
-  SIGNATURE = Regexp.new(format(Regexp.escape("([@%<user>s][])\n"), user: '(\w+)'))
+  SIGNATURE = Regexp.new(format(Regexp.escape("([@%<user>s][])\n"), user: '([\w-]+)'))
   EOF = "\n"
 
   # New entry


### PR DESCRIPTION
Fix the following build error.

```console
Failures:

  1) RuboCop Project Changelog has link definitions for all implicit
  links
     Failure/Error:
       expect(changelog.include?("[#{name}]: http"))
         .to be(true), "missing a link for #{name}. " \
                       'Please add this link to the bottom of the file.'

       missing a link for @h-lame. Please add this link to the bottom of
       the file.
     # ./spec/project_spec.rb:266:in `block (4 levels) in
       <top (required)>'
     # ./spec/project_spec.rb:265:in `each'
     # ./spec/project_spec.rb:265:in `block (3 levels) in
       <top (required)>'
     # tasks/spec_runner.rake:32:in `block in run_specs'
     # tasks/spec_runner.rake:44:in `with_encoding'
     # tasks/spec_runner.rake:28:in `run_specs'
     # tasks/spec_runner.rake:116:in `block in <top (required)>'
```

https://github.com/rubocop-hq/rubocop/runs/1607857673

And this PR makes `rake changelog:merge` aware of GitHub account name with hyphen.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
