### PR TITLE
Add `InternalAffairs/ExampleDescription` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -130,3 +130,7 @@ Performance/CollectionLiteralInLoop:
 
 RSpec/StubbedMock:
   Enabled: false
+
+InternalAffairs/ExampleDescription:
+  Include:
+    - 'spec/rubocop/cop/**/*.rb'

--- a/lib/rubocop/cop/internal_affairs.rb
+++ b/lib/rubocop/cop/internal_affairs.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'internal_affairs/empty_line_between_expect_offense_and_correction'
+require_relative 'internal_affairs/example_description'
 require_relative 'internal_affairs/method_name_equal'
 require_relative 'internal_affairs/node_destructuring'
 require_relative 'internal_affairs/node_type_predicate'

--- a/lib/rubocop/cop/internal_affairs/example_description.rb
+++ b/lib/rubocop/cop/internal_affairs/example_description.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module InternalAffairs
+      # Checks that RSpec examples that use `expects_offense`
+      # or `expects_no_offenses` do not have conflicting
+      # descriptions.
+      #
+      # @example
+      #   # bad
+      #   it 'does not register an offense' do
+      #     expect_offense('...')
+      #   end
+      #
+      #   it 'registers an offense' do
+      #     expect_no_offenses('...')
+      #   end
+      #
+      #   # good
+      #   it 'registers an offense' do
+      #     expect_offense('...')
+      #   end
+      #
+      #   it 'does not register an offense' do
+      #     expect_no_offenses('...')
+      #   end
+      class ExampleDescription < Base
+        class << self
+          attr_accessor :descriptions
+        end
+
+        MSG = 'Description does not match use of `%<method_name>s`.'
+
+        RESTRICT_ON_SEND = %i[
+          expect_offense
+          expect_no_offenses
+          expect_correction
+          expect_no_corrections
+        ].to_set.freeze
+
+        EXPECT_NO_OFFENSES_INCORRECT_DESCRIPTIONS = [
+          /^(adds|registers|reports|finds) (an? )?offense/,
+          /^flags\b/
+        ].freeze
+
+        EXPECT_OFFENSE_INCORRECT_DESCRIPTIONS = [
+          /^(does not|doesn't) (register|find|flag|report)/,
+          /^(does not|doesn't) add (a|an|any )?offense/
+        ].freeze
+
+        EXPECT_NO_CORRECTIONS_INCORRECT_DESCRIPTIONS = [
+          /^(auto[- ]?)?correct/
+        ].freeze
+
+        EXPECT_CORRECTION_INCORRECT_DESCRIPTIONS = [
+          /\b(does not|doesn't) (auto[- ]?)?correct/
+        ].freeze
+
+        def_node_matcher :offense_example?, <<~PATTERN
+          (block
+            (send _ {:it :specify} $_description)
+            _args
+            `(send nil? %RESTRICT_ON_SEND ...)
+          )
+        PATTERN
+
+        def on_send(node)
+          parent = node.each_ancestor(:block).first
+          return unless parent && (description = offense_example?(parent))
+
+          method_name = node.method_name
+          message = format(MSG, method_name: method_name)
+
+          regexp_group = self.class.const_get("#{method_name}_incorrect_descriptions".upcase)
+          check_description(description, regexp_group, message)
+        end
+
+        private
+
+        def check_description(description, regexps, message)
+          return unless regexps.any? { |regexp| regexp.match?(description.value) }
+
+          add_offense(description, message: message)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/gemspec/duplicated_assignment_spec.rb
+++ b/spec/rubocop/cop/gemspec/duplicated_assignment_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::Cop::Gemspec::DuplicatedAssignment, :config do
     RUBY
   end
 
-  it 'registers an offense when using `<<` twice' do
+  it 'does not register an offense when using `<<` twice' do
     expect_no_offenses(<<~RUBY)
       Gem::Specification.new do |spec|
         spec.requirements << 'libmagick, v6.0'
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::Gemspec::DuplicatedAssignment, :config do
     RUBY
   end
 
-  it 'registers an offense when using `spec.add_dependency` twice' do
+  it 'does not register an offense when using `spec.add_dependency` twice' do
     expect_no_offenses(<<~RUBY)
       Gem::Specification.new do |spec|
         spec.add_runtime_dependency('parallel', '~> 1.10')
@@ -51,7 +51,7 @@ RSpec.describe RuboCop::Cop::Gemspec::DuplicatedAssignment, :config do
     RUBY
   end
 
-  it 'registers an offense when `name=` method call is not block value' do
+  it 'does not register an offense when `name=` method call is not block value' do
     expect_no_offenses(<<~RUBY)
       Gem::Specification.new do |spec|
         foo = Foo.new

--- a/spec/rubocop/cop/internal_affairs/example_description_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/example_description_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::InternalAffairs::ExampleDescription, :config do
+  context 'with `expect_offense`' do
+    it 'registers an offense when given an improper description' do
+      expect_offense(<<~RUBY)
+        it 'does not register an offense' do
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Description does not match use of `expect_offense`.
+          expect_offense('code')
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when given a proper description' do
+      expect_no_offenses(<<~RUBY)
+        it 'finds an offense' do
+          expect_offense('code')
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when given an unexpected description' do
+      expect_no_offenses(<<~RUBY)
+        it 'foo bar baz' do
+          expect_offense('code')
+        end
+      RUBY
+    end
+  end
+
+  context 'with `expect_no_offenses`' do
+    it 'registers an offense when given an improper description' do
+      expect_offense(<<~RUBY)
+        it 'registers an offense' do
+           ^^^^^^^^^^^^^^^^^^^^^^ Description does not match use of `expect_no_offenses`.
+          expect_no_offenses('code')
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when given a proper description' do
+      expect_no_offenses(<<~RUBY)
+        it 'does not flag' do
+          expect_no_offense('code')
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when given an unexpected description' do
+      expect_no_offenses(<<~RUBY)
+        it 'foo bar baz' do
+          expect_offense('code')
+        end
+      RUBY
+    end
+  end
+
+  context 'with `expect_correction`' do
+    it 'registers an offense when given an improper description' do
+      expect_offense(<<~RUBY)
+        it 'does not auto-correct' do
+           ^^^^^^^^^^^^^^^^^^^^^^^ Description does not match use of `expect_correction`.
+          expect_correction('code', source: 'new code')
+        end
+      RUBY
+    end
+
+    context 'in conjunction with expect_offense' do
+      it 'registers an offense when given an improper description' do
+        expect_offense(<<~RUBY)
+          it 'registers an offense but does not auto-correct' do
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Description does not match use of `expect_correction`.
+            expect_offense('code')
+            expect_correction('code')
+          end
+        RUBY
+      end
+
+      context 'when the description is invalid for both methods' do
+        it 'registers an offense for the first method encountered' do
+          expect_offense(<<~RUBY)
+            it 'does not register an offense and does not auto-correct' do
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Description does not match use of `expect_offense`.
+              expect_offense('code')
+              expect_correction('code')
+            end
+          RUBY
+        end
+      end
+    end
+  end
+
+  context 'with `expect_no_corrections`' do
+    it 'registers an offense when given an improper description' do
+      expect_offense(<<~RUBY)
+        it 'autocorrects' do
+           ^^^^^^^^^^^^^^ Description does not match use of `expect_no_corrections`.
+          expect_no_corrections
+        end
+      RUBY
+    end
+
+    context 'in conjunction with expect_offense' do
+      it 'registers an offense when given an improper description' do
+        expect_offense(<<~RUBY)
+          it 'auto-corrects' do
+             ^^^^^^^^^^^^^^^ Description does not match use of `expect_no_corrections`.
+            expect_offense('code')
+            expect_no_corrections
+          end
+        RUBY
+      end
+    end
+  end
+
+  context 'when not making an expectation on offenses' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        it 'registers an offense' do
+        end
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/layout/array_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/array_alignment_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe RuboCop::Cop::Layout::ArrayAlignment do
       RUBY
     end
 
-    it 'does not auto-correct array within array with too much indentation' do
+    it 'auto-corrects array within array with too much indentation' do
       expect_offense(<<~RUBY)
         [:l1,
           [:l2,
@@ -82,7 +82,7 @@ RSpec.describe RuboCop::Cop::Layout::ArrayAlignment do
       RUBY
     end
 
-    it 'does not auto-correct array within array with too little indentation' do
+    it 'auto-corrects array within array with too little indentation' do
       expect_offense(<<~RUBY)
         [:l1,
         [:l2,
@@ -230,7 +230,7 @@ RSpec.describe RuboCop::Cop::Layout::ArrayAlignment do
       RUBY
     end
 
-    it 'does not auto-correct array within array with too much indentation' do
+    it 'auto-corrects array within array with too much indentation' do
       expect_offense(<<~RUBY)
         [:l1,
            [:l2,
@@ -248,7 +248,7 @@ RSpec.describe RuboCop::Cop::Layout::ArrayAlignment do
       RUBY
     end
 
-    it 'does not auto-correct array within array with too little indentation' do
+    it 'auto-corrects array within array with too little indentation' do
       expect_offense(<<~RUBY)
         [:l1,
          [:l2,

--- a/spec/rubocop/cop/layout/case_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/case_indentation_spec.rb
@@ -434,7 +434,7 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation do
   context 'when case is preceded by something else than whitespace' do
     let(:cop_config) { {} }
 
-    it 'registers an offense and does not correct' do
+    it 'registers an offense and auto-corrects' do
       expect_offense(<<~RUBY)
         case test when something
                   ^^^^ Indent `when` as deep as `case`.

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -363,7 +363,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'accepta a guard clause after a single line heredoc' do
+  it 'accepts a guard clause after a single line heredoc' do
     expect_no_offenses(<<~RUBY)
       def foo
         raise ArgumentError, <<-MSG unless path
@@ -375,7 +375,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'accepta a guard clause that is after multiline heredoc' do
+  it 'accepts a guard clause that is after multiline heredoc' do
     expect_no_offenses(<<~RUBY)
       def foo
         raise ArgumentError, <<-MSG unless path

--- a/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
@@ -633,7 +633,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
     context 'with AllowAdjacentOneLineDefs: true' do
       let(:cop_config) { { 'AllowAdjacentOneLineDefs' => true } }
 
-      it ' does not register an offense' do
+      it 'does not register an offense' do
         expect_no_offenses(<<~RUBY)
           def foo() = x
           def bar() = y

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -330,16 +330,18 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
         context 'being false' do
           sources.each do |reason, src|
             context "such as #{reason}" do
-              it 'registers offense(s)' do
-                # In these specific test cases, the extra space in question
-                # is to align comments, so it would be allowed by EITHER ONE
-                # being true.  Yes, that means technically it interferes a bit,
-                # but specifically in the way it was intended to.
-                if ['aligning tokens with empty line between',
-                    'aligning trailing comments'].include?(reason)
+              # In these specific test cases, the extra space in question
+              # is to align comments, so it would be allowed by EITHER ONE
+              # being true.  Yes, that means technically it interferes a bit,
+              # but specifically in the way it was intended to.
+              if ['aligning tokens with empty line between',
+                  'aligning trailing comments'].include?(reason)
+                it 'does not register an offense' do
                   src_without_annotations = src.gsub(/^ +\^.+\n/, '')
                   expect_no_offenses(src_without_annotations)
-                else
+                end
+              else
+                it 'registers offense(s)' do
                   expect_offense(src)
                 end
               end

--- a/spec/rubocop/cop/layout/indentation_consistency_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_consistency_spec.rb
@@ -785,7 +785,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
       RUBY
     end
 
-    it 'does not auto-correct an offense within another offense' do
+    it 'does not auto-correct an offense within another offense' do # rubocop:disable InternalAffairs/ExampleDescription
       expect_offense(<<~RUBY)
         require 'spec_helper'
         describe ArticlesController do

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
       }
     end
 
-    it 'accepts long lines matching a pattern but not other long lines' do
+    it 'only registers an offense for lines not matching the pattern' do
       expect_offense(<<~RUBY)
         class ExampleTest < TestCase
                           ^^^^^^^^^^ Line is too long. [28/18]

--- a/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
@@ -318,8 +318,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout do
     RUBY
   end
 
-  it 'does not auto-correct a trailing comma when only one argument ' \
-     'is present' do
+  it 'does not remove a trailing comma when only one argument is present' do
     expect_offense(<<~RUBY)
       def f
         X.map do |

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
     RUBY
   end
 
-  it 'does not report an offense for save_and_open_page with Kernel' do
+  it 'reports an offense for save_and_open_page with Kernel' do
     expect_offense(<<~RUBY)
       Kernel.save_and_open_page
       ^^^^^^^^^^^^^^^^^^^^^^^^^ Remove debugger entry point `Kernel.save_and_open_page`.

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods do
       RUBY
     end
 
-    it 'registers offense for a duplicate instance method in separate files' do
+    it 'only registers an offense for the second instance of a duplicate instance method in separate files' do
       expect_no_offenses(<<~RUBY, 'first.rb')
         #{opening_line}
           def some_method
@@ -191,6 +191,7 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods do
           end
         end
       RUBY
+
       expect_offense(<<~RUBY, 'second.rb')
         #{opening_line}
           def some_method

--- a/spec/rubocop/cop/lint/duplicate_regexp_character_class_element_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_regexp_character_class_element_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateRegexpCharacterClassElement do
   end
 
   context 'with no repeated character class elements' do
-    it 'registers an offense and corrects' do
+    it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)
         foo = /[xyz]/
       RUBY
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateRegexpCharacterClassElement do
   end
 
   context 'with repeated elements in different character classes' do
-    it 'registers an offense and corrects' do
+    it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)
         foo = /[xyz][xyz]/
       RUBY

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -117,13 +117,13 @@ RSpec.describe RuboCop::Cop::Lint::FormatParameterMismatch do
         RUBY
       end
 
-      it 'registers an offense for `#format`' do
+      it 'does not registes an offense for `#format`' do
         expect_no_offenses(<<~RUBY)
           puts format("%s, %s, %s", 1, 2, 3, 4, *arr)
         RUBY
       end
 
-      it 'registers an offense for `#sprintf`' do
+      it 'does not register an offense for `#sprintf`' do
         expect_no_offenses(<<~RUBY)
           puts sprintf("%s, %s, %s", 1, 2, 3, 4, *arr)
         RUBY

--- a/spec/rubocop/cop/lint/safe_navigation_consistency_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_consistency_spec.rb
@@ -99,9 +99,7 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationConsistency, :config do
       ^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
     RUBY
 
-    expect_correction(<<~RUBY)
-      foo&.zero? || foo > 5
-    RUBY
+    expect_no_corrections
   end
 
   it 'registers an offense and corrects assignment' do

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -351,7 +351,7 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedException do
         RUBY
       end
 
-      it 'registers an offense for splat arguments rescued after ' \
+      it 'does not register an offense for splat arguments rescued after ' \
          'rescuing a known exception' do
         expect_no_offenses(<<~RUBY)
           begin

--- a/spec/rubocop/cop/lint/top_level_return_with_argument_spec.rb
+++ b/spec/rubocop/cop/lint/top_level_return_with_argument_spec.rb
@@ -2,20 +2,20 @@
 
 RSpec.describe RuboCop::Cop::Lint::TopLevelReturnWithArgument, :config do
   context 'Code segment with only top-level return statement' do
-    it 'Expects no offense from the return without arguments' do
+    it 'expects no offense from the return without arguments' do
       expect_no_offenses(<<~RUBY)
         return
       RUBY
     end
 
-    it 'Expects offense from the return with arguments' do
+    it 'expects offense from the return with arguments' do
       expect_offense(<<~RUBY)
         return 1, 2, 3
         ^^^^^^^^^^^^^^ Top level return with argument detected.
       RUBY
     end
 
-    it 'Expects multiple offenses from the return with arguments statements' do
+    it 'expects multiple offenses from the return with arguments statements' do
       expect_offense(<<~RUBY)
         return 1, 2, 3
         ^^^^^^^^^^^^^^ Top level return with argument detected.
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Lint::TopLevelReturnWithArgument, :config do
   end
 
   context 'Code segment with block level returns other than the top-level return' do
-    it 'Expects no offense from the return without arguments' do
+    it 'expects no offense from the return without arguments' do
       expect_no_offenses(<<~RUBY)
         foo
 
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::Lint::TopLevelReturnWithArgument, :config do
       RUBY
     end
 
-    it 'Expects offense from the return with arguments' do
+    it 'expects offense from the return with arguments' do
       expect_offense(<<~RUBY)
         foo
 
@@ -57,7 +57,7 @@ RSpec.describe RuboCop::Cop::Lint::TopLevelReturnWithArgument, :config do
   end
 
   context 'Code segment with method-level return statements' do
-    it 'Expects offense when method-level & top-level return co-exist' do
+    it 'expects offense when method-level & top-level return co-exist' do
       expect_offense(<<~RUBY)
         def method
           return 'Hello World'
@@ -70,7 +70,7 @@ RSpec.describe RuboCop::Cop::Lint::TopLevelReturnWithArgument, :config do
   end
 
   context 'Code segment with inline if along with top-level return' do
-    it 'Expects no offense from the return without arguments' do
+    it 'expects no offense from the return without arguments' do
       expect_no_offenses(<<~RUBY)
         foo
 
@@ -84,7 +84,7 @@ RSpec.describe RuboCop::Cop::Lint::TopLevelReturnWithArgument, :config do
       RUBY
     end
 
-    it 'Expects multiple offense from the return with arguments' do
+    it 'expects multiple offense from the return with arguments' do
       expect_offense(<<~RUBY)
         foo
         return 1, 2, 3 if 1 == 1
@@ -103,7 +103,7 @@ RSpec.describe RuboCop::Cop::Lint::TopLevelReturnWithArgument, :config do
   end
 
   context 'Code segment containing semi-colon separated statements' do
-    it 'Expects an offense from the return with arguments and multi-line code' do
+    it 'expects an offense from the return with arguments and multi-line code' do
       expect_offense(<<~RUBY)
         foo
 
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::Lint::TopLevelReturnWithArgument, :config do
       RUBY
     end
 
-    it 'Expects no offense from the return with arguments and multi-line code' do
+    it 'expects no offense from the return with arguments and multi-line code' do
       expect_no_offenses(<<~RUBY)
         foo
 

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -601,7 +601,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier do
   end
 
   shared_examples 'method named by access modifier name' do |keyword, modifier|
-    it "registers an offense for `#{modifier}`" do
+    it "does not register an offense for `#{modifier}`" do
       expect_no_offenses(<<~RUBY)
         #{keyword} A
           def foo

--- a/spec/rubocop/cop/metrics/class_length_spec.rb
+++ b/spec/rubocop/cop/metrics/class_length_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
   end
 
   context 'when overlapping constant assignments' do
-    it 'registers an offense' do
+    it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)
         X = Y = Z = do_something
       RUBY

--- a/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
@@ -347,7 +347,7 @@ RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
         RUBY
       end
 
-      it 'does not correct other variables or assignments' do
+      it 'only corrects the exception variable' do
         expect_offense(<<~RUBY)
           def main
             raise

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -1098,7 +1098,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment do
         RUBY
       end
 
-      it 'registers an offense when multiple assignment is in else' do
+      it 'does not register an offense when multiple assignment is in else' do
         expect_no_offenses(<<~RUBY)
           if foo
             method_call

--- a/spec/rubocop/cop/style/double_negation_spec.rb
+++ b/spec/rubocop/cop/style/double_negation_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::Cop::Style::DoubleNegation, :config do
   end
 
   shared_examples 'common' do
-    it 'does not register an offense and corrects for `!!` when not a return location' do
+    it 'registers an offense and corrects for `!!` when not a return location' do
       expect_offense(<<~RUBY)
         def foo?
           foo

--- a/spec/rubocop/cop/style/endless_method_spec.rb
+++ b/spec/rubocop/cop/style/endless_method_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
         RUBY
       end
 
-      it 'registers an offense and corrects for a multiline endless method' do
+      it 'does not register an offense for a multiline endless method' do
         expect_no_offenses(<<~RUBY)
           def my_method() = x.foo
                              .bar
@@ -122,7 +122,7 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
         RUBY
       end
 
-      it 'registers an offense and corrects for a multiline endless method with begin' do
+      it 'does not register an offense for a multiline endless method with begin' do
         expect_no_offenses(<<~RUBY)
           def my_method() = begin
             foo && bar
@@ -130,7 +130,7 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
         RUBY
       end
 
-      it 'registers an offense and corrects for a multiline endless method with arguments' do
+      it 'does not register an offense for a multiline endless method with arguments' do
         expect_no_offenses(<<~RUBY)
           def my_method(a, b) = x.foo
                                  .bar

--- a/spec/rubocop/cop/style/format_string_token_spec.rb
+++ b/spec/rubocop/cop/style/format_string_token_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
     context 'when `IgnoredMethods: []`' do
       let(:ignored_methods) { [] }
 
-      it 'does not register an offense' do
+      it 'registers an offense' do
         expect_offense(<<~RUBY)
           redirect("%{foo}")
                     ^^^^^^ Prefer annotated tokens (like `%<foo>s`) over template tokens (like `%{foo}`).

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
         RUBY
       end
 
-      it 'does not add brackets to %w() arrays' do
+      it 'does not insert brackets for %w() arrays' do
         expect_offense(<<~RUBY)
           XXX = %w(YYY ZZZ)
                 ^^^^^^^^^^^ Freeze mutable objects assigned to constants.
@@ -185,7 +185,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
           RUBY
         end
 
-        it 'does not add parenthesis to range enclosed in parentheses' do
+        it 'does not insert parenthesis to range enclosed in parentheses' do
           expect_offense(<<~RUBY)
             XXX = (1..99)
                   ^^^^^^^ Freeze mutable objects assigned to constants.
@@ -209,7 +209,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
           RUBY
         end
 
-        it 'does not add parenthesis to range enclosed in parentheses' do
+        it 'does not insert parenthesis to range enclosed in parentheses' do
           expect_offense(<<~RUBY)
             XXX = (1...99)
                   ^^^^^^^^ Freeze mutable objects assigned to constants.
@@ -459,7 +459,7 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
         RUBY
       end
 
-      it 'does not add brackets to %w() arrays' do
+      it 'does not insert brackets for %w() arrays' do
         expect_offense(<<~RUBY)
           XXX = %w(YYY ZZZ)
                 ^^^^^^^^^^^ Freeze mutable objects assigned to constants.

--- a/spec/rubocop/cop/style/non_nil_check_spec.rb
+++ b/spec/rubocop/cop/style/non_nil_check_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe RuboCop::Cop::Style::NonNilCheck, :config do
       expect_no_offenses('!nil?')
     end
 
-    it 'does not report corrected when the code was not modified' do
+    it 'registers an offense but does not correct when the code was not modified' do
       expect_offense(<<~RUBY)
         return nil unless (line =~ //) != nil
                           ^^^^^^^^^^^^^^^^^^^ Prefer `!(line =~ //).nil?` over `(line =~ //) != nil`.
@@ -194,7 +194,7 @@ RSpec.describe RuboCop::Cop::Style::NonNilCheck, :config do
         }
       end
 
-      it 'does not register an offense for `foo != nil`' do
+      it 'registers an offense for `foo != nil`' do
         expect_offense(<<~RUBY)
           foo != nil
           ^^^^^^^^^^ Explicit non-nil checks are usually redundant.

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition do
         RUBY
       end
 
-      it 'registers an offense and corrects when using assignment by hash key access' do
+      it 'does not register an offense when using assignment by hash key access' do
         expect_no_offenses(<<~RUBY)
           if @cache[key]
             @cache[key]

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods do
         RUBY
       end
 
-      it 'does not correct to an endless method if the method body contains multiple statements' do
+      it 'corrects to a normal method if the method body contains multiple statements' do
         expect_correction(<<~RUBY.strip, source: 'def some_method; foo; bar end')
           def some_method;#{trailing_whitespace}
             foo;#{trailing_whitespace}

--- a/spec/rubocop/cop/style/struct_inheritance_spec.rb
+++ b/spec/rubocop/cop/style/struct_inheritance_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe RuboCop::Cop::Style::StructInheritance do
     expect_no_offenses('Person = Struct.new(:first_name, :last_name)')
   end
 
-  it 'acceps assignment to ::Struct.new' do
+  it 'accepts assignment to ::Struct.new' do
     expect_no_offenses('Person = ::Struct.new(:first_name, :last_name)')
   end
 


### PR DESCRIPTION
Add an InternalAffairs cop to look for rspec descriptions that don't match the expectation helper being used. For example

```ruby
it 'registers an offense' do
  expect_no_offense(...)
end
```

will register an offense because the description and expectation do not match. It looks for issues with `expect_offense`, `expect_no_offenses`, `expect_correction` and `expect_no_corrections`.

The cop most likely will have false negatives, because I tried to make it pretty generic to catch issues while not enforcing a specific message format. I started with a list of all the existing descriptions for `expect_offense` and `expect_no_offenses`, which you can see [here](https://gist.github.com/dvandersluis/efef049f8271d29a8e95cbb7de33d534). We can certainly add more regexps if necessary but this did catch quite a few issues already.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
