### PR TITLE
Required ruby version fixes

### DIFF
--- a/changelog/fix_return_minimal_known_ruby_version_from.md
+++ b/changelog/fix_return_minimal_known_ruby_version_from.md
@@ -1,0 +1,1 @@
+* [#9482](https://github.com/rubocop-hq/rubocop/issues/9482): Return minimal known ruby version from gemspecs `required_ruby_version`. ([@HeroProtagonist][])

--- a/spec/rubocop/target_ruby_spec.rb
+++ b/spec/rubocop/target_ruby_spec.rb
@@ -294,7 +294,21 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
           let(:base_path) { configuration.base_dir_for_path_parameters }
           let(:gemspec_file_path) { File.join(base_path, 'example.gemspec') }
 
-          it 'sets target_ruby from required_ruby_version from exact version' do
+          it 'sets target_ruby from exact numeric version' do
+            content =
+              <<-HEREDOC
+                Gem::Specification.new do |s|
+                  s.name = 'test'
+                  s.required_ruby_version = 2.7
+                  s.licenses = ['MIT']
+                end
+              HEREDOC
+
+            create_file(gemspec_file_path, content)
+            expect(target_ruby.version).to eq 2.7
+          end
+
+          it 'sets target_ruby from exacts string version' do
             content =
               <<-HEREDOC
                 Gem::Specification.new do |s|
@@ -308,32 +322,74 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
             expect(target_ruby.version).to eq 2.7
           end
 
-          it 'sets target_ruby from required_ruby_version from inclusive range' do
+          it 'sets target_ruby to default from unknown ruby' do
             content =
               <<-HEREDOC
                 Gem::Specification.new do |s|
                   s.name = 'test'
-                  s.required_ruby_version = '>= 3.0.0'
-                  s.licenses = ['MIT']
-                end
-              HEREDOC
-
-            create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq 3.0
-          end
-
-          it 'sets default target_ruby from exclusive range' do
-            content =
-              <<-HEREDOC
-                Gem::Specification.new do |s|
-                  s.name = 'test'
-                  s.required_ruby_version = '< 3.0.0'
+                  s.required_ruby_version = '2.3.0'
                   s.licenses = ['MIT']
                 end
               HEREDOC
 
             create_file(gemspec_file_path, content)
             expect(target_ruby.version).to eq default_version
+          end
+
+          it 'sets target_ruby from inclusive range' do
+            content =
+              <<-HEREDOC
+                Gem::Specification.new do |s|
+                  s.name = 'test'
+                  s.required_ruby_version = '>= 2.6.0'
+                  s.licenses = ['MIT']
+                end
+              HEREDOC
+
+            create_file(gemspec_file_path, content)
+            expect(target_ruby.version).to eq 2.6
+          end
+
+          it 'sets target_ruby from exclusive range' do
+            content =
+              <<-HEREDOC
+                Gem::Specification.new do |s|
+                  s.name = 'test'
+                  s.required_ruby_version = '> 2.4.0'
+                  s.licenses = ['MIT']
+                end
+              HEREDOC
+
+            create_file(gemspec_file_path, content)
+            expect(target_ruby.version).to eq 2.5
+          end
+
+          it 'sets target_ruby from approximate version' do
+            content =
+              <<-HEREDOC
+                Gem::Specification.new do |s|
+                  s.name = 'test'
+                  s.required_ruby_version = '~> 2.5.4'
+                  s.licenses = ['MIT']
+                end
+              HEREDOC
+
+            create_file(gemspec_file_path, content)
+            expect(target_ruby.version).to eq 2.5
+          end
+
+          it 'sets target_ruby from not equal version' do
+            content =
+              <<-HEREDOC
+                Gem::Specification.new do |s|
+                  s.name = 'test'
+                  s.required_ruby_version = '!= 2.4.4'
+                  s.licenses = ['MIT']
+                end
+              HEREDOC
+
+            create_file(gemspec_file_path, content)
+            expect(target_ruby.version).to eq 2.5
           end
         end
 
@@ -360,16 +416,16 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
               <<-HEREDOC
                 Gem::Specification.new do |s|
                   s.name = 'test'
-                  s.required_ruby_version = Gem::Requirement.new('>= 3.0.0')
+                  s.required_ruby_version = Gem::Requirement.new('>= 2.3.1')
                   s.licenses = ['MIT']
                 end
               HEREDOC
 
             create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq 3.0
+            expect(target_ruby.version).to eq default_version
           end
 
-          it 'sets default target_ruby from exclusive requirement range' do
+          it 'sets first known ruby version that satisfies requirement' do
             content =
               <<-HEREDOC
                 Gem::Specification.new do |s|
@@ -402,32 +458,18 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
             expect(target_ruby.version).to eq 2.6
           end
 
-          it 'sets target_ruby from required_ruby_version with inclusive range' do
+          it 'sets target_ruby from required_ruby_version with many requirements' do
             content =
               <<-HEREDOC
                 Gem::Specification.new do |s|
                   s.name = 'test'
-                  s.required_ruby_version = ['<=2.7.4', '>2.6.5']
+                  s.required_ruby_version = ['<=2.7.4', '>2.4.5', '!=2.4']
                   s.licenses = ['MIT']
                 end
               HEREDOC
 
             create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq 2.7
-          end
-
-          it 'sets default target_ruby with all exclusive ranges' do
-            content =
-              <<-HEREDOC
-                Gem::Specification.new do |s|
-                  s.name = 'test'
-                  s.required_ruby_version = ['<2.7.4', '>2.6.5']
-                  s.licenses = ['MIT']
-                end
-              HEREDOC
-
-            create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq default_version
+            expect(target_ruby.version).to eq 2.5
           end
         end
 

--- a/spec/rubocop/target_ruby_spec.rb
+++ b/spec/rubocop/target_ruby_spec.rb
@@ -294,54 +294,12 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
           let(:base_path) { configuration.base_dir_for_path_parameters }
           let(:gemspec_file_path) { File.join(base_path, 'example.gemspec') }
 
-          it 'sets target_ruby from exact numeric version' do
-            content =
-              <<-HEREDOC
-                Gem::Specification.new do |s|
-                  s.name = 'test'
-                  s.required_ruby_version = 2.7
-                  s.licenses = ['MIT']
-                end
-              HEREDOC
-
-            create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq 2.7
-          end
-
-          it 'sets target_ruby from exacts string version' do
-            content =
-              <<-HEREDOC
-                Gem::Specification.new do |s|
-                  s.name = 'test'
-                  s.required_ruby_version = '2.7.4'
-                  s.licenses = ['MIT']
-                end
-              HEREDOC
-
-            create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq 2.7
-          end
-
-          it 'sets target_ruby to default from unknown ruby' do
-            content =
-              <<-HEREDOC
-                Gem::Specification.new do |s|
-                  s.name = 'test'
-                  s.required_ruby_version = '2.3.0'
-                  s.licenses = ['MIT']
-                end
-              HEREDOC
-
-            create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq default_version
-          end
-
           it 'sets target_ruby from inclusive range' do
             content =
               <<-HEREDOC
                 Gem::Specification.new do |s|
                   s.name = 'test'
-                  s.required_ruby_version = '>= 2.6.0'
+                  s.required_ruby_version = '>= 2.6.1'
                   s.licenses = ['MIT']
                 end
               HEREDOC
@@ -355,13 +313,13 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
               <<-HEREDOC
                 Gem::Specification.new do |s|
                   s.name = 'test'
-                  s.required_ruby_version = '> 2.4.0'
+                  s.required_ruby_version = '> 2.4.1'
                   s.licenses = ['MIT']
                 end
               HEREDOC
 
             create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq 2.5
+            expect(target_ruby.version).to eq 2.4
           end
 
           it 'sets target_ruby from approximate version' do
@@ -369,21 +327,7 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
               <<-HEREDOC
                 Gem::Specification.new do |s|
                   s.name = 'test'
-                  s.required_ruby_version = '~> 2.5.4'
-                  s.licenses = ['MIT']
-                end
-              HEREDOC
-
-            create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq 2.5
-          end
-
-          it 'sets target_ruby from not equal version' do
-            content =
-              <<-HEREDOC
-                Gem::Specification.new do |s|
-                  s.name = 'test'
-                  s.required_ruby_version = '!= 2.4.4'
+                  s.required_ruby_version = '~> 2.5.0'
                   s.licenses = ['MIT']
                 end
               HEREDOC
@@ -396,20 +340,6 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
         context 'when file contains `required_ruby_version` as a requirement' do
           let(:base_path) { configuration.base_dir_for_path_parameters }
           let(:gemspec_file_path) { File.join(base_path, 'example.gemspec') }
-
-          it 'sets target_ruby from required_ruby_version from exact requirement version' do
-            content =
-              <<-HEREDOC
-                Gem::Specification.new do |s|
-                  s.name = 'test'
-                  s.required_ruby_version = Gem::Requirement.new('2.7.4')
-                  s.licenses = ['MIT']
-                end
-              HEREDOC
-
-            create_file(gemspec_file_path, content)
-            expect(target_ruby.version).to eq 2.7
-          end
 
           it 'sets target_ruby from required_ruby_version from inclusive requirement range' do
             content =
@@ -444,7 +374,7 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
           let(:base_path) { configuration.base_dir_for_path_parameters }
           let(:gemspec_file_path) { File.join(base_path, 'example.gemspec') }
 
-          it 'sets target_ruby from the lowest value' do
+          it 'sets target_ruby to the minimal version satisfying the requirements' do
             content =
               <<-HEREDOC
                 Gem::Specification.new do |s|
@@ -463,7 +393,7 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
               <<-HEREDOC
                 Gem::Specification.new do |s|
                   s.name = 'test'
-                  s.required_ruby_version = ['<=2.7.4', '>2.4.5', '!=2.4']
+                  s.required_ruby_version = ['<=2.7.4', '>2.4.5', '~>2.5.1']
                   s.licenses = ['MIT']
                 end
               HEREDOC


### PR DESCRIPTION
Closes #9482 and #9329

The class to match `required_ruby_version` from `.gemspec` files could return invalid ruby versions. 

- This PR makes it so that it will only return a value from the `KNOWN_RUBIES` array. Specifically the minimal known ruby will be returned.
- The version parsing is also greatly improved by leveraging existing classes from the `Gem` library.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
