### PR TITLE
Tweak offense messages for `Style/NonNilCheck` cop

### DIFF
--- a/spec/rubocop/cop/style/non_nil_check_spec.rb
+++ b/spec/rubocop/cop/style/non_nil_check_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::Style::NonNilCheck, :config do
     it 'registers an offense for != nil' do
       expect_offense(<<~RUBY)
         x != nil
-          ^^ Prefer `!expression.nil?` over `expression != nil`.
+        ^^^^^^^^ Prefer `!x.nil?` over `x != nil`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -72,7 +72,7 @@ RSpec.describe RuboCop::Cop::Style::NonNilCheck, :config do
     it 'does not report corrected when the code was not modified' do
       expect_offense(<<~RUBY)
         return nil unless (line =~ //) != nil
-                                       ^^ Prefer `!expression.nil?` over `expression != nil`.
+                          ^^^^^^^^^^^^^^^^^^^ Prefer `!(line =~ //).nil?` over `(line =~ //) != nil`.
       RUBY
 
       expect_no_corrections
@@ -123,6 +123,10 @@ RSpec.describe RuboCop::Cop::Style::NonNilCheck, :config do
         not x.nil?
         ^^^^^^^^^^ Explicit non-nil checks are usually redundant.
       RUBY
+
+      expect_correction(<<~RUBY)
+        x
+      RUBY
     end
 
     it 'does not blow up with ternary operators' do
@@ -132,7 +136,7 @@ RSpec.describe RuboCop::Cop::Style::NonNilCheck, :config do
     it 'autocorrects by changing `x != nil` to `x`' do
       expect_offense(<<~RUBY)
         x != nil
-          ^^ Prefer `!expression.nil?` over `expression != nil`.
+        ^^^^^^^^ Explicit non-nil checks are usually redundant.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -154,7 +158,7 @@ RSpec.describe RuboCop::Cop::Style::NonNilCheck, :config do
        'IncludeSemanticChanges were false' do
       expect_offense(<<~RUBY)
         return nil unless (line =~ //) != nil
-                                       ^^ Prefer `!expression.nil?` over `expression != nil`.
+                          ^^^^^^^^^^^^^^^^^^^ Explicit non-nil checks are usually redundant.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -192,7 +196,7 @@ RSpec.describe RuboCop::Cop::Style::NonNilCheck, :config do
       it 'does not register an offense for `foo != nil`' do
         expect_offense(<<~RUBY)
           foo != nil
-              ^^ Prefer `!expression.nil?` over `expression != nil`.
+          ^^^^^^^^^^ Explicit non-nil checks are usually redundant.
         RUBY
 
         expect_correction(<<~RUBY)


### PR DESCRIPTION
This PR tweaks offense messages for `Style/NonNilCheck` cop.

In particular, the following incorrect message will be corrected.

```ruby
% cat example.rb
foo != nil
```

```yaml
% cat .rubocop.yml
Style/NonNilCheck:
  IncludeSemanticChanges: true
```

There is a mismatch between offense message and auto-corrected code.

```console
% rubocop --only Style/NonNilCheck
(snip)

Inspecting 1 file
C

Offenses:

example.rb:1:5: C: [Corrected] Style/NonNilCheck: Prefer !expression.nil? over expression != nil.
foo != nil
    ^^

1 file inspected, 1 offense detected, 1 offense corrected

% cat example.rb
foo
```

This PR fixes to the correct message `Explicit non-nil checks are usually redundant.`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
