### PR TITLE
Specify raise with a custom exception instance

### DIFF
--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -310,6 +310,10 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
       expect_no_offenses('raise MyCustomError.new(*args)')
     end
 
+    it 'ignores a raise with an exception argument' do
+      expect_no_offenses('raise Ex.new(entity), message')
+    end
+
     it 'accepts a raise with 3 args' do
       expect_no_offenses('raise RuntimeError, msg, caller')
     end


### PR DESCRIPTION
The example when in addition to a custom exception instance initialized with an argument is passed to `raise` followed by a message.

See https://github.com/rubocop-hq/ruby-style-guide/issues/395#issuecomment-785172382

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/