### PR TITLE
[Fix #9444] Fix colorization for offenses with `Severity: info`

### DIFF
--- a/changelog/fix_fix_colorization_for_offenses_with.md
+++ b/changelog/fix_fix_colorization_for_offenses_with.md
@@ -1,0 +1,1 @@
+* [#9444](https://github.com/rubocop-hq/rubocop/issues/9444): Fix colorization for offenses with `Severity: info`. ([@dvandersluis][])

--- a/lib/rubocop/formatter/simple_text_formatter.rb
+++ b/lib/rubocop/formatter/simple_text_formatter.rb
@@ -13,6 +13,7 @@ module RuboCop
       include PathUtil
 
       COLOR_FOR_SEVERITY = {
+        info:       :gray,
         refactor:   :yellow,
         convention: :yellow,
         warning:    :magenta,


### PR DESCRIPTION
There was no color specified for the `info` severity level which was causing rainbow to raise an error. Fixes #9444.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
