### PR TITLE
[Fix #9403] Add autocorrect for `Style/EvalWithLocation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5411,3 +5411,4 @@
 [@AndreiEres]: https://github.com/AndreiEres
 [@jdufresne]: https://github.com/jdufresne
 [@adithyabsk]: https://github.com/adithyabsk
+[@cteece]: https://github.com/ceteece

--- a/changelog/new_add_autocorrect_for_styleevalwithlocation_cop.md
+++ b/changelog/new_add_autocorrect_for_styleevalwithlocation_cop.md
@@ -1,0 +1,1 @@
+* [#9403](https://github.com/rubocop-hq/rubocop/issues/9403): Add autocorrect for `Style/EvalWithLocation` cop. ([@cteece][])


### PR DESCRIPTION
Fix #9403 
- Add auto-correct to `Style/EvalWithLocation` cop for the following cases (along with unit tests to verify the corrections):
  - File argument is incorrect
  - Line argument is incorrect
  - Line argument is missing
  - Line and file arguments are missing
    - Does not attempt to autocorrect if the method being called is `eval` and the binding argument is missing

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
