### PR TITLE
[Fix #9380] Mark `Style/FloatDivision` as unsafe

### DIFF
--- a/changelog/change_mark_unsafe_for_style_float_division.md
+++ b/changelog/change_mark_unsafe_for_style_float_division.md
@@ -1,0 +1,1 @@
+* [#9380](https://github.com/rubocop-hq/rubocop/issues/9380): Mark `Style/FloatDivision` as unsafe. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3301,6 +3301,7 @@ Style/FloatDivision:
   Enabled: true
   VersionAdded: '0.72'
   VersionChanged: '1.6'
+  Safe: false
   EnforcedStyle: single_coerce
   SupportedStyles:
     - left_coerce

--- a/lib/rubocop/cop/style/float_division.rb
+++ b/lib/rubocop/cop/style/float_division.rb
@@ -7,6 +7,9 @@ module RuboCop
       # It is recommended to either always use `fdiv` or coerce one side only.
       # This cop also provides other options for code consistency.
       #
+      # This cop is marked as unsafe, because if operand variable is a string object
+      # then `.to_f` will be removed and an error will occur.
+      #
       # @example EnforcedStyle: single_coerce (default)
       #   # bad
       #   a.to_f / b.to_f


### PR DESCRIPTION
Fixes #9380.

This PR marks `Style/FloatDivision` as unsafe.

If operand variable is a string object then `.to_f` will be removed and an error will occur.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
