### PR TITLE
[Fix #9454] Fix an incorrect auto-correct for `Style/IfWithBooleanLiteralBranches`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_if_with_boolean_literal_branches.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_if_with_boolean_literal_branches.md
@@ -1,0 +1,1 @@
+* [#9454](https://github.com/rubocop-hq/rubocop/issues/9454): Fix an incorrect auto-correct for `Style/IfWithBooleanLiteralBranches` when using `elsif do_something?` with boolean literal branches. ([@koic][])

--- a/spec/rubocop/cop/style/if_with_boolean_literal_branches_spec.rb
+++ b/spec/rubocop/cop/style/if_with_boolean_literal_branches_spec.rb
@@ -157,6 +157,52 @@ RSpec.describe RuboCop::Cop::Style::IfWithBooleanLiteralBranches, :config do
         !foo.do_something?
       RUBY
     end
+
+    it 'registers and corrects an offense when using `elsif foo.do_something?` with boolean literal branches' do
+      expect_offense(<<~RUBY)
+        if condition
+          bar
+          false
+        elsif foo.do_something?
+        ^^^^^ Use `else` instead of redundant `elsif` with boolean literal branches.
+          true
+        else
+          false
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if condition
+          bar
+          false
+        else
+          foo.do_something?
+        end
+      RUBY
+    end
+
+    it 'registers and corrects an offense when using `elsif foo.do_something?` with opposite boolean literal branches' do
+      expect_offense(<<~RUBY)
+        if condition
+          bar
+          false
+        elsif foo.do_something?
+        ^^^^^ Use `else` instead of redundant `elsif` with boolean literal branches.
+          false
+        else
+          true
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if condition
+          bar
+          false
+        else
+          !foo.do_something?
+        end
+      RUBY
+    end
   end
 
   context 'when double negative is used in condition' do


### PR DESCRIPTION
Fixes #9454.

This PR fixes an incorrect auto-correct for `Style/IfWithBooleanLiteralBranches` when using `elsif do_something?` with boolean literal branches.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
