### PR TITLE
[Fixes #9399] Added `AllowedCops` configuration to `Style/DisableCopsWithinSourceCodeDirective`

### DIFF
--- a/changelog/change_added_allowedcops_configuration_to.md
+++ b/changelog/change_added_allowedcops_configuration_to.md
@@ -1,0 +1,1 @@
+* [#9399](https://github.com/rubocop-hq/rubocop/issues/9399): Added `AllowedCops` configuration to `Style/DisableCopsWithinSourceCodeDirective`. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3136,6 +3136,8 @@ Style/DisableCopsWithinSourceCodeDirective:
                  Forbids disabling/enabling cops within source code.
   Enabled: false
   VersionAdded: '0.82'
+  VersionChanged: <<next>>
+  AllowedCops: []
 
 Style/DocumentDynamicEvalDefinition:
   Description: >-

--- a/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
+++ b/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
@@ -9,37 +9,77 @@ module RuboCop
       # This is useful if want to make sure that every RuboCop error gets fixed
       # and not quickly disabled with a comment.
       #
+      # Specific cops can be allowed with the `AllowedCops` configuration. Note that
+      # if this configuration is set, `rubocop:disable all` is still disallowed.
+      #
       # @example
       #   # bad
       #   # rubocop:disable Metrics/AbcSize
-      #   def f
+      #   def foo
       #   end
       #   # rubocop:enable Metrics/AbcSize
       #
       #   # good
-      #   def fixed_method_name_and_no_rubocop_comments
+      #   def foo
       #   end
+      #
+      # @example AllowedCops: [Metrics/AbcSize]
+      #   # good
+      #   # rubocop:disable Metrics/AbcSize
+      #   def foo
+      #   end
+      #   # rubocop:enable Metrics/AbcSize
       #
       class DisableCopsWithinSourceCodeDirective < Base
         extend AutoCorrector
 
         # rubocop:enable Lint/RedundantCopDisableDirective
-        MSG = 'Comment to disable/enable RuboCop.'
+        MSG = 'Rubocop disable/enable directives are not permitted.'
+        MSG_FOR_COPS = 'Rubocop disable/enable directives for %<cops>s are not permitted.'
 
         def on_new_investigation
           processed_source.comments.each do |comment|
-            next unless rubocop_directive_comment?(comment)
+            directive_cops = directive_cops(comment)
+            disallowed_cops = directive_cops - allowed_cops
 
-            add_offense(comment) do |corrector|
-              corrector.replace(comment, '')
-            end
+            next unless disallowed_cops.any?
+
+            register_offense(comment, directive_cops, disallowed_cops)
           end
         end
 
         private
 
-        def rubocop_directive_comment?(comment)
-          CommentConfig::COMMENT_DIRECTIVE_REGEXP.match?(comment.text)
+        def register_offense(comment, directive_cops, disallowed_cops)
+          message = if any_cops_allowed?
+                      format(MSG_FOR_COPS, cops: "`#{disallowed_cops.join('`, `')}`")
+                    else
+                      MSG
+                    end
+
+          add_offense(comment, message: message) do |corrector|
+            replacement = ''
+
+            if directive_cops.length != disallowed_cops.length
+              replacement = comment.text.sub(/#{Regexp.union(disallowed_cops)},?\s*/, '')
+                                   .sub(/,\s*$/, '')
+            end
+
+            corrector.replace(comment, replacement)
+          end
+        end
+
+        def directive_cops(comment)
+          match = CommentConfig::COMMENT_DIRECTIVE_REGEXP.match(comment.text)
+          match[2] ? match[2].split(',').map(&:strip) : []
+        end
+
+        def allowed_cops
+          Array(cop_config['AllowedCops'])
+        end
+
+        def any_cops_allowed?
+          allowed_cops.any?
         end
       end
     end

--- a/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
+++ b/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
@@ -1,29 +1,85 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective do
-  subject(:cop) { described_class.new }
-
+RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :config do
   it 'registers an offense for disabled cop within source code' do
     expect_offense(<<~RUBY)
-      def choose_move(who_to_move)# rubocop:disable Metrics/CyclomaticComplexity
-                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Comment to disable/enable RuboCop.
+      def foo # rubocop:disable Metrics/CyclomaticComplexity
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Rubocop disable/enable directives are not permitted.
       end
     RUBY
+
     expect_correction(<<~RUBY)
-      def choose_move(who_to_move)
+      def foo#{trailing_whitespace}
       end
     RUBY
   end
 
   it 'registers an offense for enabled cop within source code' do
     expect_offense(<<~RUBY)
-      def choose_move(who_to_move)# rubocop:enable Metrics/CyclomaticComplexity
-                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Comment to disable/enable RuboCop.
+      def foo # rubocop:enable Metrics/CyclomaticComplexity
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Rubocop disable/enable directives are not permitted.
       end
     RUBY
+
     expect_correction(<<~RUBY)
-      def choose_move(who_to_move)
+      def foo#{trailing_whitespace}
       end
     RUBY
+  end
+
+  it 'registers an offense for disabling all cops' do
+    expect_offense(<<~RUBY)
+      def foo # rubocop:enable all
+              ^^^^^^^^^^^^^^^^^^^^ Rubocop disable/enable directives are not permitted.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo#{trailing_whitespace}
+      end
+    RUBY
+  end
+
+  context 'with AllowedCops' do
+    let(:cop_config) { { 'AllowedCops' => ['Metrics/CyclomaticComplexity', 'Metrics/AbcSize'] } }
+
+    context 'when an allowed cop is disabled' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          def foo # rubocop:disable Metrics/CyclomaticComplexity
+          end
+        RUBY
+      end
+    end
+
+    context 'when an non-allowed cop is disabled' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          def foo # rubocop:disable Layout/LineLength
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Rubocop disable/enable directives for `Layout/LineLength` are not permitted.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo#{trailing_whitespace}
+          end
+        RUBY
+      end
+    end
+
+    context 'when an mix of cops are disabled' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          def foo # rubocop:disable Metrics/AbcSize, Layout/LineLength, Metrics/CyclomaticComplexity, Style/AndOr
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Rubocop disable/enable directives for `Layout/LineLength`, `Style/AndOr` are not permitted.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+          end
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Allows specific cops to be allowed to be enabled/disabled when `Style/DisableCopsWithinSourceCodeDirective` is enabled.

I also changed the cop's message to be clearer (it'll also show which cops are not allowed when some are allowed).

Fixes #9399.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
