### PR TITLE
Add `IgnoreModules` configuration to `Style/ConstantVisibility`

### DIFF
--- a/changelog/new_add_ignore_modules_to_constant_visibility_cop.md
+++ b/changelog/new_add_ignore_modules_to_constant_visibility_cop.md
@@ -1,0 +1,1 @@
+* [#8724](https://github.com/rubocop-hq/rubocop/issues/8724): Add `IgnoreModules` configuration to `Style/ConstantVisibility` to not register offense for module definitions. ([@tejasbubane][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3087,6 +3087,8 @@ Style/ConstantVisibility:
                  visibility declarations.
   Enabled: false
   VersionAdded: '0.66'
+  VersionChanged: <<next>>
+  IgnoreModules: false
 
 # Checks that you have put a copyright in a comment before any code.
 #

--- a/lib/rubocop/cop/style/constant_visibility.rb
+++ b/lib/rubocop/cop/style/constant_visibility.rb
@@ -26,6 +26,24 @@ module RuboCop
       #     public_constant :BAZ
       #   end
       #
+      # @example IgnoreModules: false (default)
+      #   # bad
+      #   class Foo
+      #     MyClass = Struct.new()
+      #   end
+      #
+      #   # good
+      #   class Foo
+      #     MyClass = Struct.new()
+      #     public_constant :MyClass
+      #   end
+      #
+      # @example IgnoreModules: true
+      #   # good
+      #   class Foo
+      #     MyClass = Struct.new()
+      #   end
+      #
       class ConstantVisibility < Base
         MSG = 'Explicitly make `%<constant_name>s` public or private using ' \
               'either `#public_constant` or `#private_constant`.'
@@ -33,12 +51,21 @@ module RuboCop
         def on_casgn(node)
           return unless class_or_module_scope?(node)
           return if visibility_declaration?(node)
+          return if ignore_modules? && module?(node)
 
           message = message(node)
           add_offense(node, message: message)
         end
 
         private
+
+        def ignore_modules?
+          cop_config.fetch('IgnoreModules', false)
+        end
+
+        def module?(node)
+          node.children.last.class_constructor?
+        end
 
         def message(node)
           _namespace, constant_name, _value = *node

--- a/spec/rubocop/cop/style/constant_visibility_spec.rb
+++ b/spec/rubocop/cop/style/constant_visibility_spec.rb
@@ -67,6 +67,38 @@ RSpec.describe RuboCop::Cop::Style::ConstantVisibility, :config do
     end
   end
 
+  it 'registers an offense for module definitions' do
+    expect_offense(<<~RUBY)
+      module Foo
+        MyClass = Class.new()
+        ^^^^^^^^^^^^^^^^^^^^^ Explicitly make `MyClass` public or private using either `#public_constant` or `#private_constant`.
+      end
+    RUBY
+  end
+
+  context 'IgnoreModules' do
+    let(:cop_config) { { 'IgnoreModules' => true } }
+
+    it 'does not register an offense for class definitions' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          SomeClass = Class.new()
+          SomeModule = Module.new()
+          SomeStruct = Struct.new()
+        end
+      RUBY
+    end
+
+    it 'registers an offense for constants' do
+      expect_offense(<<~RUBY)
+        module Foo
+          BAR = 42
+          ^^^^^^^^ Explicitly make `BAR` public or private using either `#public_constant` or `#private_constant`.
+        end
+      RUBY
+    end
+  end
+
   it 'does not register an offense when passing a string to the ' \
      'visibility declaration' do
     expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
To not register offense for module definitions.

Issue #8724

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/