### PR TITLE
[Fix #9415] Change `Layout/ClassStructure` to detect inline modifiers

### DIFF
--- a/changelog/change_class_structure_to_detect_inline_modifiers.md
+++ b/changelog/change_class_structure_to_detect_inline_modifiers.md
@@ -1,0 +1,1 @@
+* [#9415](https://github.com/rubocop-hq/rubocop/issues/9415): Change `Layout/ClassStructure` to detect inline modifiers. ([@AndreiEres][])

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -213,7 +213,12 @@ module RuboCop
           name = node.method_name.to_s
           category, = categories.find { |_, names| names.include?(name) }
           key = category || name
-          visibility_key = "#{node_visibility(node)}_#{key}"
+          visibility_key =
+            if node.def_modifier?
+              "#{name}_methods"
+            else
+              "#{node_visibility(node)}_#{key}"
+            end
           expected_order.include?(visibility_key) ? visibility_key : key
         end
 
@@ -264,7 +269,7 @@ module RuboCop
 
         def source_range_with_comment(node)
           begin_pos, end_pos =
-            if node.def_type?
+            if node.def_type? || node.send_type? && node.def_modifier?
               start_node = find_visibility_start(node) || node
               end_node = find_visibility_end(node) || node
               [begin_pos_with_comment(start_node),

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -172,9 +172,6 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
 
         private :other_public_method
 
-        private def something_inline
-        end
-
         def yet_other_public_method
         end
 
@@ -320,5 +317,53 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
         end
       end
     RUBY
+  end
+
+  context 'when def modifier is used' do
+    it 'registers an offense and corrects public method with modifier declared after private method with modifier' do
+      expect_offense(<<~RUBY)
+        class A
+          private def foo
+          end
+
+          public def bar
+          ^^^^^^^^^^^^^^ `public_methods` is supposed to appear before `private_methods`.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class A
+          public def bar
+          end
+
+          private def foo
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects public method without modifier declared after private method with modifier' do
+      expect_offense(<<~RUBY)
+        class A
+          private def foo
+          end
+
+          def bar
+          ^^^^^^^ `public_methods` is supposed to appear before `private_methods`.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class A
+          def bar
+          end
+
+          private def foo
+          end
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Fix https://github.com/rubocop-hq/rubocop/issues/9415

* Added check for inline def modifiers. Now they can be handle as `public_methods`, `protected_methods`, and `private methods` respectively.
* Fixed autocorrection range for methods with modifier.
* Fixed test that now throws new offence for inline modifier but was created for another reason.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
