### PR TITLE
Allow `pry` to be activated in rspec if in the local gemfile.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,12 @@ require 'webmock/rspec'
 
 require_relative 'core_ext/string'
 
+begin
+  require 'pry'
+rescue LoadError
+  # Pry is not activated.
+end
+
 # Require supporting files exposed for testing.
 require 'rubocop/rspec/support'
 


### PR DESCRIPTION
Re: https://github.com/rubocop-hq/rubocop/pull/9341#issuecomment-757504942

#9341 replaced pry with irb but it is useful for debugging. This change will just allow pry to be used in rspec if it's activated from Gemfile.local.