### PR TITLE
Improve offense messages for `Style/EvalWithLocation`.

### DIFF
--- a/spec/rubocop/cop/style/eval_with_location_spec.rb
+++ b/spec/rubocop/cop/style/eval_with_location_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::Cop::Style::EvalWithLocation do
   it 'registers an offense when using `#eval` without any arguments' do
     expect_offense(<<~RUBY)
       eval <<-CODE
-      ^^^^^^^^^^^^ Pass `__FILE__` and `__LINE__` to `eval` method, as they are used by backtraces.
+      ^^^^^^^^^^^^ Pass a binding, `__FILE__` and `__LINE__` to `eval`.
         do_something
       CODE
     RUBY
@@ -17,7 +17,7 @@ RSpec.describe RuboCop::Cop::Style::EvalWithLocation do
   it 'registers an offense when using `#eval` with `binding` only' do
     expect_offense(<<~RUBY)
       eval <<-CODE, binding
-      ^^^^^^^^^^^^^^^^^^^^^ Pass `__FILE__` and `__LINE__` to `eval` method, as they are used by backtraces.
+      ^^^^^^^^^^^^^^^^^^^^^ Pass a binding, `__FILE__` and `__LINE__` to `eval`.
         do_something
       CODE
     RUBY
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::Style::EvalWithLocation do
   it 'registers an offense when using `#eval` without lineno' do
     expect_offense(<<~RUBY)
       eval <<-CODE, binding, __FILE__
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Pass `__FILE__` and `__LINE__` to `eval` method, as they are used by backtraces.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Pass a binding, `__FILE__` and `__LINE__` to `eval`.
         do_something
       CODE
     RUBY
@@ -35,7 +35,7 @@ RSpec.describe RuboCop::Cop::Style::EvalWithLocation do
   it 'registers an offense when using `#eval` with an incorrect line number' do
     expect_offense(<<~RUBY)
       eval 'do_something', binding, __FILE__, __LINE__ + 1
-                                              ^^^^^^^^^^^^ Use `__LINE__` instead of `__LINE__ + 1`, as they are used by backtraces.
+                                              ^^^^^^^^^^^^ Incorrect line number for `eval`; use `__LINE__` instead of `__LINE__ + 1`.
     RUBY
   end
 
@@ -43,7 +43,7 @@ RSpec.describe RuboCop::Cop::Style::EvalWithLocation do
      'an incorrect line number' do
     expect_offense(<<~RUBY)
       eval <<-CODE, binding, __FILE__, __LINE__ + 2
-                                       ^^^^^^^^^^^^ Use `__LINE__ + 1` instead of `__LINE__ + 2`, as they are used by backtraces.
+                                       ^^^^^^^^^^^^ Incorrect line number for `eval`; use `__LINE__ + 1` instead of `__LINE__ + 2`.
         do_something
       CODE
     RUBY
@@ -55,14 +55,14 @@ RSpec.describe RuboCop::Cop::Style::EvalWithLocation do
            binding,
            __FILE__,
            __LINE__)
-           ^^^^^^^^ Use `__LINE__ - 3` instead of `__LINE__`, as they are used by backtraces.
+           ^^^^^^^^ Incorrect line number for `eval`; use `__LINE__ - 3` instead of `__LINE__`.
     RUBY
   end
 
   it 'registers an offense when using `#class_eval` without any arguments' do
     expect_offense(<<~RUBY)
       C.class_eval <<-CODE
-      ^^^^^^^^^^^^^^^^^^^^ Pass `__FILE__` and `__LINE__` to `eval` method, as they are used by backtraces.
+      ^^^^^^^^^^^^^^^^^^^^ Pass `__FILE__` and `__LINE__` to `class_eval`.
         do_something
       CODE
     RUBY
@@ -71,7 +71,7 @@ RSpec.describe RuboCop::Cop::Style::EvalWithLocation do
   it 'registers an offense when using `#module_eval` without any arguments' do
     expect_offense(<<~RUBY)
       M.module_eval <<-CODE
-      ^^^^^^^^^^^^^^^^^^^^^ Pass `__FILE__` and `__LINE__` to `eval` method, as they are used by backtraces.
+      ^^^^^^^^^^^^^^^^^^^^^ Pass `__FILE__` and `__LINE__` to `module_eval`.
         do_something
       CODE
     RUBY
@@ -80,7 +80,7 @@ RSpec.describe RuboCop::Cop::Style::EvalWithLocation do
   it 'registers an offense when using `#instance_eval` without any arguments' do
     expect_offense(<<~RUBY)
       foo.instance_eval <<-CODE
-      ^^^^^^^^^^^^^^^^^^^^^^^^^ Pass `__FILE__` and `__LINE__` to `eval` method, as they are used by backtraces.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Pass `__FILE__` and `__LINE__` to `instance_eval`.
         do_something
       CODE
     RUBY
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::Cop::Style::EvalWithLocation do
   it 'registers an offense when using `#class_eval` with an incorrect lineno' do
     expect_offense(<<~RUBY)
       C.class_eval <<-CODE, __FILE__, __LINE__
-                                      ^^^^^^^^ Use `__LINE__ + 1` instead of `__LINE__`, as they are used by backtraces.
+                                      ^^^^^^^^ Incorrect line number for `class_eval`; use `__LINE__ + 1` instead of `__LINE__`.
         do_something
       CODE
     RUBY


### PR DESCRIPTION
The messages from `Style/EvalWithLocation` were a little over-wordy, not specific enough (it said `eval` for `class_eval`, etc.), and did not include the binding argument for `eval`. I also rewrote the cop description comment to be more clear.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
