### PR TITLE
[Fix #9298] Fix an incorrect auto-correct for `Lint/RedundantCopDisableDirective`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_redundant_cop_disable_directive.md
+++ b/changelog/fix_incorrect_autocorrect_for_redundant_cop_disable_directive.md
@@ -1,0 +1,1 @@
+* [#9298](https://github.com/rubocop-hq/rubocop/issues/9298): Fix an incorrect auto-correct for `Lint/RedundantCopDisableDirective` when there is a blank line before inline comment. ([@koic][])

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -47,6 +47,12 @@ module RuboCop
       )
     end
 
+    def comment_only_line?(line_number)
+      non_comment_token_line_numbers.none? do |non_comment_line_number|
+        non_comment_line_number == line_number
+      end
+    end
+
     private
 
     def extra_enabled_comments_with_names(extras:, names:)
@@ -164,12 +170,6 @@ module RuboCop
 
     def all_cop_names
       @all_cop_names ||= Cop::Registry.global.names - [REDUNDANT_DISABLE]
-    end
-
-    def comment_only_line?(line_number)
-      non_comment_token_line_numbers.none? do |non_comment_line_number|
-        non_comment_line_number == line_number
-      end
     end
 
     def non_comment_token_line_numbers

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -61,7 +61,8 @@ module RuboCop
         end
 
         def comment_range_with_surrounding_space(range)
-          if previous_line_blank?(range)
+          if previous_line_blank?(range) &&
+             processed_source.comment_config.comment_only_line?(range.line)
             # When the previous line is blank, it should be retained
             range_with_surrounding_space(range: range, side: :right)
           else

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -465,6 +465,29 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
           RUBY
         end
       end
+
+      context 'when there is a blank line before inline comment' do
+        it 'removes the comment and preceding whitespace' do
+          expect_offense(<<~RUBY)
+            def foo; end
+
+            def bar # rubocop:disable Metrics/ClassLength
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Metrics/ClassLength`.
+              do_something do
+              end
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            def foo; end
+
+            def bar
+              do_something do
+              end
+            end
+          RUBY
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #9298.

This PR fixes an incorrect auto-correct for `Lint/RedundantCopDisableDirective` when there is a blank line before inline comment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
