### PR TITLE
[Fix #9499] Fix a false positive for `Layout/SpaceBeforeBrackets`

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_space_before_brackets.md
+++ b/changelog/fix_a_false_positive_for_layout_space_before_brackets.md
@@ -1,0 +1,1 @@
+* [#9499](https://github.com/rubocop-hq/rubocop/issues/9499): Fix a false positive for `Layout/SpaceBeforeBrackets` when multiple spaces are inserted inside the left bracket. ([@koic][])

--- a/lib/rubocop/cop/layout/space_before_brackets.rb
+++ b/lib/rubocop/cop/layout/space_before_brackets.rb
@@ -47,7 +47,7 @@ module RuboCop
           end_pos = node.receiver.source_range.end_pos
 
           return if begin_pos - end_pos == 1 ||
-                    (range = range_between(end_pos, begin_pos - 1)).source == '['
+                    (range = range_between(end_pos, begin_pos - 1)).source.start_with?('[')
 
           range
         end

--- a/spec/rubocop/cop/layout/space_before_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_brackets_spec.rb
@@ -115,6 +115,12 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBrackets, :config do
         @collections[ index_or_key ] = :value
       RUBY
     end
+
+    it 'does not register an offense when multiple spaces are inserted inside the left bracket' do
+      expect_no_offenses(<<~RUBY)
+        @collections[  index_or_key] = value
+      RUBY
+    end
   end
 
   it 'does not register an offense when assigning an array' do


### PR DESCRIPTION
Fixes #9499.

This PR fixes a false positive for `Layout/SpaceBeforeBrackets` when multiple spaces are inserted inside the left bracket.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
