### PR TITLE
Fix mislabelled example under Lint/DuplicateBranch

### DIFF
--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -919,7 +919,7 @@ else 250
 end
 ----
 
-==== IgnoreLiteralBranches: true
+==== IgnoreConstantBranches: true
 
 [source,ruby]
 ----

--- a/lib/rubocop/cop/lint/duplicate_branch.rb
+++ b/lib/rubocop/cop/lint/duplicate_branch.rb
@@ -74,7 +74,7 @@ module RuboCop
       #   else 250
       #   end
       #
-      # @example IgnoreLiteralBranches: true
+      # @example IgnoreConstantBranches: true
       #   # good
       #   case size
       #   when "small" then SMALL_SIZE


### PR DESCRIPTION
The second `IgnoreLiteralBranches` was probably supposed to be `IgnoreContentBranches` :)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
