### PR TITLE
Tweak new cop template

### DIFF
--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -81,9 +81,7 @@ module RuboCop
       SPEC_TEMPLATE = <<~SPEC
         # frozen_string_literal: true
 
-        RSpec.describe RuboCop::Cop::%<department>s::%<cop_name>s do
-          subject(:cop) { described_class.new(config) }
-
+        RSpec.describe RuboCop::Cop::%<department>s::%<cop_name>s, :config do
           let(:config) { RuboCop::Config.new }
 
           # TODO: Write test code

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -110,9 +110,7 @@ RSpec.describe RuboCop::Cop::Generator do
       generated_source = <<~SPEC
         # frozen_string_literal: true
 
-        RSpec.describe RuboCop::Cop::Style::FakeCop do
-          subject(:cop) { described_class.new(config) }
-
+        RSpec.describe RuboCop::Cop::Style::FakeCop, :config do
           let(:config) { RuboCop::Config.new }
 
           # TODO: Write test code


### PR DESCRIPTION
Follow #9421.

This PR tweaks new cop template.

New cop development will rarely need `subject(:cop) { described_class.new(config) }`.
So I think there aren't any development tips lost by replacing it with `RSpec.describe ..., :config`.

Perhaps `let(:config) { RuboCop::Config.new }` can also be removed, but I'll look at it separately. Maybe not as explicitly unnecessary as `subject(:cop) { described_class.new(config) }`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
