### PR TITLE
Update `Style/SingleLineMethods` to correct to an endless method definition if they are allowed

### DIFF
--- a/changelog/change_update_stylesinglelinemethods_to_correct.md
+++ b/changelog/change_update_stylesinglelinemethods_to_correct.md
@@ -1,0 +1,1 @@
+* [#9295](https://github.com/rubocop-hq/rubocop/pull/9295): Update `Style/SingleLineMethods` to correct to an endless method definition if they are allowed. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4380,7 +4380,7 @@ Style/SingleLineMethods:
   StyleGuide: '#no-single-line-methods'
   Enabled: true
   VersionAdded: '0.9'
-  VersionChanged: '1.7'
+  VersionChanged: <<next>>
   AllowIfMethodIsEmpty: true
 
 Style/SlicingWithRange:

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1162,6 +1162,10 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
   end
 
   it 'can correct single line methods' do
+    create_file('.rubocop.yml', <<~YAML)
+      Style/EndlessMethod:
+        EnforcedStyle: disallow
+    YAML
     create_file('example.rb', <<~RUBY)
       def func1; do_something end # comment
       def func2() do_1; do_2; end


### PR DESCRIPTION
Follows #9281.

If `Style/EndlessMethod` is enabled and not using the `disallow` style, single line methods will be corrected to endless methods instead. My rationale here is that if the user is allowing endless methods, they are a "smaller" correction for single line methods than replacing with a normal method definition.

I went back and forth about if this should be configured independently from the `Style/EndlessMethod` configuration. I think it makes sense to keep all the configuration for endless methods in one place, but if we'd rather have it specifically configured for `Style/SingleLineMethods`,  I'd be happy to make that change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
