### PR TITLE
[Fix #9444] Fix error on colorization for offenses with `Severity: info`

### DIFF
--- a/changelog/fix_error_with_colorization_for_severity_info.md
+++ b/changelog/fix_error_with_colorization_for_severity_info.md
@@ -1,0 +1,1 @@
+* [#9444](https://github.com/rubocop-hq/rubocop/issues/9444): Fix error on colorization for offenses with `Severity: info`. ([@tejasbubane][])

--- a/lib/rubocop/formatter/simple_text_formatter.rb
+++ b/lib/rubocop/formatter/simple_text_formatter.rb
@@ -13,6 +13,7 @@ module RuboCop
       include PathUtil
 
       COLOR_FOR_SEVERITY = {
+        info:       :gray,
         refactor:   :yellow,
         convention: :yellow,
         warning:    :magenta,
@@ -76,7 +77,7 @@ module RuboCop
       end
 
       def colored_severity_code(offense)
-        color = COLOR_FOR_SEVERITY[offense.severity.name]
+        color = COLOR_FOR_SEVERITY.fetch(offense.severity.name)
         colorize(offense.severity.code, color)
       end
 

--- a/spec/rubocop/formatter/simple_text_formatter_spec.rb
+++ b/spec/rubocop/formatter/simple_text_formatter_spec.rb
@@ -13,26 +13,12 @@ RSpec.describe RuboCop::Formatter::SimpleTextFormatter do
 
   let(:output) { StringIO.new }
 
-  describe '#report_file' do
-    before do
-      formatter.report_file(file, [offense])
-    end
-
-    let(:file) { '/path/to/file' }
-
+  shared_examples 'report for severity' do |severity|
     let(:offense) do
-      RuboCop::Cop::Offense.new(:convention, location,
+      RuboCop::Cop::Offense.new(severity, location,
                                 'This is a message with `colored text`.',
                                 'CopName', status)
     end
-
-    let(:location) do
-      source_buffer = Parser::Source::Buffer.new('test', 1)
-      source_buffer.source = "a\n"
-      Parser::Source::Range.new(source_buffer, 0, 1)
-    end
-
-    let(:status) { :uncorrected }
 
     context 'the file is under the current working directory' do
       let(:file) { File.expand_path('spec/spec_helper.rb') }
@@ -89,6 +75,29 @@ RSpec.describe RuboCop::Formatter::SimpleTextFormatter do
           .to include(': [Todo] This is a message with colored text.')
       end
     end
+  end
+
+  describe '#report_file' do
+    before do
+      formatter.report_file(file, [offense])
+    end
+
+    let(:file) { '/path/to/file' }
+
+    let(:location) do
+      source_buffer = Parser::Source::Buffer.new('test', 1)
+      source_buffer.source = "a\n"
+      Parser::Source::Range.new(source_buffer, 0, 1)
+    end
+
+    let(:status) { :uncorrected }
+
+    it_behaves_like 'report for severity', :info
+    it_behaves_like 'report for severity', :refactor
+    it_behaves_like 'report for severity', :convention
+    it_behaves_like 'report for severity', :warning
+    it_behaves_like 'report for severity', :error
+    it_behaves_like 'report for severity', :fatal
   end
 
   describe '#report_summary' do


### PR DESCRIPTION
Closes #9444

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/