### PR TITLE
[Fix #9349] Fix a false positive for `Lint/MultipleComparison`

### DIFF
--- a/changelog/fix_false_positive_for_lint_multiple_comparison.md
+++ b/changelog/fix_false_positive_for_lint_multiple_comparison.md
@@ -1,0 +1,1 @@
+* [#9349](https://github.com/rubocop-hq/rubocop/issues/9349): Fix a false positive for `Lint/MultipleComparison` when using `&`, `|`, and `^` set operation operators in multiple comparison. ([@koic][])

--- a/lib/rubocop/cop/lint/multiple_comparison.rb
+++ b/lib/rubocop/cop/lint/multiple_comparison.rb
@@ -11,14 +11,10 @@ module RuboCop
       # @example
       #
       #   # bad
-      #
       #   x < y < z
       #   10 <= x <= 20
       #
-      # @example
-      #
       #   # good
-      #
       #   x < y && y < z
       #   10 <= x && x <= 20
       class MultipleComparison < Base
@@ -26,6 +22,7 @@ module RuboCop
 
         MSG = 'Use the `&&` operator to compare multiple values.'
         COMPARISON_METHODS = %i[< > <= >=].freeze
+        SET_OPERATION_OPERATORS = %i[& | ^].freeze
         RESTRICT_ON_SEND = COMPARISON_METHODS
 
         def_node_matcher :multiple_compare?, <<~PATTERN
@@ -34,6 +31,9 @@ module RuboCop
 
         def on_send(node)
           return unless (center = multiple_compare?(node))
+          # It allows multiple comparison using `&`, `|`, and `^` set operation operators.
+          # e.g. `x >= y & y < z`
+          return if center.send_type? && SET_OPERATION_OPERATORS.include?(center.method_name)
 
           add_offense(node) do |corrector|
             new_center = "#{center.source} && #{center.source}"

--- a/spec/rubocop/cop/lint/multiple_comparison_spec.rb
+++ b/spec/rubocop/cop/lint/multiple_comparison_spec.rb
@@ -22,4 +22,16 @@ RSpec.describe RuboCop::Cop::Lint::MultipleComparison, :config do
   it 'accepts to use one compare operator' do
     expect_no_offenses('x < 1')
   end
+
+  it 'accepts to use `&` operator' do
+    expect_no_offenses('x >= y & x < z')
+  end
+
+  it 'accepts to use `|` operator' do
+    expect_no_offenses('x >= y | x < z')
+  end
+
+  it 'accepts to use `^` operator' do
+    expect_no_offenses('x >= y ^ x < z')
+  end
 end


### PR DESCRIPTION
Fixes #9349.

This PR fixes a false positive for `Lint/MultipleComparison` when using `&`, `|`, and `^` (DSL) set operation operators.

e.g. `Arel::Match`'s DSL methods.
https://github.com/rails/rails/blob/v6.1.1/activerecord/lib/arel/math.rb#L21-L23

I think that the cop can probably allow using these operators by default.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
