### PR TITLE
[Fix #9308] Fix an error for `Layout/EmptyLineBetweenDefs`

### DIFF
--- a/changelog/fix_an_error_for_layout_empty_line_between_def.md
+++ b/changelog/fix_an_error_for_layout_empty_line_between_def.md
@@ -1,0 +1,1 @@
+* [#9308](https://github.com/rubocop-hq/rubocop/issues/9308): Fix an error for `Layout/EmptyLineBetweenDefs` when using endless class method. ([@koic][])

--- a/lib/rubocop/cop/layout/empty_line_between_defs.rb
+++ b/lib/rubocop/cop/layout/empty_line_between_defs.rb
@@ -210,7 +210,7 @@ module RuboCop
         end
 
         def end_loc(node)
-          if node.def_type? && node.endless?
+          if (node.def_type? || node.defs_type?) && node.endless?
             node.loc.expression.end
           else
             node.loc.end

--- a/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
@@ -554,7 +554,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
       end
     end
 
-    context 'between regular and endless  methods' do
+    context 'between regular and endless methods' do
       it 'registers an offense and corrects' do
         expect_offense(<<~RUBY)
           def foo
@@ -570,6 +570,46 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
           end
 
           def bar() = y
+        RUBY
+      end
+    end
+
+    context 'between endless class method and regular methods' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          def self.foo = x
+          def bar
+          ^^^^^^^ Use empty lines between method definitions.
+            y
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def self.foo = x
+
+          def bar
+            y
+          end
+        RUBY
+      end
+    end
+
+    context 'between endless class method and regular class methods' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          def self.foo = x
+          def self.bar
+          ^^^^^^^^^^^^ Use empty lines between method definitions.
+            y
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def self.foo = x
+
+          def self.bar
+            y
+          end
         RUBY
       end
     end


### PR DESCRIPTION
Fixes #9308.

This PR fixes an error for `Layout/EmptyLineBetweenDefs` when using endless class method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
