### PR TITLE
[Fix #9455] Fix a false positive for `Lint/SymbolConversion`

### DIFF
--- a/changelog/fix_false_positive_for_lint_symbol_conversion.md
+++ b/changelog/fix_false_positive_for_lint_symbol_conversion.md
@@ -1,0 +1,1 @@
+* [#9455](https://github.com/rubocop-hq/rubocop/issues/9455): Fix a false positive for `Lint/SymbolConversion` when hash keys that contain `":"`. ([@koic][])

--- a/lib/rubocop/cop/lint/symbol_conversion.rb
+++ b/lib/rubocop/cop/lint/symbol_conversion.rb
@@ -88,7 +88,7 @@ module RuboCop
           # will be ignored.
           return unless node.value.to_s.match?(/\A[a-z0-9_]/i)
 
-          correction = node.value.inspect.delete(':')
+          correction = node.value.inspect.gsub(/\A:/, '')
           return if properly_quoted?(node.source, correction)
 
           register_offense(

--- a/spec/rubocop/cop/lint/symbol_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/symbol_conversion_spec.rb
@@ -62,6 +62,12 @@ RSpec.describe RuboCop::Cop::Lint::SymbolConversion, :config do
         RUBY
       end
 
+      it 'does not register an offense for a require quoted symbol that contains `:`' do
+        expect_no_offenses(<<~RUBY)
+          { 'foo:bar': 'bar' }
+        RUBY
+      end
+
       it 'registers an offense for a quoted symbol' do
         expect_offense(<<~RUBY)
           { 'foo': 'bar' }


### PR DESCRIPTION
Fixes #9455.

This PR fixes a false positive for `Lint/SymbolConversion` when hash keys that contain `":"`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
