### PR TITLE
Improve comments handling in couple of auto-corrections

### DIFF
--- a/changelog/fix_handling_of_comments_during_autocorrection.md
+++ b/changelog/fix_handling_of_comments_during_autocorrection.md
@@ -1,0 +1,1 @@
+* [#9233](https://github.com/rubocop-hq/rubocop/issues/9233): Fix `Style/SoleNestedConditional` copying non-relevant comments during auto-correction. ([@Darhazer][])

--- a/lib/rubocop/cop/mixin/comments_help.rb
+++ b/lib/rubocop/cop/mixin/comments_help.rb
@@ -22,16 +22,7 @@ module RuboCop
       end
 
       def begin_pos_with_comment(node)
-        annotation_line = node.first_line - 1
-        first_comment = nil
-
-        processed_source.comments_before_line(annotation_line)
-                        .reverse_each do |comment|
-          if comment.location.line == annotation_line
-            first_comment = comment
-            annotation_line -= 1
-          end
-        end
+        first_comment = processed_source.ast_with_comments[node].first
 
         start_line_position(first_comment || node)
       end

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -100,7 +100,7 @@ module RuboCop
         def correct_for_comment(corrector, node, if_branch)
           return if config.for_cop('Style/IfUnlessModifier')['Enabled']
 
-          comments = processed_source.comments_before_line(if_branch.source_range.line)
+          comments = processed_source.ast_with_comments[if_branch]
           comment_text = comments.map(&:text).join("\n") << "\n"
 
           corrector.insert_before(node.loc.keyword, comment_text) unless comments.empty?

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -221,6 +221,27 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
           end
       RUBY
     end
+
+    it 'registers an offense and corrects when there are outer and inline comments' do
+      expect_offense(<<~RUBY)
+        # Outer comment.
+        if foo
+          # Comment.
+          if bar # nested condition
+          ^^ Consider merging nested conditions into outer `if` conditions.
+            do_something
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # Outer comment.
+        # Comment.
+        if foo && bar # nested condition
+            do_something
+          end
+      RUBY
+    end
   end
 
   it 'registers an offense and corrects when using guard conditional with outer comment' do


### PR DESCRIPTION
I learned the hard way that the `comments_before_line` won't stop until the very first line in the processed file, and that it doesn't care whether the comments begin their own line or not. So I replaced it in the 2 cops that use it.

In one of them (that uses the CommentsHelp mixin) the code already tried to limit the damage by looking for consecutive lines, so it would only break if there is a node with inline comment and missing separating line. 

The other one however would completely mess the comments, bringing all of the unrelated one to the new position, so I added spec for that case. It also fixes #9233 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
