### PR TITLE
[Fix #9438] Fix a false positive for `Layout/SpaceBeforeBrackets`

### DIFF
--- a/changelog/fix_false_positive_for_layout_space_before_bracket.md
+++ b/changelog/fix_false_positive_for_layout_space_before_bracket.md
@@ -1,0 +1,1 @@
+* [#9438](https://github.com/rubocop-hq/rubocop/issues/9438): Fix a false positive for `Layout/SpaceBeforeBrackets` when space is used in left bracket. ([@koic][])

--- a/lib/rubocop/cop/layout/space_before_brackets.rb
+++ b/lib/rubocop/cop/layout/space_before_brackets.rb
@@ -39,12 +39,17 @@ module RuboCop
 
             range_between(receiver_end_pos, selector_begin_pos)
           elsif node.method?(:[]=)
-            end_pos = node.receiver.source_range.end_pos
-
-            return if begin_pos - end_pos == 1
-
-            range_between(end_pos, begin_pos - 1)
+            offense_range_for_assignment(node, begin_pos)
           end
+        end
+
+        def offense_range_for_assignment(node, begin_pos)
+          end_pos = node.receiver.source_range.end_pos
+
+          return if begin_pos - end_pos == 1 ||
+                    (range = range_between(end_pos, begin_pos - 1)).source == '['
+
+          range
         end
 
         def register_offense(range)

--- a/spec/rubocop/cop/layout/space_before_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_brackets_spec.rb
@@ -109,6 +109,12 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBrackets, :config do
         @correction[index_or_key] = :value
       RUBY
     end
+
+    it 'does not register an offense when space is used in left bracket' do
+      expect_no_offenses(<<~RUBY)
+        @collections[ index_or_key ] = :value
+      RUBY
+    end
   end
 
   it 'does not register an offense when assigning an array' do


### PR DESCRIPTION
Fixes #9438

This PR fixes a false positive for `Layout/SpaceBeforeBrackets` when space is used in left bracket.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
