### PR TITLE
Add new `InternalAffairs/EmptyLineBetweenExpectOffenseAndCorrection` cop

### DIFF
--- a/lib/rubocop/cop/internal_affairs.rb
+++ b/lib/rubocop/cop/internal_affairs.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'internal_affairs/empty_line_between_expect_offense_and_correction'
 require_relative 'internal_affairs/method_name_equal'
 require_relative 'internal_affairs/node_destructuring'
 require_relative 'internal_affairs/node_type_predicate'

--- a/lib/rubocop/cop/internal_affairs/empty_line_between_expect_offense_and_correction.rb
+++ b/lib/rubocop/cop/internal_affairs/empty_line_between_expect_offense_and_correction.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module InternalAffairs
+      # This cop checks whether `expect_offense` and correction expectation methods
+      # (i.e. `expect_correction` and `expect_no_corrections`) are separated by empty line.
+      #
+      # @example
+      #   # bad
+      #   it 'registers and corrects an offense' do
+      #     expect_offense(<<~RUBY)
+      #       bad_method
+      #       ^^^^^^^^^^ Use `good_method`.
+      #     RUBY
+      #     expect_correction(<<~RUBY)
+      #       good_method
+      #     RUBY
+      #   end
+      #
+      #   # good
+      #   it 'registers and corrects an offense' do
+      #     expect_offense(<<~RUBY)
+      #       bad_method
+      #       ^^^^^^^^^^ Use `good_method`.
+      #     RUBY
+      #
+      #     expect_correction(<<~RUBY)
+      #       good_method
+      #     RUBY
+      #   end
+      #
+      class EmptyLineBetweenExpectOffenseAndCorrection < Base
+        extend AutoCorrector
+
+        MSG = 'Add empty line between `expect_offense` and `%<expect_correction>s`.'
+        RESTRICT_ON_SEND = %i[expect_offense].freeze
+        CORRECTION_EXPECTATION_METHODS = %i[expect_correction expect_no_corrections].freeze
+
+        def on_send(node)
+          return unless (next_sibling = node.right_sibling) && next_sibling.send_type?
+
+          method_name = next_sibling.method_name
+          return unless CORRECTION_EXPECTATION_METHODS.include?(method_name)
+
+          range = offense_range(node)
+          return unless range.last_line + 1 == next_sibling.loc.line
+
+          add_offense(range, message: format(MSG, expect_correction: method_name)) do |corrector|
+            corrector.insert_after(range, "\n")
+          end
+        end
+
+        private
+
+        def offense_range(node)
+          first_argument = node.first_argument
+
+          if first_argument.respond_to?(:heredoc?) && first_argument.heredoc?
+            first_argument.loc.heredoc_end
+          else
+            node
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/internal_affairs/empty_line_between_expect_offense_and_correction_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/empty_line_between_expect_offense_and_correction_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::InternalAffairs::EmptyLineBetweenExpectOffenseAndCorrection, :config do
+  it 'registers and corrects an offense when using no empty line between `expect_offense` and `expect_correction` ' \
+     'with heredoc argument' do
+    expect_offense(<<~RUBY)
+      expect_offense(<<~CODE)
+        bad_method
+      CODE
+      ^^^^ Add empty line between `expect_offense` and `expect_correction`.
+      expect_correction(<<~CODE)
+        good_good
+      CODE
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect_offense(<<~CODE)
+        bad_method
+      CODE
+
+      expect_correction(<<~CODE)
+        good_good
+      CODE
+    RUBY
+  end
+
+  it 'registers and corrects an offense when using no empty line between `expect_offense` and `expect_correction`' \
+     'with variable argument' do
+    expect_offense(<<~RUBY)
+      expect_offense(code)
+      ^^^^^^^^^^^^^^^^^^^^ Add empty line between `expect_offense` and `expect_correction`.
+      expect_correction(code)
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect_offense(code)
+
+      expect_correction(code)
+    RUBY
+  end
+
+  it 'registers and corrects an offense when using no empty line between `expect_offense` and `expect_no_corrections`' do
+    expect_offense(<<~RUBY)
+      expect_offense('bad_method')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add empty line between `expect_offense` and `expect_no_corrections`.
+      expect_no_corrections
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect_offense('bad_method')
+
+      expect_no_corrections
+    RUBY
+  end
+
+  it 'does not register an offense when using only `expect_offense`' do
+    expect_no_offenses(<<~RUBY)
+      expect_offense(<<~CODE)
+        bad_method
+      CODE
+    RUBY
+  end
+
+  it 'does not register an offense when using empty line between `expect_offense` and `expect_correction` ' \
+     'with heredoc argument' do
+    expect_no_offenses(<<~RUBY)
+      expect_offense(<<~CODE)
+        bad_method
+      CODE
+
+      expect_correction(<<~CODE)
+        good_method
+      CODE
+    RUBY
+  end
+
+  it 'does not register an offense when using empty line between `expect_offense` and `expect_correction`' \
+     'with variable argument' do
+    expect_no_offenses(<<~RUBY)
+      expect_offense(bad_method)
+
+      expect_correction(good_method)
+    RUBY
+  end
+
+  it 'does not register an offense when using empty line between `expect_offense` and `expect_no_corrections`' do
+    expect_no_offenses(<<~RUBY)
+      expect_offense('bad_method')
+
+      expect_no_corrections
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/layout/space_around_method_call_operator_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_method_call_operator_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundMethodCallOperator do
   shared_examples 'offense' do |name, _code, offense, correction|
     it "registers an offense and corrects when #{name}" do
       expect_offense(offense)
+
       expect_correction(correction)
     end
   end

--- a/spec/rubocop/cop/layout/space_inside_array_percent_literal_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_array_percent_literal_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayPercentLiteral do
             #{code_example('a\   b \ c')}
                   ^^ Use only a single space inside array percent literal.
           RUBY
+
           expect_correction("#{code_example('a\  b \ c')}\n")
         end
 

--- a/spec/rubocop/cop/layout/space_inside_percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_percent_literal_delimiters_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsidePercentLiteralDelimiters do
                          ^ #{message}
                ^ #{message}
           RUBY
+
           expect_correction("#{code_example('\ a b c\ ')}\n")
         end
 

--- a/spec/rubocop/cop/layout/trailing_empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_empty_lines_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
 
 
       RUBY
+
       expect_correction("x = 0\n")
     end
   end

--- a/spec/rubocop/cop/lint/empty_when_spec.rb
+++ b/spec/rubocop/cop/lint/empty_when_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyWhen, :config do
         ^^^^^^^^^ Avoid `when` branches without a body.
         end
       RUBY
+
       expect_no_corrections
     end
 
@@ -24,6 +25,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyWhen, :config do
         else 3
         end
       RUBY
+
       expect_no_corrections
     end
 
@@ -35,6 +37,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyWhen, :config do
         ^^^^^^^^^ Avoid `when` branches without a body.
         end
       RUBY
+
       expect_no_corrections
     end
 
@@ -47,6 +50,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyWhen, :config do
         else 3
         end
       RUBY
+
       expect_no_corrections
     end
 
@@ -60,6 +64,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyWhen, :config do
           # nothing
         end
       RUBY
+
       expect_no_corrections
     end
 
@@ -76,6 +81,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyWhen, :config do
           3
         end
       RUBY
+
       expect_no_corrections
     end
 
@@ -91,6 +97,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyWhen, :config do
           3
         end
       RUBY
+
       expect_no_corrections
     end
   end
@@ -181,6 +188,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyWhen, :config do
           # do nothing
         end
       RUBY
+
       expect_no_corrections
     end
   end

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
         "this is the #{%{literal}}"
                        ^{literal} Literal interpolation detected.
       RUBY
+
       expect_correction(<<~RUBY)
         "this is the #{expected}"
       RUBY
@@ -36,6 +37,7 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
         "this is the #{%{literal}} literally"
                        ^{literal} Literal interpolation detected.
       RUBY
+
       expect_correction(<<~RUBY)
         "this is the #{expected} literally"
       RUBY
@@ -47,6 +49,7 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
                 ^{literal} Literal interpolation detected.
                 _{literal}         ^{literal} Literal interpolation detected.
       RUBY
+
       expect_correction(<<~RUBY)
         "some #{expected} with #{expected} too"
       RUBY
@@ -59,6 +62,7 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
             "this is #{%{literal}} with #{a} now"
                        ^{literal} Literal interpolation detected.
           RUBY
+
           expect_correction(<<~RUBY)
             "this is #{expected} with \#{a} now"
           RUBY
@@ -71,6 +75,7 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
             "this is #{a} with #{%{literal}} now"
                                  ^{literal} Literal interpolation detected.
           RUBY
+
           expect_correction(<<~RUBY)
             "this is \#{a} with #{expected} now"
           RUBY
