### PR TITLE
Fix false negatives for `Style/EvalWithLocation`

### DIFF
--- a/changelog/fix_fix_false_negatives_for.md
+++ b/changelog/fix_fix_false_negatives_for.md
@@ -1,0 +1,1 @@
+* [#9411](https://github.com/rubocop-hq/rubocop/pull/9411): Fix false negatives for `Style/EvalWithLocation` for `Kernel.eval` and when given improper arguments. ([@dvandersluis][])


### PR DESCRIPTION
Found two issues in `Style/EvalWithLocation`:
* It did not register an offense for `Kernel.eval` (or `::Kernel.eval`)
* If given improper arguments, it did not register an offense.

Previously if `eval` methods were given any arguments in the file and line spots, the cop would not register an offense. This change allows the cop to detect improper values for file (anything other than `__FILE__`, which the cop previously was implicitly expecting) and line (as before, `__LINE__` with an offset as appropriate).

This should be merged after #9409 and I'll fix up the messages in the new tests to reflect those changes once merged.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
