### PR TITLE
[#9452] `StyleGuideBaseURL` not functioning with nested departments

### DIFF
--- a/changelog/fix_fix_styleguidebaseurl_not_functioning.md
+++ b/changelog/fix_fix_styleguidebaseurl_not_functioning.md
@@ -1,0 +1,1 @@
+* [#9452](https://github.com/rubocop-hq/rubocop/pull/9452): Fix `StyleGuideBaseURL` not functioning with nested departments. ([@tas50][])

--- a/lib/rubocop/cop/message_annotator.rb
+++ b/lib/rubocop/cop/message_annotator.rb
@@ -85,8 +85,11 @@ module RuboCop
         end
       end
 
+      # Returns the base style guide URL from AllCops or the specific department
+      #
+      # @return [String] style guide URL
       def style_guide_base_url
-        department_name = cop_name.split('/').first
+        department_name = cop_name.split('/')[0..-2].join('/')
 
         config.for_department(department_name)['StyleGuideBaseURL'] ||
           config.for_all_cops['StyleGuideBaseURL']

--- a/spec/rubocop/cop/message_annotator_spec.rb
+++ b/spec/rubocop/cop/message_annotator_spec.rb
@@ -129,6 +129,28 @@ RSpec.describe RuboCop::Cop::MessageAnnotator do
         end
       end
 
+      context 'when a nested department is specified' do
+        let(:config) do
+          RuboCop::Config.new(
+            'AllCops' => {
+              'StyleGuideBaseURL' => 'http://example.org/styleguide'
+            },
+            'Foo/Bar' => {
+              'StyleGuideBaseURL' => 'http://foo.example.org'
+            }
+          )
+        end
+
+        let(:cop_name) { 'Foo/Bar/Cop' }
+        let(:urls) { annotator.urls }
+
+        it 'returns style guide url when it is specified' do
+          config['Foo/Bar/Cop'] = { 'StyleGuide' => '#target_style_guide' }
+
+          expect(urls).to eq(%w[http://foo.example.org#target_style_guide])
+        end
+      end
+
       it 'can use a path-based setting' do
         config['Cop/Cop'] = { 'StyleGuide' => 'cop/path/rule#target_based_url' }
         expect(annotate).to include('http://example.org/cop/path/rule#target_based_url')


### PR DESCRIPTION
Currently, you can set the StyleGuideBaseURL config for cops that ship
within RuboCop or other RuboCop plugins that use a DEPT/COP format. If
the project has nested departments this doesn't work as the message
annotator does not properly split the cop name to determine the
department to lookup in the config.

With this change, just the cop name is split off from the full DEPT/COP
string allowing the StyleGuideBaseURL to function with nested
departments.

We have nested departments in Cookstyle like `Chef/Deprecations/Foo` and
we'd like to be able to enable this config by default so we can point
our users at our documentation and define the URL at the department level.

Signed-off-by: Tim Smith <tsmith@chef.io>