### PR TITLE
CI against Ruby 3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,29 @@ jobs:
     steps:
       *rubocop_steps
 
+  # Ruby 3.0
+  ruby-3.0-spec:
+    docker:
+      - image: circleci/ruby:3.0
+    environment:
+      <<: *common_env
+    steps:
+      *spec_steps
+  ruby-3.0-ascii_spec:
+    docker:
+      - image: circleci/ruby:3.0
+    environment:
+      <<: *common_env
+    steps:
+      *ascii_spec_steps
+  ruby-3.0-rubocop:
+    docker:
+      - image: circleci/ruby:3.0
+    environment:
+      <<: *common_env
+    steps:
+      *rubocop_steps
+
   # ruby-head (nightly snapshot build)
   ruby-head-spec:
     docker:
@@ -219,7 +242,7 @@ jobs:
       - run:
           name: Upload coverage results to Code Climate
           command: |
-            ./tmp/cc-test-reporter sum-coverage tmp/codeclimate.*.json --parts 5 --output tmp/codeclimate.total.json
+            ./tmp/cc-test-reporter sum-coverage tmp/codeclimate.*.json --parts 6 --output tmp/codeclimate.total.json
             ./tmp/cc-test-reporter upload-coverage --input tmp/codeclimate.total.json
 
   # Miscellaneous tasks
@@ -261,6 +284,11 @@ workflows:
             - cc-setup
       - ruby-2.7-ascii_spec
       - ruby-2.7-rubocop
+      - ruby-3.0-spec:
+          requires:
+            - cc-setup
+      - ruby-3.0-ascii_spec
+      - ruby-3.0-rubocop
       - ruby-head-spec:
           requires:
             - cc-setup
@@ -278,4 +306,5 @@ workflows:
             - ruby-2.5-spec
             - ruby-2.6-spec
             - ruby-2.7-spec
+            - ruby-3.0-spec
             - jruby-9.2-spec

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         # [ ubuntu, macos, windows ]
         os: [ windows ]
-        ruby: [ 2.4, 2.5, 2.6, 2.7, head ]
+        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', 'head' ]
         include:
           - { os: windows, ruby: mingw }
         exclude:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,6 +12,7 @@ pull_request_rules:
       - "status-success=windows 2.5"
       - "status-success=windows 2.6"
       - "status-success=windows 2.7"
+      - "status-success=windows 3.0"
       - "status-success=windows mingw"
       - "status-success=ci/circleci: cc-setup"
       - "status-success=ci/circleci: cc-upload-coverage"
@@ -31,6 +32,9 @@ pull_request_rules:
       - "status-success=ci/circleci: ruby-2.7-ascii_spec"
       - "status-success=ci/circleci: ruby-2.7-rubocop"
       - "status-success=ci/circleci: ruby-2.7-spec"
+      - "status-success=ci/circleci: ruby-3.0-ascii_spec"
+      - "status-success=ci/circleci: ruby-3.0-rubocop"
+      - "status-success=ci/circleci: ruby-3.0-spec"
       - "status-success=ci/circleci: ruby-head-ascii_spec"
       - "status-success=ci/circleci: ruby-head-rubocop"
       - "status-success=ci/circleci: ruby-head-spec"
@@ -40,4 +44,3 @@ pull_request_rules:
       - label=auto-merge
     actions:
       delete_head_branch: {}
-


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/9288.

Ruby 3.0.0 has been released and this Ruby version is available on `circleci/ruby:3.0` image.

- https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/
- https://hub.docker.com/r/circleci/ruby/tags/

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
