### PR TITLE
[Fix #9507] Fix an incorrect auto-correct for `Lint/RedundantSplatExpansion`

### DIFF
--- a/changelog/fix_an_error_for_lint_redundant_splat_expansion.md
+++ b/changelog/fix_an_error_for_lint_redundant_splat_expansion.md
@@ -1,0 +1,1 @@
+* [#9507](https://github.com/rubocop-hq/rubocop/issues/9507): Fix an incorrect auto-correct for `Lint/RedundantSplatExpansion` when expanding `Array.new` call on method argument. ([@koic][])

--- a/lib/rubocop/cop/lint/redundant_splat_expansion.rb
+++ b/lib/rubocop/cop/lint/redundant_splat_expansion.rb
@@ -140,13 +140,15 @@ module RuboCop
         def replacement_range_and_content(node)
           variable, = *node
           loc = node.loc
+          expression = loc.expression
 
           if array_new?(variable)
-            [node.parent.loc.expression, variable.source]
+            expression = node.parent.loc.expression if node.parent.array_type?
+            [expression, variable.source]
           elsif !variable.array_type?
-            [loc.expression, "[#{variable.source}]"]
+            [expression, "[#{variable.source}]"]
           elsif redundant_brackets?(node)
-            [loc.expression, remove_brackets(variable)]
+            [expression, remove_brackets(variable)]
           else
             [loc.operator, '']
           end

--- a/spec/rubocop/cop/lint/redundant_splat_expansion_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_splat_expansion_spec.rb
@@ -330,6 +330,19 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSplatExpansion, :config do
     end
   end
 
+  describe 'expanding Array.new call on method argument' do
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        send(method, *Array.new(foo))
+                     ^^^^^^^^^^^^^^^ Replace splat expansion with comma separated values.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        send(method, Array.new(foo))
+      RUBY
+    end
+  end
+
   context 'arrays being expanded with %i variants using splat expansion' do
     context 'splat expansion inside of an array' do
       it 'registers an offense and corrects %i to a list of symbols' do


### PR DESCRIPTION
Fixes #9507.

This PR fixes an incorrect auto-correct for `Lint/RedundantSplatExpansion` when expanding `Array.new` call on method argument

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
