### PR TITLE
Fix typo in Style/DoubleNegation, nagation => negation

### DIFF
--- a/lib/rubocop/cop/style/double_negation.rb
+++ b/lib/rubocop/cop/style/double_negation.rb
@@ -5,8 +5,8 @@ module RuboCop
     module Style
       # This cop checks for uses of double negation (`!!`) to convert something to a boolean value.
       #
-      # When using `EnforcedStyle: allowed_in_returns`, allow double nagation in contexts
-      # that use boolean as a return value. When using `EnforcedStyle: forbidden`, double nagation
+      # When using `EnforcedStyle: allowed_in_returns`, allow double negation in contexts
+      # that use boolean as a return value. When using `EnforcedStyle: forbidden`, double negation
       # should be forbidden always.
       #
       # @example


### PR DESCRIPTION
Fix a typo in `Style/DoubleNegation` correcting `nagation` to `negation`.
-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
