### PR TITLE
Fix a suggestion message when not auto-correctable

### DIFF
--- a/changelog/fix_a_suggestion_message_when_not_auto_correctable.md
+++ b/changelog/fix_a_suggestion_message_when_not_auto_correctable.md
@@ -1,0 +1,1 @@
+* [#9384](https://github.com/rubocop-hq/rubocop/pull/9384): Fix a suggestion message when not auto-correctable. ([@koic][])

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -351,7 +351,7 @@ module RuboCop
       def use_corrector(range, corrector)
         if autocorrect?
           attempt_correction(range, corrector)
-        elsif corrector
+        elsif corrector && cop_config.fetch('AutoCorrect', true)
           :uncorrected
         else
           :unsupported

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -1089,7 +1089,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                       '--display-style-guide',
                       'example1.rb'])).to eq(1)
 
-      output = "#{file}:1:6: C: [Correctable] Security/JSONLoad: " \
+      output = "#{file}:1:6: C: Security/JSONLoad: " \
                "Prefer `JSON.parse` over `JSON.load`. (#{url})"
       expect($stdout.string.lines.to_a[-1])
         .to eq([output, ''].join("\n"))
@@ -1782,6 +1782,26 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           '1 file inspected, 2 offenses detected, 1 offense corrected, 1 more offense '\
           "can be corrected with `rubocop -A`\n"
         )
+      end
+    end
+
+    context 'when setting `AutoCorrect: false` for `Style/StringLiterals`' do
+      before do
+        create_file('.rubocop.yml', <<~YAML)
+          Style/StringLiterals:
+            AutoCorrect: false
+        YAML
+      end
+
+      it 'does not suggest `1 more offense can be corrected with `rubocop -A` for `Style/StringLiterals`' do
+        create_file(target_file, <<~RUBY)
+          # frozen_string_literal: true
+
+          a = "Hello"
+        RUBY
+
+        expect(cli.run(['--auto-correct', '--format', 'simple', target_file])).to eq(1)
+        expect($stdout.string.lines.to_a.last).to eq("1 file inspected, 2 offenses detected\n")
       end
     end
   end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1656,6 +1656,28 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     end
   end
 
+  describe 'configuration of `AutoCorrect`' do
+    context 'when setting `AutoCorrect: false` for `Style/StringLiterals`' do
+      before do
+        create_file('.rubocop.yml', <<~YAML)
+          Style/StringLiterals:
+            AutoCorrect: false
+        YAML
+      end
+
+      it 'does not suggest `1 offense auto-correctable` for `Style/StringLiterals`' do
+        create_file('example.rb', <<~RUBY)
+          # frozen_string_literal: true
+
+          a = "Hello"
+        RUBY
+
+        expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
+        expect($stdout.string.lines.to_a.last).to eq("1 file inspected, 2 offenses detected\n")
+      end
+    end
+  end
+
   describe 'configuration of target Ruby versions' do
     context 'when configured with an unknown version' do
       it 'fails with an error message' do


### PR DESCRIPTION
This PR fixes a suggestion message when not auto-correctable.

RuboCop can specify `AutoCorrect: false`. In this case, even though auto-correct will not possible, auto-correct will be suggested.

The following sets `AutoCorrect: false` to `Style/StringLiterals`.

```console
% cat .rubocop.yml
Style/StringLiterals:
  AutoCorrect: false

% cat example.rb
# frozen_string_literal: true

puts "hello"
```

## Before

Running rubocop suggests `1 offense auto-correctable`.

```console
% rubocop
(snip)

Inspecting 1 file
C

Offenses:

example.rb:3:6: C: [Correctable] Style/StringLiterals: Prefer
single-quoted strings when you don't need string interpolation or
special symbols.
puts "hello"
     ^^^^^^^

1 file inspected, 1 offense detected, 1 offense auto-correctable
```

Running `rubocop -a` suggests `1 more offense can be corrected with rubocop -A` next.

```console
% rubocop -a
(snip)

Inspecting 1 file
C

Offenses:

example.rb:3:6: C: [Correctable] Style/StringLiterals: Prefer
single-quoted strings when you don't need string interpolation or
special symbols.
puts "hello"
     ^^^^^^^

1 file inspected, 1 offense detected, 1 more offense can be corrected with `rubocop -A`
```

Running `rubocop -A` does not auto-correct it.

```console
% rubocop -A
(snip)

Inspecting 1 file
C

Offenses:

example.rb:3:6: C: [Correctable] Style/StringLiterals: Prefer
single-quoted strings when you don't need string interpolation or
special symbols.
puts "hello"
     ^^^^^^^

1 file inspected, 1 offense detected, 1 offense auto-correctable
```

There is no change in the code.

```console
% cat example.rb
# frozen_string_literal: true

puts "hello"
```

User cannnot get the suggested behavior.

## After

RuboCop does not suggest auto-correction if `AutoCorrect: false` is configured.

```console
% rubocop
(snip)

Inspecting 1 file
C

Offenses:

example.rb:3:6: C: Style/StringLiterals: Prefer single-quoted strings
when you don't need string interpolation or special symbols.
puts "hello"
     ^^^^^^^

1 file inspected, 1 offense detected
```

I get this issue feedback from @amatsuda. Thank you!

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
