### PR TITLE
[Fix #7827] Add pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: rubocop
+  name: rubocop
+  entry: rubocop
+  language: ruby
+  types: ['ruby']
+  args: ['--auto-correct', '--force-exclusion']

--- a/changelog/new_add_precommit_hook.md
+++ b/changelog/new_add_precommit_hook.md
@@ -1,0 +1,1 @@
+* [#7827](https://github.com/rubocop-hq/rubocop/pull/7827): Add pre-commit hook. ([@jdufresne][], [@adithyabsk][])

--- a/docs/modules/ROOT/pages/integration_with_other_tools.adoc
+++ b/docs/modules/ROOT/pages/integration_with_other_tools.adoc
@@ -63,7 +63,7 @@ capabilities of this extension.
 Here's one great opportunity to contribute to RuboCop - implement
 RuboCop integration for your favorite editor.
 
-== Git pre-commit hook integration
+== Git pre-commit hook integration with overcommit
 
 https://github.com/brigade/overcommit[overcommit] is a fully configurable and
 extendable Git commit hook manager. To use RuboCop with overcommit, add the
@@ -74,6 +74,20 @@ following to your `.overcommit.yml` file:
 PreCommit:
   RuboCop:
     enabled: true
+----
+
+== Git pre-commit hook integration with pre-commit
+
+https://pre-commit.com/[pre-commit] is a framework for managing and maintaining
+multi-language pre-commit hooks. To use RuboCop with pre-commit, add the
+following to your `.pre-commit-config.yaml` file:
+
+[source,yaml]
+----
+- repo: https://github.com/rubocop-hq/rubocop
+  rev: v1.8.1
+  hooks:
+    - id: rubocop
 ----
 
 == Guard integration


### PR DESCRIPTION
Add an entry point (hook) for using RuboCop with the pre-commit
framework. The entry point allows users to add a minimal pre-commit
config to their project and then it will run RuboCop on commit.

For details on the pre-commit project, see: https://pre-commit.com/.
Here is the framework's introduction:

> Git hook scripts are useful for identifying simple issues before
> submission to code review. We run our hooks on every commit to
> automatically point out issues in code such as missing semicolons,
> trailing whitespace, and debug statements. By pointing these issues
> out before code review, this allows a code reviewer to focus on the
> architecture of a change while not wasting time with trivial style
> nitpicks.
>
> As we created more libraries and projects we recognized that sharing
> our pre-commit hooks across projects is painful. We copied and pasted
> unwieldy bash scripts from project to project and had to manually
> change the hooks to work for different project structures.
>
> We believe that you should always use the best industry standard >
> linters. Some of the best linters are written in languages that you do
> not use in your project or have installed on your machine. For example
> scss-lint is a linter for SCSS written in Ruby. If you’re writing a
> project in node you should be able to use scss-lint as a pre-commit
> hook without adding a Gemfile to your project or understanding how to
> get scss-lint installed.
>
> We built pre-commit to solve our hook issues. It is a multi-language
> package manager for pre-commit hooks. You specify a list of hooks you
> want and pre-commit manages the installation and execution of any hook
> written in any language before every commit. pre-commit is
> specifically designed to not require root access. If one of your
> developers doesn’t have node installed but modifies a JavaScript file,
> pre-commit automatically handles downloading and building node to run
> eslint without root.

Fixes #7827
Closes #8969

Co-Authored-By: Adithya Balaji <adithyabsk@gmail.com>

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests. (N/A)
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
