### PR TITLE
[Fix #9372] Fix an error for `Style/IfInsideElse`

### DIFF
--- a/changelog/fix_error_for_style_if_inside_else.md
+++ b/changelog/fix_error_for_style_if_inside_else.md
@@ -1,0 +1,1 @@
+* [#9372](https://github.com/rubocop-hq/rubocop/issues/9372): Fix an error for `Style/IfInsideElse` when nested `if` branch code is empty. ([@koic][])

--- a/lib/rubocop/cop/style/if_inside_else.rb
+++ b/lib/rubocop/cop/style/if_inside_else.rb
@@ -86,9 +86,10 @@ module RuboCop
             correct_to_elsif_from_if_inside_else_form(corrector, node, node.condition)
           end
           corrector.remove(range_by_whole_lines(find_end_range(node), include_final_newline: true))
-          corrector.remove(
-            range_by_whole_lines(node.if_branch.source_range, include_final_newline: true)
-          )
+          return unless (if_branch = node.if_branch)
+
+          range = range_by_whole_lines(if_branch.source_range, include_final_newline: true)
+          corrector.remove(range)
         end
 
         def correct_to_elsif_from_modifier_form(corrector, node)
@@ -101,10 +102,12 @@ module RuboCop
 
         def correct_to_elsif_from_if_inside_else_form(corrector, node, condition)
           corrector.replace(node.parent.loc.else, "elsif #{condition.source}")
-          if_condition_range = range_between(
-            node.loc.keyword.begin_pos, condition.source_range.end_pos
-          )
-          corrector.replace(if_condition_range, node.if_branch.source)
+          if_condition_range = if_condition_range(node, condition)
+          if (if_branch = node.if_branch)
+            corrector.replace(if_condition_range, if_branch.source)
+          else
+            corrector.remove(range_by_whole_lines(if_condition_range, include_final_newline: true))
+          end
           corrector.remove(condition)
         end
 
@@ -113,6 +116,10 @@ module RuboCop
           return end_range if end_range
 
           find_end_range(node.parent)
+        end
+
+        def if_condition_range(node, condition)
+          range_between(node.loc.keyword.begin_pos, condition.source_range.end_pos)
         end
 
         def allow_if_modifier_in_else_branch?(else_branch)

--- a/spec/rubocop/cop/style/if_inside_else_spec.rb
+++ b/spec/rubocop/cop/style/if_inside_else_spec.rb
@@ -51,6 +51,31 @@ RSpec.describe RuboCop::Cop::Style::IfInsideElse, :config do
     RUBY
   end
 
+  it 'catches an `if..else` nested inside an `else` and nested inside `if` branch code is empty' do
+    expect_offense(<<~RUBY)
+      if a
+        foo
+      else
+        if b
+        ^^ Convert `if` nested inside `else` to `elsif`.
+          # TODO: comment.
+        else
+          bar
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if a
+        foo
+      elsif b
+          # TODO: comment.
+        else
+          bar
+      end
+    RUBY
+  end
+
   it 'catches an if..elsif..else nested inside an else' do
     expect_offense(<<~RUBY)
       if a


### PR DESCRIPTION
Fixes #9372.

This PR fixes an error for `Style/IfInsideElse` when nested `if` branch code is empty.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
