### PR TITLE
[Fix #9374] Fix autocorrection for `Layout/LineLength` when the first argument to a send node is a overly long hash pair

### DIFF
--- a/changelog/fix_dont_autocorrect_layoutlinelength_for_a.md
+++ b/changelog/fix_dont_autocorrect_layoutlinelength_for_a.md
@@ -1,0 +1,1 @@
+* [#9374](https://github.com/rubocop-hq/rubocop/issues/9374): Fix autocorrection for `Layout/LineLength` when the first argument to a send node is a overly long hash pair. ([@dvandersluis][])

--- a/lib/rubocop/cop/mixin/check_line_breakable.rb
+++ b/lib/rubocop/cop/mixin/check_line_breakable.rb
@@ -69,6 +69,11 @@ module RuboCop
       # @api private
       def extract_first_element_over_column_limit(node, elements, max)
         line = node.first_line
+
+        # If the first argument is a hash pair but the method is not parenthesized,
+        # the argument cannot be moved to another line because it cause a syntax error.
+        elements.shift if node.send_type? && !node.parenthesized? && elements.first.pair_type?
+
         i = 0
         i += 1 while within_column_limit?(elements[i], max, line)
         return elements.first if i.zero?


### PR DESCRIPTION
When the first argument of a method call is a hash, and the method is not parenthesized, autocorrection would move the argument to a new line, which would cause a syntax error:

```ruby
foo x: a_really_long_value_that_triggers_the_line_length_cop

# becomes

foo
x: a_really_long_value_that_triggers_the_line_length_cop
#=> SyntaxError: unexpected ':', expecting end-of-input
```

Now, if there is more than one pair, the line break will be added after the first argument instead of before it so that the syntax error is avoided.

Fixes #9374.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
