### PR TITLE
[Fix #9473] Fix an error for `Lint/DeprecatedConstants`

### DIFF
--- a/changelog/fix_an_error_for_lint_deprecated_constants.md
+++ b/changelog/fix_an_error_for_lint_deprecated_constants.md
@@ -1,0 +1,1 @@
+* [#9473](https://github.com/rubocop-hq/rubocop/issues/9473): Fix an error for `Lint/DeprecatedConstants` when using `__ENCODING__`. ([@koic][])

--- a/lib/rubocop/cop/lint/deprecated_constants.rb
+++ b/lib/rubocop/cop/lint/deprecated_constants.rb
@@ -37,6 +37,11 @@ module RuboCop
         DO_NOT_USE_MSG = 'Do not use `%<bad>s`%<deprecated_message>s.'
 
         def on_const(node)
+          # FIXME: Workaround for "`undefined method `expression' for nil:NilClass`" when processing
+          #        `__ENCODING__`. It is better to be able to work without this condition.
+          #        Maybe further investigation of RuboCop AST will lead to an essential solution.
+          return unless node.loc
+
           constant = node.absolute? ? consntant_name(node, node.short_name.to_s) : node.source
           return unless (deprecated_constant = deprecated_constants[constant])
 

--- a/spec/rubocop/cop/lint/deprecated_constants_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_constants_spec.rb
@@ -139,4 +139,10 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedConstants, :config do
       Foo::TRUE
     RUBY
   end
+
+  it 'does not register an offense when using `__ENCODING__' do
+    expect_no_offenses(<<~RUBY)
+      __ENCODING__
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #9473.

This PR fixes the following error for `Lint/DeprecatedConstants` when using `__ENCODING__`.

```console
% cat example.rb
__ENCODING__

% bundle exec rubocop --only Lint/DeprecatedConstants -d
(snip)

Inspecting 1 file
Scanning /Users/koic/src/github.com/koic/rubocop-issues/9473/example.rb
An error occurred while Lint/DeprecatedConstants cop was inspecting /Users/koic/src/github.com/koic/rubocop-issues/9473/example.rb.
undefined method `expression' for nil:NilClass
/Users/koic/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-ast-1.4.1/lib/rubocop/ast/node.rb:244:in `source'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/lint/deprecated_constants.rb:40:in `on_const'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/cop/commissioner.rb:100:in `public_send'
```

This is a workaround for the error.
Maybe further investigation of RuboCop AST will lead to an essential solution.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
