### PR TITLE
[Fix #9354] Fix incorrect issue for `Bundler/OrderedGems` 

### DIFF
--- a/changelog/fix_issue_for_comment_and_blank_lines_separating_gems.md
+++ b/changelog/fix_issue_for_comment_and_blank_lines_separating_gems.md
@@ -1,0 +1,1 @@
+* [#9354](https://github.com/rubocop-hq/rubocop/issues/9354): Fix an issue for `Bundler/OrderedGems` when there is an empty line and a comment separating gems in the wrong order. ([@anoymouscoder][])

--- a/lib/rubocop/cop/mixin/ordered_gem_node.rb
+++ b/lib/rubocop/cop/mixin/ordered_gem_node.rb
@@ -25,11 +25,11 @@ module RuboCop
       end
 
       def consecutive_lines(previous, current)
-        first_line = get_source_range(
-          current,
-          treat_comments_as_separators
-        ).first_line
-        previous.source_range.last_line == first_line - 1
+        end_pos = current.source_range.first_line
+        begin_pos = previous.source_range.last_line
+        return true if begin_pos == end_pos - 1
+
+        !treat_comments_as_separators && contains_only_comments?(begin_pos, end_pos - 2)
       end
 
       def register_offense(previous, current)
@@ -55,6 +55,10 @@ module RuboCop
 
       def treat_comments_as_separators
         cop_config['TreatCommentsAsGroupSeparators']
+      end
+
+      def contains_only_comments?(begin_pos, end_pos)
+        processed_source.lines[begin_pos..end_pos].all? { |line| comment_line?(line) }
       end
     end
   end

--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -155,6 +155,17 @@ RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
           gem 'rubocop'
         RUBY
       end
+
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          # For code quality
+          gem 'rubocop'
+          # For
+
+          # test
+          gem 'rspec'
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
The issue is that even with `TreatCommentsAsGroupSeparators: false`, it does not generate an issue if there is an empty line and a comment separating gems in the wrong order.
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
