### PR TITLE
Add documentation for Layout/MultilineAssignmentLayout `SupportedTypes`

### DIFF
--- a/lib/rubocop/cop/layout/multiline_assignment_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_assignment_layout.rb
@@ -31,6 +31,32 @@ module RuboCop
       #   foo = if expression
       #     'bar'
       #   end
+      #
+      # @example SupportedTypes: ['block', 'case', 'class', 'if', 'kwbegin', 'module'] (default)
+      #   # good
+      #   foo =
+      #     if expression
+      #       'bar'
+      #     end
+      #
+      #   # good
+      #   foo =
+      #     [1].map do |i|
+      #       i + 1
+      #     end
+      #
+      # @example SupportedTypes: ['block']
+      #   # good
+      #   foo = if expression
+      #     'bar'
+      #   end
+      #
+      #   # good
+      #   foo =
+      #     [1].map do |i|
+      #       'bar' * i
+      #     end
+      #
       class MultilineAssignmentLayout < Base
         include CheckAssignment
         include ConfigurableEnforcedStyle


### PR DESCRIPTION
I was looking for exactly the configurable attributes `SupportedTypes` for the cop Layout/MultilineAssignmentLayout.  But, I had to look in the code to found out this attribute and in `config/default.yml` to found the available parameters. I thought it might be useful to add this info in the documentation. 

UPDATE

To make `SupportedTypes` appear in the documentation, I had to change the name of the attribute, I named it `AssignmentTypes`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
