### PR TITLE
Fix an infinite loop error for `Style/NonNilCheck` with `Style/NilComparison`

### DIFF
--- a/changelog/fix_infinite_loop_error_for_non_nil_check.md
+++ b/changelog/fix_infinite_loop_error_for_non_nil_check.md
@@ -1,0 +1,1 @@
+* [#9389](https://github.com/rubocop-hq/rubocop/pull/9389): Fix an infinite loop error for `IncludeSemanticChanges: false` of `Style/NonNilCheck` with `EnforcedStyle: comparison` of `Style/NilComparison`. ([@koic][])

--- a/spec/rubocop/cop/style/non_nil_check_spec.rb
+++ b/spec/rubocop/cop/style/non_nil_check_spec.rb
@@ -162,4 +162,43 @@ RSpec.describe RuboCop::Cop::Style::NonNilCheck, :config do
       RUBY
     end
   end
+
+  context 'when `EnforcedStyle: comparison` of `Style/NilComparison` cop' do
+    let(:other_cops) do
+      {
+        'Style/NilComparison' => { 'EnforcedStyle' => 'comparison' }
+      }
+    end
+
+    context '`IncludeSemanticChanges: false`' do
+      let(:cop_config) do
+        {
+          'IncludeSemanticChanges' => false
+        }
+      end
+
+      it 'does not register an offense for `foo != nil`' do
+        expect_no_offenses('foo != nil')
+      end
+    end
+
+    context '`IncludeSemanticChanges: true`' do
+      let(:cop_config) do
+        {
+          'IncludeSemanticChanges' => true
+        }
+      end
+
+      it 'does not register an offense for `foo != nil`' do
+        expect_offense(<<~RUBY)
+          foo != nil
+              ^^ Prefer `!expression.nil?` over `expression != nil`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes the following infinite loop error for `IncludeSemanticChanges: false` of `Style/NonNilCheck` with `EnforcedStyle: comparison` of `Style/NilComparison`.

```ruby
% cat example.rb
# frozen_string_literal: true

!(foo == nil)
```

```yaml
Style/NilComparison:
  Enabled: true
  EnforcedStyle: comparison # alternative config
```

```console
% bundle exec rubocop -A
(snip)

Inspecting 1 file
C

Offenses:

example.rb:3:1: C: [Corrected] Style/InverseMethods: Use != instead of
inverting ==.
!(foo == nil)
^^^^^^^^^^^^^
example.rb:3:5: C: [Corrected] Style/NonNilCheck: Prefer
!expression.nil? over expression != nil.
foo != nil
    ^^
example.rb:3:6: C: [Corrected] Style/NilComparison: Prefer the use of
the == comparison.
!foo.nil?
     ^^^^

0 files inspected, 3 offenses detected, 3 offenses corrected
Infinite loop detected in
/Users/koic/src/github.com/koic/rubocop-issues/9387/example.rb and
caused by Style/InverseMethods -> Style/NonNilCheck -> Style/NilComparison
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:304:in
`check_for_infinite_loop'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:287:in
`block in iterate_until_no_changes'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:286:in `loop'
```

This PR makes `Style/NonNilCheck` allows `foo != nil` when using `IncludeSemanticChanges: false` of `Style/NonNilCheck` and `EnforcedStyle: comparison` of `Style/NilComparison` cop, then `Style/NonNilCheck` cop does not register an offense for  `x != nil` and does no changes to `!x.nil?` style.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
