### PR TITLE
Support asdf's .tool-versions file

### DIFF
--- a/changelog/new_support_asdfs_toolversions_file.md
+++ b/changelog/new_support_asdfs_toolversions_file.md
@@ -1,0 +1,1 @@
+* [#9319](https://github.com/rubocop-hq/rubocop/pull/9319): Support asdf's .tool-versions file. ([@noon-ng][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -132,12 +132,13 @@ AllCops:
   # If a value is specified for TargetRubyVersion then it is used. Acceptable
   # values are specificed as a float (i.e. 2.5); the teeny version of Ruby
   # should not be included. If the project specifies a Ruby version in the
-  # .ruby-version file, Gemfile or gems.rb file, RuboCop will try to determine
-  # the desired version of Ruby by inspecting the .ruby-version file first,
-  # followed by the Gemfile.lock or gems.locked file. (Although the Ruby version
-  # is specified in the Gemfile or gems.rb file, RuboCop reads the final value
-  # from the lock file.) If the Ruby version is still unresolved, RuboCop will
-  # use the oldest officially supported Ruby version (currently Ruby 2.4).
+  # .tool-versions or .ruby-version files, Gemfile or gems.rb file, RuboCop will
+  # try to determine the desired version of Ruby by inspecting the
+  # .tool-versions file first, then .ruby-version, followed by the Gemfile.lock
+  # or gems.locked file. (Although the Ruby version is specified in the Gemfile
+  # or gems.rb file, RuboCop reads the final value from the lock file.) If the
+  # Ruby version is still unresolved, RuboCop will use the oldest officially
+  # supported Ruby version (currently Ruby 2.4).
   TargetRubyVersion: ~
   # Determines if a notification for extension libraries should be shown when
   # rubocop is run. Keys are the name of the extension, and values are an array

--- a/spec/rubocop/target_ruby_spec.rb
+++ b/spec/rubocop/target_ruby_spec.rb
@@ -96,10 +96,42 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
         end
       end
 
-      it 'does not read Gemfile.lock or gems.locked' do
+      it 'does not read .tool-versions, Gemfile.lock or gems.locked' do
+        expect(File).not_to receive(:file?).with('.tool-versions')
         expect(File).not_to receive(:file?).with('Gemfile')
         expect(File).not_to receive(:file?).with('gems.locked')
         target_ruby.version
+      end
+    end
+
+    context 'when .tool-versions is present' do
+      before do
+        dir = configuration.base_dir_for_path_parameters
+        create_file(File.join(dir, '.tool-versions'), tool_versions)
+      end
+
+      context 'when .tool-versions contains a ruby version' do
+        let(:tool_versions) { ['ruby 3.0.0', 'nodejs 14.9.0'] }
+        let(:ruby_version_to_f) { 3.0 }
+
+        it 'reads it to determine the target ruby version' do
+          expect(target_ruby.version).to eq ruby_version_to_f
+        end
+
+        it 'does not read Gemfile.lock, gems.locked' do
+          expect(File).not_to receive(:file?).with(/Gemfile/)
+          expect(File).not_to receive(:file?).with(/gems\.locked/)
+          target_ruby.version
+        end
+      end
+
+      context 'when .tool-versions does not contain a ruby version' do
+        let(:tool_versions) { ['nodejs 14.9.0'] }
+        let(:ruby_version_to_f) { 3.0 }
+
+        it 'uses the default ruby version' do
+          expect(target_ruby.version).to eq default_version
+        end
       end
     end
 


### PR DESCRIPTION
Hey all,
Happy new year! 🎉
First time contribution so apologies in advance if I'm going about this the wrong way. I figured this could be a worthwhile feature addition to Rubocop. 

For context:

I recently switched to [asdf](https://github.com/asdf-vm/asdf) from rbenv on my personal dev environment.

I decided to try out Ruby 3.0 today on a project, and when I started getting errors from Rubocop on Ruby 3.0-specific syntax, I realized that project had a leftover `.ruby-version` pointing to 2.6.3 which surprisingly Rubocop was picking up.

At that point I felt there was an opportunity to extend the target version detection logic to be aware of asdf's `.tool-versions` file, so here is a proposed change to support that.

Suggest reading the commit message for detail.

Thanks!

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
