### PR TITLE
Fix broken list in Style/EndlessMethod doc

### DIFF
--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -3195,6 +3195,7 @@ for single-lined method bodies, or disallow endless methods.
 Other method definition types are not considered by this cop.
 
 The supported styles are:
+
 * allow_single_line (default) - only single line endless method definitions are allowed.
 * allow_always - all endless method definitions are allowed.
 * disallow - all endless method definitions are disallowed.

--- a/lib/rubocop/cop/style/endless_method.rb
+++ b/lib/rubocop/cop/style/endless_method.rb
@@ -11,6 +11,7 @@ module RuboCop
       # Other method definition types are not considered by this cop.
       #
       # The supported styles are:
+      #
       # * allow_single_line (default) - only single line endless method definitions are allowed.
       # * allow_always - all endless method definitions are allowed.
       # * disallow - all endless method definitions are disallowed.


### PR DESCRIPTION
A missing blank line was causing the list to be rendered like this:

```
The supported styles are: * allow_single_line (default) - only single line endless method definitions are allowed. * allow_always - all endless
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
