### PR TITLE
Fix `Layout/TrailingEmptyLines` spec to not need to use `raise_error`.

### DIFF
--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -111,9 +111,12 @@ module RuboCop
         source
       end
 
-      def expect_offense(source, file = nil, severity: nil, **replacements)
+      def expect_offense(source, file = nil, severity: nil, chomp: false, **replacements)
         expected_annotations = parse_annotations(source, **replacements)
-        @processed_source = parse_processed_source(expected_annotations.plain_source, file)
+        source = expected_annotations.plain_source
+        source = source.chomp if chomp
+
+        @processed_source = parse_processed_source(source, file)
         @offenses = _investigate(cop, @processed_source)
         actual_annotations =
           expected_annotations.with_offense_annotations(@offenses)

--- a/spec/rubocop/cop/layout/trailing_empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_empty_lines_spec.rb
@@ -54,28 +54,24 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
     end
 
     it 'registers an offense for no final newline after assignment' do
-      expect { expect_no_offenses('x = 0') }.to raise_error(
-        RSpec::Expectations::ExpectationNotMetError,
-        /Final newline missing/
-      )
+      expect_offense(<<~RUBY, chomp: true)
+        x = 0
+             ^{} Final newline missing.
+      RUBY
     end
 
     it 'registers an offense for no final newline after block comment' do
-      expect do
-        expect_no_offenses(<<~RUBY.chomp)
-          puts 'testing rubocop when final new line is missing
-                                    after block comments'
+      expect_offense(<<~RUBY, chomp: true)
+        puts 'testing rubocop when final new line is missing
+                                  after block comments'
 
-          =begin
-          first line
-          second line
-          third line
-          =end
-        RUBY
-      end.to raise_error(
-        RSpec::Expectations::ExpectationNotMetError,
-        /Final newline missing/
-      )
+        =begin
+        first line
+        second line
+        third line
+        =end
+            ^{} Final newline missing.
+      RUBY
     end
 
     it 'auto-corrects even if some lines have space' do
@@ -96,10 +92,10 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'final_blank_line' } }
 
     it 'registers an offense for final newline' do
-      expect { expect_no_offenses("x = 0\n") }.to raise_error(
-        RSpec::Expectations::ExpectationNotMetError,
-        /Trailing blank line missing./
-      )
+      expect_offense(<<~RUBY, chomp: true)
+        x = 0\n
+        ^{} Trailing blank line missing.
+      RUBY
     end
 
     it 'registers an offense for multiple trailing blank lines' do
@@ -133,10 +129,10 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
     end
 
     it 'registers an offense for no final newline' do
-      expect { expect_no_offenses('x = 0') }.to raise_error(
-        RSpec::Expectations::ExpectationNotMetError,
-        /Final newline missing./
-      )
+      expect_offense(<<~RUBY, chomp: true)
+        x = 0
+             ^{} Final newline missing.
+      RUBY
     end
 
     it 'accepts final blank line' do


### PR DESCRIPTION
`Layout/TrailingEmptyLines` did not previously work great with `expect_offense`, because by using a heredoc with an inline annotation, a newline was added implicitly, which would make the cop succeed. Previously in #9263, these were changed to use `expect_no_offenses` in conjunction with `raise_error` to try to capture the offense. This works but makes the spec hard to read as it implies the opposite of what is actually happening.

I have now updated this to be able to properly use the "correct" expectation (ie. `expect_offense` when there's actually an offense), by adding an optional argument to `expect_offense` to `chomp` the source being processed (so that the newline added for the annotation does not become part of the source). This is only really useful for this cop in particular, but it allows the specs to be cleaner.