### PR TITLE
[Fix #9366] Fix an incorrect auto-correct for `Style/SoleNestedConditional`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_sole_nested_conditional.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_sole_nested_conditional.md
@@ -1,0 +1,1 @@
+* [#9366](https://github.com/rubocop-hq/rubocop/issues/9366): Fix an incorrect auto-correct for `Style/SoleNestedConditional` when using method arguments without parentheses for outer condition. ([@koic][])

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -210,6 +210,54 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using `unless` and method arguments without parentheses ' \
+     'in the outer condition and nested modifier condition' do
+    expect_offense(<<~RUBY)
+      unless foo.is_a? Foo
+        do_something if bar
+                     ^^ Consider merging nested conditions into outer `unless` conditions.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if !foo.is_a?(Foo) && bar
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using `unless` and method arguments with parentheses ' \
+     'in the outer condition and nested modifier condition' do
+    expect_offense(<<~RUBY)
+      unless foo.is_a?(Foo)
+        do_something if bar
+                     ^^ Consider merging nested conditions into outer `unless` conditions.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if !foo.is_a?(Foo) && bar
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using `unless` and multiple method arguments with parentheses' \
+     'in the outer condition and nested modifier condition' do
+    expect_offense(<<~RUBY)
+      unless foo.bar arg1, arg2
+        do_something if baz
+                     ^^ Consider merging nested conditions into outer `unless` conditions.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if !foo.bar(arg1, arg2) && baz
+        do_something
+      end
+    RUBY
+  end
+
   it 'registers an offense and corrects for multiple nested conditionals' do
     expect_offense(<<~RUBY)
       if foo


### PR DESCRIPTION
Fixes #9366.

This PR fixes an incorrect auto-correct for `Style/SoleNestedConditional` when using method arguments without parentheses for outer condition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
