### PR TITLE
[Fix #9316] Make `Style/EmptyLiteral` not register offense when using a numbered block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5316,3 +5316,4 @@
 [@sswander]: https://github.com/sswander
 [@makicamel]: https://github.com/makicamel
 [@h-lame]: https://github.com/h-lame
+[@agargiulo]: https://github.com/agargiulo

--- a/changelog/fix_incorrect_offense_for_style_empty_literal.md
+++ b/changelog/fix_incorrect_offense_for_style_empty_literal.md
@@ -1,0 +1,1 @@
+* [#9316](https://github.com/rubocop-hq/rubocop/issues/9316): Fix `Style/EmptyLiteral` registering wrong offense when using a numbered block for Hash.new, i.e. `Hash.new { _1[_2] = [] }`. ([@agargiulo][])

--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -32,8 +32,12 @@ module RuboCop
         def_node_matcher :str_node, '(send (const {nil? cbase} :String) :new)'
         def_node_matcher :array_with_block,
                          '(block (send (const {nil? cbase} :Array) :new) args _)'
-        def_node_matcher :hash_with_block,
-                         '(block (send (const {nil? cbase} :Hash) :new) args _)'
+        def_node_matcher :hash_with_block, <<~PATTERN
+          {
+            (block (send (const {nil? cbase} :Hash) :new) args _)
+            (numblock (send (const {nil? cbase} :Hash) :new) ...)
+          }
+        PATTERN
 
         def on_send(node)
           return unless (message = offense_message(node))

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -108,6 +108,16 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral do
       expect_no_offenses('test = ::Hash.new { block }')
     end
 
+    context 'Ruby 2.7', :ruby27 do
+      it 'does not register an offense for Hash.new { _1[_2] = [] }' do
+        expect_no_offenses('test = Hash.new { _1[_2] = [] }')
+      end
+
+      it 'does not register an offense for ::Hash.new { _1[_2] = [] }' do
+        expect_no_offenses('test = ::Hash.new { _1[_2] = [] }')
+      end
+    end
+
     it 'auto-corrects Hash.new in block ' do
       expect_offense(<<~RUBY)
         puts { Hash.new }


### PR DESCRIPTION
Fixes #9316

`Hash.new { _1[_2] = [] }` is valid code but the cop was not parsing the
numblock correctly when parsing ruby27. Now it treats both the above and
`Hash.new { |h, k| h[k] = [] }`
as valid statements.

Update the parsing in `Style/EmptyLiteral#hash_with_block` to account for `numblock`s in addition to regular `block`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
