### PR TITLE
Use IRB instead of Pry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ if RUBY_VERSION >= '2.5.0'
 else
   gem 'memory_profiler', '<= 1.0.0', platform: :mri
 end
-gem 'pry'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.9.0'

--- a/bin/console
+++ b/bin/console
@@ -2,9 +2,9 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-require 'pry'
+require 'irb'
 require 'rubocop'
 
 ARGV.clear
 
-RuboCop.pry
+IRB.start(__FILE__)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,6 @@ require 'rubocop/cop/internal_affairs'
 require 'webmock/rspec'
 
 require_relative 'core_ext/string'
-require 'pry'
 
 # Require supporting files exposed for testing.
 require 'rubocop/rspec/support'


### PR DESCRIPTION
This PR uses IRB instead of Pry.

Since IRB has many enhancements since Ruby 2.7.
https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/

It replace this PR with the standard REPL IRB.

Since use of IRB is limited to RuboCop development tool, there is no impact on end users.

TIPS: If you cannot do syntax highlighting or multi-line editing with IRB of Ruby 2.7 or higher, please check the following setting.

```ruby
# ~/.irbrc

IRB.conf[:USE_READLINE] = true
```

If `IRB.conf[:USE_READLINE]` is true, either remove it or set to `false`, Reline is used instead of Readline.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
