### PR TITLE
[Fix #9453] Fix an infinite loop error for `Layout/FirstParameterIndentation`

### DIFF
--- a/changelog/fix_infite_loop_error_for_first_parameter_indentation.md
+++ b/changelog/fix_infite_loop_error_for_first_parameter_indentation.md
@@ -1,0 +1,1 @@
+* [#9453](https://github.com/rubocop-hq/rubocop/issues/9453): Fix infinite loop error for `Layout/FirstParameterIndentation` when `EnforcedStyle: with_fixed_indentation` is specified for `Layout/ArgumentAlignment`. ([@koic][])

--- a/lib/rubocop/cop/layout/first_argument_indentation.rb
+++ b/lib/rubocop/cop/layout/first_argument_indentation.rb
@@ -4,11 +4,14 @@ module RuboCop
   module Cop
     module Layout
       # This cop checks the indentation of the first argument in a method call.
-      # Arguments after the first one are checked by Layout/ArgumentAlignment,
+      # Arguments after the first one are checked by `Layout/ArgumentAlignment`,
       # not by this cop.
       #
       # For indenting the first parameter of method _definitions_, check out
-      # Layout/FirstParameterIndentation.
+      # `Layout/FirstParameterIndentation`.
+      #
+      # This cop will respect `Layout/ArgumentAlignment` and will not work when
+      # `EnforcedStyle: with_fixed_indentation` is specified for `Layout/ArgumentAlignment`.
       #
       # @example
       #
@@ -149,6 +152,7 @@ module RuboCop
         MSG = 'Indent the first argument one step more than %<base>s.'
 
         def on_send(node)
+          return if enforce_first_argument_with_fixed_indentation?
           return if !node.arguments? || node.operator_method?
 
           indent = base_indentation(node) + configured_indentation_width
@@ -249,6 +253,16 @@ module RuboCop
 
         def on_new_investigation
           @comment_lines = nil
+        end
+
+        def enforce_first_argument_with_fixed_indentation?
+          return false unless argument_alignment_config['Enabled']
+
+          argument_alignment_config['EnforcedStyle'] == 'with_fixed_indentation'
+        end
+
+        def argument_alignment_config
+          config.for_cop('Layout/ArgumentAlignment')
         end
       end
     end

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1688,6 +1688,38 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     RUBY
   end
 
+  it 'does not crash `Layout/ArgumentAlignment` and offenses and accepts `Layout/FirstArgumentIndentation` ' \
+     'when specifying `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment`' do
+    create_file('example.rb', <<~RUBY)
+      # frozen_string_literal: true
+
+      expect(response).to redirect_to(path(
+        obj1,
+        id: obj2.id
+      ))
+    RUBY
+
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/ArgumentAlignment:
+        EnforcedStyle: with_fixed_indentation
+    YAML
+
+    expect(cli.run([
+                     '--auto-correct',
+                     '--only',
+                     'Layout/ArgumentAlignment,Layout/FirstArgumentIndentation'
+                   ])).to eq(0)
+    expect($stderr.string).to eq('')
+    expect(IO.read('example.rb')).to eq(<<~RUBY)
+      # frozen_string_literal: true
+
+      expect(response).to redirect_to(path(
+        obj1,
+        id: obj2.id
+      ))
+    RUBY
+  end
+
   it 'does not crash Lint/SafeNavigationWithEmpty and offenses and accepts Style/SafeNavigation ' \
      'when checking `foo&.empty?` in a conditional' do
     create_file('example.rb', <<~RUBY)


### PR DESCRIPTION
Fixes #9453.

This PR fixes the following infinite loop error for `Layout/FirstParameterIndentation` when `EnforcedStyle: with_fixed_indentation` is specified for `Layout/ArgumentAlignment`.

```console
% cat example.rb
# frozen_string_literal: true

RSpec.describe MyController, type: :controller do
  it 'abc' do
    expect(response).to redirect_to(path(
      obj1,
      id: obj2.id
    ))
  end
end

% cat .rubocop.yml
AllCops:
NewCops: enable

Layout/ArgumentAlignment:
  EnforcedStyle: with_fixed_indentation

% bundle exec rubocop -a --only Layout/ArgumentAlignment,Layout/FirstArgumentIndentation
(snip)

Infinite loop detected in
/Users/koic/src/github.com/koic/rubocop-issues/9453/example.rb and
caused by Layout/FirstArgumentIndentation -> Layout/ArgumentAlignment
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:304:in
`check_for_infinite_loop'
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/runner.rb:287:in
`block in iterate_until_no_changes'
```

The following is the reason why an error occurs.

First, `Layout/FirstArgumentIndentation` will auto-correct it.

```console
% bundle exec rubocop -a --only Layout/FirstArgumentIndentation
Inspecting 1 file
C

Offenses:

example.rb:6:7: C: [Corrected] Layout/FirstArgumentIndentation: Indent
the first argument one step more than path(.
obj1,
^^^^

1 file inspected, 1 offense detected, 1 offense corrected

% cat example.rb
# frozen_string_literal: true

RSpec.describe MyController, type: :controller do
  it 'abc' do
    expect(response).to redirect_to(path(
                                      obj1,
      id: obj2.id
    ))
  end
end
```

Next, `Layout/ArgumentAlignment` will auto-correct it.

```consloe
% bundle exec rubocop -a --only Layout/ArgumentAlignment
Inspecting 1 file
C

Offenses:

example.rb:6:39: C: [Corrected] Layout/ArgumentAlignment: Use one level
of indentation for arguments following the first line of a multi-line
method call.
obj1,
^^^^

1 file inspected, 1 offense detected, 1 offense corrected

% cat example.rb
# frozen_string_literal: true

RSpec.describe MyController, type: :controller do
  it 'abc' do
    expect(response).to redirect_to(path(
      obj1,
      id: obj2.id
    ))
  end
end
```

An infinite loop error occurs because it is corrected to the original code.

This PR makes `Layout/FirstParameterIndentation` respect `Layout/ArgumentAlignment` when `EnforcedStyle: with_fixed_indentation` alternative configuration is specified for `Layout/ArgumentAlignment` to prevent the error.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
