### PR TITLE
[Fix #8229] Fix faulty calculation in UncommunicativeName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5350,3 +5350,4 @@
 [@agargiulo]: https://github.com/agargiulo
 [@muirdm]: https://github.com/muirdm
 [@noon-ng]: https://github.com/noon-ng
+[@ohbarye]: https://github.com/ohbarye

--- a/changelog/fix_faulty_calculation_in_uncommunicative_name.md
+++ b/changelog/fix_faulty_calculation_in_uncommunicative_name.md
@@ -1,0 +1,1 @@
+* [#8229](https://github.com/rubocop-hq/rubocop/issues/8229): Fix faulty calculation in UncommunicativeName. ([@ohbarye][])

--- a/lib/rubocop/cop/mixin/uncommunicative_name.rb
+++ b/lib/rubocop/cop/mixin/uncommunicative_name.rb
@@ -24,7 +24,11 @@ module RuboCop
           name = full_name.gsub(/\A(_+)/, '')
           next if allowed_names.include?(name)
 
-          range = arg_range(arg, name.size)
+          length = full_name.size
+          length += 1 if arg.restarg_type?
+          length += 2 if arg.kwrestarg_type?
+
+          range = arg_range(arg, length)
           issue_offenses(node, range, name)
         end
       end

--- a/spec/rubocop/cop/naming/block_parameter_name_spec.rb
+++ b/spec/rubocop/cop/naming/block_parameter_name_spec.rb
@@ -44,6 +44,18 @@ RSpec.describe RuboCop::Cop::Naming::BlockParameterName, :config do
     RUBY
   end
 
+  it 'registers offense when param with prefix is less than minimum length' do
+    expect_offense(<<~RUBY)
+      something do |_a, __b, *c, **__d|
+                    ^^ Block parameter must be at least 2 characters long.
+                        ^^^ Block parameter must be at least 2 characters long.
+                             ^^ Block parameter must be at least 2 characters long.
+                                 ^^^^^ Block parameter must be at least 2 characters long.
+        do_stuff
+      end
+    RUBY
+  end
+
   it 'registers offense when param contains uppercase characters' do
     expect_offense(<<~RUBY)
       something { |number_One| do_stuff }

--- a/spec/rubocop/cop/naming/method_parameter_name_spec.rb
+++ b/spec/rubocop/cop/naming/method_parameter_name_spec.rb
@@ -99,6 +99,18 @@ RSpec.describe RuboCop::Cop::Naming::MethodParameterName, :config do
     RUBY
   end
 
+  it 'registers offense when parameter with prefix is less than minimum length' do
+    expect_offense(<<~RUBY)
+      def something(_a, __b, *c, **__d)
+                    ^^ Method parameter must be at least 3 characters long.
+                        ^^^ Method parameter must be at least 3 characters long.
+                             ^^ Method parameter must be at least 3 characters long.
+                                 ^^^^^ Method parameter must be at least 3 characters long.
+        do_stuff
+      end
+    RUBY
+  end
+
   it 'registers offense when parameter contains uppercase characters' do
     expect_offense(<<~RUBY)
       def something(number_One)


### PR DESCRIPTION
Fix #8229

`UncommunicativeName#check` does faulty calculation of location when a parameter has a prefix like `_`, `*`.

As for the file below,

```ruby
def test1(_a); end

def test2(__a); end

def test3(*a); end

def test4(**a); end

def test5(**__a); end
```

it shows offenses with faulty locations.

```shell
$ rubocop test.rb
Inspecting 1 file
C

Offenses:

test.rb:3:11: C: Naming/MethodParameterName: Method parameter must be at least 3 characters long.
def test1(_a); end
          ^
test.rb:5:11: C: Naming/MethodParameterName: Method parameter must be at least 3 characters long.
def test2(__a); end
          ^
test.rb:7:11: C: Naming/MethodParameterName: Method parameter must be at least 3 characters long.
def test3(*a); end
          ^
test.rb:9:11: C: Naming/MethodParameterName: Method parameter must be at least 3 characters long.
def test4(**a); end
          ^
test.rb:11:11: C: Naming/MethodParameterName: Method parameter must be at least 3 characters long.
def test5(**__a); end
          ^

1 file inspected, 5 offenses detected
```

This commit fixed the behavior and make it show the correct locations.

```shell
$ rubocop test.rb
Inspecting 1 file
C

Offenses:

test.rb:3:11: C: Naming/MethodParameterName: Method parameter must be at least 3 characters long.
def test1(_a); end
          ^^
test.rb:5:11: C: Naming/MethodParameterName: Method parameter must be at least 3 characters long.
def test2(__a); end
          ^^^
test.rb:7:11: C: Naming/MethodParameterName: Method parameter must be at least 3 characters long.
def test3(*a); end
          ^^
test.rb:9:11: C: Naming/MethodParameterName: Method parameter must be at least 3 characters long.
def test4(**a); end
          ^^^
test.rb:11:11: C: Naming/MethodParameterName: Method parameter must be at least 3 characters long.
def test5(**__a); end
          ^^^^^

1 file inspected, 5 offenses detected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
