### PR TITLE
[Fix #9490] Fix incorrect auto-correct for `Layout/FirstArgumentIndentation`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_first_argument_indentation.md
+++ b/changelog/fix_incorrect_autocorrect_for_first_argument_indentation.md
@@ -1,0 +1,1 @@
+* [#9490](https://github.com/rubocop-hq/rubocop/issues/9490): Fix incorrect auto-correct for `Layout/FirstArgumentIndentation` when specifying `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` and `EnforcedStyle: consistent` of `Layout/FirstArgumentIndentation`. ([@koic][])

--- a/lib/rubocop/cop/layout/first_argument_indentation.rb
+++ b/lib/rubocop/cop/layout/first_argument_indentation.rb
@@ -152,7 +152,7 @@ module RuboCop
         MSG = 'Indent the first argument one step more than %<base>s.'
 
         def on_send(node)
-          return if enforce_first_argument_with_fixed_indentation?
+          return if style != :consistent && enforce_first_argument_with_fixed_indentation?
           return if !node.arguments? || node.operator_method?
 
           indent = base_indentation(node) + configured_indentation_width


### PR DESCRIPTION
Fixes #9490 and a regression of #9486.

This PR fixes incorrect auto-correct for `Layout/FirstArgumentIndentation` when specifying `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` and `EnforcedStyle: consistent` of `Layout/FirstArgumentIndentation`.

And this resolves the following Standard gem build error when upgrading to RuboCop 1.9.1.

```console
2) Failure:
Standard::CliTest#test_autocorrectable
[/home/runner/work/standard/standard/test/standard/cli_test.rb:14]:
--- expected
+++ actual
@@ -98,13 +98,13 @@
```

https://github.com/testdouble/standard/runs/1805630903

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