@@ -145,6 +150,7 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
         %{prefix}[this #{%{literal}} is not significant]
         _{prefix}        ^{literal} Literal interpolation detected.
       RUBY
+
       expect_correction(<<~RUBY)
         #{prefix}[this #{word} is not significant]
       RUBY
@@ -155,6 +161,7 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
         %{prefix}[this #{%{literal}} is not significant]
         _{prefix}        ^{literal} Literal interpolation detected.
       RUBY
+
       expect_correction(<<~RUBY)
         #{prefix}[this #{word} is not significant]
       RUBY
@@ -165,6 +172,7 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
         %{prefix}[this #{%{literal}} is not significant]
         _{prefix}        ^{literal} Literal interpolation detected.
       RUBY
+
       expect_correction(<<~RUBY)
         #{prefix}[this #{[word].inspect.gsub(/"/, '\"')} is not significant]
       RUBY
@@ -175,6 +183,7 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
         %{prefix}[this #{%{literal}} is not significant]
         _{prefix}        ^{literal} Literal interpolation detected.
       RUBY
+
       expect_correction(<<~RUBY)
         #{prefix}[this #{[word.to_sym].inspect} is not significant]
       RUBY
@@ -207,6 +216,7 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
         "this is the #{%{keyword}} #{1}"
                        _{keyword}    ^ Literal interpolation detected.
       RUBY
+
       expect_correction(<<~RUBY)
         "this is the \#{#{keyword}} 1"
       RUBY
@@ -300,6 +310,7 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
         :"this is the #{%{literal}}"
                         ^{literal} Literal interpolation detected.
       RUBY
+
       expect_correction(<<~RUBY)
         :"this is the #{expected}"
       RUBY
@@ -310,6 +321,7 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
         `this is the #{%{literal}}`
                        ^{literal} Literal interpolation detected.
       RUBY
+
       expect_correction(<<~RUBY)
         \`this is the #{expected}\`
       RUBY
@@ -320,6 +332,7 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
         /this is the #{%{literal}}/
                        ^{literal} Literal interpolation detected.
       RUBY
+
       expect_correction(<<~RUBY)
         /this is the #{expected}/
       RUBY

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
                 # rubocop:disable Metrics/MethodLength
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Metrics/MethodLength`.
               RUBY
+
               expect_correction('')
             end
           end
@@ -36,6 +37,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
                 # rubocop:disable UnknownCop
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `UnknownCop` (unknown cop).
               RUBY
+
               expect_correction('')
             end
           end
@@ -121,6 +123,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
                 # rubocop:disable Metrics/ClassLength, Metrics/MethodLength
                                   ^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Metrics/ClassLength`.
               RUBY
+
               expect_correction(<<~RUBY)
                 # rubocop:disable Metrics/MethodLength
               RUBY

--- a/spec/rubocop/cop/lint/redundant_splat_expansion_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_splat_expansion_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSplatExpansion, :config do
         a = *%{literal}
             ^^{literal} Replace splat expansion with comma separated values.
       RUBY
+
       expect_correction(<<~RUBY)
         a = #{as_array}
       RUBY
@@ -47,6 +48,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSplatExpansion, :config do
           array.push(*%{literal})
                      ^^{literal} Pass array contents as separate arguments.
         RUBY
+
         expect_correction(<<~RUBY)
           array.push(#{as_args})
         RUBY
@@ -64,6 +66,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSplatExpansion, :config do
           array.push(*%{literal})
                      ^^{literal} Replace splat expansion with comma separated values.
         RUBY
+
         expect_correction(<<~RUBY)
           array.push(#{as_array})
         RUBY

--- a/spec/rubocop/cop/lint/script_permission_spec.rb
+++ b/spec/rubocop/cop/lint/script_permission_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe RuboCop::Cop::Lint::ScriptPermission do
           #!/usr/bin/ruby
           ^^^^^^^^^^^^^^^ Script file #{filename} doesn't have execute permission.
         RUBY
+
         expect_correction(<<~RUBY)
           #!/usr/bin/ruby
         RUBY
@@ -54,6 +55,7 @@ RSpec.describe RuboCop::Cop::Lint::ScriptPermission do
             #!/usr/bin/ruby
             ^^^^^^^^^^^^^^^ Script file #{filename} doesn't have execute permission.
           RUBY
+
           expect_no_corrections
           expect(file.stat.executable?).to be false
         end

--- a/spec/rubocop/cop/lint/unused_block_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_block_argument_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
               puts key
             end
           RUBY
+
           expect_correction(<<~RUBY)
             hash.each do |key, _value|
               puts key
@@ -56,6 +57,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
               key, value = value, 42
             end
           RUBY
+
           expect_correction(<<~RUBY)
             hash.each do |_key, value|
               key, value = value, 42
@@ -74,6 +76,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
             obj.method { |foo, *bars, baz| stuff(foo, baz) }
                                 ^^^^ #{message}
           RUBY
+
           expect_correction(<<~RUBY)
             obj.method { |foo, *_bars, baz| stuff(foo, baz) }
           RUBY
@@ -92,6 +95,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
               stuff(foo)
             end
           RUBY
+
           expect_correction(<<~RUBY)
             obj.method do |foo, _bar = baz|
               stuff(foo)
@@ -115,6 +119,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
               puts :something
             end
           RUBY
+
           expect_correction(<<~RUBY)
             hash = { foo: 'FOO', bar: 'BAR' }
             hash.each do |_key, _value|
@@ -138,6 +143,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
                 puts :something
               end
             RUBY
+
             expect_correction(<<~RUBY)
               hash.each do |_key,
                             _value|
@@ -161,6 +167,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
               puts :something
             end
           RUBY
+
           expect_correction(<<~RUBY)
             1.times do |_index|
               puts :something
@@ -181,6 +188,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
               puts 'baz'
             end
           RUBY
+
           expect_correction(<<~RUBY)
             define_method(:foo) do |_bar|
               puts 'baz'
@@ -199,6 +207,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
               puts index
             end
           RUBY
+
           expect_correction(<<~RUBY)
             1.times do |index; _block_local_variable|
               puts index
@@ -225,6 +234,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
                      ^^^ #{bar_message}
                 ^^^ #{foo_message}
           RUBY
+
           expect_correction(<<~RUBY)
             -> (_foo, _bar) { do_something }
           RUBY
@@ -241,6 +251,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
             -> (foo, bar) { puts bar }
                 ^^^ #{message}
           RUBY
+
           expect_correction(<<~RUBY)
             -> (_foo, bar) { puts bar }
           RUBY
@@ -271,6 +282,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
               puts 'bar'
             end
           RUBY
+
           expect_no_corrections
         end
 
@@ -298,6 +310,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
               puts 'bar'
             end
           RUBY
+
           expect_no_corrections
         end
 
@@ -359,6 +372,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
               end
             end
           RUBY
+
           expect_correction(<<~RUBY)
             test do |_key, _value|
               def other(a)
@@ -385,6 +399,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
               puts something(binding(:other))
             end
           RUBY
+
           expect_correction(<<~RUBY)
             test do |_key, _value|
               puts something(binding(:other))
@@ -406,6 +421,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
             super { |bar| }
                      ^^^ #{message}
           RUBY
+
           expect_correction(<<~RUBY)
             super { |_bar| }
           RUBY
@@ -440,6 +456,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
         ->(arg) { 1 }
            ^^^ #{message}
       RUBY
+
       expect_correction(<<~RUBY)
         ->(_arg) { 1 }
       RUBY
@@ -464,6 +481,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
                  ^^^^ #{arg2_message}
            ^^^^ #{arg1_message}
       RUBY
+
       expect_correction(<<~RUBY)
         ->(_arg1, _arg2, *_others) { 1 }
       RUBY

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
               puts bar
             end
           RUBY
+
           expect_correction(<<~RUBY)
             def some_method(_foo, bar)
               puts bar
@@ -43,6 +44,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
                 puts foo
               end
             RUBY
+
             expect_correction(<<~RUBY)
               def some_method(foo,
                   _bar)
@@ -75,6 +77,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
                 a, b = b, 42
               end
             RUBY
+
             expect_correction(<<~RUBY)
               def foo(_a, b)
                 a, b = b, 42
@@ -122,6 +125,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
             puts foo
           end
         RUBY
+
         expect_correction(<<~RUBY)
           def some_method(foo, *_bar)
             puts foo
@@ -142,6 +146,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
             puts foo
           end
         RUBY
+
         expect_correction(<<~RUBY)
           def some_method(foo, _bar = 1)
             puts foo
@@ -158,6 +163,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
             puts foo
           end
         RUBY
+
         expect_no_corrections
       end
     end
@@ -170,6 +176,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
             puts foo
           end
         RUBY
+
         expect_no_corrections
       end
 
@@ -198,6 +205,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
             foo + bar
           end
         RUBY
+
         expect_correction(<<~RUBY)
           def some_method(foo, bar)
             foo + bar
@@ -219,6 +227,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
                                ^^^ #{message}
           end
         RUBY
+
         expect_correction(<<~RUBY)
           def self.some_method(_foo)
           end
@@ -300,6 +309,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
               super(:something)
             end
           RUBY
+
           expect_correction(<<~RUBY)
             def some_method(_foo)
               super(:something)
@@ -338,6 +348,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
               end
             end
           RUBY
+
           expect_correction(<<~RUBY)
             def some_method(_foo, _bar)
               def other(a)
@@ -364,6 +375,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
               binding(:something)
             end
           RUBY
+
           expect_correction(<<~RUBY)
             def some_method(_foo)
               binding(:something)
@@ -405,6 +417,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
           1
         end
       RUBY
+
       expect_correction(<<~RUBY)
         def method(_arg)
           1
@@ -436,6 +449,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
           1
         end
       RUBY
+
       expect_correction(<<~RUBY)
         def method(_a, _b, *_others)
           1
@@ -506,6 +520,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
           1
         end
       RUBY
+
       expect_correction(<<~RUBY)
         def method(_arg)
           1
@@ -538,6 +553,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
           1
         end
       RUBY
+
       expect_correction(<<~RUBY)
         def method(_a, _b, *_others)
           1

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
             do_something
           end
         RUBY
+
         expect_correction(<<~RUBY)
           if a #{prefer} b
             do_something
@@ -46,6 +47,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
             do_something
           end
         RUBY
+
         expect_correction(<<~RUBY)
           while a #{prefer} b
             do_something
@@ -68,6 +70,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
             do_something
           end
         RUBY
+
         expect_correction(<<~RUBY)
           until a #{prefer} b
             do_something
@@ -90,6 +93,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           end while a %{operator} b
                       ^{operator} Use `#{prefer}` instead of `#{operator}`.
         RUBY
+
         expect_correction(<<~RUBY)
           begin
             do_something
@@ -112,6 +116,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           end until a %{operator} b
                       ^{operator} Use `#{prefer}` instead of `#{operator}`.
         RUBY
+
         expect_correction(<<~RUBY)
           begin
             do_something
@@ -158,6 +163,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           test if a %{operator} b
                     ^{operator} Use `#{prefer}` instead of `#{operator}`.
         RUBY
+
         expect_correction(<<~RUBY)
           test if a #{prefer} b
         RUBY
@@ -170,6 +176,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
                              ^{operator} Use `#{prefer}` instead of `#{operator}`.
           end
         RUBY
+
         expect_correction(<<~RUBY)
           def z(a, b)
             return true if a #{prefer} b
@@ -183,6 +190,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
         x = y or teststring.include? 'b'
               ^^ Use `||` instead of `or`.
       RUBY
+
       expect_correction(<<~RUBY)
         (x = y) || teststring.include?('b')
       RUBY
@@ -193,6 +201,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
         teststring.include? 'b' or x = y
                                 ^^ Use `||` instead of `or`.
       RUBY
+
       expect_correction(<<~RUBY)
         teststring.include?('b') || (x = y)
       RUBY
@@ -203,6 +212,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
         foo[:bar] and foo[:baz]
                   ^^^ Use `&&` instead of `and`.
       RUBY
+
       expect_correction(<<~RUBY)
         foo[:bar] && foo[:baz]
       RUBY
@@ -214,6 +224,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           x = a + b %{operator} return x
                     ^{operator} Use `#{prefer}` instead of `#{operator}`.
         RUBY
+
         expect_correction(<<~RUBY)
           (x = a + b) #{prefer} (return x)
         RUBY
@@ -224,6 +235,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           x = a + b if a %{operator} b
                          ^{operator} Use `#{prefer}` instead of `#{operator}`.
         RUBY
+
         expect_correction(<<~RUBY)
           x = a + b if a #{prefer} b
         RUBY
@@ -234,6 +246,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           x = a + b unless a %{operator} b
                              ^{operator} Use `#{prefer}` instead of `#{operator}`.
         RUBY
+
         expect_correction(<<~RUBY)
           x = a + b unless a #{prefer} b
         RUBY
@@ -244,6 +257,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           x = a + b while a %{operator} b
                             ^{operator} Use `#{prefer}` instead of `#{operator}`.
         RUBY
+
         expect_correction(<<~RUBY)
           x = a + b while a #{prefer} b
         RUBY
@@ -254,6 +268,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           x = a + b until a %{operator} b
                             ^{operator} Use `#{prefer}` instead of `#{operator}`.
         RUBY
+
         expect_correction(<<~RUBY)
           x = a + b until a #{prefer} b
         RUBY
@@ -264,6 +279,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           method a %{operator} b
                    ^{operator} Use `#{prefer}` instead of `#{operator}`.
         RUBY
+
         expect_correction(<<~RUBY)
           method(a) #{prefer} b
         RUBY
@@ -274,6 +290,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           method a,b %{operator} b
                      ^{operator} Use `#{prefer}` instead of `#{operator}`.
         RUBY
+
         expect_correction(<<~RUBY)
           method(a,b) #{prefer} b
         RUBY
@@ -284,6 +301,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           obj.method a %{operator} b
                        ^{operator} Use `#{prefer}` instead of `#{operator}`.
         RUBY
+
         expect_correction(<<~RUBY)
           obj.method(a) #{prefer} b
         RUBY
@@ -294,6 +312,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           obj.method a,b %{operator} b
                          ^{operator} Use `#{prefer}` instead of `#{operator}`.
         RUBY
+
         expect_correction(<<~RUBY)
           obj.method(a,b) #{prefer} b
         RUBY
@@ -304,6 +323,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           method(a, b) %{operator} b
                        ^{operator} Use `#{prefer}` instead of `#{operator}`.
         RUBY
+
         expect_correction(<<~RUBY)
           method(a, b) #{prefer} b
         RUBY
@@ -314,6 +334,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           b %{operator} method a,b
             ^{operator} Use `#{prefer}` instead of `#{operator}`.
         RUBY
+
         expect_correction(<<~RUBY)
           b #{prefer} method(a,b)
         RUBY
@@ -326,6 +347,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           x and !obj.method arg
             ^^^ Use `&&` instead of `and`.
         RUBY
+
         expect_correction(<<~RUBY)
           x && !obj.method(arg)
         RUBY
@@ -338,6 +360,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           !obj.method arg and x
                           ^^^ Use `&&` instead of `and`.
         RUBY
+
         expect_correction(<<~RUBY)
           !obj.method(arg) && x
         RUBY
@@ -350,6 +373,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           obj.method = arg and x
                            ^^^ Use `&&` instead of `and`.
         RUBY
+
         expect_correction(<<~RUBY)
           (obj.method = arg) && x
         RUBY
@@ -362,6 +386,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           obj.method= arg and x
                           ^^^ Use `&&` instead of `and`.
         RUBY
+
         expect_correction(<<~RUBY)
           (obj.method= arg) && x
         RUBY
@@ -374,6 +399,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           false or 3.is_a?Integer
                 ^^ Use `||` instead of `or`.
         RUBY
+
         expect_correction(<<~RUBY)
           false || 3.is_a?(Integer)
         RUBY
@@ -384,6 +410,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           false and 3.is_a?Integer
                 ^^^ Use `&&` instead of `and`.
         RUBY
+
         expect_correction(<<~RUBY)
           false && 3.is_a?(Integer)
         RUBY
@@ -396,6 +423,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           '1'.is_a?Integer or 1.is_a?Integer
                            ^^ Use `||` instead of `or`.
         RUBY
+
         expect_correction(<<~RUBY)
           '1'.is_a?(Integer) || 1.is_a?(Integer)
         RUBY
@@ -406,6 +434,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           '1'.is_a?Integer and 1.is_a?Integer
                            ^^^ Use `&&` instead of `and`.
         RUBY
+
         expect_correction(<<~RUBY)
           '1'.is_a?(Integer) && 1.is_a?(Integer)
         RUBY
@@ -419,6 +448,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           '1'.is_a?Integer or 1.is_a? Integer
                            ^^ Use `||` instead of `or`.
         RUBY
+
         expect_correction(<<~RUBY)
           '1'.is_a?(Integer) || 1.is_a?(Integer)
         RUBY
@@ -429,6 +459,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           '1'.is_a?Integer and 1.is_a? Integer
                            ^^^ Use `&&` instead of `and`.
         RUBY
+
         expect_correction(<<~RUBY)
           '1'.is_a?(Integer) && 1.is_a?(Integer)
         RUBY
@@ -441,6 +472,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           x and not arg
             ^^^ Use `&&` instead of `and`.
         RUBY
+
         expect_correction(<<~RUBY)
           x && (not arg)
         RUBY
@@ -453,6 +485,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           not arg and x
                   ^^^ Use `&&` instead of `and`.
         RUBY
+
         expect_correction(<<~RUBY)
           (not arg) && x
         RUBY
@@ -466,6 +499,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           !var or var.empty?
                ^^ Use `||` instead of `or`.
         RUBY
+
         expect_correction(<<~RUBY)
           !var || var.empty?
         RUBY
@@ -484,6 +518,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
                   ^^^ Use `&&` instead of `and`.
           end
         RUBY
+
         expect_correction(<<~RUBY)
           def x
           end
@@ -502,6 +537,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
           foo == bar and baz
                      ^^^ Use `&&` instead of `and`.
         RUBY
+
         expect_correction(<<~RUBY)
           (foo == bar) && baz
         RUBY
@@ -571,6 +607,7 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
                   ^^^ Use `&&` instead of `and`.
           end)
         RUBY
+
         expect_correction(<<~RUBY)
           (def y
             (a = b) && a.c

--- a/spec/rubocop/cop/style/array_join_spec.rb
+++ b/spec/rubocop/cop/style/array_join_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe RuboCop::Cop::Style::ArrayJoin do
       %w(one two three)*", "
                        ^ Favor `Array#join` over `Array#*`.
     RUBY
+
     expect_correction(<<~RUBY)
       %w(one two three).join(", ")
     RUBY
@@ -29,6 +30,7 @@ RSpec.describe RuboCop::Cop::Style::ArrayJoin do
       foo = %w(one two three)*", "
                              ^ Favor `Array#join` over `Array#*`.
     RUBY
+
     expect_correction(<<~RUBY)
       foo = %w(one two three).join(", ")
     RUBY

--- a/spec/rubocop/cop/style/attr_spec.rb
+++ b/spec/rubocop/cop/style/attr_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe RuboCop::Cop::Style::Attr do
         attr :name
         ^^^^ Do not use `attr`. Use `attr_reader` instead.
       RUBY
+
       expect_correction(<<~RUBY)
         attr_reader :name
       RUBY
@@ -68,6 +69,7 @@ RSpec.describe RuboCop::Cop::Style::Attr do
         attr :name, false
         ^^^^ Do not use `attr`. Use `attr_reader` instead.
       RUBY
+
       expect_correction(<<~RUBY)
         attr_reader :name
       RUBY
@@ -78,6 +80,7 @@ RSpec.describe RuboCop::Cop::Style::Attr do
         attr :name, true
         ^^^^ Do not use `attr`. Use `attr_accessor` instead.
       RUBY
+
       expect_correction(<<~RUBY)
         attr_accessor :name
       RUBY
@@ -88,6 +91,7 @@ RSpec.describe RuboCop::Cop::Style::Attr do
         attr :foo, :bar
         ^^^^ Do not use `attr`. Use `attr_reader` instead.
       RUBY
+
       expect_correction(<<~RUBY)
         attr_reader :foo, :bar
       RUBY

--- a/spec/rubocop/cop/style/bare_percent_literals_spec.rb
+++ b/spec/rubocop/cop/style/bare_percent_literals_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe RuboCop::Cop::Style::BarePercentLiterals, :config do
           %(hi)
           ^^ Use `%Q` instead of `%`.
         RUBY
+
         expect_correction(<<~RUBY)
           %Q(hi)
         RUBY
@@ -62,6 +63,7 @@ RSpec.describe RuboCop::Cop::Style::BarePercentLiterals, :config do
           %(#{x})
           ^^ Use `%Q` instead of `%`.
         RUBY
+
         expect_correction(<<~'RUBY')
           %Q(#{x})
         RUBY
@@ -84,6 +86,7 @@ RSpec.describe RuboCop::Cop::Style::BarePercentLiterals, :config do
           %Q(hi)
           ^^^ Use `%` instead of `%Q`.
         RUBY
+
         expect_correction(<<~RUBY)
           %(hi)
         RUBY
@@ -102,6 +105,7 @@ RSpec.describe RuboCop::Cop::Style::BarePercentLiterals, :config do
           %Q(#{x})
           ^^^ Use `%` instead of `%Q`.
         RUBY
+
         expect_correction(<<~'RUBY')
           %(#{x})
         RUBY

--- a/spec/rubocop/cop/style/block_comments_spec.rb
+++ b/spec/rubocop/cop/style/block_comments_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe RuboCop::Cop::Style::BlockComments do
       comment
       =end
     RUBY
+
     expect_correction(<<~RUBY)
       # comment
     RUBY
@@ -30,6 +31,7 @@ RSpec.describe RuboCop::Cop::Style::BlockComments do
       def foo
       end
     RUBY
+
     expect_correction(<<~RUBY)
       # comment line 1
       #
@@ -47,6 +49,7 @@ RSpec.describe RuboCop::Cop::Style::BlockComments do
       def foo
       end
     RUBY
+
     expect_correction(<<~RUBY)
       def foo
       end
@@ -63,6 +66,7 @@ RSpec.describe RuboCop::Cop::Style::BlockComments do
       comment line 2
       =end
     RUBY
+
     expect_correction(<<~RUBY)
       # comment line 1
       #

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -225,6 +225,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
             x
           }
         RUBY
+
         expect_correction(<<~RUBY)
           each do |x|
             x
@@ -239,6 +240,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
             x
           }
         RUBY
+
         expect_correction(<<~RUBY)
           each do |x|
             x
@@ -270,6 +272,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
           x
         end
       RUBY
+
       expect_correction(<<~RUBY)
         foo = map { |x|
           x
@@ -284,6 +287,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
           x
         end
       RUBY
+
       expect_correction(<<~RUBY)
         foo = map { |x|
           x
@@ -299,6 +303,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
           x
         end)
       RUBY
+
       expect_correction(<<~RUBY)
         puts (map { |x|
           x
@@ -322,6 +327,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
         block do |x| end
               ^^ Prefer `{...}` over `do...end` for single-line blocks.
       RUBY
+
       expect_correction(<<~RUBY)
         block { |x| }
       RUBY
@@ -332,6 +338,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
         s.subspec 'Subspec' do |sp| end
                             ^^ Prefer `{...}` over `do...end` for single-line blocks.
       RUBY
+
       expect_no_corrections
     end
 
@@ -434,6 +441,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
             other_method
           }
         RUBY
+
         expect_correction(<<~RUBY)
           each do |x|
             some_method
@@ -450,6 +458,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
             puts a
           }}
         RUBY
+
         expect_correction(<<~RUBY)
           (0..3).each do |a| a.times do
             puts a
@@ -630,6 +639,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
         s.subspec 'Subspec' do |sp| end
                             ^^ Prefer `{...}` over `do...end` for blocks.
       RUBY
+
       expect_no_corrections
     end
 

--- a/spec/rubocop/cop/style/character_literal_spec.rb
+++ b/spec/rubocop/cop/style/character_literal_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe RuboCop::Cop::Style::CharacterLiteral do
       x = ?x
           ^^ Do not use the character literal - use string literal instead.
     RUBY
+
     expect_correction(<<~RUBY)
       x = 'x'
     RUBY
@@ -18,6 +19,7 @@ RSpec.describe RuboCop::Cop::Style::CharacterLiteral do
       x = ?\n
           ^^^ Do not use the character literal - use string literal instead.
     RUBY
+
     expect_correction(<<~'RUBY')
       x = "\n"
     RUBY
@@ -36,6 +38,7 @@ RSpec.describe RuboCop::Cop::Style::CharacterLiteral do
       x = ?'
           ^^ Do not use the character literal - use string literal instead.
     RUBY
+
     expect_correction(<<~RUBY)
       x = "'"
     RUBY

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
               ^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
         end
       RUBY
+
       expect_correction(<<~RUBY)
         module FooClass
           class BarClass
@@ -66,6 +67,7 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
               ^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
         end
       RUBY
+
       expect_correction(<<~RUBY)
         module FooClass
           class BarClass < Super
@@ -80,6 +82,7 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
                ^^^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
         end
       RUBY
+
       expect_correction(<<~RUBY)
         module FooModule
           module BarModule
@@ -140,6 +143,7 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
           end
         end
       RUBY
+
       expect_correction(<<~RUBY)
         class FooClass::BarClass
         end
@@ -154,6 +158,7 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
           end
         end
       RUBY
+
       expect_correction(<<~RUBY)
         module FooModule::BarModule
         end

--- a/spec/rubocop/cop/style/collection_methods_spec.rb
+++ b/spec/rubocop/cop/style/collection_methods_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe RuboCop::Cop::Style::CollectionMethods, :config do
         [1, 2, 3].%{method} { |e| e + 1 }
                   ^{method} Prefer `#{preferred_method}` over `#{method}`.
       RUBY
+
       expect_correction(<<~RUBY)
         [1, 2, 3].#{preferred_method} { |e| e + 1 }
       RUBY
@@ -31,6 +32,7 @@ RSpec.describe RuboCop::Cop::Style::CollectionMethods, :config do
         [1, 2, 3].%{method}(&:test)
                   ^{method} Prefer `#{preferred_method}` over `#{method}`.
       RUBY
+
       expect_correction(<<~RUBY)
         [1, 2, 3].#{preferred_method}(&:test)
       RUBY

--- a/spec/rubocop/cop/style/colon_method_call_spec.rb
+++ b/spec/rubocop/cop/style/colon_method_call_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe RuboCop::Cop::Style::ColonMethodCall do
       test::method_name
           ^^ Do not use `::` for method calls.
     RUBY
+
     expect_correction(<<~RUBY)
       test.method_name
     RUBY
@@ -18,6 +19,7 @@ RSpec.describe RuboCop::Cop::Style::ColonMethodCall do
       test::method_name(arg)
           ^^ Do not use `::` for method calls.
     RUBY
+
     expect_correction(<<~RUBY)
       test.method_name(arg)
     RUBY
@@ -28,6 +30,7 @@ RSpec.describe RuboCop::Cop::Style::ColonMethodCall do
       Class::method_name
            ^^ Do not use `::` for method calls.
     RUBY
+
     expect_correction(<<~RUBY)
       Class.method_name
     RUBY
@@ -38,6 +41,7 @@ RSpec.describe RuboCop::Cop::Style::ColonMethodCall do
       Class::method_name(arg, arg2)
            ^^ Do not use `::` for method calls.
     RUBY
+
     expect_correction(<<~RUBY)
       Class.method_name(arg, arg2)
     RUBY

--- a/spec/rubocop/cop/style/command_literal_spec.rb
+++ b/spec/rubocop/cop/style/command_literal_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
         `ls`
         ^^^^ Use `%x` around command string.
       RUBY
+
       expect_correction(<<~RUBY)
         %x[ls]
       RUBY
@@ -53,6 +54,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
         `ls`
         ^^^^ Use `%x` around command string.
       RUBY
+
       expect_correction(<<~'RUBY')
         %x(ls)
       RUBY
@@ -70,6 +72,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
         `ls`
         ^^^^ Use `%x` around command string.
       RUBY
+
       expect_correction(<<~'RUBY')
         %x[ls]
       RUBY
@@ -103,6 +106,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
           foo = `echo \`ls\``
                 ^^^^^^^^^^^^^ Use `%x` around command string.
         RUBY
+
         expect_no_corrections
       end
 
@@ -135,6 +139,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
             echo \`ls -l\`
           `
         RUBY
+
         expect_no_corrections
       end
 
@@ -158,6 +163,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
           foo = %x(ls)
                 ^^^^^^ Use backticks around command string.
         RUBY
+
         expect_correction(<<~RUBY)
           foo = `ls`
         RUBY
@@ -177,6 +183,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
             foo = %x(echo `ls`)
                   ^^^^^^^^^^^^^ Use backticks around command string.
           RUBY
+
           expect_no_corrections
         end
       end
@@ -222,6 +229,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
               echo `ls -l`
             )
           RUBY
+
           expect_no_corrections
         end
       end
@@ -250,6 +258,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
           foo = `echo \`ls\``
                 ^^^^^^^^^^^^^ Use `%x` around command string.
         RUBY
+
         expect_no_corrections
       end
     end
@@ -282,6 +291,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
             echo \`ls -l\`
           `
         RUBY
+
         expect_no_corrections
       end
     end
@@ -336,6 +346,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
           foo = `echo \`ls\``
                 ^^^^^^^^^^^^^ Use `%x` around command string.
         RUBY
+
         expect_no_corrections
       end
 
@@ -376,6 +387,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
             echo \`ls -l\`
           `
         RUBY
+
         expect_no_corrections
       end
     end
@@ -406,6 +418,7 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
             foo = %x(echo `ls`)
                   ^^^^^^^^^^^^^ Use backticks around command string.
           RUBY
+
           expect_no_corrections
         end
       end

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
         # HACK:
           ^^^^^ Annotation comment, with keyword `HACK`, is missing a note.
       RUBY
+
       expect_no_corrections
     end
   end

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -139,6 +139,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
       foo? ? bar = "a" : bar = "b"
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
     RUBY
+
     expect_correction(<<~RUBY)
       bar = foo? ? "a" : "b"
     RUBY
@@ -169,6 +170,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
         default['key-with-dash'] << b
       end
     RUBY
+
     expect_correction(<<~RUBY)
       default['key-with-dash'] << if condition
         a
@@ -195,6 +197,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
         %{source}
         ^{source} Use the return of the conditional for variable assignment and comparison.
       RUBY
+
       expect_correction(<<~RUBY)
         bar #{method} (foo? ? 1 : 2)
       RUBY
@@ -489,6 +492,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
         bar = #{'b' * 72}
       end
     RUBY
+
     expect_correction(<<~RUBY)
       bar = if foo
         #{'a' * 72}
@@ -736,6 +740,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
         bar = 3
       end
     RUBY
+
     expect_correction(<<~RUBY)
       bar = if foo
         1
@@ -760,6 +765,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
         bar = 4
       end
     RUBY
+
     expect_correction(<<~RUBY)
       bar = if foo
         1
@@ -1117,6 +1123,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
       else bar = 2
       end
     RUBY
+
     expect_correction(<<~RUBY)
       bar = if foo then 1
       elsif cond then 2
@@ -1134,6 +1141,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
         bar = 2
       end
     RUBY
+
     expect_correction(<<~RUBY)
       bar = unless foo
         1
@@ -1151,6 +1159,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
       else baz = 2
       end
     RUBY
+
     expect_correction(<<~RUBY)
       baz = case foo
       when bar then 1
@@ -1171,6 +1180,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
         bar = 3
       end
     RUBY
+
     expect_correction(<<~RUBY)
       bar = case foo
       when foobar
@@ -1211,6 +1221,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
         foo? ? bar =~ /a/ : bar =~ /b/
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the return of the conditional for variable assignment and comparison.
       RUBY
+
       expect_correction(<<~'RUBY')
         bar =~ (foo? ? /a/ : /b/)
       RUBY
@@ -1354,6 +1365,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             array[1] = 2
           end
         RUBY
+
         expect_correction(<<~RUBY)
           array[1] = if something
             1
@@ -1386,6 +1398,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             FOO::BAR = 2
           end
         RUBY
+
         expect_correction(<<~RUBY)
           FOO::BAR = if something
             1
@@ -1404,6 +1417,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
             ::BAR = 2
           end
         RUBY
+
         expect_correction(<<~RUBY)
           ::BAR = if something
             1

--- a/spec/rubocop/cop/style/copyright_spec.rb
+++ b/spec/rubocop/cop/style/copyright_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe RuboCop::Cop::Style::Copyright, :config do
       cop_config['AutocorrectNotice'] = '# Copyright (c) 2015 Acme Inc.'
 
       expect_offense(source)
+
       expect_correction(<<~RUBY)
         # Copyright (c) 2015 Acme Inc.
         # test
@@ -81,6 +82,7 @@ RSpec.describe RuboCop::Cop::Style::Copyright, :config do
         # Copyright (c) 2015 Acme Inc.
         names << 'James'
       RUBY
+
       expect_correction(<<~RUBY)
         # Copyright (c) 2015 Acme Inc.
         # test2
@@ -98,6 +100,7 @@ RSpec.describe RuboCop::Cop::Style::Copyright, :config do
       expect_offense(<<~'RUBY')
         ^ Include a copyright notice matching [...]
       RUBY
+
       expect_correction(<<~RUBY)
         # Copyright (c) 2015 Acme Inc.
       RUBY
@@ -115,6 +118,7 @@ RSpec.describe RuboCop::Cop::Style::Copyright, :config do
         names = Array.new
         names << 'James'
       RUBY
+
       expect_correction(<<~RUBY)
         #!/usr/bin/env ruby
         # Copyright (c) 2015 Acme Inc.
@@ -135,6 +139,7 @@ RSpec.describe RuboCop::Cop::Style::Copyright, :config do
         names = Array.new
         names << 'James'
       RUBY
+
       expect_correction(<<~RUBY)
         # encoding: utf-8
         # Copyright (c) 2015 Acme Inc.
@@ -157,6 +162,7 @@ RSpec.describe RuboCop::Cop::Style::Copyright, :config do
         names = Array.new
         names << 'James'
       RUBY
+
       expect_correction(<<~RUBY)
         #!/usr/bin/env ruby
         # encoding: utf-8

--- a/spec/rubocop/cop/style/def_with_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/def_with_parentheses_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe RuboCop::Cop::Style::DefWithParentheses do
               ^ Omit the parentheses in defs when the method doesn't accept any arguments.
       end
     RUBY
+
     expect_correction(<<~RUBY)
       def func
       end
@@ -22,6 +23,7 @@ RSpec.describe RuboCop::Cop::Style::DefWithParentheses do
         something
       end
     RUBY
+
     expect_correction(<<~RUBY)
       def Test.func
         something

--- a/spec/rubocop/cop/style/dir_spec.rb
+++ b/spec/rubocop/cop/style/dir_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe RuboCop::Cop::Style::Dir, :config do
         File.expand_path(File.dirname(__FILE__))
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `__dir__` to get an absolute path to the current file's directory.
       RUBY
+
       expect_correction(<<~RUBY)
         __dir__
       RUBY
@@ -17,6 +18,7 @@ RSpec.describe RuboCop::Cop::Style::Dir, :config do
         ::File.expand_path(::File.dirname(__FILE__))
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `__dir__` to get an absolute path to the current file's directory.
       RUBY
+
       expect_correction(<<~RUBY)
         __dir__
       RUBY
@@ -29,6 +31,7 @@ RSpec.describe RuboCop::Cop::Style::Dir, :config do
         File.dirname(File.realpath(__FILE__))
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `__dir__` to get an absolute path to the current file's directory.
       RUBY
+
       expect_correction(<<~RUBY)
         __dir__
       RUBY
@@ -39,6 +42,7 @@ RSpec.describe RuboCop::Cop::Style::Dir, :config do
         ::File.dirname(::File.realpath(__FILE__))
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `__dir__` to get an absolute path to the current file's directory.
       RUBY
+
       expect_correction(<<~RUBY)
         __dir__
       RUBY

--- a/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
+++ b/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective do
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Comment to disable/enable RuboCop.
       end
     RUBY
+
     expect_correction(<<~RUBY)
       def choose_move(who_to_move)
       end
@@ -21,6 +22,7 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective do
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Comment to disable/enable RuboCop.
       end
     RUBY
+
     expect_correction(<<~RUBY)
       def choose_move(who_to_move)
       end

--- a/spec/rubocop/cop/style/double_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/style/double_cop_disable_directive_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe RuboCop::Cop::Style::DoubleCopDisableDirective do
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ More than one disable comment on one line.
       end
     RUBY
+
     expect_correction(<<~RUBY)
       def choose_move(who_to_move) # rubocop:disable Metrics/CyclomaticComplexity
       end
@@ -21,6 +22,7 @@ RSpec.describe RuboCop::Cop::Style::DoubleCopDisableDirective do
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ More than one disable comment on one line.
       end
     RUBY
+
     expect_correction(<<~RUBY)
       def choose_move(who_to_move) # rubocop:todo Metrics/CyclomaticComplexity
       end

--- a/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
+++ b/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe RuboCop::Cop::Style::EachForSimpleLoop do
         (0..10).each {}
         ^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
       RUBY
+
       expect_correction(<<~RUBY)
         11.times {}
       RUBY
@@ -78,6 +79,7 @@ RSpec.describe RuboCop::Cop::Style::EachForSimpleLoop do
         (0...10).each {}
         ^^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
       RUBY
+
       expect_correction(<<~RUBY)
         10.times {}
       RUBY

--- a/spec/rubocop/cop/style/each_with_object_spec.rb
+++ b/spec/rubocop/cop/style/each_with_object_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe RuboCop::Cop::Style::EachWithObject do
         a
       end
     RUBY
+
     expect_correction(<<~RUBY)
       [].each_with_object({}) { |e, a|  }
 
@@ -33,6 +34,7 @@ RSpec.describe RuboCop::Cop::Style::EachWithObject do
         h
       end
     RUBY
+
     expect_correction(<<~RUBY)
       [1, 2, 3].each_with_object({}) do |i, h|
         h[i] = i
@@ -47,6 +49,7 @@ RSpec.describe RuboCop::Cop::Style::EachWithObject do
         h
       end
     RUBY
+
     expect_correction(<<~RUBY)
       [1, 2, 3].each_with_object({}) do |i, h|
       end

--- a/spec/rubocop/cop/style/empty_case_condition_spec.rb
+++ b/spec/rubocop/cop/style/empty_case_condition_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition do
   shared_examples 'detect/correct empty case, accept non-empty case' do
     it 'registers an offense and autocorrects' do
       expect_offense(source)
+
       expect_correction(corrected_source)
     end
 

--- a/spec/rubocop/cop/style/empty_else_spec.rb
+++ b/spec/rubocop/cop/style/empty_else_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse do
     context 'MissingElse is disabled' do
       it 'does auto-correction' do
         expect_offense(source)
+
         expect_correction(corrected_source)
       end
     end
@@ -23,11 +24,13 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse do
         if ['both', keyword].include? missing_else_style
           it 'does not auto-correct' do
             expect_offense(source)
+
             expect_no_corrections
           end
         else
           it 'does auto-correction' do
             expect_offense(source)
+
             expect_correction(corrected_source)
           end
         end

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral do
         test = Array.new()
                ^^^^^^^^^^^ Use array literal `[]` instead of `Array.new`.
       RUBY
+
       expect_correction(<<~RUBY)
         test = []
       RUBY
@@ -19,6 +20,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral do
         test = Array.new
                ^^^^^^^^^ Use array literal `[]` instead of `Array.new`.
       RUBY
+
       expect_correction(<<~RUBY)
         test = []
       RUBY
@@ -29,6 +31,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral do
         test = ::Array.new
                ^^^^^^^^^^^ Use array literal `[]` instead of `Array.new`.
       RUBY
+
       expect_correction(<<~RUBY)
         test = []
       RUBY
@@ -43,6 +46,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral do
         puts { Array.new }
                ^^^^^^^^^ Use array literal `[]` instead of `Array.new`.
       RUBY
+
       expect_correction(<<~RUBY)
         puts { [] }
       RUBY
@@ -67,6 +71,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral do
         test = Hash.new()
                ^^^^^^^^^^ Use hash literal `{}` instead of `Hash.new`.
       RUBY
+
       expect_correction(<<~RUBY)
         test = {}
       RUBY
@@ -77,6 +82,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral do
         test = Hash.new
                ^^^^^^^^ Use hash literal `{}` instead of `Hash.new`.
       RUBY
+
       expect_correction(<<~RUBY)
         test = {}
       RUBY
@@ -87,6 +93,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral do
         test = ::Hash.new
                ^^^^^^^^^^ Use hash literal `{}` instead of `Hash.new`.
       RUBY
+
       expect_correction(<<~RUBY)
         test = {}
       RUBY
@@ -123,6 +130,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral do
         puts { Hash.new }
                ^^^^^^^^ Use hash literal `{}` instead of `Hash.new`.
       RUBY
+
       expect_correction(<<~RUBY)
         puts { {} }
       RUBY
@@ -137,6 +145,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral do
         yadayada.map { a }.reduce(Hash.new, :merge)
                                   ^^^^^^^^ Use hash literal `{}` instead of `Hash.new`.
       RUBY
+
       expect_correction(<<~RUBY)
         test = {}
         {}.merge("a" => 3)
@@ -149,6 +158,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral do
         yadayada.map { a }.reduce Hash.new
                                   ^^^^^^^^ Use hash literal `{}` instead of `Hash.new`.
       RUBY
+
       expect_correction(<<~RUBY)
         yadayada.map { a }.reduce({})
       RUBY
@@ -159,6 +169,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral do
         yadayada.map { a }.reduce Hash.new, :merge
                                   ^^^^^^^^ Use hash literal `{}` instead of `Hash.new`.
       RUBY
+
       expect_correction(<<~RUBY)
         yadayada.map { a }.reduce({}, :merge)
       RUBY
@@ -172,6 +183,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral do
                 ^^^^^^^^ Use hash literal `{}` instead of `Hash.new`.
         end
       RUBY
+
       expect_correction(<<~RUBY)
         def foo
           super({})
@@ -187,6 +199,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral do
                 ^^^^^^^^ Use hash literal `{}` instead of `Hash.new`.
         end
       RUBY
+
       expect_correction(<<~RUBY)
         def foo
           super({}, something)
@@ -201,6 +214,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral do
         test = String.new()
                ^^^^^^^^^^^^ Use string literal `''` instead of `String.new`.
       RUBY
+
       expect_correction(<<~RUBY)
         test = ''
       RUBY
@@ -211,6 +225,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral do
         test = String.new
                ^^^^^^^^^^ Use string literal `''` instead of `String.new`.
       RUBY
+
       expect_correction(<<~RUBY)
         test = ''
       RUBY
@@ -221,6 +236,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral do
         test = ::String.new
                ^^^^^^^^^^^^ Use string literal `''` instead of `String.new`.
       RUBY
+
       expect_correction(<<~RUBY)
         test = ''
       RUBY
@@ -251,6 +267,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral do
           test = String.new
                  ^^^^^^^^^^ Use string literal `""` instead of `String.new`.
         RUBY
+
         expect_correction(<<~RUBY)
           test = ""
         RUBY
@@ -261,6 +278,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral do
           test = ::String.new
                  ^^^^^^^^^^^^ Use string literal `""` instead of `String.new`.
         RUBY
+
         expect_correction(<<~RUBY)
           test = ""
         RUBY

--- a/spec/rubocop/cop/style/empty_method_spec.rb
+++ b/spec/rubocop/cop/style/empty_method_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
           ^^^^^^^ Put empty method definitions on a single line.
           end
         RUBY
+
         expect_correction(<<~'RUBY')
           def foo; end
         RUBY
@@ -22,6 +23,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
           ^^^^^^^^^^^^^^^^^ Put empty method definitions on a single line.
           end
         RUBY
+
         expect_correction(<<~'RUBY')
           def foo(bar, baz); end
         RUBY
@@ -33,6 +35,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
           ^^^^^^^^^^^^^^^^ Put empty method definitions on a single line.
           end
         RUBY
+
         expect_correction(<<~'RUBY')
           def foo bar, baz; end
         RUBY
@@ -45,6 +48,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
 
           end
         RUBY
+
         expect_correction(<<~'RUBY')
           def foo; end
         RUBY
@@ -56,6 +60,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
           ^^^^^^^^^^^ Put empty method definitions on a single line.
           ); end
         RUBY
+
         expect_correction(<<~RUBY)
           def foo(arg); end
         RUBY
@@ -95,6 +100,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
           ^^^^^^^^^^^^ Put empty method definitions on a single line.
           end
         RUBY
+
         expect_correction(<<~'RUBY')
           def self.foo; end
         RUBY
@@ -106,6 +112,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
           ^^^^^^^^^^^^^^^^^^^^^^ Put empty method definitions on a single line.
           end
         RUBY
+
         expect_correction(<<~'RUBY')
           def self.foo(bar, baz); end
         RUBY
@@ -118,6 +125,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
 
           end
         RUBY
+
         expect_correction(<<~'RUBY')
           def self.foo; end
         RUBY
@@ -175,6 +183,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
           def foo; end
           ^^^^^^^^^^^^ Put the `end` of empty method definitions on the next line.
         RUBY
+
         expect_correction(<<~'RUBY')
           def foo
           end
@@ -225,6 +234,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
           def self.foo; end
           ^^^^^^^^^^^^^^^^^ Put the `end` of empty method definitions on the next line.
         RUBY
+
         expect_correction(<<~'RUBY')
           def self.foo
           end
@@ -262,6 +272,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
             ^^^^^^^^^^^^ Put the `end` of empty method definitions on the next line.
           end
         RUBY
+
         expect_correction(<<~RUBY)
           class Foo
             def bar

--- a/spec/rubocop/cop/style/encoding_spec.rb
+++ b/spec/rubocop/cop/style/encoding_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe RuboCop::Cop::Style::Encoding, :config do
       ^^^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
       def foo() end
     RUBY
+
     expect_correction(<<~RUBY)
       def foo() end
     RUBY
@@ -32,6 +33,7 @@ RSpec.describe RuboCop::Cop::Style::Encoding, :config do
       ^^^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
       def foo() end
     RUBY
+
     expect_correction(<<~RUBY)
       #!/usr/bin/env ruby
       def foo() end
@@ -44,6 +46,7 @@ RSpec.describe RuboCop::Cop::Style::Encoding, :config do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
       def foo() end
     RUBY
+
     expect_correction(<<~RUBY)
       def foo() end
     RUBY
@@ -62,6 +65,7 @@ RSpec.describe RuboCop::Cop::Style::Encoding, :config do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary utf-8 encoding comment.
       def foo() 'ä' end
     RUBY
+
     expect_correction(<<~RUBY)
       def foo() 'ä' end
     RUBY

--- a/spec/rubocop/cop/style/even_odd_spec.rb
+++ b/spec/rubocop/cop/style/even_odd_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe RuboCop::Cop::Style::EvenOdd do
       x % 2 == 0
       ^^^^^^^^^^ Replace with `Integer#even?`.
     RUBY
+
     expect_correction(<<~RUBY)
       x.even?
     RUBY
@@ -18,6 +19,7 @@ RSpec.describe RuboCop::Cop::Style::EvenOdd do
       x % 2 != 0
       ^^^^^^^^^^ Replace with `Integer#odd?`.
     RUBY
+
     expect_correction(<<~RUBY)
       x.odd?
     RUBY
@@ -28,6 +30,7 @@ RSpec.describe RuboCop::Cop::Style::EvenOdd do
       (x % 2) == 0
       ^^^^^^^^^^^^ Replace with `Integer#even?`.
     RUBY
+
     expect_correction(<<~RUBY)
       x.even?
     RUBY
@@ -38,6 +41,7 @@ RSpec.describe RuboCop::Cop::Style::EvenOdd do
       (x % 2) != 0
       ^^^^^^^^^^^^ Replace with `Integer#odd?`.
     RUBY
+
     expect_correction(<<~RUBY)
       x.odd?
     RUBY
@@ -48,6 +52,7 @@ RSpec.describe RuboCop::Cop::Style::EvenOdd do
       x % 2 == 1
       ^^^^^^^^^^ Replace with `Integer#odd?`.
     RUBY
+
     expect_correction(<<~RUBY)
       x.odd?
     RUBY
@@ -58,6 +63,7 @@ RSpec.describe RuboCop::Cop::Style::EvenOdd do
       x % 2 != 1
       ^^^^^^^^^^ Replace with `Integer#even?`.
     RUBY
+
     expect_correction(<<~RUBY)
       x.even?
     RUBY
@@ -68,6 +74,7 @@ RSpec.describe RuboCop::Cop::Style::EvenOdd do
       (x % 2) == 1
       ^^^^^^^^^^^^ Replace with `Integer#odd?`.
     RUBY
+
     expect_correction(<<~RUBY)
       x.odd?
     RUBY
@@ -78,6 +85,7 @@ RSpec.describe RuboCop::Cop::Style::EvenOdd do
       (y % 2) != 1
       ^^^^^^^^^^^^ Replace with `Integer#even?`.
     RUBY
+
     expect_correction(<<~RUBY)
       y.even?
     RUBY
@@ -88,6 +96,7 @@ RSpec.describe RuboCop::Cop::Style::EvenOdd do
       (x.y % 2) != 1
       ^^^^^^^^^^^^^^ Replace with `Integer#even?`.
     RUBY
+
     expect_correction(<<~RUBY)
       x.y.even?
     RUBY
@@ -98,6 +107,7 @@ RSpec.describe RuboCop::Cop::Style::EvenOdd do
       (x(y) % 2) != 1
       ^^^^^^^^^^^^^^^ Replace with `Integer#even?`.
     RUBY
+
     expect_correction(<<~RUBY)
       x(y).even?
     RUBY
@@ -120,6 +130,7 @@ RSpec.describe RuboCop::Cop::Style::EvenOdd do
       (x._(y) % 2) != 1
       ^^^^^^^^^^^^^^^^^ Replace with `Integer#even?`.
     RUBY
+
     expect_correction(<<~RUBY)
       x._(y).even?
     RUBY
@@ -130,6 +141,7 @@ RSpec.describe RuboCop::Cop::Style::EvenOdd do
       (x._(y)) % 2 != 1
       ^^^^^^^^^^^^^^^^^ Replace with `Integer#even?`.
     RUBY
+
     expect_correction(<<~RUBY)
       (x._(y)).even?
     RUBY
@@ -140,6 +152,7 @@ RSpec.describe RuboCop::Cop::Style::EvenOdd do
       x._(y) % 2 != 1
       ^^^^^^^^^^^^^^^ Replace with `Integer#even?`.
     RUBY
+
     expect_correction(<<~RUBY)
       x._(y).even?
     RUBY
@@ -150,6 +163,7 @@ RSpec.describe RuboCop::Cop::Style::EvenOdd do
       1 % 2 != 1
       ^^^^^^^^^^ Replace with `Integer#even?`.
     RUBY
+
     expect_correction(<<~RUBY)
       1.even?
     RUBY
@@ -165,6 +179,7 @@ RSpec.describe RuboCop::Cop::Style::EvenOdd do
         method == :== ? :odd : :even
       end
     RUBY
+
     expect_correction(<<~RUBY)
       if y.even?
         method == :== ? :even : :odd

--- a/spec/rubocop/cop/style/format_string_spec.rb
+++ b/spec/rubocop/cop/style/format_string_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         puts "%d" % 10
                   ^ Favor `sprintf` over `String#%`.
       RUBY
+
       expect_correction(<<~RUBY)
         puts sprintf("%d", 10)
       RUBY
@@ -19,6 +20,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         puts x % [10, 11]
                ^ Favor `sprintf` over `String#%`.
       RUBY
+
       expect_correction(<<~RUBY)
         puts sprintf(x, 10, 11)
       RUBY
@@ -29,6 +31,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         puts x % { a: 10, b: 11 }
                ^ Favor `sprintf` over `String#%`.
       RUBY
+
       expect_correction(<<~RUBY)
         puts sprintf(x, a: 10, b: 11)
       RUBY
@@ -39,6 +42,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         puts "%f" % a
                   ^ Favor `sprintf` over `String#%`.
       RUBY
+
       expect_no_corrections
     end
 
@@ -49,6 +53,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         puts "%d" % a
                   ^ Favor `sprintf` over `String#%`.
       RUBY
+
       expect_no_corrections
     end
 
@@ -65,6 +70,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         puts "#{x * 5} %d #{@test}" % 10
                                     ^ Favor `sprintf` over `String#%`.
       RUBY
+
       expect_correction(<<~'RUBY')
         puts sprintf("#{x * 5} %d #{@test}", 10)
       RUBY
@@ -75,6 +81,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         format(something, a, b)
         ^^^^^^ Favor `sprintf` over `format`.
       RUBY
+
       expect_correction(<<~RUBY)
         sprintf(something, a, b)
       RUBY
@@ -85,6 +92,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         format("%X", 123)
         ^^^^^^ Favor `sprintf` over `format`.
       RUBY
+
       expect_correction(<<~RUBY)
         sprintf("%X", 123)
       RUBY
@@ -99,6 +107,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         puts "%d" % 10
                   ^ Favor `format` over `String#%`.
       RUBY
+
       expect_correction(<<~RUBY)
         puts format("%d", 10)
       RUBY
@@ -109,6 +118,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         puts x % [10, 11]
                ^ Favor `format` over `String#%`.
       RUBY
+
       expect_correction(<<~RUBY)
         puts format(x, 10, 11)
       RUBY
@@ -119,6 +129,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         puts x % { a: 10, b: 11 }
                ^ Favor `format` over `String#%`.
       RUBY
+
       expect_correction(<<~RUBY)
         puts format(x, a: 10, b: 11)
       RUBY
@@ -129,6 +140,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         puts "%f" % a
                   ^ Favor `format` over `String#%`.
       RUBY
+
       expect_no_corrections
     end
 
@@ -145,6 +157,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         puts "#{x * 5} %d #{@test}" % 10
                                     ^ Favor `format` over `String#%`.
       RUBY
+
       expect_correction(<<~'RUBY')
         puts format("#{x * 5} %d #{@test}", 10)
       RUBY
@@ -155,6 +168,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         sprintf(something, a, b)
         ^^^^^^^ Favor `format` over `sprintf`.
       RUBY
+
       expect_correction(<<~RUBY)
         format(something, a, b)
       RUBY
@@ -165,6 +179,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         sprintf('%020d', 123)
         ^^^^^^^ Favor `format` over `sprintf`.
       RUBY
+
       expect_correction(<<~RUBY)
         format('%020d', 123)
       RUBY
@@ -176,6 +191,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         puts "%d" % a
                   ^ Favor `format` over `String#%`.
       RUBY
+
       expect_no_corrections
     end
   end
@@ -188,6 +204,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         format(something, a)
         ^^^^^^ Favor `String#%` over `format`.
       RUBY
+
       expect_correction(<<~RUBY)
         something % a
       RUBY
@@ -198,6 +215,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         format(something, a, b)
         ^^^^^^ Favor `String#%` over `format`.
       RUBY
+
       expect_correction(<<~RUBY)
         something % [a, b]
       RUBY
@@ -208,6 +226,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         format(something, a: 10, b: 11)
         ^^^^^^ Favor `String#%` over `format`.
       RUBY
+
       expect_correction(<<~RUBY)
         something % { a: 10, b: 11 }
       RUBY
@@ -218,6 +237,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         sprintf(something, a)
         ^^^^^^^ Favor `String#%` over `sprintf`.
       RUBY
+
       expect_correction(<<~RUBY)
         something % a
       RUBY
@@ -228,6 +248,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         format(something, a + 42)
         ^^^^^^ Favor `String#%` over `format`.
       RUBY
+
       expect_correction(<<~RUBY)
         something % (a + 42)
       RUBY
@@ -238,6 +259,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         format("%d %04x", 123, 123)
         ^^^^^^ Favor `String#%` over `format`.
       RUBY
+
       expect_correction(<<~RUBY)
         "%d %04x" % [123, 123]
       RUBY
@@ -248,6 +270,7 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
         sprintf(something, a: 10, b: 11)
         ^^^^^^^ Favor `String#%` over `sprintf`.
       RUBY
+
       expect_correction(<<~RUBY)
         something % { a: 10, b: 11 }
       RUBY

--- a/spec/rubocop/cop/style/format_string_token_spec.rb
+++ b/spec/rubocop/cop/style/format_string_token_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
               _{annotated}       ^{template} Prefer annotated tokens [...]
           HEREDOC
         RUBY
+
         expect_no_corrections
       end
 
@@ -65,6 +66,7 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
           "a#{b}%{annotated} c#{d}%{template} e#{f}"
                 _{annotated}      ^{template} Prefer annotated tokens [...]
         RUBY
+
         expect_no_corrections
       end
 
@@ -81,6 +83,7 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
           "%{a}"
            ^^^^ Prefer annotated tokens [...]
         RUBY
+
         expect_no_corrections
 
         expect(cop.config_to_allow_offenses).to eq(
@@ -101,6 +104,7 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
               _{template}       ^{annotated} Prefer template tokens [...]
           HEREDOC
         RUBY
+
         expect_no_corrections
       end
 
@@ -109,6 +113,7 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
           "a#{b}%{template} c#{d}%{annotated} e#{f}"
                 _{template}      ^{annotated} Prefer template tokens [...]
         RUBY
+
         expect_no_corrections
       end
 
@@ -117,6 +122,7 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
           "%<a>s"
            ^^^^^ Prefer template tokens [...]
         RUBY
+
         expect_no_corrections
 
         expect(cop.config_to_allow_offenses).to eq(
@@ -179,6 +185,7 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
       "c#{b}%{template}"
             ^^^^^^^^^^^ Prefer annotated tokens (like `%<foo>s`) over template tokens (like `%{foo}`).
     RUBY
+
     expect_no_corrections
   end
 
@@ -205,6 +212,7 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
       { bar: format('%{foo}', foo: 'foo') }
                      ^^^^^^ Prefer annotated tokens (like `%<foo>s`) over template tokens (like `%{foo}`).
     RUBY
+
     expect_no_corrections
   end
 
@@ -214,6 +222,7 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
               ^^^^^ Prefer annotated tokens (like `%<foo>s`) over unannotated tokens (like `%s`).
                     ^^^^^ Prefer annotated tokens (like `%<foo>s`) over unannotated tokens (like `%s`).
     RUBY
+
     expect_no_corrections
   end
 
@@ -248,6 +257,7 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
         "%{foo}"
          ^^^^^^ Prefer annotated tokens (like `%<foo>s`) over template tokens (like `%{foo}`).
       RUBY
+
       expect_no_corrections
     end
 
@@ -281,6 +291,7 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
         "%<foo>d"
          ^^^^^^^ Prefer template tokens (like `%{foo}`) over annotated tokens (like `%<foo>s`).
       RUBY
+
       expect_no_corrections
     end
   end
@@ -293,6 +304,7 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
         "%{foo}"
          ^^^^^^ Prefer unannotated tokens (like `%s`) over template tokens (like `%{foo}`).
       RUBY
+
       expect_no_corrections
     end
   end

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                 ^^^^^ Use the new Ruby 1.9 hash syntax.
                          ^^^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           x = { a: 0, b: 2}
         RUBY
@@ -40,6 +41,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           x = { :a => 0, b: 1 }
                 ^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           x = { a: 0, b: 1 }
         RUBY
@@ -50,6 +52,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           func(3, :a => 0)
                   ^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           func(3, a: 0)
         RUBY
@@ -68,6 +71,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           x = { :"string" => 0 }
                 ^^^^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           x = { "string": 0 }
         RUBY
@@ -78,6 +82,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           { :'&&' => foo }
             ^^^^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           { '&&': foo }
         RUBY
@@ -89,6 +94,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
             x = { :a? => 0 }
                   ^^^^^^ Use the new Ruby 1.9 hash syntax.
           RUBY
+
           expect_correction(<<~RUBY)
             x = { a?: 0 }
           RUBY
@@ -99,6 +105,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
             x = { :a! => 0 }
                   ^^^^^^ Use the new Ruby 1.9 hash syntax.
           RUBY
+
           expect_correction(<<~RUBY)
             x = { a!: 0 }
           RUBY
@@ -134,6 +141,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           x = { :A => 0 }
                 ^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           x = { A: 0 }
         RUBY
@@ -155,6 +163,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
             ^^^^ Use the new Ruby 1.9 hash syntax.
                    ^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           { a: 1, b: 2 }
         RUBY
@@ -166,6 +175,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           foo:bar => 1
              ^^^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           foo bar: 1
         RUBY
@@ -217,6 +227,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
             ^^^^ Use the new Ruby 1.9 hash syntax.
                    ^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           { a: 1, b: 2 }
         RUBY
@@ -251,6 +262,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                 ^^ Use hash rockets syntax.
                       ^^ Use hash rockets syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           x = { :a => 1, :b => :c }
         RUBY
@@ -262,6 +274,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           func(3, b: :c)
                   ^^ Use hash rockets syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           func(3, :b => :c)
         RUBY
@@ -274,6 +287,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                 ^^^^^ Use the new Ruby 1.9 hash syntax.
                          ^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           x = { a: 1, b: 2 }
         RUBY
@@ -286,6 +300,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
            c: :d }
            ^^ Use hash rockets syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           x = { :a => :b,
            :c => :d }
@@ -306,6 +321,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
             ^^ Use hash rockets syntax.
                    ^^ Use hash rockets syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           { :a => :b, :c => :d }
         RUBY
@@ -334,6 +350,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
               ^^ Use hash rockets syntax.
                     ^^ Use hash rockets syntax.
       RUBY
+
       expect_correction(<<~RUBY)
         x = { :a => 0, :b => 2}
       RUBY
@@ -344,6 +361,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         x = { a => 0, b: 1 }
                       ^^ Use hash rockets syntax.
       RUBY
+
       expect_correction(<<~RUBY)
         x = { a => 0, :b => 1 }
       RUBY
@@ -354,6 +372,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         func(3, a: 0)
                 ^^ Use hash rockets syntax.
       RUBY
+
       expect_correction(<<~RUBY)
         func(3, :a => 0)
       RUBY
@@ -405,6 +424,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                 ^^^^^ Use the new Ruby 1.9 hash syntax.
                          ^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           x = { a: 0, b: 2 }
         RUBY
@@ -415,6 +435,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           x = { :a => 0, b: 1 }
                 ^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           x = { a: 0, b: 1 }
         RUBY
@@ -429,6 +450,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           func(3, :a => 0)
                   ^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           func(3, a: 0)
         RUBY
@@ -458,6 +480,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           x = { :"t o" => 0 }
                 ^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           x = { "t o": 0 }
         RUBY
@@ -468,6 +491,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           x = { :"\tab" => 1 }
                 ^^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+
         expect_correction(<<~'RUBY')
           x = { "\tab": 1 }
         RUBY
@@ -478,6 +502,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           x = { :"1" => 1 }
                 ^^^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           x = { "1": 1 }
         RUBY
@@ -502,6 +527,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                 ^^ Use hash rockets syntax.
                       ^^ Use hash rockets syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           x = { :a => 1, :b => :c }
         RUBY
@@ -513,6 +539,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           func(3, b: :c)
                   ^^ Use hash rockets syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           func(3, :b => :c)
         RUBY
@@ -525,6 +552,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
             ^^ Use hash rockets syntax.
                    ^^ Use hash rockets syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           { :a => :b, :c => :d }
         RUBY
@@ -567,6 +595,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           func(3, :a => 0)
                   ^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           func(3, a: 0)
         RUBY
@@ -596,6 +625,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           x = { :"t o" => 0 }
                 ^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           x = { "t o": 0 }
         RUBY
@@ -606,6 +636,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           x = { :"\tab" => 1 }
                 ^^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+
         expect_correction(<<~'RUBY')
           x = { "\tab": 1 }
         RUBY
@@ -616,6 +647,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           x = { :"1" => 1 }
                 ^^^^^^^ Use the new Ruby 1.9 hash syntax.
         RUBY
+
         expect_correction(<<~RUBY)
           x = { "1": 1 }
         RUBY
@@ -739,6 +771,7 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         { a: 1, :b => 2 }
                 ^^^^^ Don't mix styles in the same hash.
       RUBY
+
       expect_correction(<<~RUBY)
         { a: 1, b: 2 }
       RUBY

--- a/spec/rubocop/cop/style/infinite_loop_spec.rb
+++ b/spec/rubocop/cop/style/infinite_loop_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop do
           top
         end
       RUBY
+
       expect_correction(<<~RUBY)
         loop do
           top
@@ -31,6 +32,7 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop do
           top
         end
       RUBY
+
       expect_correction(<<~RUBY)
         loop do
           top
@@ -78,6 +80,7 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop do
                               ^^^^^ Use `Kernel#loop` for infinite loops.
       p a
     RUBY
+
     expect_correction(<<~RUBY)
       a = nil
       loop { a = next_value or break }
@@ -101,6 +104,7 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop do
       end
       puts a
     RUBY
+
     expect_correction(<<~RUBY)
       while true
         a = 42
@@ -125,6 +129,7 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop do
         break
       end
     RUBY
+
     expect_correction(<<~RUBY)
       loop do
         a = 43
@@ -149,6 +154,7 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop do
       end
       puts a
     RUBY
+
     expect_correction(<<~RUBY)
       a = 0
       loop do
@@ -173,6 +179,7 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop do
       end
       puts @a
     RUBY
+
     expect_correction(<<~RUBY)
       loop do
         @a = 42
@@ -188,6 +195,7 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop do
         something += 1 %{keyword} %{lit} # comment
                        ^{keyword} Use `Kernel#loop` for infinite loops.
       RUBY
+
       expect_correction(<<~RUBY)
         loop { something += 1 } # comment
       RUBY
@@ -206,6 +214,7 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop do
               2 %{keyword} %{lit}
                 ^{keyword} Use `Kernel#loop` for infinite loops.
         RUBY
+
         expect_correction(<<~RUBY)
           # comment
           loop do
@@ -224,6 +233,7 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop do
         end %{keyword} %{lit} # comment 3
             ^{keyword} Use `Kernel#loop` for infinite loops.
       RUBY
+
       expect_correction(<<~RUBY)
         loop do # comment 1
           something += 1 # comment 2
@@ -239,6 +249,7 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop do
         end %{keyword} %{lit}
             ^{keyword} Use `Kernel#loop` for infinite loops.
       RUBY
+
       expect_correction(<<~RUBY)
         loop do
           something += 1
@@ -252,6 +263,7 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop do
         something and something_else %{keyword} %{lit}
                                      ^{keyword} Use `Kernel#loop` for infinite loops.
       RUBY
+
       expect_correction(<<~RUBY)
         loop { something and something_else }
       RUBY
@@ -263,6 +275,7 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop do
         ^{keyword} Use `Kernel#loop` for infinite loops.
         end
       RUBY
+
       expect_correction(<<~RUBY)
         loop do
         end
@@ -275,6 +288,7 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop do
         ^{keyword} Use `Kernel#loop` for infinite loops.
         end
       RUBY
+
       expect_correction(<<~RUBY)
         loop do
         end

--- a/spec/rubocop/cop/style/lambda_call_spec.rb
+++ b/spec/rubocop/cop/style/lambda_call_spec.rb
@@ -97,6 +97,7 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
         a.call
         ^^^^^^ Prefer the use of `lambda.(...)` over `lambda.call(...)`.
       RUBY
+
       expect_correction(<<~RUBY)
         a.()
       RUBY
@@ -107,6 +108,7 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
         a.call asdf, x123
         ^^^^^^^^^^^^^^^^^ Prefer the use of `lambda.(...)` over `lambda.call(...)`.
       RUBY
+
       expect_correction(<<~RUBY)
         a.(asdf, x123)
       RUBY

--- a/spec/rubocop/cop/style/line_end_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/line_end_concatenation_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
                    ^ Use `\\` instead of `+` or `<<` to concatenate those strings.
       "top"
     RUBY
+
     expect_correction(<<~RUBY)
       top = "test" \\
       "top"
@@ -21,6 +22,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
                    ^^ Use `\\` instead of `+` or `<<` to concatenate those strings.
       "top"
     RUBY
+
     expect_correction(<<~RUBY)
       top = "test" \\
       "top"
@@ -34,6 +36,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
             ^^ Use `\\` instead of `+` or `<<` to concatenate those strings.
       "bar"
     RUBY
+
     expect_correction(<<~RUBY)
       top = "test " \\
       "foo" \\
@@ -47,6 +50,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
                        ^ Use `\` instead of `+` or `<<` to concatenate those strings.
       "top"
     RUBY
+
     expect_correction(<<~'RUBY')
       top = "test#{x}" \
       "top"
@@ -59,6 +63,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
                        ^^ Use `\` instead of `+` or `<<` to concatenate those strings.
       "top"
     RUBY
+
     expect_correction(<<~'RUBY')
       top = "test#{x}" \
       "top"
@@ -73,6 +78,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
             ^^ Use `\` instead of `+` or `<<` to concatenate those strings.
       "ubertop"
     RUBY
+
     expect_correction(<<~'RUBY')
       top = "test#{x}" \
       "top" \
@@ -88,6 +94,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
             ^ Use `\` instead of `+` or `<<` to concatenate those strings.
       "foo"
     RUBY
+
     expect_correction(<<~'RUBY')
       top = "test#{x}" \
       "top" \
@@ -106,6 +113,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
             ^^ Use `\` instead of `+` or `<<` to concatenate those strings.
       "bar"
     RUBY
+
     expect_correction(<<~'RUBY')
       top = "test#{x}" \
       "top" \
@@ -178,6 +186,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
             ^ Use `\` instead of `+` or `<<` to concatenate those strings.
       "qux"
     RUBY
+
     expect_correction(<<~'RUBY')
       top = "test#{x}" + # comment
       "foo" +
@@ -196,6 +205,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
                    ^ Use `\\` instead of `+` or `<<` to concatenate those strings.
       "top"
     RUBY
+
     expect_correction(<<~RUBY)
       top = "test" \\
       "top"
@@ -208,6 +218,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
                    ^ Use `\\` instead of `+` or `<<` to concatenate those strings.
       "top"
     RUBY
+
     expect_correction(<<~RUBY)
       top = "test" \\
       "top"
@@ -225,6 +236,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation do
       %(baz) +
       "qux"
     RUBY
+
     expect_correction(<<~'RUBY')
       top = "test#{x}" \
       "top" + # comment

--- a/spec/rubocop/cop/style/method_def_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_def_parentheses_spec.rb
@@ -86,6 +86,7 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
         def self.test(param); end
                      ^^^^^^^ Use def without parentheses.
       RUBY
+
       expect_correction(<<~RUBY)
         def self.test param; end
       RUBY

--- a/spec/rubocop/cop/style/multiline_memoization_spec.rb
+++ b/spec/rubocop/cop/style/multiline_memoization_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe RuboCop::Cop::Style::MultilineMemoization, :config do
                 baz
               )
             RUBY
+
             expect_correction(<<~RUBY)
               foo ||= begin
                 bar
@@ -93,6 +94,7 @@ RSpec.describe RuboCop::Cop::Style::MultilineMemoization, :config do
                   baz
                 )
             RUBY
+
             expect_correction(<<~RUBY)
               foo ||=
                 begin
@@ -108,6 +110,7 @@ RSpec.describe RuboCop::Cop::Style::MultilineMemoization, :config do
               ^^^^^^^^^^^^^^^ Wrap multiline memoization blocks in `begin` and `end`.
                         baz)
             RUBY
+
             expect_correction(<<~RUBY)
               foo ||= begin
                         bar ||
@@ -137,6 +140,7 @@ RSpec.describe RuboCop::Cop::Style::MultilineMemoization, :config do
                 baz
               end
             RUBY
+
             expect_correction(<<~RUBY)
               foo ||= (
                 bar
@@ -154,6 +158,7 @@ RSpec.describe RuboCop::Cop::Style::MultilineMemoization, :config do
                   baz
                 end
             RUBY
+
             expect_correction(<<~RUBY)
               foo ||=
                 (

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
             FOO = *1..10
                   ^^^^^^ Freeze mutable objects assigned to constants.
           RUBY
+
           expect_correction(<<~RUBY)
             FOO = (1..10).to_a.freeze
           RUBY
@@ -83,6 +84,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
               FOO = *(1..10)
                     ^^^^^^^^ Freeze mutable objects assigned to constants.
             RUBY
+
             expect_correction(<<~RUBY)
               FOO = (1..10).to_a.freeze
             RUBY
@@ -97,6 +99,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
           XXX = YYY, ZZZ
                 ^^^^^^^^ Freeze mutable objects assigned to constants.
         RUBY
+
         expect_correction(<<~RUBY)
           XXX = [YYY, ZZZ].freeze
         RUBY
@@ -107,6 +110,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
           XXX = %w(YYY ZZZ)
                 ^^^^^^^^^^^ Freeze mutable objects assigned to constants.
         RUBY
+
         expect_correction(<<~RUBY)
           XXX = %w(YYY ZZZ).freeze
         RUBY
@@ -162,6 +166,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
             XXX = /regexp/
                   ^^^^^^^^ Freeze mutable objects assigned to constants.
           RUBY
+
           expect_correction(<<~RUBY)
             XXX = /regexp/.freeze
           RUBY
@@ -174,6 +179,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
             XXX = 1..99
                   ^^^^^ Freeze mutable objects assigned to constants.
           RUBY
+
           expect_correction(<<~RUBY)
             XXX = (1..99).freeze
           RUBY
@@ -184,6 +190,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
             XXX = (1..99)
                   ^^^^^^^ Freeze mutable objects assigned to constants.
           RUBY
+
           expect_correction(<<~RUBY)
             XXX = (1..99).freeze
           RUBY
@@ -196,6 +203,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
             XXX = 1...99
                   ^^^^^^ Freeze mutable objects assigned to constants.
           RUBY
+
           expect_correction(<<~RUBY)
             XXX = (1...99).freeze
           RUBY
@@ -206,6 +214,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
             XXX = (1...99)
                   ^^^^^^^^ Freeze mutable objects assigned to constants.
           RUBY
+
           expect_correction(<<~RUBY)
             XXX = (1...99).freeze
           RUBY
@@ -300,6 +309,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
             FOO = *1..10
                   ^^^^^^ Freeze mutable objects assigned to constants.
           RUBY
+
           expect_correction(<<~RUBY)
             FOO = (1..10).to_a.freeze
           RUBY
@@ -311,6 +321,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
               FOO = *(1..10)
                     ^^^^^^^^ Freeze mutable objects assigned to constants.
             RUBY
+
             expect_correction(<<~RUBY)
               FOO = (1..10).to_a.freeze
             RUBY
@@ -326,6 +337,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
             CONST = FOO %{o} BAR
                     ^^^^^{o}^^^^ Freeze mutable objects assigned to constants.
           RUBY
+
           expect_correction(<<~RUBY)
             CONST = (FOO #{o} BAR).freeze
           RUBY
@@ -349,6 +361,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
           CONST = FOO + BAR + BAZ
                   ^^^^^^^^^^^^^^^ Freeze mutable objects assigned to constants.
         RUBY
+
         expect_correction(<<~RUBY)
           FOO = [1].freeze
           BAR = [2].freeze
@@ -416,6 +429,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
           CONST = FOO + 'bar'
                   ^^^^^^^^^^^ Freeze mutable objects assigned to constants.
         RUBY
+
         expect_correction(<<~RUBY)
           CONST = (FOO + 'bar').freeze
         RUBY
@@ -426,6 +440,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
           CONST = 'foo' + 'bar' + 'baz'
                   ^^^^^^^^^^^^^^^^^^^^^ Freeze mutable objects assigned to constants.
         RUBY
+
         expect_correction(<<~RUBY)
           CONST = ('foo' + 'bar' + 'baz').freeze
         RUBY
@@ -438,6 +453,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
           XXX = YYY, ZZZ
                 ^^^^^^^^ Freeze mutable objects assigned to constants.
         RUBY
+
         expect_correction(<<~RUBY)
           XXX = [YYY, ZZZ].freeze
         RUBY
@@ -448,6 +464,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
           XXX = %w(YYY ZZZ)
                 ^^^^^^^^^^^ Freeze mutable objects assigned to constants.
         RUBY
+
         expect_correction(<<~RUBY)
           XXX = %w(YYY ZZZ).freeze
         RUBY
@@ -461,6 +478,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
           SOMETHING
         HERE
       RUBY
+
       expect_correction(<<~RUBY)
         FOO = <<-HERE.freeze
           SOMETHING

--- a/spec/rubocop/cop/style/nested_modifier_spec.rb
+++ b/spec/rubocop/cop/style/nested_modifier_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier do
         something if a %{keyword} b
                   ^^ Avoid using nested modifiers.
       RUBY
+
       expect_no_corrections
     end
 
@@ -17,6 +18,7 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier do
         something %{keyword} a if b
                   ^{keyword} Avoid using nested modifiers.
       RUBY
+
       expect_no_corrections
     end
   end
@@ -26,6 +28,7 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier do
       something if a if b
                 ^^ Avoid using nested modifiers.
     RUBY
+
     expect_correction(<<~RUBY)
       something if b && a
     RUBY
@@ -36,6 +39,7 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier do
       something unless a unless b
                 ^^^^^^ Avoid using nested modifiers.
     RUBY
+
     expect_correction(<<~RUBY)
       something unless b || a
     RUBY
@@ -46,6 +50,7 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier do
       something if a unless b
                 ^^ Avoid using nested modifiers.
     RUBY
+
     expect_correction(<<~RUBY)
       something unless b || !a
     RUBY
@@ -56,6 +61,7 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier do
       something unless b > 1 if true
                 ^^^^^^ Avoid using nested modifiers.
     RUBY
+
     expect_correction(<<~RUBY)
       something if true && !(b > 1)
     RUBY
@@ -66,6 +72,7 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier do
       something unless a if b
                 ^^^^^^ Avoid using nested modifiers.
     RUBY
+
     expect_correction(<<~RUBY)
       something if b && !a
     RUBY
@@ -76,6 +83,7 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier do
       something if a || b if c || d
                 ^^ Avoid using nested modifiers.
     RUBY
+
     expect_correction(<<~RUBY)
       something if (c || d) && (a || b)
     RUBY
@@ -87,6 +95,7 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier do
       a unless [1, 2].include? a if a
         ^^^^^^ Avoid using nested modifiers.
     RUBY
+
     expect_correction(<<~RUBY)
       a if a && ![1, 2].include?(a)
     RUBY
@@ -97,6 +106,7 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier do
       something if a unless c || d
                 ^^ Avoid using nested modifiers.
     RUBY
+
     expect_correction(<<~RUBY)
       something unless c || d || !a
     RUBY
@@ -115,6 +125,7 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier do
       something until a while b unless c if d
                                 ^^^^^^ Avoid using nested modifiers.
     RUBY
+
     expect_correction(<<~RUBY)
       something until a while b if d && !c
     RUBY

--- a/spec/rubocop/cop/style/non_nil_check_spec.rb
+++ b/spec/rubocop/cop/style/non_nil_check_spec.rb
@@ -149,6 +149,7 @@ RSpec.describe RuboCop::Cop::Style::NonNilCheck, :config do
         !nil?
         ^^^^^ Explicit non-nil checks are usually redundant.
       RUBY
+
       expect_correction(<<~RUBY)
         self
       RUBY

--- a/spec/rubocop/cop/style/not_spec.rb
+++ b/spec/rubocop/cop/style/not_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe RuboCop::Cop::Style::Not, :config do
       not test
       ^^^ Use `!` instead of `not`.
     RUBY
+
     expect_correction(<<~RUBY)
       !test
     RUBY
@@ -20,6 +21,7 @@ RSpec.describe RuboCop::Cop::Style::Not, :config do
       x = 10 if not y
                 ^^^ Use `!` instead of `not`.
     RUBY
+
     expect_correction(<<~RUBY)
       x = 10 if !y
     RUBY
@@ -30,6 +32,7 @@ RSpec.describe RuboCop::Cop::Style::Not, :config do
       not(test)
       ^^^ Use `!` instead of `not`.
     RUBY
+
     expect_correction(<<~RUBY)
       !(test)
     RUBY
@@ -40,6 +43,7 @@ RSpec.describe RuboCop::Cop::Style::Not, :config do
       not x < y
       ^^^ Use `!` instead of `not`.
     RUBY
+
     expect_correction(<<~RUBY)
       x >= y
     RUBY
@@ -50,6 +54,7 @@ RSpec.describe RuboCop::Cop::Style::Not, :config do
       not a >> b
       ^^^ Use `!` instead of `not`.
     RUBY
+
     expect_correction(<<~RUBY)
       !(a >> b)
     RUBY
@@ -60,6 +65,7 @@ RSpec.describe RuboCop::Cop::Style::Not, :config do
       not a ? b : c
       ^^^ Use `!` instead of `not`.
     RUBY
+
     expect_correction(<<~RUBY)
       !(a ? b : c)
     RUBY
@@ -70,6 +76,7 @@ RSpec.describe RuboCop::Cop::Style::Not, :config do
       not a && b
       ^^^ Use `!` instead of `not`.
     RUBY
+
     expect_correction(<<~RUBY)
       !(a && b)
     RUBY
@@ -80,6 +87,7 @@ RSpec.describe RuboCop::Cop::Style::Not, :config do
       not a || b
       ^^^ Use `!` instead of `not`.
     RUBY
+
     expect_correction(<<~RUBY)
       !(a || b)
     RUBY

--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
           0 == number
           ^^^^^^^^^^^ Use `number.zero?` instead of `0 == number`.
         RUBY
+
         expect_correction(<<~RUBY)
           number.zero?
           number.zero?
@@ -27,6 +28,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
           0 == foo - 1
           ^^^^^^^^^^^^ Use `(foo - 1).zero?` instead of `0 == foo - 1`.
         RUBY
+
         expect_correction(<<~RUBY)
           (foo - 1).zero?
           (foo - 1).zero?
@@ -46,6 +48,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
               ^^^^^^^^ Use `foo.zero?` instead of `foo == 0`.
             end
           RUBY
+
           expect_correction(<<~RUBY)
             def m(foo)
               foo.zero?
@@ -60,6 +63,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
               ^^^^^^^^^^^^ Use `(foo - 1).zero?` instead of `foo - 1 == 0`.
             end
           RUBY
+
           expect_correction(<<~RUBY)
             def m(foo)
               (foo - 1).zero?
@@ -92,6 +96,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
           number > 0
           ^^^^^^^^^^ Use `number.positive?` instead of `number > 0`.
         RUBY
+
         expect_correction(<<~RUBY)
           number.positive?
         RUBY
@@ -102,6 +107,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
           0 < number
           ^^^^^^^^^^ Use `number.positive?` instead of `0 < number`.
         RUBY
+
         expect_correction(<<~RUBY)
           number.positive?
         RUBY
@@ -113,6 +119,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
             foo - 1 > 0
             ^^^^^^^^^^^ Use `(foo - 1).positive?` instead of `foo - 1 > 0`.
           RUBY
+
           expect_correction(<<~RUBY)
             (foo - 1).positive?
           RUBY
@@ -123,6 +130,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
             0 < foo - 1
             ^^^^^^^^^^^ Use `(foo - 1).positive?` instead of `0 < foo - 1`.
           RUBY
+
           expect_correction(<<~RUBY)
             (foo - 1).positive?
           RUBY
@@ -136,6 +144,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
           number < 0
           ^^^^^^^^^^ Use `number.negative?` instead of `number < 0`.
         RUBY
+
         expect_correction(<<~RUBY)
           number.negative?
         RUBY
@@ -146,6 +155,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
           0 > number
           ^^^^^^^^^^ Use `number.negative?` instead of `0 > number`.
         RUBY
+
         expect_correction(<<~RUBY)
           number.negative?
         RUBY
@@ -157,6 +167,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
             foo - 1 < 0
             ^^^^^^^^^^^ Use `(foo - 1).negative?` instead of `foo - 1 < 0`.
           RUBY
+
           expect_correction(<<~RUBY)
             (foo - 1).negative?
           RUBY
@@ -167,6 +178,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
             0 > foo - 1
             ^^^^^^^^^^^ Use `(foo - 1).negative?` instead of `0 > foo - 1`.
           RUBY
+
           expect_correction(<<~RUBY)
             (foo - 1).negative?
           RUBY
@@ -185,6 +197,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
         number.zero?
         ^^^^^^^^^^^^ Use `number == 0` instead of `number.zero?`.
       RUBY
+
       expect_correction(<<~RUBY)
         number == 0
       RUBY
@@ -199,6 +212,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
         number.positive?
         ^^^^^^^^^^^^^^^^ Use `number > 0` instead of `number.positive?`.
       RUBY
+
       expect_correction(<<~RUBY)
         number > 0
       RUBY
@@ -209,6 +223,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
         number.negative?
         ^^^^^^^^^^^^^^^^ Use `number < 0` instead of `number.negative?`.
       RUBY
+
       expect_correction(<<~RUBY)
         number < 0
       RUBY
@@ -289,6 +304,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
             exclude(number > 0)
                     ^^^^^^^^^^ Use `number.positive?` instead of `number > 0`.
           RUBY
+
           expect_correction(<<~RUBY)
             exclude(number.positive?)
           RUBY
@@ -299,6 +315,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
             exclude(number < 0)
                     ^^^^^^^^^^ Use `number.negative?` instead of `number < 0`.
           RUBY
+
           expect_correction(<<~RUBY)
             exclude(number.negative?)
           RUBY
@@ -335,6 +352,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
             exclude { number > 0 }
                       ^^^^^^^^^^ Use `number.positive?` instead of `number > 0`.
           RUBY
+
           expect_correction(<<~RUBY)
             exclude { number.positive? }
           RUBY
@@ -345,6 +363,7 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
             exclude { number < 0 }
                       ^^^^^^^^^^ Use `number.negative?` instead of `number < 0`.
           RUBY
+
           expect_correction(<<~RUBY)
             exclude { number.negative? }
           RUBY

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -133,6 +133,7 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
             foo = %r/\//
                   ^^^^^^ Use `//` around regular expression.
           RUBY
+
           expect_correction(<<~'RUBY')
             foo = /\//
           RUBY

--- a/spec/rubocop/cop/style/trailing_comma_in_block_args_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_block_args_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInBlockArgs do
         test { |a, b,| a + b }
                     ^ Useless trailing comma present in block arguments.
       RUBY
+
       expect_correction(<<~RUBY)
         test { |a, b| a + b }
       RUBY
@@ -68,6 +69,7 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInBlockArgs do
           a + b
         end
       RUBY
+
       expect_correction(<<~RUBY)
         test do |a, b|
           a + b


### PR DESCRIPTION
This PR adds new `InternalAffairs/EmptyLineBetweenExpectOffenseAndCorrection` cop.
It checks whether `expect_offense` and correction expectation methods (i.e. `expect_correction` and `expect_no_corrections`) are separated by empty line.

```ruby
# bad
it 'registers and corrects an offense' do
  expect_offense(<<~RUBY)
    bad_method
    ^^^^^^^^^^ Use `good_method`.
  RUBY
  expect_correction(<<~RUBY)
    good_method
  RUBY
end

# good
it 'registers and corrects an offense' do
  expect_offense(<<~RUBY)
    bad_method
    ^^^^^^^^^^ Use `good_method`.
  RUBY

  expect_correction(<<~RUBY)
    good_method
  RUBY
end
```

No changelog entry has been added to the changelog due to this cop is for use inside development.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
