### PR TITLE
[Fix #9342] Fix an error for `Lint/RedundantDirGlobSort`

### DIFF
--- a/changelog/fix_an_error_for_lint_redundant_dir_glob_sort.md
+++ b/changelog/fix_an_error_for_lint_redundant_dir_glob_sort.md
@@ -1,0 +1,1 @@
+* [#9342](https://github.com/rubocop-hq/rubocop/issues/9342): Fix an error for `Lint/RedundantDirGlobSort` when using `collection.sort`. ([@koic][])

--- a/lib/rubocop/cop/lint/redundant_dir_glob_sort.rb
+++ b/lib/rubocop/cop/lint/redundant_dir_glob_sort.rb
@@ -34,11 +34,13 @@ module RuboCop
 
         def on_send(node)
           return unless (receiver = node.receiver)
-          return unless receiver.receiver.const_type? && receiver.receiver.short_name == :Dir
+          return unless receiver.receiver&.const_type? && receiver.receiver.short_name == :Dir
           return unless GLOB_METHODS.include?(receiver.method_name)
 
-          add_offense(node.loc.selector) do |corrector|
-            corrector.remove(node.loc.selector)
+          selector = node.loc.selector
+
+          add_offense(selector) do |corrector|
+            corrector.remove(selector)
             corrector.remove(node.loc.dot)
           end
         end

--- a/spec/rubocop/cop/lint/redundant_dir_glob_sort_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_dir_glob_sort_spec.rb
@@ -54,6 +54,12 @@ RSpec.describe RuboCop::Cop::Lint::RedundantDirGlobSort, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense when using `collection.sort`' do
+      expect_no_offenses(<<~RUBY)
+        collection.sort
+      RUBY
+    end
   end
 
   context 'when Ruby 2.7 or lower', :ruby27 do


### PR DESCRIPTION
Fixes #9342.

This PR fixes an error for `Lint/RedundantDirGlobSort` when using `collection.sort`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
