### PR TITLE
[Fix #9387] Fix incorrect auto-correct for `Style/NilComparison`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_nil_comparison.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_nil_comparison.md
@@ -1,0 +1,1 @@
+* [#9387](https://github.com/rubocop-hq/rubocop/issues/9387): Fix incorrect auto-correct for `Style/NilComparison` when using `!x.nil?` and `EnforcedStyle: comparison`. ([@koic][])

--- a/lib/rubocop/cop/style/nil_comparison.rb
+++ b/lib/rubocop/cop/style/nil_comparison.rb
@@ -50,6 +50,7 @@ module RuboCop
                          end
 
               corrector.replace(node, new_code)
+              corrector.wrap(node, '(', ')') if node.parent&.method?(:!)
             end
           end
         end

--- a/spec/rubocop/cop/style/nil_comparison_spec.rb
+++ b/spec/rubocop/cop/style/nil_comparison_spec.rb
@@ -40,5 +40,16 @@ RSpec.describe RuboCop::Cop::Style::NilComparison, :config do
         x == nil
       RUBY
     end
+
+    it 'registers and corrects an offense for `!x.nil?`' do
+      expect_offense(<<~RUBY)
+        !x.nil?
+           ^^^^ Prefer the use of the `==` comparison.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        !(x == nil)
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Fixes #9387.

This PR fixes incorrect auto-correct for `Style/NilComparison` when using `!x.nil?` and `EnforcedStyle: comparison`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
