### PR TITLE
Fix typo in documentation syntax

### DIFF
--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -16,7 +16,7 @@ module RuboCop
       # ----
       # Lint/Debugger:
       #   WebConsole: ~
-      # ---
+      # ----
       #
       #
       # @example


### PR DESCRIPTION
The [Lint section of our documentation](https://docs.rubocop.org/rubocop/1.10/cops_lint.html#lintdebugger) is currently (as of v1.10.0) broken right in the middle of the `Lint/Debugger` section because of this code block which wasn't properly closed.

Problematic formatting was added in #9504.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
