### PR TITLE
Fix rubocop_todo link injection when YAML doc start sigil exists

### DIFF
--- a/changelog/fix_rubocop_todo_link_injection_when.md
+++ b/changelog/fix_rubocop_todo_link_injection_when.md
@@ -1,0 +1,1 @@
+* [#9406](https://github.com/rubocop-hq/rubocop/pull/9406): Fix rubocop_todo link injection when YAML doc start sigil exists. ([@dduugg][])

--- a/lib/rubocop/cli/command/auto_genenerate_config.rb
+++ b/lib/rubocop/cli/command/auto_genenerate_config.rb
@@ -9,6 +9,7 @@ module RuboCop
         self.command_name = :auto_gen_config
 
         AUTO_GENERATED_FILE = '.rubocop_todo.yml'
+        YAML_OPTIONAL_DOC_START = /\A---(\s+#|\s*\z)/.freeze
 
         PHASE_1 = 'Phase 1 of 2: run Layout/LineLength cop'
         PHASE_2 = 'Phase 2 of 2: run all cops'
@@ -130,10 +131,10 @@ module RuboCop
         end
 
         def write_config_file(file_name, file_string, rubocop_yml_contents)
-          File.open(file_name, 'w') do |f|
-            f.write "inherit_from:#{file_string}\n"
-            f.write "\n#{rubocop_yml_contents}" if /\S/.match?(rubocop_yml_contents)
-          end
+          lines = /\S/.match?(rubocop_yml_contents) ? rubocop_yml_contents.split("\n", -1) : []
+          doc_start_index = lines.index { |line| YAML_OPTIONAL_DOC_START.match?(line) } || -1
+          lines.insert(doc_start_index + 1, "inherit_from:#{file_string}\n")
+          File.open(file_name, 'w') { |f| f.write lines.join("\n") }
         end
       end
     end


### PR DESCRIPTION
The `rubocop --auto-gen-config` script will insert `inherit_from: .rubocop_todo.yml` at the top of the rubocop config file if the line doesn't already exist. However, if the config file has a YAML document start sigil (`---`), this will elide the remainder of the config file when running rubocop. This PR resolves the issue by injecting the `inherit_from` entry after the first such sigil, if one exists.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
