### PR TITLE
[Fixes #9340] Added `info` Severity level to allow offenses to be listed but not return a non-zero error code

### DIFF
--- a/changelog/new_added_info_severity_level_to_allow.md
+++ b/changelog/new_added_info_severity_level_to_allow.md
@@ -1,0 +1,1 @@
+* [#9340](https://github.com/rubocop-hq/rubocop/pull/9340): Added `info` Severity level to allow offenses to be listed but not return a non-zero error code. ([@dvandersluis][])

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -498,8 +498,11 @@ Style/Alias:
 Each cop has a default severity level based on which department it belongs
 to. The level is normally `warning` for `Lint` and `convention` for all the
 others, but this can be changed in user configuration. Cops can customize their
-severity level. Allowed values are `refactor`, `convention`, `warning`, `error`
+severity level. Allowed values are `info`, `refactor`, `convention`, `warning`, `error`
 and `fatal`.
+
+Cops with severity `info` will be reported but will not cause `rubocop` to return
+a non-zero value.
 
 There is one exception from the general rule above and that is `Lint/Syntax`, a
 special cop that checks for syntax errors before the other cops are invoked. It

--- a/lib/rubocop/cop/severity.rb
+++ b/lib/rubocop/cop/severity.rb
@@ -6,10 +6,10 @@ module RuboCop
     class Severity
       include Comparable
 
-      NAMES = %i[refactor convention warning error fatal].freeze
+      NAMES = %i[info refactor convention warning error fatal].freeze
 
       # @api private
-      CODE_TABLE = { R: :refactor, C: :convention,
+      CODE_TABLE = { I: :info, R: :refactor, C: :convention,
                      W: :warning, E: :error, F: :fatal }.freeze
 
       # @api public
@@ -18,7 +18,7 @@ module RuboCop
       #
       # @return [Symbol]
       #   severity.
-      #   any of `:refactor`, `:convention`, `:warning`, `:error` or `:fatal`.
+      #   any of `:info`, `:refactor`, `:convention`, `:warning`, `:error` or `:fatal`.
       attr_reader :name
 
       def self.name_from_code(code)

--- a/lib/rubocop/formatter/git_hub_actions_formatter.rb
+++ b/lib/rubocop/formatter/git_hub_actions_formatter.rb
@@ -23,6 +23,7 @@ module RuboCop
 
       def minimum_severity_to_fail
         @minimum_severity_to_fail ||= begin
+          # Unless given explicitly as `fail_level`, `:info` severity offenses do not fail
           name = options.fetch(:fail_level, :refactor)
           RuboCop::Cop::Severity.new(name)
         end

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -470,7 +470,7 @@ module RuboCop
                                          'This option applies to the previously',
                                          'specified --format, or the default format',
                                          'if no format is specified.'],
-      fail_level:                       ['Minimum severity (A/R/C/W/E/F) for exit',
+      fail_level:                       ['Minimum severity (A/I/R/C/W/E/F) for exit',
                                          'with error code.'],
       display_time:                     'Display elapsed time in seconds.',
       display_only_failed:              ['Only output offense messages. Omit passing',

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -390,6 +390,7 @@ module RuboCop
 
     def minimum_severity_to_fail
       @minimum_severity_to_fail ||= begin
+        # Unless given explicitly as `fail_level`, `:info` severity offenses do not fail
         name = @options[:fail_level] || :refactor
         RuboCop::Cop::Severity.new(name)
       end

--- a/spec/rubocop/cop/offense_spec.rb
+++ b/spec/rubocop/cop/offense_spec.rb
@@ -66,19 +66,27 @@ RSpec.describe RuboCop::Cop::Offense do
                      .level
     end
 
-    context 'when severity is :refactor' do
-      let(:severity) { :refactor }
+    context 'when severity is :info' do
+      let(:severity) { :info }
 
       it 'is 1' do
         expect(severity_level).to eq(1)
       end
     end
 
+    context 'when severity is :refactor' do
+      let(:severity) { :refactor }
+
+      it 'is 2' do
+        expect(severity_level).to eq(2)
+      end
+    end
+
     context 'when severity is :fatal' do
       let(:severity) { :fatal }
 
-      it 'is 5' do
-        expect(severity_level).to eq(5)
+      it 'is 6' do
+        expect(severity_level).to eq(6)
       end
     end
   end

--- a/spec/rubocop/cop/severity_spec.rb
+++ b/spec/rubocop/cop/severity_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Severity do
+  let(:info) { described_class.new(:info) }
   let(:refactor) { described_class.new(:refactor) }
   let(:convention) { described_class.new(:convention) }
   let(:warning) { described_class.new(:warning) }
@@ -26,6 +27,10 @@ RSpec.describe RuboCop::Cop::Severity do
   end
 
   describe '#code' do
+    describe 'info' do
+      it { expect(info.code).to eq('I') }
+    end
+
     describe 'refactor' do
       it { expect(refactor.code).to eq('R') }
     end
@@ -48,28 +53,36 @@ RSpec.describe RuboCop::Cop::Severity do
   end
 
   describe '#level' do
+    describe 'info' do
+      it { expect(info.level).to eq(1) }
+    end
+
     describe 'refactor' do
-      it { expect(refactor.level).to eq(1) }
+      it { expect(refactor.level).to eq(2) }
     end
 
     describe 'convention' do
-      it { expect(convention.level).to eq(2) }
+      it { expect(convention.level).to eq(3) }
     end
 
     describe 'warning' do
-      it { expect(warning.level).to eq(3) }
+      it { expect(warning.level).to eq(4) }
     end
 
     describe 'error' do
-      it { expect(error.level).to eq(4) }
+      it { expect(error.level).to eq(5) }
     end
 
     describe 'fatal' do
-      it { expect(fatal.level).to eq(5) }
+      it { expect(fatal.level).to eq(6) }
     end
   end
 
   describe 'constructs from code' do
+    describe 'I' do
+      it { expect(described_class.new('I')).to eq(info) }
+    end
+
     describe 'R' do
       it { expect(described_class.new('R')).to eq(refactor) }
     end
@@ -92,6 +105,10 @@ RSpec.describe RuboCop::Cop::Severity do
   end
 
   describe 'Comparable' do
+    describe 'info' do
+      it { expect(info).to be < refactor }
+    end
+
     describe 'refactor' do
       it { expect(refactor).to be < convention }
     end

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                   --display-only-failed        Only output offense messages. Omit passing
                                                cops. Only valid for --format junit.
               -r, --require FILE               Require Ruby file.
-                  --fail-level SEVERITY        Minimum severity (A/R/C/W/E/F) for exit
+                  --fail-level SEVERITY        Minimum severity (A/I/R/C/W/E/F) for exit
                                                with error code.
                   --display-only-fail-level-offenses
                                                Only output offense messages at
@@ -253,14 +253,14 @@ RSpec.describe RuboCop::Options, :isolated_environment do
 
     describe '--fail-level' do
       it 'accepts full severity names' do
-        %w[refactor convention warning error fatal].each do |severity|
+        %w[info refactor convention warning error fatal].each do |severity|
           expect { options.parse(['--fail-level', severity]) }
             .not_to raise_error
         end
       end
 
       it 'accepts severity initial letters' do
-        %w[R C W E F].each do |severity|
+        %w[I R C W E F].each do |severity|
           expect { options.parse(['--fail-level', severity]) }
             .not_to raise_error
         end


### PR DESCRIPTION
Cops can now be configured to have `Severity: info` which will cause offenses to be reported but not cause the `rubocop` command to return `1` if there are any. It can be overridden by `--fail-level` and works with `--display-only-fail-level-offenses`.

Fixes #9340.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
