### PR TITLE
Fix sole nested conditional handle parens

### DIFF
--- a/changelog/fix_wrap_in_parens_before_replacing_unless.md
+++ b/changelog/fix_wrap_in_parens_before_replacing_unless.md
@@ -1,0 +1,1 @@
+* [#9350](https://github.com/rubocop-hq/rubocop/pull/9350): Wrap in parens before replacing `unless` with `if` and `!`. ([@magneland][])

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -63,12 +63,12 @@ module RuboCop
         end
 
         def autocorrect(corrector, node, if_branch)
+          corrector.wrap(node.condition, '(', ')') if node.condition.or_type?
+
           if node.unless?
             corrector.replace(node.loc.keyword, 'if')
             corrector.insert_before(node.condition, '!')
           end
-
-          corrector.wrap(node.condition, '(', ')') if node.condition.or_type?
 
           and_operator = if_branch.unless? ? ' && !' : ' && '
           if if_branch.modifier_form?

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -178,6 +178,38 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using `unless` and `||` and parens in the outer condition' \
+     'and nested modifier condition ' do
+    expect_offense(<<~RUBY)
+      unless (foo || bar)
+        do_something if baz
+                     ^^ Consider merging nested conditions into outer `unless` conditions.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if !(foo || bar) && baz
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using `unless` and `||` without parens in the outer condition' \
+     'and nested modifier condition ' do
+    expect_offense(<<~RUBY)
+      unless foo || bar
+        do_something if baz
+                     ^^ Consider merging nested conditions into outer `unless` conditions.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if !(foo || bar) && baz
+        do_something
+      end
+    RUBY
+  end
+
   it 'registers an offense and corrects for multiple nested conditionals' do
     expect_offense(<<~RUBY)
       if foo


### PR DESCRIPTION
Fix edge case in `Style/SoleNestedConditional` auto-correct.

I think it only applies to an outer `unless` with multiple conditions, but without parens.

The addition of parentheses is correct.
However, the `!` is the wrong place.
It should be before the parentheses.