### PR TITLE
[Fix #9312] Fix `Layout/FirstHashElementLineBreak` for single line hash

### DIFF
--- a/changelog/fix_first_hash_element_line_break_on_single_element_hash.md
+++ b/changelog/fix_first_hash_element_line_break_on_single_element_hash.md
@@ -1,0 +1,1 @@
+* [#9312](https://github.com/rubocop-hq/rubocop/issues/9312): Fix `Layout/FirstHashElementLineBreak` to apply to multi-line hashes with only a single element. ([@muirdm][])

--- a/lib/rubocop/cop/mixin/first_element_line_break.rb
+++ b/lib/rubocop/cop/mixin/first_element_line_break.rb
@@ -21,7 +21,7 @@ module RuboCop
       end
 
       def check_children_line_break(node, children, start = node)
-        return if children.size < 2
+        return if children.empty?
 
         line = start.first_line
 

--- a/spec/rubocop/cop/layout/first_hash_element_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_hash_element_line_break_spec.rb
@@ -31,6 +31,22 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementLineBreak do
     RUBY
   end
 
+  it 'registers an offense and corrects single element multi-line hash' do
+    expect_offense(<<~RUBY)
+      { foo: {
+        ^^^^^^ Add a line break before the first element of a multi-line hash.
+        bar: 2,
+      } }
+    RUBY
+
+    expect_correction(<<~RUBY)
+      {#{trailing_whitespace}
+      foo: {
+        bar: 2,
+      } }
+    RUBY
+  end
+
   it 'ignores implicit hashes in method calls with parens' do
     expect_no_offenses(<<~RUBY)
       method(


### PR DESCRIPTION
Fix Layout/FirstHashElementLineBreak to consider below as a multi-line
hash even though it only has one element:

    {:foo => {
      :bar => "baz",
    }}

Now FirstHashElementLineBreak will correct the above to:

    {
      :foo => {
        :bar => "baz",
      },
    }

Fixes #9312.