### PR TITLE
[Fix #9459] Add `AllowedMethods` option to `Style/IfWithBooleanLiteralBranches`

### DIFF
--- a/changelog/new_add_allowed_method_option_to_if_with_boolean_literal_branche.md
+++ b/changelog/new_add_allowed_method_option_to_if_with_boolean_literal_branche.md
@@ -1,0 +1,1 @@
+* [#9459](https://github.com/rubocop-hq/rubocop/issues/9459): Add `AllowedMethods` option to `Style/IfWithBooleanLiteralBranches` and set `nonzero?` as default value. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3521,6 +3521,8 @@ Style/IfWithBooleanLiteralBranches:
   Description: 'Checks for redundant `if` with boolean literal branches.'
   Enabled: pending
   VersionAdded: '1.9'
+  AllowedMethods:
+    - nonzero?
 
 Style/IfWithSemicolon:
   Description: 'Do not use if x; .... Use the ternary operator instead.'

--- a/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb
+++ b/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb
@@ -21,7 +21,12 @@ module RuboCop
       #   # good
       #   foo == bar
       #
+      # @example AllowedMethods: ['nonzero?']
+      #   # good
+      #   num.nonzero? ? true : false
+      #
       class IfWithBooleanLiteralBranches < Base
+        include AllowedMethods
         extend AutoCorrector
 
         MSG = 'Remove redundant %<keyword>s with boolean literal branches.'
@@ -68,6 +73,7 @@ module RuboCop
 
         def assume_boolean_value?(condition)
           return false unless condition.send_type?
+          return false if allowed_method?(condition.method_name)
 
           condition.comparison_method? || condition.predicate_method? || double_negative?(condition)
         end

--- a/spec/rubocop/cop/style/if_with_boolean_literal_branches_spec.rb
+++ b/spec/rubocop/cop/style/if_with_boolean_literal_branches_spec.rb
@@ -508,4 +508,14 @@ RSpec.describe RuboCop::Cop::Style::IfWithBooleanLiteralBranches, :config do
       RUBY
     end
   end
+
+  context 'when `AllowedMethods: nonzero?`' do
+    let(:cop_config) { { 'AllowedMethods' => ['nonzero?'] } }
+
+    it 'does not register an offense when using `nonzero?`' do
+      expect_no_offenses(<<~RUBY)
+        num.nonzero? ? true : false
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #9459.

This PR adds `AllowedMethods` option to `Style/IfWithBooleanLiteralBranches` and set `nonzero?` as default value.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
