### PR TITLE
[Fix #9513] Fix an incorrect auto-correct for `Style/HashConversion`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_hash_conversion.md
+++ b/changelog/fix_incorrect_autocorrect_for_hash_conversion.md
@@ -1,0 +1,1 @@
+* [#9513](https://github.com/rubocop-hq/rubocop/issues/9513): Fix an incorrect auto-correct for `Style/HashConversion` when using hash argument `Hash[]`. ([@koic][])

--- a/spec/rubocop/cop/style/hash_conversion_spec.rb
+++ b/spec/rubocop/cop/style/hash_conversion_spec.rb
@@ -23,6 +23,17 @@ RSpec.describe RuboCop::Cop::Style::HashConversion, :config do
     RUBY
   end
 
+  it 'reports different offense for hash argument Hash[]' do
+    expect_offense(<<~RUBY)
+      Hash[a: b, c: d]
+      ^^^^^^^^^^^^^^^^ Prefer literal hash to Hash[key: value, ...].
+    RUBY
+
+    expect_correction(<<~RUBY)
+      {a: b, c: d}
+    RUBY
+  end
+
   it 'reports different offense for empty Hash[]' do
     expect_offense(<<~RUBY)
       Hash[]


### PR DESCRIPTION
Fixes #9513.

This PR fixes an incorrect auto-correct for `Style/HashConversion` when using hash argument `Hash[]`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
