### PR TITLE
[Fix #9355] Fix `Style/SingleLineMethods` autocorrection to endless method when the original code had parens

### DIFF
--- a/changelog/fix_fix_stylesinglelinemethods.md
+++ b/changelog/fix_fix_stylesinglelinemethods.md
@@ -1,0 +1,1 @@
+* [#9355](https://github.com/rubocop-hq/rubocop/issues/9355): Fix `Style/SingleLineMethods` autocorrection to endless method when the original code had parens. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -89,7 +89,8 @@ module RuboCop
         end
 
         def correct_to_endless(corrector, node)
-          replacement = "def #{node.method_name}(#{node.arguments.source}) = #{node.body.source}"
+          arguments = node.arguments.any? ? node.arguments.source : '()'
+          replacement = "def #{node.method_name}#{arguments} = #{node.body.source}"
           corrector.replace(node, replacement)
         end
 

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -176,6 +176,18 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods do
         RUBY
       end
 
+      it 'handles arguments properly' do
+        expect_correction(<<~RUBY.strip, source: 'def some_method(a, b, c) body end')
+          def some_method(a, b, c) = body
+        RUBY
+      end
+
+      it 'does not add parens if they are already present' do
+        expect_correction(<<~RUBY.strip, source: 'def some_method() body end')
+          def some_method() = body
+        RUBY
+      end
+
       it 'does not correct to an endless method if the method body contains multiple statements' do
         expect_correction(<<~RUBY.strip, source: 'def some_method; foo; bar end')
           def some_method;#{trailing_whitespace}


### PR DESCRIPTION
Previously this was adding extra parens erroneously. Fixes #9355.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
