### PR TITLE
[Fix #9523] Fix an error for `Style/TrailingMethodEndStatement`

### DIFF
--- a/changelog/fix_error_for_style_trailing_method_end_statement.md
+++ b/changelog/fix_error_for_style_trailing_method_end_statement.md
@@ -1,0 +1,1 @@
+* [#9523](https://github.com/rubocop-hq/rubocop/issues/9523): Fix an error for `Style/TrailingMethodEndStatement` when endless method definition signature and body are on different lines. ([@koic][])

--- a/lib/rubocop/cop/style/trailing_method_end_statement.rb
+++ b/lib/rubocop/cop/style/trailing_method_end_statement.rb
@@ -40,7 +40,7 @@ module RuboCop
               'its own line.'
 
         def on_def(node)
-          return unless trailing_end?(node)
+          return if node.endless? || !trailing_end?(node)
 
           add_offense(node.loc.end) do |corrector|
             corrector.insert_before(

--- a/spec/rubocop/cop/style/trailing_method_end_statement_spec.rb
+++ b/spec/rubocop/cop/style/trailing_method_end_statement_spec.rb
@@ -122,4 +122,20 @@ RSpec.describe RuboCop::Cop::Style::TrailingMethodEndStatement, :config do
       end
     RUBY
   end
+
+  context 'when Ruby 3.0 or higher', :ruby30 do
+    it 'does not register an offense when using endless method definition' do
+      expect_no_offenses(<<~RUBY)
+        def foo = bar
+      RUBY
+    end
+
+    it 'does not register an offense when endless method definition signature and body are ' \
+       'on different lines' do
+      expect_no_offenses(<<~RUBY)
+        def foo =
+                  bar
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #9523.

This PR fixes an error for `Style/TrailingMethodEndStatement`  when endless method definition signature and body are on different lines.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
