### PR TITLE
[#9526] Add `AllowSplatArgument` option to `Style/HashConversion`

### DIFF
--- a/changelog/change_add_allow_splat_argument_option_to_hash_conversion.md
+++ b/changelog/change_add_allow_splat_argument_option_to_hash_conversion.md
@@ -1,0 +1,1 @@
+* [#9526](https://github.com/rubocop-hq/rubocop/issues/9526): Add `AllowSplatArgument` option to `Style/HashConversion` and the option is true by default. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3446,6 +3446,8 @@ Style/HashConversion:
   Description: 'Avoid Hash[] in favor of ary.to_h or literal hashes.'
   Enabled: pending
   VersionAdded: '1.10'
+  VersionChanged: <<next>>
+  AllowSplatArgument: true
 
 Style/HashEachMethods:
   Description: 'Use Hash#each_key and Hash#each_value.'

--- a/spec/rubocop/cop/style/hash_conversion_spec.rb
+++ b/spec/rubocop/cop/style/hash_conversion_spec.rb
@@ -54,12 +54,26 @@ RSpec.describe RuboCop::Cop::Style::HashConversion, :config do
     expect_no_corrections
   end
 
-  it 'reports uncorrectable offense for unpacked ary' do
-    expect_offense(<<~RUBY)
-      Hash[*ary]
-      ^^^^^^^^^^ Prefer array_of_pairs.to_h to Hash[*array].
-    RUBY
+  context 'AllowSplatArgument: true' do
+    let(:cop_config) { { 'AllowSplatArgument' => true } }
 
-    expect_no_corrections
+    it 'does not register an offense for unpacked array' do
+      expect_no_offenses(<<~RUBY)
+        Hash[*ary]
+      RUBY
+    end
+  end
+
+  context 'AllowSplatArgument: false' do
+    let(:cop_config) { { 'AllowSplatArgument' => false } }
+
+    it 'reports uncorrectable offense for unpacked array' do
+      expect_offense(<<~RUBY)
+        Hash[*ary]
+        ^^^^^^^^^^ Prefer array_of_pairs.to_h to Hash[*array].
+      RUBY
+
+      expect_no_corrections
+    end
   end
 end


### PR DESCRIPTION
Resolves #9526.

This PR add `AllowSplatArgument` option to `Style/HashConversion` and the option is true by default.
This is because `Hash[*ary]` is not allowed because it is strict.

As discussed in https://github.com/rubocop-hq/rubocop/pull/9478#discussion_r567259779, the correction code from `Hash[*arg]` is not simply determined. So, I think it's better to allow it by default as a simple notation.

On the other hand, there may be case where some users want to use the existing behavior, so this PR have made it optional.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
