### PR TITLE
Change `Layout/EmptyLineAfterMagicComment` to accept `shareable_constant_values` directive

### DIFF
--- a/changelog/change_empty_line_magic_comment_with_shareable_constant_value.md
+++ b/changelog/change_empty_line_magic_comment_with_shareable_constant_value.md
@@ -1,0 +1,1 @@
+* [#9327](https://github.com/rubocop-hq/rubocop/issues/9327): Change `Layout/EmptyLineAfterMagicComment` to accept top-level `shareable_constant_values` directive. ([@tejasbubane][])

--- a/lib/rubocop/magic_comment.rb
+++ b/lib/rubocop/magic_comment.rb
@@ -27,7 +27,7 @@ module RuboCop
     end
 
     def any?
-      frozen_string_literal_specified? || encoding_specified?
+      frozen_string_literal_specified? || encoding_specified? || shareable_constant_value_specified?
     end
 
     # Does the magic comment enable the frozen string literal feature.
@@ -46,11 +46,22 @@ module RuboCop
       [true, false].include?(frozen_string_literal)
     end
 
+    def valid_shareable_constant_value?
+      %w[none literal experimental_everything experimental_copy].include?(shareable_constant_values)
+    end
+
     # Was a magic comment for the frozen string literal found?
     #
     # @return [Boolean]
     def frozen_string_literal_specified?
       specified?(frozen_string_literal)
+    end
+
+    # Was a shareable_constant_value specified?
+    #
+    # @return [Boolean]
+    def shareable_constant_value_specified?
+      specified?(shareable_constant_value)
     end
 
     # Expose the `frozen_string_literal` value coerced to a boolean if possible.
@@ -67,6 +78,13 @@ module RuboCop
       else
         setting
       end
+    end
+
+    # Expose the `shareable_constant_value` value coerced to a boolean if possible.
+    #
+    # @return [String] for shareable_constant_value config
+    def shareable_constant_value
+      extract_shareable_constant_value
     end
 
     def encoding_specified?
@@ -146,6 +164,10 @@ module RuboCop
       def extract_frozen_string_literal
         match('frozen[_-]string[_-]literal')
       end
+
+      def extract_shareable_constant_value
+        match('shareable[_-]constant[_-]values')
+      end
     end
 
     # Wrapper for Vim style magic comments.
@@ -176,6 +198,9 @@ module RuboCop
 
       # Vim comments cannot specify frozen string literal behavior.
       def frozen_string_literal; end
+
+      # Vim comments cannot specify shareable constant values behavior.
+      def shareable_constant_value; end
     end
 
     # Wrapper for regular magic comments not bound to an editor.
@@ -208,6 +233,10 @@ module RuboCop
       # @see https://git.io/vM7Mg
       def extract_frozen_string_literal
         extract(/\A\s*#\s*frozen[_-]string[_-]literal:\s*(#{TOKEN})\s*\z/io)
+      end
+
+      def extract_shareable_constant_value
+        extract(/\A\s*#\s*shareable[_-]constant[_-]value:\s*(#{TOKEN})\s*\z/io)
       end
     end
   end

--- a/spec/rubocop/cop/layout/empty_line_after_magic_comment_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_magic_comment_spec.rb
@@ -51,6 +51,47 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment do
     RUBY
   end
 
+  it 'accepts magic comment followed by encoding' do
+    expect_no_offenses(<<~RUBY)
+      # frozen_string_literal: true
+      # encoding: utf-8
+
+      class Foo; end
+    RUBY
+  end
+
+  it 'accepts magic comment with shareable_constant_value' do
+    expect_no_offenses(<<~RUBY)
+      # frozen_string_literal: true
+      # shareable_constant_value: literal
+
+      class Foo; end
+    RUBY
+
+    expect_no_offenses(<<~RUBY)
+      # shareable_constant_value: experimental_everything
+      # frozen_string_literal: true
+
+      class Foo; end
+    RUBY
+  end
+
+  it 'registers offense when frozen_string_literal used with shareable_constant_value without empty line' do
+    expect_offense(<<~RUBY)
+      # frozen_string_literal: true
+      # shareable_constant_value: none
+      class Foo; end
+      ^ Add an empty line after magic comments.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # frozen_string_literal: true
+      # shareable_constant_value: none
+
+      class Foo; end
+    RUBY
+  end
+
   it 'accepts code that separates the comment from the code with a newline' do
     expect_no_offenses(<<~RUBY)
       # frozen_string_literal: true


### PR DESCRIPTION
Closes #9327

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/