### PR TITLE
Fix a false negative for `Lint/ElseLayout`

### DIFF
--- a/changelog/fix_false_negative_for_lint_else_layout.md
+++ b/changelog/fix_false_negative_for_lint_else_layout.md
@@ -1,0 +1,1 @@
+* [#9511](https://github.com/rubocop-hq/rubocop/pull/9511): Fix a false negative for `Lint/ElseLayout` when using multiple `elsif`s. ([@koic][])

--- a/lib/rubocop/cop/lint/else_layout.rb
+++ b/lib/rubocop/cop/lint/else_layout.rb
@@ -47,7 +47,7 @@ module RuboCop
         MSG = 'Odd `else` layout detected. Did you mean to use `elsif`?'
 
         def on_if(node)
-          return if node.ternary? || node.elsif?
+          return if node.ternary?
 
           check(node)
         end

--- a/spec/rubocop/cop/lint/else_layout_spec.rb
+++ b/spec/rubocop/cop/lint/else_layout_spec.rb
@@ -69,6 +69,36 @@ RSpec.describe RuboCop::Cop::Lint::ElseLayout, :config do
     RUBY
   end
 
+  it 'registers and corrects an offense when using multiple `elsif`s' do
+    expect_offense(<<~RUBY)
+      if condition_foo
+        foo
+      elsif condition_bar
+        bar
+      elsif condition_baz
+        baz
+      else qux
+           ^^^ Odd `else` layout detected. Did you mean to use `elsif`?
+        quux
+        corge
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if condition_foo
+        foo
+      elsif condition_bar
+        bar
+      elsif condition_baz
+        baz
+      else
+        qux
+        quux
+        corge
+      end
+    RUBY
+  end
+
   it 'handles ternary ops' do
     expect_no_offenses('x ? a : b')
   end


### PR DESCRIPTION
Regression by https://github.com/rubocop-hq/rubocop/commit/219dfe1.

This PR fixes a false negative for `Lint/ElseLayout` when using multiple `elsif`s.

@kakutani (w/ @asakusarb) Thank you for finding this false negative issue.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
