### PR TITLE
[Fix #7766] Rename rescue body vars when renaming exception name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug fixes
 
+* [#7766](https://github.com/rubocop-hq/rubocop/issues/7766): Rename rescue body vars when renaming exception name. ([@asterite][])
 * [#9342](https://github.com/rubocop-hq/rubocop/issues/9342): Fix an error for `Lint/RedundantDirGlobSort` when using `collection.sort`. ([@koic][])
 * [#9304](https://github.com/rubocop-hq/rubocop/issues/9304): Do not register an offense for `Style/ExplicitBlockArgument` when the `yield` arguments are not an exact match with the block arguments. ([@dvandersluis][])
 * [#8281](https://github.com/rubocop-hq/rubocop/issues/8281): Fix Style/WhileUntilModifier handling comments and assignment when correcting to modifier form. ([@Darhazer][])
@@ -5367,3 +5368,4 @@
 [@magneland]: https://github.com/magneland
 [@k-karen]: https://github.com/k-karen
 [@uplus]: https://github.com/uplus
+[@asterite]: https://github.com/asterite

--- a/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
+++ b/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
@@ -71,7 +71,7 @@ module RuboCop
           add_offense(range, message: message) do |corrector|
             corrector.replace(range, preferred_name)
 
-            node.body&.each_descendant(:lvar) do |var|
+            node.body&.each_node(:lvar) do |var|
               next unless var.children.first == offending_name
 
               corrector.replace(var, preferred_name)

--- a/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
@@ -42,6 +42,25 @@ RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
           RUBY
         end
 
+        it 'registers an offense when using `exc` and renames its usage' do
+          expect_offense(<<~RUBY)
+            begin
+              something
+            rescue MyException => exc
+                                  ^^^ Use `e` instead of `exc`.
+              exc
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            begin
+              something
+            rescue MyException => e
+              e
+            end
+          RUBY
+        end
+
         it 'registers offenses when using `foo` and `bar` ' \
            'in multiple rescues' do
           expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #7766

The old code used `node.body&.each_descendant(:lvar)` to replace the exception variable. The problem is, that doesn't work if the rescue body is a single variable with the name of the exception variable. Using `each_node` will consider that case too.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
