### PR TITLE
[Fix #9448] Fix an error for `Style/SoleNestedConditional`

### DIFF
--- a/changelog/fix_an_error_for_sole_nested_conditional.md
+++ b/changelog/fix_an_error_for_sole_nested_conditional.md
@@ -1,0 +1,1 @@
+* [#9448](https://github.com/rubocop-hq/rubocop/issues/9448): Fix an error for `Style/SoleNestedConditional` when using nested `unless` modifier with a single expression condition. ([@koic][])

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -112,11 +112,11 @@ module RuboCop
         def correct_outer_condition(corrector, condition)
           return unless requrie_parentheses?(condition)
 
-          range = range_between(
-            condition.loc.selector.end_pos, condition.first_argument.source_range.begin_pos
-          )
+          end_pos = condition.loc.selector.end_pos
+          begin_pos = condition.first_argument.source_range.begin_pos
+          return if end_pos > begin_pos
 
-          corrector.replace(range, '(')
+          corrector.replace(range_between(end_pos, begin_pos), '(')
           corrector.insert_after(condition.last_argument.source_range, ')')
         end
 

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -113,6 +113,29 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using nested `unless` modifier with a single expression condition' do
+    expect_offense(<<~RUBY)
+      class A
+        def foo
+          if h[:a]
+            h[:b] = true unless h.has_key?(:b)
+                         ^^^^^^ Consider merging nested conditions into outer `if` conditions.
+          end
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class A
+        def foo
+          if h[:a] && !h.has_key?(:b)
+            h[:b] = true
+          end
+        end
+      end
+    RUBY
+  end
+
   it 'registers an offense and corrects when using nested `unless` modifier multiple conditional' do
     expect_offense(<<~RUBY)
       if foo


### PR DESCRIPTION
Fixes #9448.

This PR fixes an error for `Style/SoleNestedConditional` when using nested `unless` modifier single as in single expression.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
