### PR TITLE
[Fix #9303] Fix an incorrect auto-correct for `Style/RaiseArgs`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_raise_args.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_raise_args.md
@@ -1,0 +1,1 @@
+* [#9303](https://github.com/rubocop-hq/rubocop/issues/9303): Fix an incorrect auto-correct for `Style/RaiseArgs` with `EnforcedStyle: compact` when using exception instantiation argument. ([@koic][])

--- a/lib/rubocop/cop/style/raise_args.rb
+++ b/lib/rubocop/cop/style/raise_args.rb
@@ -81,11 +81,12 @@ module RuboCop
           return node.source if message_nodes.size > 1
 
           argument = message_nodes.first.source
+          exception_class = exception_node.const_name || exception_node.receiver.source
 
           if node.parent && requires_parens?(node.parent)
-            "#{node.method_name}(#{exception_node.const_name}.new(#{argument}))"
+            "#{node.method_name}(#{exception_class}.new(#{argument}))"
           else
-            "#{node.method_name} #{exception_node.const_name}.new(#{argument})"
+            "#{node.method_name} #{exception_class}.new(#{argument})"
           end
         end
 

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -17,6 +17,19 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
       end
     end
 
+    context 'with a raise with exception instantiation and message arguments' do
+      it 'reports an offense' do
+        expect_offense(<<~RUBY)
+          raise FooError.new, message
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Provide an exception object as an argument to `raise`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          raise FooError.new(message)
+        RUBY
+      end
+    end
+
     context 'when used in a ternary expression' do
       it 'registers an offense and auto-corrects' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #9303.

This PR fixes an incorrect auto-correct for `Style/RaiseArgs` with `EnforcedStyle: compact` when using exception instantiation argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
