### PR TITLE
Fix an incorrect auto-correct for `StringConcatenation` when concat string includes double quote and interpolation.

### DIFF
--- a/changelog/fix_string_concatenation_correctioon_in_handle_double_quote.md
+++ b/changelog/fix_string_concatenation_correctioon_in_handle_double_quote.md
@@ -1,0 +1,1 @@
+* [#9346](https://github.com/rubocop-hq/rubocop/pull/9346): Fix an incorrect auto-correct for `Style/StringConcatenation` when concat string include double quotes and interpolation. ([@k-karen][])

--- a/lib/rubocop/cop/style/string_concatenation.rb
+++ b/lib/rubocop/cop/style/string_concatenation.rb
@@ -116,7 +116,7 @@ module RuboCop
             parts.map do |part|
               if part.str_type?
                 if single_quoted?(part)
-                  part.value.gsub('\\') { '\\\\' }
+                  part.value.gsub(/(\\|")/, '\\\\\&')
                 else
                   part.value.inspect[1..-2]
                 end

--- a/spec/rubocop/cop/style/string_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/string_concatenation_spec.rb
@@ -190,4 +190,17 @@ RSpec.describe RuboCop::Cop::Style::StringConcatenation do
       RUBY
     end
   end
+
+  context 'double quotes inside string surrounded single quotes' do
+    it 'registers an offense and corrects with double quotes' do
+      expect_offense(<<-RUBY)
+        '"bar"' + foo
+        ^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+      RUBY
+
+      expect_correction(<<-RUBY)
+        "\\\"bar\\\"\#{foo}"
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This PR will resolve following problem. 

```ruby
'"bar"' + foo
```

after `rubocop  -A`

```ruby
""bar"#{foo}"
```

`""bar"#{foo}"` should be `"\"bar\"#{foo}"`

This pull request doesn't have related issue.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
