### PR TITLE
[Fix #9333] Fix an error for `Style/IfInsideElse`

### DIFF
--- a/changelog/fix_an_error_for_style_if_inside_else.md
+++ b/changelog/fix_an_error_for_style_if_inside_else.md
@@ -1,0 +1,1 @@
+* [#9333](https://github.com/rubocop-hq/rubocop/issues/9333): Fix an error for `Style/IfInsideElse` when using a modifier `if` nested inside an `else` after `elsif`. ([@koic][])

--- a/lib/rubocop/cop/style/if_inside_else.rb
+++ b/lib/rubocop/cop/style/if_inside_else.rb
@@ -82,12 +82,10 @@ module RuboCop
         def autocorrect(corrector, node)
           if node.modifier_form?
             correct_to_elsif_from_modifier_form(corrector, node)
-            end_range = node.parent.loc.end
           else
             correct_to_elsif_from_if_inside_else_form(corrector, node, node.condition)
-            end_range = node.loc.end
           end
-          corrector.remove(range_by_whole_lines(end_range, include_final_newline: true))
+          corrector.remove(range_by_whole_lines(find_end_range(node), include_final_newline: true))
           corrector.remove(
             range_by_whole_lines(node.if_branch.source_range, include_final_newline: true)
           )
@@ -108,6 +106,13 @@ module RuboCop
           )
           corrector.replace(if_condition_range, node.if_branch.source)
           corrector.remove(condition)
+        end
+
+        def find_end_range(node)
+          end_range = node.loc.end
+          return end_range if end_range
+
+          find_end_range(node.parent)
         end
 
         def allow_if_modifier_in_else_branch?(else_branch)

--- a/spec/rubocop/cop/style/if_inside_else_spec.rb
+++ b/spec/rubocop/cop/style/if_inside_else_spec.rb
@@ -84,6 +84,29 @@ RSpec.describe RuboCop::Cop::Style::IfInsideElse, :config do
     RUBY
   end
 
+  it 'catches a modifier if nested inside an else after elsif' do
+    expect_offense(<<~RUBY)
+      if a
+        blah
+      elsif b
+        foo
+      else
+        bar if condition
+            ^^ Convert `if` nested inside `else` to `elsif`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if a
+        blah
+      elsif b
+        foo
+      elsif condition
+        bar
+      end
+    RUBY
+  end
+
   context 'when AllowIfModifier is false' do
     it 'catches a modifier if nested inside an else' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #9333.

This PR fixes an error for `Style/IfInsideElse` when using a modifier `if` nested inside an `else` after `elsif`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
