### PR TITLE
[Fix #9433] Fix an error for `Style/EvalWithLocation`

### DIFF
--- a/changelog/fix_an_error_for_style_eval_with_location.md
+++ b/changelog/fix_an_error_for_style_eval_with_location.md
@@ -1,0 +1,1 @@
+* [#9433](https://github.com/rubocop-hq/rubocop/issues/9433): Fix an error for `Style/EvalWithLocation` when using eval with block argument. ([@koic][])

--- a/lib/rubocop/cop/style/eval_with_location.rb
+++ b/lib/rubocop/cop/style/eval_with_location.rb
@@ -64,7 +64,7 @@ module RuboCop
           return if node.method?(:eval) && !valid_eval_receiver?(node.receiver)
 
           code = node.arguments.first
-          return unless code.str_type? || code.dstr_type?
+          return unless code && (code.str_type? || code.dstr_type?)
 
           file, line = file_and_line(node)
 

--- a/spec/rubocop/cop/style/eval_with_location_spec.rb
+++ b/spec/rubocop/cop/style/eval_with_location_spec.rb
@@ -191,4 +191,14 @@ RSpec.describe RuboCop::Cop::Style::EvalWithLocation, :config do
       CODE
     RUBY
   end
+
+  it 'does not register an offense when using eval with block argument' do
+    expect_no_offenses(<<~RUBY)
+      def self.included(base)
+        base.class_eval do
+          include OtherModule
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #9433

This PR fixes an error for `Style/EvalWithLocation` when using eval with block argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
