### PR TITLE
[Fix #9488] Document how to use pre-commit with RuboCop extensions

### DIFF
--- a/docs/modules/ROOT/pages/integration_with_other_tools.adoc
+++ b/docs/modules/ROOT/pages/integration_with_other_tools.adoc
@@ -90,6 +90,20 @@ following to your `.pre-commit-config.yaml` file:
     - id: rubocop
 ----
 
+If your RuboCop configuration uses extensions, be sure to include the gems as
+entries in `additional_dependencies`:
+
+[source,yaml]
+----
+- repo: https://github.com/rubocop-hq/rubocop
+  rev: v1.8.1
+  hooks:
+    - id: rubocop
+      additional_dependencies:
+        - rubocop-rails
+        - rubocop-rspec
+----
+
 == Guard integration
 
 If you're fond of https://github.com/guard/guard[Guard] you might


### PR DESCRIPTION
When using pre-commit, extensions that require additional gems must be
specified using `additional_dependencies` in `.pre-commit-config.yaml`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
