### PR TITLE
[Fix #7452] Support `IgnoredMethods` option for `Style/FormatStringToken`

### DIFF
--- a/changelog/new_support_ignored_methods_for_style_format_string_token.md
+++ b/changelog/new_support_ignored_methods_for_style_format_string_token.md
@@ -1,0 +1,1 @@
+* [#7452](https://github.com/rubocop-hq/rubocop/issues/7452): Support `IgnoredMethods` option for `Style/FormatStringToken`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3340,6 +3340,7 @@ Style/FormatStringToken:
   MaxUnannotatedPlaceholdersAllowed: 1
   VersionAdded: '0.49'
   VersionChanged: '1.0'
+  IgnoredMethods: []
 
 Style/FrozenStringLiteralComment:
   Description: >-

--- a/lib/rubocop/cop/style/format_string_token.rb
+++ b/lib/rubocop/cop/style/format_string_token.rb
@@ -11,6 +11,8 @@ module RuboCop
       # The reason is that _unannotated_ format is very similar
       # to encoded URLs or Date/Time formatting strings.
       #
+      # This cop can be customized ignored methods with `IgnoredMethods`.
+      #
       # @example EnforcedStyle: annotated (default)
       #
       #   # bad
@@ -58,12 +60,18 @@ module RuboCop
       #
       #   # good
       #   format('%06d', 10)
+      #
+      # @example IgnoredMethods: [redirect]
+      #
+      #   # good
+      #   redirect('foo/%{bar_id}')
+      #
       class FormatStringToken < Base
         include ConfigurableEnforcedStyle
+        include IgnoredMethods
 
         def on_str(node)
-          return unless node.value.include?('%')
-          return if node.each_ancestor(:xstr, :regexp).any?
+          return if format_string_token?(node) || use_ignored_method?(node)
 
           detections = collect_detections(node)
           return if detections.empty?
@@ -87,6 +95,14 @@ module RuboCop
             ^(send %0 :% _)
           }
         PATTERN
+
+        def format_string_token?(node)
+          !node.value.include?('%') || node.each_ancestor(:xstr, :regexp).any?
+        end
+
+        def use_ignored_method?(node)
+          (parent = node.parent) && parent.send_type? && ignored_method?(parent.method_name)
+        end
 
         def unannotated_format?(node, detected_style)
           detected_style == :unannotated && !format_string_in_typical_context?(node)

--- a/spec/rubocop/cop/style/format_string_token_spec.rb
+++ b/spec/rubocop/cop/style/format_string_token_spec.rb
@@ -2,12 +2,14 @@
 
 RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
   let(:enforced_style) { :annotated }
+  let(:ignored_methods) { [] }
 
   let(:cop_config) do
     {
       'EnforcedStyle' => enforced_style,
       'SupportedStyles' => %i[annotated template unannotated],
-      'MaxUnannotatedPlaceholdersAllowed' => 0
+      'MaxUnannotatedPlaceholdersAllowed' => 0,
+      'IgnoredMethods' => ignored_methods
     }
   end
 
@@ -247,6 +249,27 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
          ^^^^^^ Prefer annotated tokens (like `%<foo>s`) over template tokens (like `%{foo}`).
       RUBY
       expect_no_corrections
+    end
+
+    context 'when `IgnoredMethods: redirect`' do
+      let(:ignored_methods) { ['redirect'] }
+
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          redirect("%{foo}")
+        RUBY
+      end
+    end
+
+    context 'when `IgnoredMethods: []`' do
+      let(:ignored_methods) { [] }
+
+      it 'does not register an offense' do
+        expect_offense(<<~RUBY)
+          redirect("%{foo}")
+                    ^^^^^^ Prefer annotated tokens (like `%<foo>s`) over template tokens (like `%{foo}`).
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #7452.

This PR supports `IgnoredMethods` option for `Style/FormatStringToken`.

It solves library-specific issues as follows:

```Ruby
# config/routes.rb
get '/catalogue/:book_id/book', to: redirect('book/%{book_id}', status: 301)
                                                   ^^^^^^^^^^ Prefer annotated tokens ...
```

The default is empty for RuboCop cores. I will set `redirect` to `IgnoredMethods` in RuboCop Rails by default.

```yaml
# config/default.yml of rubocop-rails
Style/FormatStringToken:
  IgnoredMethod:
    - redirect
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
