### PR TITLE
Fix an incorrect auto-correct for `Style/ClassMethodsDefinitions`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_class_methods_definitions.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_class_methods_definitions.md
@@ -1,0 +1,1 @@
+* [#9424](https://github.com/rubocop-hq/rubocop/pull/9424): Fix an incorrect auto-correct for `Style/ClassMethodsDefinitions` when defining class methods with `class << self` and there is no blank line between method definition and attribute accessor. ([@koic][])

--- a/lib/rubocop/cop/mixin/comments_help.rb
+++ b/lib/rubocop/cop/mixin/comments_help.rb
@@ -9,7 +9,6 @@ module RuboCop
       def source_range_with_comment(node)
         begin_pos = begin_pos_with_comment(node)
         end_pos = end_position_for(node)
-        end_pos += 1 if node.def_type?
 
         Parser::Source::Range.new(buffer, begin_pos, end_pos)
       end

--- a/spec/rubocop/cop/style/class_methods_definitions_spec.rb
+++ b/spec/rubocop/cop/style/class_methods_definitions_spec.rb
@@ -23,6 +23,32 @@ RSpec.describe RuboCop::Cop::Style::ClassMethodsDefinitions, :config do
         class A
           class << self
             attr_reader :two
+
+          end
+
+          def self.three
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects when defining class methods with `class << self` and ' \
+       'there is no blank line between method definition and attribute accessor' do
+      expect_offense(<<~RUBY)
+        class A
+          class << self
+          ^^^^^^^^^^^^^ Do not define public methods within class << self.
+            def three
+            end
+            attr_reader :two
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class A
+          class << self
+            attr_reader :two
           end
 
           def self.three
@@ -50,6 +76,7 @@ RSpec.describe RuboCop::Cop::Style::ClassMethodsDefinitions, :config do
         class A
           class << self
             attr_reader :one
+
           end
 
           # Multiline
@@ -139,6 +166,7 @@ RSpec.describe RuboCop::Cop::Style::ClassMethodsDefinitions, :config do
           class << self
             def self.one
             end
+
           end
 
           def self.two


### PR DESCRIPTION
This PR fixes the following incorrect auto-correct for `Style/ClassMethodsDefinitions` when defining class methods with `class << self` and there is no blank line between method definition and attribute accessor.

```console
% cat example.rb
class A
  class << self
    def three
    end
    attr_reader :two
  end
end
```

```console
% bundle exec rubocop --only Style/ClassMethodsDefinitions -a
(snip)

Inspecting 1 file
C

Offenses:

example.rb:2:3: C: [Corrected] Style/ClassMethodsDefinitions: Do not
define public methods within class << self.
class << self ...
^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
```

## Before

The syntax is broken as follows.

```console
% cat example.rb
class A
  class << self    attr_reader :two
  end

  def self.three
  end
end

% ruby -c example.rb
example.rb:2: syntax error, unexpected local variable or method,
expecting ';' or '\n'
class << self    attr_reader :two
example.rb:7: syntax error, unexpected `end', expecting end-of-input
```

## After

Safe auto-correction is done.

```console
% cat example.rb
class A
  class << self
  attr_reader :two
  end

  def self.three
  end
end
```

NOTE: This change may leave unwanted whitespace, which can be resolved with `Layout/EmptyLinesAroundClassBody`. On the other hand, cannot auto-correction for syntax error, so this PR fixes the syntax error first priority.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
