### PR TITLE
[Fix #9520] Fix an incorrect auto-correct for `Style/MultipleComparison`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_multiple_comparison.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_multiple_comparison.md
@@ -1,0 +1,1 @@
+* [#9520](https://github.com/rubocop-hq/rubocop/issues/9520): Fix an incorrect auto-correct for `Style/MultipleComparison` when comparing a variable with multiple items in `if` and `elsif` conditions. ([@koic][])

--- a/lib/rubocop/cop/style/multiple_comparison.rb
+++ b/lib/rubocop/cop/style/multiple_comparison.rb
@@ -47,11 +47,12 @@ module RuboCop
           'in a conditional, use `Array#include?` instead.'
 
         def on_new_investigation
-          @compared_elements = []
-          @allowed_method_comparison = false
+          @last_comparison = nil
         end
 
         def on_or(node)
+          reset_comparison if switch_comparison?(node)
+
           root_of_or_node = root_of_or_node(node)
 
           return unless node == root_of_or_node
@@ -64,6 +65,8 @@ module RuboCop
 
             corrector.replace(node, prefer_method)
           end
+
+          @last_comparison = node
         end
 
         private
@@ -129,6 +132,17 @@ module RuboCop
           else
             or_node
           end
+        end
+
+        def switch_comparison?(node)
+          return true if @last_comparison.nil?
+
+          @last_comparison.descendants.none? { |descendant| descendant == node }
+        end
+
+        def reset_comparison
+          @compared_elements = []
+          @allowed_method_comparison = false
         end
 
         def allow_method_comparison?

--- a/spec/rubocop/cop/style/multiple_comparison_spec.rb
+++ b/spec/rubocop/cop/style/multiple_comparison_spec.rb
@@ -96,6 +96,28 @@ RSpec.describe RuboCop::Cop::Style::MultipleComparison, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when `a` is compared twice in `if` and `elsif` conditions' do
+    expect_offense(<<~RUBY)
+      def foo(a)
+        if a == 'foo' || a == 'bar'
+           ^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
+        elsif a == 'baz' || a == 'qux'
+              ^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
+        elsif a == 'quux'
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo(a)
+        if ['foo', 'bar'].include?(a)
+        elsif ['baz', 'qux'].include?(a)
+        elsif a == 'quux'
+        end
+      end
+    RUBY
+  end
+
   it 'does not register an offense for comparing multiple literal strings' do
     expect_no_offenses(<<~RUBY)
       if "a" == "a" || "a" == "c"


### PR DESCRIPTION
Fixes #9520.

This PR fixes an incorrect auto-correct for `Style/MultipleComparison` when comparing a variable with multiple items in `if` and `elsif` conditions.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
