### PR TITLE
Support unicode-display_width v2

### DIFF
--- a/changelog/change_support_unicodedisplay_width_v2.md
+++ b/changelog/change_support_unicodedisplay_width_v2.md
@@ -1,0 +1,1 @@
+* [#9320](https://github.com/rubocop-hq/rubocop/pull/9320): Support unicode-display_width v2. ([@dduugg][])

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -7,7 +7,7 @@ require 'rainbow'
 require 'set'
 require 'forwardable'
 require 'regexp_parser'
-require 'unicode/display_width/no_string_ext'
+require 'unicode/display_width'
 
 # we have to require RuboCop's version, before rubocop-ast's
 require_relative 'rubocop/version'

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rexml')
   s.add_runtime_dependency('rubocop-ast', '>= 1.2.0', '< 2.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
-  s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 2.0')
+  s.add_runtime_dependency('unicode-display_width', '>= 1.4.0', '< 3.0')
 
   s.add_development_dependency('bundler', '>= 1.15.0', '< 3.0')
 end


### PR DESCRIPTION
Adds support for v2 of `unicode-display_width`. This version emits a [warning](https://github.com/janlelis/unicode-display_width/blob/main/lib/unicode/display_width/no_string_ext.rb#L3-L6) when requiring the `no_string_ext` version, since omitting `String` extensions is the default. To compensate, I've reverted to the normal `require`, but this will of course include `String` extensions when the gem version is < 2. (It may make sense to require the `unicode-display_width`version be >= 2, to avoid unintentionally using a conflicting `String` API, let me know which approach you'd prefer.)

The only use of this library appears to be an invocation of `Unicode::DisplayWidth.of` in `lib/rubocop/cop/mixin/alignment.rb`, so this should be compatible with the v2 library [changes](lib/rubocop/cop/mixin/alignment.rb).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
