### PR TITLE
Make `Lint/NonDeterministicRequireOrder` not to register offense for Ruby 3

### DIFF
--- a/changelog/change_make_deterministic_require_order_not_to_register_offense_for_ruby3.md
+++ b/changelog/change_make_deterministic_require_order_not_to_register_offense_for_ruby3.md
@@ -1,0 +1,1 @@
+* [#9300](https://github.com/rubocop-hq/rubocop/pull/9300): Make `Lint/NonDeterministicRequireOrder` not to register offense when using Ruby 3.0 or higher. ([@koic][])

--- a/lib/rubocop/cop/lint/non_deterministic_require_order.rb
+++ b/lib/rubocop/cop/lint/non_deterministic_require_order.rb
@@ -11,6 +11,11 @@ module RuboCop
       # that are hard to debug. To ensure this doesn't happen,
       # always sort the list.
       #
+      # `Dir.glob` and `Dir[]` sort globbed results by default in Ruby 3.0.
+      # So all bad cases are acceptable when Ruby 3.0 or higher are used.
+      #
+      # This cop will be deprecated and removed when supporting only Ruby 3.0 and higher.
+      #
       # @example
       #
       #   # bad
@@ -23,8 +28,6 @@ module RuboCop
       #     require file
       #   end
       #
-      # @example
-      #
       #   # bad
       #   Dir.glob(Rails.root.join(__dir__, 'test', '*.rb')) do |file|
       #     require file
@@ -35,15 +38,11 @@ module RuboCop
       #     require file
       #   end
       #
-      # @example
-      #
       #   # bad
       #   Dir['./lib/**/*.rb'].each(&method(:require))
       #
       #   # good
       #   Dir['./lib/**/*.rb'].sort.each(&method(:require))
-      #
-      # @example
       #
       #   # bad
       #   Dir.glob(Rails.root.join('test', '*.rb'), &method(:require))
@@ -51,12 +50,16 @@ module RuboCop
       #   # good
       #   Dir.glob(Rails.root.join('test', '*.rb')).sort.each(&method(:require))
       #
+      #   # good - Respect intent if `sort` keyword option is specified in Ruby 3.0 or higher.
+      #   Dir.glob(Rails.root.join(__dir__, 'test', '*.rb'), sort: false).each(&method(:require))
+      #
       class NonDeterministicRequireOrder < Base
         extend AutoCorrector
 
         MSG = 'Sort files before requiring them.'
 
         def on_block(node)
+          return if target_ruby_version >= 3.0
           return unless node.body
           return unless unsorted_dir_loop?(node.send_node)
 
@@ -70,6 +73,7 @@ module RuboCop
         end
 
         def on_block_pass(node)
+          return if target_ruby_version >= 3.0
           return unless method_require?(node)
           return unless unsorted_dir_pass?(node.parent)
 

--- a/spec/rubocop/cop/lint/non_deterministic_require_order_spec.rb
+++ b/spec/rubocop/cop/lint/non_deterministic_require_order_spec.rb
@@ -1,168 +1,288 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Lint::NonDeterministicRequireOrder do
-  subject(:cop) { described_class.new(config) }
-
-  let(:config) { RuboCop::Config.new }
-
+RSpec.describe RuboCop::Cop::Lint::NonDeterministicRequireOrder, :config do
   context 'when requiring files' do
-    context 'with unsorted index' do
-      it 'registers an offsense and autocorrects to add .sort' do
-        expect_offense(<<~RUBY)
-          Dir["./lib/**/*.rb"].each do |file|
-          ^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
-            require file
-          end
-        RUBY
-        expect_correction(<<~RUBY)
-          Dir["./lib/**/*.rb"].sort.each do |file|
-            require file
-          end
-        RUBY
-      end
-
-      it 'registers an offsense with extra logic' do
-        expect_offense(<<~RUBY)
-          Dir["./lib/**/*.rb"].each do |file|
-          ^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
-            if file.start_with?('_')
-              puts "Not required."
-            else
+    context 'when Ruby 3.0 or higher', :ruby30 do
+      context 'with `Dir[]`' do
+        it 'does not register an offsense' do
+          expect_no_offenses(<<~RUBY)
+            Dir["./lib/**/*.rb"].each do |file|
               require file
             end
-          end
-        RUBY
-        expect_correction(<<~RUBY)
-          Dir["./lib/**/*.rb"].sort.each do |file|
-            if file.start_with?('_')
-              puts "Not required."
-            else
-              require file
-            end
-          end
-        RUBY
-      end
+          RUBY
+        end
 
-      context 'with require block passed as parameter' do
-        it 'registers an offense an autocorrects to add sort' do
-          expect_offense(<<~RUBY)
-            Dir["./lib/**/*.rb"].each(&method(:require))
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
-          RUBY
-          expect_correction(<<~RUBY)
-            Dir["./lib/**/*.rb"].sort.each(&method(:require))
-          RUBY
+        context 'with extra logic' do
+          it 'does not register an offsense' do
+            expect_no_offenses(<<~RUBY)
+              Dir["./lib/**/*.rb"].each do |file|
+                if file.start_with?('_')
+                  puts "Not required."
+                else
+                  require file
+                end
+              end
+            RUBY
+          end
+        end
+
+        context 'with require block passed as parameter' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              Dir["./lib/**/*.rb"].each(&method(:require))
+            RUBY
+          end
+        end
+
+        context 'with top-level ::Dir' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              ::Dir["./lib/**/*.rb"].each do |file|
+                require file
+              end
+            RUBY
+          end
         end
       end
 
-      context 'with top-level ::Dir' do
-        it 'registers an offense and corrects to add .sort' do
-          expect_offense(<<~RUBY)
-            ::Dir["./lib/**/*.rb"].each do |file|
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
+      context 'with `Dir.glob`' do
+        it 'does not register an offsense' do
+          expect_no_offenses(<<~RUBY)
+            Dir.glob(Rails.root.join(__dir__, 'test', '*.rb'), File::FNM_DOTMATCH).each do |file|
               require file
             end
           RUBY
-          expect_correction(<<~RUBY)
-            ::Dir["./lib/**/*.rb"].sort.each do |file|
+        end
+
+        context 'with require block passed as parameter' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              Dir.glob(Rails.root.join('test', '*.rb')).each(&method(:require))
+            RUBY
+          end
+        end
+
+        context 'with top-level ::Dir' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              ::Dir.glob(Rails.root.join(__dir__, 'test', '*.rb'), ::File::FNM_DOTMATCH).each do |file|
+                require file
+              end
+            RUBY
+          end
+        end
+
+        context 'with `sort: false` keyword option' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              Dir.glob(Rails.root.join('test', '*.rb'), sort: false).each(&method(:require))
+            RUBY
+          end
+        end
+      end
+
+      context 'with direct block glob' do
+        it 'does not register an offsense' do
+          expect_no_offenses(<<~RUBY)
+            Dir.glob("./lib/**/*.rb") do |file|
               require file
             end
           RUBY
+        end
+
+        context 'with require block passed as parameter' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              Dir.glob(
+                Rails.root.join('./lib/**/*.rb'),
+                File::FNM_DOTMATCH,
+                &method(:require)
+              )
+            RUBY
+          end
+        end
+
+        context 'with top-level ::Dir' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              ::Dir.glob("./lib/**/*.rb") do |file|
+                require file
+              end
+            RUBY
+          end
         end
       end
     end
 
-    context 'with unsorted glob' do
-      it 'registers an offsense and autocorrects to add .sort' do
-        expect_offense(<<~RUBY)
-          Dir.glob(Rails.root.join(__dir__, 'test', '*.rb'), File::FNM_DOTMATCH).each do |file|
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
-            require file
-          end
-        RUBY
-        expect_correction(<<~RUBY)
-          Dir.glob(Rails.root.join(__dir__, 'test', '*.rb'), File::FNM_DOTMATCH).sort.each do |file|
-            require file
-          end
-        RUBY
-      end
-
-      context 'with require block passed as parameter' do
-        it 'registers an offense an autocorrects to add sort' do
+    context 'when Ruby 2.7 or lower', :ruby27 do
+      context 'with unsorted index' do
+        it 'registers an offsense and autocorrects to add .sort' do
           expect_offense(<<~RUBY)
-            Dir.glob(Rails.root.join('test', '*.rb')).each(&method(:require))
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
-          RUBY
-          expect_correction(<<~RUBY)
-            Dir.glob(Rails.root.join('test', '*.rb')).sort.each(&method(:require))
-          RUBY
-        end
-      end
-
-      context 'with top-level ::Dir' do
-        it 'registers an offense and corrects to add .sort' do
-          expect_offense(<<~RUBY)
-            ::Dir.glob(Rails.root.join(__dir__, 'test', '*.rb'), ::File::FNM_DOTMATCH).each do |file|
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
+            Dir["./lib/**/*.rb"].each do |file|
+            ^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
               require file
             end
           RUBY
+
           expect_correction(<<~RUBY)
-            ::Dir.glob(Rails.root.join(__dir__, 'test', '*.rb'), ::File::FNM_DOTMATCH).sort.each do |file|
+            Dir["./lib/**/*.rb"].sort.each do |file|
               require file
             end
           RUBY
         end
-      end
-    end
 
-    context 'with direct block glob' do
-      it 'registers an offsense and autocorrects to add .sort.each' do
-        expect_offense(<<~RUBY)
-          Dir.glob("./lib/**/*.rb") do |file|
-          ^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
-            require file
-          end
-        RUBY
-        expect_correction(<<~RUBY)
-          Dir.glob("./lib/**/*.rb").sort.each do |file|
-            require file
-          end
-        RUBY
-      end
-
-      context 'with require block passed as parameter' do
-        it 'registers an offense and autocorrects to add sort' do
+        it 'registers an offsense with extra logic' do
           expect_offense(<<~RUBY)
-            Dir.glob(
-            ^^^^^^^^^ Sort files before requiring them.
-              Rails.root.join('./lib/**/*.rb'),
-              File::FNM_DOTMATCH,
-              &method(:require)
-            )
+            Dir["./lib/**/*.rb"].each do |file|
+            ^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
+              if file.start_with?('_')
+                puts "Not required."
+              else
+                require file
+              end
+            end
           RUBY
+
           expect_correction(<<~RUBY)
-            Dir.glob(
-              Rails.root.join('./lib/**/*.rb'),
-              File::FNM_DOTMATCH
-            ).sort.each(&method(:require))
+            Dir["./lib/**/*.rb"].sort.each do |file|
+              if file.start_with?('_')
+                puts "Not required."
+              else
+                require file
+              end
+            end
           RUBY
+        end
+
+        context 'with require block passed as parameter' do
+          it 'registers an offense an autocorrects to add sort' do
+            expect_offense(<<~RUBY)
+              Dir["./lib/**/*.rb"].each(&method(:require))
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              Dir["./lib/**/*.rb"].sort.each(&method(:require))
+            RUBY
+          end
+        end
+
+        context 'with top-level ::Dir' do
+          it 'registers an offense and corrects to add .sort' do
+            expect_offense(<<~RUBY)
+              ::Dir["./lib/**/*.rb"].each do |file|
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
+                require file
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              ::Dir["./lib/**/*.rb"].sort.each do |file|
+                require file
+              end
+            RUBY
+          end
         end
       end
 
-      context 'with top-level ::Dir' do
-        it 'registers an offense and corrects to add .sort.each' do
+      context 'with unsorted glob' do
+        it 'registers an offsense and autocorrects to add .sort' do
           expect_offense(<<~RUBY)
-            ::Dir.glob("./lib/**/*.rb") do |file|
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
+            Dir.glob(Rails.root.join(__dir__, 'test', '*.rb'), File::FNM_DOTMATCH).each do |file|
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
               require file
             end
           RUBY
+
           expect_correction(<<~RUBY)
-            ::Dir.glob("./lib/**/*.rb").sort.each do |file|
+            Dir.glob(Rails.root.join(__dir__, 'test', '*.rb'), File::FNM_DOTMATCH).sort.each do |file|
               require file
             end
           RUBY
+        end
+
+        context 'with require block passed as parameter' do
+          it 'registers an offense an autocorrects to add sort' do
+            expect_offense(<<~RUBY)
+              Dir.glob(Rails.root.join('test', '*.rb')).each(&method(:require))
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              Dir.glob(Rails.root.join('test', '*.rb')).sort.each(&method(:require))
+            RUBY
+          end
+        end
+
+        context 'with top-level ::Dir' do
+          it 'registers an offense and corrects to add .sort' do
+            expect_offense(<<~RUBY)
+              ::Dir.glob(Rails.root.join(__dir__, 'test', '*.rb'), ::File::FNM_DOTMATCH).each do |file|
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
+                require file
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              ::Dir.glob(Rails.root.join(__dir__, 'test', '*.rb'), ::File::FNM_DOTMATCH).sort.each do |file|
+                require file
+              end
+            RUBY
+          end
+        end
+      end
+
+      context 'with direct block glob' do
+        it 'registers an offsense and autocorrects to add .sort.each' do
+          expect_offense(<<~RUBY)
+            Dir.glob("./lib/**/*.rb") do |file|
+            ^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
+              require file
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            Dir.glob("./lib/**/*.rb").sort.each do |file|
+              require file
+            end
+          RUBY
+        end
+
+        context 'with require block passed as parameter' do
+          it 'registers an offense and autocorrects to add sort' do
+            expect_offense(<<~RUBY)
+              Dir.glob(
+              ^^^^^^^^^ Sort files before requiring them.
+                Rails.root.join('./lib/**/*.rb'),
+                File::FNM_DOTMATCH,
+                &method(:require)
+              )
+            RUBY
+
+            expect_correction(<<~RUBY)
+              Dir.glob(
+                Rails.root.join('./lib/**/*.rb'),
+                File::FNM_DOTMATCH
+              ).sort.each(&method(:require))
+            RUBY
+          end
+        end
+
+        context 'with top-level ::Dir' do
+          it 'registers an offense and corrects to add .sort.each' do
+            expect_offense(<<~RUBY)
+              ::Dir.glob("./lib/**/*.rb") do |file|
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sort files before requiring them.
+                require file
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              ::Dir.glob("./lib/**/*.rb").sort.each do |file|
+                require file
+              end
+            RUBY
+          end
         end
       end
     end


### PR DESCRIPTION
`Dir.glob` and `Dir[]` sort the results by default in Ruby 3.0.

- https://bugs.ruby-lang.org/issues/8709
- https://github.com/ruby/ruby/commit/2f1081a451f21ca017cc9fdc585883e5c6ebf618

This PR will make not to register an offense when using Ruby 3.0.

So users don't need this cop when using Ruby 3.0.
It can be deprecated when supporting only Ruby 3.0 and higher.

I will open a PR about a new cop against `Dir.glob.sort` and `Dir[]`.sort, which became redundant in Ruby 3.0.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
