### PR TITLE
Fix a typo for `Style/SingleLineMethods`

### DIFF
--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -8,7 +8,7 @@ module RuboCop
       #
       # Endless methods added in Ruby 3.0 are also accepted by this cop.
       #
-      # If `Style/EndlessMethod` is enabled with `EnforcedStyle: allow` or
+      # If `Style/EndlessMethod` is enabled with `EnforcedStyle: allow_single_line` or
       # `allow_always`, single-line methods will be auto-corrected to endless
       # methods if there is only one statement in the body.
       #

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -229,8 +229,8 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods do
       end
     end
 
-    context 'with `allow` style' do
-      let(:endless_method_config) { { 'EnforcedStyle' => 'allow' } }
+    context 'with `allow_single_line` style' do
+      let(:endless_method_config) { { 'EnforcedStyle' => 'allow_single_line' } }
 
       it_behaves_like 'convert to endless method'
     end


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/9281#issuecomment-751654689.

This PR fixes a typo for `Style/SingleLineMethods`.

`EnforcedStyle: allow` -> `EnforcedStyle: allow_single_line`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
