### PR TITLE
Fixed typo in docs part 2

### DIFF
--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -595,7 +595,7 @@ Specific default groups can be disabled if necessary:
 ----
 Lint/Debugger:
   WebConsole: ~
----
+----
 
 === Examples
 


### PR DESCRIPTION
Fixed another typo in docs similar to:

https://github.com/rubocop-hq/rubocop/pull/9522

[Currently broken](https://docs.rubocop.org/rubocop/cops_lint.html#lintconstantresolution)

![image](https://user-images.githubusercontent.com/46548/108472317-8deb5280-72c7-11eb-8fc5-5788697dc6ca.png)

