### PR TITLE
[Fix #9497] Fix an error for `Style/ExplicitBlockArgument`

### DIFF
--- a/changelog/fix_an_error_for_style_explicit_block_argument.md
+++ b/changelog/fix_an_error_for_style_explicit_block_argument.md
@@ -1,0 +1,1 @@
+* [#9497](https://github.com/rubocop-hq/rubocop/issues/9497): Fix an error for `Style/ExplicitBlockArgument` when `yield` is inside block of `super`. ([@koic][])

--- a/lib/rubocop/cop/style/explicit_block_argument.rb
+++ b/lib/rubocop/cop/style/explicit_block_argument.rb
@@ -97,7 +97,7 @@ module RuboCop
             replacement = ' &block'
             replacement = ",#{replacement}" unless arg_range.source.end_with?(',')
             corrector.insert_after(arg_range, replacement) unless last_arg.blockarg_type?
-          elsif node.call_type?
+          elsif node.call_type? || node.zsuper_type?
             corrector.insert_after(node, '(&block)')
           else
             corrector.insert_after(node.loc.name, '(&block)')

--- a/spec/rubocop/cop/style/explicit_block_argument_spec.rb
+++ b/spec/rubocop/cop/style/explicit_block_argument_spec.rb
@@ -142,6 +142,21 @@ RSpec.describe RuboCop::Cop::Style::ExplicitBlockArgument, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when `yield` is inside block of `super`' do
+    expect_offense(<<~RUBY)
+      def do_something
+        super { yield }
+        ^^^^^^^^^^^^^^^ Consider using explicit block argument in the surrounding method's signature over `yield`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def do_something(&block)
+        super(&block)
+      end
+    RUBY
+  end
+
   it 'does not register an offense when `yield` is the sole block body' do
     expect_no_offenses(<<~RUBY)
       def m


### PR DESCRIPTION
Fixes #9497.

This PR fixes an error for `Style/ExplicitBlockArgument` when `yield` is inside block of `super`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
