### PR TITLE
Mark `Style/MutableConstant` as unsafe

### DIFF
--- a/changelog/change_mark_style_mutable_constant_as_unsafe.md
+++ b/changelog/change_mark_style_mutable_constant_as_unsafe.md
@@ -1,0 +1,1 @@
+* [#9331](https://github.com/rubocop-hq/rubocop/pull/9331): Mark `Style/MutableConstant` as unsafe. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3735,7 +3735,8 @@ Style/MutableConstant:
   Description: 'Do not assign mutable objects to constants.'
   Enabled: true
   VersionAdded: '0.34'
-  VersionChanged: '0.65'
+  VersionChanged: <<next>>
+  SafeAutoCorrect: false
   EnforcedStyle: literals
   SupportedStyles:
     # literals: freeze literals assigned to constants


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/8529.

`Style/MutableConstant` is the same as `Style/FrozenStringLiteralComment`, freezing object is unsafe auto-correction.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
