### PR TITLE
[Fix #9431] Fix an error for `Style/DisableCopsWithinSourceCodeDirective`

### DIFF
--- a/changelog/fix_an_eror_for_disable_cops_within_source_code_directive.md
+++ b/changelog/fix_an_eror_for_disable_cops_within_source_code_directive.md
@@ -1,0 +1,1 @@
+* [#9431](https://github.com/rubocop-hq/rubocop/issues/9431): Fix an error for `Style/DisableCopsWithinSourceCodeDirective` when using leading source comment. ([@koic][])

--- a/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
+++ b/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
@@ -71,7 +71,7 @@ module RuboCop
 
         def directive_cops(comment)
           match = CommentConfig::COMMENT_DIRECTIVE_REGEXP.match(comment.text)
-          match[2] ? match[2].split(',').map(&:strip) : []
+          match && match[2] ? match[2].split(',').map(&:strip) : []
         end
 
         def allowed_cops

--- a/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
+++ b/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
@@ -81,5 +81,16 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
         RUBY
       end
     end
+
+    context 'when using leading source comment' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          # comment
+
+          class Foo
+          end
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #9431.

Fix the following error for `Style/DisableCopsWithinSourceCodeDirective` when using leading source comment.

```console
% cat example.rb
# frozen_string_literal: true

class Foo
end

% bundle exec rubocop example.rb --only Style/DisableCopsWithinSourceCodeDirective -d
(snip)

Inspecting 1 file
Scanning /Users/koic/src/github.com/koic/rubocop-issues/master/example.rb
An error occurred while Style/DisableCopsWithinSourceCodeDirective cop
was inspecting
/Users/koic/src/github.com/koic/rubocop-issues/master/example.rb.
undefined method `[]' for nil:NilClass
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/style/
disable_cops_within_source_code_directive.rb:74:in `directive_cops'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/style/
disable_cops_within_source_code_directive.rb:42:in `block in on_new_investigation'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/style/
disable_cops_within_source_code_directive.rb:41:in `each'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/style/
disable_cops_within_source_code_directive.rb:41:in `on_new_investigation'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
