### PR TITLE
[Fix #9449] Fix an error for `Style/NilComparison`

### DIFF
--- a/changelog/fix_an_error_for_style_nil_comparison.md
+++ b/changelog/fix_an_error_for_style_nil_comparison.md
@@ -1,0 +1,1 @@
+* [#9449](https://github.com/rubocop-hq/rubocop/issues/9449): Fix an error for `Style/NilComparison` when using `x == nil` as a guard condition'. ([@koic][])

--- a/lib/rubocop/cop/style/nil_comparison.rb
+++ b/lib/rubocop/cop/style/nil_comparison.rb
@@ -50,7 +50,9 @@ module RuboCop
                          end
 
               corrector.replace(node, new_code)
-              corrector.wrap(node, '(', ')') if node.parent&.method?(:!)
+
+              parent = node.parent
+              corrector.wrap(node, '(', ')') if parent.respond_to?(:method?) && parent.method?(:!)
             end
           end
         end

--- a/spec/rubocop/cop/style/nil_comparison_spec.rb
+++ b/spec/rubocop/cop/style/nil_comparison_spec.rb
@@ -25,6 +25,17 @@ RSpec.describe RuboCop::Cop::Style::NilComparison, :config do
         x.nil?
       RUBY
     end
+
+    it 'registers and corrects an offense when using `x == nil` as a guard condition' do
+      expect_offense(<<~RUBY)
+        bar if x == nil
+                 ^^ Prefer the use of the `nil?` predicate.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        bar if x.nil?
+      RUBY
+    end
   end
 
   context 'configured with comparison preferred' do


### PR DESCRIPTION
Fixes #9449.

This PR fixes an error for `Style/NilComparison` when using `x == nil` as a guard condition'.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
