### PR TITLE
[Fix #9290] Fix a false positive for `Layout/SpaceBeforeBrackets`

### DIFF
--- a/changelog/fix_false_positive_for_layout_space_before_brackets.md
+++ b/changelog/fix_false_positive_for_layout_space_before_brackets.md
@@ -1,0 +1,1 @@
+* [#9290](https://github.com/rubocop-hq/rubocop/issues/9290): Fix a false positive for `Layout/SpaceBeforeBrackets` when using array literal method argument. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1197,7 +1197,6 @@ Layout/SpaceBeforeBrackets:
   StyleGuide: '#space-in-brackets-access'
   Enabled: pending
   VersionAdded: '1.7'
-  Safe: false
 
 Layout/SpaceBeforeComma:
   Description: 'No spaces before commas.'

--- a/spec/rubocop/cop/layout/space_before_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_brackets_spec.rb
@@ -4,26 +4,74 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBrackets, :config do
   subject(:cop) { described_class.new(config) }
 
   context 'when referencing' do
-    it 'registers an offense and corrects when using space between receiver and left brackets' do
+    it 'registers an offense and corrects when using space between lvar receiver and left brackets' do
       expect_offense(<<~RUBY)
+        collection = do_something
         collection [index_or_key]
                   ^ Remove the space before the opening brackets.
       RUBY
 
       expect_correction(<<~RUBY)
+        collection = do_something
         collection[index_or_key]
       RUBY
     end
 
-    it 'does not register an offense when not using space between receiver and left brackets' do
+    it 'registers an offense and corrects when using space between ivar receiver and left brackets' do
+      expect_offense(<<~RUBY)
+        @collection [index_or_key]
+                   ^ Remove the space before the opening brackets.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        @collection[index_or_key]
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using space between cvar receiver and left brackets' do
+      expect_offense(<<~RUBY)
+        @@collection [index_or_key]
+                    ^ Remove the space before the opening brackets.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        @@collection[index_or_key]
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using space between gvar receiver and left brackets' do
+      expect_offense(<<~RUBY)
+        $collection [index_or_key]
+                   ^ Remove the space before the opening brackets.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        $collection[index_or_key]
+      RUBY
+    end
+
+    it 'does not register an offense when using space between method call and left brackets' do
       expect_no_offenses(<<~RUBY)
+        do_something [item_of_array_literal]
+      RUBY
+    end
+
+    it 'does not register an offense when not using space between variable receiver and left brackets' do
+      expect_no_offenses(<<~RUBY)
+        collection = do_something
         collection[index_or_key]
+      RUBY
+    end
+
+    it 'does not register an offense when not using space between method call and left brackets' do
+      expect_no_offenses(<<~RUBY)
+        do_something[item_of_array_literal]
       RUBY
     end
 
     it 'does not register an offense when array literal argument is enclosed in parentheses' do
       expect_no_offenses(<<~RUBY)
-        collection([index_or_key])
+        do_something([item_of_array_literal])
       RUBY
     end
 
@@ -68,6 +116,18 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBrackets, :config do
   it 'does not register an offense when assigning an array' do
     expect_no_offenses(<<~RUBY)
       task.options = ['--no-output']
+    RUBY
+  end
+
+  it 'does not register an offense when using array literal argument without parentheses' do
+    expect_no_offenses(<<~RUBY)
+      before_validation { to_downcase ['email'] }
+    RUBY
+  end
+
+  it 'does not register an offense when using percent array literal argument without parentheses' do
+    expect_no_offenses(<<~RUBY)
+      before_validation { to_downcase %w[email] }
     RUBY
   end
 end


### PR DESCRIPTION
Fixes #9290.

This PR fixes a false positive for `Layout/SpaceBeforeBrackets` when using array literal argument for method call.

If receiver is a method call, it is difficult to prevent false positives.
Therefore, This PR change behaviour to detect only when receiver is a variable.

As a result, safe detection is possible.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
