### PR TITLE
[Fix #9466] Don't correct `Style/SingleLineMethods` using endless methods if the target ruby is < 3.0

### DIFF
--- a/changelog/fix_dont_correct_stylesinglelinemethods.md
+++ b/changelog/fix_dont_correct_stylesinglelinemethods.md
@@ -1,0 +1,1 @@
+* [#9466](https://github.com/rubocop-hq/rubocop/issues/9466): Don't correct `Style/SingleLineMethods` using endless methods if the target ruby is < 3.0. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -63,6 +63,8 @@ module RuboCop
         end
 
         def correct_to_endless?(body_node)
+          return false if target_ruby_version < 3.0
+
           endless_method_config = config.for_cop('Style/EndlessMethod')
 
           return false unless endless_method_config['Enabled']

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -2,7 +2,8 @@
 
 RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
   let(:config) do
-    RuboCop::Config.new('Style/SingleLineMethods' => cop_config,
+    RuboCop::Config.new('AllCops' => all_cops_config,
+                        'Style/SingleLineMethods' => cop_config,
                         'Layout/IndentationWidth' => { 'Width' => 2 },
                         'Style/EndlessMethod' => { 'Enabled' => false })
   end
@@ -157,7 +158,7 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
     end
   end
 
-  context 'when `Style/EndlessMethod` is enabled' do
+  context 'when `Style/EndlessMethod` is enabled', :ruby30 do
     before { config['Style/EndlessMethod'] = { 'Enabled' => true }.merge(endless_method_config) }
 
     shared_examples 'convert to endless method' do
@@ -237,6 +238,18 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
       let(:endless_method_config) { { 'EnforcedStyle' => 'allow_always' } }
 
       it_behaves_like 'convert to endless method'
+    end
+
+    context 'prior to ruby 3.0', :ruby27 do
+      let(:endless_method_config) { { 'EnforcedStyle' => 'allow_always' } }
+
+      it 'corrects to a multiline method' do
+        expect_correction(<<~RUBY.strip, source: 'def some_method; body end')
+          def some_method;#{trailing_whitespace}
+            body#{trailing_whitespace}
+          end
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
In #9295, `Style/SingleLineMethods` was updated to correct to an endless method if enabled in `Style/EndlessMethod`, however, it did not check that the correct ruby version was being targetted. Now, methods will never be corrected to endless methods prior to ruby 3.0, regardless of the config.

Fixes #9466.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
