### PR TITLE
[Fix #9345] Make `Style/AsciiComments` allow copyright notice

### DIFF
--- a/changelog/change_make_style_ascii_comments_allow_copyright_notice.md
+++ b/changelog/change_make_style_ascii_comments_allow_copyright_notice.md
@@ -1,0 +1,1 @@
+* [#9345](https://github.com/rubocop-hq/rubocop/issues/9345): Make `Style/AsciiComments` allow copyright notice by default. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2689,7 +2689,8 @@ Style/AsciiComments:
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.52'
-  AllowedChars: []
+  AllowedChars:
+    - ©
 
 Style/Attr:
   Description: 'Checks for uses of Module#attr.'

--- a/lib/rubocop/cop/style/ascii_comments.rb
+++ b/lib/rubocop/cop/style/ascii_comments.rb
@@ -7,7 +7,7 @@ module RuboCop
     module Style
       # This cop checks for non-ascii (non-English) characters
       # in comments. You could set an array of allowed non-ascii chars in
-      # AllowedChars attribute (empty by default).
+      # `AllowedChars` attribute (copyright notice "©" by default).
       #
       # @example
       #   # bad

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -1130,6 +1130,11 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
       it 'prints all cops in their right department listing' do
         lines = stdout.lines
+        # FIXME: Remove the following workaround condition for JRuby.
+        # https://github.com/jruby/jruby/issues/6528
+        if RUBY_ENGINE == 'jruby' && Encoding.default_external == Encoding::ASCII
+          lines = lines.select(&:valid_encoding?)
+        end
         lines.slice_before(/Department /).each do |slice|
           departments = registry.departments.map(&:to_s)
           current =


### PR DESCRIPTION
Fixes #9345.

This PR makes `Style/AsciiComments` allow copyright notice "©" by default.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
