### PR TITLE
[Fix #9440] Fix `Lint/SymbolConversion` for implicit `to_sym` without a receiver

### DIFF
--- a/changelog/fix_fix_lintsymbolconversion_for_implicit.md
+++ b/changelog/fix_fix_lintsymbolconversion_for_implicit.md
@@ -1,0 +1,1 @@
+* [#9440](https://github.com/rubocop-hq/rubocop/issues/9440): Fix `Lint/SymbolConversion` for implicit `to_sym` without a receiver. ([@dvandersluis][])

--- a/lib/rubocop/cop/lint/symbol_conversion.rb
+++ b/lib/rubocop/cop/lint/symbol_conversion.rb
@@ -28,6 +28,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[to_sym intern].freeze
 
         def on_send(node)
+          return unless node.receiver
           return unless node.receiver.str_type? || node.receiver.sym_type?
 
           register_offense(node, correction: node.receiver.value.to_sym.inspect)

--- a/spec/rubocop/cop/lint/symbol_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/symbol_conversion_spec.rb
@@ -126,4 +126,12 @@ RSpec.describe RuboCop::Cop::Lint::SymbolConversion, :config do
       RUBY
     end
   end
+
+  context 'implicit `to_sym` call' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        to_sym == other
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #9440.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
