### PR TITLE
Add new `Gemspec/DateAssignment` cop

### DIFF
--- a/changelog/new_add_new_gemspec_date_assignment_cop.md
+++ b/changelog/new_add_new_gemspec_date_assignment_cop.md
@@ -1,0 +1,1 @@
+* [#9496](https://github.com/rubocop-hq/rubocop/pull/9496): Add new `Gemspec/DateAssignment` cop. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -203,6 +203,13 @@ Bundler/OrderedGems:
 
 #################### Gemspec ###############################
 
+Gemspec/DateAssignment:
+  Description: 'Checks that `date =` is not used in gemspec file, it is set automatically when the gem is packaged.'
+  Enabled: pending
+  VersionAdded: '<<next>>'
+  Include:
+    - '**/*.gemspec'
+
 Gemspec/DuplicatedAssignment:
   Description: 'An attribute assignment method calls should be listed only once in a gemspec.'
   Enabled: true

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -152,6 +152,7 @@ require_relative 'rubocop/cop/bundler/gem_comment'
 require_relative 'rubocop/cop/bundler/insecure_protocol_source'
 require_relative 'rubocop/cop/bundler/ordered_gems'
 
+require_relative 'rubocop/cop/gemspec/date_assignment'
 require_relative 'rubocop/cop/gemspec/duplicated_assignment'
 require_relative 'rubocop/cop/gemspec/ordered_dependencies'
 require_relative 'rubocop/cop/gemspec/required_ruby_version'

--- a/lib/rubocop/cop/gemspec/date_assignment.rb
+++ b/lib/rubocop/cop/gemspec/date_assignment.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Gemspec
+      # This cop checks that `date =` is not used in gemspec file.
+      # It is set automatically when the gem is packaged.
+      #
+      # @example
+      #
+      #   # bad
+      #   Gem::Specification.new do |spec|
+      #     s.name = 'your_cool_gem_name'
+      #     spec.date = Time.now.strftime('%Y-%m-%d')
+      #   end
+      #
+      #   # good
+      #   Gem::Specification.new do |spec|
+      #     s.name = 'your_cool_gem_name'
+      #   end
+      #
+      class DateAssignment < Base
+        include RangeHelp
+        extend AutoCorrector
+
+        MSG = 'Do not use `date =` in gemspec, it is set automatically when the gem is packaged.'
+
+        def_node_matcher :gem_specification, <<~PATTERN
+          (block
+            (send
+              (const
+                (const {cbase nil?} :Gem) :Specification) :new)
+            ...)
+        PATTERN
+
+        def on_block(block_node)
+          return unless gem_specification(block_node)
+
+          block_parameter = block_node.arguments.first.source
+
+          date_assignment = block_node.descendants.detect do |node|
+            node.send_type? && node.receiver&.source == block_parameter && node.method?(:date=)
+          end
+
+          return unless date_assignment
+
+          add_offense(date_assignment) do |corrector|
+            range = range_by_whole_lines(date_assignment.source_range, include_final_newline: true)
+
+            corrector.remove(range)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -541,6 +541,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                 Enabled: false
               Layout:
                 Enabled: false
+              Gemspec:
+                Enabled: false
 
               Style/SomeCop:
                 Description: Something

--- a/spec/rubocop/cop/gemspec/date_assignment_spec.rb
+++ b/spec/rubocop/cop/gemspec/date_assignment_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Gemspec::DateAssignment, :config do
+  it 'registers and corrects an offense when using `s.date =`' do
+    expect_offense(<<~RUBY)
+      Gem::Specification.new do |s|
+        s.name = 'your_cool_gem_name'
+        s.date = Time.now.strftime('%Y-%m-%d')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `date =` in gemspec, it is set automatically when the gem is packaged.
+        s.bindir = 'exe'
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Gem::Specification.new do |s|
+        s.name = 'your_cool_gem_name'
+        s.bindir = 'exe'
+      end
+    RUBY
+  end
+
+  it 'registers and corrects an offense when using `spec.date =`' do
+    expect_offense(<<~RUBY)
+      Gem::Specification.new do |spec|
+        spec.name = 'your_cool_gem_name'
+        spec.date = Time.now.strftime('%Y-%m-%d')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `date =` in gemspec, it is set automatically when the gem is packaged.
+        spec.bindir = 'exe'
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Gem::Specification.new do |spec|
+        spec.name = 'your_cool_gem_name'
+        spec.bindir = 'exe'
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `s.date =` outside `Gem::Specification.new`' do
+    expect_no_offenses(<<~RUBY)
+      s.date = Time.now.strftime('%Y-%m-%d')
+    RUBY
+  end
+
+  it 'does not register an offense when using `date =` and receiver is not `Gem::Specification.new` block variable' do
+    expect_no_offenses(<<~RUBY)
+      Gem::Specification.new do |spec|
+        s.date = Time.now.strftime('%Y-%m-%d')
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop-rails/issues/432.

This PR adds new `Gemspec/DateAssignment` cop.

This cop checks that `date =` is not used in gemspec file. It is set automatically when the gem is packaged.

```ruby
# bad
Gem::Specification.new do |spec|
  s.name = 'your_cool_gem'
  spec.date = Time.now.strftime('%Y-%m-%d')
end

# good
Gem::Specification.new do |spec|
  s.name = 'your_cool_gem'
end
```

RubyGems doesn't expect the value to be set.
https://github.com/rubygems/rubygems/blob/be08d8307eda3b61f0ec0460fe7fbcf647b526e6/lib/rubygems/specification.rb#L1679-L1681

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
