### PR TITLE
[Fix #9457] Fix a false positive for `Lint/SymbolConversion`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_symbol_conversion.md
+++ b/changelog/fix_a_false_positive_for_lint_symbol_conversion.md
@@ -1,0 +1,1 @@
+* [#9457](https://github.com/rubocop-hq/rubocop/issues/9457): Fix a false positive for `Lint/SymbolConversion` when hash keys that end with `=`. ([@koic][])

--- a/lib/rubocop/cop/lint/symbol_conversion.rb
+++ b/lib/rubocop/cop/lint/symbol_conversion.rb
@@ -60,7 +60,7 @@ module RuboCop
         end
 
         def properly_quoted?(source, value)
-          return true unless source.match?(/['"]/)
+          return true if !source.match?(/['"]/) || value.end_with?('=')
 
           source == value ||
             # `Symbol#inspect` uses double quotes, but allow single-quoted

--- a/spec/rubocop/cop/lint/symbol_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/symbol_conversion_spec.rb
@@ -68,6 +68,12 @@ RSpec.describe RuboCop::Cop::Lint::SymbolConversion, :config do
         RUBY
       end
 
+      it 'does not register an offense for a require quoted symbol that ends with `=`' do
+        expect_no_offenses(<<~RUBY)
+          { 'foo=': 'bar' }
+        RUBY
+      end
+
       it 'registers an offense for a quoted symbol' do
         expect_offense(<<~RUBY)
           { 'foo': 'bar' }
@@ -76,6 +82,28 @@ RSpec.describe RuboCop::Cop::Lint::SymbolConversion, :config do
 
         expect_correction(<<~RUBY)
           { foo: 'bar' }
+        RUBY
+      end
+
+      it 'registers and corrects an offense for a quoted symbol that ends with `!`' do
+        expect_offense(<<~RUBY)
+          { 'foo!': 'bar' }
+            ^^^^^^ Unnecessary symbol conversion; use `foo!:` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          { foo!: 'bar' }
+        RUBY
+      end
+
+      it 'registers and corrects an offense for a quoted symbol that ends with `?`' do
+        expect_offense(<<~RUBY)
+          { 'foo?': 'bar' }
+            ^^^^^^ Unnecessary symbol conversion; use `foo?:` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          { foo?: 'bar' }
         RUBY
       end
 


### PR DESCRIPTION
Fixes #9457.

This PR fixes a false positive for Lint/SymbolConversion when hash keys that end with `=`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
