### PR TITLE
[Fix #9492] Fix an incorrect auto-correct for `Lint/DeprecatedOpenSSLConstant`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_lint_deprecated_open_ssl_constant.md
+++ b/changelog/fix_incorrect_autocorrect_for_lint_deprecated_open_ssl_constant.md
@@ -1,0 +1,1 @@
+* [#9492](https://github.com/rubocop-hq/rubocop/issues/9492): Fix an incorrect auto-correct for `Lint/DeprecatedOpenSSLConstant` when using no argument algorithm. ([@koic][])

--- a/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
+++ b/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
@@ -44,6 +44,8 @@ module RuboCop
         MSG = 'Use `%<constant>s.%<method>s(%<replacement_args>s)`' \
           ' instead of `%<original>s`.'
 
+        NO_ARG_ALGORITHM = %w[BF DES IDEA RC4].freeze
+
         def_node_matcher :algorithm_const, <<~PATTERN
           (send
             $(const
@@ -104,7 +106,7 @@ module RuboCop
         def algorithm_name(node)
           name = node.loc.name.source
 
-          if openssl_class(node) == 'OpenSSL::Cipher'
+          if openssl_class(node) == 'OpenSSL::Cipher' && !NO_ARG_ALGORITHM.include?(name)
             name.scan(/.{3}/).join('-')
           else
             name
@@ -124,16 +126,23 @@ module RuboCop
           algorithm_name = algorithm_name(algorithm_constant)
 
           if openssl_class(algorithm_constant) == 'OpenSSL::Cipher'
-            build_cipher_arguments(node, algorithm_name)
+            build_cipher_arguments(node, algorithm_name, node.arguments.empty?)
           else
             (["'#{algorithm_name}'"] + node.arguments.map(&:source)).join(', ')
           end
         end
 
-        def build_cipher_arguments(node, algorithm_name)
+        def build_cipher_arguments(node, algorithm_name, no_arguments)
           algorithm_parts = algorithm_name.downcase.split('-')
           size_and_mode = sanitize_arguments(node.arguments).map(&:downcase)
-          "'#{(algorithm_parts + size_and_mode + ['cbc']).take(3).join('-')}'"
+
+          if NO_ARG_ALGORITHM.include?(algorithm_parts.first.upcase) && no_arguments
+            "'#{algorithm_parts.first}'"
+          else
+            mode = 'cbc' unless size_and_mode == ['cbc']
+
+            "'#{(algorithm_parts + size_and_mode + [mode]).compact.take(3).join('-')}'"
+          end
         end
       end
     end

--- a/spec/rubocop/cop/lint/deprecated_open_ssl_constant_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_open_ssl_constant_spec.rb
@@ -34,6 +34,17 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedOpenSSLConstant, :config do
     RUBY
   end
 
+  it 'registers an offense with cipher constant and `cbc` argument and corrects' do
+    expect_offense(<<~RUBY)
+      OpenSSL::Cipher::DES.new('cbc')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `OpenSSL::Cipher.new('des-cbc')` instead of `OpenSSL::Cipher::DES.new('cbc')`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      OpenSSL::Cipher.new('des-cbc')
+    RUBY
+  end
+
   it 'registers an offense with AES + blocksize constant and mode argument and corrects' do
     expect_offense(<<~RUBY)
       OpenSSL::Cipher::AES128.new(:GCM)
@@ -43,6 +54,19 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedOpenSSLConstant, :config do
     expect_correction(<<~RUBY)
       OpenSSL::Cipher.new('aes-128-gcm')
     RUBY
+  end
+
+  RuboCop::Cop::Lint::DeprecatedOpenSSLConstant::NO_ARG_ALGORITHM.each do |algorithm_name|
+    it 'registers an offense with cipher constant and no arguments and corrects' do
+      expect_offense(<<~RUBY, algorithm_name: algorithm_name)
+        OpenSSL::Cipher::#{algorithm_name}.new
+        ^^^^^^^^^^^^^^^^^^{algorithm_name}^^^^ Use `OpenSSL::Cipher.new('#{algorithm_name.downcase}')` instead of `OpenSSL::Cipher::#{algorithm_name}.new`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        OpenSSL::Cipher.new('#{algorithm_name.downcase}')
+      RUBY
+    end
   end
 
   it 'registers an offense with AES + blocksize constant and corrects' do


### PR DESCRIPTION
Fixes #9492.

This PR fixes an incorrect auto-correct for `Lint/DeprecatedOpenSSLConstant` when using no argument algorithm.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
