### PR TITLE
[Fix #9425] Fix error in `Layout/ClassStructure` when initializer comes after private attribute macro

### DIFF
--- a/changelog/fix_error_in_layout_class_structure.md
+++ b/changelog/fix_error_in_layout_class_structure.md
@@ -1,0 +1,1 @@
+* [#9425](https://github.com/rubocop-hq/rubocop/issues/9425): Fix error in `Layout/ClassStructure` when initializer comes after private attribute macro. ([@tejasbubane][])

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -269,7 +269,7 @@ module RuboCop
 
         def source_range_with_comment(node)
           begin_pos, end_pos =
-            if node.def_type? || node.send_type? && node.def_modifier?
+            if node.def_type? && !node.method?(:initialize) || node.send_type? && node.def_modifier?
               start_node = find_visibility_start(node) || node
               end_node = find_visibility_end(node) || node
               [begin_pos_with_comment(start_node),

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -366,4 +366,31 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
       RUBY
     end
   end
+
+  context 'initializer is private and comes after attribute macro' do
+    it 'registers offense and auto-corrects' do
+      expect_offense(<<~RUBY)
+        class A
+          private
+
+          attr_accessor :foo
+
+          def initialize
+          ^^^^^^^^^^^^^^ `initializer` is supposed to appear before `private_attribute_macros`.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class A
+          private
+
+          def initialize
+          end
+          attr_accessor :foo
+
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Closes #9425

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/