### PR TITLE
[Fixes #7766] Fix `Naming/RescuedExceptionsVariableName` autocorrection issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ### Bug fixes
 
-* [#7766](https://github.com/rubocop-hq/rubocop/issues/7766): Rename rescue body vars when renaming exception name. ([@asterite][])
 * [#9342](https://github.com/rubocop-hq/rubocop/issues/9342): Fix an error for `Lint/RedundantDirGlobSort` when using `collection.sort`. ([@koic][])
 * [#9304](https://github.com/rubocop-hq/rubocop/issues/9304): Do not register an offense for `Style/ExplicitBlockArgument` when the `yield` arguments are not an exact match with the block arguments. ([@dvandersluis][])
 * [#8281](https://github.com/rubocop-hq/rubocop/issues/8281): Fix Style/WhileUntilModifier handling comments and assignment when correcting to modifier form. ([@Darhazer][])

--- a/changelog/fix_fix_namingrescuedexceptionsvariablename.md
+++ b/changelog/fix_fix_namingrescuedexceptionsvariablename.md
@@ -1,0 +1,2 @@
+* [#7766](https://github.com/rubocop-hq/rubocop/issues/7766): Fix `Naming/RescuedExceptionsVariableName` autocorrection when the rescue body returns the exception variable. ([@asterite][])
+* [#7766](https://github.com/rubocop-hq/rubocop/issues/7766): Fix `Naming/RescuedExceptionsVariableName` autocorrection to not change variables if the exception variable has been reassigned. ([@dvandersluis][])

--- a/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
+++ b/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
@@ -71,11 +71,7 @@ module RuboCop
           add_offense(range, message: message) do |corrector|
             corrector.replace(range, preferred_name)
 
-            node.body&.each_node(:lvar) do |var|
-              next unless var.children.first == offending_name
-
-              corrector.replace(var, preferred_name)
-            end
+            correct_node(corrector, node.body, offending_name, preferred_name)
           end
         end
 
@@ -84,6 +80,43 @@ module RuboCop
         def offense_range(resbody)
           variable = resbody.exception_variable
           variable.loc.expression
+        end
+
+        def variable_name_matches?(node, name)
+          if node.masgn_type?
+            node.each_descendant(:lvasgn).any? do |lvasgn_node|
+              variable_name_matches?(lvasgn_node, name)
+            end
+          else
+            node.children.first == name
+          end
+        end
+
+        def correct_node(corrector, node, offending_name, preferred_name)
+          return unless node
+
+          node.each_node(:lvar, :lvasgn, :masgn) do |child_node|
+            next unless variable_name_matches?(child_node, offending_name)
+
+            corrector.replace(child_node, preferred_name) if child_node.lvar_type?
+
+            if child_node.masgn_type? || child_node.lvasgn_type?
+              correct_reassignment(corrector, child_node, offending_name, preferred_name)
+              break
+            end
+          end
+        end
+
+        # If the exception variable is reassigned, that assignment needs to be corrected.
+        # Further `lvar` nodes will not be corrected though since they now refer to a
+        # different variable.
+        def correct_reassignment(corrector, node, offending_name, preferred_name)
+          if node.lvasgn_type?
+            correct_node(corrector, node.child_nodes.first, offending_name, preferred_name)
+          elsif node.masgn_type?
+            # With multiple assign, the assignments are in an array as the last child
+            correct_node(corrector, node.children.last, offending_name, preferred_name)
+          end
         end
 
         def preferred_name(variable_name)

--- a/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
@@ -320,6 +320,77 @@ RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
         RUBY
       end
     end
+
+    context 'when the variable is reassigned' do
+      it 'only corrects uses of the exception' do
+        expect_offense(<<~RUBY)
+          def main
+            raise
+          rescue StandardError => error
+                                  ^^^^^ Use `e` instead of `error`.
+            error = {
+              error_message: error.message
+            }
+            puts error
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def main
+            raise
+          rescue StandardError => e
+            error = {
+              error_message: e.message
+            }
+            puts error
+          end
+        RUBY
+      end
+
+      it 'does not correct other variables or assignments' do
+        expect_offense(<<~RUBY)
+          def main
+            raise
+          rescue StandardError => error
+                                  ^^^^^ Use `e` instead of `error`.
+            message = error.message
+            puts message
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def main
+            raise
+          rescue StandardError => e
+            message = e.message
+            puts message
+          end
+        RUBY
+      end
+    end
+
+    context 'when the variable is reassigned using multiple assignment' do
+      it 'only corrects uses of the exception' do
+        expect_offense(<<~RUBY)
+          def main
+            raise
+          rescue StandardError => error
+                                  ^^^^^ Use `e` instead of `error`.
+            error, foo = 1, error
+            puts error
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def main
+            raise
+          rescue StandardError => e
+            error, foo = 1, e
+            puts error
+          end
+        RUBY
+      end
+    end
   end
 
   context 'with the `PreferredName` setup' do


### PR DESCRIPTION
Follows #9398. Fixes the corrector to stop autocorrecting when the exception variable is reassigned, either with `lvasgn` or `masgn`. The assignments will be corrected but further uses of that variable will not be changed.

The previous PR also added to the wrong changelog so I've combined the two PRs into a single changelog item in `changelog/`.

Fixes #7766 (again 😆).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
