### PR TITLE
[Fix #9314] Fix an incorrect auto-correct for `Style/RedundantReturn`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_redundant_return.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_redundant_return.md
@@ -1,0 +1,1 @@
+* [#9314](https://github.com/rubocop-hq/rubocop/issues/9314): Fix an incorrect auto-correct for `Style/RedundantReturn` when multiple return values have a parenthesized return value. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -66,7 +66,7 @@ module RuboCop
         end
 
         def correct_with_arguments(return_node, corrector)
-          if return_node.arguments.size > 1
+          if return_node.children.size > 1
             add_brackets(corrector, return_node)
           elsif hash_without_braces?(return_node.first_argument)
             add_braces(corrector, return_node.first_argument)

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -244,6 +244,21 @@ RSpec.describe RuboCop::Cop::Style::RedundantReturn, :config do
         end
       RUBY
     end
+
+    it 'reports an offense when multiple return values have a parenthesized return value' do
+      expect_offense(<<~RUBY)
+        def do_something
+          return (foo && bar), 42
+          ^^^^^^ Redundant `return` detected. To return multiple values, use an array.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def do_something
+          [(foo && bar), 42]
+        end
+      RUBY
+    end
   end
 
   context 'when multi-value returns are allowed' do


### PR DESCRIPTION
Fixes #9314.

This PR fixes an incorrect auto-correct for `Style/RedundantReturn` when multiple return values have a parenthesized return value.

There may be anther approach that modifies `ReturnNode#arguments` of RuboCop AST (in future).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
