### PR TITLE
Improve documentation for Style/EvalWithLocation cop

### DIFF
--- a/changelog/change_improve_documentation_for_style_eval_with_location_cop.md
+++ b/changelog/change_improve_documentation_for_style_eval_with_location_cop.md
@@ -1,0 +1,1 @@
+* [#9405](https://github.com/rubocop-hq/rubocop/pull/9405): Improve documentation for `Style/EvalWithLocation` cop. ([@taichi-ishitani][])

--- a/lib/rubocop/cop/style/eval_with_location.rb
+++ b/lib/rubocop/cop/style/eval_with_location.rb
@@ -31,6 +31,18 @@ module RuboCop
       #     def do_something
       #     end
       #   RUBY
+      #
+      # This cop works only when a string literal is given as a code string.
+      # No offence is reported if a string variable is given as below:
+      #
+      # @example
+      #   # not checked
+      #   code = <<-RUBY
+      #     def do_something
+      #     end
+      #   RUBY
+      #   eval code
+      #
       class EvalWithLocation < Base
         MSG = 'Pass `__FILE__` and `__LINE__` to `eval` method, ' \
               'as they are used by backtraces.'


### PR DESCRIPTION
This PR is to improve documentation for `Style/EvalWithLocation` cop.
There are no description and example for the case that a string variable is given as a code string like below.

```ruby
code = <<-RUBY
def do_something
end
RUBY

eval code
```

I added description and example to make this case clear.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
