### PR TITLE
[Fix #9304] Do not register offense for `Style/ExplicitBlockArgument` when the `yield` arguments are not an exact match with the block arguments.

### DIFF
--- a/changelog/fix_do_not_register_offense_for.md
+++ b/changelog/fix_do_not_register_offense_for.md
@@ -1,0 +1,1 @@
+* [#9304](https://github.com/rubocop-hq/rubocop/issues/9304): Do not register an offense for `Style/ExplicitBlockArgument` when the `yield` arguments are not an exact match with the block arguments. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3271,9 +3271,8 @@ Style/ExplicitBlockArgument:
                   that just passes its arguments to another block.
   StyleGuide: '#block-argument'
   Enabled: true
-  # May change the yielding arity.
-  Safe: false
   VersionAdded: '0.89'
+  VersionChanged: <<next>>
 
 Style/ExponentialNotation:
   Description: 'When using exponential notation, favor a mantissa between 1 (inclusive) and 10 (exclusive).'

--- a/lib/rubocop/cop/style/explicit_block_argument.rb
+++ b/lib/rubocop/cop/style/explicit_block_argument.rb
@@ -6,6 +6,9 @@ module RuboCop
       # This cop enforces the use of explicit block argument to avoid writing
       # block literal that just passes its arguments to another block.
       #
+      # NOTE: This cop only registers an offense if the block args match the
+      # yield args exactly.
+      #
       # @example
       #   # bad
       #   def with_tmp_dir
@@ -75,7 +78,14 @@ module RuboCop
         private
 
         def yielding_arguments?(block_args, yield_args)
+          yield_args = yield_args.dup.fill(
+            nil,
+            yield_args.length, block_args.length - yield_args.length
+          )
+
           yield_args.zip(block_args).all? do |yield_arg, block_arg|
+            next false unless yield_arg && block_arg
+
             block_arg && yield_arg.children.first == block_arg.children.first
           end
         end

--- a/spec/rubocop/cop/style/explicit_block_argument_spec.rb
+++ b/spec/rubocop/cop/style/explicit_block_argument_spec.rb
@@ -18,17 +18,25 @@ RSpec.describe RuboCop::Cop::Style::ExplicitBlockArgument do
     RUBY
   end
 
-  it 'registers an offense and corrects when block yields several first its arguments' do
+  it 'registers an offense and corrects when multiple arguments are yielded' do
     expect_offense(<<~RUBY)
       def m
-        items.something { |i, j| yield i }
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Consider using explicit block argument in the surrounding method's signature over `yield`.
+        items.something(first_arg) { |i, j| yield i, j }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Consider using explicit block argument in the surrounding method's signature over `yield`.
       end
     RUBY
 
     expect_correction(<<~RUBY)
       def m(&block)
-        items.something(&block)
+        items.something(first_arg, &block)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when arguments are yielded in a different order' do
+    expect_no_offenses(<<~RUBY)
+      def m
+        items.something(first_arg) { |i, j| yield j, i }
       end
     RUBY
   end
@@ -92,8 +100,8 @@ RSpec.describe RuboCop::Cop::Style::ExplicitBlockArgument do
           3.times { yield }
           ^^^^^^^^^^^^^^^^^ Consider using explicit block argument in the surrounding method's signature over `yield`.
         else
-          other_items.something { |i, j| yield i }
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Consider using explicit block argument in the surrounding method's signature over `yield`.
+          other_items.something { |i, j| yield i, j }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Consider using explicit block argument in the surrounding method's signature over `yield`.
         end
       end
     RUBY
@@ -151,6 +159,14 @@ RSpec.describe RuboCop::Cop::Style::ExplicitBlockArgument do
     expect_no_offenses(<<~RUBY)
       def m
         items.something { |i, j, k| yield j, k }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when there is more than one block argument and not all are yielded' do
+    expect_no_offenses(<<~RUBY)
+      def m
+        items.something { |i, j| yield i }
       end
     RUBY
   end


### PR DESCRIPTION
When the block arguments and yield arguments are not an exact match, no offense is raised. Fixes #9304.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
