### PR TITLE
Mark `Style/IfWithBooleanLiteralBranche` as unsafe auto-correction

### DIFF
--- a/changelog/change_mark_unsafe_autocorrect_for_if_with_boolean_literal_branches.md
+++ b/changelog/change_mark_unsafe_autocorrect_for_if_with_boolean_literal_branches.md
@@ -1,0 +1,1 @@
+* [#9476](https://github.com/rubocop-hq/rubocop/pull/9476): Mark `Style/IfWithBooleanLiteralBranche` as unsafe auto-correction. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3521,6 +3521,7 @@ Style/IfWithBooleanLiteralBranches:
   Description: 'Checks for redundant `if` with boolean literal branches.'
   Enabled: pending
   VersionAdded: '1.9'
+  SafeAutoCorrect: false
   AllowedMethods:
     - nonzero?
 

--- a/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb
+++ b/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb
@@ -6,6 +6,8 @@ module RuboCop
       # This cop checks for redundant `if` with boolean literal branches.
       # It checks only conditions to return boolean value (`true` or `false`) for safe detection.
       # The conditions to be checked are comparison methods, predicate methods, and double negative.
+      # However, auto-correction is unsafe because there is no guarantee that all predicate methods
+      # will return boolean value. Those methods can be allowed with `AllowedMethods` config.
       #
       # @example
       #   # bad


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/9461#issuecomment-770046288.

This PR marks `Style/IfWithBooleanLiteralBranche` as unsafe auto-correction.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
